### PR TITLE
fix: route GitHub webhooks by repository id so a rename cannot silence them

### DIFF
--- a/.kamal/hooks/post-deploy
+++ b/.kamal/hooks/post-deploy
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -eu
+
+# Rollbacks can target an image created before the reconciliation script
+# existed. Only new deploy/setup runs need to apply the current subscription
+# contract to GitHub hooks that predate it.
+case "${KAMAL_COMMAND:-}" in
+  deploy|redeploy|setup) ;;
+  *) exit 0 ;;
+esac
+
+./bin/kamal app exec --primary --reuse "bin/rails runner script/reprovision_github_webhooks"

--- a/.kamal/hooks/post-deploy
+++ b/.kamal/hooks/post-deploy
@@ -1,12 +1,8 @@
 #!/bin/sh
 set -eu
 
-# Rollbacks can target an image created before the reconciliation script
-# existed. Only new deploy/setup runs need to apply the current subscription
-# contract to GitHub hooks that predate it.
-case "${KAMAL_COMMAND:-}" in
-  deploy|redeploy|setup) ;;
-  *) exit 0 ;;
-esac
-
-./bin/kamal app exec --primary --reuse "bin/rails runner script/reprovision_github_webhooks"
+# Post-deploy hooks do not receive KAMAL_COMMAND, so reconcile after every
+# successful rollout. The file guard runs inside the deployed container and
+# keeps rollbacks to images predating the reconciliation script safe.
+./bin/kamal app exec --primary --reuse \
+  "if [ -f script/reprovision_github_webhooks ]; then bin/rails runner script/reprovision_github_webhooks; fi"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -326,6 +326,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_29_000000) do
     t.index ["markdown_sync_enabled"], name: "index_github_repository_links_on_markdown_sync_enabled"
     t.index ["repository_full_name"], name: "index_github_repository_links_on_repository_full_name"
     t.index ["repository_id"], name: "index_github_repository_links_on_repository_id"
+    t.index ["webhook_hook_id"], name: "index_github_repository_links_on_webhook_hook_id"
   end
 
   create_table "github_webhook_deliveries", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_27_010000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_29_000000) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -325,6 +325,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_27_010000) do
     t.index ["markdown_root_creative_id"], name: "index_github_repository_links_on_markdown_root_creative_id", where: "markdown_root_creative_id IS NOT NULL"
     t.index ["markdown_sync_enabled"], name: "index_github_repository_links_on_markdown_sync_enabled"
     t.index ["repository_full_name"], name: "index_github_repository_links_on_repository_full_name"
+    t.index ["repository_id"], name: "index_github_repository_links_on_repository_id"
   end
 
   create_table "github_webhook_deliveries", force: :cascade do |t|

--- a/engines/collavre_github/app/controllers/collavre_github/creatives/integrations_controller.rb
+++ b/engines/collavre_github/app/controllers/collavre_github/creatives/integrations_controller.rb
@@ -45,12 +45,12 @@ module CollavreGithub
         end
 
         integration_attributes = integration_params
+        markdown_sync = integration_attributes[:markdown_sync]
         repositories = Array(integration_attributes[:repositories]).map(&:to_s).uniq
-        existing_by_name = linked_repository_links(account)
-          .index_by { |link| link.repository_full_name.downcase }
+        existing_links = linked_repository_links(account).to_a
+        existing_by_name = existing_links.index_by { |link| link.repository_full_name.downcase }
         client = CollavreGithub::Client.new(account)
         identities = {}
-        verified_repository_ids = {}
         repositories.each do |full_name|
           normalized_name = full_name.downcase
           existing = existing_by_name[normalized_name]
@@ -73,12 +73,140 @@ module CollavreGithub
             return
           end
 
-          identities[normalized_name] = identity unless existing
-          verified_repository_ids[normalized_name] = identity.id
-          verified_repository_ids[identity.full_name.downcase] = identity.id
+          identities[normalized_name] = identity
+          identities[identity.full_name.downcase] = identity
+        end
+
+        repositories = repositories.group_by do |full_name|
+          normalized_name = full_name.downcase
+          existing = existing_by_name[normalized_name]
+          identity = identities[normalized_name]
+          repository_id = identity&.id || existing&.repository_id
+
+          if repository_id.present?
+            [ :id, repository_id.to_s ]
+          else
+            canonical_name = identity&.full_name || existing&.repository_full_name || full_name
+            [ :name, canonical_name.downcase ]
+          end
+        end.values.map do |aliases|
+          identity = aliases.filter_map { |full_name| identities[full_name.downcase] }.first
+          existing = aliases.filter_map { |full_name| existing_by_name[full_name.downcase] }.first
+          identity&.full_name || existing&.repository_full_name || aliases.first
+        end
+
+        # Reject deterministic canonical-name collisions before any hook is
+        # touched. A NULL or different-id row is not the verified repository
+        # and must never replace its old-name exact-id anchor.
+        repositories.each do |full_name|
+          identity = identities[full_name.downcase]
+          next unless identity
+
+          canonical = @origin.github_repository_links
+            .where("LOWER(repository_full_name) = ?", identity.full_name.downcase)
+            .first
+          next unless canonical
+          next if canonical.repository_id.to_s == identity.id.to_s
+
+          render json: { error: I18n.t("collavre_github.setup.save_error") },
+                 status: :unprocessable_entity
+          return
+        end
+
+        # A legacy NULL-id row may point at a repository name GitHub has since
+        # reassigned. Enabling import would read that unrelated repository and
+        # archive the creative's existing sync tree before identity is proven.
+        if markdown_sync.is_a?(ActionController::Parameters) || markdown_sync.is_a?(Hash)
+          unsafe_legacy_enable = repositories.any? do |full_name|
+            link = existing_by_name[full_name.downcase]
+            next false unless link && link.repository_id.blank?
+            next false unless markdown_sync.key?(full_name)
+
+            ActiveModel::Type::Boolean.new.cast(markdown_sync[full_name])
+          end
+          if unsafe_legacy_enable
+            render json: { error: I18n.t("collavre_github.setup.save_error") },
+                   status: :unprocessable_entity
+            return
+          end
+        end
+
+        # Provision each verified repository in its own transaction. If a
+        # later repository fails, earlier successful GitHub mutations retain
+        # their matching local link/secret instead of being rolled back into a
+        # ghost-hook state.
+        repositories.each do |full_name|
+          identity = identities[full_name.downcase]
+          next unless identity
+
+          repository_failed = false
+          sync_job_link_id = nil
+          CollavreGithub::RepositoryLink.transaction(requires_new: true) do
+            anchor = linked_repository_links(account)
+              .where(repository_id: identity.id)
+              .order(:id)
+              .first
+            link = if anchor
+              synchronized = CollavreGithub::RepositoryIdentitySynchronizer.call(
+                anchor: anchor,
+                repository_id: identity.id,
+                full_name: identity.full_name,
+                trusted_secret: anchor.webhook_secret
+              )
+              synchronized.find do |candidate|
+                candidate.creative_id == @origin.id &&
+                  candidate.repository_id.to_s == identity.id.to_s
+              end
+            else
+              @origin.github_repository_links
+                .where("LOWER(repository_full_name) = ?", identity.full_name.downcase)
+                .where(repository_id: identity.id)
+                .first
+            end
+
+            unless link
+              link = @origin.github_repository_links.create!(
+                github_account: account,
+                repository_full_name: identity.full_name,
+                repository_id: identity.id
+              )
+            end
+            link.update!(github_account: account) if link.github_account_id != account.id
+
+            if markdown_sync.is_a?(ActionController::Parameters) || markdown_sync.is_a?(Hash)
+              if markdown_sync.key?(identity.full_name)
+                enabled = ActiveModel::Type::Boolean.new.cast(markdown_sync[identity.full_name])
+                was_enabled = link.markdown_sync_enabled?
+                link.update!(markdown_sync_enabled: enabled)
+                sync_job_link_id = link.id if enabled && !was_enabled
+              end
+            end
+
+            results = CollavreGithub::WebhookProvisioner.ensure_for_links(
+              account: account,
+              links: [ link ],
+              webhook_url: github_webhook_url,
+              force_hook_refresh: true
+            )
+            if results.any? { |_candidate, status| status == :failed }
+              repository_failed = true
+              raise ActiveRecord::Rollback
+            end
+          end
+
+          if repository_failed
+            render json: { error: I18n.t("collavre_github.setup.save_error") },
+                   status: :unprocessable_entity
+            return
+          end
+
+          if sync_job_link_id
+            CollavreGithub::InitialMarkdownSyncJob.perform_later(sync_job_link_id)
+          end
         end
 
         links = nil
+        sync_job_link_ids = []
         CollavreGithub::RepositoryLink.transaction do
           selected_names = repositories.map(&:downcase)
           current_links = linked_repository_links(account)
@@ -90,57 +218,25 @@ module CollavreGithub
               .delete_all
           end
 
-          repositories.each do |full_name|
-            next if existing_by_name.key?(full_name.downcase)
-
-            identity = identities.fetch(full_name.downcase)
-            @origin.github_repository_links.create!(
-              github_account: account,
-              repository_full_name: identity.full_name,
-              repository_id: identity.id
-            )
-          end
-
           links = linked_repository_links(account).to_a
-        end
 
-        # Handle markdown sync toggle BEFORE webhook provisioning
-        # so events_for() sees the updated markdown_sync_enabled state
-        markdown_sync = integration_attributes[:markdown_sync]
-        if markdown_sync.is_a?(ActionController::Parameters) || markdown_sync.is_a?(Hash)
-          links.each do |link|
-            repo = link.repository_full_name
-            next unless markdown_sync.key?(repo)
+          # Enqueue the initial import only after selection and every hook
+          # provision have succeeded.
+          if markdown_sync.is_a?(ActionController::Parameters) || markdown_sync.is_a?(Hash)
+            links.each do |link|
+              repo = link.repository_full_name
+              next unless markdown_sync.key?(repo)
 
-            enabled = ActiveModel::Type::Boolean.new.cast(markdown_sync[repo])
-            was_enabled = link.markdown_sync_enabled?
-            link.update!(markdown_sync_enabled: enabled)
+              enabled = ActiveModel::Type::Boolean.new.cast(markdown_sync[repo])
+              was_enabled = link.markdown_sync_enabled?
+              link.update!(markdown_sync_enabled: enabled)
 
-            if enabled && !was_enabled
-              CollavreGithub::InitialMarkdownSyncJob.perform_later(link.id)
+              sync_job_link_ids << link.id if enabled && !was_enabled
             end
           end
         end
 
-        # Provision only identities positively verified before the transaction.
-        # Existing name-only links may predate stable repository identities,
-        # while an ID-backed link can still carry a stale name after a missed
-        # rename. Neither may mutate whatever repository owns that name now.
-        # Legacy links are upgraded only by WebhookReprovisioner after their
-        # recorded hook id proves the live identity.
-        provisionable_links = links.select do |link|
-          verified_id = verified_repository_ids[link.repository_full_name.downcase]
-          verified_id.present? &&
-            link.repository_id.present? &&
-            verified_id.to_s == link.repository_id.to_s
-        end
-        if provisionable_links.present?
-          CollavreGithub::WebhookProvisioner.ensure_for_links(
-            account: account,
-            links: provisionable_links,
-            webhook_url: github_webhook_url
-          )
-        end
+        sync_job_link_ids.each { |link_id| CollavreGithub::InitialMarkdownSyncJob.perform_later(link_id) }
 
         render json: {
           success: true,

--- a/engines/collavre_github/app/controllers/collavre_github/creatives/integrations_controller.rb
+++ b/engines/collavre_github/app/controllers/collavre_github/creatives/integrations_controller.rb
@@ -127,10 +127,11 @@ module CollavreGithub
           identity = identities[full_name.downcase]
           next unless identity
 
-          canonical_conflict = @origin.github_repository_links
-            .where("LOWER(repository_full_name) = ?", identity.full_name.downcase)
-            .where("repository_id IS NULL OR repository_id != ?", identity.id)
-            .exists?
+          canonical_conflict = CollavreGithub::RepositoryLink.identity_conflict_in_link_scope(
+            creative: @origin,
+            full_name: identity.full_name,
+            repository_id: identity.id
+          )
           next unless canonical_conflict
 
           render json: { error: I18n.t("collavre_github.setup.save_error") },
@@ -171,75 +172,79 @@ module CollavreGithub
           repository_failed = false
           sync_job_link_id = nil
           CollavreGithub::RepositoryProvisioningLock.with_lock(identity.id) do
-            CollavreGithub::RepositoryLink.transaction(requires_new: true) do
-              live_identity = client.repository_identity(full_name)
-              unless live_identity&.id.to_s == identity.id.to_s &&
-                  live_identity&.full_name.present?
-                repository_failed = true
-                raise ActiveRecord::Rollback
-              end
-
-              canonical_conflict = @origin.github_repository_links
-                .where("LOWER(repository_full_name) = ?", live_identity.full_name.downcase)
-                .where("repository_id IS NULL OR repository_id != ?", live_identity.id)
-                .exists?
-              if canonical_conflict
-                repository_failed = true
-                raise ActiveRecord::Rollback
-              end
-
-              anchor = linked_repository_links(account)
-                .where(repository_id: live_identity.id)
-                .order(:id)
-                .first
-              link = if anchor
-                synchronized = CollavreGithub::RepositoryIdentitySynchronizer.call(
-                  anchor: anchor,
-                  repository_id: live_identity.id,
-                  full_name: live_identity.full_name,
-                  trusted_secret: anchor.webhook_secret
-                )
-                synchronized.find do |candidate|
-                  candidate.creative_id == @origin.id &&
-                    candidate.repository_id.to_s == live_identity.id.to_s
+            CollavreGithub::RepositoryProvisioningLock.with_repository_name_lock(identity.full_name) do
+              CollavreGithub::RepositoryLink.transaction(requires_new: true) do
+                live_identity = client.repository_identity(full_name)
+                unless live_identity&.id.to_s == identity.id.to_s &&
+                    live_identity&.full_name.present? &&
+                    live_identity.full_name.to_s.casecmp?(identity.full_name.to_s)
+                  repository_failed = true
+                  raise ActiveRecord::Rollback
                 end
-              else
-                @origin.github_repository_links
-                  .where("LOWER(repository_full_name) = ?", live_identity.full_name.downcase)
-                  .where(repository_id: live_identity.id)
-                  .first
-              end
 
-              unless link
-                link = @origin.github_repository_links.create!(
-                  github_account: account,
-                  repository_full_name: live_identity.full_name,
+                canonical_conflict = CollavreGithub::RepositoryLink.identity_conflict_in_link_scope(
+                  creative: @origin,
+                  full_name: live_identity.full_name,
                   repository_id: live_identity.id
                 )
-              end
-              link.update!(github_account: account) if link.github_account_id != account.id
+                if canonical_conflict
+                  repository_failed = true
+                  raise ActiveRecord::Rollback
+                end
 
-              if toggle_present
-                enabled = toggle_enabled
-                was_enabled = link.markdown_sync_enabled?
-                link.update!(markdown_sync_enabled: enabled)
-                sync_job_link_id = link.id if enabled && !was_enabled
-              end
+                anchor = linked_repository_links(account)
+                  .where(repository_id: live_identity.id)
+                  .order(:id)
+                  .first
+                link = if anchor
+                  synchronized = CollavreGithub::RepositoryIdentitySynchronizer.call(
+                    anchor: anchor,
+                    repository_id: live_identity.id,
+                    full_name: live_identity.full_name,
+                    trusted_secret: anchor.webhook_secret
+                  )
+                  synchronized.find do |candidate|
+                    candidate.creative_id == @origin.id &&
+                      candidate.repository_id.to_s == live_identity.id.to_s
+                  end
+                else
+                  @origin.github_repository_links
+                    .where("LOWER(repository_full_name) = ?", live_identity.full_name.downcase)
+                    .where(repository_id: live_identity.id)
+                    .first
+                end
 
-              results = CollavreGithub::WebhookProvisioner.ensure_for_links(
-                account: account,
-                links: [ link ],
-                webhook_url: github_webhook_url,
-                force_hook_refresh: true
-              )
-              if results.any? { |_candidate, status| status == :failed }
-                repository_failed = true
-                raise ActiveRecord::Rollback
-              end
+                unless link
+                  link = @origin.github_repository_links.create!(
+                    github_account: account,
+                    repository_full_name: live_identity.full_name,
+                    repository_id: live_identity.id
+                  )
+                end
+                link.update!(github_account: account) if link.github_account_id != account.id
 
-              live_repository_names[identity.id.to_s] = live_identity.full_name
-              if toggle_present
-                markdown_sync_by_repository[live_identity.full_name.downcase] = toggle_enabled
+                if toggle_present
+                  enabled = toggle_enabled
+                  was_enabled = link.markdown_sync_enabled?
+                  link.update!(markdown_sync_enabled: enabled)
+                  sync_job_link_id = link.id if enabled && !was_enabled
+                end
+
+                results = CollavreGithub::WebhookProvisioner.ensure_for_links(
+                  account: account,
+                  links: [ link ],
+                  webhook_url: github_webhook_url,
+                  force_hook_refresh: true
+                )
+                if results.any? { |_candidate, status| status == :failed }
+                  repository_failed = true
+                  raise ActiveRecord::Rollback
+                end
+
+                live_repository_names[identity.id.to_s] = live_identity.full_name
+                if toggle_present
+                  markdown_sync_by_repository[live_identity.full_name.downcase] = toggle_enabled
+                end
               end
             end
           end

--- a/engines/collavre_github/app/controllers/collavre_github/creatives/integrations_controller.rb
+++ b/engines/collavre_github/app/controllers/collavre_github/creatives/integrations_controller.rb
@@ -46,18 +46,56 @@ module CollavreGithub
 
         integration_attributes = integration_params
         repositories = Array(integration_attributes[:repositories]).map(&:to_s).uniq
+        existing_by_name = linked_repository_links(account)
+          .index_by { |link| link.repository_full_name.downcase }
+        client = CollavreGithub::Client.new(account)
+        identities = {}
+        verified_repository_ids = {}
+        repositories.each do |full_name|
+          normalized_name = full_name.downcase
+          existing = existing_by_name[normalized_name]
+          next if existing && existing.repository_id.blank?
+
+          identity = client.repository_identity(full_name)
+          unless identity&.id.present? && identity&.full_name.present?
+            render json: { error: I18n.t("collavre_github.setup.save_error") },
+                   status: :unprocessable_entity
+            return
+          end
+
+          if existing && existing.repository_id.to_s != identity.id.to_s
+            Rails.logger.warn(
+              "[CollavreGithub] skipping webhook provisioning for stale link #{existing.id}: " \
+              "#{full_name} resolves to repository #{identity.id}, not #{existing.repository_id}"
+            )
+            next
+          end
+
+          identities[normalized_name] = identity unless existing
+          verified_repository_ids[normalized_name] = identity.id
+          verified_repository_ids[identity.full_name.downcase] = identity.id
+        end
 
         links = nil
-
         CollavreGithub::RepositoryLink.transaction do
-          linked_repository_links(account)
-            .where.not(repository_full_name: repositories)
-            .delete_all
+          selected_names = repositories.map(&:downcase)
+          current_links = linked_repository_links(account)
+          if selected_names.empty?
+            current_links.delete_all
+          else
+            current_links
+              .where.not("LOWER(repository_full_name) IN (?)", selected_names)
+              .delete_all
+          end
 
           repositories.each do |full_name|
-            @origin.github_repository_links.find_or_create_by!(
+            next if existing_by_name.key?(full_name.downcase)
+
+            identity = identities.fetch(full_name.downcase)
+            @origin.github_repository_links.create!(
               github_account: account,
-              repository_full_name: full_name
+              repository_full_name: identity.full_name,
+              repository_id: identity.id
             )
           end
 
@@ -82,11 +120,25 @@ module CollavreGithub
           end
         end
 
-        CollavreGithub::WebhookProvisioner.ensure_for_links(
-          account: account,
-          links: links,
-          webhook_url: github_webhook_url
-        ) if links.present?
+        # Provision only identities positively verified before the transaction.
+        # Existing name-only links may predate stable repository identities,
+        # while an ID-backed link can still carry a stale name after a missed
+        # rename. Neither may mutate whatever repository owns that name now.
+        # Legacy links are upgraded only by WebhookReprovisioner after their
+        # recorded hook id proves the live identity.
+        provisionable_links = links.select do |link|
+          verified_id = verified_repository_ids[link.repository_full_name.downcase]
+          verified_id.present? &&
+            link.repository_id.present? &&
+            verified_id.to_s == link.repository_id.to_s
+        end
+        if provisionable_links.present?
+          CollavreGithub::WebhookProvisioner.ensure_for_links(
+            account: account,
+            links: provisionable_links,
+            webhook_url: github_webhook_url
+          )
+        end
 
         render json: {
           success: true,
@@ -102,6 +154,13 @@ module CollavreGithub
         }
       rescue ActiveRecord::RecordInvalid => e
         render json: { error: e.message }, status: :unprocessable_entity
+      rescue Octokit::Error, Faraday::Error => e
+        Rails.logger.warn(
+          "[CollavreGithub] repository identity lookup failed while saving integration: " \
+          "#{e.class}: #{e.message}"
+        )
+        render json: { error: I18n.t("collavre_github.setup.save_error") },
+               status: :unprocessable_entity
       end
 
       def resync

--- a/engines/collavre_github/app/controllers/collavre_github/creatives/integrations_controller.rb
+++ b/engines/collavre_github/app/controllers/collavre_github/creatives/integrations_controller.rb
@@ -141,56 +141,58 @@ module CollavreGithub
 
           repository_failed = false
           sync_job_link_id = nil
-          CollavreGithub::RepositoryLink.transaction(requires_new: true) do
-            anchor = linked_repository_links(account)
-              .where(repository_id: identity.id)
-              .order(:id)
-              .first
-            link = if anchor
-              synchronized = CollavreGithub::RepositoryIdentitySynchronizer.call(
-                anchor: anchor,
-                repository_id: identity.id,
-                full_name: identity.full_name,
-                trusted_secret: anchor.webhook_secret
-              )
-              synchronized.find do |candidate|
-                candidate.creative_id == @origin.id &&
-                  candidate.repository_id.to_s == identity.id.to_s
-              end
-            else
-              @origin.github_repository_links
-                .where("LOWER(repository_full_name) = ?", identity.full_name.downcase)
+          CollavreGithub::RepositoryProvisioningLock.with_lock(identity.id) do
+            CollavreGithub::RepositoryLink.transaction(requires_new: true) do
+              anchor = linked_repository_links(account)
                 .where(repository_id: identity.id)
+                .order(:id)
                 .first
-            end
-
-            unless link
-              link = @origin.github_repository_links.create!(
-                github_account: account,
-                repository_full_name: identity.full_name,
-                repository_id: identity.id
-              )
-            end
-            link.update!(github_account: account) if link.github_account_id != account.id
-
-            if markdown_sync.is_a?(ActionController::Parameters) || markdown_sync.is_a?(Hash)
-              if markdown_sync.key?(identity.full_name)
-                enabled = ActiveModel::Type::Boolean.new.cast(markdown_sync[identity.full_name])
-                was_enabled = link.markdown_sync_enabled?
-                link.update!(markdown_sync_enabled: enabled)
-                sync_job_link_id = link.id if enabled && !was_enabled
+              link = if anchor
+                synchronized = CollavreGithub::RepositoryIdentitySynchronizer.call(
+                  anchor: anchor,
+                  repository_id: identity.id,
+                  full_name: identity.full_name,
+                  trusted_secret: anchor.webhook_secret
+                )
+                synchronized.find do |candidate|
+                  candidate.creative_id == @origin.id &&
+                    candidate.repository_id.to_s == identity.id.to_s
+                end
+              else
+                @origin.github_repository_links
+                  .where("LOWER(repository_full_name) = ?", identity.full_name.downcase)
+                  .where(repository_id: identity.id)
+                  .first
               end
-            end
 
-            results = CollavreGithub::WebhookProvisioner.ensure_for_links(
-              account: account,
-              links: [ link ],
-              webhook_url: github_webhook_url,
-              force_hook_refresh: true
-            )
-            if results.any? { |_candidate, status| status == :failed }
-              repository_failed = true
-              raise ActiveRecord::Rollback
+              unless link
+                link = @origin.github_repository_links.create!(
+                  github_account: account,
+                  repository_full_name: identity.full_name,
+                  repository_id: identity.id
+                )
+              end
+              link.update!(github_account: account) if link.github_account_id != account.id
+
+              if markdown_sync.is_a?(ActionController::Parameters) || markdown_sync.is_a?(Hash)
+                if markdown_sync.key?(identity.full_name)
+                  enabled = ActiveModel::Type::Boolean.new.cast(markdown_sync[identity.full_name])
+                  was_enabled = link.markdown_sync_enabled?
+                  link.update!(markdown_sync_enabled: enabled)
+                  sync_job_link_id = link.id if enabled && !was_enabled
+                end
+              end
+
+              results = CollavreGithub::WebhookProvisioner.ensure_for_links(
+                account: account,
+                links: [ link ],
+                webhook_url: github_webhook_url,
+                force_hook_refresh: true
+              )
+              if results.any? { |_candidate, status| status == :failed }
+                repository_failed = true
+                raise ActiveRecord::Rollback
+              end
             end
           end
 

--- a/engines/collavre_github/app/controllers/collavre_github/creatives/integrations_controller.rb
+++ b/engines/collavre_github/app/controllers/collavre_github/creatives/integrations_controller.rb
@@ -304,7 +304,7 @@ module CollavreGithub
 
         scope = linked_repository_links(account)
 
-        removed_repositories = []
+        removed_links = []
 
         if repositories.present?
           links_to_remove = scope.where(repository_full_name: repositories).to_a
@@ -315,7 +315,7 @@ module CollavreGithub
           end
 
           CollavreGithub::RepositoryLink.transaction do
-            removed_repositories = links_to_remove.map(&:repository_full_name)
+            removed_links = links_to_remove
             links_to_remove.each(&:destroy!)
           end
         elsif repository
@@ -326,20 +326,20 @@ module CollavreGithub
           end
 
           CollavreGithub::RepositoryLink.transaction do
-            removed_repositories = [ link.repository_full_name ]
+            removed_links = [ link ]
             link.destroy!
           end
         else
           CollavreGithub::RepositoryLink.transaction do
-            removed_repositories = scope.pluck(:repository_full_name)
-            scope.destroy_all
+            removed_links = scope.to_a
+            removed_links.each(&:destroy!)
           end
         end
 
-        if removed_repositories.present?
-          CollavreGithub::WebhookProvisioner.remove_for_repositories(
+        if removed_links.present?
+          CollavreGithub::WebhookProvisioner.remove_for_links(
             account: account,
-            repositories: removed_repositories,
+            links: removed_links,
             webhook_url: github_webhook_url
           )
         end

--- a/engines/collavre_github/app/controllers/collavre_github/creatives/integrations_controller.rb
+++ b/engines/collavre_github/app/controllers/collavre_github/creatives/integrations_controller.rb
@@ -65,10 +65,12 @@ module CollavreGithub
 
           if existing && existing.repository_id.to_s != identity.id.to_s
             Rails.logger.warn(
-              "[CollavreGithub] skipping webhook provisioning for stale link #{existing.id}: " \
+              "[CollavreGithub] rejecting integration save for stale link #{existing.id}: " \
               "#{full_name} resolves to repository #{identity.id}, not #{existing.repository_id}"
             )
-            next
+            render json: { error: I18n.t("collavre_github.setup.save_error") },
+                   status: :unprocessable_entity
+            return
           end
 
           identities[normalized_name] = identity unless existing

--- a/engines/collavre_github/app/controllers/collavre_github/creatives/integrations_controller.rb
+++ b/engines/collavre_github/app/controllers/collavre_github/creatives/integrations_controller.rb
@@ -127,11 +127,11 @@ module CollavreGithub
           identity = identities[full_name.downcase]
           next unless identity
 
-          canonical = @origin.github_repository_links
+          canonical_conflict = @origin.github_repository_links
             .where("LOWER(repository_full_name) = ?", identity.full_name.downcase)
-            .first
-          next unless canonical
-          next if canonical.repository_id.to_s == identity.id.to_s
+            .where("repository_id IS NULL OR repository_id != ?", identity.id)
+            .exists?
+          next unless canonical_conflict
 
           render json: { error: I18n.t("collavre_github.setup.save_error") },
                  status: :unprocessable_entity
@@ -179,11 +179,11 @@ module CollavreGithub
                 raise ActiveRecord::Rollback
               end
 
-              canonical_collision = @origin.github_repository_links
+              canonical_conflict = @origin.github_repository_links
                 .where("LOWER(repository_full_name) = ?", live_identity.full_name.downcase)
-                .first
-              if canonical_collision &&
-                  canonical_collision.repository_id.to_s != live_identity.id.to_s
+                .where("repository_id IS NULL OR repository_id != ?", live_identity.id)
+                .exists?
+              if canonical_conflict
                 repository_failed = true
                 raise ActiveRecord::Rollback
               end

--- a/engines/collavre_github/app/controllers/collavre_github/creatives/integrations_controller.rb
+++ b/engines/collavre_github/app/controllers/collavre_github/creatives/integrations_controller.rb
@@ -46,6 +46,16 @@ module CollavreGithub
 
         integration_attributes = integration_params
         markdown_sync = integration_attributes[:markdown_sync]
+        markdown_sync_by_name =
+          if markdown_sync.is_a?(ActionController::Parameters) || markdown_sync.is_a?(Hash)
+            markdown_sync.to_h.each_with_object({}) do |(full_name, enabled), toggles|
+              key = full_name.to_s.downcase
+              toggles[key] ||= []
+              toggles[key] << ActiveModel::Type::Boolean.new.cast(enabled)
+            end
+          else
+            {}
+          end
         repositories = Array(integration_attributes[:repositories]).map(&:to_s).uniq
         existing_links = linked_repository_links(account).to_a
         existing_by_name = existing_links.index_by { |link| link.repository_full_name.downcase }
@@ -77,7 +87,8 @@ module CollavreGithub
           identities[identity.full_name.downcase] = identity
         end
 
-        repositories = repositories.group_by do |full_name|
+        markdown_sync_by_repository = {}
+        repository_groups = repositories.group_by do |full_name|
           normalized_name = full_name.downcase
           existing = existing_by_name[normalized_name]
           identity = identities[normalized_name]
@@ -89,10 +100,24 @@ module CollavreGithub
             canonical_name = identity&.full_name || existing&.repository_full_name || full_name
             [ :name, canonical_name.downcase ]
           end
-        end.values.map do |aliases|
+        end
+        repositories = repository_groups.values.map do |aliases|
           identity = aliases.filter_map { |full_name| identities[full_name.downcase] }.first
           existing = aliases.filter_map { |full_name| existing_by_name[full_name.downcase] }.first
-          identity&.full_name || existing&.repository_full_name || aliases.first
+          canonical_name = identity&.full_name || existing&.repository_full_name || aliases.first
+          toggle_keys = (aliases.map(&:downcase) + [ canonical_name.downcase ]).uniq
+          toggle_values = toggle_keys.each_with_object([]) do |key, values|
+            values.concat(markdown_sync_by_name.fetch(key, []))
+          end.uniq
+          if toggle_values.length > 1
+            render json: { error: I18n.t("collavre_github.setup.save_error") },
+                   status: :unprocessable_entity
+            return
+          end
+          if toggle_values.length == 1
+            markdown_sync_by_repository[canonical_name.downcase] = toggle_values.first
+          end
+          canonical_name
         end
 
         # Reject deterministic canonical-name collisions before any hook is
@@ -116,13 +141,13 @@ module CollavreGithub
         # A legacy NULL-id row may point at a repository name GitHub has since
         # reassigned. Enabling import would read that unrelated repository and
         # archive the creative's existing sync tree before identity is proven.
-        if markdown_sync.is_a?(ActionController::Parameters) || markdown_sync.is_a?(Hash)
+        if markdown_sync_by_repository.present?
           unsafe_legacy_enable = repositories.any? do |full_name|
             link = existing_by_name[full_name.downcase]
             next false unless link && link.repository_id.blank?
-            next false unless markdown_sync.key?(full_name)
+            next false unless markdown_sync_by_repository.key?(full_name.downcase)
 
-            ActiveModel::Type::Boolean.new.cast(markdown_sync[full_name])
+            markdown_sync_by_repository[full_name.downcase]
           end
           if unsafe_legacy_enable
             render json: { error: I18n.t("collavre_github.setup.save_error") },
@@ -135,52 +160,70 @@ module CollavreGithub
         # later repository fails, earlier successful GitHub mutations retain
         # their matching local link/secret instead of being rolled back into a
         # ghost-hook state.
+        live_repository_names = {}
         repositories.each do |full_name|
           identity = identities[full_name.downcase]
           next unless identity
 
+          toggle_key = identity.full_name.downcase
+          toggle_present = markdown_sync_by_repository.key?(toggle_key)
+          toggle_enabled = markdown_sync_by_repository[toggle_key]
           repository_failed = false
           sync_job_link_id = nil
           CollavreGithub::RepositoryProvisioningLock.with_lock(identity.id) do
             CollavreGithub::RepositoryLink.transaction(requires_new: true) do
+              live_identity = client.repository_identity(full_name)
+              unless live_identity&.id.to_s == identity.id.to_s &&
+                  live_identity&.full_name.present?
+                repository_failed = true
+                raise ActiveRecord::Rollback
+              end
+
+              canonical_collision = @origin.github_repository_links
+                .where("LOWER(repository_full_name) = ?", live_identity.full_name.downcase)
+                .first
+              if canonical_collision &&
+                  canonical_collision.repository_id.to_s != live_identity.id.to_s
+                repository_failed = true
+                raise ActiveRecord::Rollback
+              end
+
               anchor = linked_repository_links(account)
-                .where(repository_id: identity.id)
+                .where(repository_id: live_identity.id)
                 .order(:id)
                 .first
               link = if anchor
                 synchronized = CollavreGithub::RepositoryIdentitySynchronizer.call(
                   anchor: anchor,
-                  repository_id: identity.id,
-                  full_name: identity.full_name,
+                  repository_id: live_identity.id,
+                  full_name: live_identity.full_name,
                   trusted_secret: anchor.webhook_secret
                 )
                 synchronized.find do |candidate|
                   candidate.creative_id == @origin.id &&
-                    candidate.repository_id.to_s == identity.id.to_s
+                    candidate.repository_id.to_s == live_identity.id.to_s
                 end
               else
                 @origin.github_repository_links
-                  .where("LOWER(repository_full_name) = ?", identity.full_name.downcase)
-                  .where(repository_id: identity.id)
+                  .where("LOWER(repository_full_name) = ?", live_identity.full_name.downcase)
+                  .where(repository_id: live_identity.id)
                   .first
               end
 
               unless link
                 link = @origin.github_repository_links.create!(
                   github_account: account,
-                  repository_full_name: identity.full_name,
-                  repository_id: identity.id
+                  repository_full_name: live_identity.full_name,
+                  repository_id: live_identity.id
                 )
               end
               link.update!(github_account: account) if link.github_account_id != account.id
 
-              if markdown_sync.is_a?(ActionController::Parameters) || markdown_sync.is_a?(Hash)
-                if markdown_sync.key?(identity.full_name)
-                  enabled = ActiveModel::Type::Boolean.new.cast(markdown_sync[identity.full_name])
-                  was_enabled = link.markdown_sync_enabled?
-                  link.update!(markdown_sync_enabled: enabled)
-                  sync_job_link_id = link.id if enabled && !was_enabled
-                end
+              if toggle_present
+                enabled = toggle_enabled
+                was_enabled = link.markdown_sync_enabled?
+                link.update!(markdown_sync_enabled: enabled)
+                sync_job_link_id = link.id if enabled && !was_enabled
               end
 
               results = CollavreGithub::WebhookProvisioner.ensure_for_links(
@@ -192,6 +235,11 @@ module CollavreGithub
               if results.any? { |_candidate, status| status == :failed }
                 repository_failed = true
                 raise ActiveRecord::Rollback
+              end
+
+              live_repository_names[identity.id.to_s] = live_identity.full_name
+              if toggle_present
+                markdown_sync_by_repository[live_identity.full_name.downcase] = toggle_enabled
               end
             end
           end
@@ -205,6 +253,11 @@ module CollavreGithub
           if sync_job_link_id
             CollavreGithub::InitialMarkdownSyncJob.perform_later(sync_job_link_id)
           end
+        end
+
+        repositories.map! do |full_name|
+          identity = identities[full_name.downcase]
+          identity ? live_repository_names.fetch(identity.id.to_s, full_name) : full_name
         end
 
         links = nil
@@ -224,12 +277,12 @@ module CollavreGithub
 
           # Enqueue the initial import only after selection and every hook
           # provision have succeeded.
-          if markdown_sync.is_a?(ActionController::Parameters) || markdown_sync.is_a?(Hash)
+          if markdown_sync_by_repository.present?
             links.each do |link|
               repo = link.repository_full_name
-              next unless markdown_sync.key?(repo)
+              next unless markdown_sync_by_repository.key?(repo.downcase)
 
-              enabled = ActiveModel::Type::Boolean.new.cast(markdown_sync[repo])
+              enabled = markdown_sync_by_repository[repo.downcase]
               was_enabled = link.markdown_sync_enabled?
               link.update!(markdown_sync_enabled: enabled)
 

--- a/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
+++ b/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
@@ -10,7 +10,25 @@ module CollavreGithub
       raw_body = request.raw_post.presence || request.body.read
       payload = parse_payload(raw_body)
       @repository_link = find_repository_link(payload)
-      return head :unauthorized unless valid_signature?(raw_body)
+      unless valid_signature?(raw_body)
+        # A rejected delivery is otherwise visible ONLY as a red row in
+        # GitHub's hook UI. On this side it leaves no trace at all: the
+        # deliveries ledger is written below, after verification. Everyone
+        # watching the topic just sees silence where PR comments should be.
+        #
+        # Announced ONLY when no secret could be resolved — i.e. the delivery
+        # named a repository this app cannot identify. That is the failure that
+        # is worth a human's attention (a rename, or a link that was never
+        # provisioned) and it is the one that stays broken until someone acts.
+        #
+        # A signature MISMATCH is deliberately silent. There the repository was
+        # identified and a secret was found; the request simply did not sign
+        # with it, which is what an attacker probing the endpoint looks like.
+        # Announcing that would hand any unauthenticated caller who can guess a
+        # monitored repository's name a way to post into that topic on demand.
+        announce_webhook_auth_failure(payload) if webhook_secret.blank?
+        return head :unauthorized
+      end
 
       # Idempotency claim. Deliberately AFTER signature verification: the claim
       # writes a row keyed by an attacker-supplied header, so an unauthenticated
@@ -157,6 +175,23 @@ module CollavreGithub
     def process_delivery(event, payload)
       payload = payload.presence || {}
 
+      # Rename first, and terminally: the whole point is to repair the routing
+      # keys before anything downstream reads them. The other `repository`
+      # actions (archived, publicized, transferred, ...) are deliberately
+      # dropped rather than formatted into the creative feed — subscribing to
+      # this event is a routing-maintenance concern, not a feed feature.
+      if event == "repository"
+        handle_repository_renamed(payload) if payload["action"] == "renamed"
+        return
+      end
+
+      # A delivery that verified is proof this payload really describes a
+      # repository we are linked to, so it is the only safe place to learn the
+      # id. Doing it at lookup time instead would let an unauthenticated caller
+      # repoint a link's routing key at a repository they control.
+      backfill_repository_ids(payload)
+      clear_auth_failure_notices(payload)
+
       # Process all links for this repo (same repo can be linked to multiple creatives)
       all_links = all_repository_links_for(payload)
       all_links.each do |link|
@@ -194,7 +229,7 @@ module CollavreGithub
       # below would short-circuit and dispatch_to_channels (.active scope) would
       # skip the dismissed/detached row, leaving the chip hidden and the PR
       # unmonitored for the rest of its reopened life.
-      reactivate_existing_channels_on_reopen(repo, pr_number) if payload["action"] == "reopened"
+      reactivate_existing_channels_on_reopen(repo, pr_number, payload) if payload["action"] == "reopened"
 
       # Body-link path: only used to CREATE a new channel. Existing-channel paths
       # are intentionally handled above (reopened) or as a strict no-op (opened
@@ -211,8 +246,7 @@ module CollavreGithub
       # topic and have subsequent PR comments injected there. Only auto-attach
       # when the topic's creative — or any of its ancestors — is linked to this
       # repo (RepositoryLink applies to the whole subtree).
-      linked_creative_ids = CollavreGithub::RepositoryLink
-        .where("LOWER(repository_full_name) = ?", repo).pluck(:creative_id)
+      linked_creative_ids = links_for(payload).pluck(:creative_id)
       creative = topic.creative
       return unless creative
       candidate_ids = [ creative.id ] + creative.ancestors.pluck(:id)
@@ -239,9 +273,8 @@ module CollavreGithub
     # reopened`, regardless of whether the PR description currently contains a
     # topic link. Mirrors dispatch's scope re-validation so a channel whose
     # creative is no longer linked to this repo is NOT resurrected.
-    def reactivate_existing_channels_on_reopen(repo, pr_number)
-      linked_creative_ids = CollavreGithub::RepositoryLink
-        .where("LOWER(repository_full_name) = ?", repo).pluck(:creative_id)
+    def reactivate_existing_channels_on_reopen(repo, pr_number, payload)
+      linked_creative_ids = links_for(payload).pluck(:creative_id)
       return if linked_creative_ids.empty?
 
       GithubPrChannel.find_each do |channel|
@@ -293,8 +326,7 @@ module CollavreGithub
       # RepositoryLink can be removed or a topic can be moved to a different
       # creative subtree after attachment. Without re-validating here, an
       # orphaned channel would keep receiving cross-tenant PR events.
-      linked_creative_ids = CollavreGithub::RepositoryLink
-        .where("LOWER(repository_full_name) = ?", repo).pluck(:creative_id)
+      linked_creative_ids = links_for(payload).pluck(:creative_id)
 
       # Ruby-level filter for DB portability (SQLite dev/test, Postgres prod).
       # Future optimization: switch to a jsonb-portable query once an established
@@ -544,13 +576,28 @@ module CollavreGithub
       )
     end
 
-    def all_repository_links_for(payload)
-      repo = payload&.dig("repository", "full_name") || payload&.dig(:repository, :full_name)
-      return [ @repository_link ].compact if repo.blank?
+    # [github_repository_id, lowercased_full_name] from a payload that may use
+    # either string or symbol keys depending on how it was parsed.
+    def repository_identity(payload)
+      repo = payload&.dig("repository") || payload&.dig(:repository)
+      return [ nil, nil ] if repo.blank?
 
-      CollavreGithub::RepositoryLink
-        .where("LOWER(repository_full_name) = ?", repo.downcase)
-        .to_a
+      [
+        repo["id"] || repo[:id],
+        (repo["full_name"] || repo[:full_name]).to_s.downcase.presence
+      ]
+    end
+
+    def links_for(payload)
+      id, full_name = repository_identity(payload)
+      CollavreGithub::RepositoryLink.for_repository(id: id, full_name: full_name)
+    end
+
+    def all_repository_links_for(payload)
+      id, full_name = repository_identity(payload)
+      return [ @repository_link ].compact if id.blank? && full_name.blank?
+
+      links_for(payload).to_a
     end
 
     def find_repository_link(payload)
@@ -559,21 +606,158 @@ module CollavreGithub
         return
       end
 
-      repo = payload["repository"] || payload[:repository]
-      if repo.blank?
-        Rails.logger.warn("[GitHub Webhook] Repository missing in payload")
+      id, full_name = repository_identity(payload)
+      if id.blank? && full_name.blank?
+        Rails.logger.warn("[GitHub Webhook] Repository identity missing in payload")
         return
       end
 
-      full_name = repo["full_name"] || repo[:full_name]
-      if full_name.blank?
-        Rails.logger.warn("[GitHub Webhook] Repository full_name missing in payload")
-        return
+      links_for(payload).first
+    end
+
+    # Stamp the stable id onto links that predate id-based routing. Scoped to
+    # links this repository actually resolved to, and only ever fills a NULL —
+    # an existing id is never rewritten, so a payload cannot move a link that
+    # is already anchored to a different repository.
+    def backfill_repository_ids(payload)
+      id, _full_name = repository_identity(payload)
+      return if id.blank?
+
+      links_for(payload).each do |link|
+        next if link.repository_id.present?
+
+        link.update_column(:repository_id, id)
+      end
+    end
+
+    # GitHub sends `repository.renamed` with the NEW `full_name` and only the
+    # short name of the old one, so the previous full name has to be rebuilt
+    # from the owner login. The id is matched too, and matters more: it is what
+    # lets a link that was already backfilled be found even when its stored
+    # name matches nothing in the payload.
+    #
+    # Note the ordering dependency this creates. A link whose `repository_id`
+    # is still NULL when its repository is renamed cannot be repaired by this
+    # handler — the delivery carrying the rename is itself rejected 401,
+    # because the secret is looked up by the same keys. Backfill is what makes
+    # this handler reachable; `announce_webhook_auth_failure` is what covers
+    # the links that never got one.
+    def handle_repository_renamed(payload)
+      repo = payload["repository"] || {}
+      new_full_name = (repo["full_name"] || repo[:full_name]).to_s
+      return if new_full_name.blank?
+
+      repo_id = repo["id"] || repo[:id]
+      owner = repo.dig("owner", "login")
+      from = payload.dig("changes", "repository", "name", "from")
+      old_full_name = ("#{owner}/#{from}" if owner.present? && from.present?)
+
+      links = CollavreGithub::RepositoryLink.for_repository(id: repo_id, full_name: old_full_name)
+      links.each do |link|
+        next if link.repository_full_name == new_full_name
+
+        begin
+          link.update_columns(repository_full_name: new_full_name, repository_id: repo_id)
+        rescue ActiveRecord::RecordNotUnique
+          # The creative is already linked to the repository under its new
+          # name. Nothing to rename into; the surviving row is the correct one.
+          Rails.logger.warn(
+            "[CollavreGithub] rename skipped for link #{link.id}: #{new_full_name} already linked to creative #{link.creative_id}"
+          )
+        end
       end
 
-      CollavreGithub::RepositoryLink
-        .where("LOWER(repository_full_name) = ?", full_name.downcase)
-        .first
+      rename_channels(old_full_name, new_full_name) if old_full_name
+      Rails.logger.info("[CollavreGithub] repository renamed #{old_full_name.inspect} -> #{new_full_name}")
+    end
+
+    # Channels carry their own copy of the repo name (dispatch matches on it),
+    # so renaming the links alone would leave every attached PR chip orphaned.
+    def rename_channels(old_full_name, new_full_name)
+      old = old_full_name.downcase
+      GithubPrChannel.find_each do |channel|
+        next unless channel.repo_full_name.to_s.downcase == old
+
+        begin
+          channel.update!(config: channel.config.merge("repo_full_name" => new_full_name))
+        rescue => e
+          Rails.logger.error(
+            "[CollavreGithub] rename failed for channel #{channel.id}: #{e.class}: #{e.message}"
+          )
+        end
+      end
+    end
+
+    # How long a channel stays quiet after announcing a rejected delivery.
+    # GitHub retries nothing, but a busy repository produces a steady stream of
+    # events and every one of them fails the same way — without this the topic
+    # would fill with identical warnings.
+    AUTH_FAILURE_NOTICE_INTERVAL = 1.hour
+
+    # Repo-level guard on the channel scan below. This path is reachable by
+    # unauthenticated callers, so the scan must not be repeatable at request
+    # rate. Read-then-write rather than `write(unless_exist:)` so the guard
+    # fails OPEN: a cache store that reads back nil (NullStore) costs an extra
+    # scan, it does not suppress the warning this exists to deliver.
+    AUTH_FAILURE_SCAN_INTERVAL = 1.minute
+
+    # Announce a rejected delivery in every topic monitoring the repository.
+    #
+    # The payload is UNVERIFIED here — that is the whole situation — so nothing
+    # from it reaches the message. The repo name rendered is the channel's own
+    # stored value, and a channel is only selected when that value already
+    # equals the payload's. An attacker can therefore cause a canned warning in
+    # topics that are already monitoring the repository they named, at most
+    # once an hour each, and can inject no content of their own.
+    def announce_webhook_auth_failure(payload)
+      _id, repo = repository_identity(payload)
+      return if repo.blank?
+
+      scan_key = "collavre_github:auth_failure_scan:#{repo}"
+      return if Rails.cache.read(scan_key)
+      Rails.cache.write(scan_key, true, expires_in: AUTH_FAILURE_SCAN_INTERVAL)
+
+      GithubPrChannel.active.find_each do |channel|
+        next unless channel.repo_full_name.to_s.downcase == repo
+
+        begin
+          channel.with_lock do
+            last = channel.config["auth_failure_notified_at"]
+            next if last.present? && Time.zone.parse(last) > AUTH_FAILURE_NOTICE_INTERVAL.ago
+
+            # Marked before injecting: a failure while injecting must not leave
+            # the channel free to retry the same warning on the next delivery,
+            # which for a busy repo is seconds away.
+            channel.update!(config: channel.config.merge("auth_failure_notified_at" => Time.current.iso8601))
+            channel.inject_into_topic!(channel.auth_failure_message)
+          end
+        rescue => e
+          Rails.logger.error(
+            "[CollavreGithub] auth failure notice failed for channel #{channel.id}: #{e.class}: #{e.message}"
+          )
+        end
+      end
+    end
+
+    # Clear the marker once deliveries verify again, so a repository that
+    # breaks, is repaired, then breaks again months later warns the second time
+    # too. Left set, the interval above would be the only thing re-arming it.
+    def clear_auth_failure_notices(payload)
+      _id, repo = repository_identity(payload)
+      return if repo.blank?
+
+      GithubPrChannel.find_each do |channel|
+        next unless channel.repo_full_name.to_s.downcase == repo
+        next if channel.config["auth_failure_notified_at"].blank?
+
+        begin
+          channel.update!(config: channel.config.except("auth_failure_notified_at"))
+        rescue => e
+          Rails.logger.error(
+            "[CollavreGithub] clearing auth failure notice failed for channel #{channel.id}: #{e.class}: #{e.message}"
+          )
+        end
+      end
     end
 
     def valid_signature?(raw_body)
@@ -602,8 +786,13 @@ module CollavreGithub
       ActiveSupport::SecurityUtils.secure_compare(expected_signature, signature_header)
     end
 
+    # Memoized: a rejected delivery reads this twice — once to verify, once to
+    # decide whether the rejection is worth announcing — and the fallback path
+    # queries integration settings.
     def webhook_secret
-      @repository_link&.webhook_secret || fallback_webhook_secret
+      return @webhook_secret if defined?(@webhook_secret)
+
+      @webhook_secret = @repository_link&.webhook_secret || fallback_webhook_secret
     end
 
     def fallback_webhook_secret

--- a/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
+++ b/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
@@ -749,6 +749,19 @@ module CollavreGithub
       stored_names_by_creative = Hash.new { |hash, key| hash[key] = [] }
       links.each do |link|
         stored_full_name = link.repository_full_name.to_s
+        collision_resolution = resolve_repository_rename_collision(
+          link: link,
+          new_full_name: new_full_name,
+          repository_id: repository_id
+        )
+        unless collision_resolution.nil?
+          if collision_resolution
+            renamed_creative_ids << link.creative_id
+            stored_names_by_creative[stored_full_name.downcase] << link.creative_id
+          end
+          next
+        end
+
         if link.repository_full_name == new_full_name &&
             link.repository_id.to_s == repository_id.to_s
           renamed_creative_ids << link.creative_id
@@ -762,22 +775,13 @@ module CollavreGithub
           renamed_creative_ids << link.creative_id
           stored_names_by_creative[stored_full_name.downcase] << link.creative_id
         rescue ActiveRecord::RecordNotUnique
-          # The creative is already linked to the repository under its new
-          # name. Only treat that row as the same repository when its stable id
-          # agrees; otherwise leave both it and the creative's channels alone.
-          survivor = CollavreGithub::RepositoryLink
-            .where(creative_id: link.creative_id)
-            .where("LOWER(repository_full_name) = ?", new_full_name.downcase)
-            .first
-          if survivor&.repository_id.to_s == repository_id.to_s
-            merge_repository_links!(obsolete: link, survivor: survivor)
+          if resolve_repository_rename_collision(
+            link: link,
+            new_full_name: new_full_name,
+            repository_id: repository_id
+          )
             renamed_creative_ids << link.creative_id
             stored_names_by_creative[stored_full_name.downcase] << link.creative_id
-          else
-            Rails.logger.warn(
-              "[CollavreGithub] rename collision for link #{link.id}: #{new_full_name} in " \
-              "creative #{link.creative_id} belongs to repository #{survivor&.repository_id.inspect}"
-            )
           end
         end
       end
@@ -788,6 +792,37 @@ module CollavreGithub
       stored_names_by_creative.each do |stored_name, creative_ids|
         rename_channels(stored_name, new_full_name, creative_ids.uniq, repository_id)
       end
+    end
+
+    def resolve_repository_rename_collision(link:, new_full_name:, repository_id:)
+      collisions = CollavreGithub::RepositoryLink
+        .where(creative_id: link.creative_id)
+        .where.not(id: link.id)
+        .where("LOWER(repository_full_name) = ?", new_full_name.downcase)
+        .to_a
+      return if collisions.empty?
+
+      conflict = collisions.find { |candidate| candidate.repository_id.to_s != repository_id.to_s }
+      if conflict
+        Rails.logger.warn(
+          "[CollavreGithub] rename collision for link #{link.id}: #{new_full_name} in " \
+          "creative #{link.creative_id} belongs to repository #{conflict.repository_id.inspect}"
+        )
+        return false
+      end
+
+      survivor = if link.repository_full_name == new_full_name
+        link
+      else
+        collisions.find { |candidate| candidate.repository_full_name == new_full_name } || collisions.first
+      end
+      ([ link ] + collisions).uniq.each do |candidate|
+        next if candidate == survivor
+
+        merge_repository_links!(obsolete: candidate, survivor: survivor)
+      end
+      survivor.update_columns(repository_full_name: new_full_name)
+      true
     end
 
     # A delayed rename can meet a link that was already created under the new

--- a/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
+++ b/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
@@ -185,6 +185,8 @@ module CollavreGithub
         return
       end
 
+      repair_repository_identity_from_verified_hook(payload)
+
       # A delivery that verified is proof this payload really describes a
       # repository we are linked to, so it is the only safe place to learn the
       # id. Doing it at lookup time instead would let an unauthenticated caller
@@ -624,7 +626,56 @@ module CollavreGithub
       # A NULL-id name match is only a legacy candidate. Prefer the stable ID
       # row for signature lookup so a stale same-name row with another secret
       # cannot make a legitimate delivery fail depending on database order.
-      candidates.where(repository_id: id).first || candidates.first
+      authoritative = candidates.where(repository_id: id).first
+      return authoritative if authoritative
+
+      hook_link = repository_link_for_hook_id(id)
+      if hook_link
+        @repository_link_from_hook_id = true
+        return hook_link
+      end
+
+      candidates.first
+    end
+
+    # GitHub includes the stable hook registration id on every delivery. It is
+    # safe to use as a secret-selection fallback because no state changes until
+    # the request passes HMAC verification. This recovers the exact missed-
+    # rename case: both the link and channel still carry the old repository
+    # name, while the payload carries only the new one.
+    def repository_link_for_hook_id(repository_id)
+      raw_hook_id = request.headers["X-GitHub-Hook-ID"].to_s
+      hook_id = Integer(raw_hook_id, 10, exception: false)
+      return unless hook_id&.between?(1, (2**63) - 1)
+
+      candidates = CollavreGithub::RepositoryLink.where(webhook_hook_id: hook_id)
+      if repository_id.present?
+        candidates = candidates.where(repository_id: [ nil, repository_id ])
+        candidates.where(repository_id: repository_id).first || candidates.first
+      else
+        candidates.first
+      end
+    end
+
+    # Once a hook-id fallback has passed HMAC verification, the delivery proves
+    # both the stable repository id and its current canonical name. Repair the
+    # link and its in-scope channels before ordinary fan-out resolves them.
+    def repair_repository_identity_from_verified_hook(payload)
+      return unless @repository_link_from_hook_id
+
+      id, full_name = repository_identity(payload)
+      return if id.blank? || full_name.blank?
+
+      synchronized = CollavreGithub::RepositoryIdentitySynchronizer.call(
+        anchor: @repository_link,
+        repository_id: id,
+        full_name: full_name,
+        trusted_hook_id: request.headers["X-GitHub-Hook-ID"],
+        trusted_secret: webhook_secret
+      )
+      @repository_link = synchronized.find do |link|
+        link.creative_id == @repository_link.creative_id
+      end || @repository_link
     end
 
     # Stamp the stable id onto links that predate id-based routing. Scoped to
@@ -779,7 +830,13 @@ module CollavreGithub
     AUTH_FAILURE_SCAN_INTERVAL = 1.minute
     AUTH_FAILURE_SCAN_CACHE_KEY = "collavre_github:auth_failure_scan".freeze
 
-    # Announce a rejected delivery in every topic monitoring the repository.
+    # Announce a rejected delivery in every topic already monitoring the name
+    # carried by the payload. A missed rename with a registered hook does not
+    # enter this path: `repository_link_for_hook_id` selects its secret, HMAC
+    # verification succeeds, and the verified identity synchronizer repairs the
+    # old link/channel names before dispatch. Without either a name match or a
+    # recorded hook id there is no safe mapping from an unverified new name to
+    # an old channel.
     #
     # The payload is UNVERIFIED here — that is the whole situation — so nothing
     # from it reaches the message. The repo name rendered is the channel's own

--- a/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
+++ b/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
@@ -30,6 +30,19 @@ module CollavreGithub
         return head :unauthorized
       end
 
+      # NULL-id rows predate trustworthy repository identity storage. Their
+      # hook registration and secret may both have been copied across every
+      # same-name row by older provisioners, so even a valid HMAC cannot prove
+      # which row the current repository belongs to. Require the explicit
+      # reattachment workflow before processing or mutating such a link.
+      if @repository_link && @repository_link.repository_id.blank?
+        Rails.logger.warn(
+          "[CollavreGithub] rejecting delivery for unverified repository link " \
+          "#{@repository_link.id}; explicit identity verification is required"
+        )
+        return head :unauthorized
+      end
+
       # Idempotency claim. Deliberately AFTER signature verification: the claim
       # writes a row keyed by an attacker-supplied header, so an unauthenticated
       # caller must not be able to pre-claim a GUID and have GitHub's real
@@ -191,11 +204,6 @@ module CollavreGithub
       # feature.
       return if event == "repository"
 
-      # A delivery that verified is proof this payload really describes a
-      # repository we are linked to, so it is the only safe place to learn the
-      # id. Doing it at lookup time instead would let an unauthenticated caller
-      # repoint a link's routing key at a repository they control.
-      backfill_repository_ids(payload)
       clear_auth_failure_notices(payload)
 
       # Process all links for this repo (same repo can be linked to multiple creatives)
@@ -606,12 +614,7 @@ module CollavreGithub
       links = links_for(payload).to_a
       return links if id.blank?
 
-      # ID-backed rows are authoritative. A NULL-id name match is only a
-      # sibling of the authenticated repository when it carries the same HMAC
-      # secret; otherwise the name may be stale and reused by another repo.
-      links.select do |link|
-        link.repository_id.present? || secrets_match?(link.webhook_secret, webhook_secret)
-      end
+      links.select { |link| link.repository_id.to_s == id.to_s }
     end
 
     def find_repository_link(payload)
@@ -633,94 +636,35 @@ module CollavreGithub
       authoritative = candidates.where(repository_id: id).first
       return authoritative if authoritative
 
-      hook_link = repository_link_for_hook_id(id)
-      if hook_link
-        @repository_link_from_hook_id = true
-        return hook_link
-      end
-
       candidates.first
     end
 
-    # GitHub includes the stable hook registration id on every delivery. It is
-    # safe to use as a secret-selection fallback because no state changes until
-    # the request passes HMAC verification. This recovers the exact missed-
-    # rename case: both the link and channel still carry the old repository
-    # name, while the payload carries only the new one.
-    def repository_link_for_hook_id(repository_id)
-      hook_id = github_hook_id
-      return unless hook_id
-
-      candidates = CollavreGithub::RepositoryLink.where(webhook_hook_id: hook_id)
-      if repository_id.present?
-        candidates = candidates.where(repository_id: [ nil, repository_id ])
-        candidates.where(repository_id: repository_id).first || candidates.first
-      else
-        candidates.first
-      end
-    end
-
     # A verified delivery proves the current canonical name whenever its stable
-    # repository id matches the link used for HMAC verification. Hook-id
-    # fallback provides the same proof for legacy links that do not have an id
-    # yet. Repair both paths before ordinary fan-out resolves channel names.
+    # repository id matches the link used for HMAC verification. Repair that
+    # exact ID scope before ordinary fan-out resolves channel names.
     def repair_repository_identity_from_verified_delivery(payload)
       id, full_name = repository_identity(payload)
       return if id.blank? || full_name.blank?
 
       verified_by_id = @repository_link&.repository_id.present? &&
         @repository_link.repository_id.to_s == id.to_s
-      return unless verified_by_id || @repository_link_from_hook_id
+      return unless verified_by_id
 
-      if verified_by_id && !@repository_link_from_hook_id
-        stale_name_exists = CollavreGithub::RepositoryLink
-          .where(repository_id: id)
-          .where("LOWER(repository_full_name) <> ?", full_name)
-          .exists?
-        return unless stale_name_exists
-      end
+      stale_name_exists = CollavreGithub::RepositoryLink
+        .where(repository_id: id)
+        .where("LOWER(repository_full_name) <> ?", full_name)
+        .exists?
+      return unless stale_name_exists
 
-      trusted_hook_id = github_hook_id
-      authoritative_hook = trusted_hook_id.present? &&
-        CollavreGithub::RepositoryLink.exists?(
-          repository_id: id,
-          webhook_hook_id: trusted_hook_id
-        )
       synchronized = CollavreGithub::RepositoryIdentitySynchronizer.call(
         anchor: @repository_link,
         repository_id: id,
         full_name: full_name,
-        trusted_hook_id: trusted_hook_id,
-        trusted_secret: webhook_secret,
-        include_legacy: @repository_link_from_hook_id || authoritative_hook,
-        include_legacy_secret: @repository_link_from_hook_id
+        trusted_secret: webhook_secret
       )
       @repository_link = synchronized.find do |link|
         link.creative_id == @repository_link.creative_id
       end || @repository_link
-    end
-
-    def github_hook_id
-      raw_hook_id = request.headers["X-GitHub-Hook-ID"].to_s
-      hook_id = Integer(raw_hook_id, 10, exception: false)
-      hook_id if hook_id&.between?(1, (2**63) - 1)
-    end
-
-    # Stamp the stable id onto links that predate id-based routing. Scoped to
-    # links this repository actually resolved to, carrying the same secret that
-    # authenticated this delivery, and only ever fills a NULL. Name matching
-    # alone is not proof of identity: a stale NULL-id link may carry a name that
-    # GitHub has since assigned to another repository.
-    def backfill_repository_ids(payload)
-      id, _full_name = repository_identity(payload)
-      return if id.blank?
-
-      links_for(payload).each do |link|
-        next if link.repository_id.present?
-        next unless secrets_match?(link.webhook_secret, webhook_secret)
-
-        link.update_column(:repository_id, id)
-      end
     end
 
     # GitHub sends `repository.renamed` with the NEW `full_name` and only the
@@ -729,12 +673,9 @@ module CollavreGithub
     # lets a link that was already backfilled be found even when its stored
     # name matches nothing in the payload.
     #
-    # Note the ordering dependency this creates. A link whose `repository_id`
-    # is still NULL when its repository is renamed cannot be repaired by this
-    # handler — the delivery carrying the rename is itself rejected 401,
-    # because the secret is looked up by the same keys. Backfill is what makes
-    # this handler reachable; `announce_webhook_auth_failure` is what covers
-    # the links that never got one.
+    # A link whose `repository_id` is still NULL cannot be repaired by this
+    # handler. It is rejected before processing and requires the explicit
+    # identity reattachment workflow.
     def handle_repository_renamed(payload)
       repo = payload["repository"] || {}
       new_full_name = (repo["full_name"] || repo[:full_name]).to_s
@@ -750,19 +691,10 @@ module CollavreGithub
       # the rename, and a delayed/redelivered event would otherwise capture the
       # new repository's links and channels too.
       #
-      # ID-backed rows are authoritative. The legacy fallback is restricted to
-      # unbackfilled rows carrying the SAME secret that authenticated this
-      # delivery; this preserves fan-out for a half-backfilled repository
-      # without trusting the now-reusable name by itself.
+      # ID-backed rows are authoritative. NULL-id rows require explicit
+      # reattachment because older provisioners may have copied both their hook
+      # registration and secret from an unrelated same-name repository.
       links = repo_id.present? ? CollavreGithub::RepositoryLink.where(repository_id: repo_id).to_a : []
-      if old_full_name.present? && webhook_secret.present?
-        legacy = CollavreGithub::RepositoryLink
-          .where(repository_id: nil)
-          .where("LOWER(repository_full_name) = ?", old_full_name.downcase)
-          .select { |link| secrets_match?(link.webhook_secret, webhook_secret) }
-        links.concat(legacy)
-      end
-      links.uniq!(&:id)
 
       renamed_creative_ids = []
       links.each do |link|
@@ -864,12 +796,9 @@ module CollavreGithub
     AUTH_FAILURE_SCAN_CACHE_KEY = "collavre_github:auth_failure_scan".freeze
 
     # Announce a rejected delivery in every topic already monitoring the name
-    # carried by the payload. A missed rename with a registered hook does not
-    # enter this path: `repository_link_for_hook_id` selects its secret, HMAC
-    # verification succeeds, and the verified identity synchronizer repairs the
-    # old link/channel names before dispatch. Without either a name match or a
-    # recorded hook id there is no safe mapping from an unverified new name to
-    # an old channel.
+    # carried by the payload. A stale ID-backed link is repaired after HMAC
+    # verification. A NULL-id link requires explicit reattachment because its
+    # historical hook registration and secret are not row identity.
     #
     # The payload is UNVERIFIED here — that is the whole situation — so nothing
     # from it reaches the message. The repo name rendered is the channel's own

--- a/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
+++ b/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
@@ -652,31 +652,65 @@ module CollavreGithub
       from = payload.dig("changes", "repository", "name", "from")
       old_full_name = ("#{owner}/#{from}" if owner.present? && from.present?)
 
-      links = CollavreGithub::RepositoryLink.for_repository(id: repo_id, full_name: old_full_name)
+      # An authenticated rename must never mutate every row carrying the old
+      # name. GitHub allows that name to be reused by another repository after
+      # the rename, and a delayed/redelivered event would otherwise capture the
+      # new repository's links and channels too.
+      #
+      # ID-backed rows are authoritative. The legacy fallback is restricted to
+      # unbackfilled rows carrying the SAME secret that authenticated this
+      # delivery; this preserves fan-out for a half-backfilled repository
+      # without trusting the now-reusable name by itself.
+      links = repo_id.present? ? CollavreGithub::RepositoryLink.where(repository_id: repo_id).to_a : []
+      if old_full_name.present? && webhook_secret.present?
+        legacy = CollavreGithub::RepositoryLink
+          .where(repository_id: nil)
+          .where("LOWER(repository_full_name) = ?", old_full_name.downcase)
+          .select { |link| secrets_match?(link.webhook_secret, webhook_secret) }
+        links.concat(legacy)
+      end
+      links.uniq!(&:id)
+
+      renamed_creative_ids = []
       links.each do |link|
-        next if link.repository_full_name == new_full_name
+        if link.repository_full_name == new_full_name && link.repository_id.to_s == repo_id.to_s
+          renamed_creative_ids << link.creative_id
+          next
+        end
 
         begin
           link.update_columns(repository_full_name: new_full_name, repository_id: repo_id)
+          renamed_creative_ids << link.creative_id
         rescue ActiveRecord::RecordNotUnique
           # The creative is already linked to the repository under its new
-          # name. Nothing to rename into; the surviving row is the correct one.
-          Rails.logger.warn(
-            "[CollavreGithub] rename skipped for link #{link.id}: #{new_full_name} already linked to creative #{link.creative_id}"
-          )
+          # name. Only treat that row as the same repository when its stable id
+          # agrees; otherwise leave both it and the creative's channels alone.
+          survivor = CollavreGithub::RepositoryLink
+            .where(creative_id: link.creative_id)
+            .where("LOWER(repository_full_name) = ?", new_full_name.downcase)
+            .first
+          if survivor&.repository_id.to_s == repo_id.to_s
+            renamed_creative_ids << link.creative_id
+          else
+            Rails.logger.warn(
+              "[CollavreGithub] rename collision for link #{link.id}: #{new_full_name} in " \
+              "creative #{link.creative_id} belongs to repository #{survivor&.repository_id.inspect}"
+            )
+          end
         end
       end
 
-      rename_channels(old_full_name, new_full_name) if old_full_name
+      rename_channels(old_full_name, new_full_name, renamed_creative_ids) if old_full_name
       Rails.logger.info("[CollavreGithub] repository renamed #{old_full_name.inspect} -> #{new_full_name}")
     end
 
     # Channels carry their own copy of the repo name (dispatch matches on it),
     # so renaming the links alone would leave every attached PR chip orphaned.
-    def rename_channels(old_full_name, new_full_name)
+    def rename_channels(old_full_name, new_full_name, renamed_creative_ids)
       old = old_full_name.downcase
       GithubPrChannel.find_each do |channel|
         next unless channel.repo_full_name.to_s.downcase == old
+        next unless channel_in_repo_scope?(channel, renamed_creative_ids)
 
         begin
           channel.update!(config: channel.config.merge("repo_full_name" => new_full_name))
@@ -686,6 +720,14 @@ module CollavreGithub
           )
         end
       end
+    end
+
+    def secrets_match?(left, right)
+      left = left.to_s
+      right = right.to_s
+      return false if left.bytesize != right.bytesize
+
+      ActiveSupport::SecurityUtils.secure_compare(left, right)
     end
 
     # How long a channel stays quiet after announcing a rejected delivery.

--- a/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
+++ b/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
@@ -614,7 +614,10 @@ module CollavreGithub
       links = links_for(payload).to_a
       return links if id.blank?
 
-      links.select { |link| link.repository_id.to_s == id.to_s }
+      links.select do |link|
+        link.repository_id.to_s == id.to_s &&
+          link.repository_full_name.to_s.downcase == full_name
+      end
     end
 
     def find_repository_link(payload)

--- a/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
+++ b/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
@@ -736,12 +736,15 @@ module CollavreGithub
     # would fill with identical warnings.
     AUTH_FAILURE_NOTICE_INTERVAL = 1.hour
 
-    # Repo-level guard on the channel scan below. This path is reachable by
-    # unauthenticated callers, so the scan must not be repeatable at request
-    # rate. Read-then-write rather than `write(unless_exist:)` so the guard
-    # fails OPEN: a cache store that reads back nil (NullStore) costs an extra
-    # scan, it does not suppress the warning this exists to deliver.
+    # Global guard on the channel query below. This path is reachable by
+    # unauthenticated callers, so the payload's repository name must not be part
+    # of the throttle key: otherwise a caller can cycle arbitrary names to force
+    # one query and one cache entry per request. A short global interval bounds
+    # the work while still letting independently broken repositories announce
+    # promptly. `unless_exist` makes concurrent claims atomic on cache stores
+    # that support it; NullStore fails open and preserves the warning.
     AUTH_FAILURE_SCAN_INTERVAL = 1.minute
+    AUTH_FAILURE_SCAN_CACHE_KEY = "collavre_github:auth_failure_scan".freeze
 
     # Announce a rejected delivery in every topic monitoring the repository.
     #
@@ -755,13 +758,15 @@ module CollavreGithub
       _id, repo = repository_identity(payload)
       return if repo.blank?
 
-      scan_key = "collavre_github:auth_failure_scan:#{repo}"
-      return if Rails.cache.read(scan_key)
-      Rails.cache.write(scan_key, true, expires_in: AUTH_FAILURE_SCAN_INTERVAL)
+      claimed = Rails.cache.write(
+        AUTH_FAILURE_SCAN_CACHE_KEY,
+        true,
+        expires_in: AUTH_FAILURE_SCAN_INTERVAL,
+        unless_exist: true
+      )
+      return unless claimed
 
-      GithubPrChannel.active.find_each do |channel|
-        next unless channel.repo_full_name.to_s.downcase == repo
-
+      GithubPrChannel.active.where("LOWER(repo_full_name) = ?", repo).find_each do |channel|
         begin
           channel.with_lock do
             last = channel.config["auth_failure_notified_at"]
@@ -788,8 +793,7 @@ module CollavreGithub
       _id, repo = repository_identity(payload)
       return if repo.blank?
 
-      GithubPrChannel.find_each do |channel|
-        next unless channel.repo_full_name.to_s.downcase == repo
+      GithubPrChannel.where("LOWER(repo_full_name) = ?", repo).find_each do |channel|
         next if channel.config["auth_failure_notified_at"].blank?
 
         begin

--- a/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
+++ b/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
@@ -780,14 +780,6 @@ module CollavreGithub
       end
     end
 
-    def secrets_match?(left, right)
-      left = left.to_s
-      right = right.to_s
-      return false if left.bytesize != right.bytesize
-
-      ActiveSupport::SecurityUtils.secure_compare(left, right)
-    end
-
     # How long a channel stays quiet after announcing a rejected delivery.
     # GitHub retries nothing, but a busy repository produces a steady stream of
     # events and every one of them fails the same way — without this the topic

--- a/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
+++ b/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
@@ -689,6 +689,17 @@ module CollavreGithub
       from = payload.dig("changes", "repository", "name", "from")
       old_full_name = ("#{owner}/#{from}" if owner.present? && from.present?)
 
+      CollavreGithub::RepositoryLink.transaction do
+        synchronize_repository_rename!(
+          repository_id: repo_id,
+          old_full_name: old_full_name,
+          new_full_name: new_full_name
+        )
+      end
+      Rails.logger.info("[CollavreGithub] repository renamed #{old_full_name.inspect} -> #{new_full_name}")
+    end
+
+    def synchronize_repository_rename!(repository_id:, old_full_name:, new_full_name:)
       # An authenticated rename must never mutate every row carrying the old
       # name. GitHub allows that name to be reused by another repository after
       # the rename, and a delayed/redelivered event would otherwise capture the
@@ -697,19 +708,26 @@ module CollavreGithub
       # ID-backed rows are authoritative. NULL-id rows require explicit
       # reattachment because older provisioners may have copied both their hook
       # registration and secret from an unrelated same-name repository.
-      links = repo_id.present? ? CollavreGithub::RepositoryLink.where(repository_id: repo_id).to_a : []
+      links = if repository_id.present?
+        CollavreGithub::RepositoryLink.where(repository_id: repository_id).to_a
+      else
+        []
+      end
 
       renamed_creative_ids = []
       stored_names_by_creative = Hash.new { |hash, key| hash[key] = [] }
       links.each do |link|
         stored_full_name = link.repository_full_name.to_s
-        if link.repository_full_name == new_full_name && link.repository_id.to_s == repo_id.to_s
+        if link.repository_full_name == new_full_name &&
+            link.repository_id.to_s == repository_id.to_s
           renamed_creative_ids << link.creative_id
           next
         end
 
         begin
-          link.update_columns(repository_full_name: new_full_name, repository_id: repo_id)
+          CollavreGithub::RepositoryLink.transaction(requires_new: true) do
+            link.update_columns(repository_full_name: new_full_name, repository_id: repository_id)
+          end
           renamed_creative_ids << link.creative_id
           stored_names_by_creative[stored_full_name.downcase] << link.creative_id
         rescue ActiveRecord::RecordNotUnique
@@ -720,7 +738,7 @@ module CollavreGithub
             .where(creative_id: link.creative_id)
             .where("LOWER(repository_full_name) = ?", new_full_name.downcase)
             .first
-          if survivor&.repository_id.to_s == repo_id.to_s
+          if survivor&.repository_id.to_s == repository_id.to_s
             merge_repository_links!(obsolete: link, survivor: survivor)
             renamed_creative_ids << link.creative_id
             stored_names_by_creative[stored_full_name.downcase] << link.creative_id
@@ -737,9 +755,8 @@ module CollavreGithub
         stored_names_by_creative[old_full_name.downcase].concat(renamed_creative_ids)
       end
       stored_names_by_creative.each do |stored_name, creative_ids|
-        rename_channels(stored_name, new_full_name, creative_ids.uniq, repo_id)
+        rename_channels(stored_name, new_full_name, creative_ids.uniq, repository_id)
       end
-      Rails.logger.info("[CollavreGithub] repository renamed #{old_full_name.inspect} -> #{new_full_name}")
     end
 
     # A delayed rename can meet a link that was already created under the new
@@ -773,13 +790,7 @@ module CollavreGithub
           repository_id: repository_id
         )
 
-        begin
-          channel.synchronize_repository_name!(new_full_name)
-        rescue => e
-          Rails.logger.error(
-            "[CollavreGithub] rename failed for channel #{channel.id}: #{e.class}: #{e.message}"
-          )
-        end
+        channel.synchronize_repository_name!(new_full_name)
       end
     end
 

--- a/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
+++ b/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
@@ -176,16 +176,20 @@ module CollavreGithub
       payload = payload.presence || {}
 
       # Rename first, and terminally: the whole point is to repair the routing
-      # keys before anything downstream reads them. The other `repository`
-      # actions (archived, publicized, transferred, ...) are deliberately
-      # dropped rather than formatted into the creative feed — subscribing to
-      # this event is a routing-maintenance concern, not a feed feature.
-      if event == "repository"
-        handle_repository_renamed(payload) if payload["action"] == "renamed"
+      # keys before anything downstream reads them.
+      if event == "repository" && payload["action"] == "renamed"
+        handle_repository_renamed(payload)
         return
       end
 
-      repair_repository_identity_from_verified_hook(payload)
+      repair_repository_identity_from_verified_delivery(payload)
+
+      # Other `repository` actions (archived, publicized, transferred, ...) can
+      # still repair a missed rename through the verified stable id, but are
+      # deliberately dropped rather than formatted into the creative feed.
+      # Subscribing to this event is a routing-maintenance concern, not a feed
+      # feature.
+      return if event == "repository"
 
       # A delivery that verified is proof this payload really describes a
       # repository we are linked to, so it is the only safe place to learn the
@@ -644,9 +648,8 @@ module CollavreGithub
     # rename case: both the link and channel still carry the old repository
     # name, while the payload carries only the new one.
     def repository_link_for_hook_id(repository_id)
-      raw_hook_id = request.headers["X-GitHub-Hook-ID"].to_s
-      hook_id = Integer(raw_hook_id, 10, exception: false)
-      return unless hook_id&.between?(1, (2**63) - 1)
+      hook_id = github_hook_id
+      return unless hook_id
 
       candidates = CollavreGithub::RepositoryLink.where(webhook_hook_id: hook_id)
       if repository_id.present?
@@ -657,25 +660,50 @@ module CollavreGithub
       end
     end
 
-    # Once a hook-id fallback has passed HMAC verification, the delivery proves
-    # both the stable repository id and its current canonical name. Repair the
-    # link and its in-scope channels before ordinary fan-out resolves them.
-    def repair_repository_identity_from_verified_hook(payload)
-      return unless @repository_link_from_hook_id
-
+    # A verified delivery proves the current canonical name whenever its stable
+    # repository id matches the link used for HMAC verification. Hook-id
+    # fallback provides the same proof for legacy links that do not have an id
+    # yet. Repair both paths before ordinary fan-out resolves channel names.
+    def repair_repository_identity_from_verified_delivery(payload)
       id, full_name = repository_identity(payload)
       return if id.blank? || full_name.blank?
 
+      verified_by_id = @repository_link&.repository_id.present? &&
+        @repository_link.repository_id.to_s == id.to_s
+      return unless verified_by_id || @repository_link_from_hook_id
+
+      if verified_by_id && !@repository_link_from_hook_id
+        stale_name_exists = CollavreGithub::RepositoryLink
+          .where(repository_id: id)
+          .where("LOWER(repository_full_name) <> ?", full_name)
+          .exists?
+        return unless stale_name_exists
+      end
+
+      trusted_hook_id = github_hook_id
+      authoritative_hook = trusted_hook_id.present? &&
+        CollavreGithub::RepositoryLink.exists?(
+          repository_id: id,
+          webhook_hook_id: trusted_hook_id
+        )
       synchronized = CollavreGithub::RepositoryIdentitySynchronizer.call(
         anchor: @repository_link,
         repository_id: id,
         full_name: full_name,
-        trusted_hook_id: request.headers["X-GitHub-Hook-ID"],
-        trusted_secret: webhook_secret
+        trusted_hook_id: trusted_hook_id,
+        trusted_secret: webhook_secret,
+        include_legacy: @repository_link_from_hook_id || authoritative_hook,
+        include_legacy_secret: @repository_link_from_hook_id
       )
       @repository_link = synchronized.find do |link|
         link.creative_id == @repository_link.creative_id
       end || @repository_link
+    end
+
+    def github_hook_id
+      raw_hook_id = request.headers["X-GitHub-Hook-ID"].to_s
+      hook_id = Integer(raw_hook_id, 10, exception: false)
+      hook_id if hook_id&.between?(1, (2**63) - 1)
     end
 
     # Stamp the stable id onto links that predate id-based routing. Scoped to

--- a/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
+++ b/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
@@ -697,7 +697,9 @@ module CollavreGithub
       links = repo_id.present? ? CollavreGithub::RepositoryLink.where(repository_id: repo_id).to_a : []
 
       renamed_creative_ids = []
+      stored_names_by_creative = Hash.new { |hash, key| hash[key] = [] }
       links.each do |link|
+        stored_full_name = link.repository_full_name.to_s
         if link.repository_full_name == new_full_name && link.repository_id.to_s == repo_id.to_s
           renamed_creative_ids << link.creative_id
           next
@@ -706,6 +708,7 @@ module CollavreGithub
         begin
           link.update_columns(repository_full_name: new_full_name, repository_id: repo_id)
           renamed_creative_ids << link.creative_id
+          stored_names_by_creative[stored_full_name.downcase] << link.creative_id
         rescue ActiveRecord::RecordNotUnique
           # The creative is already linked to the repository under its new
           # name. Only treat that row as the same repository when its stable id
@@ -717,6 +720,7 @@ module CollavreGithub
           if survivor&.repository_id.to_s == repo_id.to_s
             merge_repository_links!(obsolete: link, survivor: survivor)
             renamed_creative_ids << link.creative_id
+            stored_names_by_creative[stored_full_name.downcase] << link.creative_id
           else
             Rails.logger.warn(
               "[CollavreGithub] rename collision for link #{link.id}: #{new_full_name} in " \
@@ -726,7 +730,12 @@ module CollavreGithub
         end
       end
 
-      rename_channels(old_full_name, new_full_name, renamed_creative_ids, repo_id) if old_full_name
+      if old_full_name
+        stored_names_by_creative[old_full_name.downcase].concat(renamed_creative_ids)
+      end
+      stored_names_by_creative.each do |stored_name, creative_ids|
+        rename_channels(stored_name, new_full_name, creative_ids.uniq, repo_id)
+      end
       Rails.logger.info("[CollavreGithub] repository renamed #{old_full_name.inspect} -> #{new_full_name}")
     end
 

--- a/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
+++ b/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
@@ -262,9 +262,13 @@ module CollavreGithub
       # repo (RepositoryLink applies to the whole subtree).
       linked_creative_ids = all_repository_links_for(payload).map(&:creative_id)
       creative = topic.creative
-      return unless creative
-      candidate_ids = [ creative.id ] + creative.ancestors.pluck(:id)
-      return if (linked_creative_ids & candidate_ids).empty?
+      repository_id, = repository_identity(payload)
+      return unless creative_in_repo_scope?(
+        creative,
+        linked_creative_ids,
+        full_name: repo,
+        repository_id: repository_id
+      )
 
       existing = GithubPrChannel.where(topic_id: topic.id).find do |c|
         c.repo_full_name.to_s.downcase == repo && c.pr_number == pr_number
@@ -291,9 +295,10 @@ module CollavreGithub
       linked_creative_ids = all_repository_links_for(payload).map(&:creative_id)
       return if linked_creative_ids.empty?
 
+      repository_id, = repository_identity(payload)
       GithubPrChannel.find_each do |channel|
         next unless channel.repo_full_name.to_s.downcase == repo && channel.pr_number == pr_number
-        next unless channel_in_repo_scope?(channel, linked_creative_ids)
+        next unless channel_in_repo_scope?(channel, linked_creative_ids, repository_id: repository_id)
 
         begin
           # Row-level lock + re-read guards against duplicate reopened announcements
@@ -347,9 +352,10 @@ module CollavreGithub
       # pattern exists in this codebase. Compare repo names case-insensitively
       # so legacy mixed-case rows continue to match the canonical lowercase
       # payload value.
+      repository_id, = repository_identity(payload)
       GithubPrChannel.active.find_each do |channel|
         next unless channel.repo_full_name.to_s.downcase == repo && channel.pr_number == pr_number
-        next unless channel_in_repo_scope?(channel, linked_creative_ids)
+        next unless channel_in_repo_scope?(channel, linked_creative_ids, repository_id: repository_id)
 
         begin
           # Row-level lock + re-check guards against duplicate dispatch when the
@@ -382,13 +388,30 @@ module CollavreGithub
     # still listed in a RepositoryLink for the webhook's repo. Mirrors the
     # auto-attach guard so removing a link severs the dispatch, not just the
     # ability to create new monitors.
-    def channel_in_repo_scope?(channel, linked_creative_ids)
+    def channel_in_repo_scope?(channel, linked_creative_ids, repository_id:)
       return false if linked_creative_ids.empty?
 
       creative = channel.topic&.creative
+      creative_in_repo_scope?(
+        creative,
+        linked_creative_ids,
+        full_name: channel.repo_full_name,
+        repository_id: repository_id
+      )
+    end
+
+    def creative_in_repo_scope?(creative, linked_creative_ids, full_name:, repository_id:)
       return false unless creative
+      return false if CollavreGithub::RepositoryLink.conflicting_repository_in_scope?(
+        creative: creative,
+        full_name: full_name,
+        repository_id: repository_id
+      )
 
       candidate_ids = [ creative.id ] + creative.ancestors.pluck(:id)
+      excluded_ids = @identity_repair_excluded_creative_ids || []
+      return false if (excluded_ids & candidate_ids).any?
+
       (linked_creative_ids & candidate_ids).any?
     end
 
@@ -614,10 +637,10 @@ module CollavreGithub
       links = links_for(payload).to_a
       return links if id.blank?
 
-      links.select do |link|
-        link.repository_id.to_s == id.to_s &&
-          link.repository_full_name.to_s.downcase == full_name
-      end
+      links.select! { |link| link.repository_id.to_s == id.to_s }
+      return links if @identity_repair_link_ids.nil?
+
+      links.select { |link| @identity_repair_link_ids.include?(link.id) }
     end
 
     def find_repository_link(payload)
@@ -653,11 +676,10 @@ module CollavreGithub
         @repository_link.repository_id.to_s == id.to_s
       return unless verified_by_id
 
-      stale_name_exists = CollavreGithub::RepositoryLink
+      repair_scope = CollavreGithub::RepositoryLink
         .where(repository_id: id)
-        .where("LOWER(repository_full_name) <> ?", full_name)
-        .exists?
-      return unless stale_name_exists
+        .pluck(:id, :repository_full_name)
+      return unless repair_scope.any? { |_link_id, name| name.to_s != full_name }
 
       synchronized = CollavreGithub::RepositoryIdentitySynchronizer.call(
         anchor: @repository_link,
@@ -665,6 +687,15 @@ module CollavreGithub
         full_name: full_name,
         trusted_secret: webhook_secret
       )
+      canonical_link_ids = CollavreGithub::RepositoryLink
+        .where(repository_id: id, repository_full_name: full_name)
+        .pluck(:id)
+      @identity_repair_link_ids = synchronized.map(&:id) & canonical_link_ids
+      @identity_repair_excluded_creative_ids = CollavreGithub::RepositoryLink
+        .where(repository_id: id)
+        .where.not(repository_full_name: full_name)
+        .distinct
+        .pluck(:creative_id)
       @repository_link = synchronized.find do |link|
         link.creative_id == @repository_link.creative_id
       end || @repository_link
@@ -783,10 +814,9 @@ module CollavreGithub
       old = old_full_name.downcase
       GithubPrChannel.find_each do |channel|
         next unless channel.repo_full_name.to_s.downcase == old
-        next unless channel_in_repo_scope?(channel, renamed_creative_ids)
-        next if CollavreGithub::RepositoryLink.conflicting_repository_in_scope?(
-          creative: channel.topic&.creative,
-          full_name: old_full_name,
+        next unless channel_in_repo_scope?(
+          channel,
+          renamed_creative_ids,
           repository_id: repository_id
         )
 

--- a/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
+++ b/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
@@ -766,7 +766,7 @@ module CollavreGithub
         end
       end
 
-      rename_channels(old_full_name, new_full_name, renamed_creative_ids) if old_full_name
+      rename_channels(old_full_name, new_full_name, renamed_creative_ids, repo_id) if old_full_name
       Rails.logger.info("[CollavreGithub] repository renamed #{old_full_name.inspect} -> #{new_full_name}")
     end
 
@@ -790,11 +790,16 @@ module CollavreGithub
 
     # Channels carry their own copy of the repo name (dispatch matches on it),
     # so renaming the links alone would leave every attached PR chip orphaned.
-    def rename_channels(old_full_name, new_full_name, renamed_creative_ids)
+    def rename_channels(old_full_name, new_full_name, renamed_creative_ids, repository_id)
       old = old_full_name.downcase
       GithubPrChannel.find_each do |channel|
         next unless channel.repo_full_name.to_s.downcase == old
         next unless channel_in_repo_scope?(channel, renamed_creative_ids)
+        next if CollavreGithub::RepositoryLink.conflicting_repository_in_scope?(
+          creative: channel.topic&.creative,
+          full_name: old_full_name,
+          repository_id: repository_id
+        )
 
         begin
           channel.update!(config: channel.config.merge("repo_full_name" => new_full_name))

--- a/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
+++ b/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
@@ -720,12 +720,14 @@ module CollavreGithub
       from = payload.dig("changes", "repository", "name", "from")
       old_full_name = ("#{owner}/#{from}" if owner.present? && from.present?)
 
-      CollavreGithub::RepositoryLink.transaction do
-        synchronize_repository_rename!(
-          repository_id: repo_id,
-          old_full_name: old_full_name,
-          new_full_name: new_full_name
-        )
+      CollavreGithub::RepositoryProvisioningLock.with_repository_name_lock(new_full_name) do
+        CollavreGithub::RepositoryLink.transaction do
+          synchronize_repository_rename!(
+            repository_id: repo_id,
+            old_full_name: old_full_name,
+            new_full_name: new_full_name
+          )
+        end
       end
       Rails.logger.info("[CollavreGithub] repository renamed #{old_full_name.inspect} -> #{new_full_name}")
     end
@@ -765,6 +767,20 @@ module CollavreGithub
         if link.repository_full_name == new_full_name &&
             link.repository_id.to_s == repository_id.to_s
           renamed_creative_ids << link.creative_id
+          next
+        end
+
+        conflicting_link = CollavreGithub::RepositoryLink.identity_conflict_in_link_scope(
+          creative: link.creative,
+          full_name: new_full_name,
+          repository_id: repository_id,
+          excluding_id: link.id
+        )
+        if conflicting_link
+          Rails.logger.warn(
+            "[CollavreGithub] rename collision for link #{link.id}: #{new_full_name} in " \
+            "creative #{link.creative_id} belongs to repository #{conflicting_link.repository_id.inspect}"
+          )
           next
         end
 

--- a/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
+++ b/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
@@ -802,7 +802,7 @@ module CollavreGithub
         )
 
         begin
-          channel.update!(config: channel.config.merge("repo_full_name" => new_full_name))
+          channel.synchronize_repository_name!(new_full_name)
         rescue => e
           Rails.logger.error(
             "[CollavreGithub] rename failed for channel #{channel.id}: #{e.class}: #{e.message}"

--- a/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
+++ b/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
@@ -620,7 +620,11 @@ module CollavreGithub
         return
       end
 
-      links_for(payload).first
+      candidates = links_for(payload)
+      # A NULL-id name match is only a legacy candidate. Prefer the stable ID
+      # row for signature lookup so a stale same-name row with another secret
+      # cannot make a legitimate delivery fail depending on database order.
+      candidates.where(repository_id: id).first || candidates.first
     end
 
     # Stamp the stable id onto links that predate id-based routing. Scoped to

--- a/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
+++ b/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
@@ -246,7 +246,7 @@ module CollavreGithub
       # topic and have subsequent PR comments injected there. Only auto-attach
       # when the topic's creative — or any of its ancestors — is linked to this
       # repo (RepositoryLink applies to the whole subtree).
-      linked_creative_ids = links_for(payload).pluck(:creative_id)
+      linked_creative_ids = all_repository_links_for(payload).map(&:creative_id)
       creative = topic.creative
       return unless creative
       candidate_ids = [ creative.id ] + creative.ancestors.pluck(:id)
@@ -274,7 +274,7 @@ module CollavreGithub
     # topic link. Mirrors dispatch's scope re-validation so a channel whose
     # creative is no longer linked to this repo is NOT resurrected.
     def reactivate_existing_channels_on_reopen(repo, pr_number, payload)
-      linked_creative_ids = links_for(payload).pluck(:creative_id)
+      linked_creative_ids = all_repository_links_for(payload).map(&:creative_id)
       return if linked_creative_ids.empty?
 
       GithubPrChannel.find_each do |channel|
@@ -326,7 +326,7 @@ module CollavreGithub
       # RepositoryLink can be removed or a topic can be moved to a different
       # creative subtree after attachment. Without re-validating here, an
       # orphaned channel would keep receiving cross-tenant PR events.
-      linked_creative_ids = links_for(payload).pluck(:creative_id)
+      linked_creative_ids = all_repository_links_for(payload).map(&:creative_id)
 
       # Ruby-level filter for DB portability (SQLite dev/test, Postgres prod).
       # Future optimization: switch to a jsonb-portable query once an established
@@ -597,7 +597,15 @@ module CollavreGithub
       id, full_name = repository_identity(payload)
       return [ @repository_link ].compact if id.blank? && full_name.blank?
 
-      links_for(payload).to_a
+      links = links_for(payload).to_a
+      return links if id.blank?
+
+      # ID-backed rows are authoritative. A NULL-id name match is only a
+      # sibling of the authenticated repository when it carries the same HMAC
+      # secret; otherwise the name may be stale and reused by another repo.
+      links.select do |link|
+        link.repository_id.present? || secrets_match?(link.webhook_secret, webhook_secret)
+      end
     end
 
     def find_repository_link(payload)
@@ -616,15 +624,17 @@ module CollavreGithub
     end
 
     # Stamp the stable id onto links that predate id-based routing. Scoped to
-    # links this repository actually resolved to, and only ever fills a NULL —
-    # an existing id is never rewritten, so a payload cannot move a link that
-    # is already anchored to a different repository.
+    # links this repository actually resolved to, carrying the same secret that
+    # authenticated this delivery, and only ever fills a NULL. Name matching
+    # alone is not proof of identity: a stale NULL-id link may carry a name that
+    # GitHub has since assigned to another repository.
     def backfill_repository_ids(payload)
       id, _full_name = repository_identity(payload)
       return if id.blank?
 
       links_for(payload).each do |link|
         next if link.repository_id.present?
+        next unless secrets_match?(link.webhook_secret, webhook_secret)
 
         link.update_column(:repository_id, id)
       end
@@ -690,6 +700,7 @@ module CollavreGithub
             .where("LOWER(repository_full_name) = ?", new_full_name.downcase)
             .first
           if survivor&.repository_id.to_s == repo_id.to_s
+            merge_repository_links!(obsolete: link, survivor: survivor)
             renamed_creative_ids << link.creative_id
           else
             Rails.logger.warn(
@@ -702,6 +713,24 @@ module CollavreGithub
 
       rename_channels(old_full_name, new_full_name, renamed_creative_ids) if old_full_name
       Rails.logger.info("[CollavreGithub] repository renamed #{old_full_name.inspect} -> #{new_full_name}")
+    end
+
+    # A delayed rename can meet a link that was already created under the new
+    # name in the same creative. Leaving both rows behind would make every
+    # subsequent ID lookup process that creative twice. Keep the new-name row,
+    # align it with the secret that authenticated the delivery, preserve the
+    # obsolete row's sync/registration state where the survivor has none, and
+    # remove the duplicate.
+    def merge_repository_links!(obsolete:, survivor:)
+      survivor.update!(
+        webhook_secret: webhook_secret,
+        webhook_hook_id: survivor.webhook_hook_id || obsolete.webhook_hook_id,
+        markdown_sync_enabled: survivor.markdown_sync_enabled? || obsolete.markdown_sync_enabled?,
+        markdown_root_creative_id: survivor.markdown_root_creative_id || obsolete.markdown_root_creative_id,
+        sync_branch: survivor.sync_branch.presence || obsolete.sync_branch,
+        last_synced_at: [ survivor.last_synced_at, obsolete.last_synced_at ].compact.max
+      )
+      obsolete.destroy!
     end
 
     # Channels carry their own copy of the repo name (dispatch matches on it),

--- a/engines/collavre_github/app/models/collavre_github/github_pr_channel.rb
+++ b/engines/collavre_github/app/models/collavre_github/github_pr_channel.rb
@@ -74,6 +74,14 @@ module CollavreGithub
         .first
 
       if survivor
+        if preferred_over?(survivor)
+          self.class.transaction do
+            survivor.destroy!
+            update!(config: config.merge("repo_full_name" => canonical_full_name))
+          end
+          return self
+        end
+
         survivor.update!(
           config: survivor.config.merge("repo_full_name" => canonical_full_name)
         )
@@ -129,6 +137,17 @@ module CollavreGithub
     end
 
     private
+
+    def preferred_over?(other)
+      (lifecycle_priority(self) <=> lifecycle_priority(other)) == 1
+    end
+
+    def lifecycle_priority(channel)
+      [
+        channel.active? ? 1 : 0,
+        channel.dismissed? ? 0 : 1
+      ]
+    end
 
     def handle_pull_request(payload)
       return nil unless payload["action"] == "closed"

--- a/engines/collavre_github/app/models/collavre_github/github_pr_channel.rb
+++ b/engines/collavre_github/app/models/collavre_github/github_pr_channel.rb
@@ -67,6 +67,18 @@ module CollavreGithub
       )
     end
 
+    # Shown when GitHub's delivery could not be authenticated. Renders this
+    # channel's OWN stored repo name, never the rejected payload's — the
+    # payload is unverified by definition at the point this is built.
+    def auth_failure_message
+      Collavre::Channel::InjectedMessage.new(
+        speaker: channel_bot_user,
+        message: t("auth_failure_message", repo: repo_full_name, label: label, url: pr_url),
+        label: label,
+        link: pr_url
+      )
+    end
+
     def reopened_message
       Collavre::Channel::InjectedMessage.new(
         speaker: channel_bot_user,

--- a/engines/collavre_github/app/models/collavre_github/github_pr_channel.rb
+++ b/engines/collavre_github/app/models/collavre_github/github_pr_channel.rb
@@ -2,6 +2,8 @@ module CollavreGithub
   class GithubPrChannel < Collavre::Channel
     self.table_name = "channels"
 
+    after_destroy_commit :broadcast_chips_changed
+
     def repo_full_name
       config["repo_full_name"]
     end
@@ -56,6 +58,31 @@ module CollavreGithub
       value = value.to_s
       raise ArgumentError, "Invalid pr_state: #{value.inspect}" unless PR_STATES.include?(value)
       self.config = config.merge("pr_state" => value)
+    end
+
+    # Keep a single monitor when identity repair meets a channel that a user
+    # already attached under the canonical repository name. The explicit
+    # canonical channel survives; topic comments are not owned by channels, so
+    # removing the obsolete routing row loses no timeline content.
+    def synchronize_repository_name!(canonical_full_name)
+      return self if repo_full_name == canonical_full_name
+
+      survivor = self.class
+        .where(topic_id: topic_id, pr_number: pr_number)
+        .where("LOWER(repo_full_name) = ?", canonical_full_name.to_s.downcase)
+        .where.not(id: id)
+        .first
+
+      if survivor
+        survivor.update!(
+          config: survivor.config.merge("repo_full_name" => canonical_full_name)
+        )
+        destroy!
+        survivor
+      else
+        update!(config: config.merge("repo_full_name" => canonical_full_name))
+        self
+      end
     end
 
     def attached_message

--- a/engines/collavre_github/app/models/collavre_github/repository_link.rb
+++ b/engines/collavre_github/app/models/collavre_github/repository_link.rb
@@ -52,6 +52,21 @@ module CollavreGithub
       name ? where("LOWER(repository_full_name) = ?", name) : none
     end
 
+    # A parent link normally applies to every descendant, but a descendant may
+    # carry its own authoritative link for a different repository that reused
+    # the same name. In that case the descendant's channels belong to the
+    # conflicting repository and must not be renamed through the parent.
+    def self.conflicting_repository_in_scope?(creative:, full_name:, repository_id:)
+      return false if creative.blank? || full_name.blank? || repository_id.blank?
+
+      creative_ids = [ creative.id ] + creative.ancestors.pluck(:id)
+      where(creative_id: creative_ids)
+        .where("LOWER(repository_full_name) = ?", full_name.to_s.downcase)
+        .where.not(repository_id: nil)
+        .where.not(repository_id: repository_id)
+        .exists?
+    end
+
     def markdown_sync_branch
       sync_branch.presence || "main"
     end

--- a/engines/collavre_github/app/models/collavre_github/repository_link.rb
+++ b/engines/collavre_github/app/models/collavre_github/repository_link.rb
@@ -21,7 +21,8 @@ module CollavreGithub
 
     scope :markdown_sync, -> { where(markdown_sync_enabled: true) }
 
-    # Every link for one GitHub repository, matched by BOTH identifiers.
+    # Every link for one GitHub repository, matched by its stable id plus
+    # unbackfilled name-only siblings.
     #
     # `repository_full_name` is the only key webhook routing used to have, and
     # it is not stable: renaming a repository on GitHub changes `full_name` in
@@ -32,18 +33,23 @@ module CollavreGithub
     # signature verification. `repository.id` does survive a rename, which is
     # why it is matched first-class here.
     #
-    # Deliberately a UNION, not id-first-else-name. A repository linked to two
-    # creatives can be half-backfilled (one row stamped, its sibling still
-    # nil); preferring the id match would silently drop the un-stamped sibling
-    # from the fan-out — the exact class of bug this method exists to fix.
+    # When an id is present, name matching is restricted to NULL-id rows. A
+    # repository linked to two creatives can be half-backfilled (one row
+    # stamped, its sibling still nil), so those legacy siblings must remain in
+    # the fan-out. Rows carrying another id are authoritative links to another
+    # repository, even when GitHub has reused their stored name.
     def self.for_repository(id:, full_name:)
       name = full_name.to_s.downcase.presence
-      by_id = id.present? ? where(repository_id: id) : nil
-      by_name = name ? where("LOWER(repository_full_name) = ?", name) : nil
+      if id.present?
+        by_id = where(repository_id: id)
+        return by_id unless name
 
-      return by_id.or(by_name) if by_id && by_name
+        unbackfilled_by_name = where(repository_id: nil)
+          .where("LOWER(repository_full_name) = ?", name)
+        return by_id.or(unbackfilled_by_name)
+      end
 
-      by_id || by_name || none
+      name ? where("LOWER(repository_full_name) = ?", name) : none
     end
 
     def markdown_sync_branch

--- a/engines/collavre_github/app/models/collavre_github/repository_link.rb
+++ b/engines/collavre_github/app/models/collavre_github/repository_link.rb
@@ -21,6 +21,31 @@ module CollavreGithub
 
     scope :markdown_sync, -> { where(markdown_sync_enabled: true) }
 
+    # Every link for one GitHub repository, matched by BOTH identifiers.
+    #
+    # `repository_full_name` is the only key webhook routing used to have, and
+    # it is not stable: renaming a repository on GitHub changes `full_name` in
+    # every subsequent payload with no local event to notice it. The lookup
+    # then found nothing, the controller fell through to a fallback secret that
+    # production does not configure, and every delivery was answered 401 before
+    # dispatch — silently, since the deliveries ledger is only written after
+    # signature verification. `repository.id` does survive a rename, which is
+    # why it is matched first-class here.
+    #
+    # Deliberately a UNION, not id-first-else-name. A repository linked to two
+    # creatives can be half-backfilled (one row stamped, its sibling still
+    # nil); preferring the id match would silently drop the un-stamped sibling
+    # from the fan-out — the exact class of bug this method exists to fix.
+    def self.for_repository(id:, full_name:)
+      name = full_name.to_s.downcase.presence
+      by_id = id.present? ? where(repository_id: id) : nil
+      by_name = name ? where("LOWER(repository_full_name) = ?", name) : nil
+
+      return by_id.or(by_name) if by_id && by_name
+
+      by_id || by_name || none
+    end
+
     def markdown_sync_branch
       sync_branch.presence || "main"
     end

--- a/engines/collavre_github/app/models/collavre_github/repository_link.rb
+++ b/engines/collavre_github/app/models/collavre_github/repository_link.rb
@@ -67,6 +67,21 @@ module CollavreGithub
         .exists?
     end
 
+    # Link mutations affect the link's whole descendant subtree, while an
+    # ancestor link is inherited into the same scope. Before assigning a
+    # canonical name, reject any NULL/different-id row in either direction so
+    # case variants cannot leave both repositories permanently undispatchable.
+    def self.identity_conflict_in_link_scope(creative:, full_name:, repository_id:, excluding_id: nil)
+      return if creative.blank? || full_name.blank? || repository_id.blank?
+
+      creative_ids = creative.subtree_ids + creative.ancestors.pluck(:id)
+      candidates = where(creative_id: creative_ids)
+        .where("LOWER(repository_full_name) = ?", full_name.to_s.downcase)
+        .where("repository_id IS NULL OR repository_id <> ?", repository_id)
+      candidates = candidates.where.not(id: excluding_id) if excluding_id
+      candidates.order(:id).first
+    end
+
     def markdown_sync_branch
       sync_branch.presence || "main"
     end

--- a/engines/collavre_github/app/models/collavre_github/repository_link.rb
+++ b/engines/collavre_github/app/models/collavre_github/repository_link.rb
@@ -53,17 +53,17 @@ module CollavreGithub
     end
 
     # A parent link normally applies to every descendant, but a descendant may
-    # carry its own authoritative link for a different repository that reused
-    # the same name. In that case the descendant's channels belong to the
-    # conflicting repository and must not be renamed through the parent.
+    # carry its own link for another repository that reused the same name. An
+    # explicit different id proves the conflict; a NULL id is unverified and
+    # must fail closed. In either case, the descendant's channels must not be
+    # renamed through the parent.
     def self.conflicting_repository_in_scope?(creative:, full_name:, repository_id:)
       return false if creative.blank? || full_name.blank? || repository_id.blank?
 
       creative_ids = [ creative.id ] + creative.ancestors.pluck(:id)
       where(creative_id: creative_ids)
         .where("LOWER(repository_full_name) = ?", full_name.to_s.downcase)
-        .where.not(repository_id: nil)
-        .where.not(repository_id: repository_id)
+        .where("repository_id IS NULL OR repository_id <> ?", repository_id)
         .exists?
     end
 

--- a/engines/collavre_github/app/services/collavre_github/client.rb
+++ b/engines/collavre_github/app/services/collavre_github/client.rb
@@ -1,6 +1,7 @@
 module CollavreGithub
   class Client
     MOCK_SERVER_DEFAULT = "http://localhost:4567"
+    RepositoryIdentity = Data.define(:id, :full_name)
 
     def initialize(account)
       options = { access_token: account.token }
@@ -79,8 +80,13 @@ module CollavreGithub
       client.hooks(repo_full_name)
     end
 
+    def repository_identity(repo_full_name)
+      repository = client.repository(repo_full_name)
+      RepositoryIdentity.new(id: repository.id, full_name: repository.full_name)
+    end
+
     def repository_id(repo_full_name)
-      client.repository(repo_full_name).id
+      repository_identity(repo_full_name).id
     end
 
     def create_repository_webhook(repo_full_name, url:, secret:, events:, content_type: "json")

--- a/engines/collavre_github/app/services/collavre_github/client.rb
+++ b/engines/collavre_github/app/services/collavre_github/client.rb
@@ -85,10 +85,6 @@ module CollavreGithub
       RepositoryIdentity.new(id: repository.id, full_name: repository.full_name)
     end
 
-    def repository_id(repo_full_name)
-      repository_identity(repo_full_name).id
-    end
-
     def create_repository_webhook(repo_full_name, url:, secret:, events:, content_type: "json")
       client.create_hook(
         repo_full_name,

--- a/engines/collavre_github/app/services/collavre_github/client.rb
+++ b/engines/collavre_github/app/services/collavre_github/client.rb
@@ -79,6 +79,10 @@ module CollavreGithub
       client.hooks(repo_full_name)
     end
 
+    def repository_id(repo_full_name)
+      client.repository(repo_full_name).id
+    end
+
     def create_repository_webhook(repo_full_name, url:, secret:, events:, content_type: "json")
       client.create_hook(
         repo_full_name,

--- a/engines/collavre_github/app/services/collavre_github/client.rb
+++ b/engines/collavre_github/app/services/collavre_github/client.rb
@@ -125,6 +125,18 @@ module CollavreGithub
       nil
     end
 
+    # GitHub's numeric repository id — the one identifier that survives a
+    # rename, which is what webhook routing falls back to when the stored
+    # `repository_full_name` has gone stale. nil on any error: a link with no
+    # id is still usable (it matches by name), so this must never fail a
+    # provisioning run.
+    def repository_id(repo_full_name)
+      client.repository(repo_full_name).id
+    rescue Octokit::Error, Faraday::Error => e
+      Rails.logger.warn("GitHub repository id fetch failed for #{repo_full_name}: #{e.message}")
+      nil
+    end
+
     # Fetch the default branch name for a repository
     def default_branch(repo_full_name)
       repo = client.repository(repo_full_name)

--- a/engines/collavre_github/app/services/collavre_github/client.rb
+++ b/engines/collavre_github/app/services/collavre_github/client.rb
@@ -125,18 +125,6 @@ module CollavreGithub
       nil
     end
 
-    # GitHub's numeric repository id — the one identifier that survives a
-    # rename, which is what webhook routing falls back to when the stored
-    # `repository_full_name` has gone stale. nil on any error: a link with no
-    # id is still usable (it matches by name), so this must never fail a
-    # provisioning run.
-    def repository_id(repo_full_name)
-      client.repository(repo_full_name).id
-    rescue Octokit::Error, Faraday::Error => e
-      Rails.logger.warn("GitHub repository id fetch failed for #{repo_full_name}: #{e.message}")
-      nil
-    end
-
     # Fetch the default branch name for a repository
     def default_branch(repo_full_name)
       repo = client.repository(repo_full_name)

--- a/engines/collavre_github/app/services/collavre_github/repository_identity_synchronizer.rb
+++ b/engines/collavre_github/app/services/collavre_github/repository_identity_synchronizer.rb
@@ -13,13 +13,17 @@ module CollavreGithub
       trusted_secret: nil,
       allow_anchor_backfill: false
     )
-      new(
-        anchor: anchor,
-        repository_id: repository_id,
-        full_name: full_name,
-        trusted_secret: trusted_secret,
-        allow_anchor_backfill: allow_anchor_backfill
-      ).call
+      return [] if anchor.blank? || repository_id.blank? || full_name.blank?
+
+      RepositoryProvisioningLock.with_repository_name_lock(full_name) do
+        new(
+          anchor: anchor,
+          repository_id: repository_id,
+          full_name: full_name,
+          trusted_secret: trusted_secret,
+          allow_anchor_backfill: allow_anchor_backfill
+        ).call
+      end
     end
 
     def initialize(
@@ -83,6 +87,14 @@ module CollavreGithub
           link.repository_id.to_s == repository_id.to_s
         return link
       end
+
+      conflict = RepositoryLink.identity_conflict_in_link_scope(
+        creative: link.creative,
+        full_name: full_name,
+        repository_id: repository_id,
+        excluding_id: link.id
+      )
+      return if conflict
 
       survivor = RepositoryLink
         .where(creative_id: link.creative_id)

--- a/engines/collavre_github/app/services/collavre_github/repository_identity_synchronizer.rb
+++ b/engines/collavre_github/app/services/collavre_github/repository_identity_synchronizer.rb
@@ -1,0 +1,132 @@
+module CollavreGithub
+  # Persists a repository identity established through trusted evidence and
+  # keeps attached channel routing keys in sync with the canonical GitHub name.
+  #
+  # Stable repository ids are authoritative. NULL-id siblings are included
+  # only when they share the verified hook registration or HMAC secret with the
+  # anchor link; a name alone is never enough because GitHub can reuse it.
+  class RepositoryIdentitySynchronizer
+    def self.call(anchor:, repository_id:, full_name:, trusted_hook_id: nil, trusted_secret: nil)
+      new(
+        anchor: anchor,
+        repository_id: repository_id,
+        full_name: full_name,
+        trusted_hook_id: trusted_hook_id,
+        trusted_secret: trusted_secret
+      ).call
+    end
+
+    def initialize(anchor:, repository_id:, full_name:, trusted_hook_id:, trusted_secret:)
+      @anchor = anchor
+      @repository_id = repository_id
+      @full_name = full_name.to_s
+      @trusted_hook_id = trusted_hook_id
+      @trusted_secret = trusted_secret
+    end
+
+    def call
+      return [] if anchor.blank? || repository_id.blank? || full_name.blank?
+
+      synchronized = []
+      old_names_by_creative = Hash.new { |hash, key| hash[key] = [] }
+
+      RepositoryLink.transaction do
+        candidate_links.each do |link|
+          old_name = link.repository_full_name
+          survivor = synchronize_link(link)
+          next unless survivor
+
+          synchronized << survivor
+          if old_name.to_s == full_name
+            next
+          end
+
+          old_names_by_creative[old_name.to_s.downcase] << survivor.creative_id
+        end
+
+        old_names_by_creative.each do |old_name, creative_ids|
+          rename_channels(old_name, creative_ids.uniq)
+        end
+      end
+
+      synchronized.uniq(&:id)
+    end
+
+    private
+
+    attr_reader :anchor, :repository_id, :full_name, :trusted_hook_id, :trusted_secret
+
+    def candidate_links
+      links = RepositoryLink.where(repository_id: repository_id).to_a
+      legacy = RepositoryLink
+        .where(repository_id: nil)
+        .where("LOWER(repository_full_name) = ?", anchor.repository_full_name.to_s.downcase)
+        .select { |link| trusted_legacy_link?(link) }
+
+      (links + legacy + [ anchor ]).uniq(&:id)
+    end
+
+    def trusted_legacy_link?(link)
+      hook_matches = trusted_hook_id.present? &&
+        link.webhook_hook_id.to_s == trusted_hook_id.to_s
+      secret_matches = trusted_secret.present? &&
+        secrets_match?(link.webhook_secret, trusted_secret)
+      hook_matches || secret_matches
+    end
+
+    def synchronize_link(link)
+      if link.repository_full_name.to_s == full_name &&
+          link.repository_id.to_s == repository_id.to_s
+        return link
+      end
+
+      survivor = RepositoryLink
+        .where(creative_id: link.creative_id)
+        .where("LOWER(repository_full_name) = ?", full_name.downcase)
+        .where.not(id: link.id)
+        .first
+
+      if survivor
+        return unless survivor.repository_id.to_s == repository_id.to_s
+
+        merge_links!(obsolete: link, survivor: survivor)
+        return survivor
+      end
+
+      link.update_columns(repository_id: repository_id, repository_full_name: full_name)
+      link
+    end
+
+    def merge_links!(obsolete:, survivor:)
+      survivor.update!(
+        webhook_secret: trusted_secret.presence || survivor.webhook_secret,
+        webhook_hook_id: survivor.webhook_hook_id || obsolete.webhook_hook_id,
+        markdown_sync_enabled: survivor.markdown_sync_enabled? || obsolete.markdown_sync_enabled?,
+        markdown_root_creative_id: survivor.markdown_root_creative_id || obsolete.markdown_root_creative_id,
+        sync_branch: survivor.sync_branch.presence || obsolete.sync_branch,
+        last_synced_at: [ survivor.last_synced_at, obsolete.last_synced_at ].compact.max
+      )
+      obsolete.destroy!
+    end
+
+    def rename_channels(old_name, creative_ids)
+      GithubPrChannel.where("LOWER(repo_full_name) = ?", old_name).find_each do |channel|
+        creative = channel.topic&.creative
+        next unless creative
+
+        candidate_ids = [ creative.id ] + creative.ancestors.pluck(:id)
+        next if (creative_ids & candidate_ids).empty?
+
+        channel.update!(config: channel.config.merge("repo_full_name" => full_name))
+      end
+    end
+
+    def secrets_match?(left, right)
+      left = left.to_s
+      right = right.to_s
+      return false if left.bytesize != right.bytesize
+
+      ActiveSupport::SecurityUtils.secure_compare(left, right)
+    end
+  end
+end

--- a/engines/collavre_github/app/services/collavre_github/repository_identity_synchronizer.rb
+++ b/engines/collavre_github/app/services/collavre_github/repository_identity_synchronizer.rb
@@ -122,7 +122,7 @@ module CollavreGithub
           repository_id: repository_id
         )
 
-        channel.update!(config: channel.config.merge("repo_full_name" => full_name))
+        channel.synchronize_repository_name!(full_name)
       end
     end
 

--- a/engines/collavre_github/app/services/collavre_github/repository_identity_synchronizer.rb
+++ b/engines/collavre_github/app/services/collavre_github/repository_identity_synchronizer.rb
@@ -2,27 +2,23 @@ module CollavreGithub
   # Persists a repository identity established through trusted evidence and
   # keeps attached channel routing keys in sync with the canonical GitHub name.
   #
-  # Stable repository ids are authoritative. NULL-id siblings are included
-  # only when they share the verified hook registration or HMAC secret with the
-  # anchor link; a name alone is never enough because GitHub can reuse it.
+  # Stable repository ids are authoritative. A NULL-id anchor is accepted only
+  # by the explicit operator reattachment workflow; hook registrations and HMAC
+  # secrets are not row identity because older provisioners propagated both.
   class RepositoryIdentitySynchronizer
     def self.call(
       anchor:,
       repository_id:,
       full_name:,
-      trusted_hook_id: nil,
       trusted_secret: nil,
-      include_legacy: true,
-      include_legacy_secret: true
+      allow_anchor_backfill: false
     )
       new(
         anchor: anchor,
         repository_id: repository_id,
         full_name: full_name,
-        trusted_hook_id: trusted_hook_id,
         trusted_secret: trusted_secret,
-        include_legacy: include_legacy,
-        include_legacy_secret: include_legacy_secret
+        allow_anchor_backfill: allow_anchor_backfill
       ).call
     end
 
@@ -30,18 +26,14 @@ module CollavreGithub
       anchor:,
       repository_id:,
       full_name:,
-      trusted_hook_id:,
       trusted_secret:,
-      include_legacy:,
-      include_legacy_secret:
+      allow_anchor_backfill:
     )
       @anchor = anchor
       @repository_id = repository_id
       @full_name = full_name.to_s
-      @trusted_hook_id = trusted_hook_id
       @trusted_secret = trusted_secret
-      @include_legacy = include_legacy
-      @include_legacy_secret = include_legacy_secret
+      @allow_anchor_backfill = allow_anchor_backfill
     end
 
     def call
@@ -77,31 +69,13 @@ module CollavreGithub
     attr_reader :anchor,
       :repository_id,
       :full_name,
-      :trusted_hook_id,
       :trusted_secret,
-      :include_legacy,
-      :include_legacy_secret
+      :allow_anchor_backfill
 
     def candidate_links
       links = RepositoryLink.where(repository_id: repository_id).to_a
-      legacy = if include_legacy
-        RepositoryLink
-          .where(repository_id: nil)
-          .where("LOWER(repository_full_name) = ?", anchor.repository_full_name.to_s.downcase)
-          .select { |link| trusted_legacy_link?(link) }
-      else
-        []
-      end
-
-      (links + legacy + [ anchor ]).uniq(&:id)
-    end
-
-    def trusted_legacy_link?(link)
-      hook_matches = trusted_hook_id.present? &&
-        link.webhook_hook_id.to_s == trusted_hook_id.to_s
-      secret_matches = include_legacy_secret && trusted_secret.present? &&
-        secrets_match?(link.webhook_secret, trusted_secret)
-      hook_matches || secret_matches
+      links << anchor if allow_anchor_backfill || anchor.repository_id.to_s == repository_id.to_s
+      links.uniq(&:id)
     end
 
     def synchronize_link(link)
@@ -154,14 +128,6 @@ module CollavreGithub
 
         channel.synchronize_repository_name!(full_name)
       end
-    end
-
-    def secrets_match?(left, right)
-      left = left.to_s
-      right = right.to_s
-      return false if left.bytesize != right.bytesize
-
-      ActiveSupport::SecurityUtils.secure_compare(left, right)
     end
   end
 end

--- a/engines/collavre_github/app/services/collavre_github/repository_identity_synchronizer.rb
+++ b/engines/collavre_github/app/services/collavre_github/repository_identity_synchronizer.rb
@@ -116,6 +116,11 @@ module CollavreGithub
 
         candidate_ids = [ creative.id ] + creative.ancestors.pluck(:id)
         next if (creative_ids & candidate_ids).empty?
+        next if RepositoryLink.conflicting_repository_in_scope?(
+          creative: creative,
+          full_name: old_name,
+          repository_id: repository_id
+        )
 
         channel.update!(config: channel.config.merge("repo_full_name" => full_name))
       end

--- a/engines/collavre_github/app/services/collavre_github/repository_identity_synchronizer.rb
+++ b/engines/collavre_github/app/services/collavre_github/repository_identity_synchronizer.rb
@@ -6,22 +6,42 @@ module CollavreGithub
   # only when they share the verified hook registration or HMAC secret with the
   # anchor link; a name alone is never enough because GitHub can reuse it.
   class RepositoryIdentitySynchronizer
-    def self.call(anchor:, repository_id:, full_name:, trusted_hook_id: nil, trusted_secret: nil)
+    def self.call(
+      anchor:,
+      repository_id:,
+      full_name:,
+      trusted_hook_id: nil,
+      trusted_secret: nil,
+      include_legacy: true,
+      include_legacy_secret: true
+    )
       new(
         anchor: anchor,
         repository_id: repository_id,
         full_name: full_name,
         trusted_hook_id: trusted_hook_id,
-        trusted_secret: trusted_secret
+        trusted_secret: trusted_secret,
+        include_legacy: include_legacy,
+        include_legacy_secret: include_legacy_secret
       ).call
     end
 
-    def initialize(anchor:, repository_id:, full_name:, trusted_hook_id:, trusted_secret:)
+    def initialize(
+      anchor:,
+      repository_id:,
+      full_name:,
+      trusted_hook_id:,
+      trusted_secret:,
+      include_legacy:,
+      include_legacy_secret:
+    )
       @anchor = anchor
       @repository_id = repository_id
       @full_name = full_name.to_s
       @trusted_hook_id = trusted_hook_id
       @trusted_secret = trusted_secret
+      @include_legacy = include_legacy
+      @include_legacy_secret = include_legacy_secret
     end
 
     def call
@@ -54,14 +74,24 @@ module CollavreGithub
 
     private
 
-    attr_reader :anchor, :repository_id, :full_name, :trusted_hook_id, :trusted_secret
+    attr_reader :anchor,
+      :repository_id,
+      :full_name,
+      :trusted_hook_id,
+      :trusted_secret,
+      :include_legacy,
+      :include_legacy_secret
 
     def candidate_links
       links = RepositoryLink.where(repository_id: repository_id).to_a
-      legacy = RepositoryLink
-        .where(repository_id: nil)
-        .where("LOWER(repository_full_name) = ?", anchor.repository_full_name.to_s.downcase)
-        .select { |link| trusted_legacy_link?(link) }
+      legacy = if include_legacy
+        RepositoryLink
+          .where(repository_id: nil)
+          .where("LOWER(repository_full_name) = ?", anchor.repository_full_name.to_s.downcase)
+          .select { |link| trusted_legacy_link?(link) }
+      else
+        []
+      end
 
       (links + legacy + [ anchor ]).uniq(&:id)
     end
@@ -69,7 +99,7 @@ module CollavreGithub
     def trusted_legacy_link?(link)
       hook_matches = trusted_hook_id.present? &&
         link.webhook_hook_id.to_s == trusted_hook_id.to_s
-      secret_matches = trusted_secret.present? &&
+      secret_matches = include_legacy_secret && trusted_secret.present? &&
         secrets_match?(link.webhook_secret, trusted_secret)
       hook_matches || secret_matches
     end

--- a/engines/collavre_github/app/services/collavre_github/repository_provisioning_lock.rb
+++ b/engines/collavre_github/app/services/collavre_github/repository_provisioning_lock.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "digest"
+
+module CollavreGithub
+  # Serializes link persistence and remote webhook mutation for one stable
+  # GitHub repository identity. Without this boundary, two creatives attaching
+  # a previously unseen repository can each provision from an uncommitted link
+  # and publish different secrets (or create duplicate hooks).
+  class RepositoryProvisioningLock
+    LOCK_PURPOSE = "collavre_github:repository_provisioning".freeze
+
+    @mutex_registry_guard = Mutex.new
+    @mutex_registry = {}
+
+    class << self
+      def with_lock(repository_id, &block)
+        key = repository_id.to_s
+        raise ArgumentError, "repository_id is required" if key.blank?
+
+        if postgres?
+          with_postgres_lock(key, &block)
+        else
+          # SQLite is used by tests and the single-process desktop app. Its
+          # adapter has no advisory-lock primitive, so use the process boundary.
+          with_process_lock(key, &block)
+        end
+      end
+
+      private
+
+      def postgres?
+        CollavreGithub::RepositoryLink.connection.adapter_name.casecmp?("PostgreSQL")
+      end
+
+      def with_postgres_lock(repository_id)
+        CollavreGithub::RepositoryLink.connection_pool.with_connection do |connection|
+          key = advisory_lock_key(repository_id)
+          # Schedule the matching unlock before asking PostgreSQL to acquire.
+          # If an asynchronous exception lands after PostgreSQL grants the lock
+          # but before the adapter returns, the ensure still releases it rather
+          # than returning a locked session to the connection pool.
+          unlock_required = true
+          connection.select_value("SELECT pg_advisory_lock(#{connection.quote(key)})")
+          yield
+        ensure
+          connection.select_value("SELECT pg_advisory_unlock(#{connection.quote(key)})") if unlock_required
+        end
+      end
+
+      def advisory_lock_key(repository_id)
+        Digest::SHA256.digest("#{LOCK_PURPOSE}:#{repository_id}").unpack1("q>")
+      end
+
+      def with_process_lock(repository_id)
+        mutex = register_mutex(repository_id)
+        mutex.synchronize { yield }
+      ensure
+        unregister_mutex(repository_id, mutex) if mutex
+      end
+
+      def register_mutex(repository_id)
+        @mutex_registry_guard.synchronize do
+          entry = (@mutex_registry[repository_id] ||= { mutex: Mutex.new, users: 0 })
+          entry[:users] += 1
+          entry[:mutex]
+        end
+      end
+
+      def unregister_mutex(repository_id, mutex)
+        @mutex_registry_guard.synchronize do
+          entry = @mutex_registry[repository_id]
+          return unless entry && entry[:mutex].equal?(mutex)
+
+          entry[:users] -= 1
+          @mutex_registry.delete(repository_id) if entry[:users].zero?
+        end
+      end
+    end
+  end
+end

--- a/engines/collavre_github/app/services/collavre_github/repository_provisioning_lock.rb
+++ b/engines/collavre_github/app/services/collavre_github/repository_provisioning_lock.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "digest"
+require "monitor"
 
 module CollavreGithub
   # Serializes link persistence and remote webhook mutation for one stable
@@ -18,6 +19,19 @@ module CollavreGithub
         key = repository_id.to_s
         raise ArgumentError, "repository_id is required" if key.blank?
 
+        with_key_lock(key, &block)
+      end
+
+      def with_repository_name_lock(full_name, &block)
+        normalized_name = full_name.to_s.downcase
+        raise ArgumentError, "repository full name is required" if normalized_name.blank?
+
+        with_key_lock("name:#{normalized_name}", &block)
+      end
+
+      private
+
+      def with_key_lock(key, &block)
         if postgres?
           with_postgres_lock(key, &block)
         else
@@ -27,53 +41,53 @@ module CollavreGithub
         end
       end
 
-      private
-
       def postgres?
         CollavreGithub::RepositoryLink.connection.adapter_name.casecmp?("PostgreSQL")
       end
 
-      def with_postgres_lock(repository_id)
+      def with_postgres_lock(key)
         CollavreGithub::RepositoryLink.connection_pool.with_connection do |connection|
-          key = advisory_lock_key(repository_id)
+          advisory_key = advisory_lock_key(key)
           # Schedule the matching unlock before asking PostgreSQL to acquire.
           # If an asynchronous exception lands after PostgreSQL grants the lock
           # but before the adapter returns, the ensure still releases it rather
           # than returning a locked session to the connection pool.
           unlock_required = true
-          connection.select_value("SELECT pg_advisory_lock(#{connection.quote(key)})")
+          connection.select_value("SELECT pg_advisory_lock(#{connection.quote(advisory_key)})")
           yield
         ensure
-          connection.select_value("SELECT pg_advisory_unlock(#{connection.quote(key)})") if unlock_required
+          if unlock_required
+            connection.select_value("SELECT pg_advisory_unlock(#{connection.quote(advisory_key)})")
+          end
         end
       end
 
-      def advisory_lock_key(repository_id)
-        Digest::SHA256.digest("#{LOCK_PURPOSE}:#{repository_id}").unpack1("q>")
+      def advisory_lock_key(key)
+        Digest::SHA256.digest("#{LOCK_PURPOSE}:#{key}").unpack1("q>")
       end
 
-      def with_process_lock(repository_id)
-        mutex = register_mutex(repository_id)
+      def with_process_lock(key)
+        mutex = register_mutex(key)
         mutex.synchronize { yield }
       ensure
-        unregister_mutex(repository_id, mutex) if mutex
+        unregister_mutex(key, mutex) if mutex
       end
 
-      def register_mutex(repository_id)
+      def register_mutex(key)
         @mutex_registry_guard.synchronize do
-          entry = (@mutex_registry[repository_id] ||= { mutex: Mutex.new, users: 0 })
+          entry = (@mutex_registry[key] ||= { mutex: Monitor.new, users: 0 })
           entry[:users] += 1
           entry[:mutex]
         end
       end
 
-      def unregister_mutex(repository_id, mutex)
+      def unregister_mutex(key, mutex)
         @mutex_registry_guard.synchronize do
-          entry = @mutex_registry[repository_id]
+          entry = @mutex_registry[key]
           return unless entry && entry[:mutex].equal?(mutex)
 
           entry[:users] -= 1
-          @mutex_registry.delete(repository_id) if entry[:users].zero?
+          @mutex_registry.delete(key) if entry[:users].zero?
         end
       end
     end

--- a/engines/collavre_github/app/services/collavre_github/tools/pr_monitor_service.rb
+++ b/engines/collavre_github/app/services/collavre_github/tools/pr_monitor_service.rb
@@ -84,25 +84,17 @@ module CollavreGithub
       # Returns a warning string when provisioning cannot run or fails; nil on
       # success so the MCP response stays clean.
       def ensure_webhook_events(topic, repo)
-        scoped_link = scoped_repository_link_for(topic, repo)
-        return "no RepositoryLink found for #{repo} in topic creative scope; webhook events not auto-provisioned" unless scoped_link
-
-        # Provision through the *global* primary link (lowest id across all
-        # creatives), not the scoped link. WebhookProvisioner only patches hook
-        # events when the link IS the primary; non-primary links short-circuit
-        # to secret alignment and skip the GitHub edit_hook call. So if we
-        # provisioned the scoped link and it was not the global primary, the
-        # existing hook would keep its old event list. The scoped link is only
-        # used as an authorization gate above.
-        provisioning_link = global_primary_repository_link_for(repo) || scoped_link
-
-        account = provisioning_link.github_account
-        return "RepositoryLink for #{repo} has no GitHub account; webhook events not auto-provisioned" unless account
+        scoped_link = verified_scoped_repository_link_for(topic, repo)
+        unless scoped_link
+          return "no verified RepositoryLink found for #{repo} in topic creative scope; " \
+                 "webhook events not auto-provisioned"
+        end
 
         results = CollavreGithub::WebhookProvisioner.ensure_for_links(
-          account: account,
-          links: [ provisioning_link ],
-          webhook_url: github_webhook_url
+          account: scoped_link.github_account,
+          links: [ scoped_link ],
+          webhook_url: github_webhook_url,
+          force_hook_refresh: true
         )
         status = results.first&.last
         # :failed means Client returned nil (Octokit/Faraday error rescued in
@@ -124,31 +116,38 @@ module CollavreGithub
         "webhook provisioning failed: #{e.message}"
       end
 
-      # Authorization gate: a RepositoryLink for `repo` must live in this
-      # topic's creative subtree (the topic creative itself or one of its
-      # ancestors). Without one, the dispatch path in WebhooksController would
-      # silently drop events for this topic anyway.
-      def scoped_repository_link_for(topic, repo)
+      # Authorization and identity gate: a RepositoryLink for `repo` must live
+      # in this topic's creative subtree, carry a stable repository id, and
+      # resolve to that same id through its GitHub account. A stored name alone
+      # is not safe provisioning evidence because GitHub can reuse a renamed
+      # repository's old name.
+      def verified_scoped_repository_link_for(topic, repo)
         creative = topic.creative
         return nil unless creative
 
         candidate_ids = [ creative.id ] + creative.ancestors.pluck(:id)
-        CollavreGithub::RepositoryLink
+        candidates = CollavreGithub::RepositoryLink
           .where("LOWER(repository_full_name) = ?", repo.downcase)
           .where(creative_id: candidate_ids)
           .order(:id)
-          .first
-      end
+          .to_a
+        identities = {}
 
-      # Mirrors WebhookProvisioner#primary_link_for: the lowest-id link for the
-      # repo across ALL creatives. This is the link whose secret + events the
-      # hook is aligned to, so we must provision through it to trigger an
-      # actual edit_hook call.
-      def global_primary_repository_link_for(repo)
-        CollavreGithub::RepositoryLink
-          .where("LOWER(repository_full_name) = ?", repo.downcase)
-          .order(:id)
-          .first
+        candidates.find do |link|
+          account = link.github_account
+          next false if link.repository_id.blank? || account.nil?
+
+          identity = identities.fetch(account.id) do
+            identities[account.id] = CollavreGithub::Client.new(account).repository_identity(repo)
+          rescue Octokit::Error, Faraday::Error => e
+            Rails.logger.warn(
+              "[pr_monitor] repository identity lookup failed for #{repo} through " \
+              "account #{account.id}: #{e.class}: #{e.message}"
+            )
+            identities[account.id] = nil
+          end
+          identity&.id.to_s == link.repository_id.to_s
+        end
       end
 
       def github_webhook_url

--- a/engines/collavre_github/app/services/collavre_github/tools/pr_monitor_service.rb
+++ b/engines/collavre_github/app/services/collavre_github/tools/pr_monitor_service.rb
@@ -84,36 +84,54 @@ module CollavreGithub
       # Returns a warning string when provisioning cannot run or fails; nil on
       # success so the MCP response stays clean.
       def ensure_webhook_events(topic, repo)
-        scoped_link = verified_scoped_repository_link_for(topic, repo)
-        unless scoped_link
-          return "no verified RepositoryLink found for #{repo} in topic creative scope; " \
-                 "webhook events not auto-provisioned"
+        scoped_repository_ids(topic, repo).each do |repository_id|
+          outcome = CollavreGithub::RepositoryProvisioningLock.with_lock(repository_id) do
+            scoped_links = verified_scoped_repository_links_for(
+              topic,
+              repo,
+              repository_id: repository_id
+            )
+            next :unverified if scoped_links.empty?
+
+            all_failed = scoped_links.all? do |scoped_link|
+              results = CollavreGithub::WebhookProvisioner.ensure_for_links(
+                account: scoped_link.github_account,
+                links: [ scoped_link ],
+                webhook_url: github_webhook_url,
+                force_hook_refresh: true
+              )
+              results.first&.last == :failed
+            end
+            if all_failed
+              "webhook provisioning failed: GitHub API rejected the hook request (see logs)"
+            end
+          end
+          next if outcome == :unverified
+
+          # A nil outcome means a verified hook was refreshed successfully.
+          # :shared is also success: the registered hook was patched before
+          # WebhookProvisioner returned that status.
+          return outcome
         end
 
-        results = CollavreGithub::WebhookProvisioner.ensure_for_links(
-          account: scoped_link.github_account,
-          links: [ scoped_link ],
-          webhook_url: github_webhook_url,
-          force_hook_refresh: true
-        )
-        status = results.first&.last
-        # :failed means Client returned nil (Octokit/Faraday error rescued in
-        # CollavreGithub::Client). Surface that to the MCP caller so they know
-        # webhook events were not actually patched.
-        return "webhook provisioning failed: GitHub API rejected the hook request (see logs)" if status == :failed
-        # :shared is NOT a warning. It means a hook registered in this database
-        # already exists, so this instance reused it instead of adding a second
-        # one, and its events and secret have been patched from here — a patch
-        # that fails comes back as :failed and is reported above. (The other
-        # route to :shared is losing the creation race to a sibling, whose hook
-        # was just built from these same RepositoryLink rows, so its
-        # subscriptions are current by construction.) Only the hook's URL is
-        # left pointing at the sibling, which pr_monitor does not depend on.
-        # Warning here reported a provisioning problem where there is none.
-        nil
+        "no verified RepositoryLink found for #{repo} in topic creative scope; " \
+          "webhook events not auto-provisioned"
       rescue => e
         Rails.logger.warn("[pr_monitor] webhook provisioning failed for #{repo}: #{e.class}: #{e.message}")
         "webhook provisioning failed: #{e.message}"
+      end
+
+      def scoped_repository_ids(topic, repo)
+        creative = topic.creative
+        return [] unless creative
+
+        candidate_ids = [ creative.id ] + creative.ancestors.pluck(:id)
+        CollavreGithub::RepositoryLink
+          .where("LOWER(repository_full_name) = ?", repo.downcase)
+          .where(creative_id: candidate_ids)
+          .where.not(repository_id: nil)
+          .distinct
+          .pluck(:repository_id)
       end
 
       # Authorization and identity gate: a RepositoryLink for `repo` must live
@@ -121,19 +139,20 @@ module CollavreGithub
       # resolve to that same id through its GitHub account. A stored name alone
       # is not safe provisioning evidence because GitHub can reuse a renamed
       # repository's old name.
-      def verified_scoped_repository_link_for(topic, repo)
+      def verified_scoped_repository_links_for(topic, repo, repository_id:)
         creative = topic.creative
-        return nil unless creative
+        return [] unless creative
 
         candidate_ids = [ creative.id ] + creative.ancestors.pluck(:id)
         candidates = CollavreGithub::RepositoryLink
           .where("LOWER(repository_full_name) = ?", repo.downcase)
           .where(creative_id: candidate_ids)
+          .where(repository_id: repository_id)
           .order(:id)
           .to_a
         identities = {}
 
-        candidates.find do |link|
+        candidates.uniq(&:github_account_id).select do |link|
           account = link.github_account
           next false if link.repository_id.blank? || account.nil?
 

--- a/engines/collavre_github/app/services/collavre_github/webhook_provisioner.rb
+++ b/engines/collavre_github/app/services/collavre_github/webhook_provisioner.rb
@@ -35,8 +35,8 @@ module CollavreGithub
       ).ensure_for_links(Array(links))
     end
 
-    def self.remove_for_repositories(account:, repositories:, webhook_url:)
-      new(account: account, webhook_url: webhook_url).remove_for_repositories(Array(repositories))
+    def self.remove_for_links(account:, links:, webhook_url:)
+      new(account: account, webhook_url: webhook_url).remove_for_links(Array(links))
     end
 
     def initialize(
@@ -75,24 +75,25 @@ module CollavreGithub
       links.map { |link| [ link, ensure_webhook(link) ] }
     end
 
-    def remove_for_repositories(repositories)
-      # Batch-query to avoid N+1: find all repo names that still have links.
-      # Compared case-insensitively — see `links_for`. Matching exactly would
-      # miss a surviving link stored under different casing and tear down a
-      # hook the repository still needs.
-      names = repositories.map { |name| normalize_repository_name(name) }
-      linked_names = CollavreGithub::RepositoryLink
-        .where("LOWER(repository_full_name) IN (?)", names)
-        .distinct
-        .pluck(:repository_full_name)
-        .map { |name| normalize_repository_name(name) }
-        .to_set
+    # Link objects retain their stable identity after destroy, allowing removal
+    # to find a surviving sibling even when it still stores a pre-rename name.
+    # Once the last ID-backed link is gone, re-resolve its stored name and
+    # require GitHub's live numeric id to match before touching the remote hook.
+    # NULL-id links fail closed: their name may have been reassigned and cannot
+    # safely identify a repository for an outbound mutation.
+    def remove_for_links(links)
+      links
+        .select { |link| link.repository_id.present? }
+        .group_by { |link| link.repository_id.to_s }
+        .each_value do |candidates|
+          repository_id = candidates.first.repository_id
+          CollavreGithub::RepositoryProvisioningLock.with_lock(repository_id) do
+            next if CollavreGithub::RepositoryLink.where(repository_id: repository_id).exists?
 
-      repositories.each do |repository_full_name|
-        next if linked_names.include?(normalize_repository_name(repository_full_name))
-
-        remove_webhook(repository_full_name)
-      end
+            verified_name = candidates.filter_map { |link| verified_removal_name(link) }.first
+            remove_webhook(verified_name) if verified_name
+          end
+        end
     end
 
     private
@@ -307,34 +308,42 @@ module CollavreGithub
       end
     end
 
-    # Every single-repository link lookup in this class goes through here
-    # (`remove_for_repositories` batches many names and normalizes them the same
-    # way inline). GitHub treats
-    # `owner/repo` case-insensitively and serves one repository — and one set of
-    # hooks — regardless of the spelling used, but `repository_full_name` is
-    # stored verbatim from whatever the caller supplied. Two creatives linking
-    # the same repository with different casing therefore produce link rows an
-    # exact match cannot see across, which would hide the registered hook id and
-    # let the next run create a second hook: precisely the proliferation this
-    # class exists to prevent. The webhook controller and pr_monitor already
-    # compare with `LOWER(repository_full_name)`; this matches them.
-    #
-    # The selected link bounds every primary-link, registration, and event
-    # lookup for this provisioning attempt. An ID-backed link uses that exact
-    # stable identity. A name-only link can share state only with other
-    # name-only links: an ID-backed row with the same stale/reused name may
-    # belong to another repository and must not contribute its secret, hook
-    # registration, or markdown-sync settings.
+    # Every primary-link, registration, and event lookup is bounded by the
+    # selected link's identity. ID-backed attempts use the stable repository id
+    # across every stored-name alias, including links that missed a rename.
+    # Name-only attempts remain limited to same-name NULL-id links: a row with
+    # an authoritative id under that reused name may belong to another
+    # repository and must not contribute its secret, registration, or settings.
     def links_for(repository_full_name)
+      if provisioning_link&.repository_id.present?
+        return CollavreGithub::RepositoryLink.where(repository_id: provisioning_link.repository_id)
+      end
+
       links = CollavreGithub::RepositoryLink
         .where("LOWER(repository_full_name) = ?", normalize_repository_name(repository_full_name))
       return links unless provisioning_link
 
-      links.where(repository_id: provisioning_link.repository_id)
+      links.where(repository_id: nil)
     end
 
     def normalize_repository_name(repository_full_name)
       repository_full_name.to_s.downcase
+    end
+
+    def verified_removal_name(link)
+      return if link.repository_id.blank?
+
+      identity = client.repository_identity(link.repository_full_name)
+      return if identity&.id.blank? || identity&.full_name.blank?
+      return unless identity.id.to_s == link.repository_id.to_s
+
+      identity.full_name
+    rescue Octokit::Error, Faraday::Error => e
+      Rails.logger.warn(
+        "[CollavreGithub] webhook removal identity verification failed for " \
+        "#{link.repository_full_name}: #{e.class}: #{e.message}"
+      )
+      nil
     end
 
     def registered_hook_id(repository_full_name)

--- a/engines/collavre_github/app/services/collavre_github/webhook_provisioner.rb
+++ b/engines/collavre_github/app/services/collavre_github/webhook_provisioner.rb
@@ -6,8 +6,17 @@ module CollavreGithub
     # a channel that silently misses comments. `pull_request` is required by
     # the auto-attach + close detection paths.
     CHANNEL_EVENTS = %w[issue_comment pull_request_review pull_request_review_comment].freeze
-    EVENTS = (%w[pull_request] + CHANNEL_EVENTS).freeze
-    EVENTS_WITH_PUSH = (%w[pull_request push] + CHANNEL_EVENTS).freeze
+
+    # `repository` carries the `renamed` action. Without it a rename is
+    # invisible to this app: `repository_full_name` goes stale on every link at
+    # once and, for links with no `repository_id` yet, there is no other key to
+    # find them by — so every subsequent delivery is answered 401 and the
+    # rename event that would repair it is rejected along with the rest.
+    # NOT a member of CHANNEL_EVENTS: it is routing maintenance, and the
+    # controller drops it rather than formatting it into any feed.
+    MAINTENANCE_EVENTS = %w[repository].freeze
+    EVENTS = (%w[pull_request] + CHANNEL_EVENTS + MAINTENANCE_EVENTS).freeze
+    EVENTS_WITH_PUSH = (%w[pull_request push] + CHANNEL_EVENTS + MAINTENANCE_EVENTS).freeze
     CONTENT_TYPE = "json".freeze
 
     # Last path segment of the deprecated singular `post "webhook"` route. The
@@ -80,7 +89,23 @@ module CollavreGithub
 
     attr_reader :client, :webhook_url
 
+    # Stamp the rename-stable id at provisioning time so a link is protected
+    # from its first moment, rather than from its first inbound delivery. Only
+    # ever fills a NULL, and a failed fetch is a no-op — name matching still
+    # works, and the webhook backfill remains as the later safety net.
+    def ensure_repository_id(link)
+      return if link.repository_id.present?
+
+      id = client.repository_id(link.repository_full_name)
+      link.update_column(:repository_id, id) if id.present?
+    rescue => e
+      Rails.logger.warn(
+        "[CollavreGithub] repository id backfill failed for #{link.repository_full_name}: #{e.class}: #{e.message}"
+      )
+    end
+
     def ensure_webhook(link)
+      ensure_repository_id(link)
       repository_full_name = link.repository_full_name
       primary_link = primary_link_for(repository_full_name)
       hooks = repository_hooks(repository_full_name)

--- a/engines/collavre_github/app/services/collavre_github/webhook_provisioner.rb
+++ b/engines/collavre_github/app/services/collavre_github/webhook_provisioner.rb
@@ -89,23 +89,7 @@ module CollavreGithub
 
     attr_reader :client, :webhook_url
 
-    # Stamp the rename-stable id at provisioning time so a link is protected
-    # from its first moment, rather than from its first inbound delivery. Only
-    # ever fills a NULL, and a failed fetch is a no-op — name matching still
-    # works, and the webhook backfill remains as the later safety net.
-    def ensure_repository_id(link)
-      return if link.repository_id.present?
-
-      id = client.repository_id(link.repository_full_name)
-      link.update_column(:repository_id, id) if id.present?
-    rescue => e
-      Rails.logger.warn(
-        "[CollavreGithub] repository id backfill failed for #{link.repository_full_name}: #{e.class}: #{e.message}"
-      )
-    end
-
     def ensure_webhook(link)
-      ensure_repository_id(link)
       repository_full_name = link.repository_full_name
       primary_link = primary_link_for(repository_full_name)
       hooks = repository_hooks(repository_full_name)

--- a/engines/collavre_github/app/services/collavre_github/webhook_provisioner.rb
+++ b/engines/collavre_github/app/services/collavre_github/webhook_provisioner.rb
@@ -27,17 +27,27 @@ module CollavreGithub
     LEGACY_ROUTE_SEGMENT = "webhook".freeze
     ROUTE_SEGMENT = "webhooks".freeze
 
-    def self.ensure_for_links(account:, links:, webhook_url:)
-      new(account: account, webhook_url: webhook_url).ensure_for_links(Array(links))
+    def self.ensure_for_links(account:, links:, webhook_url:, force_hook_refresh: false)
+      new(
+        account: account,
+        webhook_url: webhook_url,
+        force_hook_refresh: force_hook_refresh
+      ).ensure_for_links(Array(links))
     end
 
     def self.remove_for_repositories(account:, repositories:, webhook_url:)
       new(account: account, webhook_url: webhook_url).remove_for_repositories(Array(repositories))
     end
 
-    def initialize(account:, webhook_url:, client: CollavreGithub::Client.new(account))
+    def initialize(
+      account:,
+      webhook_url:,
+      client: CollavreGithub::Client.new(account),
+      force_hook_refresh: false
+    )
       @client = client
       @webhook_url = webhook_url
+      @force_hook_refresh = force_hook_refresh
     end
 
     # Returns [[link, status], ...] so callers can detect silent GitHub
@@ -87,10 +97,12 @@ module CollavreGithub
 
     private
 
-    attr_reader :client, :webhook_url, :repository_id_scope
+    attr_reader :client, :webhook_url, :provisioning_link, :force_hook_refresh,
+                :superseding_hook
 
     def ensure_webhook(link)
-      @repository_id_scope = link.repository_id
+      @provisioning_link = link
+      @superseding_hook = nil
       repository_full_name = link.repository_full_name
       primary_link = primary_link_for(repository_full_name)
       hooks = repository_hooks(repository_full_name)
@@ -132,7 +144,8 @@ module CollavreGithub
       )
       :failed
     ensure
-      @repository_id_scope = nil
+      @provisioning_link = nil
+      @superseding_hook = nil
     end
 
     def provision_hook(link, repository_full_name, primary_link, hooks, hook, shared)
@@ -141,7 +154,15 @@ module CollavreGithub
 
         if primary_link && primary_link != link
           align_link_secret(link, primary_link.webhook_secret)
-          :secret_aligned
+          if force_hook_refresh
+            update_webhook(
+              repository_full_name,
+              hook.id,
+              primary_link.webhook_secret
+            ) ? :updated : :failed
+          else
+            :secret_aligned
+          end
         else
           update_webhook(repository_full_name, hook.id, link.webhook_secret) ? :updated : :failed
         end
@@ -183,7 +204,13 @@ module CollavreGithub
         # a working hook on a guess would leave the repository with none at
         # all — strictly worse than the duplicate delivery that keeping it may
         # cost, which the GUID ledger collapses anyway.
-        return :created unless register_hook(repository_full_name, created_id, hooks) == :superseded
+        registration = register_hook(repository_full_name, created_id, hooks)
+        return :created unless registration == :superseded
+
+        if force_hook_refresh
+          return :failed unless superseding_hook &&
+            update_shared_webhook(repository_full_name, superseding_hook, secret)
+        end
 
         # A sibling instance created and registered its own hook while this one
         # was creating its own. Both feed this database, so keeping both would
@@ -292,19 +319,18 @@ module CollavreGithub
     # class exists to prevent. The webhook controller and pr_monitor already
     # compare with `LOWER(repository_full_name)`; this matches them.
     #
-    # Once the caller supplies an ID-backed link, that stable identity also
-    # bounds every primary-link, registration, and event lookup for this
-    # provisioning attempt. A stale link for another repository may carry the
-    # same reused name, but neither a conflicting ID nor an unverified NULL ID
-    # may contribute its secret, hook registration, or markdown-sync settings.
-    # Proven legacy siblings have already been stamped by
-    # RepositoryIdentitySynchronizer before the reprovisioner reaches here.
+    # The selected link bounds every primary-link, registration, and event
+    # lookup for this provisioning attempt. An ID-backed link uses that exact
+    # stable identity. A name-only link can share state only with other
+    # name-only links: an ID-backed row with the same stale/reused name may
+    # belong to another repository and must not contribute its secret, hook
+    # registration, or markdown-sync settings.
     def links_for(repository_full_name)
       links = CollavreGithub::RepositoryLink
         .where("LOWER(repository_full_name) = ?", normalize_repository_name(repository_full_name))
-      return links if repository_id_scope.blank?
+      return links unless provisioning_link
 
-      links.where(repository_id: repository_id_scope)
+      links.where(repository_id: provisioning_link.repository_id)
     end
 
     def normalize_repository_name(repository_full_name)
@@ -357,7 +383,10 @@ module CollavreGithub
       # to: this run is replacing that hook, not racing a sibling for it.
       # Deferring would discard the replacement just created and then delete the
       # legacy hook, leaving the repository with none at all.
-      return :superseded if live && !legacy_hook?(live)
+      if live && !legacy_hook?(live)
+        @superseding_hook = live
+        return :superseded
+      end
 
       links_for(repository_full_name)
         .where(webhook_hook_id: [ nil, registered ].uniq)

--- a/engines/collavre_github/app/services/collavre_github/webhook_provisioner.rb
+++ b/engines/collavre_github/app/services/collavre_github/webhook_provisioner.rb
@@ -87,9 +87,10 @@ module CollavreGithub
 
     private
 
-    attr_reader :client, :webhook_url
+    attr_reader :client, :webhook_url, :repository_id_scope
 
     def ensure_webhook(link)
+      @repository_id_scope = link.repository_id
       repository_full_name = link.repository_full_name
       primary_link = primary_link_for(repository_full_name)
       hooks = repository_hooks(repository_full_name)
@@ -130,6 +131,8 @@ module CollavreGithub
         "GitHub webhook provisioning failed for #{repository_full_name}: #{e.message}"
       )
       :failed
+    ensure
+      @repository_id_scope = nil
     end
 
     def provision_hook(link, repository_full_name, primary_link, hooks, hook, shared)
@@ -288,9 +291,20 @@ module CollavreGithub
     # let the next run create a second hook: precisely the proliferation this
     # class exists to prevent. The webhook controller and pr_monitor already
     # compare with `LOWER(repository_full_name)`; this matches them.
+    #
+    # Once the caller supplies an ID-backed link, that stable identity also
+    # bounds every primary-link, registration, and event lookup for this
+    # provisioning attempt. A stale link for another repository may carry the
+    # same reused name, but neither a conflicting ID nor an unverified NULL ID
+    # may contribute its secret, hook registration, or markdown-sync settings.
+    # Proven legacy siblings have already been stamped by
+    # RepositoryIdentitySynchronizer before the reprovisioner reaches here.
     def links_for(repository_full_name)
-      CollavreGithub::RepositoryLink
+      links = CollavreGithub::RepositoryLink
         .where("LOWER(repository_full_name) = ?", normalize_repository_name(repository_full_name))
+      return links if repository_id_scope.blank?
+
+      links.where(repository_id: repository_id_scope)
     end
 
     def normalize_repository_name(repository_full_name)

--- a/engines/collavre_github/app/services/collavre_github/webhook_reprovisioner.rb
+++ b/engines/collavre_github/app/services/collavre_github/webhook_reprovisioner.rb
@@ -1,7 +1,9 @@
 module CollavreGithub
-  # Reconciles every existing repository hook with WebhookProvisioner's current
-  # event list. New event subscriptions in code do not change hooks already
-  # stored at GitHub, so deploys run this once after the new app is live.
+  # Reconciles every identity-backed repository hook with
+  # WebhookProvisioner's current event list. New event subscriptions in code do
+  # not change hooks already stored at GitHub, so deploys run this once after
+  # the new app is live. Name-only legacy links are skipped because their names
+  # may be stale and already reused by another repository.
   class WebhookReprovisioner
     def self.call(webhook_url: default_webhook_url)
       new(webhook_url: webhook_url).call
@@ -39,9 +41,15 @@ module CollavreGithub
     def reprovision(repository_name)
       link = CollavreGithub::RepositoryLink
         .where("LOWER(repository_full_name) = ?", repository_name)
+        .where.not(repository_id: nil)
         .order(:id)
         .first
-      return :failed unless link&.github_account
+      # A name-only legacy link cannot be reconciled safely: the stored name
+      # may be stale and already reused by another GitHub repository. Let a
+      # verified delivery establish its stable id instead of mutating hooks on
+      # the repository that happens to own the name now.
+      return :skipped_unverified unless link
+      return :failed unless link.github_account
 
       result = CollavreGithub::WebhookProvisioner.ensure_for_links(
         account: link.github_account,

--- a/engines/collavre_github/app/services/collavre_github/webhook_reprovisioner.rb
+++ b/engines/collavre_github/app/services/collavre_github/webhook_reprovisioner.rb
@@ -58,7 +58,8 @@ module CollavreGithub
         result = CollavreGithub::WebhookProvisioner.ensure_for_links(
           account: link.github_account,
           links: [ link ],
-          webhook_url: webhook_url
+          webhook_url: webhook_url,
+          force_hook_refresh: true
         )
         status = result.first&.last || :failed
         if status == :failed

--- a/engines/collavre_github/app/services/collavre_github/webhook_reprovisioner.rb
+++ b/engines/collavre_github/app/services/collavre_github/webhook_reprovisioner.rb
@@ -1,0 +1,59 @@
+module CollavreGithub
+  # Reconciles every existing repository hook with WebhookProvisioner's current
+  # event list. New event subscriptions in code do not change hooks already
+  # stored at GitHub, so deploys run this once after the new app is live.
+  class WebhookReprovisioner
+    def self.call(webhook_url: default_webhook_url)
+      new(webhook_url: webhook_url).call
+    end
+
+    def self.default_webhook_url
+      CollavreGithub::Engine.routes.url_helpers.webhooks_url(
+        Rails.application.config.action_mailer.default_url_options
+      )
+    end
+
+    def initialize(webhook_url:)
+      @webhook_url = webhook_url
+    end
+
+    def call
+      repository_names.map do |repository_name|
+        [ repository_name, reprovision(repository_name) ]
+      end
+    end
+
+    private
+
+    attr_reader :webhook_url
+
+    def repository_names
+      CollavreGithub::RepositoryLink
+        .order(:id)
+        .pluck(:repository_full_name)
+        .filter_map { |name| name.to_s.downcase.presence }
+        .uniq
+        .sort
+    end
+
+    def reprovision(repository_name)
+      link = CollavreGithub::RepositoryLink
+        .where("LOWER(repository_full_name) = ?", repository_name)
+        .order(:id)
+        .first
+      return :failed unless link&.github_account
+
+      result = CollavreGithub::WebhookProvisioner.ensure_for_links(
+        account: link.github_account,
+        links: [ link ],
+        webhook_url: webhook_url
+      )
+      result.first&.last || :failed
+    rescue => e
+      Rails.logger.warn(
+        "[CollavreGithub::WebhookReprovisioner] #{repository_name} failed: #{e.class}: #{e.message}"
+      )
+      :failed
+    end
+  end
+end

--- a/engines/collavre_github/app/services/collavre_github/webhook_reprovisioner.rb
+++ b/engines/collavre_github/app/services/collavre_github/webhook_reprovisioner.rb
@@ -1,10 +1,13 @@
 module CollavreGithub
-  # Reconciles every safely identifiable repository hook with
-  # WebhookProvisioner's current event list. New event subscriptions in code do
-  # not change hooks already stored at GitHub, so deploys run this once after
-  # the new app is live. For a name-only legacy link, the stored hook id must
-  # still exist under that name before the name is trusted: a stale name may
-  # have been reused, but the unrelated repository cannot also own our hook id.
+  # Reconciles every ID-backed repository hook with WebhookProvisioner's current
+  # event list. New event subscriptions in code do not change hooks already
+  # stored at GitHub, so deploys run this once after the new app is live.
+  #
+  # Name-only legacy rows are never mutated automatically. Older provisioners
+  # copied a hook registration and secret to every same-name row, so neither
+  # value is independent proof that a legacy row belongs to the repository
+  # currently owning that name. Their presence is reported as requiring manual
+  # verification so deploys cannot silently leave them unreconciled.
   class WebhookReprovisioner
     def self.call(webhook_url: default_webhook_url)
       new(webhook_url: webhook_url).call
@@ -44,9 +47,10 @@ module CollavreGithub
         .where("LOWER(repository_full_name) = ?", repository_name)
         .order(:id)
         .to_a
+      manual_verification_required = links.any? { |link| link.repository_id.blank? }
       failed = false
 
-      links.each do |candidate|
+      links.select { |link| link.repository_id.present? }.each do |candidate|
         unless candidate.github_account
           failed = true
           next
@@ -67,13 +71,18 @@ module CollavreGithub
           next
         end
 
+        return :manual_verification_required if manual_verification_required
+
         return status
       rescue => e
         failed = true
         log_failure(repository_name, e)
       end
 
-      failed ? :failed : :skipped_unverified
+      return :failed if failed
+      return :manual_verification_required if manual_verification_required
+
+      :skipped_unverified
     end
 
     def log_failure(repository_name, error)
@@ -84,24 +93,17 @@ module CollavreGithub
     end
 
     def establish_repository_identity(link)
+      return if link.repository_id.blank?
+
       client = CollavreGithub::Client.new(link.github_account)
-      if link.repository_id.blank?
-        return if link.webhook_hook_id.blank?
-
-        hook_ids = client.repository_hooks!(link.repository_full_name).map { |hook| hook.id.to_s }
-        return unless hook_ids.include?(link.webhook_hook_id.to_s)
-      end
-
       identity = client.repository_identity(link.repository_full_name)
       return if identity&.id.blank? || identity&.full_name.blank?
-      return if link.repository_id.present? && link.repository_id.to_s != identity.id.to_s
+      return if link.repository_id.to_s != identity.id.to_s
 
       synchronized = CollavreGithub::RepositoryIdentitySynchronizer.call(
         anchor: link,
         repository_id: identity.id,
-        full_name: identity.full_name,
-        trusted_hook_id: link.webhook_hook_id,
-        trusted_secret: link.webhook_secret
+        full_name: identity.full_name
       )
       synchronized.find { |candidate| candidate.creative_id == link.creative_id }
     end

--- a/engines/collavre_github/app/services/collavre_github/webhook_reprovisioner.rb
+++ b/engines/collavre_github/app/services/collavre_github/webhook_reprovisioner.rb
@@ -1,9 +1,10 @@
 module CollavreGithub
-  # Reconciles every identity-backed repository hook with
+  # Reconciles every safely identifiable repository hook with
   # WebhookProvisioner's current event list. New event subscriptions in code do
   # not change hooks already stored at GitHub, so deploys run this once after
-  # the new app is live. Name-only legacy links are skipped because their names
-  # may be stale and already reused by another repository.
+  # the new app is live. For a name-only legacy link, the stored hook id must
+  # still exist under that name before the name is trusted: a stale name may
+  # have been reused, but the unrelated repository cannot also own our hook id.
   class WebhookReprovisioner
     def self.call(webhook_url: default_webhook_url)
       new(webhook_url: webhook_url).call
@@ -41,15 +42,11 @@ module CollavreGithub
     def reprovision(repository_name)
       link = CollavreGithub::RepositoryLink
         .where("LOWER(repository_full_name) = ?", repository_name)
-        .where.not(repository_id: nil)
         .order(:id)
         .first
-      # A name-only legacy link cannot be reconciled safely: the stored name
-      # may be stale and already reused by another GitHub repository. Let a
-      # verified delivery establish its stable id instead of mutating hooks on
-      # the repository that happens to own the name now.
-      return :skipped_unverified unless link
       return :failed unless link.github_account
+
+      return :skipped_unverified unless establish_legacy_identity(link)
 
       result = CollavreGithub::WebhookProvisioner.ensure_for_links(
         account: link.github_account,
@@ -62,6 +59,21 @@ module CollavreGithub
         "[CollavreGithub::WebhookReprovisioner] #{repository_name} failed: #{e.class}: #{e.message}"
       )
       :failed
+    end
+
+    def establish_legacy_identity(link)
+      return true if link.repository_id.present?
+      return false if link.webhook_hook_id.blank?
+
+      client = CollavreGithub::Client.new(link.github_account)
+      hook_ids = client.repository_hooks!(link.repository_full_name).map { |hook| hook.id.to_s }
+      return false unless hook_ids.include?(link.webhook_hook_id.to_s)
+
+      repository_id = client.repository_id(link.repository_full_name)
+      return false if repository_id.blank?
+
+      link.update_column(:repository_id, repository_id)
+      true
     end
   end
 end

--- a/engines/collavre_github/app/services/collavre_github/webhook_reprovisioner.rb
+++ b/engines/collavre_github/app/services/collavre_github/webhook_reprovisioner.rb
@@ -46,7 +46,8 @@ module CollavreGithub
         .first
       return :failed unless link.github_account
 
-      return :skipped_unverified unless establish_legacy_identity(link)
+      link = establish_repository_identity(link)
+      return :skipped_unverified unless link
 
       result = CollavreGithub::WebhookProvisioner.ensure_for_links(
         account: link.github_account,
@@ -61,19 +62,27 @@ module CollavreGithub
       :failed
     end
 
-    def establish_legacy_identity(link)
-      return true if link.repository_id.present?
-      return false if link.webhook_hook_id.blank?
-
+    def establish_repository_identity(link)
       client = CollavreGithub::Client.new(link.github_account)
-      hook_ids = client.repository_hooks!(link.repository_full_name).map { |hook| hook.id.to_s }
-      return false unless hook_ids.include?(link.webhook_hook_id.to_s)
+      if link.repository_id.blank?
+        return if link.webhook_hook_id.blank?
 
-      repository_id = client.repository_id(link.repository_full_name)
-      return false if repository_id.blank?
+        hook_ids = client.repository_hooks!(link.repository_full_name).map { |hook| hook.id.to_s }
+        return unless hook_ids.include?(link.webhook_hook_id.to_s)
+      end
 
-      link.update_column(:repository_id, repository_id)
-      true
+      identity = client.repository_identity(link.repository_full_name)
+      return if identity&.id.blank? || identity&.full_name.blank?
+      return if link.repository_id.present? && link.repository_id.to_s != identity.id.to_s
+
+      synchronized = CollavreGithub::RepositoryIdentitySynchronizer.call(
+        anchor: link,
+        repository_id: identity.id,
+        full_name: identity.full_name,
+        trusted_hook_id: link.webhook_hook_id,
+        trusted_secret: link.webhook_secret
+      )
+      synchronized.find { |candidate| candidate.creative_id == link.creative_id }
     end
   end
 end

--- a/engines/collavre_github/app/services/collavre_github/webhook_reprovisioner.rb
+++ b/engines/collavre_github/app/services/collavre_github/webhook_reprovisioner.rb
@@ -60,7 +60,13 @@ module CollavreGithub
           links: [ link ],
           webhook_url: webhook_url
         )
-        return result.first&.last || :failed
+        status = result.first&.last || :failed
+        if status == :failed
+          failed = true
+          next
+        end
+
+        return status
       rescue => e
         failed = true
         log_failure(repository_name, e)

--- a/engines/collavre_github/app/services/collavre_github/webhook_reprovisioner.rb
+++ b/engines/collavre_github/app/services/collavre_github/webhook_reprovisioner.rb
@@ -40,26 +40,40 @@ module CollavreGithub
     end
 
     def reprovision(repository_name)
-      link = CollavreGithub::RepositoryLink
+      links = CollavreGithub::RepositoryLink
         .where("LOWER(repository_full_name) = ?", repository_name)
         .order(:id)
-        .first
-      return :failed unless link.github_account
+        .to_a
+      failed = false
 
-      link = establish_repository_identity(link)
-      return :skipped_unverified unless link
+      links.each do |candidate|
+        unless candidate.github_account
+          failed = true
+          next
+        end
 
-      result = CollavreGithub::WebhookProvisioner.ensure_for_links(
-        account: link.github_account,
-        links: [ link ],
-        webhook_url: webhook_url
-      )
-      result.first&.last || :failed
-    rescue => e
+        link = establish_repository_identity(candidate)
+        next unless link
+
+        result = CollavreGithub::WebhookProvisioner.ensure_for_links(
+          account: link.github_account,
+          links: [ link ],
+          webhook_url: webhook_url
+        )
+        return result.first&.last || :failed
+      rescue => e
+        failed = true
+        log_failure(repository_name, e)
+      end
+
+      failed ? :failed : :skipped_unverified
+    end
+
+    def log_failure(repository_name, error)
       Rails.logger.warn(
-        "[CollavreGithub::WebhookReprovisioner] #{repository_name} failed: #{e.class}: #{e.message}"
+        "[CollavreGithub::WebhookReprovisioner] #{repository_name} failed: " \
+        "#{error.class}: #{error.message}"
       )
-      :failed
     end
 
     def establish_repository_identity(link)

--- a/engines/collavre_github/app/services/collavre_github/webhook_reprovisioner.rb
+++ b/engines/collavre_github/app/services/collavre_github/webhook_reprovisioner.rb
@@ -51,25 +51,32 @@ module CollavreGithub
       failed = false
 
       links.select { |link| link.repository_id.present? }.each do |candidate|
-        unless candidate.github_account
-          failed = true
-          next
+        repository_id = candidate.repository_id
+        status = CollavreGithub::RepositoryProvisioningLock.with_lock(repository_id) do
+          locked_candidate = CollavreGithub::RepositoryLink.find_by(
+            id: candidate.id,
+            repository_id: repository_id
+          )
+          next :skipped_unverified unless locked_candidate
+          next :failed unless locked_candidate.github_account
+
+          link = establish_repository_identity(locked_candidate)
+          next :skipped_unverified unless link
+
+          result = CollavreGithub::WebhookProvisioner.ensure_for_links(
+            account: link.github_account,
+            links: [ link ],
+            webhook_url: webhook_url,
+            force_hook_refresh: true
+          )
+          result.first&.last || :failed
         end
 
-        link = establish_repository_identity(candidate)
-        next unless link
-
-        result = CollavreGithub::WebhookProvisioner.ensure_for_links(
-          account: link.github_account,
-          links: [ link ],
-          webhook_url: webhook_url,
-          force_hook_refresh: true
-        )
-        status = result.first&.last || :failed
         if status == :failed
           failed = true
           next
         end
+        next if status == :skipped_unverified
 
         return :manual_verification_required if manual_verification_required
 

--- a/engines/collavre_github/config/locales/en.yml
+++ b/engines/collavre_github/config/locales/en.yml
@@ -107,6 +107,7 @@ en:
         closed_message: "%{label} was **%{verb}**. Detaching channel."
         attached_message: "%{label} monitoring started.\n\n%{url}"
         reopened_message: "%{label} was reopened. Monitoring resumed.\n\n%{url}"
+        auth_failure_message: "⚠️ A GitHub webhook delivery for `%{repo}` could not be verified, so events for %{label} are **not being received**.\n\nThis usually means the repository was renamed or its webhook secret was changed. Re-run the GitHub integration setup for this repository to restore delivery.\n\n%{url}"
         badge:
           open: "Open"
           merged: "Merged"

--- a/engines/collavre_github/config/locales/ko.yml
+++ b/engines/collavre_github/config/locales/ko.yml
@@ -107,6 +107,7 @@ ko:
         closed_message: "%{label}이(가) **%{verb}** 되었습니다. 채널을 해제합니다."
         attached_message: "%{label} 모니터링이 시작되었습니다.\n\n%{url}"
         reopened_message: "%{label}이(가) 재오픈되어 모니터링이 재개되었습니다.\n\n%{url}"
+        auth_failure_message: "⚠️ `%{repo}` 저장소의 GitHub 웹훅 전달을 검증하지 못해 %{label}의 이벤트를 **수신하지 못하고 있습니다**.\n\n저장소 이름이 변경되었거나 웹훅 시크릿이 바뀐 경우입니다. 해당 저장소의 GitHub 연동 설정을 다시 실행하면 복구됩니다.\n\n%{url}"
         badge:
           open: "열림"
           merged: "머지됨"

--- a/engines/collavre_github/db/migrate/20260729000000_add_repository_id_index_to_github_repository_links.rb
+++ b/engines/collavre_github/db/migrate/20260729000000_add_repository_id_index_to_github_repository_links.rb
@@ -2,9 +2,12 @@ class AddRepositoryIdIndexToGithubRepositoryLinks < ActiveRecord::Migration[8.1]
   # The column has existed since the engine's first migration but was never
   # written or read. Webhook routing now matches on it (it is the only
   # repository identifier that survives a rename), so it needs an index.
+  # `webhook_hook_id` is also used as a request-time fallback for links that
+  # have not received a repository id yet, and must not require a table scan.
   #
   # Not unique: one repository is deliberately linked to many creatives.
   def change
     add_index :github_repository_links, :repository_id
+    add_index :github_repository_links, :webhook_hook_id
   end
 end

--- a/engines/collavre_github/db/migrate/20260729000000_add_repository_id_index_to_github_repository_links.rb
+++ b/engines/collavre_github/db/migrate/20260729000000_add_repository_id_index_to_github_repository_links.rb
@@ -1,0 +1,10 @@
+class AddRepositoryIdIndexToGithubRepositoryLinks < ActiveRecord::Migration[8.1]
+  # The column has existed since the engine's first migration but was never
+  # written or read. Webhook routing now matches on it (it is the only
+  # repository identifier that survives a rename), so it needs an index.
+  #
+  # Not unique: one repository is deliberately linked to many creatives.
+  def change
+    add_index :github_repository_links, :repository_id
+  end
+end

--- a/engines/collavre_github/test/controllers/collavre_github/integrations_controller_test.rb
+++ b/engines/collavre_github/test/controllers/collavre_github/integrations_controller_test.rb
@@ -191,6 +191,54 @@ module CollavreGithub
       assert_equal [ [ :entered, 101 ], [ :released, 101 ] ], lock_events
     end
 
+    test "update revalidates repository identity after acquiring the provisioning lock" do
+      link = CollavreGithub::RepositoryLink.create!(
+        creative: @creative.effective_origin,
+        github_account: @account,
+        repository_full_name: "testuser/old-name",
+        repository_id: 101,
+        webhook_secret: "repository-a-secret"
+      )
+      sign_in_as(@user)
+      identity_stub = stub_request(:get, "https://api.github.com/repos/testuser/old-name")
+        .to_return(
+          {
+            status: 200,
+            body: { id: 101, full_name: "testuser/old-name" }.to_json,
+            headers: { "Content-Type" => "application/json" }
+          },
+          {
+            status: 200,
+            body: { id: 202, full_name: "testuser/old-name" }.to_json,
+            headers: { "Content-Type" => "application/json" }
+          }
+        )
+      provisioned = false
+
+      CollavreGithub::WebhookProvisioner.stub(
+        :ensure_for_links,
+        ->(**) {
+          provisioned = true
+          []
+        }
+      ) do
+        patch "/github/creatives/#{@creative.id}/integration",
+              params: { repositories: [ "testuser/old-name" ] },
+              headers: { "Content-Type" => "application/json", "Accept" => "application/json" },
+              as: :json
+      end
+
+      assert_response :unprocessable_entity
+      assert_requested identity_stub, times: 2
+      assert_not provisioned
+      assert_equal "testuser/old-name", link.reload.repository_full_name
+      assert_equal 101, link.repository_id
+      assert_equal "repository-a-secret", link.webhook_secret
+      assert_not_requested :get, %r{https://api\.github\.com/repos/testuser/old-name/hooks}
+      assert_not_requested :post, %r{https://api\.github\.com/repos/testuser/old-name/hooks}
+      assert_not_requested :patch, %r{https://api\.github\.com/repos/testuser/old-name/hooks/}
+    end
+
     test "update deduplicates aliases that resolve to the same repository" do
       sign_in_as(@user)
 
@@ -316,6 +364,7 @@ module CollavreGithub
       sign_in_as(@user)
 
       stub_github_repository("testuser/old-name", id: 101, full_name: "testuser/repo1")
+      stub_github_repository("testuser/repo1", id: 101)
       provision = lambda do |account:, links:, **|
         assert_equal @account, account
         assert_equal [ canonical.id ], links.map(&:id)
@@ -430,6 +479,123 @@ module CollavreGithub
       link = @creative.effective_origin.github_repository_links.find_by!(github_account: @account)
       assert link.markdown_sync_enabled?
       assert_equal [ link.id ], enqueued_link_ids
+    end
+
+    test "canonicalization preserves a markdown disable keyed by the submitted alias" do
+      link = CollavreGithub::RepositoryLink.create!(
+        creative: @creative.effective_origin,
+        github_account: @account,
+        repository_full_name: "testuser/old-name",
+        repository_id: 101,
+        markdown_sync_enabled: true
+      )
+      sign_in_as(@user)
+      stub_github_repository("testuser/old-name", id: 101, full_name: "testuser/repo1")
+      stub_github_repository("testuser/repo1", id: 101)
+
+      provision = lambda do |links:, **|
+        assert_not links.fetch(0).markdown_sync_enabled?
+        [ [ links.fetch(0), :updated ] ]
+      end
+
+      CollavreGithub::WebhookProvisioner.stub(:ensure_for_links, provision) do
+        patch "/github/creatives/#{@creative.id}/integration",
+              params: {
+                repositories: [ "testuser/old-name" ],
+                markdown_sync: { "testuser/old-name" => false }
+              },
+              headers: { "Content-Type" => "application/json", "Accept" => "application/json" },
+              as: :json
+      end
+
+      assert_response :success
+      assert_equal "testuser/repo1", link.reload.repository_full_name
+      assert_not link.markdown_sync_enabled?
+    end
+
+    test "canonicalization preserves a markdown enable keyed by the submitted alias" do
+      link = CollavreGithub::RepositoryLink.create!(
+        creative: @creative.effective_origin,
+        github_account: @account,
+        repository_full_name: "testuser/old-name",
+        repository_id: 101,
+        markdown_sync_enabled: false
+      )
+      sign_in_as(@user)
+      stub_github_repository("testuser/old-name", id: 101, full_name: "testuser/repo1")
+      stub_github_repository("testuser/repo1", id: 101)
+      enqueued_link_ids = []
+
+      provision = lambda do |links:, **|
+        assert links.fetch(0).markdown_sync_enabled?
+        [ [ links.fetch(0), :updated ] ]
+      end
+
+      CollavreGithub::WebhookProvisioner.stub(:ensure_for_links, provision) do
+        CollavreGithub::InitialMarkdownSyncJob.stub(
+          :perform_later,
+          ->(link_id) { enqueued_link_ids << link_id }
+        ) do
+          patch "/github/creatives/#{@creative.id}/integration",
+                params: {
+                  repositories: [ "testuser/old-name" ],
+                  markdown_sync: { "testuser/old-name" => true }
+                },
+                headers: { "Content-Type" => "application/json", "Accept" => "application/json" },
+                as: :json
+        end
+      end
+
+      assert_response :success
+      assert_equal "testuser/repo1", link.reload.repository_full_name
+      assert link.markdown_sync_enabled?
+      assert_equal [ link.id ], enqueued_link_ids
+    end
+
+    test "canonicalization rejects conflicting markdown toggles for repository aliases" do
+      sign_in_as(@user)
+      stub_github_repository("testuser/old-name", id: 101, full_name: "testuser/repo1")
+      stub_github_repository("testuser/repo1", id: 101)
+
+      patch "/github/creatives/#{@creative.id}/integration",
+            params: {
+              repositories: [ "testuser/old-name", "testuser/repo1" ],
+              markdown_sync: {
+                "testuser/old-name" => true,
+                "testuser/repo1" => false
+              }
+            },
+            headers: { "Content-Type" => "application/json", "Accept" => "application/json" },
+            as: :json
+
+      assert_response :unprocessable_entity
+      assert_empty @creative.effective_origin.github_repository_links
+      assert_not_requested :get, %r{https://api\.github\.com/repos/testuser/repo1/hooks}
+      assert_not_requested :post, %r{https://api\.github\.com/repos/testuser/repo1/hooks}
+      assert_not_requested :patch, %r{https://api\.github\.com/repos/testuser/repo1/hooks/}
+    end
+
+    test "canonicalization rejects conflicting toggles for case-only aliases" do
+      sign_in_as(@user)
+      stub_github_repository("TestUser/Repo1", id: 101, full_name: "testuser/repo1")
+      stub_github_repository("testuser/repo1", id: 101)
+
+      patch "/github/creatives/#{@creative.id}/integration",
+            params: {
+              repositories: [ "TestUser/Repo1", "testuser/repo1" ],
+              markdown_sync: {
+                "TestUser/Repo1" => true,
+                "testuser/repo1" => false
+              }
+            },
+            headers: { "Content-Type" => "application/json", "Accept" => "application/json" },
+            as: :json
+
+      assert_response :unprocessable_entity
+      assert_empty @creative.effective_origin.github_repository_links
+      assert_not_requested :get, %r{https://api\.github\.com/repos/testuser/repo1/hooks}
+      assert_not_requested :post, %r{https://api\.github\.com/repos/testuser/repo1/hooks}
+      assert_not_requested :patch, %r{https://api\.github\.com/repos/testuser/repo1/hooks/}
     end
 
     test "update replaces existing repositories" do

--- a/engines/collavre_github/test/controllers/collavre_github/integrations_controller_test.rb
+++ b/engines/collavre_github/test/controllers/collavre_github/integrations_controller_test.rb
@@ -166,6 +166,7 @@ module CollavreGithub
     test "update links repositories" do
       sign_in_as(@user)
 
+      stub_github_repository("testuser/repo1", id: 101)
       stub_github_hooks("testuser/repo1")
       stub_github_create_hook("testuser/repo1")
 
@@ -190,6 +191,7 @@ module CollavreGithub
         repository_full_name: "testuser/old-repo"
       )
 
+      stub_github_repository("testuser/new-repo", id: 202)
       stub_github_hooks("testuser/new-repo")
       stub_github_create_hook("testuser/new-repo")
 
@@ -202,6 +204,79 @@ module CollavreGithub
       data = JSON.parse(response.body)
       assert_includes data["selected_repositories"], "testuser/new-repo"
       assert_not_includes data["selected_repositories"], "testuser/old-repo"
+    end
+
+    test "new links persist identity before sharing an existing repository hook" do
+      existing = CollavreGithub::RepositoryLink.create!(
+        creative: create_creative(@user),
+        github_account: @account,
+        repository_full_name: "testuser/repo1",
+        repository_id: 101,
+        webhook_secret: "existing-secret"
+      )
+      sign_in_as(@user)
+
+      stub_github_repository("testuser/repo1", id: 101)
+      stub_github_hooks("testuser/repo1")
+      stub_github_create_hook("testuser/repo1")
+
+      patch "/github/creatives/#{@creative.id}/integration",
+            params: { repositories: [ "testuser/repo1" ] },
+            headers: { "Content-Type" => "application/json", "Accept" => "application/json" },
+            as: :json
+
+      assert_response :success
+      linked = @creative.effective_origin.github_repository_links.find_by!(
+        github_account: @account,
+        repository_full_name: "testuser/repo1"
+      )
+      assert_equal 101, linked.repository_id
+      assert_equal existing.webhook_secret, linked.webhook_secret
+    end
+
+    test "re-saving a name-only legacy link does not provision the reused name" do
+      legacy = CollavreGithub::RepositoryLink.create!(
+        creative: @creative.effective_origin,
+        github_account: @account,
+        repository_full_name: "testuser/reused",
+        repository_id: nil,
+        webhook_secret: "legacy-secret"
+      )
+      sign_in_as(@user)
+
+      patch "/github/creatives/#{@creative.id}/integration",
+            params: { repositories: [ "testuser/reused" ] },
+            headers: { "Content-Type" => "application/json", "Accept" => "application/json" },
+            as: :json
+
+      assert_response :success
+      assert_nil legacy.reload.repository_id
+      assert_not_requested :get, %r{https://api\.github\.com/repos/testuser/reused}
+      assert_not_requested :post, %r{https://api\.github\.com/repos/testuser/reused/hooks}
+      assert_not_requested :patch, %r{https://api\.github\.com/repos/testuser/reused/hooks/}
+    end
+
+    test "re-saving a stale id-backed link does not provision the reused name" do
+      stale = CollavreGithub::RepositoryLink.create!(
+        creative: @creative.effective_origin,
+        github_account: @account,
+        repository_full_name: "testuser/reused",
+        repository_id: 111,
+        webhook_secret: "stale-secret"
+      )
+      sign_in_as(@user)
+      stub_github_repository("testuser/reused", id: 222)
+
+      patch "/github/creatives/#{@creative.id}/integration",
+            params: { repositories: [ "testuser/reused" ] },
+            headers: { "Content-Type" => "application/json", "Accept" => "application/json" },
+            as: :json
+
+      assert_response :success
+      assert_equal 111, stale.reload.repository_id
+      assert_not_requested :get, %r{https://api\.github\.com/repos/testuser/reused/hooks}
+      assert_not_requested :post, %r{https://api\.github\.com/repos/testuser/reused/hooks}
+      assert_not_requested :patch, %r{https://api\.github\.com/repos/testuser/reused/hooks/}
     end
 
     test "update returns error when not connected" do

--- a/engines/collavre_github/test/controllers/collavre_github/integrations_controller_test.rb
+++ b/engines/collavre_github/test/controllers/collavre_github/integrations_controller_test.rb
@@ -182,6 +182,247 @@ module CollavreGithub
       assert data["webhooks"]["testuser/repo1"].present?
     end
 
+    test "update deduplicates aliases that resolve to the same repository" do
+      sign_in_as(@user)
+
+      stub_github_repository("TestUser/Repo1", id: 101, full_name: "testuser/repo1")
+      stub_github_repository("testuser/repo1", id: 101)
+      stub_github_hooks("testuser/repo1")
+      stub_github_create_hook("testuser/repo1")
+
+      patch "/github/creatives/#{@creative.id}/integration",
+            params: { repositories: [ "TestUser/Repo1", "testuser/repo1" ] },
+            headers: { "Content-Type" => "application/json", "Accept" => "application/json" },
+            as: :json
+
+      assert_response :success
+      links = @creative.effective_origin.github_repository_links.where(github_account: @account)
+      assert_equal 1, links.count
+      assert_equal 101, links.first.repository_id
+      assert_equal "testuser/repo1", links.first.repository_full_name
+    end
+
+    test "alias dedup preserves an existing canonical link and its settings" do
+      existing = CollavreGithub::RepositoryLink.create!(
+        creative: @creative.effective_origin,
+        github_account: @account,
+        repository_full_name: "testuser/old-name",
+        repository_id: 101,
+        webhook_hook_id: 77,
+        markdown_sync_enabled: true,
+        markdown_root_creative: @creative.effective_origin,
+        sync_branch: "docs"
+      )
+      sign_in_as(@user)
+
+      stub_github_repository("testuser/old-name", id: 101, full_name: "testuser/repo1")
+      stub_github_repository("testuser/repo1", id: 101)
+      provision = lambda do |links:, **|
+        assert_equal [ existing.id ], links.map(&:id)
+        assert_equal "testuser/repo1", links.first.repository_full_name
+        []
+      end
+
+      CollavreGithub::WebhookProvisioner.stub(:ensure_for_links, provision) do
+        patch "/github/creatives/#{@creative.id}/integration",
+              params: {
+                repositories: [ "testuser/old-name", "testuser/repo1" ],
+                markdown_sync: { "testuser/repo1" => false }
+              },
+              headers: { "Content-Type" => "application/json", "Accept" => "application/json" },
+              as: :json
+      end
+
+      assert_response :success
+      links = @creative.effective_origin.github_repository_links.where(github_account: @account)
+      assert_equal [ existing.id ], links.pluck(:id)
+      existing.reload
+      assert_equal "testuser/repo1", existing.repository_full_name
+      assert_equal 77, existing.webhook_hook_id
+      assert_not existing.markdown_sync_enabled?
+      assert_equal @creative.effective_origin, existing.markdown_root_creative
+      assert_equal "docs", existing.sync_branch
+    end
+
+    test "failed hook refresh rolls a canonical collision merge back" do
+      stale = CollavreGithub::RepositoryLink.create!(
+        creative: @creative.effective_origin,
+        github_account: @account,
+        repository_full_name: "testuser/old-name",
+        repository_id: 101,
+        webhook_secret: "active-secret",
+        webhook_hook_id: 77,
+        markdown_sync_enabled: true
+      )
+      canonical = CollavreGithub::RepositoryLink.create!(
+        creative: @creative.effective_origin,
+        github_account: @account,
+        repository_full_name: "testuser/repo1",
+        repository_id: 101,
+        webhook_secret: "canonical-secret"
+      )
+      sign_in_as(@user)
+
+      stub_github_repository("testuser/old-name", id: 101, full_name: "testuser/repo1")
+      stub_github_repository("testuser/repo1", id: 101)
+      provision = lambda do |links:, **|
+        assert_equal [ canonical.id ], links.map(&:id)
+        assert_equal "active-secret", links.first.webhook_secret
+        [ [ links.first, :failed ] ]
+      end
+
+      CollavreGithub::WebhookProvisioner.stub(:ensure_for_links, provision) do
+        patch "/github/creatives/#{@creative.id}/integration",
+              params: { repositories: [ "testuser/old-name", "testuser/repo1" ] },
+              headers: { "Content-Type" => "application/json", "Accept" => "application/json" },
+              as: :json
+      end
+
+      assert_response :unprocessable_entity
+      assert_equal "testuser/old-name", stale.reload.repository_full_name
+      assert_equal "active-secret", stale.webhook_secret
+      assert_equal 77, stale.webhook_hook_id
+      assert stale.markdown_sync_enabled?
+      assert_equal "testuser/repo1", canonical.reload.repository_full_name
+      assert_equal "canonical-secret", canonical.webhook_secret
+    end
+
+    test "canonical collision keeps the verified account and anchor secret" do
+      stale = CollavreGithub::RepositoryLink.create!(
+        creative: @creative.effective_origin,
+        github_account: @account,
+        repository_full_name: "testuser/old-name",
+        repository_id: 101,
+        webhook_secret: "active-secret"
+      )
+      other_user = create_user(email: "gh-other-account@example.com", name: "Other GitHub User")
+      other_account = create_github_account(other_user)
+      canonical = CollavreGithub::RepositoryLink.create!(
+        creative: @creative.effective_origin,
+        github_account: other_account,
+        repository_full_name: "testuser/repo1",
+        repository_id: 101,
+        webhook_secret: "other-secret"
+      )
+      sign_in_as(@user)
+
+      stub_github_repository("testuser/old-name", id: 101, full_name: "testuser/repo1")
+      provision = lambda do |account:, links:, **|
+        assert_equal @account, account
+        assert_equal [ canonical.id ], links.map(&:id)
+        assert_equal @account, links.first.github_account
+        assert_equal "active-secret", links.first.webhook_secret
+        [ [ links.first, :updated ] ]
+      end
+
+      CollavreGithub::WebhookProvisioner.stub(:ensure_for_links, provision) do
+        patch "/github/creatives/#{@creative.id}/integration",
+              params: { repositories: [ "testuser/old-name" ] },
+              headers: { "Content-Type" => "application/json", "Accept" => "application/json" },
+              as: :json
+      end
+
+      assert_response :success
+      assert_not CollavreGithub::RepositoryLink.exists?(stale.id)
+      canonical.reload
+      assert_equal @account, canonical.github_account
+      assert_equal "active-secret", canonical.webhook_secret
+      assert_equal "testuser/repo1", canonical.repository_full_name
+    end
+
+    test "canonicalization rejects an unverified canonical-name collision" do
+      stale = CollavreGithub::RepositoryLink.create!(
+        creative: @creative.effective_origin,
+        github_account: @account,
+        repository_full_name: "testuser/old-name",
+        repository_id: 101,
+        webhook_secret: "active-secret"
+      )
+      collision = CollavreGithub::RepositoryLink.create!(
+        creative: @creative.effective_origin,
+        github_account: @account,
+        repository_full_name: "testuser/repo1",
+        repository_id: nil,
+        webhook_secret: "unverified-secret"
+      )
+      sign_in_as(@user)
+
+      stub_github_repository("testuser/old-name", id: 101, full_name: "testuser/repo1")
+
+      patch "/github/creatives/#{@creative.id}/integration",
+            params: { repositories: [ "testuser/old-name" ] },
+            headers: { "Content-Type" => "application/json", "Accept" => "application/json" },
+            as: :json
+
+      assert_response :unprocessable_entity
+      assert_equal "testuser/old-name", stale.reload.repository_full_name
+      assert_equal 101, stale.repository_id
+      assert_equal "testuser/repo1", collision.reload.repository_full_name
+      assert_nil collision.repository_id
+      assert_not_requested :get, %r{https://api\.github\.com/repos/testuser/repo1/hooks}
+      assert_not_requested :post, %r{https://api\.github\.com/repos/testuser/repo1/hooks}
+      assert_not_requested :patch, %r{https://api\.github\.com/repos/testuser/repo1/hooks/}
+    end
+
+    test "a later provisioning failure does not roll back an earlier successful repository" do
+      sign_in_as(@user)
+
+      stub_github_repository("testuser/repo1", id: 101)
+      stub_github_repository("testuser/repo2", id: 202)
+      provisioned = []
+      provision = lambda do |links:, **|
+        link = links.fetch(0)
+        provisioned << link.repository_full_name
+        status = link.repository_id == 101 ? :updated : :failed
+        [ [ link, status ] ]
+      end
+
+      CollavreGithub::WebhookProvisioner.stub(:ensure_for_links, provision) do
+        patch "/github/creatives/#{@creative.id}/integration",
+              params: { repositories: [ "testuser/repo1", "testuser/repo2" ] },
+              headers: { "Content-Type" => "application/json", "Accept" => "application/json" },
+              as: :json
+      end
+
+      assert_response :unprocessable_entity
+      assert_equal [ "testuser/repo1", "testuser/repo2" ], provisioned
+      links = @creative.effective_origin.github_repository_links.where(github_account: @account)
+      assert_equal [ [ "testuser/repo1", 101 ] ],
+        links.order(:repository_full_name).pluck(:repository_full_name, :repository_id)
+    end
+
+    test "markdown sync is applied before a forced hook refresh" do
+      sign_in_as(@user)
+
+      stub_github_repository("testuser/repo1", id: 101)
+      provision = lambda do |links:, force_hook_refresh:, **|
+        assert links.fetch(0).markdown_sync_enabled?
+        assert force_hook_refresh
+        [ [ links.fetch(0), :updated ] ]
+      end
+      enqueued_link_ids = []
+
+      CollavreGithub::WebhookProvisioner.stub(:ensure_for_links, provision) do
+        CollavreGithub::InitialMarkdownSyncJob.stub(
+          :perform_later,
+          ->(link_id) { enqueued_link_ids << link_id }
+        ) do
+          patch "/github/creatives/#{@creative.id}/integration",
+                params: {
+                  repositories: [ "testuser/repo1" ],
+                  markdown_sync: { "testuser/repo1" => true }
+                },
+                headers: { "Content-Type" => "application/json", "Accept" => "application/json" },
+                as: :json
+        end
+      end
+
+      assert_response :success
+      link = @creative.effective_origin.github_repository_links.find_by!(github_account: @account)
+      assert link.markdown_sync_enabled?
+      assert_equal [ link.id ], enqueued_link_ids
+    end
+
     test "update replaces existing repositories" do
       sign_in_as(@user)
 
@@ -251,6 +492,35 @@ module CollavreGithub
 
       assert_response :success
       assert_nil legacy.reload.repository_id
+      assert_not_requested :get, %r{https://api\.github\.com/repos/testuser/reused}
+      assert_not_requested :post, %r{https://api\.github\.com/repos/testuser/reused/hooks}
+      assert_not_requested :patch, %r{https://api\.github\.com/repos/testuser/reused/hooks/}
+    end
+
+    test "a name-only legacy link cannot enable markdown import" do
+      legacy = CollavreGithub::RepositoryLink.create!(
+        creative: @creative.effective_origin,
+        github_account: @account,
+        repository_full_name: "testuser/reused",
+        repository_id: nil,
+        webhook_secret: "legacy-secret"
+      )
+      sign_in_as(@user)
+      sync_enqueued = false
+
+      CollavreGithub::InitialMarkdownSyncJob.stub(:perform_later, ->(*) { sync_enqueued = true }) do
+        patch "/github/creatives/#{@creative.id}/integration",
+              params: {
+                repositories: [ "testuser/reused" ],
+                markdown_sync: { "testuser/reused" => true }
+              },
+              headers: { "Content-Type" => "application/json", "Accept" => "application/json" },
+              as: :json
+      end
+
+      assert_response :unprocessable_entity
+      assert_not sync_enqueued
+      assert_not legacy.reload.markdown_sync_enabled?
       assert_not_requested :get, %r{https://api\.github\.com/repos/testuser/reused}
       assert_not_requested :post, %r{https://api\.github\.com/repos/testuser/reused/hooks}
       assert_not_requested :patch, %r{https://api\.github\.com/repos/testuser/reused/hooks/}

--- a/engines/collavre_github/test/controllers/collavre_github/integrations_controller_test.rb
+++ b/engines/collavre_github/test/controllers/collavre_github/integrations_controller_test.rb
@@ -256,7 +256,7 @@ module CollavreGithub
       assert_not_requested :patch, %r{https://api\.github\.com/repos/testuser/reused/hooks/}
     end
 
-    test "re-saving a stale id-backed link does not provision the reused name" do
+    test "re-saving a stale id-backed link rejects all downstream mutations" do
       stale = CollavreGithub::RepositoryLink.create!(
         creative: @creative.effective_origin,
         github_account: @account,
@@ -267,13 +267,21 @@ module CollavreGithub
       sign_in_as(@user)
       stub_github_repository("testuser/reused", id: 222)
 
-      patch "/github/creatives/#{@creative.id}/integration",
-            params: { repositories: [ "testuser/reused" ] },
-            headers: { "Content-Type" => "application/json", "Accept" => "application/json" },
-            as: :json
+      sync_enqueued = false
+      CollavreGithub::InitialMarkdownSyncJob.stub(:perform_later, ->(*) { sync_enqueued = true }) do
+        patch "/github/creatives/#{@creative.id}/integration",
+              params: {
+                repositories: [ "testuser/reused" ],
+                markdown_sync: { "testuser/reused" => true }
+              },
+              headers: { "Content-Type" => "application/json", "Accept" => "application/json" },
+              as: :json
+      end
 
-      assert_response :success
+      assert_response :unprocessable_entity
+      assert_not sync_enqueued
       assert_equal 111, stale.reload.repository_id
+      assert_not stale.markdown_sync_enabled?
       assert_not_requested :get, %r{https://api\.github\.com/repos/testuser/reused/hooks}
       assert_not_requested :post, %r{https://api\.github\.com/repos/testuser/reused/hooks}
       assert_not_requested :patch, %r{https://api\.github\.com/repos/testuser/reused/hooks/}

--- a/engines/collavre_github/test/controllers/collavre_github/integrations_controller_test.rb
+++ b/engines/collavre_github/test/controllers/collavre_github/integrations_controller_test.rb
@@ -422,6 +422,97 @@ module CollavreGithub
       assert_not_requested :patch, %r{https://api\.github\.com/repos/testuser/repo1/hooks/}
     end
 
+    test "canonicalization checks every case-insensitive collision row" do
+      stale = CollavreGithub::RepositoryLink.create!(
+        creative: @creative.effective_origin,
+        github_account: @account,
+        repository_full_name: "testuser/old-name",
+        repository_id: 101,
+        webhook_secret: "active-secret"
+      )
+      same_id = CollavreGithub::RepositoryLink.create!(
+        creative: @creative.effective_origin,
+        github_account: @account,
+        repository_full_name: "TestUser/Repo1",
+        repository_id: 101,
+        webhook_secret: "same-repository-secret"
+      )
+      conflict = CollavreGithub::RepositoryLink.create!(
+        creative: @creative.effective_origin,
+        github_account: @account,
+        repository_full_name: "testuser/repo1",
+        repository_id: nil,
+        webhook_secret: "unverified-secret"
+      )
+      sign_in_as(@user)
+      stub_github_repository("testuser/old-name", id: 101, full_name: "testuser/repo1")
+
+      patch "/github/creatives/#{@creative.id}/integration",
+            params: { repositories: [ "testuser/old-name" ] },
+            headers: { "Content-Type" => "application/json", "Accept" => "application/json" },
+            as: :json
+
+      assert_response :unprocessable_entity
+      assert_equal "testuser/old-name", stale.reload.repository_full_name
+      assert_equal "TestUser/Repo1", same_id.reload.repository_full_name
+      assert_equal "testuser/repo1", conflict.reload.repository_full_name
+      assert_nil conflict.repository_id
+      assert_not_requested :get, %r{https://api\.github\.com/repos/testuser/repo1/hooks}
+      assert_not_requested :post, %r{https://api\.github\.com/repos/testuser/repo1/hooks}
+      assert_not_requested :patch, %r{https://api\.github\.com/repos/testuser/repo1/hooks/}
+    end
+
+    test "canonicalization rechecks every collision row inside the provisioning lock" do
+      stale = CollavreGithub::RepositoryLink.create!(
+        creative: @creative.effective_origin,
+        github_account: @account,
+        repository_full_name: "testuser/old-name",
+        repository_id: 101,
+        webhook_secret: "active-secret"
+      )
+      sign_in_as(@user)
+      stub_github_repository("testuser/old-name", id: 101, full_name: "testuser/repo1")
+      stub_github_repository("testuser/repo1", id: 101)
+      conflict = nil
+      lock = lambda do |repository_id, &block|
+        assert_equal 101, repository_id
+        conflict = CollavreGithub::RepositoryLink.create!(
+          creative: @creative.effective_origin,
+          github_account: @account,
+          repository_full_name: "testuser/repo1",
+          repository_id: 202,
+          webhook_secret: "conflicting-secret"
+        )
+        block.call
+      end
+      provisioned = false
+
+      CollavreGithub::RepositoryProvisioningLock.stub(:with_lock, lock) do
+        CollavreGithub::WebhookProvisioner.stub(
+          :ensure_for_links,
+          ->(**) {
+            provisioned = true
+            []
+          }
+        ) do
+          patch "/github/creatives/#{@creative.id}/integration",
+                params: { repositories: [ "testuser/old-name" ] },
+                headers: { "Content-Type" => "application/json", "Accept" => "application/json" },
+                as: :json
+        end
+      end
+
+      assert_response :unprocessable_entity
+      assert_not provisioned
+      assert_equal "testuser/old-name", stale.reload.repository_full_name
+      assert_equal 101, stale.repository_id
+      assert_equal "testuser/repo1", conflict.reload.repository_full_name
+      assert_equal 202, conflict.repository_id
+      assert_not_requested :get, %r{https://api\.github\.com/repos/testuser/repo1/hooks}
+      assert_not_requested :post, %r{https://api\.github\.com/repos/testuser/repo1/hooks}
+      assert_not_requested :patch, %r{https://api\.github\.com/repos/testuser/repo1/hooks/}
+    end
+
     test "a later provisioning failure does not roll back an earlier successful repository" do
       sign_in_as(@user)
 

--- a/engines/collavre_github/test/controllers/collavre_github/integrations_controller_test.rb
+++ b/engines/collavre_github/test/controllers/collavre_github/integrations_controller_test.rb
@@ -169,17 +169,26 @@ module CollavreGithub
       stub_github_repository("testuser/repo1", id: 101)
       stub_github_hooks("testuser/repo1")
       stub_github_create_hook("testuser/repo1")
+      lock_events = []
+      lock = lambda do |repository_id, &block|
+        lock_events << [ :entered, repository_id ]
+        block.call
+        lock_events << [ :released, repository_id ]
+      end
 
-      patch "/github/creatives/#{@creative.id}/integration",
-            params: { repositories: [ "testuser/repo1" ] },
-            headers: { "Content-Type" => "application/json", "Accept" => "application/json" },
-            as: :json
+      CollavreGithub::RepositoryProvisioningLock.stub(:with_lock, lock) do
+        patch "/github/creatives/#{@creative.id}/integration",
+              params: { repositories: [ "testuser/repo1" ] },
+              headers: { "Content-Type" => "application/json", "Accept" => "application/json" },
+              as: :json
+      end
 
       assert_response :success
       data = JSON.parse(response.body)
       assert data["success"]
       assert_includes data["selected_repositories"], "testuser/repo1"
       assert data["webhooks"]["testuser/repo1"].present?
+      assert_equal [ [ :entered, 101 ], [ :released, 101 ] ], lock_events
     end
 
     test "update deduplicates aliases that resolve to the same repository" do

--- a/engines/collavre_github/test/controllers/collavre_github/integrations_controller_test.rb
+++ b/engines/collavre_github/test/controllers/collavre_github/integrations_controller_test.rb
@@ -170,17 +170,24 @@ module CollavreGithub
       stub_github_hooks("testuser/repo1")
       stub_github_create_hook("testuser/repo1")
       lock_events = []
-      lock = lambda do |repository_id, &block|
-        lock_events << [ :entered, repository_id ]
+      repository_lock = lambda do |repository_id, &block|
+        lock_events << [ :repository_entered, repository_id ]
         block.call
-        lock_events << [ :released, repository_id ]
+        lock_events << [ :repository_released, repository_id ]
+      end
+      name_lock = lambda do |full_name, &block|
+        lock_events << [ :name_entered, full_name ]
+        block.call
+        lock_events << [ :name_released, full_name ]
       end
 
-      CollavreGithub::RepositoryProvisioningLock.stub(:with_lock, lock) do
-        patch "/github/creatives/#{@creative.id}/integration",
-              params: { repositories: [ "testuser/repo1" ] },
-              headers: { "Content-Type" => "application/json", "Accept" => "application/json" },
-              as: :json
+      CollavreGithub::RepositoryProvisioningLock.stub(:with_lock, repository_lock) do
+        CollavreGithub::RepositoryProvisioningLock.stub(:with_repository_name_lock, name_lock) do
+          patch "/github/creatives/#{@creative.id}/integration",
+                params: { repositories: [ "testuser/repo1" ] },
+                headers: { "Content-Type" => "application/json", "Accept" => "application/json" },
+                as: :json
+        end
       end
 
       assert_response :success
@@ -188,7 +195,12 @@ module CollavreGithub
       assert data["success"]
       assert_includes data["selected_repositories"], "testuser/repo1"
       assert data["webhooks"]["testuser/repo1"].present?
-      assert_equal [ [ :entered, 101 ], [ :released, 101 ] ], lock_events
+      assert_equal [
+        [ :repository_entered, 101 ],
+        [ :name_entered, "testuser/repo1" ],
+        [ :name_released, "testuser/repo1" ],
+        [ :repository_released, 101 ]
+      ], lock_events
     end
 
     test "update revalidates repository identity after acquiring the provisioning lock" do
@@ -508,6 +520,36 @@ module CollavreGithub
       assert_equal 101, stale.repository_id
       assert_equal "testuser/repo1", conflict.reload.repository_full_name
       assert_equal 202, conflict.repository_id
+      assert_not_requested :get, %r{https://api\.github\.com/repos/testuser/repo1/hooks}
+      assert_not_requested :post, %r{https://api\.github\.com/repos/testuser/repo1/hooks}
+      assert_not_requested :patch, %r{https://api\.github\.com/repos/testuser/repo1/hooks/}
+    end
+
+    test "update rejects a canonical repository name owned by another id in an ancestor" do
+      parent = create_creative(@user)
+      @creative.update!(parent: parent)
+      ancestor_link = CollavreGithub::RepositoryLink.create!(
+        creative: parent,
+        github_account: @account,
+        repository_full_name: "TestUser/Repo1",
+        repository_id: 101,
+        webhook_secret: "ancestor-secret"
+      )
+      sign_in_as(@user)
+      stub_github_repository("testuser/repo1", id: 202)
+
+      patch "/github/creatives/#{@creative.id}/integration",
+            params: { repositories: [ "testuser/repo1" ] },
+            headers: { "Content-Type" => "application/json", "Accept" => "application/json" },
+            as: :json
+
+      assert_response :unprocessable_entity
+      assert_equal "TestUser/Repo1", ancestor_link.reload.repository_full_name
+      assert_equal 101, ancestor_link.repository_id
+      assert_not CollavreGithub::RepositoryLink.exists?(
+        creative: @creative,
+        repository_id: 202
+      )
       assert_not_requested :get, %r{https://api\.github\.com/repos/testuser/repo1/hooks}
       assert_not_requested :post, %r{https://api\.github\.com/repos/testuser/repo1/hooks}
       assert_not_requested :patch, %r{https://api\.github\.com/repos/testuser/repo1/hooks/}

--- a/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_auto_attach_test.rb
+++ b/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_auto_attach_test.rb
@@ -11,7 +11,7 @@ module CollavreGithub
       )
       @link = CollavreGithub::RepositoryLink.create!(
         creative: @creative, github_account: @account,
-        repository_full_name: "owner/repo"
+        repository_full_name: "owner/repo", repository_id: 123
       )
       @topic = Collavre::Topic.create!(creative: @creative, user: @user, name: "T")
     end

--- a/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_channels_test.rb
+++ b/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_channels_test.rb
@@ -15,7 +15,8 @@ module CollavreGithub
       @link = CollavreGithub::RepositoryLink.create!(
         creative: @creative,
         github_account: @account,
-        repository_full_name: "owner/repo"
+        repository_full_name: "owner/repo",
+        repository_id: 123
       )
       @topic = Collavre::Topic.create!(creative: @creative, user: @user, name: "T")
       @channel = GithubPrChannel.create!(

--- a/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_dedup_test.rb
+++ b/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_dedup_test.rb
@@ -20,7 +20,8 @@ module CollavreGithub
       @link = CollavreGithub::RepositoryLink.create!(
         creative: @creative,
         github_account: @account,
-        repository_full_name: "owner/repo"
+        repository_full_name: "owner/repo",
+        repository_id: 123
       )
       @topic = Collavre::Topic.create!(creative: @creative, user: @user, name: "T")
       @channel = GithubPrChannel.create!(

--- a/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_multi_creative_test.rb
+++ b/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_multi_creative_test.rb
@@ -1,0 +1,166 @@
+require_relative "../../test_helper"
+
+module CollavreGithub
+  # One repository reachable from TWO creatives. Every existing fan-out test
+  # puts the sibling topics under a SINGLE creative with a SINGLE
+  # RepositoryLink, so the variants below are uncovered.
+  class WebhooksControllerMultiCreativeTest < ActionDispatch::IntegrationTest
+    REPO = "owner/repo".freeze
+    PR = 99
+
+    setup do
+      @user = users(:one)
+      @account = CollavreGithub::Account.create!(
+        user: @user,
+        github_uid: "12345",
+        login: "testuser",
+        name: "Test",
+        token: "test-token"
+      )
+    end
+
+    # Variant 1: two independent creatives, each carrying its own link.
+    test "V1 two independent creatives each with their own link both receive" do
+      a = creatives(:tshirt)
+      b = creatives(:root_parent)
+      link!(a)
+      link!(b)
+      ta, tb = topic_with_channel(a), topic_with_channel(b)
+
+      deliver_issue_comment
+
+      assert_equal 1, comments(ta), "creative A channel"
+      assert_equal 1, comments(tb), "creative B channel"
+    end
+
+    # Variant 2: link lives only on a shared ancestor; topics hang off two
+    # different descendant creatives.
+    test "V2 link on a common ancestor reaches topics in both descendants" do
+      root = creatives(:root_parent)
+      link!(root)
+      ta = topic_with_channel(creatives(:unconvert_target))
+      tb = topic_with_channel(creatives(:childless_creative))
+
+      deliver_issue_comment
+
+      assert_equal 1, comments(ta), "descendant A channel"
+      assert_equal 1, comments(tb), "descendant B channel"
+    end
+
+    # Variant 3: the second creative is a LINKED creative (origin_id set) whose
+    # origin carries the repository link. Linking always writes to
+    # `effective_origin`, so this is the row the UI produces.
+    #
+    # KNOWN GAP, characterized rather than asserted-as-desired. The scope gate
+    # compares raw creative ids and never resolves `effective_origin`, so an
+    # alias is out of scope even though the link on its origin is what the UI
+    # wrote. Latent in practice — topics resolve to `effective_origin` on
+    # creation (topics_controller.rb) — so no live path reaches it today.
+    #
+    # Widening the gate is a security decision, not a cleanup: the same check
+    # is what stops a PR description from injecting into another tenant's
+    # topic. Left for that decision; if the gate changes, this test fails and
+    # tells you to make the change deliberately.
+    test "V3 alias creative is out of scope even when its origin holds the link" do
+      origin = creatives(:tshirt)
+      link!(origin)
+      ta = topic_with_channel(origin)
+
+      alias_creative = Collavre::Creative.create!(
+        user: @user, origin: origin, description: "Alias of tshirt"
+      )
+      tb = topic_with_channel(alias_creative)
+
+      deliver_issue_comment
+
+      assert_equal 1, comments(ta), "origin creative channel"
+      assert_equal 0, comments(tb), "alias creative channel — known gap, see comment"
+    end
+
+    # Variant 4: pr_monitor attaches a channel on a creative with no link in
+    # scope. Does the tool report the attach as successful anyway?
+    test "V4 pr_monitor on an unlinked creative reports ok but never delivers" do
+      linked = creatives(:tshirt)
+      link!(linked)
+      unlinked = creatives(:root_parent)
+      topic = Collavre::Topic.create!(creative: unlinked, user: @user, name: "Unlinked")
+
+      Collavre::Current.user = @user
+      result = CollavreGithub::Tools::PrMonitorService.new.call(
+        topic_id: topic.id, pr_url: "https://github.com/#{REPO}/pull/#{PR}"
+      )
+      assert result[:ok], "pr_monitor reported failure; expected the silent-success path"
+      assert result[:webhook_warning].present?,
+        "the only trace of the silent failure is this warning field, which callers ignore"
+
+      before = comments(topic)
+      deliver_issue_comment
+      assert_equal before, comments(topic),
+        "channel attached on an unlinked creative received the event"
+    end
+
+    # Variant 5: the repo is linked on a creative that is a DESCENDANT of the
+    # topic's creative (linking happens wherever the user opened the settings
+    # modal; the scope check only walks upward).
+    #
+    # KNOWN GAP, characterized rather than asserted-as-desired — same decision
+    # as V3. A link is only ever valid DOWN its own subtree, so a topic sitting
+    # above the linked creative is silently unreachable: the chip attaches, the
+    # "monitoring started" message posts, and no event ever arrives. Widening
+    # the gate downward would mean "a link anywhere below me lets a PR body
+    # inject above me", which is the guard's whole purpose.
+    test "V5 link on a descendant of the topic creative never reaches the topic" do
+      parent = creatives(:root_parent)
+      link!(creatives(:unconvert_target)) # a child of root_parent
+      topic = topic_with_channel(parent)
+
+      deliver_issue_comment
+
+      assert_equal 0, comments(topic),
+        "topic whose creative sits ABOVE the linked creative — known gap, see comment"
+    end
+
+    private
+
+    def link!(creative)
+      CollavreGithub::RepositoryLink.create!(
+        creative: creative, github_account: @account, repository_full_name: REPO
+      )
+    end
+
+    def topic_with_channel(creative)
+      topic = Collavre::Topic.create!(creative: creative, user: @user, name: "T#{creative.id}")
+      GithubPrChannel.create!(
+        topic: topic, config: { "repo_full_name" => REPO, "pr_number" => PR }
+      )
+      topic
+    end
+
+    def comments(topic)
+      Collavre::Comment.where(topic_id: topic.id).count
+    end
+
+    def deliver_issue_comment
+      payload = {
+        action: "created",
+        comment: { id: 1, body: "review ping", user: { login: "alice", type: "User", id: 1 } },
+        issue: { number: PR, pull_request: {} },
+        repository: { full_name: REPO }
+      }.to_json
+
+      secret = CollavreGithub::RepositoryLink
+        .where("LOWER(repository_full_name) = ?", REPO).first.webhook_secret
+      sig = "sha256=" + OpenSSL::HMAC.hexdigest("SHA256", secret, payload)
+
+      post "/github/webhooks",
+        params: payload,
+        headers: {
+          "Content-Type" => "application/json",
+          "X-GitHub-Event" => "issue_comment",
+          "X-GitHub-Delivery" => SecureRandom.uuid,
+          "X-Hub-Signature-256" => sig
+        }
+      assert_response :ok
+    end
+  end
+end

--- a/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_multi_creative_test.rb
+++ b/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_multi_creative_test.rb
@@ -124,7 +124,10 @@ module CollavreGithub
 
     def link!(creative)
       CollavreGithub::RepositoryLink.create!(
-        creative: creative, github_account: @account, repository_full_name: REPO
+        creative: creative,
+        github_account: @account,
+        repository_full_name: REPO,
+        repository_id: 123
       )
     end
 

--- a/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_rename_test.rb
+++ b/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_rename_test.rb
@@ -291,6 +291,25 @@ module CollavreGithub
       assert_equal NEW_NAME, @channel.reload.repo_full_name
     end
 
+    test "repository.renamed removes an old-name channel when the canonical channel already exists" do
+      survivor = GithubPrChannel.create!(
+        topic: @topic,
+        config: { "repo_full_name" => NEW_NAME, "pr_number" => 99 }
+      )
+
+      post_event("repository", {
+        action: "renamed",
+        changes: { repository: { name: { from: "old-name" } } },
+        repository: { id: REPO_ID, full_name: NEW_NAME, name: "new-name", owner: { login: "owner" } }
+      })
+
+      assert_response :ok
+      assert_not GithubPrChannel.exists?(@channel.id)
+      assert GithubPrChannel.exists?(survivor.id)
+      assert_equal [ survivor.id ],
+        GithubPrChannel.where(topic: @topic, repo_full_name: NEW_NAME, pr_number: 99).pluck(:id)
+    end
+
     test "renamed repo keeps dispatching to its channel afterwards" do
       # End-to-end: the rename must leave the (link, channel) pair consistent
       # enough that the very next PR comment still lands in the topic.
@@ -457,6 +476,29 @@ module CollavreGithub
       assert_equal "docs", survivor.sync_branch
       assert_equal [ survivor.id ],
         CollavreGithub::RepositoryLink.where(creative: @creative, repository_id: REPO_ID).pluck(:id)
+      assert_equal NEW_NAME, @channel.reload.repo_full_name
+    end
+
+    test "repository.renamed merges a same-id link whose new name differs only by case" do
+      CollavreGithub::RepositoryLink.create!(
+        creative: @creative,
+        github_account: @account,
+        repository_full_name: NEW_NAME.upcase,
+        repository_id: REPO_ID,
+        webhook_secret: "obsolete-secret"
+      )
+
+      post_event("repository", {
+        action: "renamed",
+        changes: { repository: { name: { from: "old-name" } } },
+        repository: { id: REPO_ID, full_name: NEW_NAME, name: "new-name", owner: { login: "owner" } }
+      })
+
+      assert_response :ok
+      links = CollavreGithub::RepositoryLink.where(creative: @creative, repository_id: REPO_ID)
+      assert_equal 1, links.count
+      assert_equal NEW_NAME, links.first.repository_full_name
+      assert_equal @link.webhook_secret, links.first.webhook_secret
       assert_equal NEW_NAME, @channel.reload.repo_full_name
     end
 

--- a/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_rename_test.rb
+++ b/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_rename_test.rb
@@ -143,6 +143,35 @@ module CollavreGithub
       assert_equal REPO_ID, @link.reload.repository_id
     end
 
+    test "repository_id is not backfilled onto a stale name match with another secret" do
+      other_creative = creatives(:childless_creative)
+      other = CollavreGithub::RepositoryLink.create!(
+        creative: other_creative,
+        github_account: @account,
+        repository_full_name: OLD_NAME,
+        repository_id: nil,
+        webhook_secret: "other-repository-secret"
+      )
+      other_topic = Collavre::Topic.create!(creative: other_creative, user: @user, name: "Other")
+      GithubPrChannel.create!(
+        topic: other_topic,
+        config: { "repo_full_name" => OLD_NAME, "pr_number" => 99 }
+      )
+
+      assert_no_difference -> { Collavre::Comment.where(topic_id: other_topic.id).count } do
+        post_event("issue_comment", {
+          action: "created",
+          comment: { id: 21, body: "hi", user: { login: "alice", type: "User", id: 1 } },
+          issue: { number: 99, pull_request: {} },
+          repository: { id: REPO_ID, full_name: OLD_NAME }
+        })
+      end
+
+      assert_response :ok
+      assert_equal REPO_ID, @link.reload.repository_id
+      assert_nil other.reload.repository_id
+    end
+
     test "repository_id is NOT backfilled from an unverified delivery" do
       # The lookup runs before signature verification, so an unauthenticated
       # caller can reach it. Stamping an id there would let anyone repoint a
@@ -292,6 +321,40 @@ module CollavreGithub
       assert_response :ok
       assert_equal OLD_NAME, @link.reload.repository_full_name
       assert_equal OLD_NAME, @channel.reload.repo_full_name
+    end
+
+    test "repository.renamed merges an obsolete same-id link into the new-name survivor" do
+      @link.update!(
+        webhook_hook_id: 123,
+        markdown_sync_enabled: true,
+        markdown_root_creative: @creative,
+        sync_branch: "docs"
+      )
+      survivor = CollavreGithub::RepositoryLink.create!(
+        creative: @creative,
+        github_account: @account,
+        repository_full_name: NEW_NAME,
+        repository_id: REPO_ID,
+        webhook_secret: "obsolete-secret"
+      )
+
+      post_event("repository", {
+        action: "renamed",
+        changes: { repository: { name: { from: "old-name" } } },
+        repository: { id: REPO_ID, full_name: NEW_NAME, name: "new-name", owner: { login: "owner" } }
+      })
+
+      assert_response :ok
+      assert_not CollavreGithub::RepositoryLink.exists?(@link.id)
+      survivor.reload
+      assert_equal @link.webhook_secret, survivor.webhook_secret
+      assert_equal 123, survivor.webhook_hook_id
+      assert survivor.markdown_sync_enabled?
+      assert_equal @creative, survivor.markdown_root_creative
+      assert_equal "docs", survivor.sync_branch
+      assert_equal [ survivor.id ],
+        CollavreGithub::RepositoryLink.where(creative: @creative, repository_id: REPO_ID).pluck(:id)
+      assert_equal NEW_NAME, @channel.reload.repo_full_name
     end
 
     # --- 401 visibility ----------------------------------------------------

--- a/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_rename_test.rb
+++ b/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_rename_test.rb
@@ -307,12 +307,12 @@ module CollavreGithub
       @link.update_columns(repository_full_name: "owner/somewhere-else", repository_id: nil)
     end
 
-    def post_unidentifiable(id_seed)
+    def post_unidentifiable(id_seed, full_name: OLD_NAME, repository_id: REPO_ID)
       post_event("issue_comment", {
         action: "created",
         comment: { id: id_seed, body: "hi", user: { login: "alice", type: "User", id: 1 } },
         issue: { number: 99, pull_request: {} },
-        repository: { id: REPO_ID, full_name: OLD_NAME }
+        repository: { id: repository_id, full_name: full_name }
       }, secret: "any-secret-at-all")
     end
 
@@ -346,6 +346,26 @@ module CollavreGithub
       3.times { |i| post_unidentifiable(10 + i) ; assert_response :unauthorized }
 
       assert_equal 1, Collavre::Comment.where(topic_id: @topic.id).count
+    end
+
+    test "unknown repository scans are globally throttled across names" do
+      orphan_the_link!
+      other_topic = Collavre::Topic.create!(creative: @creative, user: @user, name: "Other repo")
+      GithubPrChannel.create!(
+        topic: other_topic,
+        config: { "repo_full_name" => "owner/other", "pr_number" => 100 }
+      )
+
+      post_unidentifiable(15)
+      post_unidentifiable(16, full_name: "owner/other", repository_id: 777)
+
+      assert_equal 1, Collavre::Comment.where(topic_id: @topic.id).count
+      assert_equal 0, Collavre::Comment.where(topic_id: other_topic.id).count
+
+      travel 2.minutes do
+        post_unidentifiable(17, full_name: "owner/other", repository_id: 777)
+      end
+      assert_equal 1, Collavre::Comment.where(topic_id: other_topic.id).count
     end
 
     test "announcement is throttled per channel, not globally" do

--- a/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_rename_test.rb
+++ b/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_rename_test.rb
@@ -39,17 +39,19 @@ module CollavreGithub
       )
     end
 
-    def post_event(event, payload, secret: @link.webhook_secret, guid: SecureRandom.uuid)
+    def post_event(event, payload, secret: @link.webhook_secret, guid: SecureRandom.uuid, hook_id: nil)
       body = payload.to_json
       sig = "sha256=" + OpenSSL::HMAC.hexdigest("SHA256", secret, body)
+      headers = {
+        "Content-Type" => "application/json",
+        "X-GitHub-Event" => event,
+        "X-GitHub-Delivery" => guid,
+        "X-Hub-Signature-256" => sig
+      }
+      headers["X-GitHub-Hook-ID"] = hook_id.to_s if hook_id
       post "/github/webhooks",
         params: body,
-        headers: {
-          "Content-Type" => "application/json",
-          "X-GitHub-Event" => event,
-          "X-GitHub-Delivery" => guid,
-          "X-Hub-Signature-256" => sig
-        }
+        headers: headers
     end
 
     # --- repository_id matching -------------------------------------------
@@ -214,6 +216,55 @@ module CollavreGithub
 
       assert_response :unauthorized
       assert_nil @link.reload.repository_id
+    end
+
+    test "a verified hook id repairs a missed rename and dispatches the current event" do
+      @link.update_columns(repository_id: nil, webhook_hook_id: 77)
+
+      assert_difference -> { Collavre::Comment.where(topic_id: @topic.id).count }, 1 do
+        post_event("issue_comment", {
+          action: "created",
+          comment: { id: 31, body: "after missed rename", user: { login: "alice", type: "User", id: 1 } },
+          issue: { number: 99, pull_request: {} },
+          repository: { id: REPO_ID, full_name: NEW_NAME }
+        }, hook_id: 77)
+      end
+
+      assert_response :ok
+      assert_equal REPO_ID, @link.reload.repository_id
+      assert_equal NEW_NAME, @link.repository_full_name
+      assert_equal NEW_NAME, @channel.reload.repo_full_name
+    end
+
+    test "an unverified hook id cannot repair repository identity" do
+      @link.update_columns(repository_id: nil, webhook_hook_id: 77)
+
+      post_event("issue_comment", {
+        action: "created",
+        comment: { id: 32, body: "forged", user: { login: "alice", type: "User", id: 1 } },
+        issue: { number: 99, pull_request: {} },
+        repository: { id: REPO_ID, full_name: NEW_NAME }
+      }, secret: "wrong-secret", hook_id: 77)
+
+      assert_response :unauthorized
+      assert_nil @link.reload.repository_id
+      assert_equal OLD_NAME, @link.repository_full_name
+      assert_equal OLD_NAME, @channel.reload.repo_full_name
+    end
+
+    test "a malformed hook id is rejected without querying it as a bigint" do
+      @link.update_columns(repository_id: nil, webhook_hook_id: 77)
+
+      post_event("issue_comment", {
+        action: "created",
+        comment: { id: 33, body: "forged", user: { login: "alice", type: "User", id: 1 } },
+        issue: { number: 99, pull_request: {} },
+        repository: { id: REPO_ID, full_name: NEW_NAME }
+      }, hook_id: "not-a-number")
+
+      assert_response :unauthorized
+      assert_nil @link.reload.repository_id
+      assert_equal OLD_NAME, @link.repository_full_name
     end
 
     # --- repository.renamed ------------------------------------------------

--- a/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_rename_test.rb
+++ b/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_rename_test.rb
@@ -1,0 +1,284 @@
+require_relative "../../test_helper"
+
+module CollavreGithub
+  # A repository rename changes `repository.full_name` in every subsequent
+  # webhook payload while `repository.id` stays constant. Before these tests the
+  # only lookup key was the name, so a rename detached every link at once: the
+  # controller found no link, fell through to a fallback secret that production
+  # does not set, and answered 401 *before* dispatch. Nothing was written to the
+  # deliveries ledger, so the failure was invisible on this side.
+  class WebhooksControllerRenameTest < ActionDispatch::IntegrationTest
+    OLD_NAME = "owner/old-name".freeze
+    NEW_NAME = "owner/new-name".freeze
+    REPO_ID = 4242
+
+    setup do
+      # The announcement path carries a per-repo scan guard in Rails.cache, and
+      # the test store is a memory store shared by every test in this process.
+      # Without this, whichever test runs second sees the first one's guard.
+      Rails.cache.clear
+      @user = users(:one)
+      @creative = creatives(:tshirt)
+      @account = CollavreGithub::Account.create!(
+        user: @user,
+        github_uid: "12345",
+        login: "testuser",
+        name: "Test",
+        token: "test-token"
+      )
+      @link = CollavreGithub::RepositoryLink.create!(
+        creative: @creative,
+        github_account: @account,
+        repository_full_name: OLD_NAME,
+        repository_id: REPO_ID
+      )
+      @topic = Collavre::Topic.create!(creative: @creative, user: @user, name: "T")
+      @channel = GithubPrChannel.create!(
+        topic: @topic,
+        config: { "repo_full_name" => OLD_NAME, "pr_number" => 99 }
+      )
+    end
+
+    def post_event(event, payload, secret: @link.webhook_secret, guid: SecureRandom.uuid)
+      body = payload.to_json
+      sig = "sha256=" + OpenSSL::HMAC.hexdigest("SHA256", secret, body)
+      post "/github/webhooks",
+        params: body,
+        headers: {
+          "Content-Type" => "application/json",
+          "X-GitHub-Event" => event,
+          "X-GitHub-Delivery" => guid,
+          "X-Hub-Signature-256" => sig
+        }
+    end
+
+    # --- repository_id matching -------------------------------------------
+
+    test "signature verifies against a renamed repo when repository_id matches" do
+      # The name in the payload matches nothing in the DB. Only the id does.
+      post_event("issue_comment", {
+        action: "created",
+        comment: { id: 1, body: "hi", user: { login: "alice", type: "User", id: 1 } },
+        issue: { number: 99, pull_request: {} },
+        repository: { id: REPO_ID, full_name: NEW_NAME }
+      })
+
+      assert_response :ok
+    end
+
+    test "repository_id lookup does not displace sibling links matched by name" do
+      # Fan-out regression guard: one link backfilled, one not. Both must
+      # continue to receive. An id-first-else-name lookup would drop the
+      # un-backfilled sibling the moment the first one was stamped.
+      other_creative = creatives(:childless_creative)
+      legacy = CollavreGithub::RepositoryLink.create!(
+        creative: other_creative,
+        github_account: @account,
+        repository_full_name: OLD_NAME,
+        repository_id: nil
+      )
+
+      links = CollavreGithub::RepositoryLink.for_repository(id: REPO_ID, full_name: OLD_NAME)
+      assert_includes links, @link
+      assert_includes links, legacy
+    end
+
+    test "blank repository_id falls back to name matching" do
+      links = CollavreGithub::RepositoryLink.for_repository(id: nil, full_name: OLD_NAME)
+      assert_includes links, @link
+    end
+
+    test "repository_id is backfilled from a verified delivery" do
+      @link.update_column(:repository_id, nil)
+
+      post_event("issue_comment", {
+        action: "created",
+        comment: { id: 2, body: "hi", user: { login: "alice", type: "User", id: 1 } },
+        issue: { number: 99, pull_request: {} },
+        repository: { id: REPO_ID, full_name: OLD_NAME }
+      })
+
+      assert_response :ok
+      assert_equal REPO_ID, @link.reload.repository_id
+    end
+
+    test "repository_id is NOT backfilled from an unverified delivery" do
+      # The lookup runs before signature verification, so an unauthenticated
+      # caller can reach it. Stamping an id there would let anyone repoint a
+      # link's routing key at a repository they control.
+      @link.update_column(:repository_id, nil)
+
+      post_event("issue_comment", {
+        action: "created",
+        comment: { id: 3, body: "hi", user: { login: "alice", type: "User", id: 1 } },
+        issue: { number: 99, pull_request: {} },
+        repository: { id: 999_999, full_name: OLD_NAME }
+      }, secret: "wrong-secret")
+
+      assert_response :unauthorized
+      assert_nil @link.reload.repository_id
+    end
+
+    # --- repository.renamed ------------------------------------------------
+
+    test "repository.renamed rewrites the link's full name" do
+      post_event("repository", {
+        action: "renamed",
+        changes: { repository: { name: { from: "old-name" } } },
+        repository: { id: REPO_ID, full_name: NEW_NAME, name: "new-name", owner: { login: "owner" } }
+      })
+
+      assert_response :ok
+      assert_equal NEW_NAME, @link.reload.repository_full_name
+    end
+
+    test "repository.renamed rewrites attached channels' repo_full_name" do
+      post_event("repository", {
+        action: "renamed",
+        changes: { repository: { name: { from: "old-name" } } },
+        repository: { id: REPO_ID, full_name: NEW_NAME, name: "new-name", owner: { login: "owner" } }
+      })
+
+      assert_response :ok
+      assert_equal NEW_NAME, @channel.reload.repo_full_name
+    end
+
+    test "renamed repo keeps dispatching to its channel afterwards" do
+      # End-to-end: the rename must leave the (link, channel) pair consistent
+      # enough that the very next PR comment still lands in the topic.
+      post_event("repository", {
+        action: "renamed",
+        changes: { repository: { name: { from: "old-name" } } },
+        repository: { id: REPO_ID, full_name: NEW_NAME, name: "new-name", owner: { login: "owner" } }
+      })
+      assert_response :ok
+
+      assert_difference -> { Collavre::Comment.where(topic_id: @topic.id).count }, 1 do
+        post_event("issue_comment", {
+          action: "created",
+          comment: { id: 4, body: "after rename", user: { login: "alice", type: "User", id: 1 } },
+          issue: { number: 99, pull_request: {} },
+          repository: { id: REPO_ID, full_name: NEW_NAME }
+        })
+      end
+      assert_response :ok
+    end
+
+    test "repository.renamed leaves links for other repositories alone" do
+      other = CollavreGithub::RepositoryLink.create!(
+        creative: creatives(:childless_creative),
+        github_account: @account,
+        repository_full_name: "owner/unrelated",
+        repository_id: 777
+      )
+
+      post_event("repository", {
+        action: "renamed",
+        changes: { repository: { name: { from: "old-name" } } },
+        repository: { id: REPO_ID, full_name: NEW_NAME, name: "new-name", owner: { login: "owner" } }
+      })
+
+      assert_equal "owner/unrelated", other.reload.repository_full_name
+    end
+
+    # --- 401 visibility ----------------------------------------------------
+    #
+    # These model the production incident exactly: the channel still carries the
+    # repository name, but no RepositoryLink resolves to it any more, so no
+    # secret can be found and every delivery is refused before dispatch.
+    #
+    # `orphan_the_link!` reproduces that state — a link whose stored name has
+    # gone stale and which has no id to be found by either.
+
+    def orphan_the_link!
+      @link.update_columns(repository_full_name: "owner/somewhere-else", repository_id: nil)
+    end
+
+    def post_unidentifiable(id_seed)
+      post_event("issue_comment", {
+        action: "created",
+        comment: { id: id_seed, body: "hi", user: { login: "alice", type: "User", id: 1 } },
+        issue: { number: 99, pull_request: {} },
+        repository: { id: REPO_ID, full_name: OLD_NAME }
+      }, secret: "any-secret-at-all")
+    end
+
+    test "delivery for an unidentifiable repo announces itself in the monitoring channel" do
+      # This is the whole point: a rejected delivery used to be visible only as
+      # a red row in GitHub's hook UI. The people watching the topic saw
+      # nothing at all — just silence where PR comments should have been.
+      orphan_the_link!
+
+      assert_difference -> { Collavre::Comment.where(topic_id: @topic.id).count }, 1 do
+        post_unidentifiable(5)
+      end
+      assert_response :unauthorized
+
+      assert_match(/#{Regexp.escape(OLD_NAME)}/, Collavre::Comment.where(topic_id: @topic.id).last.content)
+    end
+
+    test "a mere signature mismatch announces nothing" do
+      # The repository IS identifiable and a secret WAS found — the caller just
+      # did not sign with it. Announcing here would let anyone who can guess a
+      # monitored repository's name post into that topic at will.
+      assert_no_difference -> { Collavre::Comment.count } do
+        post_unidentifiable(6)
+      end
+      assert_response :unauthorized
+    end
+
+    test "repeated unidentifiable deliveries announce at most once per window" do
+      orphan_the_link!
+
+      3.times { |i| post_unidentifiable(10 + i) ; assert_response :unauthorized }
+
+      assert_equal 1, Collavre::Comment.where(topic_id: @topic.id).count
+    end
+
+    test "announcement is throttled per channel, not globally" do
+      orphan_the_link!
+      other_topic = Collavre::Topic.create!(creative: @creative, user: @user, name: "T2")
+      GithubPrChannel.create!(
+        topic: other_topic,
+        config: { "repo_full_name" => OLD_NAME, "pr_number" => 100 }
+      )
+
+      post_unidentifiable(20)
+
+      assert_equal 1, Collavre::Comment.where(topic_id: @topic.id).count
+      assert_equal 1, Collavre::Comment.where(topic_id: other_topic.id).count
+    end
+
+    test "delivery for an unmonitored repo announces nothing" do
+      assert_no_difference -> { Collavre::Comment.count } do
+        post_event("issue_comment", {
+          action: "created",
+          comment: { id: 30, body: "hi", user: { login: "alice", type: "User", id: 1 } },
+          issue: { number: 99, pull_request: {} },
+          repository: { id: 1, full_name: "someone/else" }
+        }, secret: "wrong-secret")
+      end
+      assert_response :unauthorized
+    end
+
+    test "successful delivery clears the announcement throttle" do
+      # Otherwise a repo that breaks, is repaired, then breaks again months
+      # later stays silent the second time.
+      orphan_the_link!
+      post_unidentifiable(40)
+      assert @channel.reload.config["auth_failure_notified_at"].present?
+
+      # Repair: the link is pointed back at the repository it belongs to.
+      @link.update_columns(repository_full_name: OLD_NAME, repository_id: REPO_ID)
+
+      post_event("issue_comment", {
+        action: "created",
+        comment: { id: 41, body: "ok now", user: { login: "alice", type: "User", id: 1 } },
+        issue: { number: 99, pull_request: {} },
+        repository: { id: REPO_ID, full_name: OLD_NAME }
+      })
+      assert_response :ok
+      assert_nil @channel.reload.config["auth_failure_notified_at"]
+    end
+  end
+end

--- a/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_rename_test.rb
+++ b/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_rename_test.rb
@@ -161,6 +161,8 @@ module CollavreGithub
       end
 
       assert_response :ok
+      assert_equal OLD_NAME, @link.reload.repository_full_name
+      assert_equal OLD_NAME, @channel.reload.repo_full_name
     end
 
     test "partial alias repair does not hide another conflicted link in the same creative" do
@@ -822,6 +824,55 @@ module CollavreGithub
       assert_equal OLD_NAME, @channel.reload.repo_full_name
       assert_equal NEW_NAME.upcase, conflicting.reload.repository_full_name
       assert_equal 777, conflicting.repository_id
+    end
+
+    test "repository.renamed rejects a case-variant conflict in the linked creative subtree" do
+      child = Collavre::Creative.create!(parent: @creative, user: @user, description: "Child")
+      conflicting_link = CollavreGithub::RepositoryLink.create!(
+        creative: child,
+        github_account: @account,
+        repository_full_name: "Owner/New-Name",
+        repository_id: 777
+      )
+      child_topic = Collavre::Topic.create!(creative: child, user: @user, name: "Child monitor")
+      child_channel = GithubPrChannel.create!(
+        topic: child_topic,
+        config: { "repo_full_name" => OLD_NAME, "pr_number" => 100 }
+      )
+
+      post_event("repository", {
+        action: "renamed",
+        changes: { repository: { name: { from: "old-name" } } },
+        repository: { id: REPO_ID, full_name: NEW_NAME, name: "new-name", owner: { login: "owner" } }
+      })
+
+      assert_response :ok
+      assert_equal OLD_NAME, @link.reload.repository_full_name
+      assert_equal OLD_NAME, @channel.reload.repo_full_name
+      assert_equal OLD_NAME, child_channel.reload.repo_full_name
+      assert_equal "Owner/New-Name", conflicting_link.reload.repository_full_name
+    end
+
+    test "repository.renamed rejects a case-variant conflict in an ancestor creative" do
+      parent = Collavre::Creative.create!(user: @user, description: "Parent")
+      @creative.update!(parent: parent)
+      conflicting_link = CollavreGithub::RepositoryLink.create!(
+        creative: parent,
+        github_account: @account,
+        repository_full_name: "Owner/New-Name",
+        repository_id: 777
+      )
+
+      post_event("repository", {
+        action: "renamed",
+        changes: { repository: { name: { from: "old-name" } } },
+        repository: { id: REPO_ID, full_name: NEW_NAME, name: "new-name", owner: { login: "owner" } }
+      })
+
+      assert_response :ok
+      assert_equal OLD_NAME, @link.reload.repository_full_name
+      assert_equal OLD_NAME, @channel.reload.repo_full_name
+      assert_equal "Owner/New-Name", conflicting_link.reload.repository_full_name
     end
 
     test "repository.renamed does not rename channels through a canonical link with a case-insensitive conflict" do

--- a/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_rename_test.rb
+++ b/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_rename_test.rb
@@ -103,7 +103,7 @@ module CollavreGithub
       assert_response :ok
     end
 
-    test "identity-conflicted stale links are excluded from markdown fan-out" do
+    test "identity-conflicted link is excluded from markdown sync fan-out" do
       @link.update!(markdown_sync_enabled: true)
       CollavreGithub::RepositoryLink.create!(
         creative: @creative,
@@ -111,22 +111,135 @@ module CollavreGithub
         repository_full_name: NEW_NAME,
         repository_id: 777
       )
-      sync_jobs = []
+      sync_calls = []
 
       CollavreGithub::MarkdownSyncJob.stub(
         :perform_later,
-        ->(*args) { sync_jobs << args }
+        ->(*args) { sync_calls << args }
       ) do
         post_event("push", {
           ref: "refs/heads/main",
+          pusher: { name: "alice" },
+          commits: [],
           repository: { id: REPO_ID, full_name: NEW_NAME }
         })
       end
 
       assert_response :ok
-      assert_empty sync_jobs
+      assert_empty sync_calls
       assert_equal OLD_NAME, @link.reload.repository_full_name
       assert_equal REPO_ID, @link.repository_id
+    end
+
+    test "identity-conflicted descendant channel is excluded despite a valid ancestor link" do
+      child = Collavre::Creative.create!(parent: @creative, user: @user, description: "Child")
+      CollavreGithub::RepositoryLink.create!(
+        creative: child,
+        github_account: @account,
+        repository_full_name: OLD_NAME,
+        repository_id: REPO_ID
+      )
+      CollavreGithub::RepositoryLink.create!(
+        creative: child,
+        github_account: @account,
+        repository_full_name: NEW_NAME,
+        repository_id: 777
+      )
+      child_topic = Collavre::Topic.create!(creative: child, user: @user, name: "Conflicted")
+      GithubPrChannel.create!(
+        topic: child_topic,
+        config: { "repo_full_name" => NEW_NAME, "pr_number" => 99 }
+      )
+
+      assert_no_difference -> { Collavre::Comment.where(topic_id: child_topic.id).count } do
+        post_event("issue_comment", {
+          action: "created",
+          comment: { id: 93, body: "must not leak", user: { login: "alice", type: "User", id: 1 } },
+          issue: { number: 99, pull_request: {} },
+          repository: { id: REPO_ID, full_name: NEW_NAME }
+        })
+      end
+
+      assert_response :ok
+    end
+
+    test "partial alias repair does not hide another conflicted link in the same creative" do
+      @link.update!(markdown_sync_enabled: true)
+      case_variant = CollavreGithub::RepositoryLink.create!(
+        creative: @creative,
+        github_account: @account,
+        repository_full_name: "Owner/New-Name",
+        repository_id: REPO_ID
+      )
+      CollavreGithub::RepositoryLink.create!(
+        creative: @creative,
+        github_account: @account,
+        repository_full_name: NEW_NAME,
+        repository_id: 777
+      )
+      conflicting_topic = Collavre::Topic.create!(
+        creative: @creative,
+        user: @user,
+        name: "Case-conflicted"
+      )
+      GithubPrChannel.create!(
+        topic: conflicting_topic,
+        config: { "repo_full_name" => NEW_NAME, "pr_number" => 99 }
+      )
+      sync_calls = []
+
+      assert_no_difference -> { Collavre::Comment.where(topic_id: conflicting_topic.id).count } do
+        post_event("issue_comment", {
+          action: "created",
+          comment: { id: 94, body: "must not leak", user: { login: "alice", type: "User", id: 1 } },
+          issue: { number: 99, pull_request: {} },
+          repository: { id: REPO_ID, full_name: NEW_NAME }
+        })
+      end
+      assert_response :ok
+
+      CollavreGithub::MarkdownSyncJob.stub(:perform_later, ->(*args) { sync_calls << args }) do
+        post_event("push", {
+          ref: "refs/heads/main",
+          pusher: { name: "alice" },
+          commits: [],
+          repository: { id: REPO_ID, full_name: NEW_NAME }
+        }, secret: @link.webhook_secret)
+      end
+
+      assert_response :ok
+      assert_empty sync_calls
+      assert_equal "Owner/New-Name", case_variant.reload.repository_full_name
+    end
+
+    test "canonical link does not authorize a case-variant conflicting repository channel" do
+      @link.update!(repository_full_name: NEW_NAME)
+      CollavreGithub::RepositoryLink.create!(
+        creative: @creative,
+        github_account: @account,
+        repository_full_name: "Owner/New-Name",
+        repository_id: 777
+      )
+      conflicting_topic = Collavre::Topic.create!(
+        creative: @creative,
+        user: @user,
+        name: "Case-variant repository"
+      )
+      GithubPrChannel.create!(
+        topic: conflicting_topic,
+        config: { "repo_full_name" => "Owner/New-Name", "pr_number" => 99 }
+      )
+
+      assert_no_difference -> { Collavre::Comment.where(topic_id: conflicting_topic.id).count } do
+        post_event("issue_comment", {
+          action: "created",
+          comment: { id: 95, body: "must not leak", user: { login: "alice", type: "User", id: 1 } },
+          issue: { number: 99, pull_request: {} },
+          repository: { id: REPO_ID, full_name: NEW_NAME }
+        })
+      end
+
+      assert_response :ok
     end
 
     test "ID-backed missed-rename repair does not capture a NULL-id same-secret link" do

--- a/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_rename_test.rb
+++ b/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_rename_test.rb
@@ -438,6 +438,48 @@ module CollavreGithub
       assert_equal NEW_NAME, @channel.reload.repo_full_name
     end
 
+    test "repository.renamed repairs channels left behind by an earlier missed rename" do
+      final_name = "owner/final-name"
+
+      post_event("repository", {
+        action: "renamed",
+        changes: { repository: { name: { from: "new-name" } } },
+        repository: { id: REPO_ID, full_name: final_name, name: "final-name", owner: { login: "owner" } }
+      })
+
+      assert_response :ok
+      assert_equal final_name, @link.reload.repository_full_name
+      assert_equal final_name, @channel.reload.repo_full_name
+    end
+
+    test "stale-name repair excludes a descendant anchored to an unverified link" do
+      child = Collavre::Creative.create!(parent: @creative, user: @user, description: "Child")
+      legacy = CollavreGithub::RepositoryLink.create!(
+        creative: child,
+        github_account: @account,
+        repository_full_name: OLD_NAME,
+        repository_id: nil
+      )
+      child_topic = Collavre::Topic.create!(creative: child, user: @user, name: "Unverified repository")
+      child_channel = GithubPrChannel.create!(
+        topic: child_topic,
+        config: { "repo_full_name" => OLD_NAME, "pr_number" => 100 }
+      )
+      final_name = "owner/final-name"
+
+      post_event("repository", {
+        action: "renamed",
+        changes: { repository: { name: { from: "new-name" } } },
+        repository: { id: REPO_ID, full_name: final_name, name: "final-name", owner: { login: "owner" } }
+      })
+
+      assert_response :ok
+      assert_equal final_name, @channel.reload.repo_full_name
+      assert_nil legacy.reload.repository_id
+      assert_equal OLD_NAME, legacy.repository_full_name
+      assert_equal OLD_NAME, child_channel.reload.repo_full_name
+    end
+
     test "repository.renamed removes an old-name channel when the canonical channel already exists" do
       survivor = GithubPrChannel.create!(
         topic: @topic,

--- a/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_rename_test.rb
+++ b/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_rename_test.rb
@@ -803,6 +803,56 @@ module CollavreGithub
       assert_equal OLD_NAME, @channel.reload.repo_full_name
     end
 
+    test "repository.renamed leaves a creative unchanged for a case-insensitive conflicting id" do
+      conflicting = CollavreGithub::RepositoryLink.create!(
+        creative: @creative,
+        github_account: @account,
+        repository_full_name: NEW_NAME.upcase,
+        repository_id: 777
+      )
+
+      post_event("repository", {
+        action: "renamed",
+        changes: { repository: { name: { from: "old-name" } } },
+        repository: { id: REPO_ID, full_name: NEW_NAME, name: "new-name", owner: { login: "owner" } }
+      })
+
+      assert_response :ok
+      assert_equal OLD_NAME, @link.reload.repository_full_name
+      assert_equal OLD_NAME, @channel.reload.repo_full_name
+      assert_equal NEW_NAME.upcase, conflicting.reload.repository_full_name
+      assert_equal 777, conflicting.repository_id
+    end
+
+    test "repository.renamed does not rename channels through a canonical link with a case-insensitive conflict" do
+      @link.update!(repository_full_name: NEW_NAME)
+      conflicting_link = CollavreGithub::RepositoryLink.create!(
+        creative: @creative,
+        github_account: @account,
+        repository_full_name: NEW_NAME.upcase,
+        repository_id: 777
+      )
+      conflicting_channel = GithubPrChannel.create!(
+        topic: @topic,
+        state: :detached,
+        dismissed_at: 1.hour.ago,
+        config: { "repo_full_name" => NEW_NAME.upcase, "pr_number" => 99 }
+      )
+
+      post_event("repository", {
+        action: "renamed",
+        changes: { repository: { name: { from: "old-name" } } },
+        repository: { id: REPO_ID, full_name: NEW_NAME, name: "new-name", owner: { login: "owner" } }
+      })
+
+      assert_response :ok
+      assert_equal OLD_NAME, @channel.reload.repo_full_name
+      assert GithubPrChannel.exists?(conflicting_channel.id)
+      assert_equal NEW_NAME.upcase, conflicting_channel.reload.repo_full_name
+      assert CollavreGithub::RepositoryLink.exists?(conflicting_link.id)
+      assert_equal 777, conflicting_link.reload.repository_id
+    end
+
     test "repository.renamed merges an obsolete same-id link into the new-name survivor" do
       @link.update!(
         webhook_hook_id: 123,
@@ -817,25 +867,13 @@ module CollavreGithub
         repository_id: REPO_ID,
         webhook_secret: "obsolete-secret"
       )
-      transaction_options = []
-      original_transaction = CollavreGithub::RepositoryLink.method(:transaction)
-
-      CollavreGithub::RepositoryLink.stub(
-        :transaction,
-        lambda do |**options, &block|
-          transaction_options << options
-          original_transaction.call(**options, &block)
-        end
-      ) do
-        post_event("repository", {
-          action: "renamed",
-          changes: { repository: { name: { from: "old-name" } } },
-          repository: { id: REPO_ID, full_name: NEW_NAME, name: "new-name", owner: { login: "owner" } }
-        })
-      end
+      post_event("repository", {
+        action: "renamed",
+        changes: { repository: { name: { from: "old-name" } } },
+        repository: { id: REPO_ID, full_name: NEW_NAME, name: "new-name", owner: { login: "owner" } }
+      })
 
       assert_response :ok
-      assert_includes transaction_options, { requires_new: true }
       assert_not CollavreGithub::RepositoryLink.exists?(@link.id)
       survivor.reload
       assert_equal @link.webhook_secret, survivor.webhook_secret

--- a/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_rename_test.rb
+++ b/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_rename_test.rb
@@ -464,6 +464,36 @@ module CollavreGithub
       assert_equal NEW_NAME, @channel.reload.repo_full_name
     end
 
+    test "repository.renamed rolls back links and releases the claim when a channel rename fails" do
+      guid = "rename-channel-failure"
+      payload = {
+        action: "renamed",
+        changes: { repository: { name: { from: "old-name" } } },
+        repository: { id: REPO_ID, full_name: NEW_NAME, name: "new-name", owner: { login: "owner" } }
+      }
+
+      assert_raises(ActiveRecord::StatementInvalid) do
+        GithubPrChannel.stub(:find_each, ->(&block) { block.call(@channel) }) do
+          @channel.stub(
+            :synchronize_repository_name!,
+            ->(*) { raise ActiveRecord::StatementInvalid, "transient rename failure" }
+          ) do
+            post_event("repository", payload, guid: guid)
+          end
+        end
+      end
+
+      assert_equal OLD_NAME, @link.reload.repository_full_name
+      assert_equal OLD_NAME, @channel.reload.repo_full_name
+      assert_nil CollavreGithub::WebhookDelivery.find_by(delivery_guid: guid)
+
+      post_event("repository", payload, guid: guid)
+
+      assert_response :ok
+      assert_equal NEW_NAME, @link.reload.repository_full_name
+      assert_equal NEW_NAME, @channel.reload.repo_full_name
+    end
+
     test "repository.renamed repairs channels left behind by an earlier missed rename" do
       final_name = "owner/final-name"
 
@@ -674,14 +704,25 @@ module CollavreGithub
         repository_id: REPO_ID,
         webhook_secret: "obsolete-secret"
       )
+      transaction_options = []
+      original_transaction = CollavreGithub::RepositoryLink.method(:transaction)
 
-      post_event("repository", {
-        action: "renamed",
-        changes: { repository: { name: { from: "old-name" } } },
-        repository: { id: REPO_ID, full_name: NEW_NAME, name: "new-name", owner: { login: "owner" } }
-      })
+      CollavreGithub::RepositoryLink.stub(
+        :transaction,
+        lambda do |**options, &block|
+          transaction_options << options
+          original_transaction.call(**options, &block)
+        end
+      ) do
+        post_event("repository", {
+          action: "renamed",
+          changes: { repository: { name: { from: "old-name" } } },
+          repository: { id: REPO_ID, full_name: NEW_NAME, name: "new-name", owner: { login: "owner" } }
+        })
+      end
 
       assert_response :ok
+      assert_includes transaction_options, { requires_new: true }
       assert_not CollavreGithub::RepositoryLink.exists?(@link.id)
       survivor.reload
       assert_equal @link.webhook_secret, survivor.webhook_secret

--- a/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_rename_test.rb
+++ b/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_rename_test.rb
@@ -96,6 +96,33 @@ module CollavreGithub
       assert_not_includes links, reused_name
     end
 
+    test "signature lookup prefers an ID-backed link over an older NULL-id name match" do
+      @link.destroy!
+      stale = CollavreGithub::RepositoryLink.create!(
+        creative: creatives(:childless_creative),
+        github_account: @account,
+        repository_full_name: OLD_NAME,
+        repository_id: nil,
+        webhook_secret: "stale-secret"
+      )
+      @link = CollavreGithub::RepositoryLink.create!(
+        creative: @creative,
+        github_account: @account,
+        repository_full_name: OLD_NAME,
+        repository_id: REPO_ID
+      )
+
+      post_event("issue_comment", {
+        action: "created",
+        comment: { id: 100, body: "hi", user: { login: "alice", type: "User", id: 1 } },
+        issue: { number: 99, pull_request: {} },
+        repository: { id: REPO_ID, full_name: OLD_NAME }
+      })
+
+      assert_response :ok
+      assert_nil stale.reload.repository_id
+    end
+
     test "a reused repository name does not receive another repository's event" do
       other_creative = creatives(:childless_creative)
       CollavreGithub::RepositoryLink.create!(

--- a/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_rename_test.rb
+++ b/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_rename_test.rb
@@ -83,6 +83,47 @@ module CollavreGithub
       assert_includes links, legacy
     end
 
+    test "repository_id lookup excludes name matches anchored to another repository" do
+      reused_name = CollavreGithub::RepositoryLink.create!(
+        creative: creatives(:childless_creative),
+        github_account: @account,
+        repository_full_name: OLD_NAME,
+        repository_id: 777
+      )
+
+      links = CollavreGithub::RepositoryLink.for_repository(id: REPO_ID, full_name: OLD_NAME)
+      assert_includes links, @link
+      assert_not_includes links, reused_name
+    end
+
+    test "a reused repository name does not receive another repository's event" do
+      other_creative = creatives(:childless_creative)
+      CollavreGithub::RepositoryLink.create!(
+        creative: other_creative,
+        github_account: @account,
+        repository_full_name: OLD_NAME,
+        repository_id: 777,
+        webhook_secret: @link.webhook_secret
+      )
+      other_topic = Collavre::Topic.create!(creative: other_creative, user: @user, name: "Other")
+      GithubPrChannel.create!(
+        topic: other_topic,
+        config: { "repo_full_name" => OLD_NAME, "pr_number" => 99 }
+      )
+
+      assert_no_difference -> { Collavre::Comment.where(topic_id: other_topic.id).count } do
+        assert_difference -> { Collavre::Comment.where(topic_id: @topic.id).count }, 1 do
+          post_event("issue_comment", {
+            action: "created",
+            comment: { id: 101, body: "private", user: { login: "alice", type: "User", id: 1 } },
+            issue: { number: 99, pull_request: {} },
+            repository: { id: REPO_ID, full_name: OLD_NAME }
+          })
+        end
+      end
+      assert_response :ok
+    end
+
     test "blank repository_id falls back to name matching" do
       links = CollavreGithub::RepositoryLink.for_repository(id: nil, full_name: OLD_NAME)
       assert_includes links, @link

--- a/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_rename_test.rb
+++ b/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_rename_test.rb
@@ -181,6 +181,78 @@ module CollavreGithub
       assert_equal "owner/unrelated", other.reload.repository_full_name
     end
 
+    test "repository.renamed does not capture a different repository that reused the old name" do
+      other_creative = creatives(:childless_creative)
+      other = CollavreGithub::RepositoryLink.create!(
+        creative: other_creative,
+        github_account: @account,
+        repository_full_name: OLD_NAME,
+        repository_id: 777
+      )
+      other_topic = Collavre::Topic.create!(creative: other_creative, user: @user, name: "Other")
+      other_channel = GithubPrChannel.create!(
+        topic: other_topic,
+        config: { "repo_full_name" => OLD_NAME, "pr_number" => 100 }
+      )
+
+      post_event("repository", {
+        action: "renamed",
+        changes: { repository: { name: { from: "old-name" } } },
+        repository: { id: REPO_ID, full_name: NEW_NAME, name: "new-name", owner: { login: "owner" } }
+      })
+
+      assert_response :ok
+      assert_equal NEW_NAME, @link.reload.repository_full_name
+      assert_equal OLD_NAME, other.reload.repository_full_name
+      assert_equal OLD_NAME, other_channel.reload.repo_full_name
+    end
+
+    test "repository.renamed repairs an unbackfilled sibling with the verified secret" do
+      other_creative = creatives(:childless_creative)
+      sibling = CollavreGithub::RepositoryLink.create!(
+        creative: other_creative,
+        github_account: @account,
+        repository_full_name: OLD_NAME,
+        repository_id: nil,
+        webhook_secret: @link.webhook_secret
+      )
+      sibling_topic = Collavre::Topic.create!(creative: other_creative, user: @user, name: "Sibling")
+      sibling_channel = GithubPrChannel.create!(
+        topic: sibling_topic,
+        config: { "repo_full_name" => OLD_NAME, "pr_number" => 100 }
+      )
+
+      post_event("repository", {
+        action: "renamed",
+        changes: { repository: { name: { from: "old-name" } } },
+        repository: { id: REPO_ID, full_name: NEW_NAME, name: "new-name", owner: { login: "owner" } }
+      })
+
+      assert_response :ok
+      assert_equal NEW_NAME, sibling.reload.repository_full_name
+      assert_equal REPO_ID, sibling.repository_id
+      assert_equal NEW_NAME, sibling_channel.reload.repo_full_name
+    end
+
+    test "repository.renamed leaves a creative unchanged when the new name belongs to another id" do
+      CollavreGithub::RepositoryLink.create!(
+        creative: @creative,
+        github_account: @account,
+        repository_full_name: NEW_NAME,
+        repository_id: 777
+      )
+
+      post_event("repository", {
+        action: "renamed",
+        changes: { repository: { name: { from: "old-name" } } },
+        repository: { id: REPO_ID, full_name: NEW_NAME, name: "new-name", owner: { login: "owner" } }
+      })
+
+      assert_response :ok
+      assert_equal OLD_NAME, @link.reload.repository_full_name
+      assert_equal OLD_NAME, @channel.reload.repo_full_name
+    end
+
     # --- 401 visibility ----------------------------------------------------
     #
     # These model the production incident exactly: the channel still carries the

--- a/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_rename_test.rb
+++ b/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_rename_test.rb
@@ -56,14 +56,128 @@ module CollavreGithub
 
     # --- repository_id matching -------------------------------------------
 
-    test "signature verifies against a renamed repo when repository_id matches" do
+    test "verified ID-backed delivery repairs a missed rename and dispatches the current event" do
       # The name in the payload matches nothing in the DB. Only the id does.
-      post_event("issue_comment", {
-        action: "created",
-        comment: { id: 1, body: "hi", user: { login: "alice", type: "User", id: 1 } },
-        issue: { number: 99, pull_request: {} },
-        repository: { id: REPO_ID, full_name: NEW_NAME }
-      })
+      assert_difference -> { Collavre::Comment.where(topic_id: @topic.id).count }, 1 do
+        post_event("issue_comment", {
+          action: "created",
+          comment: { id: 1, body: "hi", user: { login: "alice", type: "User", id: 1 } },
+          issue: { number: 99, pull_request: {} },
+          repository: { id: REPO_ID, full_name: NEW_NAME }
+        })
+      end
+
+      assert_response :ok
+      assert_equal NEW_NAME, @link.reload.repository_full_name
+      assert_equal NEW_NAME, @channel.reload.repo_full_name
+    end
+
+    test "ID-backed missed-rename repair does not capture a NULL-id same-secret link" do
+      other_creative = creatives(:childless_creative)
+      legacy = CollavreGithub::RepositoryLink.create!(
+        creative: other_creative,
+        github_account: @account,
+        repository_full_name: OLD_NAME,
+        repository_id: nil,
+        webhook_secret: @link.webhook_secret
+      )
+      other_topic = Collavre::Topic.create!(creative: other_creative, user: @user, name: "Other")
+      other_channel = GithubPrChannel.create!(
+        topic: other_topic,
+        config: { "repo_full_name" => OLD_NAME, "pr_number" => 99 }
+      )
+
+      assert_no_difference -> { Collavre::Comment.where(topic_id: other_topic.id).count } do
+        post_event("issue_comment", {
+          action: "created",
+          comment: { id: 2, body: "hi", user: { login: "alice", type: "User", id: 1 } },
+          issue: { number: 99, pull_request: {} },
+          repository: { id: REPO_ID, full_name: NEW_NAME }
+        })
+      end
+
+      assert_response :ok
+      assert_nil legacy.reload.repository_id
+      assert_equal OLD_NAME, legacy.repository_full_name
+      assert_equal OLD_NAME, other_channel.reload.repo_full_name
+    end
+
+    test "ID-backed missed-rename repair preserves a NULL-id same-hook sibling" do
+      @link.update!(webhook_hook_id: 77)
+      other_creative = creatives(:childless_creative)
+      legacy = CollavreGithub::RepositoryLink.create!(
+        creative: other_creative,
+        github_account: @account,
+        repository_full_name: OLD_NAME,
+        repository_id: nil,
+        webhook_hook_id: 77,
+        webhook_secret: @link.webhook_secret
+      )
+      other_topic = Collavre::Topic.create!(creative: other_creative, user: @user, name: "Other")
+      other_channel = GithubPrChannel.create!(
+        topic: other_topic,
+        config: { "repo_full_name" => OLD_NAME, "pr_number" => 99 }
+      )
+
+      assert_difference -> { Collavre::Comment.where(topic_id: other_topic.id).count }, 1 do
+        post_event("issue_comment", {
+          action: "created",
+          comment: { id: 3, body: "hi", user: { login: "alice", type: "User", id: 1 } },
+          issue: { number: 99, pull_request: {} },
+          repository: { id: REPO_ID, full_name: NEW_NAME }
+        }, hook_id: 77)
+      end
+
+      assert_response :ok
+      assert_equal REPO_ID, legacy.reload.repository_id
+      assert_equal NEW_NAME, legacy.repository_full_name
+      assert_equal NEW_NAME, other_channel.reload.repo_full_name
+    end
+
+    test "ID-backed repair rejects a hook id not registered to the authoritative repository" do
+      @link.update!(webhook_hook_id: 77)
+      other_creative = creatives(:childless_creative)
+      legacy = CollavreGithub::RepositoryLink.create!(
+        creative: other_creative,
+        github_account: @account,
+        repository_full_name: OLD_NAME,
+        repository_id: nil,
+        webhook_hook_id: 88,
+        webhook_secret: @link.webhook_secret
+      )
+      other_topic = Collavre::Topic.create!(creative: other_creative, user: @user, name: "Other")
+      other_channel = GithubPrChannel.create!(
+        topic: other_topic,
+        config: { "repo_full_name" => OLD_NAME, "pr_number" => 99 }
+      )
+
+      assert_no_difference -> { Collavre::Comment.where(topic_id: other_topic.id).count } do
+        post_event("issue_comment", {
+          action: "created",
+          comment: { id: 4, body: "hi", user: { login: "alice", type: "User", id: 1 } },
+          issue: { number: 99, pull_request: {} },
+          repository: { id: REPO_ID, full_name: NEW_NAME }
+        }, hook_id: 88)
+      end
+
+      assert_response :ok
+      assert_nil legacy.reload.repository_id
+      assert_equal OLD_NAME, legacy.repository_full_name
+      assert_equal OLD_NAME, other_channel.reload.repo_full_name
+    end
+
+    test "canonical ID-backed delivery does not run identity synchronization" do
+      CollavreGithub::RepositoryIdentitySynchronizer.stub(
+        :call,
+        ->(**) { flunk("canonical delivery must not run identity synchronization") }
+      ) do
+        post_event("issue_comment", {
+          action: "created",
+          comment: { id: 3, body: "hi", user: { login: "alice", type: "User", id: 1 } },
+          issue: { number: 99, pull_request: {} },
+          repository: { id: REPO_ID, full_name: OLD_NAME }
+        })
+      end
 
       assert_response :ok
     end

--- a/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_rename_test.rb
+++ b/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_rename_test.rb
@@ -355,6 +355,31 @@ module CollavreGithub
       assert_equal OLD_NAME, other_channel.reload.repo_full_name
     end
 
+    test "repository.renamed does not capture a descendant channel linked to a conflicting id" do
+      child = Collavre::Creative.create!(parent: @creative, user: @user, description: "Child")
+      CollavreGithub::RepositoryLink.create!(
+        creative: child,
+        github_account: @account,
+        repository_full_name: OLD_NAME,
+        repository_id: 777
+      )
+      child_topic = Collavre::Topic.create!(creative: child, user: @user, name: "Other repository")
+      child_channel = GithubPrChannel.create!(
+        topic: child_topic,
+        config: { "repo_full_name" => OLD_NAME, "pr_number" => 100 }
+      )
+
+      post_event("repository", {
+        action: "renamed",
+        changes: { repository: { name: { from: "old-name" } } },
+        repository: { id: REPO_ID, full_name: NEW_NAME, name: "new-name", owner: { login: "owner" } }
+      })
+
+      assert_response :ok
+      assert_equal NEW_NAME, @channel.reload.repo_full_name
+      assert_equal OLD_NAME, child_channel.reload.repo_full_name
+    end
+
     test "repository.renamed repairs an unbackfilled sibling with the verified secret" do
       other_creative = creatives(:childless_creative)
       sibling = CollavreGithub::RepositoryLink.create!(

--- a/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_rename_test.rb
+++ b/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_rename_test.rb
@@ -103,6 +103,32 @@ module CollavreGithub
       assert_response :ok
     end
 
+    test "identity-conflicted stale links are excluded from markdown fan-out" do
+      @link.update!(markdown_sync_enabled: true)
+      CollavreGithub::RepositoryLink.create!(
+        creative: @creative,
+        github_account: @account,
+        repository_full_name: NEW_NAME,
+        repository_id: 777
+      )
+      sync_jobs = []
+
+      CollavreGithub::MarkdownSyncJob.stub(
+        :perform_later,
+        ->(*args) { sync_jobs << args }
+      ) do
+        post_event("push", {
+          ref: "refs/heads/main",
+          repository: { id: REPO_ID, full_name: NEW_NAME }
+        })
+      end
+
+      assert_response :ok
+      assert_empty sync_jobs
+      assert_equal OLD_NAME, @link.reload.repository_full_name
+      assert_equal REPO_ID, @link.repository_id
+    end
+
     test "ID-backed missed-rename repair does not capture a NULL-id same-secret link" do
       other_creative = creatives(:childless_creative)
       legacy = CollavreGithub::RepositoryLink.create!(

--- a/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_rename_test.rb
+++ b/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_rename_test.rb
@@ -72,6 +72,37 @@ module CollavreGithub
       assert_equal NEW_NAME, @channel.reload.repo_full_name
     end
 
+    test "ordinary missed-rename collision preserves the verified secret for later deliveries" do
+      survivor = CollavreGithub::RepositoryLink.create!(
+        creative: @creative,
+        github_account: @account,
+        repository_full_name: NEW_NAME,
+        repository_id: REPO_ID,
+        webhook_secret: "unverified-survivor-secret"
+      )
+
+      post_event("issue_comment", {
+        action: "created",
+        comment: { id: 91, body: "first", user: { login: "alice", type: "User", id: 1 } },
+        issue: { number: 99, pull_request: {} },
+        repository: { id: REPO_ID, full_name: NEW_NAME }
+      })
+      assert_response :ok
+
+      assert_not CollavreGithub::RepositoryLink.exists?(@link.id)
+      assert_equal @link.webhook_secret, survivor.reload.webhook_secret
+
+      assert_difference -> { Collavre::Comment.where(topic_id: @topic.id).count }, 1 do
+        post_event("issue_comment", {
+          action: "created",
+          comment: { id: 92, body: "second", user: { login: "alice", type: "User", id: 1 } },
+          issue: { number: 99, pull_request: {} },
+          repository: { id: REPO_ID, full_name: NEW_NAME }
+        }, secret: @link.webhook_secret)
+      end
+      assert_response :ok
+    end
+
     test "ID-backed missed-rename repair does not capture a NULL-id same-secret link" do
       other_creative = creatives(:childless_creative)
       legacy = CollavreGithub::RepositoryLink.create!(
@@ -102,7 +133,7 @@ module CollavreGithub
       assert_equal OLD_NAME, other_channel.reload.repo_full_name
     end
 
-    test "ID-backed missed-rename repair preserves a NULL-id same-hook sibling" do
+    test "ID-backed missed-rename repair does not capture a NULL-id same-hook sibling" do
       @link.update!(webhook_hook_id: 77)
       other_creative = creatives(:childless_creative)
       legacy = CollavreGithub::RepositoryLink.create!(
@@ -119,7 +150,7 @@ module CollavreGithub
         config: { "repo_full_name" => OLD_NAME, "pr_number" => 99 }
       )
 
-      assert_difference -> { Collavre::Comment.where(topic_id: other_topic.id).count }, 1 do
+      assert_no_difference -> { Collavre::Comment.where(topic_id: other_topic.id).count } do
         post_event("issue_comment", {
           action: "created",
           comment: { id: 3, body: "hi", user: { login: "alice", type: "User", id: 1 } },
@@ -129,9 +160,9 @@ module CollavreGithub
       end
 
       assert_response :ok
-      assert_equal REPO_ID, legacy.reload.repository_id
-      assert_equal NEW_NAME, legacy.repository_full_name
-      assert_equal NEW_NAME, other_channel.reload.repo_full_name
+      assert_nil legacy.reload.repository_id
+      assert_equal OLD_NAME, legacy.repository_full_name
+      assert_equal OLD_NAME, other_channel.reload.repo_full_name
     end
 
     test "ID-backed repair rejects a hook id not registered to the authoritative repository" do
@@ -272,18 +303,20 @@ module CollavreGithub
       assert_includes links, @link
     end
 
-    test "repository_id is backfilled from a verified delivery" do
+    test "a name-only link requires explicit verification before delivery processing" do
       @link.update_column(:repository_id, nil)
 
-      post_event("issue_comment", {
-        action: "created",
-        comment: { id: 2, body: "hi", user: { login: "alice", type: "User", id: 1 } },
-        issue: { number: 99, pull_request: {} },
-        repository: { id: REPO_ID, full_name: OLD_NAME }
-      })
+      assert_no_difference -> { Collavre::Comment.where(topic_id: @topic.id).count } do
+        post_event("issue_comment", {
+          action: "created",
+          comment: { id: 2, body: "hi", user: { login: "alice", type: "User", id: 1 } },
+          issue: { number: 99, pull_request: {} },
+          repository: { id: REPO_ID, full_name: OLD_NAME }
+        })
+      end
 
-      assert_response :ok
-      assert_equal REPO_ID, @link.reload.repository_id
+      assert_response :unauthorized
+      assert_nil @link.reload.repository_id
     end
 
     test "repository_id is not backfilled onto a stale name match with another secret" do
@@ -332,10 +365,10 @@ module CollavreGithub
       assert_nil @link.reload.repository_id
     end
 
-    test "a verified hook id repairs a missed rename and dispatches the current event" do
+    test "a hook id and valid secret cannot establish a legacy row identity" do
       @link.update_columns(repository_id: nil, webhook_hook_id: 77)
 
-      assert_difference -> { Collavre::Comment.where(topic_id: @topic.id).count }, 1 do
+      assert_no_difference -> { Collavre::Comment.where(topic_id: @topic.id).count } do
         post_event("issue_comment", {
           action: "created",
           comment: { id: 31, body: "after missed rename", user: { login: "alice", type: "User", id: 1 } },
@@ -344,10 +377,10 @@ module CollavreGithub
         }, hook_id: 77)
       end
 
-      assert_response :ok
-      assert_equal REPO_ID, @link.reload.repository_id
-      assert_equal NEW_NAME, @link.repository_full_name
-      assert_equal NEW_NAME, @channel.reload.repo_full_name
+      assert_response :unauthorized
+      assert_nil @link.reload.repository_id
+      assert_equal OLD_NAME, @link.repository_full_name
+      assert_equal OLD_NAME, @channel.reload.repo_full_name
     end
 
     test "an unverified hook id cannot repair repository identity" do
@@ -513,7 +546,7 @@ module CollavreGithub
       assert_equal OLD_NAME, child_channel.reload.repo_full_name
     end
 
-    test "repository.renamed repairs an unbackfilled sibling with the verified secret" do
+    test "repository.renamed does not capture an unbackfilled same-secret sibling" do
       other_creative = creatives(:childless_creative)
       sibling = CollavreGithub::RepositoryLink.create!(
         creative: other_creative,
@@ -535,9 +568,9 @@ module CollavreGithub
       })
 
       assert_response :ok
-      assert_equal NEW_NAME, sibling.reload.repository_full_name
-      assert_equal REPO_ID, sibling.repository_id
-      assert_equal NEW_NAME, sibling_channel.reload.repo_full_name
+      assert_equal OLD_NAME, sibling.reload.repository_full_name
+      assert_nil sibling.repository_id
+      assert_equal OLD_NAME, sibling_channel.reload.repo_full_name
     end
 
     test "repository.renamed leaves a creative unchanged when the new name belongs to another id" do

--- a/engines/collavre_github/test/integration/pr_channel_end_to_end_test.rb
+++ b/engines/collavre_github/test/integration/pr_channel_end_to_end_test.rb
@@ -15,7 +15,8 @@ module CollavreGithub
       @link = CollavreGithub::RepositoryLink.create!(
         creative: @creative,
         github_account: @account,
-        repository_full_name: "owner/repo"
+        repository_full_name: "owner/repo",
+        repository_id: 123
       )
       @topic = Collavre::Topic.create!(creative: @creative, user: @user, name: "T")
       @channel = GithubPrChannel.create!(

--- a/engines/collavre_github/test/models/collavre_github/github_pr_channel_test.rb
+++ b/engines/collavre_github/test/models/collavre_github/github_pr_channel_test.rb
@@ -196,5 +196,16 @@ module CollavreGithub
         assert_equal s, @channel.reload.pr_state
       end
     end
+
+    test "destroy broadcasts a channel chip refresh" do
+      broadcasts = []
+      callback = ->(*args, **kwargs) { broadcasts << [ args, kwargs ] }
+
+      Collavre::CommentsPresenceChannel.stub(:broadcast_channel_chips_changed, callback) do
+        @channel.destroy!
+      end
+
+      assert_equal [ [ [ @creative.id ], { topic_id: @topic.id } ] ], broadcasts
+    end
   end
 end

--- a/engines/collavre_github/test/models/collavre_github/github_pr_channel_test.rb
+++ b/engines/collavre_github/test/models/collavre_github/github_pr_channel_test.rb
@@ -207,5 +207,64 @@ module CollavreGithub
 
       assert_equal [ [ [ @creative.id ], { topic_id: @topic.id } ] ], broadcasts
     end
+
+    test "repository name collision preserves the active monitor" do
+      canonical = GithubPrChannel.create!(
+        topic: @topic,
+        state: :detached,
+        dismissed_at: 1.hour.ago,
+        config: { "repo_full_name" => "owner/renamed", "pr_number" => 42 }
+      )
+
+      result = @channel.synchronize_repository_name!("owner/renamed")
+
+      assert_equal @channel, result
+      assert_predicate @channel.reload, :active?
+      assert_nil @channel.dismissed_at
+      assert_equal "owner/renamed", @channel.repo_full_name
+      assert_not GithubPrChannel.exists?(canonical.id)
+    end
+
+    test "repository name collision preserves a detached visible monitor" do
+      @channel.update!(state: :detached)
+      canonical = GithubPrChannel.create!(
+        topic: @topic,
+        state: :detached,
+        dismissed_at: 1.hour.ago,
+        config: { "repo_full_name" => "owner/renamed", "pr_number" => 42 }
+      )
+
+      result = @channel.synchronize_repository_name!("owner/renamed")
+
+      assert_equal @channel, result
+      assert_predicate @channel.reload, :detached?
+      assert_nil @channel.dismissed_at
+      assert_equal "owner/renamed", @channel.repo_full_name
+      assert_not GithubPrChannel.exists?(canonical.id)
+    end
+
+    test "repository name collision rolls back survivor deletion when canonical update fails" do
+      canonical = GithubPrChannel.create!(
+        topic: @topic,
+        state: :detached,
+        dismissed_at: 1.hour.ago,
+        config: { "repo_full_name" => "owner/renamed", "pr_number" => 42 }
+      )
+      broadcasts = []
+      callback = ->(*args, **kwargs) { broadcasts << [ args, kwargs ] }
+      failure = ->(*) { raise ActiveRecord::RecordInvalid, @channel }
+
+      Collavre::CommentsPresenceChannel.stub(:broadcast_channel_chips_changed, callback) do
+        @channel.stub(:update!, failure) do
+          assert_raises(ActiveRecord::RecordInvalid) do
+            @channel.synchronize_repository_name!("owner/renamed")
+          end
+        end
+      end
+
+      assert GithubPrChannel.exists?(canonical.id)
+      assert_equal "owner/repo", @channel.reload.repo_full_name
+      assert_empty broadcasts
+    end
   end
 end

--- a/engines/collavre_github/test/services/collavre_github/repository_provisioning_lock_test.rb
+++ b/engines/collavre_github/test/services/collavre_github/repository_provisioning_lock_test.rb
@@ -59,6 +59,52 @@ module CollavreGithub
       [ first, second ].compact.each(&:join)
     end
 
+    test "serializes repository names case-insensitively" do
+      first_entered = Queue.new
+      release_first = Queue.new
+      events = Queue.new
+
+      first = Thread.new do
+        RepositoryProvisioningLock.with_repository_name_lock("Owner/Repo") do
+          events << :first_entered
+          first_entered << true
+          release_first.pop
+          events << :first_leaving
+        end
+      end
+      first_entered.pop
+
+      second = Thread.new do
+        RepositoryProvisioningLock.with_repository_name_lock("owner/repo") do
+          events << :second_entered
+        end
+      end
+
+      assert_equal :first_entered, events.pop
+      assert events.empty?, "case-variant repository names entered the lock concurrently"
+
+      release_first << true
+      [ first, second ].each(&:join)
+
+      assert_equal :first_leaving, events.pop
+      assert_equal :second_entered, events.pop
+    ensure
+      release_first << true if first&.alive?
+      [ first, second ].compact.each(&:join)
+    end
+
+    test "allows a repository name lock to be reacquired by the same thread" do
+      entered = []
+
+      RepositoryProvisioningLock.with_repository_name_lock("Owner/Repo") do
+        RepositoryProvisioningLock.with_repository_name_lock("owner/repo") do
+          entered << true
+        end
+      end
+
+      assert_equal [ true ], entered
+    end
+
     test "releases a postgres lock when acquisition result handling raises" do
       connection = Class.new do
         attr_reader :queries

--- a/engines/collavre_github/test/services/collavre_github/repository_provisioning_lock_test.rb
+++ b/engines/collavre_github/test/services/collavre_github/repository_provisioning_lock_test.rb
@@ -1,0 +1,104 @@
+require_relative "../../test_helper"
+
+module CollavreGithub
+  class RepositoryProvisioningLockTest < ActiveSupport::TestCase
+    test "serializes callers for the same repository" do
+      first_entered = Queue.new
+      release_first = Queue.new
+      events = Queue.new
+
+      first = Thread.new do
+        RepositoryProvisioningLock.with_lock(101) do
+          events << :first_entered
+          first_entered << true
+          release_first.pop
+          events << :first_leaving
+        end
+      end
+      first_entered.pop
+
+      second = Thread.new do
+        RepositoryProvisioningLock.with_lock(101) do
+          events << :second_entered
+        end
+      end
+
+      assert_equal :first_entered, events.pop
+      assert events.empty?, "second caller entered before the first released the repository lock"
+
+      release_first << true
+      [ first, second ].each(&:join)
+
+      assert_equal :first_leaving, events.pop
+      assert_equal :second_entered, events.pop
+    ensure
+      release_first << true if first&.alive?
+      [ first, second ].compact.each(&:join)
+    end
+
+    test "does not serialize different repositories" do
+      first_entered = Queue.new
+      release_first = Queue.new
+      second_entered = Queue.new
+
+      first = Thread.new do
+        RepositoryProvisioningLock.with_lock(101) do
+          first_entered << true
+          release_first.pop
+        end
+      end
+      first_entered.pop
+
+      second = Thread.new do
+        RepositoryProvisioningLock.with_lock(202) { second_entered << true }
+      end
+
+      assert second_entered.pop
+    ensure
+      release_first << true if first&.alive?
+      [ first, second ].compact.each(&:join)
+    end
+
+    test "releases a postgres lock when acquisition result handling raises" do
+      connection = Class.new do
+        attr_reader :queries
+
+        def initialize
+          @queries = []
+        end
+
+        def adapter_name
+          "PostgreSQL"
+        end
+
+        def quote(value)
+          value.to_s
+        end
+
+        def select_value(query)
+          queries << query
+          raise "interrupted after server acquisition" if queries.one?
+
+          true
+        end
+      end.new
+      pool = Struct.new(:connection) do
+        def with_connection
+          yield connection
+        end
+      end.new(connection)
+
+      CollavreGithub::RepositoryLink.stub(:connection, connection) do
+        CollavreGithub::RepositoryLink.stub(:connection_pool, pool) do
+          error = assert_raises(RuntimeError) do
+            RepositoryProvisioningLock.with_lock(101) { flunk("lock body must not run") }
+          end
+          assert_equal "interrupted after server acquisition", error.message
+        end
+      end
+
+      assert_match(/\ASELECT pg_advisory_lock\(-?\d+\)\z/, connection.queries.first)
+      assert_match(/\ASELECT pg_advisory_unlock\(-?\d+\)\z/, connection.queries.second)
+    end
+  end
+end

--- a/engines/collavre_github/test/services/collavre_github/tools/pr_monitor_service_test.rb
+++ b/engines/collavre_github/test/services/collavre_github/tools/pr_monitor_service_test.rb
@@ -190,7 +190,92 @@ module CollavreGithub
         # No CollavreGithub::RepositoryLink exists for owner/repo in @creative's
         # subtree, so pr_monitor cannot provision webhook events. It should
         # surface this in the response rather than silently succeeding.
-        assert_includes result[:webhook_warning].to_s, "no RepositoryLink found"
+        assert_includes result[:webhook_warning].to_s, "no verified RepositoryLink found"
+      end
+
+      test "does not provision through a name-only legacy link" do
+        account = CollavreGithub::Account.create!(
+          user: @user,
+          github_uid: "pr-monitor-legacy",
+          login: "owner",
+          name: @user.name,
+          token: "ghp-test-token-legacy"
+        )
+        CollavreGithub::RepositoryLink.create!(
+          creative: @creative,
+          github_account: account,
+          repository_full_name: "owner/repo",
+          repository_id: nil
+        )
+
+        result = PrMonitorService.new.call(
+          topic_id: @topic.id,
+          pr_url: "https://github.com/owner/repo/pull/77"
+        )
+
+        assert_includes result[:webhook_warning].to_s, "no verified RepositoryLink found"
+        assert_not_requested :get, %r{https://api\.github\.com/repos/owner/repo}
+        assert_not_requested :post, %r{https://api\.github\.com/repos/owner/repo/hooks}
+        assert_not_requested :patch, %r{https://api\.github\.com/repos/owner/repo/hooks/}
+      end
+
+      test "skips a stale scoped id candidate and provisions through the live repository link" do
+        child = Collavre::Creative.create!(
+          parent: @creative,
+          description: "Child",
+          user: @user
+        )
+        child_topic = Collavre::Topic.create!(name: "Child topic", creative: child, user: @user)
+        account = CollavreGithub::Account.create!(
+          user: @user,
+          github_uid: "pr-monitor-reused-name",
+          login: "owner",
+          name: @user.name,
+          token: "ghp-test-token-reused"
+        )
+        CollavreGithub::RepositoryLink.create!(
+          creative: @creative,
+          github_account: account,
+          repository_full_name: "owner/repo",
+          repository_id: 111,
+          webhook_secret: "stale-secret"
+        )
+        CollavreGithub::RepositoryLink.create!(
+          creative: child,
+          github_account: account,
+          repository_full_name: "owner/repo",
+          repository_id: 222,
+          webhook_secret: "live-secret"
+        )
+        stub_github_repository("owner/repo", id: 222)
+        webhook_url = CollavreGithub::Engine.routes.url_helpers.webhooks_url(
+          Rails.application.config.action_mailer.default_url_options
+        )
+        hook_id = 31313131
+        stub_github_hooks(
+          "owner/repo",
+          hooks: [ { id: hook_id, config: { url: webhook_url }, events: [ "pull_request" ] } ]
+        )
+        patched_body = nil
+        stub_request(:patch, "https://api.github.com/repos/owner/repo/hooks/#{hook_id}")
+          .with do |request|
+            patched_body = JSON.parse(request.body)
+            true
+          end
+          .to_return(
+            status: 200,
+            body: { id: hook_id, active: true }.to_json,
+            headers: { "Content-Type" => "application/json" }
+          )
+
+        result = PrMonitorService.new.call(
+          topic_id: child_topic.id,
+          pr_url: "https://github.com/owner/repo/pull/77"
+        )
+
+        assert_nil result[:webhook_warning]
+        assert_equal "live-secret", patched_body["config"]["secret"]
+        assert_includes patched_body["events"], "repository"
       end
 
       test "auto-provisions PR-channel webhook events when a RepositoryLink exists" do
@@ -205,8 +290,10 @@ module CollavreGithub
           creative: @creative,
           github_account: account,
           repository_full_name: "owner/repo",
+          repository_id: 101,
           webhook_secret: "secret-1234567890"
         )
+        stub_github_repository("owner/repo", id: 101)
 
         # Existing hook on the repo is subscribed only to `pull_request` —
         # exactly the production bug. WebhookProvisioner must PATCH it to add
@@ -266,8 +353,10 @@ module CollavreGithub
           creative: @creative,
           github_account: account,
           repository_full_name: "owner/repo",
+          repository_id: 101,
           webhook_secret: "secret-fail-1234"
         )
+        stub_github_repository("owner/repo", id: 101)
 
         webhook_url = CollavreGithub::Engine.routes.url_helpers.webhooks_url(
           Rails.application.config.action_mailer.default_url_options
@@ -313,11 +402,13 @@ module CollavreGithub
           creative: @creative,
           github_account: account,
           repository_full_name: "owner/repo",
+          repository_id: 101,
           webhook_secret: "secret-sibling-1234",
           # Registered in this database: written by the sibling instance that
           # created the hook, which is what proves the two share state.
           webhook_hook_id: sibling_hook_id
         )
+        stub_github_repository("owner/repo", id: 101)
 
         sibling_url = "https://local.collavre.com/github/webhooks"
         stub_request(:get, %r{https://api\.github\.com/repos/owner/repo/hooks})
@@ -352,7 +443,7 @@ module CollavreGithub
           "the sibling's URL must survive the patch"
       end
 
-      test "provisions through the global primary link when topic's scoped link is non-primary" do
+      test "force-refreshes through a verified scoped link when it is non-primary" do
         # When the same repo is linked from multiple creatives,
         # WebhookProvisioner only PATCHes hook events for the lowest-id
         # (primary) link. Non-primary links short-circuit to secret alignment
@@ -379,6 +470,7 @@ module CollavreGithub
           creative: sibling_creative,
           github_account: account,
           repository_full_name: "owner/repo",
+          repository_id: 101,
           webhook_secret: "primary-secret-1234"
         )
         # Higher id, sits in the topic's creative subtree → satisfies the
@@ -387,8 +479,10 @@ module CollavreGithub
           creative: @creative,
           github_account: account,
           repository_full_name: "owner/repo",
+          repository_id: 101,
           webhook_secret: "scoped-secret-5678"
         )
+        stub_github_repository("owner/repo", id: 101)
 
         webhook_url = CollavreGithub::Engine.routes.url_helpers.webhooks_url(
           Rails.application.config.action_mailer.default_url_options

--- a/engines/collavre_github/test/services/collavre_github/tools/pr_monitor_service_test.rb
+++ b/engines/collavre_github/test/services/collavre_github/tools/pr_monitor_service_test.rb
@@ -337,6 +337,126 @@ module CollavreGithub
         assert_includes patched_events, "pull_request"
       end
 
+      test "serializes identity verification and forced refresh by repository id" do
+        account = CollavreGithub::Account.create!(
+          user: @user,
+          github_uid: "pr-monitor-prov-lock",
+          login: "owner",
+          name: @user.name,
+          token: "ghp-test-token-lock"
+        )
+        link = CollavreGithub::RepositoryLink.create!(
+          creative: @creative,
+          github_account: account,
+          repository_full_name: "owner/repo",
+          repository_id: 101,
+          webhook_secret: "secret-lock-1234"
+        )
+
+        inside_lock = false
+        identity_requests = 0
+        identity_verified_inside_lock = false
+        stub_request(:get, "https://api.github.com/repos/owner/repo")
+          .with do
+            identity_requests += 1
+            identity_verified_inside_lock = inside_lock
+            true
+          end
+          .to_return(
+            status: 200,
+            body: { id: 101, full_name: "owner/repo" }.to_json,
+            headers: { "Content-Type" => "application/json" }
+          )
+        lock_events = []
+        lock = lambda do |repository_id, &block|
+          assert_equal 101, repository_id
+          lock_events << :entered
+          inside_lock = true
+          block.call
+        ensure
+          inside_lock = false
+          lock_events << :released
+        end
+        provision = lambda do |links:, force_hook_refresh:, **|
+          assert inside_lock
+          assert_equal [ link.id ], links.map(&:id)
+          assert force_hook_refresh
+          [ [ links.fetch(0), :updated ] ]
+        end
+
+        CollavreGithub::RepositoryProvisioningLock.stub(:with_lock, lock) do
+          CollavreGithub::WebhookProvisioner.stub(:ensure_for_links, provision) do
+            result = PrMonitorService.new.call(
+              topic_id: @topic.id,
+              pr_url: "https://github.com/owner/repo/pull/77"
+            )
+
+            assert_nil result[:webhook_warning]
+          end
+        end
+
+        assert_equal [ :entered, :released ], lock_events
+        assert_equal 1, identity_requests
+        assert identity_verified_inside_lock,
+          "repository identity must be verified inside the provisioning lock"
+      end
+
+      test "tries another identity-valid account when the first hook refresh fails" do
+        first_account = CollavreGithub::Account.create!(
+          user: @user,
+          github_uid: "pr-monitor-prov-first",
+          login: "owner",
+          name: @user.name,
+          token: "ghp-test-token-first"
+        )
+        second_user = users(:two)
+        second_account = CollavreGithub::Account.create!(
+          user: second_user,
+          github_uid: "pr-monitor-prov-second",
+          login: "owner",
+          name: second_user.name,
+          token: "ghp-test-token-second"
+        )
+        child = Collavre::Creative.create!(
+          parent: @creative,
+          description: "Child",
+          user: @user
+        )
+        child_topic = Collavre::Topic.create!(name: "Child topic", creative: child, user: @user)
+        CollavreGithub::RepositoryLink.create!(
+          creative: @creative,
+          github_account: first_account,
+          repository_full_name: "owner/repo",
+          repository_id: 101,
+          webhook_secret: "secret-#{first_account.id}"
+        )
+        CollavreGithub::RepositoryLink.create!(
+          creative: child,
+          github_account: second_account,
+          repository_full_name: "owner/repo",
+          repository_id: 101,
+          webhook_secret: "secret-#{second_account.id}"
+        )
+        stub_github_repository("owner/repo", id: 101)
+        attempts = []
+        provision = lambda do |account:, links:, **|
+          attempts << account.id
+          status = account == first_account ? :failed : :updated
+          [ [ links.fetch(0), status ] ]
+        end
+
+        result = nil
+        CollavreGithub::WebhookProvisioner.stub(:ensure_for_links, provision) do
+          result = PrMonitorService.new.call(
+            topic_id: child_topic.id,
+            pr_url: "https://github.com/owner/repo/pull/77"
+          )
+        end
+
+        assert_nil result[:webhook_warning]
+        assert_equal [ first_account.id, second_account.id ], attempts
+      end
+
       test "surfaces webhook_warning when GitHub rejects the hook PATCH" do
         # CollavreGithub::Client rescues Octokit/Faraday errors silently and
         # returns nil. Without surfacing that result, pr_monitor would report

--- a/engines/collavre_github/test/services/collavre_github/webhook_provisioner_test.rb
+++ b/engines/collavre_github/test/services/collavre_github/webhook_provisioner_test.rb
@@ -561,6 +561,53 @@ module CollavreGithub
       assert_includes client.created.first[:events], "push"
     end
 
+    test "scopes provisioning to the selected repository id when a stale name is reused" do
+      @link.update!(
+        repository_id: 111,
+        webhook_secret: "stale-secret",
+        markdown_sync_enabled: true
+      )
+      valid = CollavreGithub::RepositoryLink.create!(
+        creative: creatives(:root_parent),
+        github_account: @account,
+        repository_full_name: @link.repository_full_name,
+        repository_id: 222,
+        webhook_secret: "valid-secret"
+      )
+      client = FakeClient.new(hooks: [ Hook.new(7, { "url" => OWN_URL }) ])
+
+      assert_equal [ [ valid, :updated ] ], provision(client, links: [ valid ])
+      assert_equal "valid-secret", valid.reload.webhook_secret
+      assert_nil @link.reload.webhook_hook_id
+      assert_equal 7, valid.reload.webhook_hook_id
+      assert_equal "valid-secret", client.updated.first[:secret]
+      assert_not_includes client.updated.first[:events], "push"
+    end
+
+    test "excludes name-only stale links from id-scoped provisioning" do
+      @link.update!(
+        repository_id: nil,
+        webhook_secret: "unverified-secret",
+        webhook_hook_id: 99,
+        markdown_sync_enabled: true
+      )
+      valid = CollavreGithub::RepositoryLink.create!(
+        creative: creatives(:root_parent),
+        github_account: @account,
+        repository_full_name: @link.repository_full_name,
+        repository_id: 222,
+        webhook_secret: "valid-secret"
+      )
+      client = FakeClient.new(hooks: [ Hook.new(7, { "url" => OWN_URL }) ])
+
+      assert_equal [ [ valid, :updated ] ], provision(client, links: [ valid ])
+      assert_equal "valid-secret", valid.reload.webhook_secret
+      assert_equal 99, @link.reload.webhook_hook_id
+      assert_equal 7, valid.reload.webhook_hook_id
+      assert_equal "valid-secret", client.updated.first[:secret]
+      assert_not_includes client.updated.first[:events], "push"
+    end
+
     private
 
     # Captured at WARN so the level itself is under test: an informational log

--- a/engines/collavre_github/test/services/collavre_github/webhook_provisioner_test.rb
+++ b/engines/collavre_github/test/services/collavre_github/webhook_provisioner_test.rb
@@ -489,6 +489,18 @@ module CollavreGithub
         "the winner's registration must stand"
     end
 
+    test "force refresh patches the winner after losing the registration race" do
+      sibling_hook = Hook.new(555, { "url" => SIBLING_URL })
+      client = RacingClient.new(sibling_hook: sibling_hook)
+
+      assert_equal [ [ @link, :shared ] ], provision(client, force_hook_refresh: true)
+
+      assert_equal [ 555 ], client.updated.map { |update| update[:hook_id] }
+      assert_equal SIBLING_URL, client.updated.first[:url]
+      assert_includes client.updated.first[:events], "repository"
+      assert_equal [ 101 ], client.deleted.map { |deletion| deletion[:hook_id] }
+    end
+
     test "a registration whose hook is gone from GitHub is still replaced" do
       # The counterpart to the race above, and the reason it cannot simply defer
       # to any registration it finds: a registration left behind by a deleted
@@ -608,6 +620,48 @@ module CollavreGithub
       assert_not_includes client.updated.first[:events], "push"
     end
 
+    test "isolates name-only provisioning from id-backed links with a reused name" do
+      @link.update!(
+        repository_id: 111,
+        webhook_secret: "stale-secret",
+        webhook_hook_id: 99,
+        markdown_sync_enabled: true
+      )
+      current = CollavreGithub::RepositoryLink.create!(
+        creative: creatives(:root_parent),
+        github_account: @account,
+        repository_full_name: @link.repository_full_name,
+        repository_id: nil,
+        webhook_secret: "current-secret"
+      )
+      client = FakeClient.new(hooks: [ Hook.new(7, { "url" => OWN_URL }) ])
+
+      assert_equal [ [ current, :updated ] ], provision(client, links: [ current ])
+      assert_equal "current-secret", current.reload.webhook_secret
+      assert_equal 99, @link.reload.webhook_hook_id
+      assert_equal 7, current.reload.webhook_hook_id
+      assert_equal "current-secret", client.updated.first[:secret]
+      assert_not_includes client.updated.first[:events], "push"
+    end
+
+    test "force refresh updates an existing hook through a non-primary account link" do
+      @link.update!(repository_id: 222, webhook_secret: "primary-secret")
+      fallback = CollavreGithub::RepositoryLink.create!(
+        creative: creatives(:root_parent),
+        github_account: @account,
+        repository_full_name: @link.repository_full_name,
+        repository_id: 222,
+        webhook_secret: "fallback-secret"
+      )
+      client = FakeClient.new(hooks: [ Hook.new(7, { "url" => OWN_URL }) ])
+
+      assert_equal [ [ fallback, :updated ] ],
+        provision(client, links: [ fallback ], force_hook_refresh: true)
+      assert_equal "primary-secret", fallback.reload.webhook_secret
+      assert_equal "primary-secret", client.updated.first[:secret]
+      assert_includes client.updated.first[:events], "repository"
+    end
+
     private
 
     # Captured at WARN so the level itself is under test: an informational log
@@ -623,9 +677,12 @@ module CollavreGithub
       Rails.logger = original
     end
 
-    def provision(client, webhook_url: OWN_URL, links: nil)
+    def provision(client, webhook_url: OWN_URL, links: nil, force_hook_refresh: false)
       CollavreGithub::WebhookProvisioner.new(
-        account: @account, webhook_url: webhook_url, client: client
+        account: @account,
+        webhook_url: webhook_url,
+        client: client,
+        force_hook_refresh: force_hook_refresh
       ).ensure_for_links(Array(links || @link))
     end
   end

--- a/engines/collavre_github/test/services/collavre_github/webhook_provisioner_test.rb
+++ b/engines/collavre_github/test/services/collavre_github/webhook_provisioner_test.rb
@@ -13,20 +13,12 @@ module CollavreGithub
       attr_reader :created, :updated, :deleted
       attr_accessor :hooks
 
-      attr_accessor :repo_id
-
-      def initialize(hooks: [], next_id: 100, repo_id: 555)
+      def initialize(hooks: [], next_id: 100)
         @hooks = hooks
         @created = []
         @updated = []
         @deleted = []
         @next_id = next_id
-        @repo_id = repo_id
-      end
-
-      # Mirrors Client#repository_id, which answers nil on any GitHub error.
-      def repository_id(_repo)
-        @repo_id
       end
 
       def repository_hooks(_repo)
@@ -116,32 +108,26 @@ module CollavreGithub
       )
     end
 
-    # `repository_id` is the only routing key that survives a repository
-    # rename. Stamping it at provisioning time protects a link from its first
-    # moment rather than from its first inbound delivery.
-    test "stamps the repository id onto a link that has none" do
-      client = FakeClient.new(repo_id: 4242)
+    test "does not infer a repository id from the current name during provisioning" do
+      # The stored name can be stale and already reused by another repository.
+      # Even an authenticated API lookup only proves what owns the name now,
+      # not what this legacy link originally represented.
+      client = FakeClient.new
+      client.define_singleton_method(:repository_id) { |_repo| 4242 }
       provision(client)
 
-      assert_equal 4242, @link.reload.repository_id
+      assert_nil @link.reload.repository_id
     end
 
     test "does not overwrite a repository id that is already set" do
       # An existing id anchors the link to a specific repository. Letting a
       # provisioning run move it would undo exactly the protection it provides.
       @link.update!(repository_id: 1)
-      provision(FakeClient.new(repo_id: 4242))
+      client = FakeClient.new
+      client.define_singleton_method(:repository_id) { |_repo| 4242 }
+      provision(client)
 
       assert_equal 1, @link.reload.repository_id
-    end
-
-    test "a failed repository id fetch does not fail provisioning" do
-      # Name matching still works without an id, so this must never be the
-      # thing that stops a hook being created.
-      client = FakeClient.new(repo_id: nil)
-
-      assert_equal [ [ @link, :created ] ], provision(client)
-      assert_nil @link.reload.repository_id
     end
 
     test "creates a hook when the repo has none" do

--- a/engines/collavre_github/test/services/collavre_github/webhook_provisioner_test.rb
+++ b/engines/collavre_github/test/services/collavre_github/webhook_provisioner_test.rb
@@ -13,12 +13,13 @@ module CollavreGithub
       attr_reader :created, :updated, :deleted
       attr_accessor :hooks
 
-      def initialize(hooks: [], next_id: 100)
+      def initialize(hooks: [], next_id: 100, repository_identities: {})
         @hooks = hooks
         @created = []
         @updated = []
         @deleted = []
         @next_id = next_id
+        @repository_identities = repository_identities
       end
 
       def repository_hooks(_repo)
@@ -44,6 +45,10 @@ module CollavreGithub
       def delete_repository_webhook(repo, hook_id)
         @deleted << { repo: repo, hook_id: hook_id }
         true
+      end
+
+      def repository_identity(repo)
+        @repository_identities[repo]
       end
     end
 
@@ -435,25 +440,48 @@ module CollavreGithub
     end
 
     test "removal deletes its own hook but leaves a sibling in place" do
+      @link.update!(repository_id: 222)
       client = FakeClient.new(hooks: [
         Hook.new(9, { "url" => OWN_URL }),
         Hook.new(10, { "url" => SIBLING_URL })
-      ])
+      ], repository_identities: {
+        "owner/repo" => CollavreGithub::Client::RepositoryIdentity.new(
+          id: 222,
+          full_name: "owner/repo"
+        )
+      })
       @link.destroy!
+      lock_events = []
+      lock = lambda do |repository_id, &block|
+        lock_events << [ :entered, repository_id ]
+        block.call
+        lock_events << [ :released, repository_id ]
+      end
 
-      CollavreGithub::WebhookProvisioner.new(
-        account: @account, webhook_url: OWN_URL, client: client
-      ).remove_for_repositories([ "owner/repo" ])
+      CollavreGithub::RepositoryProvisioningLock.stub(:with_lock, lock) do
+        CollavreGithub::WebhookProvisioner.new(
+          account: @account, webhook_url: OWN_URL, client: client
+        ).remove_for_links([ @link ])
+      end
 
       assert_equal [ 9 ], client.deleted.map { |d| d[:hook_id] }
+      assert_equal [ [ :entered, 222 ], [ :released, 222 ] ], lock_events
     end
 
     test "removal does not delete any hook while a link still exists" do
+      @link.update!(repository_id: 222)
+      removed = CollavreGithub::RepositoryLink.create!(
+        creative: creatives(:root_parent),
+        github_account: @account,
+        repository_full_name: "owner/repo",
+        repository_id: 222
+      )
+      removed.destroy!
       client = FakeClient.new(hooks: [ Hook.new(11, { "url" => OWN_URL }) ])
 
       CollavreGithub::WebhookProvisioner.new(
         account: @account, webhook_url: OWN_URL, client: client
-      ).remove_for_repositories([ "owner/repo" ])
+      ).remove_for_links([ removed ])
 
       assert_empty client.deleted
     end
@@ -462,12 +490,99 @@ module CollavreGithub
       # The link that still needs the hook is spelled differently from the name
       # being unlinked. Comparing exactly would conclude nothing links the repo
       # any more and tear down a hook that is still in use.
-      @link.update!(repository_full_name: "Owner/Repo")
+      @link.update!(repository_full_name: "Owner/Repo", repository_id: 222)
+      removed = CollavreGithub::RepositoryLink.create!(
+        creative: creatives(:root_parent),
+        github_account: @account,
+        repository_full_name: "owner/repo",
+        repository_id: 222
+      )
+      removed.destroy!
       client = FakeClient.new(hooks: [ Hook.new(11, { "url" => OWN_URL }) ])
 
       CollavreGithub::WebhookProvisioner.new(
         account: @account, webhook_url: OWN_URL, client: client
-      ).remove_for_repositories([ "owner/repo" ])
+      ).remove_for_links([ removed ])
+
+      assert_empty client.deleted
+    end
+
+    test "removal keeps the hook for a stale-name sibling with the same repository id" do
+      @link.update!(repository_full_name: "owner/old-name", repository_id: 222)
+      removed = CollavreGithub::RepositoryLink.create!(
+        creative: creatives(:root_parent),
+        github_account: @account,
+        repository_full_name: "owner/repo",
+        repository_id: 222
+      )
+      removed.destroy!
+      client = FakeClient.new(hooks: [ Hook.new(11, { "url" => OWN_URL }) ])
+
+      CollavreGithub::WebhookProvisioner.new(
+        account: @account, webhook_url: OWN_URL, client: client
+      ).remove_for_links([ removed ])
+
+      assert_empty client.deleted
+    end
+
+    test "removal does not use a stale name that resolves to another repository id" do
+      @link.update!(repository_full_name: "owner/reused", repository_id: 111)
+      @link.destroy!
+      client = FakeClient.new(
+        hooks: [ Hook.new(11, { "url" => OWN_URL }) ],
+        repository_identities: {
+          "owner/reused" => CollavreGithub::Client::RepositoryIdentity.new(
+            id: 222,
+            full_name: "owner/reused"
+          )
+        }
+      )
+
+      CollavreGithub::WebhookProvisioner.new(
+        account: @account, webhook_url: OWN_URL, client: client
+      ).remove_for_links([ @link ])
+
+      assert_empty client.deleted
+    end
+
+    test "removal tries every deleted alias until one verifies the repository id" do
+      @link.update!(repository_full_name: "owner/reused", repository_id: 111)
+      canonical = CollavreGithub::RepositoryLink.create!(
+        creative: creatives(:root_parent),
+        github_account: @account,
+        repository_full_name: "owner/canonical",
+        repository_id: 111
+      )
+      @link.destroy!
+      canonical.destroy!
+      client = FakeClient.new(
+        hooks: [ Hook.new(11, { "url" => OWN_URL }) ],
+        repository_identities: {
+          "owner/reused" => CollavreGithub::Client::RepositoryIdentity.new(
+            id: 222,
+            full_name: "owner/reused"
+          ),
+          "owner/canonical" => CollavreGithub::Client::RepositoryIdentity.new(
+            id: 111,
+            full_name: "owner/canonical"
+          )
+        }
+      )
+
+      CollavreGithub::WebhookProvisioner.new(
+        account: @account, webhook_url: OWN_URL, client: client
+      ).remove_for_links([ @link, canonical ])
+
+      assert_equal [ { repo: "owner/canonical", hook_id: 11 } ], client.deleted
+    end
+
+    test "removal fails closed for a name-only link" do
+      @link.destroy!
+      client = FakeClient.new(hooks: [ Hook.new(11, { "url" => OWN_URL }) ])
+
+      CollavreGithub::WebhookProvisioner.new(
+        account: @account, webhook_url: OWN_URL, client: client
+      ).remove_for_links([ @link ])
 
       assert_empty client.deleted
     end
@@ -618,6 +733,32 @@ module CollavreGithub
       assert_equal 7, valid.reload.webhook_hook_id
       assert_equal "valid-secret", client.updated.first[:secret]
       assert_not_includes client.updated.first[:events], "push"
+    end
+
+    test "id-scoped provisioning includes siblings stored under a stale name" do
+      @link.update!(
+        repository_full_name: "owner/old-name",
+        repository_id: 222,
+        webhook_secret: "primary-secret",
+        webhook_hook_id: 7,
+        markdown_sync_enabled: true
+      )
+      canonical = CollavreGithub::RepositoryLink.create!(
+        creative: creatives(:root_parent),
+        github_account: @account,
+        repository_full_name: "owner/repo",
+        repository_id: 222,
+        webhook_secret: "canonical-secret"
+      )
+      client = FakeClient.new(hooks: [ Hook.new(7, { "url" => OWN_URL }) ])
+
+      assert_equal [ [ canonical, :updated ] ],
+        provision(client, links: [ canonical ], force_hook_refresh: true)
+      assert_equal "primary-secret", @link.reload.webhook_secret
+      assert_equal "primary-secret", canonical.reload.webhook_secret
+      assert_equal 7, canonical.webhook_hook_id
+      assert_equal "primary-secret", client.updated.first[:secret]
+      assert_includes client.updated.first[:events], "push"
     end
 
     test "isolates name-only provisioning from id-backed links with a reused name" do

--- a/engines/collavre_github/test/services/collavre_github/webhook_provisioner_test.rb
+++ b/engines/collavre_github/test/services/collavre_github/webhook_provisioner_test.rb
@@ -13,12 +13,20 @@ module CollavreGithub
       attr_reader :created, :updated, :deleted
       attr_accessor :hooks
 
-      def initialize(hooks: [], next_id: 100)
+      attr_accessor :repo_id
+
+      def initialize(hooks: [], next_id: 100, repo_id: 555)
         @hooks = hooks
         @created = []
         @updated = []
         @deleted = []
         @next_id = next_id
+        @repo_id = repo_id
+      end
+
+      # Mirrors Client#repository_id, which answers nil on any GitHub error.
+      def repository_id(_repo)
+        @repo_id
       end
 
       def repository_hooks(_repo)
@@ -106,6 +114,34 @@ module CollavreGithub
         github_account: @account,
         repository_full_name: "owner/repo"
       )
+    end
+
+    # `repository_id` is the only routing key that survives a repository
+    # rename. Stamping it at provisioning time protects a link from its first
+    # moment rather than from its first inbound delivery.
+    test "stamps the repository id onto a link that has none" do
+      client = FakeClient.new(repo_id: 4242)
+      provision(client)
+
+      assert_equal 4242, @link.reload.repository_id
+    end
+
+    test "does not overwrite a repository id that is already set" do
+      # An existing id anchors the link to a specific repository. Letting a
+      # provisioning run move it would undo exactly the protection it provides.
+      @link.update!(repository_id: 1)
+      provision(FakeClient.new(repo_id: 4242))
+
+      assert_equal 1, @link.reload.repository_id
+    end
+
+    test "a failed repository id fetch does not fail provisioning" do
+      # Name matching still works without an id, so this must never be the
+      # thing that stops a hook being created.
+      client = FakeClient.new(repo_id: nil)
+
+      assert_equal [ [ @link, :created ] ], provision(client)
+      assert_nil @link.reload.repository_id
     end
 
     test "creates a hook when the repo has none" do

--- a/engines/collavre_github/test/services/collavre_github/webhook_reprovisioner_test.rb
+++ b/engines/collavre_github/test/services/collavre_github/webhook_reprovisioner_test.rb
@@ -383,6 +383,77 @@ module CollavreGithub
       assert calls.all? { |call| call[:force_hook_refresh] }
     end
 
+    test "serializes identity repair and hook refresh by repository id" do
+      @primary.destroy!
+      @sibling.destroy!
+      inside_lock = false
+      identity_verified_inside_lock = false
+      lock_events = []
+      test_case = self
+      client = Object.new
+      client.define_singleton_method(:repository_identity) do |repository_name|
+        identity_verified_inside_lock = inside_lock
+        RepositoryIdentity.new(202, repository_name)
+      end
+      lock = lambda do |repository_id, &block|
+        test_case.assert_equal 202, repository_id
+        lock_events << :entered
+        @other.update_column(:markdown_sync_enabled, true)
+        inside_lock = true
+        block.call
+      ensure
+        inside_lock = false
+        lock_events << :released
+      end
+      provision = lambda do |links:, force_hook_refresh:, **|
+        test_case.assert inside_lock
+        test_case.assert_equal [ @other.id ], links.map(&:id)
+        test_case.assert links.fetch(0).markdown_sync_enabled?
+        test_case.assert force_hook_refresh
+        [ [ links.fetch(0), :updated ] ]
+      end
+
+      results = CollavreGithub::Client.stub(:new, client) do
+        CollavreGithub::RepositoryProvisioningLock.stub(:with_lock, lock) do
+          CollavreGithub::WebhookProvisioner.stub(:ensure_for_links, provision) do
+            CollavreGithub::WebhookReprovisioner.call(
+              webhook_url: "https://example.com/github/webhooks"
+            )
+          end
+        end
+      end
+
+      assert_equal [ [ "owner/other", :updated ] ], results
+      assert_equal [ :entered, :released ], lock_events
+      assert identity_verified_inside_lock,
+        "repository identity must be verified inside the provisioning lock"
+    end
+
+    test "skips a candidate removed while waiting for the repository lock" do
+      @primary.destroy!
+      @sibling.destroy!
+      calls = []
+      lock = lambda do |_repository_id, &block|
+        @other.destroy!
+        block.call
+      end
+      provision = lambda do |**kwargs|
+        calls << kwargs
+        [ [ kwargs[:links].first, :updated ] ]
+      end
+
+      results = CollavreGithub::RepositoryProvisioningLock.stub(:with_lock, lock) do
+        CollavreGithub::WebhookProvisioner.stub(:ensure_for_links, provision) do
+          CollavreGithub::WebhookReprovisioner.call(
+            webhook_url: "https://example.com/github/webhooks"
+          )
+        end
+      end
+
+      assert_equal [ [ "owner/other", :skipped_unverified ] ], results
+      assert_empty calls
+    end
+
     test "skips a name-only legacy repository with no registered hook" do
       @other.update_columns(repository_id: nil, webhook_hook_id: nil)
       calls = []

--- a/engines/collavre_github/test/services/collavre_github/webhook_reprovisioner_test.rb
+++ b/engines/collavre_github/test/services/collavre_github/webhook_reprovisioner_test.rb
@@ -14,17 +14,20 @@ module CollavreGithub
       @primary = CollavreGithub::RepositoryLink.create!(
         creative: creatives(:tshirt),
         github_account: @account,
-        repository_full_name: "Owner/Repo"
+        repository_full_name: "Owner/Repo",
+        repository_id: 101
       )
       @sibling = CollavreGithub::RepositoryLink.create!(
         creative: creatives(:childless_creative),
         github_account: @account,
-        repository_full_name: "owner/repo"
+        repository_full_name: "owner/repo",
+        repository_id: 101
       )
       @other = CollavreGithub::RepositoryLink.create!(
         creative: creatives(:root_parent),
         github_account: @account,
-        repository_full_name: "owner/other"
+        repository_full_name: "owner/other",
+        repository_id: 202
       )
     end
 
@@ -57,6 +60,22 @@ module CollavreGithub
       end
 
       assert_equal [ [ "owner/other", :failed ], [ "owner/repo", :updated ] ], results
+    end
+
+    test "skips a name-only legacy repository rather than provisioning its current owner" do
+      @other.update_column(:repository_id, nil)
+      calls = []
+      provision = lambda do |**kwargs|
+        calls << kwargs
+        [ [ kwargs[:links].first, :updated ] ]
+      end
+
+      results = CollavreGithub::WebhookProvisioner.stub(:ensure_for_links, provision) do
+        CollavreGithub::WebhookReprovisioner.call(webhook_url: "https://example.com/github/webhooks")
+      end
+
+      assert_equal [ [ "owner/other", :skipped_unverified ], [ "owner/repo", :updated ] ], results
+      assert_equal [ @primary ], calls.map { |call| call[:links].first }
     end
   end
 end

--- a/engines/collavre_github/test/services/collavre_github/webhook_reprovisioner_test.rb
+++ b/engines/collavre_github/test/services/collavre_github/webhook_reprovisioner_test.rb
@@ -1,0 +1,62 @@
+require_relative "../../test_helper"
+
+module CollavreGithub
+  class WebhookReprovisionerTest < ActiveSupport::TestCase
+    setup do
+      @user = users(:one)
+      @account = CollavreGithub::Account.create!(
+        user: @user,
+        github_uid: "reprovisioner",
+        login: "reprovisioner",
+        name: "Reprovisioner",
+        token: "test-token"
+      )
+      @primary = CollavreGithub::RepositoryLink.create!(
+        creative: creatives(:tshirt),
+        github_account: @account,
+        repository_full_name: "Owner/Repo"
+      )
+      @sibling = CollavreGithub::RepositoryLink.create!(
+        creative: creatives(:childless_creative),
+        github_account: @account,
+        repository_full_name: "owner/repo"
+      )
+      @other = CollavreGithub::RepositoryLink.create!(
+        creative: creatives(:root_parent),
+        github_account: @account,
+        repository_full_name: "owner/other"
+      )
+    end
+
+    test "reprovisions every existing repository once through its primary link" do
+      calls = []
+      provision = lambda do |account:, links:, webhook_url:|
+        calls << { account: account, links: links, webhook_url: webhook_url }
+        [ [ links.first, :updated ] ]
+      end
+
+      results = CollavreGithub::WebhookProvisioner.stub(:ensure_for_links, provision) do
+        CollavreGithub::WebhookReprovisioner.call(webhook_url: "https://example.com/github/webhooks")
+      end
+
+      assert_equal [ [ "owner/other", :updated ], [ "owner/repo", :updated ] ], results
+      assert_equal [ @other, @primary ], calls.map { |call| call[:links].first }
+      assert calls.all? { |call| call[:account] == @account }
+      assert calls.all? { |call| call[:webhook_url] == "https://example.com/github/webhooks" }
+      assert_not_includes calls.map { |call| call[:links].first }, @sibling
+    end
+
+    test "reports a failed repository and continues reprovisioning the rest" do
+      provision = lambda do |account:, links:, webhook_url:|
+        status = links.first == @other ? :failed : :updated
+        [ [ links.first, status ] ]
+      end
+
+      results = CollavreGithub::WebhookProvisioner.stub(:ensure_for_links, provision) do
+        CollavreGithub::WebhookReprovisioner.call(webhook_url: "https://example.com/github/webhooks")
+      end
+
+      assert_equal [ [ "owner/other", :failed ], [ "owner/repo", :updated ] ], results
+    end
+  end
+end

--- a/engines/collavre_github/test/services/collavre_github/webhook_reprovisioner_test.rb
+++ b/engines/collavre_github/test/services/collavre_github/webhook_reprovisioner_test.rb
@@ -140,6 +140,18 @@ module CollavreGithub
         topic: topic,
         config: { "repo_full_name" => "owner/other", "pr_number" => 9 }
       )
+      child = Collavre::Creative.create!(parent: @other.creative, user: @user, description: "Child")
+      CollavreGithub::RepositoryLink.create!(
+        creative: child,
+        github_account: @account,
+        repository_full_name: "owner/other",
+        repository_id: 999
+      )
+      child_topic = Collavre::Topic.create!(creative: child, user: @user, name: "Conflicting repository")
+      child_channel = GithubPrChannel.create!(
+        topic: child_topic,
+        config: { "repo_full_name" => "owner/other", "pr_number" => 10 }
+      )
       client = IdentityClient.new(
         hooks: [ Hook.new(77) ],
         repository_id: 202,
@@ -160,6 +172,7 @@ module CollavreGithub
       assert_equal 202, @other.reload.repository_id
       assert_equal "owner/renamed", @other.repository_full_name
       assert_equal "owner/renamed", channel.reload.repo_full_name
+      assert_equal "owner/other", child_channel.reload.repo_full_name
     end
 
     test "skips an ID-backed stale name that now resolves to another repository" do
@@ -182,6 +195,40 @@ module CollavreGithub
       assert_empty calls
       assert_equal 202, @other.reload.repository_id
       assert_equal "owner/other", @other.repository_full_name
+    end
+
+    test "tries later same-name links when the first ID-backed candidate is stale" do
+      @primary.destroy!
+      @sibling.destroy!
+      @other.destroy!
+      stale = CollavreGithub::RepositoryLink.create!(
+        creative: creatives(:tshirt),
+        github_account: @account,
+        repository_full_name: "owner/shared",
+        repository_id: 111
+      )
+      valid = CollavreGithub::RepositoryLink.create!(
+        creative: creatives(:childless_creative),
+        github_account: @account,
+        repository_full_name: "owner/shared",
+        repository_id: 222
+      )
+      calls = []
+      provision = lambda do |**kwargs|
+        calls << kwargs
+        [ [ kwargs[:links].first, :updated ] ]
+      end
+      client = IdentityClient.new(hooks: [], repository_id: 222)
+
+      results = CollavreGithub::Client.stub(:new, client) do
+        CollavreGithub::WebhookProvisioner.stub(:ensure_for_links, provision) do
+          CollavreGithub::WebhookReprovisioner.call(webhook_url: "https://example.com/github/webhooks")
+        end
+      end
+
+      assert_equal [ [ "owner/shared", :updated ] ], results
+      assert_equal [ valid ], calls.map { |call| call[:links].first }
+      assert_equal 111, stale.reload.repository_id
     end
 
     test "skips a name-only legacy repository with no registered hook" do

--- a/engines/collavre_github/test/services/collavre_github/webhook_reprovisioner_test.rb
+++ b/engines/collavre_github/test/services/collavre_github/webhook_reprovisioner_test.rb
@@ -65,8 +65,13 @@ module CollavreGithub
 
     test "reprovisions every existing repository once through its primary link" do
       calls = []
-      provision = lambda do |account:, links:, webhook_url:|
-        calls << { account: account, links: links, webhook_url: webhook_url }
+      provision = lambda do |account:, links:, webhook_url:, force_hook_refresh:|
+        calls << {
+          account: account,
+          links: links,
+          webhook_url: webhook_url,
+          force_hook_refresh: force_hook_refresh
+        }
         [ [ links.first, :updated ] ]
       end
 
@@ -84,11 +89,13 @@ module CollavreGithub
       assert_equal [ @other, @primary ], calls.map { |call| call[:links].first }
       assert calls.all? { |call| call[:account] == @account }
       assert calls.all? { |call| call[:webhook_url] == "https://example.com/github/webhooks" }
+      assert calls.all? { |call| call[:force_hook_refresh] }
       assert_not_includes calls.map { |call| call[:links].first }, @sibling
     end
 
     test "reports a failed repository and continues reprovisioning the rest" do
-      provision = lambda do |account:, links:, webhook_url:|
+      provision = lambda do |account:, links:, webhook_url:, force_hook_refresh:|
+        assert force_hook_refresh
         status = links.first == @other ? :failed : :updated
         [ [ links.first, status ] ]
       end
@@ -309,6 +316,7 @@ module CollavreGithub
       assert_equal [ [ "owner/shared", :updated ] ], results
       assert_equal [ first, second ], calls.map { |call| call[:links].first }
       assert_equal [ first_account, second_account ], calls.map { |call| call[:account] }
+      assert calls.all? { |call| call[:force_hook_refresh] }
     end
 
     test "skips a name-only legacy repository with no registered hook" do

--- a/engines/collavre_github/test/services/collavre_github/webhook_reprovisioner_test.rb
+++ b/engines/collavre_github/test/services/collavre_github/webhook_reprovisioner_test.rb
@@ -175,6 +175,43 @@ module CollavreGithub
       assert_equal "owner/other", child_channel.reload.repo_full_name
     end
 
+    test "merges an old-name channel when the canonical channel already exists" do
+      @primary.destroy!
+      @sibling.destroy!
+      topic = Collavre::Topic.create!(creative: @other.creative, user: @user, name: "Duplicate")
+      obsolete = GithubPrChannel.create!(
+        topic: topic,
+        config: { "repo_full_name" => "owner/other", "pr_number" => 9 }
+      )
+      survivor = GithubPrChannel.create!(
+        topic: topic,
+        config: {
+          "repo_full_name" => "OWNER/RENAMED",
+          "pr_number" => 9,
+          "ignore_actor_logins" => [ "existing-bot" ]
+        }
+      )
+      client = IdentityClient.new(
+        hooks: [],
+        repository_id: 202,
+        repository_full_name: "owner/renamed"
+      )
+      provision = ->(**kwargs) { [ [ kwargs[:links].first, :updated ] ] }
+
+      results = CollavreGithub::Client.stub(:new, client) do
+        CollavreGithub::WebhookProvisioner.stub(:ensure_for_links, provision) do
+          CollavreGithub::WebhookReprovisioner.call(webhook_url: "https://example.com/github/webhooks")
+        end
+      end
+
+      assert_equal [ [ "owner/other", :updated ] ], results
+      assert_not GithubPrChannel.exists?(obsolete.id)
+      assert GithubPrChannel.exists?(survivor.id)
+      assert_equal [ survivor.id ],
+        GithubPrChannel.where(topic: topic, repo_full_name: "owner/renamed", pr_number: 9).pluck(:id)
+      assert_equal [ "existing-bot" ], survivor.reload.config["ignore_actor_logins"]
+    end
+
     test "skips an ID-backed stale name that now resolves to another repository" do
       @primary.destroy!
       @sibling.destroy!

--- a/engines/collavre_github/test/services/collavre_github/webhook_reprovisioner_test.rb
+++ b/engines/collavre_github/test/services/collavre_github/webhook_reprovisioner_test.rb
@@ -3,13 +3,15 @@ require_relative "../../test_helper"
 module CollavreGithub
   class WebhookReprovisionerTest < ActiveSupport::TestCase
     Hook = Struct.new(:id)
+    RepositoryIdentity = Struct.new(:id, :full_name)
 
     class IdentityClient
       attr_reader :repository_names
 
-      def initialize(hooks:, repository_id:)
+      def initialize(hooks:, repository_id:, repository_full_name: nil)
         @hooks = hooks
         @repository_id = repository_id
+        @repository_full_name = repository_full_name
         @repository_names = []
       end
 
@@ -18,9 +20,17 @@ module CollavreGithub
         @hooks
       end
 
-      def repository_id(repository_name)
+      def repository_identity(repository_name)
         @repository_names << repository_name
-        @repository_id
+        repository_id = configured_value(@repository_id, repository_name)
+        full_name = configured_value(@repository_full_name, repository_name) || repository_name
+        RepositoryIdentity.new(repository_id, full_name)
+      end
+
+      private
+
+      def configured_value(value, repository_name)
+        value.is_a?(Hash) ? value.fetch(repository_name.downcase) : value
       end
     end
 
@@ -60,8 +70,14 @@ module CollavreGithub
         [ [ links.first, :updated ] ]
       end
 
-      results = CollavreGithub::WebhookProvisioner.stub(:ensure_for_links, provision) do
-        CollavreGithub::WebhookReprovisioner.call(webhook_url: "https://example.com/github/webhooks")
+      client = IdentityClient.new(
+        hooks: [],
+        repository_id: { "owner/other" => 202, "owner/repo" => 101 }
+      )
+      results = CollavreGithub::Client.stub(:new, client) do
+        CollavreGithub::WebhookProvisioner.stub(:ensure_for_links, provision) do
+          CollavreGithub::WebhookReprovisioner.call(webhook_url: "https://example.com/github/webhooks")
+        end
       end
 
       assert_equal [ [ "owner/other", :updated ], [ "owner/repo", :updated ] ], results
@@ -77,8 +93,14 @@ module CollavreGithub
         [ [ links.first, status ] ]
       end
 
-      results = CollavreGithub::WebhookProvisioner.stub(:ensure_for_links, provision) do
-        CollavreGithub::WebhookReprovisioner.call(webhook_url: "https://example.com/github/webhooks")
+      client = IdentityClient.new(
+        hooks: [],
+        repository_id: { "owner/other" => 202, "owner/repo" => 101 }
+      )
+      results = CollavreGithub::Client.stub(:new, client) do
+        CollavreGithub::WebhookProvisioner.stub(:ensure_for_links, provision) do
+          CollavreGithub::WebhookReprovisioner.call(webhook_url: "https://example.com/github/webhooks")
+        end
       end
 
       assert_equal [ [ "owner/other", :failed ], [ "owner/repo", :updated ] ], results
@@ -92,7 +114,10 @@ module CollavreGithub
         calls << kwargs
         [ [ kwargs[:links].first, :updated ] ]
       end
-      client = IdentityClient.new(hooks: [ Hook.new(77) ], repository_id: 202)
+      client = IdentityClient.new(
+        hooks: [ Hook.new(77) ],
+        repository_id: { "owner/other" => 202, "owner/repo" => 101 }
+      )
 
       results = CollavreGithub::Client.stub(:new, client) do
         CollavreGithub::WebhookProvisioner.stub(:ensure_for_links, provision) do
@@ -103,7 +128,60 @@ module CollavreGithub
       assert_equal [ [ "owner/other", :updated ], [ "owner/repo", :updated ] ], results
       assert_equal [ @other, @primary ], calls.map { |call| call[:links].first }
       assert_equal 202, @other.reload.repository_id
-      assert_equal [ "owner/other", "owner/other" ], client.repository_names
+      assert_equal [ "owner/other", "owner/other", "Owner/Repo" ], client.repository_names
+    end
+
+    test "persists the canonical repository name and renames channels during legacy reconciliation" do
+      @primary.destroy!
+      @sibling.destroy!
+      @other.update_columns(repository_id: nil, webhook_hook_id: 77)
+      topic = Collavre::Topic.create!(creative: @other.creative, user: @user, name: "Legacy")
+      channel = GithubPrChannel.create!(
+        topic: topic,
+        config: { "repo_full_name" => "owner/other", "pr_number" => 9 }
+      )
+      client = IdentityClient.new(
+        hooks: [ Hook.new(77) ],
+        repository_id: 202,
+        repository_full_name: "owner/renamed"
+      )
+      provision = lambda do |**kwargs|
+        assert_equal "owner/renamed", kwargs[:links].first.repository_full_name
+        [ [ kwargs[:links].first, :updated ] ]
+      end
+
+      results = CollavreGithub::Client.stub(:new, client) do
+        CollavreGithub::WebhookProvisioner.stub(:ensure_for_links, provision) do
+          CollavreGithub::WebhookReprovisioner.call(webhook_url: "https://example.com/github/webhooks")
+        end
+      end
+
+      assert_equal [ [ "owner/other", :updated ] ], results
+      assert_equal 202, @other.reload.repository_id
+      assert_equal "owner/renamed", @other.repository_full_name
+      assert_equal "owner/renamed", channel.reload.repo_full_name
+    end
+
+    test "skips an ID-backed stale name that now resolves to another repository" do
+      @primary.destroy!
+      @sibling.destroy!
+      calls = []
+      provision = lambda do |**kwargs|
+        calls << kwargs
+        [ [ kwargs[:links].first, :updated ] ]
+      end
+      client = IdentityClient.new(hooks: [], repository_id: 999)
+
+      results = CollavreGithub::Client.stub(:new, client) do
+        CollavreGithub::WebhookProvisioner.stub(:ensure_for_links, provision) do
+          CollavreGithub::WebhookReprovisioner.call(webhook_url: "https://example.com/github/webhooks")
+        end
+      end
+
+      assert_equal [ [ "owner/other", :skipped_unverified ] ], results
+      assert_empty calls
+      assert_equal 202, @other.reload.repository_id
+      assert_equal "owner/other", @other.repository_full_name
     end
 
     test "skips a name-only legacy repository with no registered hook" do
@@ -114,8 +192,11 @@ module CollavreGithub
         [ [ kwargs[:links].first, :updated ] ]
       end
 
-      results = CollavreGithub::WebhookProvisioner.stub(:ensure_for_links, provision) do
-        CollavreGithub::WebhookReprovisioner.call(webhook_url: "https://example.com/github/webhooks")
+      client = IdentityClient.new(hooks: [], repository_id: 101)
+      results = CollavreGithub::Client.stub(:new, client) do
+        CollavreGithub::WebhookProvisioner.stub(:ensure_for_links, provision) do
+          CollavreGithub::WebhookReprovisioner.call(webhook_url: "https://example.com/github/webhooks")
+        end
       end
 
       assert_equal [ [ "owner/other", :skipped_unverified ], [ "owner/repo", :updated ] ], results
@@ -130,7 +211,10 @@ module CollavreGithub
         calls << kwargs
         [ [ kwargs[:links].first, :updated ] ]
       end
-      client = IdentityClient.new(hooks: [ Hook.new(88) ], repository_id: 999)
+      client = IdentityClient.new(
+        hooks: [ Hook.new(88) ],
+        repository_id: { "owner/other" => 999, "owner/repo" => 101 }
+      )
 
       results = CollavreGithub::Client.stub(:new, client) do
         CollavreGithub::WebhookProvisioner.stub(:ensure_for_links, provision) do
@@ -141,7 +225,7 @@ module CollavreGithub
       assert_equal [ [ "owner/other", :skipped_unverified ], [ "owner/repo", :updated ] ], results
       assert_equal [ @primary ], calls.map { |call| call[:links].first }
       assert_nil @other.reload.repository_id
-      assert_equal [ "owner/other" ], client.repository_names
+      assert_equal [ "owner/other", "Owner/Repo" ], client.repository_names
     end
   end
 end

--- a/engines/collavre_github/test/services/collavre_github/webhook_reprovisioner_test.rb
+++ b/engines/collavre_github/test/services/collavre_github/webhook_reprovisioner_test.rb
@@ -268,6 +268,49 @@ module CollavreGithub
       assert_equal 111, stale.reload.repository_id
     end
 
+    test "tries a later account when an identity-valid candidate cannot update the hook" do
+      @primary.destroy!
+      @sibling.destroy!
+      @other.destroy!
+      first_account = @account
+      second_account = CollavreGithub::Account.create!(
+        user: users(:two),
+        github_uid: "second-reprovisioner",
+        login: "second-reprovisioner",
+        name: "Second Reprovisioner",
+        token: "second-token"
+      )
+      first = CollavreGithub::RepositoryLink.create!(
+        creative: creatives(:tshirt),
+        github_account: first_account,
+        repository_full_name: "owner/shared",
+        repository_id: 222
+      )
+      second = CollavreGithub::RepositoryLink.create!(
+        creative: creatives(:childless_creative),
+        github_account: second_account,
+        repository_full_name: "owner/shared",
+        repository_id: 222
+      )
+      calls = []
+      provision = lambda do |**kwargs|
+        calls << kwargs
+        status = kwargs[:account] == first_account ? :failed : :updated
+        [ [ kwargs[:links].first, status ] ]
+      end
+      client = IdentityClient.new(hooks: [], repository_id: 222)
+
+      results = CollavreGithub::Client.stub(:new, client) do
+        CollavreGithub::WebhookProvisioner.stub(:ensure_for_links, provision) do
+          CollavreGithub::WebhookReprovisioner.call(webhook_url: "https://example.com/github/webhooks")
+        end
+      end
+
+      assert_equal [ [ "owner/shared", :updated ] ], results
+      assert_equal [ first, second ], calls.map { |call| call[:links].first }
+      assert_equal [ first_account, second_account ], calls.map { |call| call[:account] }
+    end
+
     test "skips a name-only legacy repository with no registered hook" do
       @other.update_columns(repository_id: nil, webhook_hook_id: nil)
       calls = []

--- a/engines/collavre_github/test/services/collavre_github/webhook_reprovisioner_test.rb
+++ b/engines/collavre_github/test/services/collavre_github/webhook_reprovisioner_test.rb
@@ -2,6 +2,28 @@ require_relative "../../test_helper"
 
 module CollavreGithub
   class WebhookReprovisionerTest < ActiveSupport::TestCase
+    Hook = Struct.new(:id)
+
+    class IdentityClient
+      attr_reader :repository_names
+
+      def initialize(hooks:, repository_id:)
+        @hooks = hooks
+        @repository_id = repository_id
+        @repository_names = []
+      end
+
+      def repository_hooks!(repository_name)
+        @repository_names << repository_name
+        @hooks
+      end
+
+      def repository_id(repository_name)
+        @repository_names << repository_name
+        @repository_id
+      end
+    end
+
     setup do
       @user = users(:one)
       @account = CollavreGithub::Account.create!(
@@ -62,8 +84,30 @@ module CollavreGithub
       assert_equal [ [ "owner/other", :failed ], [ "owner/repo", :updated ] ], results
     end
 
-    test "skips a name-only legacy repository rather than provisioning its current owner" do
+    test "reprovisions a name-only legacy repository after its registered hook proves identity" do
       @other.update_column(:repository_id, nil)
+      @other.update_column(:webhook_hook_id, 77)
+      calls = []
+      provision = lambda do |**kwargs|
+        calls << kwargs
+        [ [ kwargs[:links].first, :updated ] ]
+      end
+      client = IdentityClient.new(hooks: [ Hook.new(77) ], repository_id: 202)
+
+      results = CollavreGithub::Client.stub(:new, client) do
+        CollavreGithub::WebhookProvisioner.stub(:ensure_for_links, provision) do
+          CollavreGithub::WebhookReprovisioner.call(webhook_url: "https://example.com/github/webhooks")
+        end
+      end
+
+      assert_equal [ [ "owner/other", :updated ], [ "owner/repo", :updated ] ], results
+      assert_equal [ @other, @primary ], calls.map { |call| call[:links].first }
+      assert_equal 202, @other.reload.repository_id
+      assert_equal [ "owner/other", "owner/other" ], client.repository_names
+    end
+
+    test "skips a name-only legacy repository with no registered hook" do
+      @other.update_columns(repository_id: nil, webhook_hook_id: nil)
       calls = []
       provision = lambda do |**kwargs|
         calls << kwargs
@@ -76,6 +120,28 @@ module CollavreGithub
 
       assert_equal [ [ "owner/other", :skipped_unverified ], [ "owner/repo", :updated ] ], results
       assert_equal [ @primary ], calls.map { |call| call[:links].first }
+      assert_nil @other.reload.repository_id
+    end
+
+    test "skips a stale legacy name when the current repository does not own the registered hook" do
+      @other.update_columns(repository_id: nil, webhook_hook_id: 77)
+      calls = []
+      provision = lambda do |**kwargs|
+        calls << kwargs
+        [ [ kwargs[:links].first, :updated ] ]
+      end
+      client = IdentityClient.new(hooks: [ Hook.new(88) ], repository_id: 999)
+
+      results = CollavreGithub::Client.stub(:new, client) do
+        CollavreGithub::WebhookProvisioner.stub(:ensure_for_links, provision) do
+          CollavreGithub::WebhookReprovisioner.call(webhook_url: "https://example.com/github/webhooks")
+        end
+      end
+
+      assert_equal [ [ "owner/other", :skipped_unverified ], [ "owner/repo", :updated ] ], results
+      assert_equal [ @primary ], calls.map { |call| call[:links].first }
+      assert_nil @other.reload.repository_id
+      assert_equal [ "owner/other" ], client.repository_names
     end
   end
 end

--- a/engines/collavre_github/test/services/collavre_github/webhook_reprovisioner_test.rb
+++ b/engines/collavre_github/test/services/collavre_github/webhook_reprovisioner_test.rb
@@ -113,7 +113,7 @@ module CollavreGithub
       assert_equal [ [ "owner/other", :failed ], [ "owner/repo", :updated ] ], results
     end
 
-    test "reprovisions a name-only legacy repository after its registered hook proves identity" do
+    test "skips a name-only legacy repository even when its registered hook is live" do
       @other.update_column(:repository_id, nil)
       @other.update_column(:webhook_hook_id, 77)
       calls = []
@@ -132,16 +132,80 @@ module CollavreGithub
         end
       end
 
-      assert_equal [ [ "owner/other", :updated ], [ "owner/repo", :updated ] ], results
-      assert_equal [ @other, @primary ], calls.map { |call| call[:links].first }
-      assert_equal 202, @other.reload.repository_id
-      assert_equal [ "owner/other", "owner/other", "Owner/Repo" ], client.repository_names
+      assert_equal [ [ "owner/other", :manual_verification_required ], [ "owner/repo", :updated ] ], results
+      assert_equal [ @primary ], calls.map { |call| call[:links].first }
+      assert_nil @other.reload.repository_id
+      assert_equal [ "Owner/Repo" ], client.repository_names
     end
 
-    test "persists the canonical repository name and renames channels during legacy reconciliation" do
+    test "does not treat a copied legacy hook registration as repository identity" do
       @primary.destroy!
       @sibling.destroy!
-      @other.update_columns(repository_id: nil, webhook_hook_id: 77)
+      @other.destroy!
+      contaminated = CollavreGithub::RepositoryLink.create!(
+        creative: creatives(:tshirt),
+        github_account: @account,
+        repository_full_name: "owner/reused",
+        repository_id: nil,
+        webhook_hook_id: 77,
+        webhook_secret: "shared-secret"
+      )
+      valid = CollavreGithub::RepositoryLink.create!(
+        creative: creatives(:childless_creative),
+        github_account: @account,
+        repository_full_name: "owner/reused",
+        repository_id: 222,
+        webhook_hook_id: 77,
+        webhook_secret: "shared-secret"
+      )
+      calls = []
+      provision = lambda do |**kwargs|
+        calls << kwargs
+        [ [ kwargs[:links].first, :updated ] ]
+      end
+      client = IdentityClient.new(
+        hooks: [ Hook.new(77) ],
+        repository_id: 222
+      )
+
+      results = CollavreGithub::Client.stub(:new, client) do
+        CollavreGithub::WebhookProvisioner.stub(:ensure_for_links, provision) do
+          CollavreGithub::WebhookReprovisioner.call(webhook_url: "https://example.com/github/webhooks")
+        end
+      end
+
+      assert_equal [ [ "owner/reused", :manual_verification_required ] ], results
+      assert_equal [ valid ], calls.map { |call| call[:links].first }
+      assert_nil contaminated.reload.repository_id
+      assert_equal "owner/reused", contaminated.repository_full_name
+    end
+
+    test "reports a failed ID-backed candidate when its same-name legacy row also needs verification" do
+      legacy = CollavreGithub::RepositoryLink.create!(
+        creative: creatives(:root_parent),
+        github_account: @account,
+        repository_full_name: "owner/repo",
+        repository_id: nil,
+        webhook_hook_id: @primary.webhook_hook_id,
+        webhook_secret: @primary.webhook_secret
+      )
+      client = IdentityClient.new(hooks: [], repository_id: 101)
+      provision = ->(**kwargs) { [ [ kwargs[:links].first, :failed ] ] }
+
+      results = CollavreGithub::Client.stub(:new, client) do
+        CollavreGithub::WebhookProvisioner.stub(:ensure_for_links, provision) do
+          CollavreGithub::WebhookReprovisioner.call(webhook_url: "https://example.com/github/webhooks")
+        end
+      end
+
+      assert_equal :failed, results.assoc("owner/repo").last
+      assert_nil legacy.reload.repository_id
+    end
+
+    test "persists the canonical repository name and renames channels during reconciliation" do
+      @primary.destroy!
+      @sibling.destroy!
+      @other.update_column(:webhook_hook_id, 77)
       topic = Collavre::Topic.create!(creative: @other.creative, user: @user, name: "Legacy")
       channel = GithubPrChannel.create!(
         topic: topic,
@@ -334,7 +398,7 @@ module CollavreGithub
         end
       end
 
-      assert_equal [ [ "owner/other", :skipped_unverified ], [ "owner/repo", :updated ] ], results
+      assert_equal [ [ "owner/other", :manual_verification_required ], [ "owner/repo", :updated ] ], results
       assert_equal [ @primary ], calls.map { |call| call[:links].first }
       assert_nil @other.reload.repository_id
     end
@@ -357,10 +421,10 @@ module CollavreGithub
         end
       end
 
-      assert_equal [ [ "owner/other", :skipped_unverified ], [ "owner/repo", :updated ] ], results
+      assert_equal [ [ "owner/other", :manual_verification_required ], [ "owner/repo", :updated ] ], results
       assert_equal [ @primary ], calls.map { |call| call[:links].first }
       assert_nil @other.reload.repository_id
-      assert_equal [ "owner/other", "Owner/Repo" ], client.repository_names
+      assert_equal [ "Owner/Repo" ], client.repository_names
     end
   end
 end

--- a/engines/collavre_github/test/test_helper.rb
+++ b/engines/collavre_github/test/test_helper.rb
@@ -78,6 +78,15 @@ module CollavreGithubTestHelpers
       )
   end
 
+  def stub_github_repository(repo, id:, full_name: repo)
+    stub_request(:get, "https://api.github.com/repos/#{repo}")
+      .to_return(
+        status: 200,
+        body: { id: id, full_name: full_name }.to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+  end
+
   def stub_github_create_hook(repo)
     stub_request(:post, "https://api.github.com/repos/#{repo}/hooks")
       .to_return(

--- a/script/reprovision_github_webhooks
+++ b/script/reprovision_github_webhooks
@@ -5,4 +5,29 @@ results.each do |repository, status|
 end
 
 failed = results.select { |_repository, status| status == :failed }
-abort "GitHub webhook reprovisioning failed for: #{failed.map(&:first).join(", ")}" if failed.any?
+warn "GitHub webhook reprovisioning failed for: #{failed.map(&:first).join(", ")}" if failed.any?
+
+manual_links = CollavreGithub::RepositoryLink
+  .where(repository_id: nil)
+  .includes(:github_account)
+  .order(:id)
+  .to_a
+if manual_links.any?
+  warn "GitHub repository links requiring explicit identity verification:"
+  manual_links.each do |link|
+    warn(
+      "  link_id=#{link.id} creative_id=#{link.creative_id} " \
+      "account_id=#{link.github_account_id} account=#{link.github_account&.login.inspect} " \
+      "stored_name=#{link.repository_full_name.inspect}"
+    )
+  end
+  manual_names = manual_links.map { |link| link.repository_full_name.downcase }.uniq.sort
+  warn(
+    "GitHub repository identity verification required for: #{manual_names.join(", ")}. " \
+    "For each row, run GITHUB_REPOSITORY_LINK_ID=<link_id> " \
+    "GITHUB_REPOSITORY=<owner/name> bin/rails runner " \
+    "script/verify_github_repository_link_identity, then rerun this script."
+  )
+end
+
+abort "GitHub webhook reconciliation requires operator action" if failed.any? || manual_links.any?

--- a/script/reprovision_github_webhooks
+++ b/script/reprovision_github_webhooks
@@ -1,0 +1,8 @@
+results = CollavreGithub::WebhookReprovisioner.call
+
+results.each do |repository, status|
+  puts "#{repository}: #{status}"
+end
+
+failed = results.select { |_repository, status| status == :failed }
+abort "GitHub webhook reprovisioning failed for: #{failed.map(&:first).join(", ")}" if failed.any?

--- a/script/verify_github_repository_link_identity
+++ b/script/verify_github_repository_link_identity
@@ -1,0 +1,63 @@
+link_id = Integer(ENV["GITHUB_REPOSITORY_LINK_ID"].to_s, 10, exception: false)
+repository_name = ENV["GITHUB_REPOSITORY"].to_s.strip
+unless link_id&.positive? && repository_name.present?
+  abort(
+    "Usage: GITHUB_REPOSITORY_LINK_ID=<link_id> GITHUB_REPOSITORY=<owner/name> " \
+    "bin/rails runner script/verify_github_repository_link_identity"
+  )
+end
+
+link = CollavreGithub::RepositoryLink.find_by(id: link_id)
+abort "GitHub repository link #{link_id} was not found" unless link
+abort "GitHub repository link #{link_id} already has repository_id=#{link.repository_id}" if link.repository_id.present?
+abort "GitHub repository link #{link_id} has no GitHub account" unless link.github_account
+
+begin
+  client = CollavreGithub::Client.new(link.github_account)
+  identity = client.repository_identity(repository_name)
+  unless identity&.id.present? && identity&.full_name.present?
+    abort "GitHub could not verify repository #{repository_name.inspect} for link #{link_id}"
+  end
+
+  provisioning_account = link.github_account
+  verified_link = nil
+  status = :failed
+  failure_message = nil
+  CollavreGithub::RepositoryLink.transaction do
+    synchronized = CollavreGithub::RepositoryIdentitySynchronizer.call(
+      anchor: link,
+      repository_id: identity.id,
+      full_name: identity.full_name,
+      trusted_secret: link.webhook_secret,
+      allow_anchor_backfill: true
+    )
+    verified_link = synchronized.find { |candidate| candidate.creative_id == link.creative_id }
+    unless verified_link
+      failure_message = "GitHub repository link #{link_id} could not be reattached safely"
+      raise ActiveRecord::Rollback
+    end
+    if verified_link.github_account_id != provisioning_account.id
+      verified_link.update!(github_account: provisioning_account)
+    end
+
+    result = CollavreGithub::WebhookProvisioner.ensure_for_links(
+      account: provisioning_account,
+      links: [ verified_link ],
+      webhook_url: CollavreGithub::WebhookReprovisioner.default_webhook_url,
+      force_hook_refresh: true
+    )
+    status = result.first&.last || :failed
+    if status == :failed
+      failure_message = "GitHub webhook provisioning failed for #{identity.full_name}"
+      raise ActiveRecord::Rollback
+    end
+  end
+  abort failure_message if failure_message
+
+  puts(
+    "GitHub repository link #{verified_link.id} verified as " \
+    "#{identity.full_name} (repository_id=#{identity.id}); webhook=#{status}"
+  )
+rescue Octokit::Error, Faraday::Error => e
+  abort "GitHub repository verification failed: #{e.class}: #{e.message}"
+end

--- a/script/verify_github_repository_link_identity
+++ b/script/verify_github_repository_link_identity
@@ -19,37 +19,55 @@ begin
     abort "GitHub could not verify repository #{repository_name.inspect} for link #{link_id}"
   end
 
-  provisioning_account = link.github_account
+  expected_account_id = link.github_account_id
   verified_link = nil
   status = :failed
   failure_message = nil
-  CollavreGithub::RepositoryLink.transaction do
-    synchronized = CollavreGithub::RepositoryIdentitySynchronizer.call(
-      anchor: link,
-      repository_id: identity.id,
-      full_name: identity.full_name,
-      trusted_secret: link.webhook_secret,
-      allow_anchor_backfill: true
-    )
-    verified_link = synchronized.find { |candidate| candidate.creative_id == link.creative_id }
-    unless verified_link
-      failure_message = "GitHub repository link #{link_id} could not be reattached safely"
-      raise ActiveRecord::Rollback
-    end
-    if verified_link.github_account_id != provisioning_account.id
-      verified_link.update!(github_account: provisioning_account)
-    end
+  CollavreGithub::RepositoryProvisioningLock.with_lock(identity.id) do
+    CollavreGithub::RepositoryLink.transaction do
+      locked_link = CollavreGithub::RepositoryLink.find_by(id: link_id)
+      unless locked_link && locked_link.repository_id.nil? &&
+          locked_link.github_account_id == expected_account_id
+        failure_message = "GitHub repository link #{link_id} changed while awaiting verification"
+        raise ActiveRecord::Rollback
+      end
 
-    result = CollavreGithub::WebhookProvisioner.ensure_for_links(
-      account: provisioning_account,
-      links: [ verified_link ],
-      webhook_url: CollavreGithub::WebhookReprovisioner.default_webhook_url,
-      force_hook_refresh: true
-    )
-    status = result.first&.last || :failed
-    if status == :failed
-      failure_message = "GitHub webhook provisioning failed for #{identity.full_name}"
-      raise ActiveRecord::Rollback
+      provisioning_account = locked_link.github_account.reload
+      locked_client = CollavreGithub::Client.new(provisioning_account)
+      locked_identity = locked_client.repository_identity(repository_name)
+      unless locked_identity&.id.to_s == identity.id.to_s && locked_identity&.full_name.present?
+        failure_message = "GitHub repository #{repository_name.inspect} changed while awaiting verification"
+        raise ActiveRecord::Rollback
+      end
+      identity = locked_identity
+
+      synchronized = CollavreGithub::RepositoryIdentitySynchronizer.call(
+        anchor: locked_link,
+        repository_id: identity.id,
+        full_name: identity.full_name,
+        trusted_secret: locked_link.webhook_secret,
+        allow_anchor_backfill: true
+      )
+      verified_link = synchronized.find { |candidate| candidate.creative_id == locked_link.creative_id }
+      unless verified_link
+        failure_message = "GitHub repository link #{link_id} could not be reattached safely"
+        raise ActiveRecord::Rollback
+      end
+      if verified_link.github_account_id != provisioning_account.id
+        verified_link.update!(github_account: provisioning_account)
+      end
+
+      result = CollavreGithub::WebhookProvisioner.ensure_for_links(
+        account: provisioning_account,
+        links: [ verified_link ],
+        webhook_url: CollavreGithub::WebhookReprovisioner.default_webhook_url,
+        force_hook_refresh: true
+      )
+      status = result.first&.last || :failed
+      if status == :failed
+        failure_message = "GitHub webhook provisioning failed for #{identity.full_name}"
+        raise ActiveRecord::Rollback
+      end
     end
   end
   abort failure_message if failure_message

--- a/test/controllers/github/webhooks_controller_test.rb
+++ b/test/controllers/github/webhooks_controller_test.rb
@@ -16,6 +16,7 @@ class CollavreGithub::WebhooksControllerTest < ActionDispatch::IntegrationTest
       creative: @creative,
       github_account: @account,
       repository_full_name: "webhook-user/example",
+      repository_id: 123,
       webhook_secret: "existing-secret"
     )
     @payload = {

--- a/test/lib/kamal_post_deploy_hook_test.rb
+++ b/test/lib/kamal_post_deploy_hook_test.rb
@@ -1,0 +1,37 @@
+require "test_helper"
+require "fileutils"
+require "open3"
+require "tmpdir"
+
+class KamalPostDeployHookTest < ActiveSupport::TestCase
+  test "reprovisions webhooks when post-deploy omits KAMAL_COMMAND" do
+    Dir.mktmpdir do |directory|
+      FileUtils.mkdir_p("#{directory}/.kamal/hooks")
+      FileUtils.mkdir_p("#{directory}/bin")
+      FileUtils.cp(Rails.root.join(".kamal/hooks/post-deploy"), "#{directory}/.kamal/hooks/post-deploy")
+      File.write(
+        "#{directory}/bin/kamal",
+        <<~SH
+          #!/bin/sh
+          printf '%s\n' "$@" > kamal-arguments
+        SH
+      )
+      FileUtils.chmod("+x", "#{directory}/bin/kamal")
+
+      _stdout, stderr, status = Open3.capture3(
+        { "KAMAL_COMMAND" => nil },
+        "#{directory}/.kamal/hooks/post-deploy",
+        chdir: directory
+      )
+
+      assert status.success?, stderr
+      arguments = File.readlines("#{directory}/kamal-arguments", chomp: true)
+      assert_equal [ "app", "exec", "--primary", "--reuse" ], arguments.first(4)
+      assert_equal(
+        "if [ -f script/reprovision_github_webhooks ]; " \
+          "then bin/rails runner script/reprovision_github_webhooks; fi",
+        arguments.last
+      )
+    end
+  end
+end

--- a/test/lib/reprovision_github_webhooks_script_test.rb
+++ b/test/lib/reprovision_github_webhooks_script_test.rb
@@ -1,0 +1,206 @@
+require "test_helper"
+
+class ReprovisionGithubWebhooksScriptTest < ActiveSupport::TestCase
+  RepositoryIdentity = Struct.new(:id, :full_name)
+
+  test "fails with remediation when legacy links need identity verification" do
+    account = CollavreGithub::Account.create!(
+      user: users(:one),
+      github_uid: "legacy-script",
+      login: "legacy-script",
+      name: "Legacy Script",
+      token: "test-token"
+    )
+    link = CollavreGithub::RepositoryLink.create!(
+      creative: creatives(:tshirt),
+      github_account: account,
+      repository_full_name: "owner/legacy",
+      repository_id: nil
+    )
+    results = [
+      [ "owner/legacy", :failed ]
+    ]
+
+    _stdout, stderr = capture_io do
+      CollavreGithub::WebhookReprovisioner.stub(:call, results) do
+        error = assert_raises(SystemExit) do
+          load Rails.root.join("script/reprovision_github_webhooks")
+        end
+        assert_equal 1, error.status
+      end
+    end
+
+    assert_includes stderr, "GitHub repository identity verification required for: owner/legacy"
+    assert_includes stderr, "GitHub webhook reprovisioning failed for: owner/legacy"
+    assert_includes stderr, "link_id=#{link.id} creative_id=#{link.creative_id}"
+    assert_includes stderr, "account_id=#{account.id} account=\"legacy-script\""
+    assert_includes stderr, "script/verify_github_repository_link_identity"
+  end
+
+  test "explicitly verifies and reattaches a legacy link without replacing it" do
+    account = CollavreGithub::Account.create!(
+      user: users(:one),
+      github_uid: "reattach-script",
+      login: "reattach-script",
+      name: "Reattach Script",
+      token: "test-token"
+    )
+    link = CollavreGithub::RepositoryLink.create!(
+      creative: creatives(:tshirt),
+      github_account: account,
+      repository_full_name: "owner/stale",
+      repository_id: nil,
+      markdown_sync_enabled: true,
+      sync_branch: "docs"
+    )
+    client = Object.new
+    client.define_singleton_method(:repository_identity) do |_repository_name|
+      RepositoryIdentity.new(4242, "owner/canonical")
+    end
+    provision = lambda do |account:, links:, webhook_url:, force_hook_refresh:|
+      assert_equal link.github_account, account
+      assert_equal [ link.id ], links.map(&:id)
+      assert_equal 4242, links.first.repository_id
+      assert force_hook_refresh
+      assert webhook_url.present?
+      [ [ links.first, :updated ] ]
+    end
+
+    previous_link_id = ENV["GITHUB_REPOSITORY_LINK_ID"]
+    previous_repository = ENV["GITHUB_REPOSITORY"]
+    ENV["GITHUB_REPOSITORY_LINK_ID"] = link.id.to_s
+    ENV["GITHUB_REPOSITORY"] = "owner/selected"
+    stdout, _stderr = capture_io do
+      CollavreGithub::Client.stub(:new, client) do
+        CollavreGithub::WebhookProvisioner.stub(:ensure_for_links, provision) do
+          load Rails.root.join("script/verify_github_repository_link_identity")
+        end
+      end
+    end
+
+    link.reload
+    assert_equal 4242, link.repository_id
+    assert_equal "owner/canonical", link.repository_full_name
+    assert link.markdown_sync_enabled?
+    assert_equal "docs", link.sync_branch
+    assert_includes stdout, "repository_id=4242"
+  ensure
+    ENV["GITHUB_REPOSITORY_LINK_ID"] = previous_link_id
+    ENV["GITHUB_REPOSITORY"] = previous_repository
+  end
+
+  test "failed hook refresh rolls explicit identity changes back" do
+    account = CollavreGithub::Account.create!(
+      user: users(:one),
+      github_uid: "reattach-rollback",
+      login: "reattach-rollback",
+      name: "Reattach Rollback",
+      token: "test-token"
+    )
+    link = CollavreGithub::RepositoryLink.create!(
+      creative: creatives(:tshirt),
+      github_account: account,
+      repository_full_name: "owner/stale",
+      repository_id: nil,
+      markdown_sync_enabled: true,
+      sync_branch: "docs"
+    )
+    client = Object.new
+    client.define_singleton_method(:repository_identity) do |_repository_name|
+      RepositoryIdentity.new(4242, "owner/canonical")
+    end
+    provision = ->(**) { [ [ link, :failed ] ] }
+
+    previous_link_id = ENV["GITHUB_REPOSITORY_LINK_ID"]
+    previous_repository = ENV["GITHUB_REPOSITORY"]
+    ENV["GITHUB_REPOSITORY_LINK_ID"] = link.id.to_s
+    ENV["GITHUB_REPOSITORY"] = "owner/selected"
+    _stdout, stderr = capture_io do
+      CollavreGithub::Client.stub(:new, client) do
+        CollavreGithub::WebhookProvisioner.stub(:ensure_for_links, provision) do
+          error = assert_raises(SystemExit) do
+            load Rails.root.join("script/verify_github_repository_link_identity")
+          end
+          assert_equal 1, error.status
+        end
+      end
+    end
+
+    link.reload
+    assert_nil link.repository_id
+    assert_equal "owner/stale", link.repository_full_name
+    assert link.markdown_sync_enabled?
+    assert_equal "docs", link.sync_branch
+    assert_includes stderr, "GitHub webhook provisioning failed for owner/canonical"
+  ensure
+    ENV["GITHUB_REPOSITORY_LINK_ID"] = previous_link_id
+    ENV["GITHUB_REPOSITORY"] = previous_repository
+  end
+
+  test "reattach provisions through the explicitly verified account after a survivor merge" do
+    verified_account = CollavreGithub::Account.create!(
+      user: users(:one),
+      github_uid: "reattach-verified",
+      login: "reattach-verified",
+      name: "Reattach Verified",
+      token: "verified-token"
+    )
+    survivor_account = CollavreGithub::Account.create!(
+      user: users(:two),
+      github_uid: "reattach-survivor",
+      login: "reattach-survivor",
+      name: "Reattach Survivor",
+      token: "survivor-token"
+    )
+    link = CollavreGithub::RepositoryLink.create!(
+      creative: creatives(:tshirt),
+      github_account: verified_account,
+      repository_full_name: "owner/stale",
+      repository_id: nil,
+      webhook_secret: "verified-secret",
+      markdown_sync_enabled: true
+    )
+    survivor = CollavreGithub::RepositoryLink.create!(
+      creative: link.creative,
+      github_account: survivor_account,
+      repository_full_name: "owner/canonical",
+      repository_id: 4242,
+      webhook_secret: "survivor-secret"
+    )
+    client = Object.new
+    client.define_singleton_method(:repository_identity) do |_repository_name|
+      RepositoryIdentity.new(4242, "owner/canonical")
+    end
+    provision = lambda do |account:, links:, **|
+      assert_equal verified_account, account
+      assert_equal [ survivor.id ], links.map(&:id)
+      [ [ links.first, :updated ] ]
+    end
+
+    previous_link_id = ENV["GITHUB_REPOSITORY_LINK_ID"]
+    previous_repository = ENV["GITHUB_REPOSITORY"]
+    ENV["GITHUB_REPOSITORY_LINK_ID"] = link.id.to_s
+    ENV["GITHUB_REPOSITORY"] = "owner/selected"
+    CollavreGithub::Client.stub(:new, client) do
+      CollavreGithub::WebhookProvisioner.stub(:ensure_for_links, provision) do
+        capture_io { load Rails.root.join("script/verify_github_repository_link_identity") }
+      end
+    end
+
+    assert_not CollavreGithub::RepositoryLink.exists?(link.id)
+    survivor.reload
+    assert_equal verified_account, survivor.github_account
+    assert_equal "verified-secret", survivor.webhook_secret
+    assert survivor.markdown_sync_enabled?
+
+    results = CollavreGithub::Client.stub(:new, client) do
+      CollavreGithub::WebhookProvisioner.stub(:ensure_for_links, provision) do
+        CollavreGithub::WebhookReprovisioner.call(webhook_url: "https://example.com/github/webhooks")
+      end
+    end
+    assert_equal [ [ "owner/canonical", :updated ] ], results
+  ensure
+    ENV["GITHUB_REPOSITORY_LINK_ID"] = previous_link_id
+    ENV["GITHUB_REPOSITORY"] = previous_repository
+  end
+end

--- a/test/lib/reprovision_github_webhooks_script_test.rb
+++ b/test/lib/reprovision_github_webhooks_script_test.rb
@@ -53,12 +53,31 @@ class ReprovisionGithubWebhooksScriptTest < ActiveSupport::TestCase
       markdown_sync_enabled: true,
       sync_branch: "docs"
     )
+    locked = false
+    lock_ids = []
+    identity_lookups_inside_lock = []
+    lock = lambda do |repository_id, &block|
+      lock_ids << repository_id
+      account.update!(token: "rotated-token")
+      locked = true
+      block.call
+    ensure
+      locked = false
+    end
     client = Object.new
     client.define_singleton_method(:repository_identity) do |_repository_name|
+      identity_lookups_inside_lock << locked
       RepositoryIdentity.new(4242, "owner/canonical")
     end
+    client_tokens = []
+    client_factory = lambda do |client_account|
+      client_tokens << client_account.token
+      client
+    end
     provision = lambda do |account:, links:, webhook_url:, force_hook_refresh:|
+      assert locked
       assert_equal link.github_account, account
+      assert_equal "rotated-token", account.token
       assert_equal [ link.id ], links.map(&:id)
       assert_equal 4242, links.first.repository_id
       assert force_hook_refresh
@@ -71,13 +90,18 @@ class ReprovisionGithubWebhooksScriptTest < ActiveSupport::TestCase
     ENV["GITHUB_REPOSITORY_LINK_ID"] = link.id.to_s
     ENV["GITHUB_REPOSITORY"] = "owner/selected"
     stdout, _stderr = capture_io do
-      CollavreGithub::Client.stub(:new, client) do
-        CollavreGithub::WebhookProvisioner.stub(:ensure_for_links, provision) do
-          load Rails.root.join("script/verify_github_repository_link_identity")
+      CollavreGithub::RepositoryProvisioningLock.stub(:with_lock, lock) do
+        CollavreGithub::Client.stub(:new, client_factory) do
+          CollavreGithub::WebhookProvisioner.stub(:ensure_for_links, provision) do
+            load Rails.root.join("script/verify_github_repository_link_identity")
+          end
         end
       end
     end
 
+    assert_equal [ 4242 ], lock_ids
+    assert_equal [ false, true ], identity_lookups_inside_lock
+    assert_equal [ "test-token", "rotated-token" ], client_tokens
     link.reload
     assert_equal 4242, link.repository_id
     assert_equal "owner/canonical", link.repository_full_name


### PR DESCRIPTION
## Problem

`sh1nj1/claude-max-api-proxy` was renamed to `sh1nj1/cli-openai-proxy` on GitHub. From that moment every webhook delivery for the repository was answered **401**, in every linked creative at once.

`repository_full_name` was the only key webhook routing matched on:

1. Payload carries the new `repository.full_name`
2. `find_repository_link` matched on the name only → `nil`
3. `webhook_secret` fell through to a fallback that production does not configure
4. `secret.blank?` → `head :unauthorized`, **before dispatch**

The deliveries ledger is written after signature verification, so this left no local trace. PR chips stayed attached, the "monitoring started" message had already posted, and the topics just went quiet. The only evidence was a red row in GitHub's hook UI.

This was originally reported as "a repo linked to two creatives only delivers to one". Fan-out itself is fine — both creatives were dead, for this reason.

## Changes

**Match on `repository.id`.** It survives a rename; the name does not. When an ID is present, signature lookup prioritizes an exact ID-backed row, and fan-out, rename, synchronization, and dispatch are restricted to that exact ID. Rows carrying another ID or a NULL ID are excluded.

Repository IDs are accepted only from authenticated GitHub API selection or explicit operator reattachment. Older name-scoped provisioners could propagate hook registrations and secrets across unrelated same-name rows, so neither value is treated as row identity. NULL-ID inbound deliveries fail closed and are never auto-backfilled or promoted through hook IDs or shared secrets.

Outbound hook mutations use the same boundary. Newly selected repositories persist the stable ID returned by the authenticated GitHub API before provisioning. Existing integration links and `pr_monitor` candidates are revalidated against the live ID; NULL-ID or mismatched stale-name links cannot read, create, or update hooks. Post-deploy reconciliation forces a real hook refresh through fallback accounts and also refreshes a registration-race winner before discarding the duplicate hook.

Concurrent integration saves are serialized by stable repository ID before opening the per-repository transaction. The lock spans link persistence, remote hook mutation, and commit/rollback, so a second creative reuses the first committed secret and hook registration instead of racing an isolated uncommitted row.

ID-backed provisioning shares primary secrets, hook registration, and event requirements across every stored-name alias for the exact repository ID. Removal uses the same repository lock, rechecks exact-ID survivors after locking, verifies each deleted alias against GitHub's live stable ID, and deletes only through the verified canonical name. NULL-ID removal fails closed.

**Require explicit verification for legacy NULL-ID links.** Post-deploy reconciliation refreshes safe ID-backed hooks, lists every NULL-ID link with its link, creative, account, and stored repository name, and exits non-zero. `script/verify_github_repository_link_identity` lets an operator map one selected link to the intended repository: it resolves the stable ID through that link's authenticated account, preserves link settings and the verified account through collisions, force-refreshes the hook transactionally, and rolls the database state back if the refresh fails.

**Repair a missed rename from any verified ID-backed delivery.** When an ordinary delivery authenticates through the stable repository ID but carries a different canonical name, the controller repairs exact-ID links and channels before dispatching the current event. Collision survivors retain the secret that authenticated the delivery. NULL-ID siblings never join automatically, and canonical deliveries keep a fast path that skips synchronization.

**Handle `repository`/`renamed`**, rewriting both links and attached channels' `repo_full_name`, and subscribe hooks to the event. If a delayed rename collides with an existing new-name link for the same repository and creative, the obsolete row is merged into the survivor. Channel renames also reject descendant scopes that carry an ID-backed conflicting repository under the old name, so an ancestor link cannot capture a child repository's monitor.

**Reprovision existing hooks after deploy.** A Kamal `post-deploy` hook reconciles ID-backed repositories against the current event list, including the `repository` event. For a reused name it tries every ID-backed candidate until one proves the live GitHub identity; a stale first row cannot hide a later valid link. Mixed ID/NULL groups may refresh the proven hook but still report manual verification, and every NULL-ID row is listed independently even when another candidate fails. The script exits non-zero for either reconciliation failures or unresolved legacy identity.

**Announce other unidentifiable deliveries in matching monitoring channels.** A rejected delivery for an already monitored name now posts a canned warning, throttled to once an hour per channel. The lookup is guarded by one fixed global cache key and uses an indexed name query. ID-backed missed renames are repaired through the stable repository ID. A NULL-ID link requires explicit reattachment because neither a stored name, hook ID, nor shared secret safely proves which repository owns that row.

A mere signature **mismatch** stays silent. There the repository was identified and a secret was found; the caller just did not sign with it, which is what probing looks like. The message renders the channel's own stored repo name, never the rejected payload's.

## Known gaps characterized, not fixed

Two pre-existing scope-gate asymmetries are pinned by tests asserting **current** behaviour, so they cannot change by accident:

- an alias creative (`origin_id` set) is out of scope even when its origin holds the link
- a link held on a *descendant* of the topic's creative never reaches the topic

Widening that gate is a security decision — the same check is what stops a PR description from injecting into another tenant's topic — so it is left for an explicit call.

`pr_monitor` still returns `ok: true` with only a `webhook_warning` field when it attaches outside link scope. Also left as-is; now asserted so the silent-success path is at least visible in the suite.

## Verification

- Full suite: 3,331 runs, 10,506 assertions, 0 failures
- GitHub-focused regression set: 276 runs, 1,025 assertions, 0 failures
- System suite: 45 runs, 225 assertions, 0 failures, 2 skips
- RuboCop: 1,114 files, 0 offenses; i18n en/ko parity checked
- Production data repaired ahead of this PR (links repointed at the new name and stamped with the repo id); the hook's `last_response` went from `401 Invalid HTTP Response` to `200 OK`


