### PR TITLE
fix: prevent password save prompts for secret fields

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/secret_fields.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/secret_fields.css
@@ -1,0 +1,3 @@
+.masked-secret-field {
+  -webkit-text-security: disc;
+}

--- a/engines/collavre/app/controllers/concerns/collavre/users_controller/ai_user_management.rb
+++ b/engines/collavre/app/controllers/concerns/collavre/users_controller/ai_user_management.rb
@@ -59,6 +59,7 @@ module Collavre
 
     def update_ai
       ai_params = params.require(:user).permit(:name, :system_prompt, :llm_vendor, :llm_model, :llm_api_key, :gateway_url, :searchable, :routing_expression, :agent_conf, tools: [])
+      ai_params.delete(:llm_api_key) if ai_params[:llm_api_key].blank?
 
       if @user.update(ai_params)
         redirect_to edit_ai_user_path(@user), notice: I18n.t("collavre.users.update_ai.success")

--- a/engines/collavre/app/controllers/concerns/collavre/users_controller/ai_user_management.rb
+++ b/engines/collavre/app/controllers/concerns/collavre/users_controller/ai_user_management.rb
@@ -58,8 +58,14 @@ module Collavre
     end
 
     def update_ai
-      ai_params = params.require(:user).permit(:name, :system_prompt, :llm_vendor, :llm_model, :llm_api_key, :gateway_url, :searchable, :routing_expression, :agent_conf, tools: [])
-      ai_params.delete(:llm_api_key) if ai_params[:llm_api_key].blank?
+      ai_params = params.require(:user).permit(:name, :system_prompt, :llm_vendor, :llm_model, :llm_api_key, :clear_llm_api_key, :gateway_url, :searchable, :routing_expression, :agent_conf, tools: [])
+      clear_llm_api_key = ActiveModel::Type::Boolean.new.cast(ai_params.delete(:clear_llm_api_key))
+
+      if clear_llm_api_key
+        ai_params[:llm_api_key] = nil
+      elsif ai_params[:llm_api_key].blank?
+        ai_params.delete(:llm_api_key)
+      end
 
       if @user.update(ai_params)
         redirect_to edit_ai_user_path(@user), notice: I18n.t("collavre.users.update_ai.success")

--- a/engines/collavre/app/controllers/concerns/collavre/users_controller/ai_user_management.rb
+++ b/engines/collavre/app/controllers/concerns/collavre/users_controller/ai_user_management.rb
@@ -55,11 +55,14 @@ module Collavre
 
     def edit_ai
       @available_tools = load_available_tools
+      @has_stored_llm_api_key = @user.llm_api_key.present?
     end
 
     def update_ai
       ai_params = params.require(:user).permit(:name, :system_prompt, :llm_vendor, :llm_model, :llm_api_key, :clear_llm_api_key, :gateway_url, :searchable, :routing_expression, :agent_conf, tools: [])
       clear_llm_api_key = ActiveModel::Type::Boolean.new.cast(ai_params.delete(:clear_llm_api_key))
+      @has_stored_llm_api_key = @user.llm_api_key.present?
+      @clear_llm_api_key = clear_llm_api_key
 
       if clear_llm_api_key
         ai_params[:llm_api_key] = nil

--- a/engines/collavre/app/helpers/collavre/application_helper.rb
+++ b/engines/collavre/app/helpers/collavre/application_helper.rb
@@ -6,6 +6,7 @@ module Collavre
     COLLAVRE_STYLESHEETS = %w[
       collavre/design_tokens
       collavre/dark_mode
+      collavre/secret_fields
       collavre/gnb
       collavre/creatives
       collavre/actiontext
@@ -41,6 +42,14 @@ module Collavre
         stylesheet_link_tag(sheet, media: "print")
       end
       safe_join(tags, "\n    ")
+    end
+
+    def masked_secret_field(form, method, options = {})
+      form.text_field(method, masked_secret_field_options(options))
+    end
+
+    def masked_secret_field_tag(name, value = nil, options = {})
+      text_field_tag(name, value, masked_secret_field_options(options))
     end
 
     # Returns the body CSS class for the current user's theme.
@@ -96,6 +105,10 @@ module Collavre
     end
 
     private
+
+    def masked_secret_field_options(options)
+      options.merge(autocomplete: "off", spellcheck: false, class: class_names("masked-secret-field", options[:class]))
+    end
 
     CSS_VARIABLE_KEY_PATTERN = /\A--[a-zA-Z0-9_-]+\z/
     CSS_VARIABLE_VALUE_PATTERN = /\A[^;}{<>"']+\z/

--- a/engines/collavre/app/helpers/collavre/application_helper.rb
+++ b/engines/collavre/app/helpers/collavre/application_helper.rb
@@ -107,7 +107,12 @@ module Collavre
     private
 
     def masked_secret_field_options(options)
-      options.merge(autocomplete: "off", spellcheck: false, class: class_names("masked-secret-field", options[:class]))
+      options.merge(
+        autocomplete: "off",
+        autocapitalize: "none",
+        spellcheck: false,
+        class: class_names("masked-secret-field", options[:class])
+      )
     end
 
     CSS_VARIABLE_KEY_PATTERN = /\A--[a-zA-Z0-9_-]+\z/

--- a/engines/collavre/app/views/collavre/admin/integrations/_setting_row.html.erb
+++ b/engines/collavre/app/views/collavre/admin/integrations/_setting_row.html.erb
@@ -38,14 +38,11 @@
             rows: 8,
             style: "width: 100%; font-family: var(--font-mono, monospace); font-size: 0.85em; min-height: 8em;" %>
     <% else %>
-      <% input_tag = definition.sensitive ? :password_field_tag : :text_field_tag %>
-      <%= send(input_tag,
-            "integration_setting[#{key_str}]",
-            nil,
-            form: bulk_form_id,
-            placeholder: current_display,
-            autocomplete: "off",
-            style: "width: 100%;") %>
+      <% if definition.sensitive %>
+	<%= masked_secret_field_tag "integration_setting[#{key_str}]", nil, form: bulk_form_id, placeholder: current_display, style: "width: 100%;" %>
+      <% else %>
+	<%= text_field_tag "integration_setting[#{key_str}]", nil, form: bulk_form_id, placeholder: current_display, autocomplete: "off", style: "width: 100%;" %>
+      <% end %>
     <% end %>
     <div style="font-size: 0.8em; margin-top: 0.25em;">
       <span class="badge badge-source-<%= row[:source] %>" style="display: inline-block; padding: 0.1em 0.5em; font-size: 0.85em; border-radius: 3px; background: <%= source_bg %>; color: <%= source_fg %>;">

--- a/engines/collavre/app/views/collavre/users/edit_ai.html.erb
+++ b/engines/collavre/app/views/collavre/users/edit_ai.html.erb
@@ -42,7 +42,7 @@
 
   <div class="form-group">
     <%= form.label :llm_api_key, t('collavre.users.new_ai.api_key_label') %>
-    <%= form.password_field :llm_api_key, class: "stacked-form-control", placeholder: "sk-...", value: @user.llm_api_key %>
+    <%= masked_secret_field form, :llm_api_key, class: "stacked-form-control", placeholder: "sk-...", value: @user.llm_api_key %>
     <small class="form-text text-muted"><%= t('collavre.users.new_ai.api_key_help') %></small>
   </div>
 

--- a/engines/collavre/app/views/collavre/users/edit_ai.html.erb
+++ b/engines/collavre/app/views/collavre/users/edit_ai.html.erb
@@ -44,6 +44,13 @@
     <%= form.label :llm_api_key, t('collavre.users.new_ai.api_key_label') %>
     <%= masked_secret_field form, :llm_api_key, class: "stacked-form-control", placeholder: "sk-...", value: nil %>
     <small class="form-text text-muted"><%= t('collavre.users.new_ai.api_key_help') %></small>
+    <% if @user.llm_api_key.present? %>
+      <div class="form-check mt-2">
+        <%= check_box_tag "user[clear_llm_api_key]", "1", false, id: "user_clear_llm_api_key", class: "form-check-input" %>
+        <%= label_tag "user_clear_llm_api_key", t("collavre.users.edit_ai.clear_api_key_label"), class: "form-check-label" %>
+      </div>
+      <small class="form-text text-muted"><%= t("collavre.users.edit_ai.clear_api_key_help") %></small>
+    <% end %>
   </div>
 
   <div class="form-group">

--- a/engines/collavre/app/views/collavre/users/edit_ai.html.erb
+++ b/engines/collavre/app/views/collavre/users/edit_ai.html.erb
@@ -44,9 +44,9 @@
     <%= form.label :llm_api_key, t('collavre.users.new_ai.api_key_label') %>
     <%= masked_secret_field form, :llm_api_key, class: "stacked-form-control", placeholder: "sk-...", value: nil %>
     <small class="form-text text-muted"><%= t('collavre.users.new_ai.api_key_help') %></small>
-    <% if @user.llm_api_key.present? %>
+    <% if @has_stored_llm_api_key %>
       <div class="form-check mt-2">
-        <%= check_box_tag "user[clear_llm_api_key]", "1", false, id: "user_clear_llm_api_key", class: "form-check-input" %>
+	<%= check_box_tag "user[clear_llm_api_key]", "1", @clear_llm_api_key, id: "user_clear_llm_api_key", class: "form-check-input" %>
         <%= label_tag "user_clear_llm_api_key", t("collavre.users.edit_ai.clear_api_key_label"), class: "form-check-label" %>
       </div>
       <small class="form-text text-muted"><%= t("collavre.users.edit_ai.clear_api_key_help") %></small>

--- a/engines/collavre/app/views/collavre/users/edit_ai.html.erb
+++ b/engines/collavre/app/views/collavre/users/edit_ai.html.erb
@@ -42,7 +42,7 @@
 
   <div class="form-group">
     <%= form.label :llm_api_key, t('collavre.users.new_ai.api_key_label') %>
-    <%= masked_secret_field form, :llm_api_key, class: "stacked-form-control", placeholder: "sk-...", value: @user.llm_api_key %>
+    <%= masked_secret_field form, :llm_api_key, class: "stacked-form-control", placeholder: "sk-...", value: nil %>
     <small class="form-text text-muted"><%= t('collavre.users.new_ai.api_key_help') %></small>
   </div>
 

--- a/engines/collavre/app/views/collavre/users/new_ai.html.erb
+++ b/engines/collavre/app/views/collavre/users/new_ai.html.erb
@@ -57,7 +57,7 @@
 
   <div class="form-group">
     <%= form.label :llm_api_key, t('collavre.users.new_ai.api_key_label') %>
-    <%= form.password_field :llm_api_key, class: "stacked-form-control", placeholder: "sk-..." %>
+    <%= masked_secret_field form, :llm_api_key, class: "stacked-form-control", placeholder: "sk-..." %>
     <small class="form-text text-muted"><%= t('collavre.users.new_ai.api_key_help') %></small>
   </div>
 

--- a/engines/collavre/config/locales/users.en.yml
+++ b/engines/collavre/config/locales/users.en.yml
@@ -54,6 +54,9 @@ en:
         tools_title: Available Tools
         tools_description: These tools are available for the agent to use.
         no_tools_found: No tools found.
+        clear_api_key_label: Remove stored API key
+        clear_api_key_help: After saving, the agent will use the system default or
+          a keyless gateway.
         agent_conf_label: "Agent Configuration (YAML)"
         agent_conf_help: "YAML configuration for agent behavior. chat_history: max previous messages (default 50), chat_history_size: max total characters (default 100000), context.creative_children_level: depth of children to include in creative context (default nil → follows user setting, 0=no children, 1=direct children, 2=grandchildren)."
         chat_title: Chat with Agent

--- a/engines/collavre/config/locales/users.ko.yml
+++ b/engines/collavre/config/locales/users.ko.yml
@@ -52,6 +52,8 @@ ko:
         tools_title: 사용 가능한 도구
         tools_description: 에이전트가 사용할 수 있는 도구 목록입니다.
         no_tools_found: 사용 가능한 도구가 없습니다.
+        clear_api_key_label: 저장된 API 키 삭제
+        clear_api_key_help: 저장 후 시스템 기본 키 또는 키가 필요 없는 게이트웨이를 사용합니다.
         agent_conf_label: "에이전트 설정 (YAML)"
         agent_conf_help: "에이전트 동작을 위한 YAML 설정. chat_history: 최대 이전 메시지 수 (기본 50), chat_history_size: 최대 총 문자 수 (기본 100000), context.creative_children_level: 크리에이티브 컨텍스트에 포함할 자식 깊이 (기본 nil → 사용자 설정 따름, 0=자식 없음, 1=직접 자식, 2=손자까지)."
         chat_title: 에이전트와 대화하기

--- a/engines/collavre/test/controllers/admin_integrations_controller_test.rb
+++ b/engines/collavre/test/controllers/admin_integrations_controller_test.rb
@@ -56,6 +56,16 @@ class AdminIntegrationsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "index masks sensitive inputs without using password fields" do
+    sign_in_as(@admin, password: "password")
+
+    get collavre.admin_integrations_path
+
+    assert_select "input[type='text'][name='integration_setting[slack_client_secret]'].masked-secret-field[autocomplete='off'][spellcheck='false']"
+    assert_select "input[type='password'][name='integration_setting[slack_client_secret]']", count: 0
+    assert_select "input[type='text'][name='integration_setting[slack_client_id]']:not(.masked-secret-field)"
+  end
+
   # ---------- index display ----------
 
   test "index masks sensitive values" do

--- a/engines/collavre/test/controllers/admin_integrations_controller_test.rb
+++ b/engines/collavre/test/controllers/admin_integrations_controller_test.rb
@@ -61,7 +61,7 @@ class AdminIntegrationsControllerTest < ActionDispatch::IntegrationTest
 
     get collavre.admin_integrations_path
 
-    assert_select "input[type='text'][name='integration_setting[slack_client_secret]'].masked-secret-field[autocomplete='off'][spellcheck='false']"
+    assert_select "input[type='text'][name='integration_setting[slack_client_secret]'].masked-secret-field[autocomplete='off'][autocapitalize='none'][spellcheck='false']"
     assert_select "input[type='password'][name='integration_setting[slack_client_secret]']", count: 0
     assert_select "input[type='text'][name='integration_setting[slack_client_id]']:not(.masked-secret-field)"
   end

--- a/engines/collavre/test/controllers/users_controller_ai_test.rb
+++ b/engines/collavre/test/controllers/users_controller_ai_test.rb
@@ -100,6 +100,19 @@ class UsersControllerAiTest < ActionDispatch::IntegrationTest
     assert_nil @ai_user.reload.llm_api_key
   end
 
+  test "should preserve api key removal intent after validation failure" do
+    @ai_user.update!(llm_api_key: "existing-secret-key")
+
+    patch update_ai_user_url(@ai_user), params: {
+      user: { name: "", llm_api_key: "", clear_llm_api_key: "1" }
+    }
+
+    assert_response :unprocessable_entity
+    assert_select "input[type='checkbox'][name='user[clear_llm_api_key]'][checked='checked']"
+    assert_equal "existing-secret-key", @ai_user.reload.llm_api_key
+    assert_not_includes response.body, "existing-secret-key"
+  end
+
   test "should update api key when submitted value is present" do
     @ai_user.update!(llm_api_key: "existing-secret-key")
 

--- a/engines/collavre/test/controllers/users_controller_ai_test.rb
+++ b/engines/collavre/test/controllers/users_controller_ai_test.rb
@@ -12,7 +12,7 @@ class UsersControllerAiTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select "h1", I18n.t("collavre.users.new_ai.title")
     assert_select "form[action=?]", create_ai_users_path
-    assert_select "input[type='text'][name='llm_api_key'].masked-secret-field[autocomplete='off'][spellcheck='false']"
+    assert_select "input[type='text'][name='llm_api_key'].masked-secret-field[autocomplete='off'][autocapitalize='none'][spellcheck='false']"
     # Verify tools section is rendered
     assert_select "label", I18n.t("collavre.users.edit_ai.tools_title")
   end
@@ -48,7 +48,9 @@ class UsersControllerAiTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select "h1", "Edit AI Agent"
     assert_select "form[action=?]", update_ai_user_path(@ai_user)
-    assert_select "input[type='text'][name='user[llm_api_key]'].masked-secret-field[autocomplete='off'][spellcheck='false']"
+    assert_select "input[type='text'][name='user[llm_api_key]'].masked-secret-field[autocomplete='off'][autocapitalize='none'][spellcheck='false']"
+    assert_select "input[type='checkbox'][name='user[clear_llm_api_key]'][value='1']"
+    assert_select "label[for='user_clear_llm_api_key']", I18n.t("collavre.users.edit_ai.clear_api_key_label")
     assert_predicate css_select("input[name='user[llm_api_key]']").first["value"], :blank?
     assert_not_includes response.body, "existing-secret-key"
   end
@@ -85,6 +87,17 @@ class UsersControllerAiTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to edit_ai_user_path(@ai_user)
     assert_equal "existing-secret-key", @ai_user.reload.llm_api_key
+  end
+
+  test "should clear existing api key when explicitly requested" do
+    @ai_user.update!(llm_api_key: "existing-secret-key")
+
+    patch update_ai_user_url(@ai_user), params: {
+      user: { llm_api_key: "", clear_llm_api_key: "1" }
+    }
+
+    assert_redirected_to edit_ai_user_path(@ai_user)
+    assert_nil @ai_user.reload.llm_api_key
   end
 
   test "should update api key when submitted value is present" do

--- a/engines/collavre/test/controllers/users_controller_ai_test.rb
+++ b/engines/collavre/test/controllers/users_controller_ai_test.rb
@@ -12,6 +12,7 @@ class UsersControllerAiTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select "h1", I18n.t("collavre.users.new_ai.title")
     assert_select "form[action=?]", create_ai_users_path
+    assert_select "input[type='text'][name='llm_api_key'].masked-secret-field[autocomplete='off'][spellcheck='false']"
     # Verify tools section is rendered
     assert_select "label", I18n.t("collavre.users.edit_ai.tools_title")
   end
@@ -44,6 +45,7 @@ class UsersControllerAiTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select "h1", "Edit AI Agent"
     assert_select "form[action=?]", update_ai_user_path(@ai_user)
+    assert_select "input[type='text'][name='user[llm_api_key]'].masked-secret-field[autocomplete='off'][spellcheck='false']"
   end
 
   test "should not get edit_ai for normal user" do

--- a/engines/collavre/test/controllers/users_controller_ai_test.rb
+++ b/engines/collavre/test/controllers/users_controller_ai_test.rb
@@ -41,11 +41,16 @@ class UsersControllerAiTest < ActionDispatch::IntegrationTest
   end
 
   test "should get edit_ai for ai user" do
+    @ai_user.update!(llm_api_key: "existing-secret-key")
+
     get edit_ai_user_url(@ai_user)
+
     assert_response :success
     assert_select "h1", "Edit AI Agent"
     assert_select "form[action=?]", update_ai_user_path(@ai_user)
     assert_select "input[type='text'][name='user[llm_api_key]'].masked-secret-field[autocomplete='off'][spellcheck='false']"
+    assert_predicate css_select("input[name='user[llm_api_key]']").first["value"], :blank?
+    assert_not_includes response.body, "existing-secret-key"
   end
 
   test "should not get edit_ai for normal user" do
@@ -69,6 +74,28 @@ class UsersControllerAiTest < ActionDispatch::IntegrationTest
     assert_equal "New prompt", @ai_user.system_prompt
     assert_equal "gemini-1.5-pro", @ai_user.llm_model
     assert @ai_user.searchable
+  end
+
+  test "should preserve existing api key when submitted value is blank" do
+    @ai_user.update!(llm_api_key: "existing-secret-key")
+
+    patch update_ai_user_url(@ai_user), params: {
+      user: { name: "Updated Bot Name", llm_api_key: "" }
+    }
+
+    assert_redirected_to edit_ai_user_path(@ai_user)
+    assert_equal "existing-secret-key", @ai_user.reload.llm_api_key
+  end
+
+  test "should update api key when submitted value is present" do
+    @ai_user.update!(llm_api_key: "existing-secret-key")
+
+    patch update_ai_user_url(@ai_user), params: {
+      user: { llm_api_key: "replacement-secret-key" }
+    }
+
+    assert_redirected_to edit_ai_user_path(@ai_user)
+    assert_equal "replacement-secret-key", @ai_user.reload.llm_api_key
   end
 
   test "should not update ai user if not authorized" do


### PR DESCRIPTION
## What changed

- Added shared helpers for masked secret inputs.
- Rendered AI agent API keys and single-line sensitive integration settings as text inputs with CSS masking.
- Disabled autocomplete and spellcheck for those inputs.
- Added regression coverage for AI agent and admin integration forms.

## Why

Chrome can ignore `autocomplete="off"` on `type="password"` inputs and display a save-password prompt when secret configuration forms are submitted. These values are API keys and integration secrets, not login passwords.

## Impact

AI agent create/edit forms and all single-line sensitive keys under Admin Settings > Integrations remain visually masked without being classified as password fields by Chrome.

## Root cause

The forms used native password inputs, causing Chrome Password Manager to treat API keys and integration secrets as credentials.

## Validation

- `mise exec -- bin/rails test engines/collavre/test/controllers/users_controller_ai_test.rb engines/collavre/test/controllers/admin_integrations_controller_test.rb`
- `mise exec -- ./bin/rubocop engines/collavre/app/helpers/collavre/application_helper.rb engines/collavre/test/controllers/users_controller_ai_test.rb engines/collavre/test/controllers/admin_integrations_controller_test.rb`
- `mise exec -- ./node_modules/.bin/stylelint engines/collavre/app/assets/stylesheets/collavre/secret_fields.css`
- `git diff --check`