### PR TITLE
fix: keep AI agent API keys out of edit forms

### DIFF
--- a/engines/collavre/app/controllers/concerns/collavre/users_controller/ai_user_management.rb
+++ b/engines/collavre/app/controllers/concerns/collavre/users_controller/ai_user_management.rb
@@ -59,6 +59,7 @@ module Collavre
 
     def update_ai
       ai_params = params.require(:user).permit(:name, :system_prompt, :llm_vendor, :llm_model, :llm_api_key, :gateway_url, :searchable, :routing_expression, :agent_conf, tools: [])
+      ai_params.delete(:llm_api_key) if ai_params[:llm_api_key].blank?
 
       if @user.update(ai_params)
         redirect_to edit_ai_user_path(@user), notice: I18n.t("collavre.users.update_ai.success")

--- a/engines/collavre/app/views/collavre/users/edit_ai.html.erb
+++ b/engines/collavre/app/views/collavre/users/edit_ai.html.erb
@@ -42,7 +42,7 @@
 
   <div class="form-group">
     <%= form.label :llm_api_key, t('collavre.users.new_ai.api_key_label') %>
-    <%= masked_secret_field form, :llm_api_key, class: "stacked-form-control", placeholder: "sk-...", value: @user.llm_api_key %>
+    <%= masked_secret_field form, :llm_api_key, class: "stacked-form-control", placeholder: "sk-...", value: nil %>
     <small class="form-text text-muted"><%= t('collavre.users.new_ai.api_key_help') %></small>
   </div>
 

--- a/engines/collavre/test/controllers/users_controller_ai_test.rb
+++ b/engines/collavre/test/controllers/users_controller_ai_test.rb
@@ -41,11 +41,16 @@ class UsersControllerAiTest < ActionDispatch::IntegrationTest
   end
 
   test "should get edit_ai for ai user" do
+    @ai_user.update!(llm_api_key: "existing-secret-key")
+
     get edit_ai_user_url(@ai_user)
+
     assert_response :success
     assert_select "h1", "Edit AI Agent"
     assert_select "form[action=?]", update_ai_user_path(@ai_user)
     assert_select "input[type='text'][name='user[llm_api_key]'].masked-secret-field[autocomplete='off'][spellcheck='false']"
+    assert_predicate css_select("input[name='user[llm_api_key]']").first["value"], :blank?
+    assert_not_includes response.body, "existing-secret-key"
   end
 
   test "should not get edit_ai for normal user" do
@@ -69,6 +74,28 @@ class UsersControllerAiTest < ActionDispatch::IntegrationTest
     assert_equal "New prompt", @ai_user.system_prompt
     assert_equal "gemini-1.5-pro", @ai_user.llm_model
     assert @ai_user.searchable
+  end
+
+  test "should preserve existing api key when submitted value is blank" do
+    @ai_user.update!(llm_api_key: "existing-secret-key")
+
+    patch update_ai_user_url(@ai_user), params: {
+      user: { name: "Updated Bot Name", llm_api_key: "" }
+    }
+
+    assert_redirected_to edit_ai_user_path(@ai_user)
+    assert_equal "existing-secret-key", @ai_user.reload.llm_api_key
+  end
+
+  test "should update api key when submitted value is present" do
+    @ai_user.update!(llm_api_key: "existing-secret-key")
+
+    patch update_ai_user_url(@ai_user), params: {
+      user: { llm_api_key: "replacement-secret-key" }
+    }
+
+    assert_redirected_to edit_ai_user_path(@ai_user)
+    assert_equal "replacement-secret-key", @ai_user.reload.llm_api_key
   end
 
   test "should not update ai user if not authorized" do


### PR DESCRIPTION
## What changed

- Stopped rendering the decrypted AI agent API key into the edit form.
- Preserved the stored API key when the edit form submits a blank key.
- Kept explicit non-blank API key replacement behavior.
- Added regression coverage for HTML exposure, blank preservation, and replacement.

## Why

The AI agent edit page placed the decrypted API key in the input value. That exposed the secret in the HTML response and made an unchanged edit depend on resubmitting the secret.

## Impact

The edit form now starts with an empty API key field. Leaving it blank keeps the existing encrypted value; entering a new key replaces it.

## Root cause

The model-bound field was explicitly populated with `@user.llm_api_key`, and blank submissions were passed directly to the model update.

## Dependency

This is a stacked PR based on #1466 so the security fix remains separate from the shared secret-field implementation. After #1466 merges, this PR can be retargeted to `main`.

## Validation

- `mise exec -- bin/rails test engines/collavre/test/controllers/users_controller_ai_test.rb`
- `mise exec -- ./bin/rubocop engines/collavre/app/controllers/concerns/collavre/users_controller/ai_user_management.rb engines/collavre/test/controllers/users_controller_ai_test.rb`
- `git diff --check`