### PR TITLE
fix: add Open Graph metadata to invitation links

### DIFF
--- a/engines/collavre/app/controllers/collavre/invites_controller.rb
+++ b/engines/collavre/app/controllers/collavre/invites_controller.rb
@@ -1,5 +1,10 @@
 module Collavre
   class InvitesController < ApplicationController
+    LINK_PREVIEW_USER_AGENT_PATTERN = /
+      bot\b|crawler\b|spider\b|preview\b|scrap(?:e|er)?\b|
+      facebookexternalhit|whatsapp|iframely|embedly
+    /ix
+
     allow_unauthenticated_access only: :show
     before_action :set_invitation, only: :show
 
@@ -17,10 +22,16 @@ module Collavre
     end
 
     def show
-      @invitation.update(clicked_at: Time.current) unless @invitation.clicked_at
+      return if @invitation.clicked_at || link_preview_crawler?
+
+      @invitation.update(clicked_at: Time.current)
     end
 
     private
+
+    def link_preview_crawler?
+      request.user_agent.to_s.match?(LINK_PREVIEW_USER_AGENT_PATTERN)
+    end
 
     def set_invitation
       @invitation = Invitation.find_by_token_for(:invite, params[:token])

--- a/engines/collavre/app/views/collavre/invites/show.html.erb
+++ b/engines/collavre/app/views/collavre/invites/show.html.erb
@@ -1,3 +1,16 @@
+<% creative_title = CGI.unescapeHTML(strip_tags(@invitation.creative.effective_origin.description).to_s).squish %>
+<% meta_title = t(".meta.title", creative: creative_title) %>
+<% content_for :title, meta_title %>
+<% content_for :head do %>
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="<%= t("app.name") %>">
+  <meta property="og:title" content="<%= meta_title %>">
+  <meta property="og:description" content="<%= t(".meta.description", inviter: @invitation.inviter.display_name) %>">
+  <meta property="og:url" content="<%= request.original_url %>">
+  <meta property="og:image" content="<%= "#{request.base_url}/icon-1e3cf549d2.png" %>">
+  <meta property="og:image:alt" content="<%= t("app.name") %>">
+<% end %>
+
 <h1 class="no-top-margin"><%= t('.title') %></h1>
 <p><%= t('collavre.invites.show.invited_by', inviter: @invitation.inviter.display_name, email: @invitation.inviter.email, creative: strip_tags(@invitation.creative.effective_origin.description)) %></p>
 <p><%= t('collavre.invites.show.prompt') %></p>

--- a/engines/collavre/config/locales/invites.en.yml
+++ b/engines/collavre/config/locales/invites.en.yml
@@ -10,6 +10,9 @@ en:
         prompt: To accept the invitation, please log in or sign up.
         login: Log in
         sign_up: Sign up
+        meta:
+          title: 'Invitation to "%{creative}"'
+          description: "%{inviter} invited you to collaborate on Collavre."
     invitation_mailer:
       invite:
         subject: You're invited to Collavre

--- a/engines/collavre/config/locales/invites.ko.yml
+++ b/engines/collavre/config/locales/invites.ko.yml
@@ -10,6 +10,9 @@ ko:
         prompt: 초대를 수락하려면 로그인하거나 회원 가입을 해주세요.
         login: 로그인
         sign_up: 회원 가입
+        meta:
+          title: '"%{creative}" 크리에이티브 초대'
+          description: "%{inviter}님이 콜라브에서 함께 협업하도록 초대했습니다."
     invitation_mailer:
       invite:
         subject: 콜라브에 초대되었습니다

--- a/engines/collavre/test/integration/invitation_flow_test.rb
+++ b/engines/collavre/test/integration/invitation_flow_test.rb
@@ -30,6 +30,25 @@ class InvitationFlowTest < ActionDispatch::IntegrationTest
     assert_match inviter.display_name, response.body
     assert_match inviter.email, response.body
     assert_match ActionController::Base.helpers.strip_tags(creative.description), response.body
+    meta_title = I18n.t("collavre.invites.show.meta.title", creative: "Test creative")
+    meta_description = I18n.t("collavre.invites.show.meta.description", inviter: inviter.display_name)
+    assert_select "title", text: meta_title
+    assert_select 'meta[property="og:type"][content="website"]', count: 1
+    assert_select 'meta[property="og:site_name"]', count: 1 do |tags|
+      assert_equal I18n.t("app.name"), tags.first["content"]
+    end
+    assert_select 'meta[property="og:title"]', count: 1 do |tags|
+      assert_equal meta_title, tags.first["content"]
+    end
+    assert_select 'meta[property="og:description"]', count: 1 do |tags|
+      assert_equal meta_description, tags.first["content"]
+    end
+    assert_select 'meta[property="og:url"]', count: 1 do |tags|
+      assert_equal collavre.invite_url(token: token), tags.first["content"]
+    end
+    assert_select 'meta[property="og:image"]', count: 1 do |tags|
+      assert_equal "http://www.example.com/icon-1e3cf549d2.png", tags.first["content"]
+    end
     assert_select "a[href=?]", collavre.new_session_path(invite_token: token),
                   text: I18n.t("collavre.invites.show.login")
     assert_select "a[href=?]", collavre.new_user_path(invite_token: token),
@@ -53,5 +72,47 @@ class InvitationFlowTest < ActionDispatch::IntegrationTest
     share = CreativeShare.find_by(creative: creative, user: invitee)
     assert share
     assert_equal "read", share.permission
+  end
+
+  test "invitation metadata is localized and strips markup from the creative title" do
+    inviter = User.create!(email: "inviter-ko@example.com", password: TEST_PASSWORD, name: "초대자")
+    creative = Creative.create!(user: inviter, description: "<strong>로드맵 &amp; 출시</strong>")
+    invitation = Invitation.create!(inviter: inviter, creative: creative, permission: :read)
+    token = invitation.generate_token_for(:invite)
+
+    get collavre.invite_path(token: token), headers: { "Accept-Language" => "ko" }
+
+    assert_response :success
+    expected_title = I18n.t("collavre.invites.show.meta.title", locale: :ko, creative: "로드맵 & 출시")
+    expected_description = I18n.t("collavre.invites.show.meta.description",
+                                  locale: :ko,
+                                  inviter: inviter.display_name)
+    assert_select 'meta[property="og:title"]', count: 1 do |tags|
+      assert_equal expected_title, tags.first["content"]
+    end
+    assert_select 'meta[property="og:description"]', count: 1 do |tags|
+      assert_equal expected_description, tags.first["content"]
+    end
+  end
+
+  test "link preview crawlers do not mark the invitation as clicked" do
+    inviter = User.create!(email: "preview-inviter@example.com", password: TEST_PASSWORD, name: "Inviter")
+    creative = Creative.create!(user: inviter, description: "Preview creative")
+    invitation = Invitation.create!(inviter: inviter, creative: creative, permission: :read)
+    token = invitation.generate_token_for(:invite)
+    user_agents = [
+      "Slackbot-LinkExpanding 1.0",
+      "facebookexternalhit/1.1",
+      "KAKAOTALK-SCRAP/1.0",
+      "WhatsApp/2.23"
+    ]
+
+    user_agents.each do |user_agent|
+      get collavre.invite_path(token: token), headers: { "User-Agent" => user_agent }
+
+      assert_response :success
+      assert_nil invitation.reload.clicked_at, user_agent
+      assert_select 'meta[property="og:title"]', count: 1
+    end
   end
 end


### PR DESCRIPTION
## Summary

- add localized Open Graph metadata to invitation pages
- expose the invited creative title in the preview title
- include description, canonical invitation URL, site name, type, and application icon
- avoid recording link-preview crawler requests as invitation clicks

## Root cause

Invitation pages did not populate the application layout's `head` content, so shared invitation URLs rendered without any Open Graph metadata. Preview crawlers also triggered the existing first-visit click tracking.

## Impact

Slack, KakaoTalk, and other Open Graph consumers can render a useful invitation preview with the creative title, while crawler fetches no longer pollute `clicked_at`.

## Validation

- `mise exec -- ./bin/rubocop -a` — 1,121 files, no offenses
- `RAILS_ENV=test mise exec -- bundle exec dotenv -f .env.development -- bin/rails test engines/collavre/test/integration/invitation_flow_test.rb` — 4 runs, 51 assertions, passed
- `RAILS_ENV=test mise exec -- bundle exec dotenv -f .env.development -- bundle exec rake test:system` — all engine system tests passed (45 runs total, 2 existing skips)

## Known test-environment issue

`bin/rails test` currently reports 11 errors in existing GitHub webhook/reprovision tests because Active Record encryption credentials are missing during those tests. The invitation integration tests and full engine system suite pass.