### PR TITLE
fix: allow email entry for public invitations

### DIFF
--- a/engines/collavre/app/controllers/concerns/collavre/users_controller/registration.rb
+++ b/engines/collavre/app/controllers/concerns/collavre/users_controller/registration.rb
@@ -11,7 +11,7 @@ module Collavre
       @user = Collavre::User.new
       if params[:invite_token].present?
         @invitation = Collavre::Invitation.find_by_token_for(:invite, params[:invite_token])
-        @user.email = @invitation&.email
+        @user.email = @invitation.email if @invitation&.email.present?
       end
     end
 
@@ -22,7 +22,7 @@ module Collavre
           invitation = Collavre::Invitation.find_by_token_for(:invite, params[:invite_token])
           if invitation
             @invitation = invitation
-            @user.email = invitation.email
+            @user.email = invitation.email if invitation.email.present?
           end
         end
         if @user.save

--- a/engines/collavre/app/views/collavre/users/new.html.erb
+++ b/engines/collavre/app/views/collavre/users/new.html.erb
@@ -11,7 +11,9 @@
   <% if defined?(@invitation) && @invitation.present? %>
     <%= hidden_field_tag :invite_token, params[:invite_token] || params[:token] %>
   <% end %>
-  <%= render 'collavre/users/id_pwd_fields', form: form, disable_email: defined?(@invitation) && @invitation.present? %>
+  <%= render 'collavre/users/id_pwd_fields',
+             form: form,
+             disable_email: defined?(@invitation) && @invitation&.email.present? %>
 
   <%= form.password_field :password_confirmation,
                           required: true,

--- a/engines/collavre/test/integration/invitation_flow_test.rb
+++ b/engines/collavre/test/integration/invitation_flow_test.rb
@@ -74,6 +74,69 @@ class InvitationFlowTest < ActionDispatch::IntegrationTest
     assert_equal "read", share.permission
   end
 
+  test "public invitation signup accepts the user-provided email" do
+    inviter = User.create!(email: "public-inviter@example.com", password: TEST_PASSWORD, name: "Inviter")
+    creative = Creative.create!(user: inviter, description: "Public invite")
+    invitation = Invitation.create!(inviter: inviter, creative: creative, permission: :write)
+    token = invitation.generate_token_for(:invite)
+
+    get new_user_path(invite_token: token)
+
+    assert_response :success
+    assert_select 'input[name="user[email]"]', count: 1 do |inputs|
+      refute inputs.first.key?("readonly")
+    end
+
+    assert_difference("User.count", 1) do
+      post users_path, params: {
+        invite_token: token,
+        user: {
+          name: "Public Invitee",
+          email: "public-invitee@example.com",
+          password: TEST_PASSWORD,
+          password_confirmation: TEST_PASSWORD
+        }
+      }
+    end
+
+    invitee = User.find_by!(email: "public-invitee@example.com")
+    share = CreativeShare.find_by!(creative: creative, user: invitee)
+    assert_equal "write", share.permission
+    assert_not_nil invitation.reload.accepted_at
+  end
+
+  test "email-specific invitation signup keeps the invited email locked" do
+    inviter = User.create!(email: "specific-inviter@example.com", password: TEST_PASSWORD, name: "Inviter")
+    creative = Creative.create!(user: inviter, description: "Specific invite")
+    invitation = Invitation.create!(
+      email: "intended-invitee@example.com",
+      inviter: inviter,
+      creative: creative,
+      permission: :read
+    )
+    token = invitation.generate_token_for(:invite)
+
+    get new_user_path(invite_token: token)
+
+    assert_response :success
+    assert_select 'input[name="user[email]"][readonly="readonly"][value="intended-invitee@example.com"]', count: 1
+
+    assert_difference("User.count", 1) do
+      post users_path, params: {
+        invite_token: token,
+        user: {
+          name: "Intended Invitee",
+          email: "different@example.com",
+          password: TEST_PASSWORD,
+          password_confirmation: TEST_PASSWORD
+        }
+      }
+    end
+
+    assert User.exists?(email: "intended-invitee@example.com")
+    refute User.exists?(email: "different@example.com")
+  end
+
   test "invitation metadata is localized and strips markup from the creative title" do
     inviter = User.create!(email: "inviter-ko@example.com", password: TEST_PASSWORD, name: "초대자")
     creative = Creative.create!(user: inviter, description: "<strong>로드맵 &amp; 출시</strong>")


### PR DESCRIPTION
## Summary
- Keep the email field editable when signing up through a public invitation without a preassigned email.
- Preserve the submitted email for public invitation registrations.
- Continue locking and enforcing the recipient email for email-specific invitations.

## Root cause
The registration form treated every invitation as email-specific. It marked the email input as read-only whenever an invitation token resolved, and the create action then overwrote the submitted email with the invitation's email. Public invitations store no email, so users saw a locked empty field and registration could not proceed.

## Impact
Users who follow a public invitation can enter their own email and complete registration. Email-specific invitation behavior remains unchanged.

## Validation
- `mise exec -- bin/rails test engines/collavre/test/integration/invitation_flow_test.rb` (6 runs, 64 assertions)
- `mise exec -- bundle exec rubocop engines/collavre/app/controllers/concerns/collavre/users_controller/registration.rb engines/collavre/test/integration/invitation_flow_test.rb`