### PR TITLE
Fix Kamal post-deploy shell execution

### DIFF
--- a/.kamal/hooks/post-deploy
+++ b/.kamal/hooks/post-deploy
@@ -5,4 +5,4 @@ set -eu
 # successful rollout. The file guard runs inside the deployed container and
 # keeps rollbacks to images predating the reconciliation script safe.
 ./bin/kamal app exec --primary --reuse \
-  "if [ -f script/reprovision_github_webhooks ]; then bin/rails runner script/reprovision_github_webhooks; fi"
+  "sh -c 'if [ -f script/reprovision_github_webhooks ]; then bin/rails runner script/reprovision_github_webhooks; fi'"

--- a/test/lib/kamal_post_deploy_hook_test.rb
+++ b/test/lib/kamal_post_deploy_hook_test.rb
@@ -28,8 +28,8 @@ class KamalPostDeployHookTest < ActiveSupport::TestCase
       arguments = File.readlines("#{directory}/kamal-arguments", chomp: true)
       assert_equal [ "app", "exec", "--primary", "--reuse" ], arguments.first(4)
       assert_equal(
-        "if [ -f script/reprovision_github_webhooks ]; " \
-          "then bin/rails runner script/reprovision_github_webhooks; fi",
+        "sh -c 'if [ -f script/reprovision_github_webhooks ]; " \
+          "then bin/rails runner script/reprovision_github_webhooks; fi'",
         arguments.last
       )
     end


### PR DESCRIPTION
## Summary

- run the post-deploy webhook reprovision guard through an explicit POSIX shell
- update the hook regression test to require the shell-wrapped command

## Root cause

Kamal forwarded the conditional directly to `docker exec`, so `if` was treated as the container command instead of shell syntax. The hook therefore failed before `script/reprovision_github_webhooks` could run.

## Impact

Successful deployments can complete the post-deploy webhook reconciliation without the `bash: syntax error near unexpected token 'then'` failure. The existing file guard remains safe for rollback images that predate the script.

## Validation

- `mise exec -- bin/rails test test/lib/kamal_post_deploy_hook_test.rb`
- `mise exec -- bundle exec rubocop test/lib/kamal_post_deploy_hook_test.rb`
- `sh -n .kamal/hooks/post-deploy`