### PR TITLE
Fix Kamal clear environment value types

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -84,7 +84,7 @@ env:
     # with another deployment set SOLID_QUEUE_IN_PUMA=false in their env file so
     # only one host claims from the shared queue — a host running older code
     # otherwise picks up jobs it cannot run.
-    SOLID_QUEUE_IN_PUMA: <%= ENV.fetch('SOLID_QUEUE_IN_PUMA', 'true') %>
+    SOLID_QUEUE_IN_PUMA: "<%= ENV.fetch('SOLID_QUEUE_IN_PUMA', 'true') %>"
 
     # Set number of processes dedicated to Solid Queue (default: 1)
     # JOB_CONCURRENCY: 3
@@ -92,13 +92,13 @@ env:
     # Threads for the dedicated ai_agents Solid Queue worker (long-running AI
     # agent turns). Sets execution capacity; orchestrator's max_concurrent_jobs
     # (default 5) gates admission—raise both together if needed.
-    AI_AGENT_THREADS: <%= ENV.fetch('AI_AGENT_THREADS', '12') %>
+    AI_AGENT_THREADS: "<%= ENV.fetch('AI_AGENT_THREADS', '12') %>"
 
     # Override the Active Record pool size formula in config/database.yml
     # (RAILS_MAX_THREADS + AI_AGENT_THREADS + 10). Only passed through when set
     # on the deploy machine, so the in-container formula stays the default.
 <% if ENV['DB_POOL'].to_s.strip != '' %>
-    DB_POOL: <%= ENV['DB_POOL'] %>
+    DB_POOL: "<%= ENV['DB_POOL'] %>"
 <% end %>
 
     # Set number of cores available to the application on each server (default: 1).

--- a/test/lib/kamal_deploy_config_test.rb
+++ b/test/lib/kamal_deploy_config_test.rb
@@ -1,0 +1,45 @@
+require "test_helper"
+require "erb"
+require "yaml"
+
+class KamalDeployConfigTest < ActiveSupport::TestCase
+  ENVIRONMENT_VARIABLES = %w[AI_AGENT_THREADS DB_POOL SOLID_QUEUE_IN_PUMA].freeze
+
+  setup do
+    @original_environment = ENVIRONMENT_VARIABLES.to_h { |key| [ key, ENV[key] ] }
+  end
+
+  teardown do
+    @original_environment.each do |key, value|
+      value.nil? ? ENV.delete(key) : ENV[key] = value
+    end
+  end
+
+  test "renders default clear environment values as strings" do
+    ENVIRONMENT_VARIABLES.each { |key| ENV.delete(key) }
+
+    clear_environment = rendered_clear_environment
+
+    assert_equal "12", clear_environment["AI_AGENT_THREADS"]
+    assert_equal "true", clear_environment["SOLID_QUEUE_IN_PUMA"]
+    assert_not clear_environment.key?("DB_POOL")
+  end
+
+  test "renders numeric and boolean-looking overrides as strings" do
+    ENV["AI_AGENT_THREADS"] = "24"
+    ENV["DB_POOL"] = "48"
+    ENV["SOLID_QUEUE_IN_PUMA"] = "false"
+
+    clear_environment = rendered_clear_environment
+
+    assert_equal "24", clear_environment["AI_AGENT_THREADS"]
+    assert_equal "48", clear_environment["DB_POOL"]
+    assert_equal "false", clear_environment["SOLID_QUEUE_IN_PUMA"]
+  end
+
+  private
+    def rendered_clear_environment
+      template = ERB.new(Rails.root.join("config/deploy.yml").read).result
+      YAML.safe_load(template).dig("env", "clear")
+    end
+end


### PR DESCRIPTION
## Summary

- render Kamal `env.clear` values for `AI_AGENT_THREADS`, `DB_POOL`, and `SOLID_QUEUE_IN_PUMA` as YAML strings
- add regression coverage for defaults and numeric/boolean-looking overrides

## Root cause

Unquoted ERB output was parsed by YAML as integers or booleans. Kamal requires clear environment values to be strings, so the post-deploy hook failed while reloading the deployment configuration.

## Impact

Post-deploy commands can reload the Kamal configuration without failing on these environment variable types.

## Validation

- `mise exec -- ./bin/rubocop -a test/lib/kamal_deploy_config_test.rb`
- `mise exec -- bin/rails test test/lib/kamal_deploy_config_test.rb test/lib/kamal_post_deploy_hook_test.rb`
- `bin/kamal config` with numeric and boolean-looking overrides