### PR TITLE
Fix FCM initialization from database-backed service account settings

### DIFF
--- a/config/fcm_configuration.rb
+++ b/config/fcm_configuration.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+resolve = ->(key, credentials_path) {
+  value = CollavreCompat.call(Collavre::IntegrationSettings, :fetch, key, boot_safe: true)
+  value.presence || Rails.application.credentials.dig(*credentials_path)
+}
+
+fcm_scope = [ Google::Apis::FcmV1::AUTH_FIREBASE_MESSAGING ].freeze
+
+# Default AWS Workload Identity Federation settings. Used as a fallback so the
+# pre-existing production deploy — which only injects FCM_SENDER_ID (the GCP
+# project number) and FCM_WIF_SERVICE_ACCOUNT_EMAIL (the SA email) — keeps
+# working without having to set the explicit fcm_wif_* overrides. Admins can
+# override either piece via the admin UI / ENV for non-default pools/providers.
+default_aws_audience = ->(project_number) {
+  "//iam.googleapis.com/projects/#{project_number}/locations/global/workloadIdentityPools/aws-pool/providers/aws-provider"
+}
+default_aws_credential_source = {
+  environment_id: "aws1",
+  region_url: "http://169.254.169.254/latest/meta-data/placement/availability-zone",
+  url: "http://169.254.169.254/latest/meta-data/iam/security-credentials",
+  regional_cred_verification_url: "https://sts.{region}.amazonaws.com?Action=GetCallerIdentity&Version=2011-06-15",
+  imdsv2_session_token_url: "http://169.254.169.254/latest/api/token"
+}.freeze
+
+server_key                  = resolve.call(:fcm_server_key,                 %i[fcm server_key])
+project_id                  = resolve.call(:firebase_project_id,            %i[firebase project_id])
+project_number              = resolve.call(:fcm_sender_id,                  %i[fcm sender_id])
+service_account_json_body   = resolve.call(:firebase_service_account_json,  %i[fcm service_account_json])
+wif_audience_explicit       = resolve.call(:fcm_wif_audience,               %i[fcm wif_audience])
+wif_credential_source_raw   = resolve.call(:fcm_wif_credential_source,      %i[fcm wif_credential_source])
+# Single SA-email key, resolved from FCM_WIF_SERVICE_ACCOUNT_EMAIL (DB > ENV);
+# the `firebase` credentials path stays readable as an extra fallback for older
+# setups.
+wif_sa_email                = resolve.call(:fcm_wif_service_account_email,  %i[fcm wif_service_account_email]).presence ||
+                              Rails.application.credentials.dig(:firebase, :service_account)
+adc_path                    = resolve.call(:google_application_credentials, %i[fcm google_application_credentials])
+
+build_service_account_credentials = ->(json_body) {
+  Google::Auth::ServiceAccountCredentials.make_creds(
+    json_key_io: StringIO.new(json_body),
+    scope: fcm_scope
+  )
+}
+
+build_adc_credentials = ->(path) {
+  # `Google::Auth.get_application_default` reads `ENV["GOOGLE_APPLICATION_CREDENTIALS"]`,
+  # so we must export the resolved path before the ADC lookup. Overwrite
+  # unconditionally — `resolve` already applied DB > ENV precedence, so any
+  # pre-existing ENV value lost that race and must not leak back into ADC.
+  ENV["GOOGLE_APPLICATION_CREDENTIALS"] = path
+  Google::Auth.get_application_default(scope: fcm_scope)
+}
+
+build_wif_credentials = ->(audience, credential_source_raw, sa_email) {
+  # AwsCredentials reads the source with symbol keys (`source[:environment_id]`),
+  # so explicit JSON must be parsed with symbolize_names. Parsing happens here
+  # (lazily, inside the rescued attempt) so a malformed override can't crash boot.
+  credential_source = credential_source_raw.present? ?
+    JSON.parse(credential_source_raw, symbolize_names: true) :
+    default_aws_credential_source
+
+  impersonation_url = sa_email.present? ?
+    "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/#{sa_email}:generateAccessToken" :
+    nil
+
+  Google::Auth::ExternalAccount::AwsCredentials.new(
+    universe_domain: "googleapis.com",
+    type: "external_account",
+    audience: audience,
+    subject_token_type: "urn:ietf:params:aws:token-type:aws4_request",
+    token_url: "https://sts.googleapis.com/v1/token",
+    scope: fcm_scope,
+    credential_source: credential_source,
+    service_account_impersonation_url: impersonation_url
+  )
+}
+
+# WIF is reachable two ways:
+#   * explicit — admin/ENV sets both fcm_wif_audience and fcm_wif_credential_source
+#     (works in any environment, for non-AWS-default pools/providers)
+#   * legacy   — production with only FCM_SENDER_ID set; audience + credential
+#     source fall back to the AWS defaults (preserves pre-existing prod behavior)
+wif_audience = wif_audience_explicit.presence ||
+               (project_number.present? ? default_aws_audience.call(project_number) : nil)
+wif_explicit = wif_audience_explicit.present? && wif_credential_source_raw.present?
+wif_legacy   = Rails.env.production? && project_number.present?
+wif_enabled  = wif_audience.present? && (wif_explicit || wif_legacy)
+
+# Ordered credential attempts. Each is tried only when its inputs are present,
+# and a failure falls through to the next instead of dead-ending — so a malformed
+# service-account JSON paste cannot silently disable a working WIF/ADC setup.
+attempts = []
+if service_account_json_body.present?
+  attempts << [ "service account JSON (DB/ENV)", -> { build_service_account_credentials.call(service_account_json_body) } ]
+end
+if wif_enabled
+  attempts << [ "Workload Identity Federation (AWS)", -> { build_wif_credentials.call(wif_audience, wif_credential_source_raw, wif_sa_email) } ]
+end
+if adc_path.present? && File.exist?(adc_path)
+  attempts << [ "ADC file (#{adc_path})", -> { build_adc_credentials.call(adc_path) } ]
+end
+
+credentials = nil
+mode = nil
+attempts.each do |attempt_mode, builder|
+  begin
+    credentials = builder.call
+    mode = attempt_mode
+    break if credentials
+  rescue StandardError => e
+    # Log the error class only — never the message. JSON::ParserError#message
+    # echoes the surrounding source, which for a service-account key includes
+    # part of the private_key and would leak it into log sinks.
+    Rails.logger.error "FCM: #{attempt_mode} credential init failed: #{e.class}"
+  end
+end
+
+if credentials && project_id.present?
+  service = Google::Apis::FcmV1::FirebaseCloudMessagingService.new
+  service.authorization = credentials
+
+  Rails.application.config.x.fcm_service = service
+  Rails.application.config.x.fcm_project_id = project_id
+
+  Rails.logger.info "FCM initialized with #{mode}"
+  puts "FCM initialized with #{mode}"
+elsif Rails.env.production?
+  reason =
+    if credentials && project_id.blank?
+      # Credentials built fine; the operator just forgot the project id. Say so
+      # explicitly so they don't go hunting for a bogus credentials problem.
+      "credentials resolved via #{mode} but firebase_project_id is blank"
+    elsif credentials.nil? && project_id.present?
+      "no valid credentials found"
+    else
+      "no valid credentials found and firebase_project_id is blank"
+    end
+  Rails.logger.warn "FCM not initialized: #{reason}"
+end
+
+if server_key.present?
+  Rails.application.config.x.fcm_client = FCM.new(server_key)
+end

--- a/config/initializers/fcm.rb
+++ b/config/initializers/fcm.rb
@@ -18,7 +18,8 @@ if defined?(Collavre::IntegrationSettings::Registry)
                                                       input_type: :textarea)
   # No custom env_var: the default (FCM_WIF_SERVICE_ACCOUNT_EMAIL == key.upcase)
   # MUST match key.upcase. `IntegrationSettings.fetch(boot_safe: true)` — used
-  # below at boot — falls back to ENV[key.upcase] when the DB is unreachable,
+  # by the deferred FCM configuration — falls back to ENV[key.upcase] when the
+  # DB is unreachable,
   # while the runtime Resolver reads ENV[env_var]. A custom env_var splits the
   # two, so a value present at runtime is absent at boot (see creative #14282:
   # the WIF impersonation URL was never built → every push failed Unauthorized).
@@ -33,145 +34,10 @@ if defined?(Collavre::IntegrationSettings::Registry)
                                                       admin_visible: false)
 end
 
-resolve = ->(key, credentials_path) {
-  value = CollavreCompat.call(Collavre::IntegrationSettings, :fetch, key, boot_safe: true)
-  value.presence || Rails.application.credentials.dig(*credentials_path)
-}
-
-fcm_scope = [ Google::Apis::FcmV1::AUTH_FIREBASE_MESSAGING ].freeze
-
-# Default AWS Workload Identity Federation settings. Used as a fallback so the
-# pre-existing production deploy — which only injects FCM_SENDER_ID (the GCP
-# project number) and FCM_WIF_SERVICE_ACCOUNT_EMAIL (the SA email) — keeps
-# working without having to set the explicit fcm_wif_* overrides. Admins can
-# override either piece via the admin UI / ENV for non-default pools/providers.
-default_aws_audience = ->(project_number) {
-  "//iam.googleapis.com/projects/#{project_number}/locations/global/workloadIdentityPools/aws-pool/providers/aws-provider"
-}
-default_aws_credential_source = {
-  environment_id: "aws1",
-  region_url: "http://169.254.169.254/latest/meta-data/placement/availability-zone",
-  url: "http://169.254.169.254/latest/meta-data/iam/security-credentials",
-  regional_cred_verification_url: "https://sts.{region}.amazonaws.com?Action=GetCallerIdentity&Version=2011-06-15",
-  imdsv2_session_token_url: "http://169.254.169.254/latest/api/token"
-}.freeze
-
-server_key                  = resolve.call(:fcm_server_key,                 %i[fcm server_key])
-project_id                  = resolve.call(:firebase_project_id,            %i[firebase project_id])
-project_number              = resolve.call(:fcm_sender_id,                  %i[fcm sender_id])
-service_account_json_body   = resolve.call(:firebase_service_account_json,  %i[fcm service_account_json])
-wif_audience_explicit       = resolve.call(:fcm_wif_audience,               %i[fcm wif_audience])
-wif_credential_source_raw   = resolve.call(:fcm_wif_credential_source,      %i[fcm wif_credential_source])
-# Single SA-email key, resolved from FCM_WIF_SERVICE_ACCOUNT_EMAIL (DB > ENV);
-# the `firebase` credentials path stays readable as an extra fallback for older
-# setups.
-wif_sa_email                = resolve.call(:fcm_wif_service_account_email,  %i[fcm wif_service_account_email]).presence ||
-                              Rails.application.credentials.dig(:firebase, :service_account)
-adc_path                    = resolve.call(:google_application_credentials, %i[fcm google_application_credentials])
-
-build_service_account_credentials = ->(json_body) {
-  Google::Auth::ServiceAccountCredentials.make_creds(
-    json_key_io: StringIO.new(json_body),
-    scope: fcm_scope
-  )
-}
-
-build_adc_credentials = ->(path) {
-  # `Google::Auth.get_application_default` reads `ENV["GOOGLE_APPLICATION_CREDENTIALS"]`,
-  # so we must export the resolved path before the ADC lookup. Overwrite
-  # unconditionally — `resolve` already applied DB > ENV precedence, so any
-  # pre-existing ENV value lost that race and must not leak back into ADC.
-  ENV["GOOGLE_APPLICATION_CREDENTIALS"] = path
-  Google::Auth.get_application_default(scope: fcm_scope)
-}
-
-build_wif_credentials = ->(audience, credential_source_raw, sa_email) {
-  # AwsCredentials reads the source with symbol keys (`source[:environment_id]`),
-  # so explicit JSON must be parsed with symbolize_names. Parsing happens here
-  # (lazily, inside the rescued attempt) so a malformed override can't crash boot.
-  credential_source = credential_source_raw.present? ?
-    JSON.parse(credential_source_raw, symbolize_names: true) :
-    default_aws_credential_source
-
-  impersonation_url = sa_email.present? ?
-    "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/#{sa_email}:generateAccessToken" :
-    nil
-
-  Google::Auth::ExternalAccount::AwsCredentials.new(
-    universe_domain: "googleapis.com",
-    type: "external_account",
-    audience: audience,
-    subject_token_type: "urn:ietf:params:aws:token-type:aws4_request",
-    token_url: "https://sts.googleapis.com/v1/token",
-    scope: fcm_scope,
-    credential_source: credential_source,
-    service_account_impersonation_url: impersonation_url
-  )
-}
-
-# WIF is reachable two ways:
-#   * explicit — admin/ENV sets both fcm_wif_audience and fcm_wif_credential_source
-#     (works in any environment, for non-AWS-default pools/providers)
-#   * legacy   — production with only FCM_SENDER_ID set; audience + credential
-#     source fall back to the AWS defaults (preserves pre-existing prod behavior)
-wif_audience = wif_audience_explicit.presence ||
-               (project_number.present? ? default_aws_audience.call(project_number) : nil)
-wif_explicit = wif_audience_explicit.present? && wif_credential_source_raw.present?
-wif_legacy   = Rails.env.production? && project_number.present?
-wif_enabled  = wif_audience.present? && (wif_explicit || wif_legacy)
-
-# Ordered credential attempts. Each is tried only when its inputs are present,
-# and a failure falls through to the next instead of dead-ending — so a malformed
-# service-account JSON paste cannot silently disable a working WIF/ADC setup.
-attempts = []
-if service_account_json_body.present?
-  attempts << [ "service account JSON (DB/ENV)", -> { build_service_account_credentials.call(service_account_json_body) } ]
-end
-if wif_enabled
-  attempts << [ "Workload Identity Federation (AWS)", -> { build_wif_credentials.call(wif_audience, wif_credential_source_raw, wif_sa_email) } ]
-end
-if adc_path.present? && File.exist?(adc_path)
-  attempts << [ "ADC file (#{adc_path})", -> { build_adc_credentials.call(adc_path) } ]
-end
-
-credentials = nil
-mode = nil
-attempts.each do |attempt_mode, builder|
-  begin
-    credentials = builder.call
-    mode = attempt_mode
-    break if credentials
-  rescue StandardError => e
-    # Log the error class only — never the message. JSON::ParserError#message
-    # echoes the surrounding source, which for a service-account key includes
-    # part of the private_key and would leak it into log sinks.
-    Rails.logger.error "FCM: #{attempt_mode} credential init failed: #{e.class}"
-  end
-end
-
-if credentials && project_id.present?
-  service = Google::Apis::FcmV1::FirebaseCloudMessagingService.new
-  service.authorization = credentials
-
-  Rails.application.config.x.fcm_service = service
-  Rails.application.config.x.fcm_project_id = project_id
-
-  Rails.logger.info "FCM initialized with #{mode}"
-  puts "FCM initialized with #{mode}"
-elsif Rails.env.production?
-  reason =
-    if credentials && project_id.blank?
-      # Credentials built fine; the operator just forgot the project id. Say so
-      # explicitly so they don't go hunting for a bogus credentials problem.
-      "credentials resolved via #{mode} but firebase_project_id is blank"
-    elsif credentials.nil? && project_id.present?
-      "no valid credentials found"
-    else
-      "no valid credentials found and firebase_project_id is blank"
-    end
-  Rails.logger.warn "FCM not initialized: #{reason}"
-end
-
-if server_key.present?
-  Rails.application.config.x.fcm_client = FCM.new(server_key)
+# FCM configuration reads encrypted integration settings from the database.
+# Defer it until Rails has finished eager loading so IntegrationSetting is
+# available; otherwise production boot silently falls back to ENV and can pick
+# the legacy WIF path even when an admin saved a service account JSON key.
+Rails.application.config.after_initialize do
+  require Rails.root.join("config/fcm_configuration").to_s
 end

--- a/test/config/initializers/fcm_initializer_test.rb
+++ b/test/config/initializers/fcm_initializer_test.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class FcmInitializerTest < ActiveSupport::TestCase
+  test "defers database-backed FCM configuration until after initialization" do
+    initializer_source = Rails.root.join("config/initializers/fcm.rb").read
+    configuration_source = Rails.root.join("config/fcm_configuration.rb").read
+
+    assert_match(
+      /Rails\.application\.config\.after_initialize do\s+require Rails\.root\.join\("config\/fcm_configuration"\)\.to_s\s+end/,
+      initializer_source
+    )
+    assert_includes configuration_source, "Collavre::IntegrationSettings, :fetch"
+  end
+end


### PR DESCRIPTION
## What changed

- Keep Firebase/FCM integration key registration in the normal initializer phase.
- Defer database-backed FCM client configuration until `after_initialize`, when `Collavre::IntegrationSetting` is available.
- Move the existing credential selection logic unchanged into `config/fcm_configuration.rb`.
- Add a regression test that guards the deferred initialization boundary.

## Root cause

`config/initializers/fcm.rb` resolved integration settings before production eager loading completed. `Collavre::IntegrationSetting` was not available yet, so `IntegrationSettings.fetch` rescued the resulting `NameError` and silently fell back to environment variables. That bypassed the service account JSON saved in the admin integration settings and selected the legacy AWS WIF path instead.

## Impact

After a restart or deploy, an administrator-provided Firebase service account JSON is now read from the database and takes precedence over WIF as intended. No additional Firebase or deployment environment configuration is required.

## Validation

- `./bin/rubocop -a` — 1,126 files, no offenses
- `bundle exec rake test` — 3,560 runs, 11,271 assertions, 0 failures, 0 errors
- `bundle exec rake test:system` — all engine system suites passed (45 runs total, 2 existing skips)
- Fresh-process boot smoke test with a temporary local service account fixture and `FCM_SENDER_ID` present verified `service account JSON (DB/ENV)` is selected; the fixture was removed afterward