### PR TITLE
fix: allow native text selection across creative rows in the list

### DIFF
--- a/engines/collavre/app/javascript/components/__tests__/creative_tree_row_text_selection.test.js
+++ b/engines/collavre/app/javascript/components/__tests__/creative_tree_row_text_selection.test.js
@@ -46,6 +46,10 @@ function mouseUpWindow() {
   window.dispatchEvent(new window.MouseEvent("mouseup"));
 }
 
+function mouseMoveWindow(opts = {}) {
+  window.dispatchEvent(new window.MouseEvent("mousemove", opts));
+}
+
 function click(target) {
   target.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
 }
@@ -163,20 +167,76 @@ describe("creative-tree-row text selection", () => {
       expect(tree.getAttribute("draggable")).toBe("true");
     });
 
-    test("mousedown is a no-op when the row is not currently draggable", async () => {
+    test("mousedown leaves a row that is not drag-enabled alone", async () => {
+      // A row rendered without the draggable attribute never took part in
+      // drag-and-drop; the handler must not add the attribute on its way out.
+      const el = await mountRow({ creativeId: "1", parentId: "", level: 2, canWrite: true });
+      const tree = treeOf(el);
+      tree.removeAttribute("draggable");
+
+      mouseDown(contentOf(el));
+      expect(tree.hasAttribute("draggable")).toBe(false);
+
+      mouseUpWindow();
+      expect(tree.hasAttribute("draggable")).toBe(false);
+    });
+
+    test("a pointer move with no button held re-arms the row", async () => {
+      // Releasing outside the viewport without changing focus delivers neither
+      // mouseup, dragend nor blur; the pointer coming back with the button up
+      // is the only signal that the gesture ended.
+      const el = await mountRow({ creativeId: "1", parentId: "", level: 2, canWrite: true });
+      const tree = treeOf(el);
+
+      mouseDown(contentOf(el));
+      mouseMoveWindow({ buttons: 1 }); // still dragging — leave the row alone
+      expect(tree.getAttribute("draggable")).toBe("false");
+
+      mouseMoveWindow({ buttons: 0 });
+      expect(tree.getAttribute("draggable")).toBe("true");
+
+      // One-shot: a later move must not touch the attribute again.
+      tree.setAttribute("draggable", "false");
+      mouseMoveWindow({ buttons: 0 });
+      expect(tree.getAttribute("draggable")).toBe("false");
+    });
+
+    test("a stale disarmed row re-arms itself on the next press", async () => {
+      // Belt and braces for the same lost-release case: even with no pointer
+      // move in between, the next press must not bail out on the guard and
+      // strand the row non-draggable.
       const el = await mountRow({ creativeId: "1", parentId: "", level: 2, canWrite: true });
       const tree = treeOf(el);
 
       mouseDown(contentOf(el));
       expect(tree.getAttribute("draggable")).toBe("false");
 
-      // A second mousedown before mouseup (or any state where draggable is not
-      // "true") must not stack extra restore listeners or flip the attribute.
+      // Simulate the release never arriving: press again on the content.
       mouseDown(contentOf(el));
       expect(tree.getAttribute("draggable")).toBe("false");
 
+      // The stale gesture's listeners were dropped, so this press owns the
+      // restore and a single mouseup fully re-arms the row.
       mouseUpWindow();
       expect(tree.getAttribute("draggable")).toBe("true");
+    });
+
+    test("removing a row mid-gesture drops its window listeners", async () => {
+      const el = await mountRow({ creativeId: "1", parentId: "", level: 2, canWrite: true });
+      const tree = treeOf(el);
+
+      mouseDown(contentOf(el));
+      expect(tree.getAttribute("draggable")).toBe("false");
+
+      el.remove();
+      expect(tree.getAttribute("draggable")).toBe("true");
+
+      // Nothing is listening any more: window events must not touch the row.
+      tree.setAttribute("draggable", "false");
+      mouseUpWindow();
+      mouseMoveWindow({ buttons: 0 });
+      window.dispatchEvent(new window.Event("blur"));
+      expect(tree.getAttribute("draggable")).toBe("false");
     });
   });
 

--- a/engines/collavre/app/javascript/components/__tests__/creative_tree_row_text_selection.test.js
+++ b/engines/collavre/app/javascript/components/__tests__/creative_tree_row_text_selection.test.js
@@ -1,0 +1,146 @@
+/**
+ * Text selection on the creative list.
+ *
+ * The `.creative-tree` wrapper carries `draggable="true"` so rows can be
+ * reordered, but a draggable ancestor makes the browser turn mousedown+move
+ * into an HTML5 drag gesture — native drag-to-select over the row text was
+ * impossible. The component now drops the attribute while the pointer is down
+ * over `.creative-content` (restoring it on mouseup/dragend), and skips the
+ * click-to-navigate behavior when the click ends with a non-collapsed text
+ * selection (navigating would destroy the selection the user just made).
+ */
+
+import { jest } from "@jest/globals";
+
+// The component calls `customElements.define(...)` at module-eval time and reads
+// `customElements` as a bare global. The jest environment only exposes it on
+// `window`, so bridge it before importing the component.
+beforeAll(() => {
+  if (typeof globalThis.customElements === "undefined") {
+    globalThis.customElements = window.customElements;
+  }
+});
+
+async function mountRow(props) {
+  await import("../creative_tree_row.js");
+  const el = document.createElement("creative-tree-row");
+  Object.assign(el, props);
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+
+function treeOf(el) {
+  return el.querySelector(".creative-tree");
+}
+
+function contentOf(el) {
+  return el.querySelector(".creative-content");
+}
+
+function mouseDown(target, opts = {}) {
+  target.dispatchEvent(new window.MouseEvent("mousedown", { bubbles: true, button: 0, ...opts }));
+}
+
+function mouseUpWindow() {
+  window.dispatchEvent(new window.MouseEvent("mouseup"));
+}
+
+function click(target) {
+  target.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  jest.restoreAllMocks();
+  delete window.Turbo;
+});
+
+describe("creative-tree-row text selection", () => {
+  describe("draggable toggling on mousedown over content", () => {
+    test("left mousedown on content disables row drag until mouseup", async () => {
+      const el = await mountRow({ creativeId: "1", parentId: "", level: 2, canWrite: true });
+      const tree = treeOf(el);
+      expect(tree.getAttribute("draggable")).toBe("true");
+
+      mouseDown(contentOf(el));
+      // With draggable off, the browser starts a text selection instead of a
+      // row drag, and drag_drop's handleDragStart guard ignores the row.
+      expect(tree.getAttribute("draggable")).toBe("false");
+
+      mouseUpWindow();
+      expect(tree.getAttribute("draggable")).toBe("true");
+    });
+
+    test("dragend also restores draggable (native selection drag path)", async () => {
+      const el = await mountRow({ creativeId: "1", parentId: "", level: 2, canWrite: true });
+      const tree = treeOf(el);
+
+      mouseDown(contentOf(el));
+      expect(tree.getAttribute("draggable")).toBe("false");
+
+      window.dispatchEvent(new window.Event("dragend"));
+      expect(tree.getAttribute("draggable")).toBe("true");
+
+      // The restore listeners are one-shot: a later unrelated mouseup must not
+      // touch the attribute again after it has been restored.
+      tree.setAttribute("draggable", "false");
+      mouseUpWindow();
+      expect(tree.getAttribute("draggable")).toBe("false");
+    });
+
+    test("non-left button keeps the row draggable", async () => {
+      const el = await mountRow({ creativeId: "1", parentId: "", level: 2, canWrite: true });
+
+      mouseDown(contentOf(el), { button: 2 });
+      expect(treeOf(el).getAttribute("draggable")).toBe("true");
+    });
+
+    test("select mode leaves mousedown to the select-mode controller", async () => {
+      const el = await mountRow({ creativeId: "1", parentId: "", level: 2, canWrite: true, selectMode: true });
+      const tree = treeOf(el);
+      expect(tree.getAttribute("draggable")).toBe("true");
+
+      mouseDown(contentOf(el));
+      expect(tree.getAttribute("draggable")).toBe("true");
+    });
+
+    test("mousedown is a no-op when the row is not currently draggable", async () => {
+      const el = await mountRow({ creativeId: "1", parentId: "", level: 2, canWrite: true });
+      const tree = treeOf(el);
+
+      mouseDown(contentOf(el));
+      expect(tree.getAttribute("draggable")).toBe("false");
+
+      // A second mousedown before mouseup (or any state where draggable is not
+      // "true") must not stack extra restore listeners or flip the attribute.
+      mouseDown(contentOf(el));
+      expect(tree.getAttribute("draggable")).toBe("false");
+
+      mouseUpWindow();
+      expect(tree.getAttribute("draggable")).toBe("true");
+    });
+  });
+
+  describe("click-to-navigate vs text selection", () => {
+    test("click with a non-collapsed selection does not navigate", async () => {
+      const el = await mountRow({ creativeId: "1", parentId: "", level: 2, canWrite: true, linkUrl: "/creatives/1" });
+      window.Turbo = { visit: jest.fn() };
+      jest.spyOn(window, "getSelection").mockReturnValue({ isCollapsed: false });
+
+      click(contentOf(el));
+
+      expect(window.Turbo.visit).not.toHaveBeenCalled();
+    });
+
+    test("plain click (collapsed selection) still navigates", async () => {
+      const el = await mountRow({ creativeId: "1", parentId: "", level: 2, canWrite: true, linkUrl: "/creatives/1" });
+      window.Turbo = { visit: jest.fn() };
+      jest.spyOn(window, "getSelection").mockReturnValue({ isCollapsed: true });
+
+      click(contentOf(el));
+
+      expect(window.Turbo.visit).toHaveBeenCalledWith("/creatives/1");
+    });
+  });
+});

--- a/engines/collavre/app/javascript/components/__tests__/creative_tree_row_text_selection.test.js
+++ b/engines/collavre/app/javascript/components/__tests__/creative_tree_row_text_selection.test.js
@@ -105,6 +105,64 @@ describe("creative-tree-row text selection", () => {
       expect(tree.getAttribute("draggable")).toBe("true");
     });
 
+    test("an active select-mode container leaves mousedown to the controller", async () => {
+      // select_mode_controller.toggle() cannot reflect onto rows that are
+      // already rendered, so it publishes the mode on its container element.
+      // Flipping draggable here would make handleRowMouseDown take its
+      // !isDraggable branch and deselect a row instead of dragging the bundle.
+      const container = document.createElement("div");
+      container.className = "select-mode-active";
+      document.body.appendChild(container);
+
+      await import("../creative_tree_row.js");
+      const el = document.createElement("creative-tree-row");
+      Object.assign(el, { creativeId: "1", parentId: "", level: 2, canWrite: true });
+      container.appendChild(el);
+      await el.updateComplete;
+
+      mouseDown(contentOf(el));
+      expect(treeOf(el).getAttribute("draggable")).toBe("true");
+
+      // Leaving select mode restores normal text-selection behavior.
+      container.classList.remove("select-mode-active");
+      mouseDown(contentOf(el));
+      expect(treeOf(el).getAttribute("draggable")).toBe("false");
+      mouseUpWindow();
+    });
+
+    test("losing window focus restores draggable", async () => {
+      // Pressing on the text and releasing in another window (Alt+Tab) delivers
+      // neither mouseup nor dragend, which would strand the row non-draggable.
+      const el = await mountRow({ creativeId: "1", parentId: "", level: 2, canWrite: true });
+      const tree = treeOf(el);
+
+      mouseDown(contentOf(el));
+      expect(tree.getAttribute("draggable")).toBe("false");
+
+      window.dispatchEvent(new window.Event("blur"));
+      expect(tree.getAttribute("draggable")).toBe("true");
+
+      // One-shot: the row is drag-armed again on the next press.
+      mouseDown(contentOf(el));
+      expect(tree.getAttribute("draggable")).toBe("false");
+      mouseUpWindow();
+      expect(tree.getAttribute("draggable")).toBe("true");
+    });
+
+    test("focus moving inside the page does not cut the selection short", async () => {
+      // blur does not bubble, but a capturing window listener would still see
+      // an inner element losing focus and restore draggable mid-gesture.
+      const el = await mountRow({ creativeId: "1", parentId: "", level: 2, canWrite: true });
+      const tree = treeOf(el);
+
+      mouseDown(contentOf(el));
+      contentOf(el).dispatchEvent(new window.Event("blur"));
+      expect(tree.getAttribute("draggable")).toBe("false");
+
+      mouseUpWindow();
+      expect(tree.getAttribute("draggable")).toBe("true");
+    });
+
     test("mousedown is a no-op when the row is not currently draggable", async () => {
       const el = await mountRow({ creativeId: "1", parentId: "", level: 2, canWrite: true });
       const tree = treeOf(el);
@@ -140,7 +198,8 @@ describe("creative-tree-row text selection", () => {
 
       click(contentOf(el));
 
-      expect(window.Turbo.visit).toHaveBeenCalledWith("/creatives/1");
+      // Outside a turbo-frame workspace the row passes no visit options.
+      expect(window.Turbo.visit).toHaveBeenCalledWith("/creatives/1", undefined);
     });
   });
 });

--- a/engines/collavre/app/javascript/components/creative_tree_row.js
+++ b/engines/collavre/app/javascript/components/creative_tree_row.js
@@ -106,6 +106,9 @@ class CreativeTreeRow extends LitElement {
   disconnectedCallback() {
     super.disconnectedCallback();
     this._stopAnimation();
+    // A row torn down mid-gesture (re-render, turbo navigation) would otherwise
+    // leave its window listeners behind, holding on to the detached element.
+    if (this._restoreDraggable) this._restoreDraggable();
   }
 
   get descriptionHtml() {
@@ -630,22 +633,41 @@ class CreativeTreeRow extends LitElement {
     if (this.closest(".select-mode-active")) return;
     if (event.button !== 0) return;
     const tree = this.querySelector(".creative-tree");
-    if (!tree || tree.getAttribute("draggable") !== "true") return;
+    if (!tree) return;
+    // A gesture whose release never reached us (button let go outside the
+    // viewport, no focus change) leaves the row disarmed with its restore
+    // still pending. Run it first so this press starts from a known state
+    // instead of bailing out and stranding the row non-draggable forever.
+    if (this._restoreDraggable) this._restoreDraggable();
+    if (tree.getAttribute("draggable") !== "true") return;
     tree.setAttribute("draggable", "false");
     const restore = () => {
       window.removeEventListener("mouseup", restore, true);
       window.removeEventListener("dragend", restore, true);
+      window.removeEventListener("mousemove", this._restoreOnButtonlessMove, true);
       window.removeEventListener("blur", restore);
+      this._restoreDraggable = null;
       tree.setAttribute("draggable", "true");
     };
+    this._restoreDraggable = restore;
     window.addEventListener("mouseup", restore, true);
     window.addEventListener("dragend", restore, true);
     // Releasing the button after switching windows (Alt+Tab) delivers neither
-    // mouseup nor dragend here, and the guard above would then refuse to re-arm
-    // the row forever. Non-capturing on purpose: blur does not bubble, so this
-    // only sees the window losing focus, not focus moves inside the page.
+    // mouseup nor dragend here. Non-capturing on purpose: blur does not bubble,
+    // so this only sees the window losing focus, not focus moves inside the page.
     window.addEventListener("blur", restore);
+    // Releasing outside the viewport without changing focus delivers none of
+    // the three above; the first pointer move with no button held means the
+    // gesture is over, so re-arm the row for drag-and-drop right then.
+    window.addEventListener("mousemove", this._restoreOnButtonlessMove, true);
   }
+
+  // Bound once so the capture-phase listener can be removed by identity; the
+  // move only ends a gesture when every button is already up.
+  _restoreOnButtonlessMove = (event) => {
+    if (event.buttons !== 0) return;
+    if (this._restoreDraggable) this._restoreDraggable();
+  };
 
   _handleContentClick(event) {
     // In select mode, block navigation — selection toggle is handled by

--- a/engines/collavre/app/javascript/components/creative_tree_row.js
+++ b/engines/collavre/app/javascript/components/creative_tree_row.js
@@ -623,6 +623,11 @@ class CreativeTreeRow extends LitElement {
   // selection works; row drag stays available from the rest of the row.
   _handleContentMouseDown(event) {
     if (this.selectMode) return; // select mode owns mousedown (row selection)
+    // The toolbar's select mode lives on an ancestor Stimulus controller and is
+    // not reflected onto rows that were already rendered. That controller reads
+    // the draggable attribute on mousedown to decide whether an already-selected
+    // row starts a bundle drag, so leave the attribute alone while it is on.
+    if (this.closest(".select-mode-active")) return;
     if (event.button !== 0) return;
     const tree = this.querySelector(".creative-tree");
     if (!tree || tree.getAttribute("draggable") !== "true") return;
@@ -630,10 +635,16 @@ class CreativeTreeRow extends LitElement {
     const restore = () => {
       window.removeEventListener("mouseup", restore, true);
       window.removeEventListener("dragend", restore, true);
+      window.removeEventListener("blur", restore);
       tree.setAttribute("draggable", "true");
     };
     window.addEventListener("mouseup", restore, true);
     window.addEventListener("dragend", restore, true);
+    // Releasing the button after switching windows (Alt+Tab) delivers neither
+    // mouseup nor dragend here, and the guard above would then refuse to re-arm
+    // the row forever. Non-capturing on purpose: blur does not bubble, so this
+    // only sees the window losing focus, not focus moves inside the page.
+    window.addEventListener("blur", restore);
   }
 
   _handleContentClick(event) {

--- a/engines/collavre/app/javascript/components/creative_tree_row.js
+++ b/engines/collavre/app/javascript/components/creative_tree_row.js
@@ -354,7 +354,11 @@ class CreativeTreeRow extends LitElement {
     // Toggle is now rendered outside
     const githubBadge = this._renderGithubBadge();
     const content = html`
-      <div class="creative-content" @click=${this._handleContentClick}>
+      <div
+        class="creative-content"
+        @click=${this._handleContentClick}
+        @mousedown=${this._handleContentMouseDown}
+      >
         ${githubBadge}${unsafeHTML(this.descriptionHtml || "")}
       </div>
     `;
@@ -613,6 +617,25 @@ class CreativeTreeRow extends LitElement {
     }
   }
 
+  // The tree wrapper's draggable="true" makes the browser treat mouse-drag as
+  // an HTML5 row-drag gesture, which kills native drag-to-select over the text.
+  // Drop the attribute while the pointer is down over the content so text
+  // selection works; row drag stays available from the rest of the row.
+  _handleContentMouseDown(event) {
+    if (this.selectMode) return; // select mode owns mousedown (row selection)
+    if (event.button !== 0) return;
+    const tree = this.querySelector(".creative-tree");
+    if (!tree || tree.getAttribute("draggable") !== "true") return;
+    tree.setAttribute("draggable", "false");
+    const restore = () => {
+      window.removeEventListener("mouseup", restore, true);
+      window.removeEventListener("dragend", restore, true);
+      tree.setAttribute("draggable", "true");
+    };
+    window.addEventListener("mouseup", restore, true);
+    window.addEventListener("dragend", restore, true);
+  }
+
   _handleContentClick(event) {
     // In select mode, block navigation — selection toggle is handled by
     // select_mode_controller's mousedown handler to avoid double-toggling.
@@ -631,6 +654,11 @@ class CreativeTreeRow extends LitElement {
       // Allow default behavior for these elements (e.g. download link, image click)
       return;
     }
+
+    // Releasing a drag-to-select gesture fires a click on this row; navigating
+    // away would destroy the selection the user just made.
+    const selection = window.getSelection && window.getSelection();
+    if (selection && !selection.isCollapsed) return;
 
     // If not interactive, navigate to the linkUrl
     if (this.linkUrl && this.linkUrl !== "#") {

--- a/engines/collavre/app/javascript/controllers/creatives/__tests__/select_mode_controller_active_class.test.js
+++ b/engines/collavre/app/javascript/controllers/creatives/__tests__/select_mode_controller_active_class.test.js
@@ -1,0 +1,88 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Select mode is toggled from the toolbar long after the creative rows have
+ * rendered, so rows cannot learn about it from their own attributes. The
+ * controller publishes it as `.select-mode-active` on its container, which
+ * creative-tree-row checks before it temporarily clears the draggable
+ * attribute for text selection — that attribute is what handleRowMouseDown
+ * reads to tell a bundle drag from a selection toggle.
+ */
+import { Application } from '@hotwired/stimulus'
+
+const { default: SelectModeController } = await import('../select_mode_controller')
+
+describe('SelectModeController select-mode-active class', () => {
+  let application
+  let element
+  let toggleButton
+
+  beforeEach(async () => {
+    document.body.innerHTML = `
+      <div data-controller="select-mode">
+        <button type="button"
+                data-select-mode-target="toggle"
+                data-action="select-mode#toggle"
+                data-select-text="Select"
+                data-cancel-text="Cancel">Select</button>
+        <div class="creative-row" data-select-mode-target="row">
+          <input type="checkbox" class="select-creative-checkbox" data-select-mode-target="checkbox">
+        </div>
+      </div>
+    `
+    element = document.querySelector('[data-controller="select-mode"]')
+    toggleButton = element.querySelector('[data-select-mode-target="toggle"]')
+
+    application = Application.start()
+    application.register('select-mode', SelectModeController)
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  })
+
+  afterEach(() => {
+    application.stop()
+    document.body.innerHTML = ''
+  })
+
+  test('is absent until select mode is entered', () => {
+    expect(element.classList.contains('select-mode-active')).toBe(false)
+  })
+
+  test('is added on toggle and removed on cancel', () => {
+    toggleButton.click()
+    expect(element.classList.contains('select-mode-active')).toBe(true)
+
+    toggleButton.click()
+    expect(element.classList.contains('select-mode-active')).toBe(false)
+  })
+
+  test('is cleared when the controller disconnects while active', async () => {
+    toggleButton.click()
+    expect(element.classList.contains('select-mode-active')).toBe(true)
+
+    element.remove()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(element.classList.contains('select-mode-active')).toBe(false)
+  })
+
+  test('an already-selected row still starts a bundle drag in select mode', () => {
+    // Regression guard for the interaction the class exists to protect: with
+    // draggable left at "true", handleRowMouseDown must not toggle the row off.
+    const row = element.querySelector('.creative-row')
+    const tree = document.createElement('div')
+    tree.className = 'creative-tree'
+    tree.setAttribute('draggable', 'true')
+    row.parentNode.insertBefore(tree, row)
+    tree.appendChild(row)
+
+    toggleButton.click()
+    const checkbox = row.querySelector('.select-creative-checkbox')
+    checkbox.checked = true
+    row.classList.add('selected')
+
+    row.dispatchEvent(new window.MouseEvent('mousedown', { bubbles: true, button: 0 }))
+
+    expect(checkbox.checked).toBe(true)
+    expect(row.classList.contains('selected')).toBe(true)
+  })
+})

--- a/engines/collavre/app/javascript/controllers/creatives/select_mode_controller.js
+++ b/engines/collavre/app/javascript/controllers/creatives/select_mode_controller.js
@@ -13,11 +13,17 @@ export default class extends Controller {
     'setPlan',
   ]
 
+  initialize() {
+    // rowTargetConnected() runs before connect(), so the registry has to exist
+    // by then — and connect() must not replace it, or the rows registered in
+    // that window would get a second set of listeners from attachRowHandlers().
+    this.rowListeners = new Map()
+  }
+
   connect() {
     this.active = false
     this.dragging = false
     this.dragMode = 'toggle'
-    this.rowListeners = new Map()
 
     this.handleDocumentMouseUp = this.handleDocumentMouseUp.bind(this)
     document.addEventListener('mouseup', this.handleDocumentMouseUp)
@@ -29,6 +35,7 @@ export default class extends Controller {
   }
 
   disconnect() {
+    this.element.classList.remove('select-mode-active')
     document.removeEventListener('mouseup', this.handleDocumentMouseUp)
     document.removeEventListener('turbo:load', this.handleTurboLoad)
 
@@ -207,6 +214,12 @@ export default class extends Controller {
 
   updateUiForMode() {
     const show = this.active
+
+    // Rows are rendered before this mode is toggled, so they cannot know about
+    // it from their own attributes. Publish it on the container instead:
+    // creative-tree-row checks for this class before touching the draggable
+    // attribute that handleRowMouseDown reads to detect a bundle drag.
+    this.element.classList.toggle('select-mode-active', show)
 
     this.checkboxTargets.forEach((checkbox) => {
       checkbox.style.display = show ? '' : 'none'


### PR DESCRIPTION
## Summary
Users could not select/copy text on the creative list page the way a normal page allows — dragging over row text always started an HTML5 row drag, and even a completed selection was destroyed by the row's click-to-navigate handler.

Root causes:
1. Every `.creative-tree` wrapper is rendered with a static `draggable="true"`, so the browser routes mousedown+move into a drag gesture instead of a text-selection gesture.
2. `_handleContentClick` navigates via `Turbo.visit` on any non-interactive click, so the click fired when releasing a selection inside a row navigated away.

## Changes
- `creative_tree_row.js`: on left mousedown over `.creative-content`, temporarily set `draggable="false"` on the row's `.creative-tree` and restore it on `mouseup`/`dragend`. The browser then starts a native text selection, which can extend across multiple creative rows. Row drag & drop still works from everywhere else on the row (toggle, indent area, bullet, row background), and `handleDragStart`'s existing `tree.draggable === false` guard keeps the Stimulus drag pipeline out of the way. Select mode is untouched (its own mousedown handler owns row selection).
- `_handleContentClick`: skip navigation when the click ends with a non-collapsed text selection, so releasing the mouse at the end of a selection no longer discards it.

## Tests
- New Jest suite `creative_tree_row_text_selection.test.js` covering: draggable toggling on mousedown/mouseup, dragend restore + one-shot listener cleanup, non-left button, select mode, repeated mousedown, and click navigation with collapsed vs non-collapsed selections (7 tests, 100% of the new branches).
- Full Jest suite passes (61 suites, 730 tests). The HTML5 DnD system test is unaffected because the static `draggable="true"` default is preserved (synthetic drag events don't go through mousedown).