### PR TITLE
feat: add persistent three-column creative workspace

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -42,7 +42,7 @@
 
     <%= render 'collavre/shared/custom_theme_style' %>
   </head>
-  <body class="<%= body_theme_class %>" data-current-user-id="<%= Current.user&.id %>" data-system-admin="<%= Current.user&.system_admin? %>" data-controller="action-text-attachment-link" data-action="click->action-text-attachment-link#download">
+  <body class="<%= class_names(body_theme_class, 'creative-workspace': creative_workspace?) %>" data-current-user-id="<%= Current.user&.id %>" data-system-admin="<%= Current.user&.system_admin? %>" data-controller="action-text-attachment-link" data-action="click->action-text-attachment-link#download">
     <%= render 'collavre/shared/link_creative_modal' %>
     <% if Current.user %>
       <%= turbo_stream_from ["inbox", Current.user] %>
@@ -65,11 +65,21 @@
         </div>
       </div>
     </div>
-<% end %>
+    <% end %>
 
-    <main>
-      <%= yield %>
-    </main>
+    <% if creative_workspace? %>
+      <div class="creative-workspace-shell">
+        <%= render "collavre/creatives/workspace_tree" %>
+        <main>
+          <%= yield %>
+        </main>
+        <%= render "collavre/comments/comments_popup", docked: true, creative: @parent_creative %>
+      </div>
+    <% else %>
+      <main>
+        <%= yield %>
+      </main>
+    <% end %>
 
     <%= render 'shared/footer' %>
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_29_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_05_000000) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -928,6 +928,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_29_000000) do
     t.string "calendar_id"
     t.datetime "created_at", null: false
     t.integer "created_by_id"
+    t.boolean "creative_workspace_enabled", default: false, null: false
     t.string "email", null: false
     t.datetime "email_verified_at"
     t.integer "failed_login_attempts", default: 0, null: false

--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -1896,6 +1896,11 @@ body.chat-fullscreen {
   position: static;
 }
 
+/* Chevron icon shown while the docked chat is collapsed */
+.comments-popup-actions .popup-close-btn svg {
+  display: block;
+}
+
 /* Streaming indicator for AI comments */
 .comment-content.streaming {
     min-height: 1.5em;

--- a/engines/collavre/app/assets/stylesheets/collavre/workspace.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/workspace.css
@@ -23,6 +23,11 @@ body.creative-workspace > nav {
     overflow: auto;
 }
 
+#creative-workspace-content {
+    display: block;
+    min-width: 0;
+}
+
 body.creative-workspace .creative-content {
     min-width: 0;
     max-width: none;

--- a/engines/collavre/app/assets/stylesheets/collavre/workspace.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/workspace.css
@@ -5,7 +5,7 @@ body.creative-workspace {
 
 .creative-workspace-shell {
     display: grid;
-    grid-template-columns: minmax(240px, 300px) minmax(0, 1fr) minmax(320px, 420px);
+    grid-template-columns: minmax(240px, 300px) minmax(0, 1fr) minmax(0, 1fr);
     flex: 1;
     width: 100%;
     min-height: 0;
@@ -183,7 +183,7 @@ body.creative-workspace .creative-content {
 
 @media (min-width: 768px) and (max-width: 1279px) {
     .creative-workspace-shell {
-        grid-template-columns: minmax(0, 1fr) minmax(320px, 420px);
+        grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
     }
 
     .creative-workspace-shell > main {

--- a/engines/collavre/app/assets/stylesheets/collavre/workspace.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/workspace.css
@@ -1,0 +1,255 @@
+body.creative-workspace {
+    height: 100dvh;
+    overflow: hidden;
+}
+
+.creative-workspace-shell {
+    display: grid;
+    grid-template-columns: minmax(240px, 300px) minmax(0, 1fr) minmax(320px, 420px);
+    flex: 1;
+    width: 100%;
+    min-height: 0;
+}
+
+body.creative-workspace > nav {
+    max-width: none;
+}
+
+.creative-workspace-shell > main {
+    grid-column: 2;
+    width: 100%;
+    max-width: none;
+    min-width: 0;
+    overflow: auto;
+}
+
+body.creative-workspace .creative-content {
+    min-width: 0;
+    max-width: none;
+}
+
+.creative-workspace-tree-region {
+    grid-column: 1;
+    min-width: 0;
+    overflow: hidden;
+    background: var(--surface-section);
+    border-right: var(--border-1) solid var(--border-color);
+}
+
+#creative-workspace-tree {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    min-height: 0;
+}
+
+.creative-workspace-tree-header {
+    padding: var(--space-3);
+    border-bottom: var(--border-1) solid var(--border-color);
+}
+
+.creative-workspace-tree-header h2 {
+    margin: 0;
+    font-size: var(--text-2);
+}
+
+.creative-workspace-tree-nav {
+    display: block;
+    flex: 1;
+    max-width: none;
+    min-height: 0;
+    padding: var(--space-2);
+    overflow: auto;
+    background: transparent;
+    border: 0;
+}
+
+.creative-workspace-tree-list {
+    margin: 0;
+    padding: 0 0 0 var(--space-3);
+    list-style: none;
+}
+
+.creative-workspace-tree-nav > .creative-workspace-tree-list {
+    padding-left: 0;
+}
+
+.creative-workspace-tree-row {
+    display: flex;
+    align-items: center;
+    min-width: 0;
+}
+
+.creative-workspace-tree-branch-toggle,
+.creative-workspace-tree-branch-spacer {
+    width: 1.75rem;
+    min-width: 1.75rem;
+}
+
+.creative-workspace-tree-branch-toggle {
+    padding: var(--space-1);
+    color: var(--text-muted);
+    background: transparent;
+    border: 0;
+    cursor: pointer;
+}
+
+.creative-workspace-tree-link {
+    display: block;
+    flex: 1;
+    min-width: 0;
+    padding: var(--space-2);
+    overflow: hidden;
+    color: var(--text-primary);
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    border-radius: var(--radius-2);
+}
+
+.creative-workspace-tree-link:hover,
+.creative-workspace-tree-link.is-current {
+    background: var(--surface-hover);
+}
+
+.creative-workspace-tree-link.is-current {
+    color: var(--color-active);
+    font-weight: var(--weight-6);
+}
+
+.creative-workspace-tree-status {
+    padding: var(--space-3);
+    color: var(--text-muted);
+    text-align: center;
+}
+
+.creative-workspace-tree-toggle {
+    display: none;
+}
+
+#comments-list.docked-empty {
+    align-items: center;
+    justify-content: center;
+    color: var(--text-muted);
+    text-align: center;
+    background: transparent;
+}
+
+#comments-list.docked-empty::before {
+    display: none;
+}
+
+@media (min-width: 768px) {
+    .creative-workspace-shell > #comments-popup[data-docked="true"]:not([data-fullscreen="true"]) {
+        display: flex;
+        position: static;
+        grid-column: 3;
+        width: auto;
+        height: auto;
+        max-width: none !important;
+        max-height: none;
+        min-width: 0;
+        min-height: 0;
+        z-index: auto;
+        border-width: 0 0 0 var(--border-1);
+        border-color: var(--border-color);
+        border-radius: 0;
+        box-shadow: none;
+        transition: none;
+    }
+
+    .creative-workspace-shell > #comments-popup[data-docked="true"]:not([data-fullscreen="true"]) .resize-handle {
+        display: none;
+    }
+
+    .creative-workspace-shell:has(#comments-popup.docked-collapsed) {
+        grid-template-columns: minmax(240px, 300px) minmax(0, 1fr) 3rem;
+    }
+
+    #comments-popup.docked-collapsed:not([data-fullscreen="true"]) {
+        padding: var(--space-2);
+    }
+
+    #comments-popup.docked-collapsed:not([data-fullscreen="true"]) > :not(.comments-popup-header),
+    #comments-popup.docked-collapsed:not([data-fullscreen="true"]) .comments-popup-header > :not(.comments-popup-actions),
+    #comments-popup.docked-collapsed:not([data-fullscreen="true"]) .comments-popup-actions > :not(#close-comments-btn) {
+        display: none !important;
+    }
+}
+
+@media (min-width: 768px) and (max-width: 1279px) {
+    .creative-workspace-shell {
+        grid-template-columns: minmax(0, 1fr) minmax(320px, 420px);
+    }
+
+    .creative-workspace-shell > main {
+        grid-column: 1;
+    }
+
+    .creative-workspace-shell > #comments-popup[data-docked="true"]:not([data-fullscreen="true"]) {
+        grid-column: 2;
+    }
+
+    .creative-workspace-shell:has(#comments-popup.docked-collapsed) {
+        grid-template-columns: minmax(0, 1fr) 3rem;
+    }
+
+    .creative-workspace-tree-region {
+        position: fixed;
+        top: 0;
+        bottom: 0;
+        left: 0;
+        z-index: var(--layer-modal);
+        width: min(300px, 80vw);
+        overflow: visible;
+        box-shadow: var(--shadow-3);
+        transform: translateX(-100%);
+        transition: transform 0.2s var(--ease-out-2);
+    }
+
+    .creative-workspace-tree-region.is-open {
+        transform: translateX(0);
+    }
+
+    .creative-workspace-tree-toggle {
+        position: absolute;
+        top: 5rem;
+        right: -2.75rem;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 2.75rem;
+        height: 2.75rem;
+        padding: 0;
+        color: var(--text-primary);
+        background: var(--surface-section);
+        border: var(--border-1) solid var(--border-color);
+        border-left: 0;
+        border-radius: 0 var(--radius-2) var(--radius-2) 0;
+        cursor: pointer;
+    }
+
+    .creative-workspace-tree-region.is-open .creative-workspace-tree-toggle-icon {
+        transform: rotate(180deg);
+    }
+}
+
+@media (max-width: 767px) {
+    body.creative-workspace {
+        height: auto;
+        overflow: visible;
+    }
+
+    .creative-workspace-shell {
+        display: block;
+    }
+
+    body.creative-workspace > nav,
+    .creative-workspace-shell > main {
+        max-width: var(--max-width);
+    }
+
+    .creative-workspace-tree-region {
+        display: none;
+    }
+
+}

--- a/engines/collavre/app/assets/stylesheets/collavre/workspace.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/workspace.css
@@ -211,8 +211,16 @@ body.creative-workspace .creative-content {
         transition: transform 0.2s var(--ease-out-2);
     }
 
+    .creative-workspace-tree-region > aside {
+        visibility: hidden;
+    }
+
     .creative-workspace-tree-region.is-open {
         transform: translateX(0);
+    }
+
+    .creative-workspace-tree-region.is-open > aside {
+        visibility: visible;
     }
 
     .creative-workspace-tree-toggle {

--- a/engines/collavre/app/controllers/collavre/creatives_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creatives_controller.rb
@@ -31,6 +31,10 @@ module Collavre
           end
           @creatives = []  # CSR will fetch via JSON
           @shared_list = @parent_creative ? @parent_creative.all_shared_users : []
+          @workspace_path_ids = Creatives::WorkspacePathResolver.new(
+            creative: @parent_creative,
+            user: Current.user
+          ).call
         end
         format.json do
           # Full query only for JSON requests

--- a/engines/collavre/app/controllers/collavre/creatives_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creatives_controller.rb
@@ -55,6 +55,18 @@ module Collavre
           @allowed_creative_ids = index_result.allowed_creative_ids
           @progress_map = index_result.progress_map
 
+          if params[:workspace_tree] == "1"
+            expires_now
+            render json: {
+              creatives: Collavre::Creatives::WorkspaceTreeBuilder.new(
+                user: Current.user,
+                view_context: view_context,
+                max_level: Collavre::SystemSetting.display_level
+              ).build(index_result.creatives)
+            }
+            return
+          end
+
           # Set filtered_progress on parent creative if progress_map is available
           if @parent_creative && @progress_map && @progress_map.key?(@parent_creative.id.to_s)
             @parent_creative.filtered_progress = @progress_map[@parent_creative.id.to_s]

--- a/engines/collavre/app/controllers/collavre/creatives_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creatives_controller.rb
@@ -31,10 +31,12 @@ module Collavre
           end
           @creatives = []  # CSR will fetch via JSON
           @shared_list = @parent_creative ? @parent_creative.all_shared_users : []
-          @workspace_path_ids = Creatives::WorkspacePathResolver.new(
-            creative: @parent_creative,
-            user: Current.user
-          ).call
+          if Current.user&.creative_workspace_enabled?
+            @workspace_path_ids = Creatives::WorkspacePathResolver.new(
+              creative: @parent_creative,
+              user: Current.user
+            ).call
+          end
         end
         format.json do
           # Full query only for JSON requests

--- a/engines/collavre/app/controllers/concerns/collavre/users_controller/profile_and_settings.rb
+++ b/engines/collavre/app/controllers/concerns/collavre/users_controller/profile_and_settings.rb
@@ -98,6 +98,7 @@ module Collavre
         :calendar_id,
         :timezone,
         :locale,
+        :creative_workspace_enabled,
         :typo_correction_enabled,
         :typo_correction_threshold,
         :typo_correction_on_soft_keyboard,

--- a/engines/collavre/app/helpers/collavre/application_helper.rb
+++ b/engines/collavre/app/helpers/collavre/application_helper.rb
@@ -71,7 +71,7 @@ module Collavre
     end
 
     def creative_workspace?
-      Current.user.present? &&
+      Current.user&.creative_workspace_enabled? &&
         controller_path == "collavre/creatives" &&
         action_name == "index" &&
         !@auto_fullscreen

--- a/engines/collavre/app/helpers/collavre/application_helper.rb
+++ b/engines/collavre/app/helpers/collavre/application_helper.rb
@@ -15,6 +15,7 @@ module Collavre
       collavre/org_chart
       collavre/popup
       collavre/comments_popup
+      collavre/workspace
       collavre/tables
       collavre/code_highlight
       collavre/comment_versions
@@ -67,6 +68,13 @@ module Collavre
       else
         "light-mode" # Custom theme: neutralize OS dark mode
       end
+    end
+
+    def creative_workspace?
+      Current.user.present? &&
+        controller_path == "collavre/creatives" &&
+        action_name == "index" &&
+        !@auto_fullscreen
     end
 
     # Renders CSS for admin-configured default themes (light/dark mode)

--- a/engines/collavre/app/javascript/components/__tests__/creative_tree_row_parent_id.test.js
+++ b/engines/collavre/app/javascript/components/__tests__/creative_tree_row_parent_id.test.js
@@ -14,17 +14,19 @@
 // The component calls `customElements.define(...)` at module-eval time and reads
 // `customElements` as a bare global. The jest environment only exposes it on
 // `window`, so bridge it before importing the component.
+import { jest } from '@jest/globals'
+
 beforeAll(() => {
   if (typeof globalThis.customElements === "undefined") {
     globalThis.customElements = window.customElements;
   }
 });
 
-async function mountRow(props) {
+async function mountRow(props, parent = document.body) {
   await import("../creative_tree_row.js");
   const el = document.createElement("creative-tree-row");
   Object.assign(el, props);
-  document.body.appendChild(el);
+  parent.appendChild(el);
   await el.updateComplete;
   return el;
 }
@@ -83,5 +85,22 @@ describe("creative-tree-row parentId convention", () => {
 
     const derivedParentId = prev.dataset.parentId || "";
     expect(derivedParentId).toBe("5"); // sibling inherits the page-title parent
+  });
+
+  test("content navigation stays inside the persistent workspace frame", async () => {
+    const frame = document.createElement("turbo-frame");
+    frame.id = "creative-workspace-content";
+    document.body.appendChild(frame);
+    const visit = jest.fn();
+    window.Turbo = { visit };
+    const el = await mountRow({ creativeId: "8", linkUrl: "/creatives/8" }, frame);
+
+    el.querySelector(".creative-content").dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+
+    expect(visit).toHaveBeenCalledWith("/creatives/8", {
+      action: "advance",
+      frame: "creative-workspace-content",
+    });
+    delete window.Turbo;
   });
 });

--- a/engines/collavre/app/javascript/components/creative_tree_row.js
+++ b/engines/collavre/app/javascript/components/creative_tree_row.js
@@ -635,7 +635,11 @@ class CreativeTreeRow extends LitElement {
     // If not interactive, navigate to the linkUrl
     if (this.linkUrl && this.linkUrl !== "#") {
       if (window.Turbo) {
-        window.Turbo.visit(this.linkUrl);
+        const workspaceFrame = this.closest("turbo-frame#creative-workspace-content");
+        const options = workspaceFrame
+          ? { action: "advance", frame: workspaceFrame.id }
+          : undefined;
+        window.Turbo.visit(this.linkUrl, options);
       } else {
         window.location.href = this.linkUrl;
       }

--- a/engines/collavre/app/javascript/controllers/__tests__/workspace_tree_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/workspace_tree_controller.test.js
@@ -164,6 +164,41 @@ describe('WorkspaceTreeController', () => {
     document.removeEventListener('creative-comments-click', chatListener)
   })
 
+  test('forwards comment targets only from authoritative frame loads', () => {
+    const chatListener = jest.fn()
+    document.addEventListener('creative-comments-click', chatListener)
+    const frame = document.getElementById('creative-workspace-content')
+    window.history.replaceState({}, '', '/creatives/2/comments/456')
+
+    frame.dispatchEvent(new CustomEvent('turbo:frame-render', { bubbles: true }))
+    expect(chatListener).toHaveBeenLastCalledWith(expect.objectContaining({
+      detail: expect.objectContaining({ creativeId: '2', highlightId: undefined }),
+    }))
+
+    frame.dispatchEvent(new CustomEvent('turbo:frame-load', { bubbles: true }))
+    expect(chatListener).toHaveBeenLastCalledWith(expect.objectContaining({
+      detail: expect.objectContaining({ creativeId: '2', highlightId: '456' }),
+    }))
+    document.removeEventListener('creative-comments-click', chatListener)
+  })
+
+  test('extracts query, path, and hash comment targets from workspace URLs', () => {
+    window.history.replaceState({}, '', '/creatives?id=2&comment_id=456')
+    expect(controller.commentIdFromLocation()).toBe('456')
+
+    window.history.replaceState({}, '', '/creatives?id=2&highlight_comment_id=567')
+    expect(controller.commentIdFromLocation()).toBe('567')
+
+    window.history.replaceState({}, '', '/creatives/2/comments/678')
+    expect(controller.commentIdFromLocation()).toBe('678')
+
+    window.history.replaceState({}, '', '/creatives?id=2#comment_789')
+    expect(controller.commentIdFromLocation()).toBe('789')
+
+    window.history.replaceState({}, '', '/creatives?id=2')
+    expect(controller.commentIdFromLocation()).toBeUndefined()
+  })
+
   test('trusts the completed frame response when an inaccessible id falls back to root', () => {
     const chatListener = jest.fn()
     document.addEventListener('creative-comments-click', chatListener)

--- a/engines/collavre/app/javascript/controllers/__tests__/workspace_tree_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/workspace_tree_controller.test.js
@@ -529,6 +529,49 @@ describe('WorkspaceTreeController', () => {
     document.removeEventListener('creative-comments-click', chatListener)
   })
 
+  test('reloads the center frame when a history restore renders mismatched state', async () => {
+    const frame = document.getElementById('creative-workspace-content')
+    window.history.replaceState({}, '', '/creatives?id=5')
+
+    document.dispatchEvent(new CustomEvent('turbo:visit', { detail: { action: 'restore' } }))
+    document.dispatchEvent(new Event('turbo:render'))
+    await new Promise((resolve) => requestAnimationFrame(resolve))
+
+    expect(frame.src).toBe(window.location.href)
+  })
+
+  test('reloads the center frame when a history restore renders no navigation state', async () => {
+    const frame = document.getElementById('creative-workspace-content')
+    frame.innerHTML = ''
+
+    document.dispatchEvent(new CustomEvent('turbo:visit', { detail: { action: 'restore' } }))
+    document.dispatchEvent(new Event('turbo:render'))
+    await new Promise((resolve) => requestAnimationFrame(resolve))
+
+    expect(frame.src).toBe(window.location.href)
+  })
+
+  test('leaves the center frame alone when a restore matches the URL', async () => {
+    const frame = document.getElementById('creative-workspace-content')
+
+    document.dispatchEvent(new CustomEvent('turbo:visit', { detail: { action: 'restore' } }))
+    document.dispatchEvent(new Event('turbo:render'))
+    await new Promise((resolve) => requestAnimationFrame(resolve))
+
+    expect(frame.src).toBeUndefined()
+  })
+
+  test('does not reload the frame for non-restore visits with transient mismatches', async () => {
+    const frame = document.getElementById('creative-workspace-content')
+    window.history.replaceState({}, '', '/creatives?id=5')
+
+    document.dispatchEvent(new CustomEvent('turbo:visit', { detail: { action: 'advance' } }))
+    document.dispatchEvent(new Event('turbo:render'))
+    await new Promise((resolve) => requestAnimationFrame(resolve))
+
+    expect(frame.src).toBeUndefined()
+  })
+
   test('shows the empty state', async () => {
     const controllerElement = document.querySelector('[data-controller="workspace-tree"]')
     const controller = application.getControllerForElementAndIdentifier(controllerElement, 'workspace-tree')

--- a/engines/collavre/app/javascript/controllers/__tests__/workspace_tree_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/workspace_tree_controller.test.js
@@ -378,6 +378,87 @@ describe('WorkspaceTreeController', () => {
     document.removeEventListener('creative-comments-click', chatListener)
   })
 
+  test('restores a re-granted leaf creative from an authoritative frame response', async () => {
+    const chatListener = jest.fn()
+    document.addEventListener('creative-comments-click', chatListener)
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        creatives: [{ id: 1, label: 'Root', url: '/creatives?id=1', children: [] }],
+      }),
+    })
+
+    document.dispatchEvent(new CustomEvent('workspace-tree:invalidate', {
+      detail: { creativeIds: ['2'] },
+    }))
+    await new Promise((resolve) => setTimeout(resolve, 120))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(controller.invalidatedCreativeIds.has('2')).toBe(true)
+
+    chatListener.mockClear()
+    const frame = document.getElementById('creative-workspace-content')
+    frame.dispatchEvent(new CustomEvent('turbo:before-fetch-request', { bubbles: true }))
+    frame.dispatchEvent(new CustomEvent('turbo:frame-load', { bubbles: true }))
+
+    expect(controller.invalidatedCreativeIds.has('2')).toBe(false)
+    expect(chatListener).toHaveBeenCalledWith(expect.objectContaining({
+      detail: expect.objectContaining({ creativeId: '2', workspaceSync: true }),
+    }))
+    document.removeEventListener('creative-comments-click', chatListener)
+  })
+
+  test('does not restore a leaf from a frame request started before invalidation', async () => {
+    const chatListener = jest.fn()
+    document.addEventListener('creative-comments-click', chatListener)
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ creatives: [] }),
+    })
+
+    const frame = document.getElementById('creative-workspace-content')
+    frame.dispatchEvent(new CustomEvent('turbo:before-fetch-request', { bubbles: true }))
+    document.dispatchEvent(new CustomEvent('workspace-tree:invalidate', {
+      detail: { creativeIds: ['2'] },
+    }))
+    await new Promise((resolve) => setTimeout(resolve, 120))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    chatListener.mockClear()
+    frame.dispatchEvent(new CustomEvent('turbo:frame-load', { bubbles: true }))
+
+    expect(controller.invalidatedCreativeIds.has('2')).toBe(true)
+    expect(chatListener).not.toHaveBeenCalledWith(expect.objectContaining({
+      detail: expect.objectContaining({ creativeId: '2' }),
+    }))
+    document.removeEventListener('creative-comments-click', chatListener)
+  })
+
+  test('never restores destroyed creatives from an authoritative frame response', async () => {
+    const chatListener = jest.fn()
+    document.addEventListener('creative-comments-click', chatListener)
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ creatives: [] }),
+    })
+
+    document.dispatchEvent(new CustomEvent('creative-destroyed', {
+      detail: { creativeIds: ['2'] },
+    }))
+    await new Promise((resolve) => setTimeout(resolve, 120))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    chatListener.mockClear()
+    const frame = document.getElementById('creative-workspace-content')
+    frame.dispatchEvent(new CustomEvent('turbo:before-fetch-request', { bubbles: true }))
+    frame.dispatchEvent(new CustomEvent('turbo:frame-load', { bubbles: true }))
+
+    expect(controller.invalidatedCreativeIds.has('2')).toBe(true)
+    expect(chatListener).not.toHaveBeenCalledWith(expect.objectContaining({
+      detail: expect.objectContaining({ creativeId: '2' }),
+    }))
+    document.removeEventListener('creative-comments-click', chatListener)
+  })
+
   test('does not restore access from a tree request started before invalidation', async () => {
     let resolveStaleFetch
     fetchMock.mockReturnValueOnce(new Promise((resolve) => {

--- a/engines/collavre/app/javascript/controllers/__tests__/workspace_tree_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/workspace_tree_controller.test.js
@@ -1,0 +1,99 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { Application } from '@hotwired/stimulus'
+import { jest } from '@jest/globals'
+import WorkspaceTreeController from '../workspace_tree_controller'
+
+describe('WorkspaceTreeController', () => {
+  let application
+  let fetchMock
+
+  beforeEach(async () => {
+    fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        creatives: [
+          {
+            id: 1,
+            label: 'Root',
+            url: '/creatives/1',
+            children: [
+              { id: 2, label: 'Current branch', url: '/creatives/2', children: [] },
+            ],
+          },
+        ],
+      }),
+    })
+    global.fetch = fetchMock
+    document.body.innerHTML = `
+      <section data-controller="workspace-tree"
+               data-workspace-tree-url-value="/creatives.json?workspace_tree=1"
+               data-workspace-tree-current-path-value="[1,2,3]"
+               data-workspace-tree-loading-text-value="Loading"
+               data-workspace-tree-empty-text-value="Empty"
+               data-workspace-tree-error-text-value="Error">
+        <button data-workspace-tree-target="panelToggle" data-action="workspace-tree#togglePanel" aria-expanded="false"></button>
+        <nav data-workspace-tree-target="tree"></nav>
+      </section>
+    `
+
+    application = Application.start()
+    application.register('workspace-tree', WorkspaceTreeController)
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  })
+
+  afterEach(() => {
+    application.stop()
+    document.body.innerHTML = ''
+    delete global.fetch
+  })
+
+  test('renders the tree, expands the current path, and marks the deepest visible node', () => {
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/creatives.json?workspace_tree=1',
+      expect.objectContaining({ headers: { Accept: 'application/json' } })
+    )
+    expect(document.querySelector('[data-creative-id="1"] > ul').hidden).toBe(false)
+    expect(document.querySelector('[data-creative-id="2"] a').classList.contains('is-current')).toBe(true)
+    expect(document.querySelector('[data-creative-id="2"] a').getAttribute('aria-current')).toBe('page')
+  })
+
+  test('toggles branches and the medium-width panel', () => {
+    const branchToggle = document.querySelector('.creative-workspace-tree-branch-toggle')
+    branchToggle.click()
+    expect(document.querySelector('[data-creative-id="1"] > ul').hidden).toBe(true)
+    expect(branchToggle.getAttribute('aria-expanded')).toBe('false')
+
+    const panelToggle = document.querySelector('[data-workspace-tree-target="panelToggle"]')
+    panelToggle.click()
+    expect(panelToggle.closest('section').classList.contains('is-open')).toBe(true)
+    expect(panelToggle.getAttribute('aria-expanded')).toBe('true')
+
+    document.querySelector('.creative-workspace-tree-link').click()
+    expect(panelToggle.closest('section').classList.contains('is-open')).toBe(false)
+  })
+
+  test('shows the empty state', async () => {
+    const controllerElement = document.querySelector('[data-controller="workspace-tree"]')
+    const controller = application.getControllerForElementAndIdentifier(controllerElement, 'workspace-tree')
+
+    controller.render([])
+
+    expect(document.querySelector('.creative-workspace-tree-status').textContent).toBe('Empty')
+  })
+
+  test('shows the localized error state when loading fails', async () => {
+    const controllerElement = document.querySelector('[data-controller="workspace-tree"]')
+    const controller = application.getControllerForElementAndIdentifier(controllerElement, 'workspace-tree')
+    fetchMock.mockRejectedValueOnce(new Error('offline'))
+    jest.spyOn(console, 'error').mockImplementation(() => {})
+
+    await controller.load()
+
+    expect(document.querySelector('.creative-workspace-tree-status').textContent).toBe('Error')
+    console.error.mockRestore()
+  })
+})

--- a/engines/collavre/app/javascript/controllers/__tests__/workspace_tree_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/workspace_tree_controller.test.js
@@ -86,6 +86,7 @@ describe('WorkspaceTreeController', () => {
     expect(document.querySelector('[data-creative-id="2"] a').getAttribute('aria-current')).toBe('page')
     expect(document.querySelector('[data-creative-id="2"] a').dataset.turboFrame).toBe('creative-workspace-content')
     expect(document.querySelector('[data-creative-id="2"] a').dataset.turboAction).toBe('advance')
+    expect(document.querySelector('.creative-workspace-tree-branch-toggle').getAttribute('aria-label')).toBe('Root')
   })
 
   test('toggles branches and the medium-width panel', () => {

--- a/engines/collavre/app/javascript/controllers/__tests__/workspace_tree_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/workspace_tree_controller.test.js
@@ -223,6 +223,53 @@ describe('WorkspaceTreeController', () => {
     expect(document.querySelector('.creative-workspace-tree-branch-toggle').getAttribute('aria-expanded')).toBe('false')
   })
 
+  test('does not reopen an invalidated chat from stale frame state after tree refresh', async () => {
+    const chatListener = jest.fn()
+    document.addEventListener('creative-comments-click', chatListener)
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ creatives: [] }),
+    })
+
+    document.dispatchEvent(new CustomEvent('creative-destroyed', {
+      detail: { creativeIds: ['2'] },
+    }))
+    await new Promise((resolve) => setTimeout(resolve, 120))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(chatListener).toHaveBeenCalledWith(expect.objectContaining({
+      detail: expect.objectContaining({ creativeId: undefined, workspaceSync: true }),
+    }))
+    expect(chatListener).not.toHaveBeenCalledWith(expect.objectContaining({
+      detail: expect.objectContaining({ creativeId: '2' }),
+    }))
+    expect(document.querySelector('.creative-workspace-tree-link.is-current')).toBeNull()
+
+    chatListener.mockClear()
+    document.getElementById('creative-workspace-content')
+      .dispatchEvent(new CustomEvent('turbo:frame-load', { bubbles: true }))
+    expect(chatListener).toHaveBeenCalledWith(expect.objectContaining({
+      detail: expect.objectContaining({ creativeId: undefined, workspaceSync: true }),
+    }))
+    expect(chatListener).not.toHaveBeenCalledWith(expect.objectContaining({
+      detail: expect.objectContaining({ creativeId: '2' }),
+    }))
+    document.removeEventListener('creative-comments-click', chatListener)
+  })
+
+  test('does not optimistically open an invalidated tree link', () => {
+    const chatListener = jest.fn()
+    document.addEventListener('creative-comments-click', chatListener)
+    const rootLink = document.querySelector('[data-creative-id="1"] > div > a')
+    controller.rememberInvalidatedCreativeIds({ detail: { creativeIds: ['1'] } })
+
+    rootLink.dispatchEvent(new MouseEvent('click', { bubbles: true, button: 0, cancelable: true }))
+
+    expect(chatListener).not.toHaveBeenCalled()
+    expect(document.querySelector('[data-creative-id="2"] a').classList.contains('is-current')).toBe(true)
+    document.removeEventListener('creative-comments-click', chatListener)
+  })
+
   test('shows the empty state', async () => {
     const controllerElement = document.querySelector('[data-controller="workspace-tree"]')
     const controller = application.getControllerForElementAndIdentifier(controllerElement, 'workspace-tree')

--- a/engines/collavre/app/javascript/controllers/__tests__/workspace_tree_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/workspace_tree_controller.test.js
@@ -8,7 +8,9 @@ import WorkspaceTreeController from '../workspace_tree_controller'
 
 describe('WorkspaceTreeController', () => {
   let application
+  let controller
   let fetchMock
+  let preventNavigation
 
   beforeEach(async () => {
     fetchMock = jest.fn().mockResolvedValue({
@@ -18,15 +20,27 @@ describe('WorkspaceTreeController', () => {
           {
             id: 1,
             label: 'Root',
-            url: '/creatives/1',
+            snippet: 'Root chat',
+            can_comment: true,
+            url: '/creatives?id=1',
             children: [
-              { id: 2, label: 'Current branch', url: '/creatives/2', children: [] },
+              {
+                id: 2,
+                label: 'Current branch',
+                snippet: 'Branch chat',
+                can_comment: false,
+                url: '/creatives?id=2',
+                children: [],
+              },
             ],
           },
         ],
       }),
     })
     global.fetch = fetchMock
+    window.history.replaceState({}, '', '/creatives?id=2')
+    preventNavigation = (event) => event.preventDefault()
+    document.addEventListener('click', preventNavigation)
     document.body.innerHTML = `
       <section data-controller="workspace-tree"
                data-workspace-tree-url-value="/creatives.json?workspace_tree=1"
@@ -37,16 +51,27 @@ describe('WorkspaceTreeController', () => {
         <button data-workspace-tree-target="panelToggle" data-action="workspace-tree#togglePanel" aria-expanded="false"></button>
         <nav data-workspace-tree-target="tree"></nav>
       </section>
+      <turbo-frame id="creative-workspace-content">
+        <div data-workspace-navigation-state
+             data-creative-id="2"
+             data-creative-snippet="Branch chat"
+             data-can-comment="false"
+             data-creative-path="[1,2,3]"></div>
+      </turbo-frame>
     `
 
     application = Application.start()
     application.register('workspace-tree', WorkspaceTreeController)
     await new Promise((resolve) => setTimeout(resolve, 0))
     await new Promise((resolve) => setTimeout(resolve, 0))
+    const controllerElement = document.querySelector('[data-controller="workspace-tree"]')
+    controller = application.getControllerForElementAndIdentifier(controllerElement, 'workspace-tree')
   })
 
   afterEach(() => {
+    controller.disconnect()
     application.stop()
+    document.removeEventListener('click', preventNavigation)
     document.body.innerHTML = ''
     delete global.fetch
   })
@@ -59,6 +84,8 @@ describe('WorkspaceTreeController', () => {
     expect(document.querySelector('[data-creative-id="1"] > ul').hidden).toBe(false)
     expect(document.querySelector('[data-creative-id="2"] a').classList.contains('is-current')).toBe(true)
     expect(document.querySelector('[data-creative-id="2"] a').getAttribute('aria-current')).toBe('page')
+    expect(document.querySelector('[data-creative-id="2"] a').dataset.turboFrame).toBe('creative-workspace-content')
+    expect(document.querySelector('[data-creative-id="2"] a').dataset.turboAction).toBe('advance')
   })
 
   test('toggles branches and the medium-width panel', () => {
@@ -74,6 +101,121 @@ describe('WorkspaceTreeController', () => {
 
     document.querySelector('.creative-workspace-tree-link').click()
     expect(panelToggle.closest('section').classList.contains('is-open')).toBe(false)
+  })
+
+  test('keeps the mounted tree state and switches chat while the center frame navigates', () => {
+    const treeRegion = document.querySelector('[data-controller="workspace-tree"]')
+    const rootLink = document.querySelector('[data-creative-id="1"] > div > a')
+    const chatListener = jest.fn()
+    document.addEventListener('creative-comments-click', chatListener)
+
+    rootLink.dispatchEvent(new MouseEvent('click', { bubbles: true, button: 0, cancelable: true }))
+    window.history.replaceState({}, '', '/creatives?id=1')
+
+    expect(rootLink.classList.contains('is-current')).toBe(true)
+    expect(chatListener).toHaveBeenCalledWith(expect.objectContaining({
+      detail: expect.objectContaining({ creativeId: '1', button: rootLink }),
+    }))
+
+    const frame = document.getElementById('creative-workspace-content')
+    const state = frame.querySelector('[data-workspace-navigation-state]')
+    state.dataset.creativeId = '1'
+    state.dataset.creativePath = '[1]'
+    frame.dispatchEvent(new CustomEvent('turbo:frame-load', { bubbles: true }))
+
+    expect(document.querySelector('[data-controller="workspace-tree"]')).toBe(treeRegion)
+    expect(rootLink.classList.contains('is-current')).toBe(true)
+    document.removeEventListener('creative-comments-click', chatListener)
+  })
+
+  test('syncs leaf and root chat state independently of visible tree links', () => {
+    const chatListener = jest.fn()
+    document.addEventListener('creative-comments-click', chatListener)
+    const frame = document.getElementById('creative-workspace-content')
+    const state = frame.querySelector('[data-workspace-navigation-state]')
+
+    state.dataset.creativeId = '3'
+    state.dataset.creativeSnippet = 'Leaf chat'
+    state.dataset.canComment = 'true'
+    state.dataset.creativePath = '[1,2,3]'
+    window.history.replaceState({}, '', '/creatives?id=3')
+    frame.dispatchEvent(new CustomEvent('turbo:frame-load', { bubbles: true }))
+
+    expect(document.querySelector('[data-creative-id="2"] a').classList.contains('is-current')).toBe(true)
+    expect(chatListener).toHaveBeenLastCalledWith(expect.objectContaining({
+      detail: expect.objectContaining({ creativeId: '3', button: state }),
+    }))
+
+    delete state.dataset.creativeId
+    state.dataset.creativePath = '[]'
+    window.history.replaceState({}, '', '/creatives')
+    frame.dispatchEvent(new CustomEvent('turbo:frame-load', { bubbles: true }))
+
+    expect(document.querySelector('.creative-workspace-tree-link.is-current')).toBeNull()
+    expect(chatListener).toHaveBeenLastCalledWith(expect.objectContaining({
+      detail: expect.objectContaining({ creativeId: undefined, button: expect.any(HTMLElement) }),
+    }))
+    expect(chatListener.mock.lastCall[0].detail.button.dataset.workspaceNavigationState).toBe('true')
+    document.removeEventListener('creative-comments-click', chatListener)
+  })
+
+  test('trusts the completed frame response when an inaccessible id falls back to root', () => {
+    const chatListener = jest.fn()
+    document.addEventListener('creative-comments-click', chatListener)
+    const frame = document.getElementById('creative-workspace-content')
+    const state = frame.querySelector('[data-workspace-navigation-state]')
+
+    delete state.dataset.creativeId
+    state.dataset.creativePath = '[]'
+    window.history.replaceState({}, '', '/creatives?id=999999')
+    frame.dispatchEvent(new CustomEvent('turbo:frame-load', { bubbles: true }))
+
+    expect(document.querySelector('.creative-workspace-tree-link.is-current')).toBeNull()
+    expect(chatListener).toHaveBeenLastCalledWith(expect.objectContaining({
+      detail: expect.objectContaining({ creativeId: undefined }),
+    }))
+    document.removeEventListener('creative-comments-click', chatListener)
+  })
+
+  test('ignores a pre-load frame render while the URL and frame state disagree', () => {
+    const chatListener = jest.fn()
+    document.addEventListener('creative-comments-click', chatListener)
+    const frame = document.getElementById('creative-workspace-content')
+    const state = frame.querySelector('[data-workspace-navigation-state]')
+
+    state.dataset.creativeId = '1'
+    state.dataset.creativePath = '[1]'
+    window.history.replaceState({}, '', '/creatives?id=2')
+    frame.dispatchEvent(new CustomEvent('turbo:frame-render', { bubbles: true }))
+
+    expect(document.querySelector('[data-creative-id="2"] a').classList.contains('is-current')).toBe(true)
+    expect(chatListener).not.toHaveBeenCalled()
+    document.removeEventListener('creative-comments-click', chatListener)
+  })
+
+  test('refreshes stale data while preserving explicit branch state', async () => {
+    const branchToggle = document.querySelector('.creative-workspace-tree-branch-toggle')
+    branchToggle.click()
+    expect(branchToggle.getAttribute('aria-expanded')).toBe('false')
+
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        creatives: [{
+          id: 1,
+          label: 'Renamed root',
+          url: '/creatives?id=1',
+          children: [{ id: 2, label: 'Current branch', url: '/creatives?id=2', children: [] }],
+        }],
+      }),
+    })
+    document.dispatchEvent(new CustomEvent('workspace-tree:invalidate'))
+    await new Promise((resolve) => setTimeout(resolve, 120))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(document.querySelector('[data-creative-id="1"] > div > a').textContent).toBe('Renamed root')
+    expect(document.querySelector('.creative-workspace-tree-branch-toggle').getAttribute('aria-expanded')).toBe('false')
   })
 
   test('shows the empty state', async () => {

--- a/engines/collavre/app/javascript/controllers/__tests__/workspace_tree_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/workspace_tree_controller.test.js
@@ -346,6 +346,95 @@ describe('WorkspaceTreeController', () => {
     document.removeEventListener('creative-comments-click', chatListener)
   })
 
+  test('restores a re-shared creative after a successful tree refresh proves access', async () => {
+    const chatListener = jest.fn()
+    document.addEventListener('creative-comments-click', chatListener)
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        creatives: [{
+          id: 1,
+          label: 'Root',
+          url: '/creatives?id=1',
+          children: [{ id: 2, label: 'Re-shared branch', url: '/creatives?id=2', children: [] }],
+        }],
+      }),
+    })
+
+    document.dispatchEvent(new CustomEvent('workspace-tree:invalidate', {
+      detail: { creativeIds: ['2'] },
+    }))
+    await new Promise((resolve) => setTimeout(resolve, 120))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    chatListener.mockClear()
+    document.getElementById('creative-workspace-content')
+      .dispatchEvent(new CustomEvent('turbo:frame-load', { bubbles: true }))
+
+    expect(chatListener).toHaveBeenCalledWith(expect.objectContaining({
+      detail: expect.objectContaining({ creativeId: '2', workspaceSync: true }),
+    }))
+    expect(document.querySelector('[data-creative-id="2"] a').classList.contains('is-current')).toBe(true)
+    document.removeEventListener('creative-comments-click', chatListener)
+  })
+
+  test('does not restore access from a tree request started before invalidation', async () => {
+    let resolveStaleFetch
+    fetchMock.mockReturnValueOnce(new Promise((resolve) => {
+      resolveStaleFetch = resolve
+    }))
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ creatives: [] }),
+    })
+    const staleLoad = controller.load({ showLoading: false, syncChat: false })
+
+    document.dispatchEvent(new CustomEvent('workspace-tree:invalidate', {
+      detail: { creativeIds: ['2'] },
+    }))
+    resolveStaleFetch({
+      ok: true,
+      json: async () => ({
+        creatives: [{
+          id: 1,
+          label: 'Stale root',
+          url: '/creatives?id=1',
+          children: [{ id: 2, label: 'Stale branch', url: '/creatives?id=2', children: [] }],
+        }],
+      }),
+    })
+    await staleLoad
+
+    expect(controller.invalidatedCreativeIds.has('2')).toBe(true)
+
+    await new Promise((resolve) => setTimeout(resolve, 120))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(controller.invalidatedCreativeIds.has('2')).toBe(true)
+  })
+
+  test('keeps destroyed creatives invalidated when a stale tree response contains them', async () => {
+    const chatListener = jest.fn()
+    document.addEventListener('creative-comments-click', chatListener)
+
+    document.dispatchEvent(new CustomEvent('creative-destroyed', {
+      detail: { creativeIds: ['2'] },
+    }))
+    await new Promise((resolve) => setTimeout(resolve, 120))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    chatListener.mockClear()
+    document.getElementById('creative-workspace-content')
+      .dispatchEvent(new CustomEvent('turbo:frame-load', { bubbles: true }))
+
+    expect(chatListener).toHaveBeenCalledWith(expect.objectContaining({
+      detail: expect.objectContaining({ creativeId: undefined, workspaceSync: true }),
+    }))
+    expect(chatListener).not.toHaveBeenCalledWith(expect.objectContaining({
+      detail: expect.objectContaining({ creativeId: '2' }),
+    }))
+    document.removeEventListener('creative-comments-click', chatListener)
+  })
+
   test('does not optimistically open an invalidated tree link', () => {
     const chatListener = jest.fn()
     document.addEventListener('creative-comments-click', chatListener)

--- a/engines/collavre/app/javascript/controllers/__tests__/workspace_tree_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/workspace_tree_controller.test.js
@@ -223,6 +223,65 @@ describe('WorkspaceTreeController', () => {
     expect(document.querySelector('.creative-workspace-tree-branch-toggle').getAttribute('aria-expanded')).toBe('false')
   })
 
+  test('does not replace an explicitly opened chat during a background tree refresh', async () => {
+    const chatListener = jest.fn()
+    document.addEventListener('creative-comments-click', chatListener)
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        creatives: [{
+          id: 1,
+          label: 'Refreshed root',
+          url: '/creatives?id=1',
+          children: [{ id: 2, label: 'Current branch', url: '/creatives?id=2', children: [] }],
+        }],
+      }),
+    })
+
+    document.dispatchEvent(new CustomEvent('workspace-tree:invalidate'))
+    await new Promise((resolve) => setTimeout(resolve, 120))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(document.querySelector('[data-creative-id="1"] > div > a').textContent).toBe('Refreshed root')
+    expect(chatListener).not.toHaveBeenCalled()
+
+    const frame = document.getElementById('creative-workspace-content')
+    frame.dispatchEvent(new CustomEvent('turbo:frame-load', { bubbles: true }))
+    expect(chatListener).toHaveBeenCalledWith(expect.objectContaining({
+      detail: expect.objectContaining({ creativeId: '2', workspaceSync: true }),
+    }))
+    document.removeEventListener('creative-comments-click', chatListener)
+  })
+
+  test('does not dispatch stale frame chat state after a delayed initial tree load', async () => {
+    controller.disconnect()
+    application.stop()
+
+    let resolveFetch
+    fetchMock.mockReset()
+    fetchMock.mockReturnValue(new Promise((resolve) => {
+      resolveFetch = resolve
+    }))
+    const chatListener = jest.fn()
+    document.addEventListener('creative-comments-click', chatListener)
+
+    application = Application.start()
+    application.register('workspace-tree', WorkspaceTreeController)
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    resolveFetch({
+      ok: true,
+      json: async () => ({ creatives: [] }),
+    })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    const controllerElement = document.querySelector('[data-controller="workspace-tree"]')
+    controller = application.getControllerForElementAndIdentifier(controllerElement, 'workspace-tree')
+    expect(chatListener).not.toHaveBeenCalled()
+    document.removeEventListener('creative-comments-click', chatListener)
+  })
+
   test('does not reopen an invalidated chat from stale frame state after tree refresh', async () => {
     const chatListener = jest.fn()
     document.addEventListener('creative-comments-click', chatListener)
@@ -237,12 +296,7 @@ describe('WorkspaceTreeController', () => {
     await new Promise((resolve) => setTimeout(resolve, 120))
     await new Promise((resolve) => setTimeout(resolve, 0))
 
-    expect(chatListener).toHaveBeenCalledWith(expect.objectContaining({
-      detail: expect.objectContaining({ creativeId: undefined, workspaceSync: true }),
-    }))
-    expect(chatListener).not.toHaveBeenCalledWith(expect.objectContaining({
-      detail: expect.objectContaining({ creativeId: '2' }),
-    }))
+    expect(chatListener).not.toHaveBeenCalled()
     expect(document.querySelector('.creative-workspace-tree-link.is-current')).toBeNull()
 
     chatListener.mockClear()

--- a/engines/collavre/app/javascript/controllers/__tests__/workspace_tree_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/workspace_tree_controller.test.js
@@ -114,7 +114,7 @@ describe('WorkspaceTreeController', () => {
 
     expect(rootLink.classList.contains('is-current')).toBe(true)
     expect(chatListener).toHaveBeenCalledWith(expect.objectContaining({
-      detail: expect.objectContaining({ creativeId: '1', button: rootLink }),
+      detail: expect.objectContaining({ creativeId: '1', button: rootLink, workspaceSync: true }),
     }))
 
     const frame = document.getElementById('creative-workspace-content')
@@ -143,7 +143,7 @@ describe('WorkspaceTreeController', () => {
 
     expect(document.querySelector('[data-creative-id="2"] a').classList.contains('is-current')).toBe(true)
     expect(chatListener).toHaveBeenLastCalledWith(expect.objectContaining({
-      detail: expect.objectContaining({ creativeId: '3', button: state }),
+      detail: expect.objectContaining({ creativeId: '3', button: state, workspaceSync: true }),
     }))
 
     delete state.dataset.creativeId
@@ -153,7 +153,11 @@ describe('WorkspaceTreeController', () => {
 
     expect(document.querySelector('.creative-workspace-tree-link.is-current')).toBeNull()
     expect(chatListener).toHaveBeenLastCalledWith(expect.objectContaining({
-      detail: expect.objectContaining({ creativeId: undefined, button: expect.any(HTMLElement) }),
+      detail: expect.objectContaining({
+        creativeId: undefined,
+        button: expect.any(HTMLElement),
+        workspaceSync: true,
+      }),
     }))
     expect(chatListener.mock.lastCall[0].detail.button.dataset.workspaceNavigationState).toBe('true')
     document.removeEventListener('creative-comments-click', chatListener)

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/list_controller_docked.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/list_controller_docked.test.js
@@ -18,4 +18,76 @@ describe('CommentsListController docked startup', () => {
     expect(controller.resetToLatest).not.toHaveBeenCalled()
     expect(controller.highlightAfterLoad).toBe('34')
   })
+
+  test('loads the newly selected topic when it supersedes a pending deep link', () => {
+    const controller = Object.create(CommentsListController.prototype)
+    controller.currentTopicId = '12'
+    controller.highlightAfterLoad = '34'
+    controller.initialLoadComplete = false
+    controller.resetToLatest = jest.fn()
+
+    controller.handleTopicChange({ detail: { topicId: '13' } })
+
+    expect(controller.currentTopicId).toBe('13')
+    expect(controller.highlightAfterLoad).toBeNull()
+    expect(controller.resetToLatest).toHaveBeenCalledTimes(1)
+  })
+
+  test('suppresses only the topic event emitted during popup initialization', () => {
+    const controller = Object.create(CommentsListController.prototype)
+    controller.currentTopicId = '12'
+    controller.highlightAfterLoad = '34'
+    controller.initialLoadComplete = false
+    controller.suppressTopicChangeLoad = true
+    controller.resetToLatest = jest.fn()
+
+    controller.handleTopicChange({ detail: { topicId: '13' } })
+
+    expect(controller.currentTopicId).toBe('13')
+    expect(controller.highlightAfterLoad).toBe('34')
+    expect(controller.resetToLatest).not.toHaveBeenCalled()
+  })
+
+  test('does not carry a pending highlight into a different creative', () => {
+    const controller = Object.create(CommentsListController.prototype)
+    controller.creativeId = '12'
+    controller.highlightAfterLoad = '34'
+    controller.highlightCreativeId = '12'
+    controller.deepLinkCommentId = null
+    controller.resetState = jest.fn()
+    controller.loadInitialComments = jest.fn()
+    controller.listTarget = { innerHTML: '' }
+    Object.defineProperty(controller, 'element', { value: { dataset: { loadingText: 'Loading' } } })
+    Object.defineProperty(controller, 'presenceController', { value: null })
+
+    // Popup initialization pre-sets creativeId before this method runs, so the
+    // highlight must be tied to its original creative rather than that field.
+    controller.creativeId = '13'
+    controller.onPopupOpened({ creativeId: '13' })
+
+    expect(controller.highlightAfterLoad).toBeNull()
+    expect(controller.loadInitialComments).toHaveBeenCalledTimes(1)
+  })
+
+  test('ignores a rejected comments request after the popup closes', async () => {
+    const controller = Object.create(CommentsListController.prototype)
+    let rejectRequest
+    controller.creativeId = '12'
+    controller.currentTopicId = ''
+    controller.highlightAfterLoad = null
+    controller._loadCommentsVersion = 0
+    controller.selection = new Set()
+    controller.prevMsgNavigator = { reset: jest.fn() }
+    controller.fetchComments = jest.fn(() => new Promise((_resolve, reject) => { rejectRequest = reject }))
+    controller.resetState = jest.fn()
+    controller.listTarget = { innerHTML: 'Loading' }
+
+    controller.loadInitialComments()
+    controller.onPopupClosed()
+    rejectRequest(new Error('stale failure'))
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(controller.listTarget.innerHTML).toBe('')
+  })
 })

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/list_controller_docked.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/list_controller_docked.test.js
@@ -1,0 +1,21 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { jest } from '@jest/globals'
+import CommentsListController from '../list_controller'
+
+describe('CommentsListController docked startup', () => {
+  test('ignores a repeated topic selection while a deep link is loading', () => {
+    const controller = Object.create(CommentsListController.prototype)
+    controller.currentTopicId = '12'
+    controller.highlightAfterLoad = '34'
+    controller.initialLoadComplete = false
+    controller.resetToLatest = jest.fn()
+
+    controller.handleTopicChange({ detail: { topicId: '12' } })
+
+    expect(controller.resetToLatest).not.toHaveBeenCalled()
+    expect(controller.highlightAfterLoad).toBe('34')
+  })
+})

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/popup_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/popup_controller.test.js
@@ -126,6 +126,20 @@ describe('CommentsPopupController', () => {
         expect(controller.closeButtonTarget.getAttribute('aria-label')).toBe('Expand chat')
     })
 
+    test('restores the floating close button label after leaving docked mode', () => {
+        const popup = document.getElementById('comments-popup')
+        popup.dataset.docked = 'true'
+        popup.dataset.closeLabel = 'Close chat'
+        controller.enterDockedMode()
+        controller.dockedMediaQuery.matches = false
+
+        controller.syncDockedUI()
+
+        expect(controller.closeButtonTarget.textContent).toBe('×')
+        expect(controller.closeButtonTarget.getAttribute('aria-label')).toBe('Close chat')
+        expect(controller.closeButtonTarget.title).toBe('Close chat')
+    })
+
     test('empty docked workspace does not request a wake lock', () => {
         const popup = document.getElementById('comments-popup')
         const requestWakeLock = jest.spyOn(controller, '_requestWakeLock')
@@ -176,7 +190,31 @@ describe('CommentsPopupController', () => {
         await Promise.resolve()
 
         expect(release).toHaveBeenCalledTimes(1)
-        expect(controller._wakeLock).toBeUndefined()
+        expect(controller._wakeLock).toBeNull()
+        delete navigator.wakeLock
+    })
+
+    test('deduplicates concurrent wake lock requests', async () => {
+        const popup = document.getElementById('comments-popup')
+        const wakeLock = { release: jest.fn(), addEventListener: jest.fn() }
+        let finishRequest
+        Object.defineProperty(navigator, 'wakeLock', {
+            configurable: true,
+            value: {
+                request: jest.fn(() => new Promise(resolve => { finishRequest = resolve })),
+            },
+        })
+        popup.dataset.docked = 'true'
+        popup.dataset.creativeId = '123'
+        popup.style.display = 'flex'
+
+        const firstRequest = controller._requestWakeLock()
+        const secondRequest = controller._requestWakeLock()
+
+        expect(navigator.wakeLock.request).toHaveBeenCalledTimes(1)
+        finishRequest(wakeLock)
+        await Promise.all([firstRequest, secondRequest])
+        expect(controller._wakeLock).toBe(wakeLock)
         delete navigator.wakeLock
     })
 
@@ -330,6 +368,47 @@ describe('CommentsPopupController', () => {
 
         expect(popup.dataset.creativeId).toBe('')
         expect(dispatchEvent).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'comments-popup:opened' }))
+    })
+
+    test('an obsolete open does not clear the current topic suppression guard', async () => {
+        const listController = {
+            creativeId: null,
+            suppressTopicChangeLoad: false,
+            onPopupOpened: jest.fn(),
+        }
+        const pendingTopics = new Map()
+        const topicsController = {
+            clearOverrideTopicId: jest.fn(),
+            currentTopicId: '7',
+            onPopupOpened: jest.fn(({ creativeId }) => new Promise(resolve => {
+                pendingTopics.set(creativeId, resolve)
+            })),
+        }
+        Object.defineProperty(controller, 'listController', { configurable: true, value: listController })
+        Object.defineProperty(controller, 'topicsController', { configurable: true, value: topicsController })
+
+        controller.openGeneration = 1
+        const firstOpen = controller.notifyChildControllers({
+            creativeId: '123', canComment: true, openGeneration: 1,
+        })
+        await Promise.resolve()
+
+        controller.openGeneration = 2
+        const secondOpen = controller.notifyChildControllers({
+            creativeId: '456', canComment: true, openGeneration: 2,
+        })
+        await Promise.resolve()
+
+        pendingTopics.get('123')()
+        expect(await firstOpen).toBe(false)
+        expect(listController.suppressTopicChangeLoad).toBe(true)
+
+        pendingTopics.get('456')()
+        expect(await secondOpen).toBe(true)
+        expect(listController.suppressTopicChangeLoad).toBe(false)
+        expect(listController.onPopupOpened).toHaveBeenCalledWith({
+            creativeId: '456', highlightId: undefined, topicId: '7',
+        })
     })
 
 })

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/popup_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/popup_controller.test.js
@@ -126,6 +126,60 @@ describe('CommentsPopupController', () => {
         expect(controller.closeButtonTarget.getAttribute('aria-label')).toBe('Expand chat')
     })
 
+    test('empty docked workspace does not request a wake lock', () => {
+        const popup = document.getElementById('comments-popup')
+        const requestWakeLock = jest.spyOn(controller, '_requestWakeLock')
+        const releaseWakeLock = jest.spyOn(controller, '_releaseWakeLock')
+        popup.dataset.docked = 'true'
+        popup.dataset.creativeId = ''
+
+        controller.enterDockedMode()
+
+        expect(requestWakeLock).not.toHaveBeenCalled()
+        expect(releaseWakeLock).toHaveBeenCalled()
+    })
+
+    test('collapsing docked chat releases wake lock and expanding reacquires it', () => {
+        const popup = document.getElementById('comments-popup')
+        popup.dataset.docked = 'true'
+        popup.dataset.creativeId = '123'
+        controller.enterDockedMode()
+        const requestWakeLock = jest.spyOn(controller, '_requestWakeLock')
+        const releaseWakeLock = jest.spyOn(controller, '_releaseWakeLock')
+
+        controller.toggleDocked()
+
+        expect(releaseWakeLock).toHaveBeenCalledTimes(1)
+        expect(requestWakeLock).not.toHaveBeenCalled()
+
+        controller.toggleDocked()
+
+        expect(requestWakeLock).toHaveBeenCalledTimes(1)
+    })
+
+    test('pending wake lock is released if docked chat collapses before acquisition', async () => {
+        const popup = document.getElementById('comments-popup')
+        const release = jest.fn()
+        let finishRequest
+        Object.defineProperty(navigator, 'wakeLock', {
+            configurable: true,
+            value: {
+                request: jest.fn(() => new Promise(resolve => { finishRequest = resolve })),
+            },
+        })
+        popup.dataset.docked = 'true'
+        popup.dataset.creativeId = '123'
+        controller.enterDockedMode()
+
+        controller.toggleDocked()
+        finishRequest({ release, addEventListener: jest.fn() })
+        await Promise.resolve()
+
+        expect(release).toHaveBeenCalledTimes(1)
+        expect(controller._wakeLock).toBeUndefined()
+        delete navigator.wakeLock
+    })
+
     test('docked chat forwards a comment deep link without starting a second open', async () => {
         const popup = document.getElementById('comments-popup')
         popup.dataset.docked = 'true'

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/popup_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/popup_controller.test.js
@@ -126,7 +126,7 @@ describe('CommentsPopupController', () => {
         expect(controller.closeButtonTarget.getAttribute('aria-label')).toBe('Expand chat')
     })
 
-    test('docked close button keeps the original close icon when toggling collapse/expand', () => {
+    test('docked close button keeps the close icon while expanded and shows a chevron when collapsed', () => {
         const popup = document.getElementById('comments-popup')
         popup.dataset.docked = 'true'
         popup.dataset.collapseDockedLabel = 'Collapse chat'
@@ -135,12 +135,39 @@ describe('CommentsPopupController', () => {
         controller.enterDockedMode()
         controller.syncDockedUI()
         expect(controller.closeButtonTarget.textContent).toBe('×')
+        expect(controller.closeButtonTarget.querySelector('svg')).toBeNull()
         expect(controller.closeButtonTarget.getAttribute('aria-label')).toBe('Collapse chat')
 
         controller.toggleDocked()
         expect(popup.classList.contains('docked-collapsed')).toBe(true)
-        expect(controller.closeButtonTarget.textContent).toBe('×')
+        const icon = controller.closeButtonTarget.querySelector('svg')
+        expect(icon).not.toBeNull()
+        expect(icon.getAttribute('aria-hidden')).toBe('true')
+        expect(controller.closeButtonTarget.textContent.trim()).toBe('')
         expect(controller.closeButtonTarget.getAttribute('aria-label')).toBe('Expand chat')
+
+        controller.toggleDocked()
+        expect(popup.classList.contains('docked-collapsed')).toBe(false)
+        expect(controller.closeButtonTarget.querySelector('svg')).toBeNull()
+        expect(controller.closeButtonTarget.textContent).toBe('×')
+        expect(controller.closeButtonTarget.getAttribute('aria-label')).toBe('Collapse chat')
+    })
+
+    test('leaving docked mode while collapsed restores the close glyph', () => {
+        const popup = document.getElementById('comments-popup')
+        popup.dataset.docked = 'true'
+        popup.dataset.closeLabel = 'Close chat'
+        popup.dataset.expandDockedLabel = 'Expand chat'
+
+        controller.enterDockedMode()
+        controller.toggleDocked()
+        expect(controller.closeButtonTarget.querySelector('svg')).not.toBeNull()
+
+        controller.dockedMediaQuery.matches = false
+        controller.syncDockedUI()
+
+        expect(controller.closeButtonTarget.querySelector('svg')).toBeNull()
+        expect(controller.closeButtonTarget.textContent).toBe('×')
     })
 
     test('restores the floating close button label after leaving docked mode', () => {

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/popup_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/popup_controller.test.js
@@ -234,6 +234,68 @@ describe('CommentsPopupController', () => {
         expect(openFromUrl).not.toHaveBeenCalled()
     })
 
+    test('same-creative workspace deep links refresh the docked chat highlight', () => {
+        const popup = document.getElementById('comments-popup')
+        const triggerBtn = document.getElementById('trigger-btn')
+        popup.dataset.docked = 'true'
+        popup.dataset.creativeId = '123'
+        popup.style.display = 'flex'
+        const open = jest.spyOn(controller, 'open').mockResolvedValue()
+
+        document.dispatchEvent(new CustomEvent('creative-comments-click', {
+            detail: {
+                button: triggerBtn,
+                creativeId: '123',
+                workspaceSync: true,
+                highlightId: '456',
+            },
+        }))
+
+        expect(open).toHaveBeenCalledWith(triggerBtn, {
+            creativeId: '123',
+            highlightId: '456',
+        })
+    })
+
+    test('same-creative workspace sync without a deep link keeps the docked chat', () => {
+        const popup = document.getElementById('comments-popup')
+        const triggerBtn = document.getElementById('trigger-btn')
+        popup.dataset.docked = 'true'
+        popup.dataset.creativeId = '123'
+        popup.style.display = 'flex'
+        const open = jest.spyOn(controller, 'open').mockResolvedValue()
+
+        document.dispatchEvent(new CustomEvent('creative-comments-click', {
+            detail: { button: triggerBtn, creativeId: '123', workspaceSync: true },
+        }))
+
+        expect(open).not.toHaveBeenCalled()
+        expect(popup.dataset.creativeId).toBe('123')
+    })
+
+    test('workspace deep links pass the highlight when switching creatives', () => {
+        const popup = document.getElementById('comments-popup')
+        const triggerBtn = document.getElementById('trigger-btn')
+        popup.dataset.docked = 'true'
+        popup.dataset.creativeId = '999'
+        popup.style.display = 'flex'
+        const open = jest.spyOn(controller, 'open').mockResolvedValue()
+
+        document.dispatchEvent(new CustomEvent('creative-comments-click', {
+            detail: {
+                button: triggerBtn,
+                creativeId: '123',
+                workspaceSync: true,
+                highlightId: '456',
+            },
+        }))
+
+        expect(open).toHaveBeenCalledWith(triggerBtn, {
+            creativeId: '123',
+            highlightId: '456',
+        })
+    })
+
     test('root workspace navigation resets docked chat to its empty state', () => {
         const popup = document.getElementById('comments-popup')
         popup.dataset.docked = 'true'

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/popup_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/popup_controller.test.js
@@ -317,6 +317,63 @@ describe('CommentsPopupController', () => {
         expect(popup.dataset.creativeId).toBe('123')
     })
 
+    test('chat icon expands a collapsed docked chat showing the same creative', () => {
+        const popup = document.getElementById('comments-popup')
+        const triggerBtn = document.getElementById('trigger-btn')
+        popup.dataset.docked = 'true'
+        popup.dataset.creativeId = '123'
+        popup.dataset.collapseDockedLabel = 'Collapse chat'
+        popup.dataset.expandDockedLabel = 'Expand chat'
+        controller.enterDockedMode()
+        controller.toggleDocked()
+        expect(popup.classList.contains('docked-collapsed')).toBe(true)
+        const open = jest.spyOn(controller, 'open').mockResolvedValue()
+
+        document.dispatchEvent(new CustomEvent('creative-comments-click', {
+            detail: { button: triggerBtn, creativeId: '123' },
+        }))
+
+        expect(popup.classList.contains('docked-collapsed')).toBe(false)
+        expect(controller.closeButtonTarget.getAttribute('aria-label')).toBe('Collapse chat')
+        // The chat is already loaded for this creative — expanding must not
+        // reload it, which would drop the draft and subscriptions.
+        expect(open).not.toHaveBeenCalled()
+    })
+
+    test('chat icon expands a collapsed docked chat when switching creatives', () => {
+        const popup = document.getElementById('comments-popup')
+        const triggerBtn = document.getElementById('trigger-btn')
+        popup.dataset.docked = 'true'
+        popup.dataset.creativeId = '999'
+        controller.enterDockedMode()
+        controller.toggleDocked()
+        const open = jest.spyOn(controller, 'open').mockResolvedValue()
+
+        document.dispatchEvent(new CustomEvent('creative-comments-click', {
+            detail: { button: triggerBtn, creativeId: '123' },
+        }))
+
+        expect(popup.classList.contains('docked-collapsed')).toBe(false)
+        expect(open).toHaveBeenCalledWith(triggerBtn, { creativeId: '123' })
+    })
+
+    test('workspace navigation keeps a collapsed docked chat collapsed', () => {
+        const popup = document.getElementById('comments-popup')
+        const triggerBtn = document.getElementById('trigger-btn')
+        popup.dataset.docked = 'true'
+        popup.dataset.creativeId = '999'
+        controller.enterDockedMode()
+        controller.toggleDocked()
+        const open = jest.spyOn(controller, 'open').mockResolvedValue()
+
+        document.dispatchEvent(new CustomEvent('creative-comments-click', {
+            detail: { button: triggerBtn, creativeId: '123', workspaceSync: true },
+        }))
+
+        expect(open).toHaveBeenCalledWith(triggerBtn, { creativeId: '123' })
+        expect(popup.classList.contains('docked-collapsed')).toBe(true)
+    })
+
     test('workspace deep links pass the highlight when switching creatives', () => {
         const popup = document.getElementById('comments-popup')
         const triggerBtn = document.getElementById('trigger-btn')

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/popup_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/popup_controller.test.js
@@ -126,6 +126,23 @@ describe('CommentsPopupController', () => {
         expect(controller.closeButtonTarget.getAttribute('aria-label')).toBe('Expand chat')
     })
 
+    test('docked close button keeps the original close icon when toggling collapse/expand', () => {
+        const popup = document.getElementById('comments-popup')
+        popup.dataset.docked = 'true'
+        popup.dataset.collapseDockedLabel = 'Collapse chat'
+        popup.dataset.expandDockedLabel = 'Expand chat'
+
+        controller.enterDockedMode()
+        controller.syncDockedUI()
+        expect(controller.closeButtonTarget.textContent).toBe('×')
+        expect(controller.closeButtonTarget.getAttribute('aria-label')).toBe('Collapse chat')
+
+        controller.toggleDocked()
+        expect(popup.classList.contains('docked-collapsed')).toBe(true)
+        expect(controller.closeButtonTarget.textContent).toBe('×')
+        expect(controller.closeButtonTarget.getAttribute('aria-label')).toBe('Expand chat')
+    })
+
     test('restores the floating close button label after leaving docked mode', () => {
         const popup = document.getElementById('comments-popup')
         popup.dataset.docked = 'true'

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/popup_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/popup_controller.test.js
@@ -162,6 +162,58 @@ describe('CommentsPopupController', () => {
         expect(popup.style.display).toBe('flex')
     })
 
+    test('workspace navigation does not auto-open chat outside the docked layout', async () => {
+        const popup = document.getElementById('comments-popup')
+        const triggerBtn = document.getElementById('trigger-btn')
+        const open = jest.spyOn(controller, 'open')
+        popup.dataset.docked = 'true'
+        controller.dockedMediaQuery.matches = false
+
+        document.dispatchEvent(new CustomEvent('creative-comments-click', {
+            detail: { button: triggerBtn, creativeId: '123', workspaceSync: true },
+        }))
+
+        expect(open).not.toHaveBeenCalled()
+        expect(popup.style.display).not.toBe('flex')
+
+        document.dispatchEvent(new CustomEvent('creative-comments-click', {
+            detail: { button: triggerBtn, creativeId: '123' },
+        }))
+        await Promise.resolve()
+
+        expect(open).toHaveBeenCalledWith(triggerBtn, { creativeId: '123' })
+    })
+
+    test('workspace navigation closes an existing floating chat', async () => {
+        const popup = document.getElementById('comments-popup')
+        const triggerBtn = document.getElementById('trigger-btn')
+        popup.dataset.docked = 'true'
+        controller.dockedMediaQuery.matches = false
+        await controller.open(triggerBtn)
+
+        document.dispatchEvent(new CustomEvent('creative-comments-click', {
+            detail: { button: triggerBtn, creativeId: '456', workspaceSync: true },
+        }))
+
+        expect(popup.style.display).toBe('none')
+        expect(popup.dataset.creativeId).toBe('123')
+    })
+
+    test('late workspace sync keeps a manually opened chat for the same creative', async () => {
+        const popup = document.getElementById('comments-popup')
+        const triggerBtn = document.getElementById('trigger-btn')
+        popup.dataset.docked = 'true'
+        controller.dockedMediaQuery.matches = false
+        await controller.open(triggerBtn)
+
+        document.dispatchEvent(new CustomEvent('creative-comments-click', {
+            detail: { button: triggerBtn, creativeId: '123', workspaceSync: true },
+        }))
+
+        expect(popup.style.display).toBe('flex')
+        expect(popup.dataset.creativeId).toBe('123')
+    })
+
     test('destroying the active creative resets docked chat instead of collapsing it', () => {
         const popup = document.getElementById('comments-popup')
         popup.dataset.docked = 'true'

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/popup_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/popup_controller.test.js
@@ -162,4 +162,68 @@ describe('CommentsPopupController', () => {
         expect(popup.style.display).toBe('flex')
     })
 
+    test('destroying the active creative resets docked chat instead of collapsing it', () => {
+        const popup = document.getElementById('comments-popup')
+        popup.dataset.docked = 'true'
+        popup.dataset.creativeId = '123'
+        popup.dataset.defaultTitle = 'Comments'
+        popup.dataset.dockedEmptyText = 'Select a creative'
+        controller.enterDockedMode()
+        const closeChildControllers = jest.spyOn(controller, 'closeChildControllers')
+
+        document.dispatchEvent(new CustomEvent('creative-destroyed', {
+            detail: { creativeIds: ['123'] },
+        }))
+
+        expect(popup.dataset.creativeId).toBe('')
+        expect(controller.listTarget.textContent).toBe('Select a creative')
+        expect(popup.classList.contains('docked-collapsed')).toBe(false)
+        expect(popup.style.display).toBe('flex')
+        expect(closeChildControllers).toHaveBeenCalled()
+    })
+
+    test('destroying the active creative closes a floating chat', async () => {
+        const popup = document.getElementById('comments-popup')
+        const triggerBtn = document.getElementById('trigger-btn')
+        await controller.open(triggerBtn)
+
+        document.dispatchEvent(new CustomEvent('creative-destroyed', {
+            detail: { creativeIds: ['123'] },
+        }))
+
+        expect(popup.style.display).toBe('none')
+    })
+
+    test('destroying a creative invalidates its pending docked chat open', async () => {
+        const popup = document.getElementById('comments-popup')
+        const triggerBtn = document.getElementById('trigger-btn')
+        popup.dataset.docked = 'true'
+        popup.dataset.creativeId = '123'
+        popup.dataset.defaultTitle = 'Comments'
+        popup.dataset.dockedEmptyText = 'Select a creative'
+        controller.enterDockedMode()
+
+        let finishTopicsLoad
+        Object.defineProperty(controller, 'topicsController', {
+            configurable: true,
+            value: {
+                clearOverrideTopicId: jest.fn(),
+                onPopupOpened: jest.fn(() => new Promise(resolve => { finishTopicsLoad = resolve })),
+                onPopupClosed: jest.fn(),
+            },
+        })
+        const dispatchEvent = jest.spyOn(popup, 'dispatchEvent')
+        const pendingOpen = controller.open(triggerBtn)
+        await Promise.resolve()
+
+        document.dispatchEvent(new CustomEvent('creative-destroyed', {
+            detail: { creativeIds: ['123'] },
+        }))
+        finishTopicsLoad()
+        await pendingOpen
+
+        expect(popup.dataset.creativeId).toBe('')
+        expect(dispatchEvent).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'comments-popup:opened' }))
+    })
+
 })

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/popup_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/popup_controller.test.js
@@ -142,4 +142,24 @@ describe('CommentsPopupController', () => {
         expect(openFromUrl).not.toHaveBeenCalled()
     })
 
+    test('root workspace navigation resets docked chat to its empty state', () => {
+        const popup = document.getElementById('comments-popup')
+        popup.dataset.docked = 'true'
+        popup.dataset.creativeId = '123'
+        popup.dataset.defaultTitle = 'Comments'
+        popup.dataset.dockedEmptyText = 'Select a creative'
+        const state = document.createElement('div')
+        state.dataset.workspaceNavigationState = 'true'
+
+        document.dispatchEvent(new CustomEvent('creative-comments-click', {
+            detail: { button: state, creativeId: undefined },
+        }))
+
+        expect(popup.dataset.creativeId).toBe('')
+        expect(controller.titleTarget.textContent).toBe('Comments')
+        expect(controller.listTarget.textContent).toBe('Select a creative')
+        expect(controller.listTarget.classList.contains('docked-empty')).toBe(true)
+        expect(popup.style.display).toBe('flex')
+    })
+
 })

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/popup_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/popup_controller.test.js
@@ -4,6 +4,7 @@
  */
 
 import { Application } from '@hotwired/stimulus'
+import { jest } from '@jest/globals'
 import CommentsPopupController from '../popup_controller'
 
 describe('CommentsPopupController', () => {
@@ -109,6 +110,36 @@ describe('CommentsPopupController', () => {
         await controller.openForCreative()
 
         expect(popup.dataset.autoFocusOnOpen).toBe('true')
+    })
+
+    test('docked chat opens by default and close collapses instead of hiding it', async () => {
+        const popup = document.getElementById('comments-popup')
+        popup.dataset.docked = 'true'
+        popup.dataset.collapseDockedLabel = 'Collapse chat'
+        popup.dataset.expandDockedLabel = 'Expand chat'
+
+        controller.enterDockedMode()
+        controller.close()
+
+        expect(popup.style.display).toBe('flex')
+        expect(popup.classList.contains('docked-collapsed')).toBe(true)
+        expect(controller.closeButtonTarget.getAttribute('aria-label')).toBe('Expand chat')
+    })
+
+    test('docked chat forwards a comment deep link without starting a second open', async () => {
+        const popup = document.getElementById('comments-popup')
+        popup.dataset.docked = 'true'
+        popup.dataset.creativeId = '123'
+        window.history.replaceState({}, '', '/creatives/123/comments/456')
+        const openForCreative = jest.spyOn(controller, 'openForCreative').mockResolvedValue()
+        const openFromUrl = jest.spyOn(controller, 'openFromUrl')
+
+        controller.enterDockedMode()
+        await new Promise(resolve => requestAnimationFrame(resolve))
+        await new Promise(resolve => setTimeout(resolve, 110))
+
+        expect(openForCreative).toHaveBeenCalledWith({ highlightId: '456' })
+        expect(openFromUrl).not.toHaveBeenCalled()
     })
 
 })

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/popup_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/popup_controller.test.js
@@ -254,6 +254,33 @@ describe('CommentsPopupController', () => {
         expect(popup.style.display).toBe('flex')
     })
 
+    test('resetting a fullscreen docked chat exits fullscreen before showing empty state', () => {
+        const popup = document.getElementById('comments-popup')
+        popup.dataset.docked = 'true'
+        popup.dataset.creativeId = '123'
+        popup.dataset.fullscreen = 'true'
+        popup.dataset.dockedEmptyText = 'Select a creative'
+        popup.style.display = 'flex'
+        popup.style.position = 'fixed'
+        popup.style.width = '100%'
+        popup.style.height = '100%'
+        document.body.classList.add('chat-fullscreen')
+        window.history.replaceState({}, '', '/creatives/123/comments/fullscreen')
+        controller._previousUrl = '/creatives/123'
+
+        controller.resetDockedToEmpty()
+
+        expect(popup.dataset.fullscreen).toBe('false')
+        expect(document.body.classList.contains('chat-fullscreen')).toBe(false)
+        expect(popup.dataset.creativeId).toBe('')
+        expect(controller.listTarget.textContent).toBe('Select a creative')
+        expect(popup.style.display).toBe('flex')
+        expect(popup.style.position).toBe('')
+        expect(popup.style.width).toBe('')
+        expect(popup.style.height).toBe('')
+        expect(window.location.pathname).toBe('/creatives/123')
+    })
+
     test('workspace navigation does not auto-open chat outside the docked layout', async () => {
         const popup = document.getElementById('comments-popup')
         const triggerBtn = document.getElementById('trigger-btn')

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/presence_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/presence_controller.test.js
@@ -98,6 +98,9 @@ describe('CommentsPresenceController', () => {
     expect(resetDockedToEmpty).toHaveBeenCalled()
     expect(close).not.toHaveBeenCalled()
     expect(workspaceListener).toHaveBeenCalledTimes(1)
+    expect(workspaceListener).toHaveBeenCalledWith(expect.objectContaining({
+      detail: { creativeIds: ['123'] },
+    }))
     expect(global.fetch).not.toHaveBeenCalled()
     document.removeEventListener('workspace-tree:invalidate', workspaceListener)
   })

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/presence_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/presence_controller.test.js
@@ -64,19 +64,21 @@ describe('CommentsPresenceController', () => {
     })
 
     expect(setCommentPermission).toHaveBeenCalledWith(false)
-    expect(loadParticipantsSpy).toHaveBeenCalledWith({ closeOnForbidden: false })
+    expect(loadParticipantsSpy).toHaveBeenCalledWith()
     expect(close).not.toHaveBeenCalled()
   })
 
-  test('closes popup when affected user loses access', async () => {
+  test('clears docked chat and invalidates the workspace tree when access is revoked', async () => {
     const close = jest.fn()
-    jest.spyOn(controller, 'popupController', 'get').mockReturnValue({ close })
-    jest.spyOn(controller, 'formController', 'get').mockReturnValue({ setCommentPermission: jest.fn() })
-
-    global.fetch.mockResolvedValue({
-      ok: false,
-      json: async () => ({ error: 'No permission' }),
+    const resetDockedToEmpty = jest.fn()
+    const workspaceListener = jest.fn()
+    document.addEventListener('workspace-tree:invalidate', workspaceListener)
+    jest.spyOn(controller, 'popupController', 'get').mockReturnValue({
+      close,
+      isDocked: () => true,
+      resetDockedToEmpty,
     })
+    jest.spyOn(controller, 'formController', 'get').mockReturnValue({ setCommentPermission: jest.fn() })
 
     controller.handlePresenceMessage({
       shares_changed: {
@@ -93,7 +95,34 @@ describe('CommentsPresenceController', () => {
     // alertDialog renders an in-app modal (replacing native alert for the
     // Tauri webview); assert the message surfaced there instead.
     expect(document.querySelector('.confirm-dialog-message')?.textContent).toBe('No permission')
+    expect(resetDockedToEmpty).toHaveBeenCalled()
+    expect(close).not.toHaveBeenCalled()
+    expect(workspaceListener).toHaveBeenCalledTimes(1)
+    expect(global.fetch).not.toHaveBeenCalled()
+    document.removeEventListener('workspace-tree:invalidate', workspaceListener)
+  })
+
+  test('closes a floating popup immediately when access is revoked', () => {
+    const close = jest.fn()
+    jest.spyOn(controller, 'popupController', 'get').mockReturnValue({
+      close,
+      isDocked: () => false,
+      resetDockedToEmpty: jest.fn(),
+    })
+    jest.spyOn(controller, 'formController', 'get').mockReturnValue({ setCommentPermission: jest.fn() })
+
+    controller.handlePresenceMessage({
+      shares_changed: {
+        user_id: 7,
+        has_access: false,
+        can_comment: false,
+        has_access_changed: true,
+        can_comment_changed: true,
+      },
+    })
+
     expect(close).toHaveBeenCalled()
+    expect(global.fetch).not.toHaveBeenCalled()
   })
 
   test('keeps popup open for unaffected users and only refreshes participants', () => {

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_docked.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_docked.test.js
@@ -1,0 +1,32 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { jest } from '@jest/globals'
+import CommentsTopicsController from '../topics_controller'
+
+describe('CommentsTopicsController docked lifecycle', () => {
+  test('does not render a topics response that arrives after the popup closes', async () => {
+    const controller = Object.create(CommentsTopicsController.prototype)
+    let finishRequest
+    controller.creativeIdValue = '123'
+    controller._loadTopicsVersion = 0
+    Object.defineProperty(controller, 'element', { value: document.createElement('div') })
+    controller.unsubscribe = jest.fn()
+    controller.renderTopics = jest.fn()
+    global.fetch = jest.fn(() => new Promise(resolve => { finishRequest = resolve }))
+
+    const loading = controller.loadTopics()
+    controller.onPopupClosed()
+    finishRequest({
+      ok: true,
+      status: 200,
+      json: async () => ({ topics: [{ id: 1, name: 'Stale' }] }),
+    })
+    await loading
+
+    expect(controller.renderTopics).not.toHaveBeenCalled()
+    expect(controller.topics).toEqual([])
+    delete global.fetch
+  })
+})

--- a/engines/collavre/app/javascript/controllers/comments/list_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/list_controller.js
@@ -26,6 +26,7 @@ export default class extends Controller {
     this.movingComments = false
     this.manualSearchQuery = null
     this.initialLoadComplete = false
+    this.markReadTimeout = null
     this.prevMsgNavigator = new PrevMessageNavigator()
 
     this.handleScroll = this.handleScroll.bind(this)
@@ -54,7 +55,7 @@ export default class extends Controller {
     // If we have a creativeId from data attribute or parent (unlikely directly on list, 
     // usually set via onPopupOpened), try loading.
     // If not, onPopupOpened will trigger it.
-    if (this.element.dataset.creativeId) {
+    if (this.element.dataset.creativeId && this.element.dataset.docked !== 'true') {
       this.creativeId = this.element.dataset.creativeId
       this.loadInitialComments()
     }
@@ -73,18 +74,25 @@ export default class extends Controller {
   }
 
   handleTopicChange(event) {
+    const nextTopicId = event.detail.topicId
+    if (
+      this.currentTopicId !== undefined &&
+      String(this.currentTopicId || '') === String(nextTopicId || '')
+    ) return
+
     // During notifyChildControllers, topic loading fires change events before
     // onPopupOpened sets up highlightAfterLoad. Suppress these to avoid a
     // race where a non-highlight load overwrites the deep-link highlight load.
-    if (this.suppressTopicChangeLoad) {
-      this.currentTopicId = event.detail.topicId
+    if (this.suppressTopicChangeLoad || (this.highlightAfterLoad && !this.initialLoadComplete)) {
+      this.currentTopicId = nextTopicId
       return
     }
-    this.currentTopicId = event.detail.topicId
+    this.currentTopicId = nextTopicId
     this.resetToLatest()
   }
 
   disconnect() {
+    if (this.markReadTimeout) window.clearTimeout(this.markReadTimeout)
     this.listTarget.removeEventListener('scroll', this.handleScroll)
     PREV_MSG_USER_INPUT_EVENTS.forEach((name) => {
       this.listTarget.removeEventListener(name, this.handlePrevMsgUserInput)
@@ -121,8 +129,9 @@ export default class extends Controller {
 
   onPopupOpened({ creativeId, highlightId, topicId } = {}) {
     this.creativeId = creativeId
+    this.initialLoadComplete = false
     // highlightId from popup args takes precedence, else fallback to URL param if first load
-    this.highlightAfterLoad = highlightId || this.deepLinkCommentId
+    this.highlightAfterLoad = highlightId || this.highlightAfterLoad || this.deepLinkCommentId
 
     if (topicId !== undefined) {
       this.currentTopicId = topicId
@@ -138,6 +147,10 @@ export default class extends Controller {
   }
 
   onPopupClosed() {
+    if (this.markReadTimeout) {
+      window.clearTimeout(this.markReadTimeout)
+      this.markReadTimeout = null
+    }
     this.resetState()
     this.listTarget.innerHTML = ''
     this.initialLoadComplete = false
@@ -370,14 +383,19 @@ export default class extends Controller {
 
   markCommentsRead() {
     if (!this.creativeId) return
-    window.setTimeout(() => {
+    if (this.markReadTimeout) window.clearTimeout(this.markReadTimeout)
+    const creativeId = this.creativeId
+    this.markReadTimeout = window.setTimeout(() => {
+      this.markReadTimeout = null
+      if (!this.element.isConnected || this.creativeId !== creativeId) return
+
       fetch('/comment_read_pointers/update', {
         method: 'POST',
         headers: {
           'X-CSRF-Token': document.querySelector('meta[name=csrf-token]').content,
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ creative_id: this.creativeId }),
+        body: JSON.stringify({ creative_id: creativeId }),
       }).catch(() => { /* ignore — creative may have been deleted */ })
     }, 2000);
   }

--- a/engines/collavre/app/javascript/controllers/comments/list_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/list_controller.js
@@ -26,6 +26,8 @@ export default class extends Controller {
     this.movingComments = false
     this.manualSearchQuery = null
     this.initialLoadComplete = false
+    this.highlightCreativeId = null
+    this._loadCommentsVersion = 0
     this.markReadTimeout = null
     this.prevMsgNavigator = new PrevMessageNavigator()
 
@@ -83,11 +85,16 @@ export default class extends Controller {
     // During notifyChildControllers, topic loading fires change events before
     // onPopupOpened sets up highlightAfterLoad. Suppress these to avoid a
     // race where a non-highlight load overwrites the deep-link highlight load.
-    if (this.suppressTopicChangeLoad || (this.highlightAfterLoad && !this.initialLoadComplete)) {
+    if (this.suppressTopicChangeLoad) {
       this.currentTopicId = nextTopicId
       return
     }
     this.currentTopicId = nextTopicId
+    // A user-selected topic supersedes any outstanding deep-link window.
+    // The old request is discarded by the topic/version guards below, while
+    // this replacement load starts from the selected topic's latest messages.
+    this.highlightAfterLoad = null
+    this.highlightCreativeId = null
     this.resetToLatest()
   }
 
@@ -128,10 +135,15 @@ export default class extends Controller {
   }
 
   onPopupOpened({ creativeId, highlightId, topicId } = {}) {
+    const normalizedCreativeId = String(creativeId || '')
+    const pendingHighlight = String(this.highlightCreativeId || '') === normalizedCreativeId
+      ? this.highlightAfterLoad
+      : null
     this.creativeId = creativeId
     this.initialLoadComplete = false
     // highlightId from popup args takes precedence, else fallback to URL param if first load
-    this.highlightAfterLoad = highlightId || this.highlightAfterLoad || this.deepLinkCommentId
+    this.highlightAfterLoad = highlightId || pendingHighlight || this.deepLinkCommentId
+    this.highlightCreativeId = this.highlightAfterLoad ? normalizedCreativeId : null
 
     if (topicId !== undefined) {
       this.currentTopicId = topicId
@@ -151,6 +163,11 @@ export default class extends Controller {
       window.clearTimeout(this.markReadTimeout)
       this.markReadTimeout = null
     }
+    this._loadCommentsVersion += 1
+    this.creativeId = null
+    this.highlightAfterLoad = null
+    this.highlightCreativeId = null
+    this.suppressTopicChangeLoad = false
     this.resetState()
     this.listTarget.innerHTML = ''
     this.initialLoadComplete = false
@@ -182,6 +199,7 @@ export default class extends Controller {
     // The list is about to be replaced wholesale; any anchor we hold is stale.
     this.prevMsgNavigator.reset()
 
+    const requestVersion = ++this._loadCommentsVersion
     const params = {}
     if (this.highlightAfterLoad) {
       params.around_comment_id = this.highlightAfterLoad
@@ -194,6 +212,7 @@ export default class extends Controller {
       // Discard stale responses if creative or topic changed while fetching.
       // This prevents a race condition where switching creatives causes
       // the old creative's comments to overwrite the new creative's list.
+      if (requestVersion !== this._loadCommentsVersion) return
       if (this.creativeId !== requestCreativeId) return
       if (String(this.currentTopicId || "") !== String(requestTopicId)) return
 
@@ -207,6 +226,7 @@ export default class extends Controller {
         this.allNewerLoaded = false // We are likely in middle
         this.highlightComment(this.highlightAfterLoad)
         this.highlightAfterLoad = null
+        this.highlightCreativeId = null
       } else {
         // Standard load -> Scroll to bottom (latest)
         this.scrollToBottom()
@@ -221,6 +241,9 @@ export default class extends Controller {
       this.markCommentsRead()
 
     }).catch((error) => {
+      if (requestVersion !== this._loadCommentsVersion) return
+      if (this.creativeId !== requestCreativeId) return
+      if (String(this.currentTopicId || "") !== String(requestTopicId)) return
       this.listTarget.innerHTML = `<div class="comments-list-error">${error.message}</div>`
     })
   }

--- a/engines/collavre/app/javascript/controllers/comments/popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_controller.js
@@ -31,6 +31,7 @@ export default class extends Controller {
     this.touchStartY = null
     this.openFromUrlObserver = null
     this.openFromUrlTimeout = null
+    this.dockedOpenTimeout = null
     this.handleCreativeClick = this.handleCreativeClick.bind(this)
     this.handleCreativeDestroyed = this.handleCreativeDestroyed.bind(this)
     this.handleEditingStart = this.handleEditingStart.bind(this)
@@ -48,6 +49,7 @@ export default class extends Controller {
     this.handlePopupWheel = this.handlePopupWheel.bind(this)
     this.handleChatNavKeydown = this.handleChatNavKeydown.bind(this)
     this.handleDropdownOutsideClick = this.handleDropdownOutsideClick.bind(this)
+    this.handleDockedMediaChange = this.handleDockedMediaChange.bind(this)
     this._longPressTimer = null
     this._longPressTriggered = false
     this._isNavigating = false
@@ -64,6 +66,16 @@ export default class extends Controller {
     document.addEventListener('visibilitychange', this.handleVisibilityChange)
     window.addEventListener('popstate', this.handlePopState)
     document.addEventListener('keydown', this.handleChatNavKeydown)
+    this.dockedMediaQuery = typeof window.matchMedia === 'function'
+      ? window.matchMedia('(min-width: 768px)')
+      : {
+          matches: window.innerWidth >= 768,
+          addEventListener() {},
+          removeEventListener() {},
+        }
+    if (this.element.dataset.docked === 'true') {
+      this.dockedMediaQuery.addEventListener('change', this.handleDockedMediaChange)
+    }
 
     // Long press on nav buttons
     this._setupNavLongPress()
@@ -115,6 +127,8 @@ export default class extends Controller {
       this._syncFullscreenUI(true)
       // Defer to ensure all sibling controllers are connected
       requestAnimationFrame(() => this.openForCreative())
+    } else if (this.isDocked()) {
+      this.enterDockedMode()
     } else {
       this.openFromUrl()
     }
@@ -123,6 +137,7 @@ export default class extends Controller {
   disconnect() {
     this._releaseWakeLock()
     this.clearPendingOpenFromUrl()
+    if (this.dockedOpenTimeout) window.clearTimeout(this.dockedOpenTimeout)
     document.removeEventListener(CREATIVE_CLICK_EVENT, this.handleCreativeClick)
     document.removeEventListener(CREATIVE_DESTROYED_EVENT, this.handleCreativeDestroyed)
     document.removeEventListener('creative-editing:start', this.handleEditingStart)
@@ -133,6 +148,7 @@ export default class extends Controller {
     document.removeEventListener('visibilitychange', this.handleVisibilityChange)
     window.removeEventListener('popstate', this.handlePopState)
     document.removeEventListener('keydown', this.handleChatNavKeydown)
+    this.dockedMediaQuery?.removeEventListener('change', this.handleDockedMediaChange)
     document.removeEventListener('click', this.handleDropdownOutsideClick)
     this._clearLongPressTimer()
     if (this.hasHeaderTarget) {
@@ -189,6 +205,7 @@ export default class extends Controller {
       this.element.style.display === 'flex' &&
       this.element.dataset.creativeId === (creativeId || button.dataset.creativeId)
     ) {
+      if (this.isDocked()) return
       this.close()
       return
     }
@@ -219,6 +236,7 @@ export default class extends Controller {
   }
 
   async open(button, { creativeId, highlightId } = {}) {
+    if (this.hasListTarget) this.listTarget.classList.remove('docked-empty')
     this.currentButton = button
     const resolvedCreativeId = creativeId || button?.dataset.creativeId
     const canComment = button.dataset.canComment === 'true'
@@ -254,7 +272,8 @@ export default class extends Controller {
     }))
   }
 
-  async openForCreative() {
+  async openForCreative({ highlightId } = {}) {
+    if (this.hasListTarget) this.listTarget.classList.remove('docked-empty')
     const resolvedCreativeId = this.element.dataset.creativeId
     const canComment = this.element.dataset.canComment === 'true'
     const snippet = this.element.dataset.creativeSnippet || ''
@@ -269,7 +288,7 @@ export default class extends Controller {
 
     this.showPopup()
 
-    await this.notifyChildControllers({ creativeId: resolvedCreativeId, canComment })
+    await this.notifyChildControllers({ creativeId: resolvedCreativeId, canComment, highlightId })
 
     // Track in chat navigation history
     if (!this._isNavigating) {
@@ -343,6 +362,11 @@ export default class extends Controller {
   }
 
   close() {
+    if (this.isDocked() && !this.isFullscreen()) {
+      this.toggleDocked()
+      return
+    }
+
     if (this.presenceController) {
       this.presenceController.onPopupClosed()
     }
@@ -415,6 +439,8 @@ export default class extends Controller {
   }
 
   prepareSize() {
+    if (this.isDocked()) return
+
     const stored = window.localStorage.getItem(SIZE_STORAGE_KEY)
     if (!stored) return
     try {
@@ -432,7 +458,10 @@ export default class extends Controller {
 
   showPopup() {
     this.element.style.display = 'flex'
-    if (this.isMobile()) {
+    if (this.isDocked()) {
+      this.element.classList.add('docked')
+      this.syncDockedUI()
+    } else if (this.isMobile()) {
       this.element.classList.add('open')
     }
     this._requestWakeLock()
@@ -446,8 +475,79 @@ export default class extends Controller {
     return window.innerWidth <= 600
   }
 
+  isDocked() {
+    return this.element.dataset.docked === 'true' && this.dockedMediaQuery?.matches === true
+  }
+
+  enterDockedMode() {
+    const el = this.element
+    if (this.dockedOpenTimeout) window.clearTimeout(this.dockedOpenTimeout)
+    el.classList.add('docked')
+    el.classList.remove('open')
+    el.style.position = ''
+    el.style.top = ''
+    el.style.left = ''
+    el.style.right = ''
+    el.style.bottom = ''
+    el.style.width = ''
+    el.style.height = ''
+    delete el.dataset.resized
+    this.showPopup()
+
+    if (el.dataset.creativeId) {
+      requestAnimationFrame(() => {
+        this.dockedOpenTimeout = window.setTimeout(() => {
+          this.dockedOpenTimeout = null
+          if (!this.element.isConnected || !this.isDocked()) return
+
+          this.openForCreative({ highlightId: this.commentIdFromUrl() })
+        }, 0)
+      })
+    } else if (this.hasListTarget) {
+      this.listTarget.classList.add('docked-empty')
+      this.listTarget.textContent = el.dataset.dockedEmptyText || ''
+    }
+  }
+
+  handleDockedMediaChange(event) {
+    if (event.matches) {
+      this.enterDockedMode()
+    } else {
+      this.element.classList.remove('docked', 'docked-collapsed')
+      this.syncDockedUI()
+      this.close()
+    }
+  }
+
+  toggleDocked() {
+    if (!this.isDocked()) return
+
+    this.element.classList.toggle('docked-collapsed')
+    this.syncDockedUI()
+    if (!this.element.classList.contains('docked-collapsed')) {
+      requestAnimationFrame(() => this.listController?.scrollToBottom())
+    }
+  }
+
+  syncDockedUI() {
+    if (!this.hasCloseButtonTarget) return
+
+    if (!this.isDocked()) {
+      this.closeButtonTarget.textContent = '×'
+      return
+    }
+
+    const collapsed = this.element.classList.contains('docked-collapsed')
+    const label = collapsed
+      ? (this.element.dataset.expandDockedLabel || '')
+      : (this.element.dataset.collapseDockedLabel || '')
+    this.closeButtonTarget.textContent = collapsed ? '‹' : '›'
+    this.closeButtonTarget.setAttribute('aria-label', label)
+    this.closeButtonTarget.title = label
+  }
+
   updatePosition() {
-    if (this.isFullscreen() || !this.currentButton || this.isMobile() || this.element.dataset.resized === 'true') return
+    if (this.isDocked() || this.isFullscreen() || !this.currentButton || this.isMobile() || this.element.dataset.resized === 'true') return
     const rect = this.currentButton.getBoundingClientRect()
     const popupWidth = this.element.offsetWidth
     const popupHeight = this.element.offsetHeight
@@ -473,6 +573,8 @@ export default class extends Controller {
   }
 
   startResize(event, direction) {
+    if (this.isDocked()) return
+
     event.preventDefault()
     const rect = this.element.getBoundingClientRect()
     this.resizeStartX = event.clientX
@@ -799,6 +901,34 @@ export default class extends Controller {
         return
       }
 
+      if (this.isDocked()) {
+        el.style.transition = 'none'
+        el.dataset.fullscreen = 'false'
+        document.body.classList.remove('chat-fullscreen')
+        el.style.position = ''
+        el.style.top = ''
+        el.style.left = ''
+        el.style.right = ''
+        el.style.bottom = ''
+        el.style.width = ''
+        el.style.height = ''
+        this._savedStyles = null
+        this._syncFullscreenUI(false)
+        this.syncDockedUI()
+        el.offsetHeight // eslint-disable-line no-unused-expressions
+        el.style.transition = ''
+
+        let backUrl = this._previousUrl || (creativeId ? `/creatives/${creativeId}` : null)
+        if (backUrl) {
+          const url = new URL(backUrl, window.location.origin)
+          url.searchParams.set('open_comments', 'true')
+          window.history.pushState({ fullscreen: false }, '', url.pathname + url.search)
+        }
+        this._previousUrl = null
+        requestAnimationFrame(() => this.listController?.scrollToBottom())
+        return
+      }
+
       // Desktop: animated exit to target position
       // Calculate target position using viewport-relative coords (popup is position: fixed)
       let finalTop = ''      // px string (viewport-relative)
@@ -976,6 +1106,10 @@ export default class extends Controller {
       el.dataset.fullscreen = isFs ? 'true' : 'false'
       document.body.classList.toggle('chat-fullscreen', isFs)
       this._syncFullscreenUI(isFs)
+      if (!isFs && this.isDocked()) {
+        el.style.display = 'flex'
+        this.syncDockedUI()
+      }
 
       if (!isFs && this._savedStyles) {
         Object.assign(el.style, this._savedStyles)
@@ -998,10 +1132,10 @@ export default class extends Controller {
       this.exitFullscreenIconTarget.style.display = entering ? '' : 'none'
     }
     if (this.hasLeftHandleTarget) {
-      this.leftHandleTarget.style.display = entering ? 'none' : ''
+      this.leftHandleTarget.style.display = entering || this.isDocked() ? 'none' : ''
     }
     if (this.hasRightHandleTarget) {
-      this.rightHandleTarget.style.display = entering ? 'none' : ''
+      this.rightHandleTarget.style.display = entering || this.isDocked() ? 'none' : ''
     }
     if (this.hasCloseButtonTarget) {
       this.closeButtonTarget.style.display = entering ? 'none' : ''
@@ -1012,11 +1146,11 @@ export default class extends Controller {
         : (this.element.dataset.fullscreenLabel || 'Full screen')
       this.fullscreenButtonTarget.setAttribute('aria-label', label)
     }
+    if (!entering) this.syncDockedUI()
   }
 
-  openFromUrl() {
+  commentIdFromUrl() {
     const params = new URLSearchParams(window.location.search)
-    const openComments = params.get('open_comments') === 'true'
     let commentId = params.get('comment_id')
     if (!commentId) {
       const pathCommentMatch = window.location.pathname.match(/\/creatives\/\d+\/comments\/(\d+)/)
@@ -1030,6 +1164,14 @@ export default class extends Controller {
         commentId = hashMatch[1]
       }
     }
+
+    return commentId || undefined
+  }
+
+  openFromUrl() {
+    const params = new URLSearchParams(window.location.search)
+    const openComments = params.get('open_comments') === 'true'
+    const commentId = this.commentIdFromUrl()
 
     let creativeId = params.get('id')
     if (!creativeId) {

--- a/engines/collavre/app/javascript/controllers/comments/popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_controller.js
@@ -32,6 +32,7 @@ export default class extends Controller {
     this.openFromUrlObserver = null
     this.openFromUrlTimeout = null
     this.dockedOpenTimeout = null
+    this.openGeneration = 0
     this.handleCreativeClick = this.handleCreativeClick.bind(this)
     this.handleCreativeDestroyed = this.handleCreativeDestroyed.bind(this)
     this.handleEditingStart = this.handleEditingStart.bind(this)
@@ -217,6 +218,8 @@ export default class extends Controller {
   }
 
   resetDockedToEmpty() {
+    this.openGeneration += 1
+
     if (this.dockedOpenTimeout) {
       window.clearTimeout(this.dockedOpenTimeout)
       this.dockedOpenTimeout = null
@@ -251,7 +254,11 @@ export default class extends Controller {
 
     if (this.element.style.display !== 'flex') return
     if (destroyedIds.includes(this.element.dataset.creativeId)) {
-      this.close()
+      if (this.isDocked() && !this.isFullscreen()) {
+        this.resetDockedToEmpty()
+      } else {
+        this.close()
+      }
     }
   }
 
@@ -266,6 +273,7 @@ export default class extends Controller {
   }
 
   async open(button, { creativeId, highlightId } = {}) {
+    const openGeneration = ++this.openGeneration
     if (this.hasListTarget) this.listTarget.classList.remove('docked-empty')
     this.currentButton = button
     const resolvedCreativeId = creativeId || button?.dataset.creativeId
@@ -284,7 +292,13 @@ export default class extends Controller {
     this.showPopup()
     this.updatePosition()
 
-    await this.notifyChildControllers({ creativeId: resolvedCreativeId, canComment, highlightId })
+    const opened = await this.notifyChildControllers({
+      creativeId: resolvedCreativeId,
+      canComment,
+      highlightId,
+      openGeneration,
+    })
+    if (!opened) return
 
     // Track in chat navigation history (skip if navigating via back/forward)
     if (!this._isNavigating) {
@@ -303,6 +317,7 @@ export default class extends Controller {
   }
 
   async openForCreative({ highlightId } = {}) {
+    const openGeneration = ++this.openGeneration
     if (this.hasListTarget) this.listTarget.classList.remove('docked-empty')
     const resolvedCreativeId = this.element.dataset.creativeId
     const canComment = this.element.dataset.canComment === 'true'
@@ -318,7 +333,13 @@ export default class extends Controller {
 
     this.showPopup()
 
-    await this.notifyChildControllers({ creativeId: resolvedCreativeId, canComment, highlightId })
+    const opened = await this.notifyChildControllers({
+      creativeId: resolvedCreativeId,
+      canComment,
+      highlightId,
+      openGeneration,
+    })
+    if (!opened) return
 
     // Track in chat navigation history
     if (!this._isNavigating) {
@@ -336,7 +357,7 @@ export default class extends Controller {
     }))
   }
 
-  async notifyChildControllers({ creativeId, canComment, highlightId }) {
+  async notifyChildControllers({ creativeId, canComment, highlightId, openGeneration }) {
     this.topicsController?.clearOverrideTopicId()
     // Drop the previous creative's topic selection from the form controller
     // synchronously, BEFORE topics loadTopics() dispatches `comments--topics:change`
@@ -370,6 +391,8 @@ export default class extends Controller {
       this.listController.suppressTopicChangeLoad = false
     }
 
+    if (openGeneration !== this.openGeneration) return false
+
     if (this.formController) {
       this.formController.onPopupOpened({ creativeId, canComment })
     }
@@ -389,6 +412,7 @@ export default class extends Controller {
     if (this.dropTriggerController) {
       this.dropTriggerController.onPopupOpened({ creativeId })
     }
+    return true
   }
 
   close() {
@@ -396,6 +420,8 @@ export default class extends Controller {
       this.toggleDocked()
       return
     }
+
+    this.openGeneration += 1
 
     this.closeChildControllers()
     this.dispatchPopupClosed()

--- a/engines/collavre/app/javascript/controllers/comments/popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_controller.js
@@ -522,7 +522,7 @@ export default class extends Controller {
     } else if (this.isMobile()) {
       this.element.classList.add('open')
     }
-    this._requestWakeLock()
+    this._syncWakeLock()
   }
 
   isFullscreen() {
@@ -582,6 +582,7 @@ export default class extends Controller {
 
     this.element.classList.toggle('docked-collapsed')
     this.syncDockedUI()
+    this._syncWakeLock()
     if (!this.element.classList.contains('docked-collapsed')) {
       requestAnimationFrame(() => this.listController?.scrollToBottom())
     }
@@ -743,7 +744,7 @@ export default class extends Controller {
     if (!document.hidden && this.element.style.display === 'flex') {
       this.listController?.loadInitialComments()
       // Re-acquire wake lock — released automatically when tab loses visibility
-      this._requestWakeLock()
+      this._syncWakeLock()
     }
   }
 
@@ -1559,12 +1560,35 @@ export default class extends Controller {
   // is open.  The browser automatically releases the lock when the tab
   // loses visibility, so we re-acquire it in handleVisibilityChange().
 
+  _shouldHoldWakeLock() {
+    if (this.element.style.display !== 'flex') return false
+    if (this.isFullscreen()) return true
+    if (!this.isDocked()) return true
+
+    return Boolean(this.element.dataset.creativeId) &&
+      !this.element.classList.contains('docked-collapsed')
+  }
+
+  _syncWakeLock() {
+    if (this._shouldHoldWakeLock()) {
+      this._requestWakeLock()
+    } else {
+      this._releaseWakeLock()
+    }
+  }
+
   async _requestWakeLock() {
-    if (!('wakeLock' in navigator)) return
+    if (!this._shouldHoldWakeLock() || !('wakeLock' in navigator)) return
 
     try {
-      this._wakeLock = await navigator.wakeLock.request('screen')
-      this._wakeLock.addEventListener('release', () => {
+      const wakeLock = await navigator.wakeLock.request('screen')
+      if (!this._shouldHoldWakeLock()) {
+        wakeLock.release()
+        return
+      }
+
+      this._wakeLock = wakeLock
+      wakeLock.addEventListener('release', () => {
         this._wakeLock = null
       })
     } catch (err) {

--- a/engines/collavre/app/javascript/controllers/comments/popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_controller.js
@@ -225,12 +225,20 @@ export default class extends Controller {
       this.resetDockedToEmpty()
       return
     }
+    // A collapsed docked chat is a 3rem rail, so an explicit chat-icon click has
+    // to expand it. Workspace tree navigation must not: the user collapsed the
+    // chat on purpose and moving around the tree should leave it that way.
+    const userRequestedOpen = !event.detail?.workspaceSync
     if (
       this.element.style.display === 'flex' &&
       this.element.dataset.creativeId === (creativeId || button.dataset.creativeId)
     ) {
       if (this.isDocked()) {
-        if (event.detail?.workspaceSync && highlightId) {
+        if (userRequestedOpen) {
+          // Already loaded for this creative — expand only, so the draft and
+          // subscriptions survive.
+          this.expandDocked()
+        } else if (highlightId) {
           this.open(button, { creativeId, highlightId })
         }
         return
@@ -238,6 +246,7 @@ export default class extends Controller {
       this.close()
       return
     }
+    if (userRequestedOpen) this.expandDocked()
     const openOptions = { creativeId }
     if (highlightId) openOptions.highlightId = highlightId
     this.open(button, openOptions)
@@ -624,12 +633,24 @@ export default class extends Controller {
   toggleDocked() {
     if (!this.isDocked()) return
 
-    this.element.classList.toggle('docked-collapsed')
+    if (this.element.classList.contains('docked-collapsed')) {
+      this.expandDocked()
+      return
+    }
+
+    this.element.classList.add('docked-collapsed')
     this.syncDockedUI()
     this._syncWakeLock()
-    if (!this.element.classList.contains('docked-collapsed')) {
-      requestAnimationFrame(() => this.listController?.scrollToBottom())
-    }
+  }
+
+  expandDocked() {
+    if (!this.isDocked()) return
+    if (!this.element.classList.contains('docked-collapsed')) return
+
+    this.element.classList.remove('docked-collapsed')
+    this.syncDockedUI()
+    this._syncWakeLock()
+    requestAnimationFrame(() => this.listController?.scrollToBottom())
   }
 
   syncDockedUI() {

--- a/engines/collavre/app/javascript/controllers/comments/popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_controller.js
@@ -202,6 +202,16 @@ export default class extends Controller {
     const button = event.detail?.button
     const creativeId = event.detail?.creativeId
     if (!button) return
+    if (event.detail?.workspaceSync && !this.isDocked()) {
+      const nextCreativeId = creativeId || button.dataset.creativeId || ''
+      if (
+        this.element.style.display === 'flex' &&
+        this.element.dataset.creativeId !== String(nextCreativeId)
+      ) {
+        this.close()
+      }
+      return
+    }
     if (!creativeId && button.dataset.workspaceNavigationState === 'true' && this.isDocked()) {
       this.resetDockedToEmpty()
       return

--- a/engines/collavre/app/javascript/controllers/comments/popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_controller.js
@@ -201,6 +201,10 @@ export default class extends Controller {
     const button = event.detail?.button
     const creativeId = event.detail?.creativeId
     if (!button) return
+    if (!creativeId && button.dataset.workspaceNavigationState === 'true' && this.isDocked()) {
+      this.resetDockedToEmpty()
+      return
+    }
     if (
       this.element.style.display === 'flex' &&
       this.element.dataset.creativeId === (creativeId || button.dataset.creativeId)
@@ -210,6 +214,32 @@ export default class extends Controller {
       return
     }
     this.open(button, { creativeId })
+  }
+
+  resetDockedToEmpty() {
+    if (this.dockedOpenTimeout) {
+      window.clearTimeout(this.dockedOpenTimeout)
+      this.dockedOpenTimeout = null
+    }
+
+    this.currentButton = null
+    this.element.dataset.creativeId = ''
+    this.element.dataset.canComment = 'false'
+    this.element.dataset.creativeSnippet = ''
+    this.titleTarget.textContent = this.element.dataset.defaultTitle || ''
+    this._clearChatActiveRow()
+    this._hideNavDropdown()
+
+    if (this.listController) this.listController.creativeId = null
+    this.closeChildControllers()
+    this.formController?.setCommentPermission(false)
+    this.element.querySelector('#comment-topics')?.replaceChildren()
+    if (this.hasListTarget) {
+      this.listTarget.classList.add('docked-empty')
+      this.listTarget.textContent = this.element.dataset.dockedEmptyText || ''
+    }
+    this.showPopup()
+    this.dispatchPopupClosed()
   }
 
   handleCreativeDestroyed(event) {
@@ -367,35 +397,8 @@ export default class extends Controller {
       return
     }
 
-    if (this.presenceController) {
-      this.presenceController.onPopupClosed()
-    }
-    if (this.formController) {
-      this.formController.onPopupClosed()
-    }
-    if (this.listController) {
-      this.listController.onPopupClosed()
-    }
-    if (this.mentionMenuController) {
-      this.mentionMenuController.onPopupClosed()
-    }
-    if (this.topicsController) {
-      this.topicsController.onPopupClosed()
-    }
-    if (this.contextsController) {
-      this.contextsController.onPopupClosed()
-    }
-    if (this.dropTriggerController) {
-      this.dropTriggerController.onPopupClosed()
-    }
-
-    // Dispatch event for integrations
-    this.element.dispatchEvent(new CustomEvent('comments-popup:closed', {
-      bubbles: true,
-      detail: {
-        badgeContainer: this.element.querySelector('[data-integration-badges]')
-      }
-    }))
+    this.closeChildControllers()
+    this.dispatchPopupClosed()
 
     // Exit fullscreen state if active
     if (this.isFullscreen()) {
@@ -436,6 +439,25 @@ export default class extends Controller {
     this.element.style.bottom = ''
     this.element.style.position = ''
     delete this.element.dataset.resized
+  }
+
+  closeChildControllers() {
+    this.presenceController?.onPopupClosed()
+    this.formController?.onPopupClosed()
+    this.listController?.onPopupClosed()
+    this.mentionMenuController?.onPopupClosed()
+    this.topicsController?.onPopupClosed()
+    this.contextsController?.onPopupClosed()
+    this.dropTriggerController?.onPopupClosed()
+  }
+
+  dispatchPopupClosed() {
+    this.element.dispatchEvent(new CustomEvent('comments-popup:closed', {
+      bubbles: true,
+      detail: {
+        badgeContainer: this.element.querySelector('[data-integration-badges]')
+      }
+    }))
   }
 
   prepareSize() {

--- a/engines/collavre/app/javascript/controllers/comments/popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_controller.js
@@ -231,6 +231,8 @@ export default class extends Controller {
   resetDockedToEmpty() {
     this.openGeneration += 1
 
+    if (this.isFullscreen()) this._exitFullscreenState()
+
     if (this.dockedOpenTimeout) {
       window.clearTimeout(this.dockedOpenTimeout)
       this.dockedOpenTimeout = null
@@ -445,30 +447,7 @@ export default class extends Controller {
     this.closeChildControllers()
     this.dispatchPopupClosed()
 
-    // Exit fullscreen state if active
-    if (this.isFullscreen()) {
-      this.element.dataset.fullscreen = 'false'
-      document.body.classList.remove('chat-fullscreen')
-      this._syncFullscreenUI(false)
-      this._savedStyles = null
-
-      // Navigate back from fullscreen URL — use replaceState to consume the
-      // fullscreen history entry instead of pushing a new one, preventing a
-      // stale fullscreen entry from being reached via the Back button.
-      const creativeId = this.element.dataset.creativeId
-      const backUrl = this._previousUrl || (creativeId ? `/creatives/${creativeId}` : null)
-      if (backUrl) {
-        const url = new URL(backUrl, window.location.origin)
-        // Strip comment auto-open markers so a refresh after close doesn't
-        // re-open the popup (handles ?open_comments, ?comment_id, #comment_*).
-        url.searchParams.delete('open_comments')
-        url.searchParams.delete('comment_id')
-        const cleanPath = url.pathname.replace(/\/comments\/\d+$/, '')
-        url.hash = url.hash.replace(/^#comment_\d+$/, '')
-        window.history.replaceState({ fullscreen: false }, '', cleanPath + url.search + url.hash)
-      }
-      this._previousUrl = null
-    }
+    this._exitFullscreenState()
 
     this._clearChatActiveRow()
     this._hideNavDropdown()
@@ -484,6 +463,47 @@ export default class extends Controller {
     this.element.style.bottom = ''
     this.element.style.position = ''
     delete this.element.dataset.resized
+  }
+
+  _exitFullscreenState() {
+    if (!this.isFullscreen()) return
+
+    if (this._enterCleanupTimer) {
+      window.clearTimeout(this._enterCleanupTimer)
+      this._enterCleanupTimer = null
+    }
+    if (this._enterCleanupFn) {
+      this.element.removeEventListener('transitionend', this._enterCleanupFn)
+      this._enterCleanupFn = null
+    }
+
+    this.element.dataset.fullscreen = 'false'
+    document.body.classList.remove('chat-fullscreen')
+    this._syncFullscreenUI(false)
+    this._savedStyles = null
+    this.element.style.transition = ''
+    this.element.style.position = ''
+    this.element.style.top = ''
+    this.element.style.left = ''
+    this.element.style.right = ''
+    this.element.style.bottom = ''
+    this.element.style.width = ''
+    this.element.style.height = ''
+    this.element.style.transform = ''
+
+    // Consume the fullscreen history entry and remove markers that could
+    // reopen the invalidated chat after a reset or close.
+    const creativeId = this.element.dataset.creativeId
+    const backUrl = this._previousUrl || (creativeId ? `/creatives/${creativeId}` : null)
+    if (backUrl) {
+      const url = new URL(backUrl, window.location.origin)
+      url.searchParams.delete('open_comments')
+      url.searchParams.delete('comment_id')
+      const cleanPath = url.pathname.replace(/\/comments\/\d+$/, '')
+      url.hash = url.hash.replace(/^#comment_\d+$/, '')
+      window.history.replaceState({ fullscreen: false }, '', cleanPath + url.search + url.hash)
+    }
+    this._previousUrl = null
   }
 
   closeChildControllers() {

--- a/engines/collavre/app/javascript/controllers/comments/popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_controller.js
@@ -640,7 +640,7 @@ export default class extends Controller {
     const label = collapsed
       ? (this.element.dataset.expandDockedLabel || '')
       : (this.element.dataset.collapseDockedLabel || '')
-    this.closeButtonTarget.textContent = collapsed ? '‹' : '›'
+    this.closeButtonTarget.textContent = '×'
     this.closeButtonTarget.setAttribute('aria-label', label)
     this.closeButtonTarget.title = label
   }

--- a/engines/collavre/app/javascript/controllers/comments/popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_controller.js
@@ -33,6 +33,7 @@ export default class extends Controller {
     this.openFromUrlTimeout = null
     this.dockedOpenTimeout = null
     this.openGeneration = 0
+    this._wakeLockRequest = null
     this.handleCreativeClick = this.handleCreativeClick.bind(this)
     this.handleCreativeDestroyed = this.handleCreativeDestroyed.bind(this)
     this.handleEditingStart = this.handleEditingStart.bind(this)
@@ -387,21 +388,29 @@ export default class extends Controller {
     // Without this, the topic change event fires loadInitialComments() before
     // onPopupOpened sets highlightAfterLoad, causing a race where the non-highlight
     // load can overwrite the deep-link highlight load.
-    if (this.listController) {
-      this.listController.creativeId = creativeId
-      this.listController.suppressTopicChangeLoad = true
+    const suppressedListController = this.listController
+    if (suppressedListController) {
+      suppressedListController.creativeId = creativeId
+      suppressedListController.suppressTopicChangeLoad = true
     }
 
     // Load topics first to establish context
-    if (this.topicsController) {
-      await this.topicsController.onPopupOpened({ creativeId })
-    }
-
-    if (this.listController) {
-      this.listController.suppressTopicChangeLoad = false
+    try {
+      if (this.topicsController) {
+        await this.topicsController.onPopupOpened({ creativeId })
+      }
+    } catch (error) {
+      if (openGeneration === this.openGeneration && suppressedListController) {
+        suppressedListController.suppressTopicChangeLoad = false
+      }
+      throw error
     }
 
     if (openGeneration !== this.openGeneration) return false
+
+    if (suppressedListController) {
+      suppressedListController.suppressTopicChangeLoad = false
+    }
 
     if (this.formController) {
       this.formController.onPopupOpened({ creativeId, canComment })
@@ -592,7 +601,10 @@ export default class extends Controller {
     if (!this.hasCloseButtonTarget) return
 
     if (!this.isDocked()) {
+      const label = this.element.dataset.closeLabel || ''
       this.closeButtonTarget.textContent = '×'
+      this.closeButtonTarget.setAttribute('aria-label', label)
+      this.closeButtonTarget.title = label
       return
     }
 
@@ -1578,10 +1590,24 @@ export default class extends Controller {
   }
 
   async _requestWakeLock() {
-    if (!this._shouldHoldWakeLock() || !('wakeLock' in navigator)) return
+    if (
+      !this._shouldHoldWakeLock() ||
+      !('wakeLock' in navigator) ||
+      this._wakeLock ||
+      this._wakeLockRequest
+    ) return
 
+    let request
     try {
-      const wakeLock = await navigator.wakeLock.request('screen')
+      request = navigator.wakeLock.request('screen')
+      this._wakeLockRequest = request
+      const wakeLock = await request
+      if (this._wakeLockRequest !== request) {
+        wakeLock.release()
+        return
+      }
+
+      this._wakeLockRequest = null
       if (!this._shouldHoldWakeLock()) {
         wakeLock.release()
         return
@@ -1589,9 +1615,10 @@ export default class extends Controller {
 
       this._wakeLock = wakeLock
       wakeLock.addEventListener('release', () => {
-        this._wakeLock = null
+        if (this._wakeLock === wakeLock) this._wakeLock = null
       })
     } catch (err) {
+      if (this._wakeLockRequest === request) this._wakeLockRequest = null
       // Wake lock request can fail (e.g. low battery, browser policy).
       // This is non-critical — just log and continue.
       console.debug('[chat] Wake lock request failed:', err.message)
@@ -1599,9 +1626,9 @@ export default class extends Controller {
   }
 
   _releaseWakeLock() {
-    if (this._wakeLock) {
-      this._wakeLock.release()
-      this._wakeLock = null
-    }
+    this._wakeLockRequest = null
+    const wakeLock = this._wakeLock
+    this._wakeLock = null
+    wakeLock?.release()
   }
 }

--- a/engines/collavre/app/javascript/controllers/comments/popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_controller.js
@@ -6,6 +6,13 @@ const CREATIVE_CLICK_EVENT = 'creative-comments-click'
 const CREATIVE_DESTROYED_EVENT = 'creative-destroyed'
 const LONG_PRESS_MS = 500
 
+// A collapsed docked chat shrinks to a 3rem rail where the close button is the
+// only visible control, so it acts as the expand affordance and shows a chevron
+// instead of the close glyph. Matched to the tree chevrons
+// (link_creative_controller.js) so the affordance reads the same everywhere.
+const EXPAND_CHEVRON =
+  '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M15 6L9 12L15 18"/></svg>'
+
 export default class extends Controller {
   static targets = [
     'title',
@@ -640,7 +647,11 @@ export default class extends Controller {
     const label = collapsed
       ? (this.element.dataset.expandDockedLabel || '')
       : (this.element.dataset.collapseDockedLabel || '')
-    this.closeButtonTarget.textContent = '×'
+    if (collapsed) {
+      this.closeButtonTarget.innerHTML = EXPAND_CHEVRON
+    } else {
+      this.closeButtonTarget.textContent = '×'
+    }
     this.closeButtonTarget.setAttribute('aria-label', label)
     this.closeButtonTarget.title = label
   }

--- a/engines/collavre/app/javascript/controllers/comments/popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_controller.js
@@ -202,6 +202,7 @@ export default class extends Controller {
   handleCreativeClick(event) {
     const button = event.detail?.button
     const creativeId = event.detail?.creativeId
+    const highlightId = event.detail?.highlightId
     if (!button) return
     if (event.detail?.workspaceSync && !this.isDocked()) {
       const nextCreativeId = creativeId || button.dataset.creativeId || ''
@@ -221,11 +222,18 @@ export default class extends Controller {
       this.element.style.display === 'flex' &&
       this.element.dataset.creativeId === (creativeId || button.dataset.creativeId)
     ) {
-      if (this.isDocked()) return
+      if (this.isDocked()) {
+        if (event.detail?.workspaceSync && highlightId) {
+          this.open(button, { creativeId, highlightId })
+        }
+        return
+      }
       this.close()
       return
     }
-    this.open(button, { creativeId })
+    const openOptions = { creativeId }
+    if (highlightId) openOptions.highlightId = highlightId
+    this.open(button, openOptions)
   }
 
   resetDockedToEmpty() {

--- a/engines/collavre/app/javascript/controllers/comments/presence_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/presence_controller.js
@@ -320,7 +320,9 @@ export default class extends Controller {
       }
 
       if (shareChange.has_access === false) {
-        document.dispatchEvent(new CustomEvent('workspace-tree:invalidate'))
+        document.dispatchEvent(new CustomEvent('workspace-tree:invalidate', {
+          detail: { creativeIds: [String(this.creativeId)] },
+        }))
         alertDialog(this.element.dataset.noPermissionText || 'No permission')
         if (this.popupController?.isDocked()) {
           this.popupController.resetDockedToEmpty()

--- a/engines/collavre/app/javascript/controllers/comments/presence_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/presence_controller.js
@@ -216,7 +216,7 @@ export default class extends Controller {
     this.presenceSubscription.perform('running_agents', { topic_id: this.selectedTopicId })
   }
 
-  loadParticipants({ closeOnForbidden = false } = {}) {
+  loadParticipants() {
     if (!this.creativeId) return
     fetch(`/creatives/${this.creativeId}/comments/participants`, {
       cache: 'no-store',
@@ -236,16 +236,11 @@ export default class extends Controller {
         this.renderParticipants(this.currentPresentIds)
         this.renderTypingIndicator()
       })
-      .catch((error) => {
+      .catch(() => {
         this.participantsData = []
         this.canShare = false
         this.renderParticipants([])
         this.renderTypingIndicator()
-
-        if (closeOnForbidden) {
-          alertDialog(error.message)
-          this.popupController?.close()
-        }
       })
   }
 
@@ -324,7 +319,18 @@ export default class extends Controller {
         this.formController?.setCommentPermission(shareChange.can_comment)
       }
 
-      this.loadParticipants({ closeOnForbidden: shareChange.has_access === false })
+      if (shareChange.has_access === false) {
+        document.dispatchEvent(new CustomEvent('workspace-tree:invalidate'))
+        alertDialog(this.element.dataset.noPermissionText || 'No permission')
+        if (this.popupController?.isDocked()) {
+          this.popupController.resetDockedToEmpty()
+        } else {
+          this.popupController?.close()
+        }
+        return
+      }
+
+      this.loadParticipants()
       return
     }
     if (data.channel_chips) {

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -50,8 +50,12 @@ export default class extends Controller {
     }
 
     onPopupClosed() {
+        this._loadTopicsVersion += 1
         this.unsubscribe()
         this.creativeIdValue = null
+        this.topics = []
+        this.mainTopicId = null
+        delete this.element.dataset.effectiveCreativeId
     }
 
     get creativeId() {

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -18,7 +18,7 @@ export default class extends Controller {
         this.topicsSubscription = null
         this._loadTopicsVersion = 0
         // Initial load if creativeId is available (e.g. from dataset if set server-side)
-        if (this.creativeId) {
+        if (this.creativeId && this.element.dataset.docked !== 'true') {
             this.loadTopics()
             this.subscribe()
         }

--- a/engines/collavre/app/javascript/controllers/index.js
+++ b/engines/collavre/app/javascript/controllers/index.js
@@ -36,6 +36,7 @@ import ImageLightboxController from "./image_lightbox_controller"
 import SearchPopupController from "./search_popup_controller"
 import LandingVideoController from "./landing_video_controller"
 import InboxBadgeController from "./inbox_badge_controller"
+import WorkspaceTreeController from "./workspace_tree_controller"
 
 // Export all controllers
 export {
@@ -73,7 +74,8 @@ export {
   SearchPopupController,
   CommentBadgeController,
   LandingVideoController,
-  InboxBadgeController
+  InboxBadgeController,
+  WorkspaceTreeController
 }
 
 // Registration function for use with a Stimulus application
@@ -114,4 +116,5 @@ export function registerControllers(application) {
   application.register("comment-badge", CommentBadgeController)
   application.register("landing-video", LandingVideoController)
   application.register("inbox-badge", InboxBadgeController)
+  application.register("workspace-tree", WorkspaceTreeController)
 }

--- a/engines/collavre/app/javascript/controllers/workspace_tree_controller.js
+++ b/engines/collavre/app/javascript/controllers/workspace_tree_controller.js
@@ -225,7 +225,11 @@ export default class extends Controller {
     const activeId = this.deepestVisiblePathId(this.nodesData || [], path)
     this.setActiveId(activeId)
 
-    if (syncChat) this.openChat(state)
+    if (syncChat) {
+      this.openChat(state, {
+        highlightId: authoritative ? this.commentIdFromLocation() : undefined,
+      })
+    }
   }
 
   setActiveId(id) {
@@ -243,9 +247,14 @@ export default class extends Controller {
     this.activeId = String(id)
   }
 
-  openChat(link) {
+  openChat(link, { highlightId } = {}) {
     document.dispatchEvent(new CustomEvent('creative-comments-click', {
-      detail: { button: link, creativeId: link.dataset.creativeId, workspaceSync: true },
+      detail: {
+        button: link,
+        creativeId: link.dataset.creativeId,
+        workspaceSync: true,
+        highlightId,
+      },
     }))
   }
 
@@ -271,6 +280,17 @@ export default class extends Controller {
     if (queryId) return queryId
 
     return window.location.pathname.match(/\/creatives\/(\d+)/)?.[1]
+  }
+
+  commentIdFromLocation() {
+    const params = new URLSearchParams(window.location.search)
+    const queryCommentId = params.get('comment_id') || params.get('highlight_comment_id')
+    if (queryCommentId) return queryCommentId
+
+    const pathCommentId = window.location.pathname.match(/\/creatives\/\d+\/comments\/(\d+)/)?.[1]
+    if (pathCommentId) return pathCommentId
+
+    return window.location.hash.match(/comment_(\d+)/)?.[1]
   }
 
   rootState() {

--- a/engines/collavre/app/javascript/controllers/workspace_tree_controller.js
+++ b/engines/collavre/app/javascript/controllers/workspace_tree_controller.js
@@ -97,6 +97,7 @@ export default class extends Controller {
       toggle.type = 'button'
       toggle.className = 'creative-workspace-tree-branch-toggle'
       toggle.setAttribute('aria-expanded', String(expanded))
+      toggle.setAttribute('aria-label', node.label)
       toggle.textContent = expanded ? '▾' : '▸'
       toggle.addEventListener('click', () => this.toggleBranch(item, toggle))
       row.appendChild(toggle)

--- a/engines/collavre/app/javascript/controllers/workspace_tree_controller.js
+++ b/engines/collavre/app/javascript/controllers/workspace_tree_controller.js
@@ -12,21 +12,41 @@ export default class extends Controller {
   }
 
   connect() {
-    this.abortController = new AbortController()
+    this.handleFrameLoad = this.handleFrameLoad.bind(this)
+    this.handleTurboRender = this.handleTurboRender.bind(this)
+    this.queueRefresh = this.queueRefresh.bind(this)
+    document.addEventListener('turbo:frame-load', this.handleFrameLoad)
+    document.addEventListener('turbo:frame-render', this.handleFrameLoad)
+    document.addEventListener('turbo:render', this.handleTurboRender)
+    document.addEventListener('workspace-tree:invalidate', this.queueRefresh)
+    document.addEventListener('creative-destroyed', this.queueRefresh)
+    window.addEventListener('collavre:creative-drop-complete', this.queueRefresh)
+    this.observeWorkspaceFrame()
     this.load()
   }
 
   disconnect() {
-    this.abortController?.abort()
+    this.loadAbortController?.abort()
+    this.frameObserver?.disconnect()
+    if (this.refreshTimeout) window.clearTimeout(this.refreshTimeout)
+    document.removeEventListener('turbo:frame-load', this.handleFrameLoad)
+    document.removeEventListener('turbo:frame-render', this.handleFrameLoad)
+    document.removeEventListener('turbo:render', this.handleTurboRender)
+    document.removeEventListener('workspace-tree:invalidate', this.queueRefresh)
+    document.removeEventListener('creative-destroyed', this.queueRefresh)
+    window.removeEventListener('collavre:creative-drop-complete', this.queueRefresh)
   }
 
-  async load() {
-    this.showStatus(this.loadingTextValue)
+  async load({ preserveState = false, showLoading = true } = {}) {
+    this.loadAbortController?.abort()
+    this.loadAbortController = new AbortController()
+    this.preservedBranchState = preserveState ? this.branchState() : new Map()
+    if (showLoading) this.showStatus(this.loadingTextValue)
 
     try {
       const response = await fetch(this.urlValue, {
         headers: { Accept: 'application/json' },
-        signal: this.abortController.signal,
+        signal: this.loadAbortController.signal,
       })
       if (!response.ok) throw new Error(`Failed to load workspace tree: ${response.status}`)
 
@@ -35,19 +55,22 @@ export default class extends Controller {
     } catch (error) {
       if (error.name === 'AbortError') return
       console.error(error)
-      this.showStatus(this.errorTextValue)
+      if (showLoading) this.showStatus(this.errorTextValue)
     }
   }
 
   render(nodes) {
+    this.nodesData = nodes
     this.treeTarget.replaceChildren()
     if (nodes.length === 0) {
       this.showStatus(this.emptyTextValue)
+      this.syncFromWorkspaceFrame()
       return
     }
 
-    this.activeId = this.deepestVisiblePathId(nodes)
+    this.activeId = this.deepestVisiblePathId(nodes, this.currentPathValue)
     this.treeTarget.appendChild(this.buildList(nodes))
+    this.syncFromWorkspaceFrame()
   }
 
   buildList(nodes) {
@@ -66,7 +89,8 @@ export default class extends Controller {
     const row = document.createElement('div')
     row.className = 'creative-workspace-tree-row'
     const children = Array.isArray(node.children) ? node.children : []
-    const expanded = children.length > 0 && this.currentPathValue.map(String).includes(String(node.id))
+    const savedExpanded = this.preservedBranchState?.get(String(node.id))
+    const expanded = children.length > 0 && (savedExpanded ?? this.currentPathValue.map(String).includes(String(node.id)))
 
     if (children.length > 0) {
       const toggle = document.createElement('button')
@@ -87,11 +111,16 @@ export default class extends Controller {
     link.href = node.url
     link.textContent = node.label
     link.className = 'creative-workspace-tree-link'
+    link.dataset.turboFrame = 'creative-workspace-content'
+    link.dataset.turboAction = 'advance'
+    link.dataset.creativeId = String(node.id)
+    link.dataset.creativeSnippet = node.snippet || node.label
+    link.dataset.canComment = String(node.can_comment === true)
     if (String(node.id) === String(this.activeId)) {
       link.classList.add('is-current')
       link.setAttribute('aria-current', 'page')
     }
-    link.addEventListener('click', () => this.closePanel())
+    link.addEventListener('click', (event) => this.selectNode(event))
     row.appendChild(link)
     item.appendChild(row)
 
@@ -123,7 +152,137 @@ export default class extends Controller {
     this.panelToggleTarget.setAttribute('aria-expanded', 'false')
   }
 
-  deepestVisiblePathId(nodes) {
+  selectNode(event) {
+    if (!this.isUnmodifiedPrimaryClick(event)) return
+
+    const link = event.currentTarget
+    this.setActiveId(link.dataset.creativeId)
+    this.closePanel()
+    this.openChat(link)
+  }
+
+  handleFrameLoad(event) {
+    if (event.target.id !== 'creative-workspace-content') return
+
+    this.syncFromWorkspaceFrame(event.target, { authoritative: event.type === 'turbo:frame-load' })
+  }
+
+  handleTurboRender() {
+    requestAnimationFrame(() => {
+      if (this.element.isConnected) this.syncFromWorkspaceFrame()
+    })
+  }
+
+  observeWorkspaceFrame() {
+    const frame = document.getElementById('creative-workspace-content')
+    if (!frame) return
+
+    this.frameObserver = new MutationObserver(() => {
+      if (this.element.isConnected) this.syncFromWorkspaceFrame(frame)
+    })
+    this.frameObserver.observe(frame, { childList: true })
+  }
+
+  queueRefresh() {
+    if (this.refreshTimeout) window.clearTimeout(this.refreshTimeout)
+    this.refreshTimeout = window.setTimeout(() => {
+      this.refreshTimeout = null
+      this.load({ preserveState: true, showLoading: false })
+    }, 100)
+  }
+
+  syncFromWorkspaceFrame(
+    frame = document.getElementById('creative-workspace-content'),
+    { authoritative = false } = {}
+  ) {
+    if (!frame) return
+
+    const state = frame.querySelector('[data-workspace-navigation-state]')
+    if (!state) return
+
+    const stateCreativeId = state.dataset.creativeId
+    const locationCreativeId = this.creativeIdFromLocation()
+    if (!stateCreativeId && (authoritative || !locationCreativeId)) {
+      this.setActiveId(null)
+      this.openChat(this.rootState())
+      return
+    }
+    if (!stateCreativeId || (!authoritative && stateCreativeId !== locationCreativeId)) return
+
+    const path = this.parsePath(state.dataset.creativePath)
+    const activeId = this.deepestVisiblePathId(this.nodesData || [], path)
+    this.setActiveId(activeId)
+
+    this.openChat(state)
+  }
+
+  setActiveId(id) {
+    this.treeTarget.querySelectorAll('.creative-workspace-tree-link.is-current').forEach((link) => {
+      link.classList.remove('is-current')
+      link.removeAttribute('aria-current')
+    })
+
+    this.activeId = null
+    const link = id && this.linkForId(id)
+    if (!link) return
+
+    link.classList.add('is-current')
+    link.setAttribute('aria-current', 'page')
+    this.activeId = String(id)
+  }
+
+  openChat(link) {
+    document.dispatchEvent(new CustomEvent('creative-comments-click', {
+      detail: { button: link, creativeId: link.dataset.creativeId },
+    }))
+  }
+
+  linkForId(id) {
+    return [...this.treeTarget.querySelectorAll('.creative-workspace-tree-item[data-creative-id]')]
+      .find((item) => item.dataset.creativeId === String(id))
+      ?.querySelector(':scope > .creative-workspace-tree-row > .creative-workspace-tree-link')
+  }
+
+  branchState() {
+    return new Map(
+      [...this.treeTarget.querySelectorAll('.creative-workspace-tree-branch-toggle')]
+        .map((toggle) => [
+          toggle.closest('.creative-workspace-tree-item')?.dataset.creativeId,
+          toggle.getAttribute('aria-expanded') === 'true',
+        ])
+        .filter(([id]) => id)
+    )
+  }
+
+  creativeIdFromLocation() {
+    const queryId = new URLSearchParams(window.location.search).get('id')
+    if (queryId) return queryId
+
+    return window.location.pathname.match(/\/creatives\/(\d+)/)?.[1]
+  }
+
+  rootState() {
+    if (!this.rootNavigationState) {
+      this.rootNavigationState = document.createElement('div')
+      this.rootNavigationState.dataset.workspaceNavigationState = 'true'
+    }
+    return this.rootNavigationState
+  }
+
+  parsePath(value) {
+    try {
+      const parsed = JSON.parse(value || '[]')
+      return Array.isArray(parsed) ? parsed : []
+    } catch (_error) {
+      return []
+    }
+  }
+
+  isUnmodifiedPrimaryClick(event) {
+    return event.button === 0 && !event.metaKey && !event.ctrlKey && !event.shiftKey && !event.altKey
+  }
+
+  deepestVisiblePathId(nodes, path = []) {
     const visibleIds = new Set()
     const collect = (items) => items.forEach((item) => {
       visibleIds.add(String(item.id))
@@ -131,7 +290,7 @@ export default class extends Controller {
     })
     collect(nodes)
 
-    return [...this.currentPathValue].reverse().find((id) => visibleIds.has(String(id)))
+    return [...path].reverse().find((id) => visibleIds.has(String(id)))
   }
 
   showStatus(text) {

--- a/engines/collavre/app/javascript/controllers/workspace_tree_controller.js
+++ b/engines/collavre/app/javascript/controllers/workspace_tree_controller.js
@@ -1,0 +1,143 @@
+import { Controller } from '@hotwired/stimulus'
+
+export default class extends Controller {
+  static targets = ['tree', 'panelToggle']
+
+  static values = {
+    url: String,
+    currentPath: Array,
+    loadingText: String,
+    emptyText: String,
+    errorText: String,
+  }
+
+  connect() {
+    this.abortController = new AbortController()
+    this.load()
+  }
+
+  disconnect() {
+    this.abortController?.abort()
+  }
+
+  async load() {
+    this.showStatus(this.loadingTextValue)
+
+    try {
+      const response = await fetch(this.urlValue, {
+        headers: { Accept: 'application/json' },
+        signal: this.abortController.signal,
+      })
+      if (!response.ok) throw new Error(`Failed to load workspace tree: ${response.status}`)
+
+      const data = await response.json()
+      this.render(Array.isArray(data.creatives) ? data.creatives : [])
+    } catch (error) {
+      if (error.name === 'AbortError') return
+      console.error(error)
+      this.showStatus(this.errorTextValue)
+    }
+  }
+
+  render(nodes) {
+    this.treeTarget.replaceChildren()
+    if (nodes.length === 0) {
+      this.showStatus(this.emptyTextValue)
+      return
+    }
+
+    this.activeId = this.deepestVisiblePathId(nodes)
+    this.treeTarget.appendChild(this.buildList(nodes))
+  }
+
+  buildList(nodes) {
+    const list = document.createElement('ul')
+    list.className = 'creative-workspace-tree-list'
+
+    nodes.forEach((node) => list.appendChild(this.buildNode(node)))
+    return list
+  }
+
+  buildNode(node) {
+    const item = document.createElement('li')
+    item.className = 'creative-workspace-tree-item'
+    item.dataset.creativeId = String(node.id)
+
+    const row = document.createElement('div')
+    row.className = 'creative-workspace-tree-row'
+    const children = Array.isArray(node.children) ? node.children : []
+    const expanded = children.length > 0 && this.currentPathValue.map(String).includes(String(node.id))
+
+    if (children.length > 0) {
+      const toggle = document.createElement('button')
+      toggle.type = 'button'
+      toggle.className = 'creative-workspace-tree-branch-toggle'
+      toggle.setAttribute('aria-expanded', String(expanded))
+      toggle.textContent = expanded ? '▾' : '▸'
+      toggle.addEventListener('click', () => this.toggleBranch(item, toggle))
+      row.appendChild(toggle)
+    } else {
+      const spacer = document.createElement('span')
+      spacer.className = 'creative-workspace-tree-branch-spacer'
+      spacer.setAttribute('aria-hidden', 'true')
+      row.appendChild(spacer)
+    }
+
+    const link = document.createElement('a')
+    link.href = node.url
+    link.textContent = node.label
+    link.className = 'creative-workspace-tree-link'
+    if (String(node.id) === String(this.activeId)) {
+      link.classList.add('is-current')
+      link.setAttribute('aria-current', 'page')
+    }
+    link.addEventListener('click', () => this.closePanel())
+    row.appendChild(link)
+    item.appendChild(row)
+
+    if (children.length > 0) {
+      const childList = this.buildList(children)
+      childList.hidden = !expanded
+      item.appendChild(childList)
+    }
+
+    return item
+  }
+
+  toggleBranch(item, toggle) {
+    const childList = item.querySelector(':scope > .creative-workspace-tree-list')
+    if (!childList) return
+
+    childList.hidden = !childList.hidden
+    toggle.setAttribute('aria-expanded', String(!childList.hidden))
+    toggle.textContent = childList.hidden ? '▸' : '▾'
+  }
+
+  togglePanel() {
+    const open = this.element.classList.toggle('is-open')
+    this.panelToggleTarget.setAttribute('aria-expanded', String(open))
+  }
+
+  closePanel() {
+    this.element.classList.remove('is-open')
+    this.panelToggleTarget.setAttribute('aria-expanded', 'false')
+  }
+
+  deepestVisiblePathId(nodes) {
+    const visibleIds = new Set()
+    const collect = (items) => items.forEach((item) => {
+      visibleIds.add(String(item.id))
+      collect(Array.isArray(item.children) ? item.children : [])
+    })
+    collect(nodes)
+
+    return [...this.currentPathValue].reverse().find((id) => visibleIds.has(String(id)))
+  }
+
+  showStatus(text) {
+    const status = document.createElement('p')
+    status.className = 'creative-workspace-tree-status'
+    status.textContent = text
+    this.treeTarget.replaceChildren(status)
+  }
+}

--- a/engines/collavre/app/javascript/controllers/workspace_tree_controller.js
+++ b/engines/collavre/app/javascript/controllers/workspace_tree_controller.js
@@ -23,7 +23,7 @@ export default class extends Controller {
     document.addEventListener('creative-destroyed', this.queueRefresh)
     window.addEventListener('collavre:creative-drop-complete', this.queueRefresh)
     this.observeWorkspaceFrame()
-    this.load()
+    this.load({ syncChat: false })
   }
 
   disconnect() {
@@ -38,7 +38,7 @@ export default class extends Controller {
     window.removeEventListener('collavre:creative-drop-complete', this.queueRefresh)
   }
 
-  async load({ preserveState = false, showLoading = true } = {}) {
+  async load({ preserveState = false, showLoading = true, syncChat = true } = {}) {
     this.loadAbortController?.abort()
     this.loadAbortController = new AbortController()
     this.preservedBranchState = preserveState ? this.branchState() : new Map()
@@ -52,7 +52,7 @@ export default class extends Controller {
       if (!response.ok) throw new Error(`Failed to load workspace tree: ${response.status}`)
 
       const data = await response.json()
-      this.render(Array.isArray(data.creatives) ? data.creatives : [])
+      this.render(Array.isArray(data.creatives) ? data.creatives : [], { syncChat })
     } catch (error) {
       if (error.name === 'AbortError') return
       console.error(error)
@@ -60,18 +60,18 @@ export default class extends Controller {
     }
   }
 
-  render(nodes) {
+  render(nodes, { syncChat = true } = {}) {
     this.nodesData = nodes
     this.treeTarget.replaceChildren()
     if (nodes.length === 0) {
       this.showStatus(this.emptyTextValue)
-      this.syncFromWorkspaceFrame()
+      this.syncFromWorkspaceFrame(undefined, { syncChat })
       return
     }
 
     this.activeId = this.deepestVisiblePathId(nodes, this.currentPathValue)
     this.treeTarget.appendChild(this.buildList(nodes))
-    this.syncFromWorkspaceFrame()
+    this.syncFromWorkspaceFrame(undefined, { syncChat })
   }
 
   buildList(nodes) {
@@ -194,13 +194,13 @@ export default class extends Controller {
     if (this.refreshTimeout) window.clearTimeout(this.refreshTimeout)
     this.refreshTimeout = window.setTimeout(() => {
       this.refreshTimeout = null
-      this.load({ preserveState: true, showLoading: false })
+      this.load({ preserveState: true, showLoading: false, syncChat: false })
     }, 100)
   }
 
   syncFromWorkspaceFrame(
     frame = document.getElementById('creative-workspace-content'),
-    { authoritative = false } = {}
+    { authoritative = false, syncChat = true } = {}
   ) {
     if (!frame) return
 
@@ -211,13 +211,13 @@ export default class extends Controller {
     const locationCreativeId = this.creativeIdFromLocation()
     if (!stateCreativeId && (authoritative || !locationCreativeId)) {
       this.setActiveId(null)
-      this.openChat(this.rootState())
+      if (syncChat) this.openChat(this.rootState())
       return
     }
     if (!stateCreativeId || (!authoritative && stateCreativeId !== locationCreativeId)) return
     if (this.invalidatedCreativeIds.has(String(stateCreativeId))) {
       this.setActiveId(null)
-      this.openChat(this.rootState())
+      if (syncChat) this.openChat(this.rootState())
       return
     }
 
@@ -225,7 +225,7 @@ export default class extends Controller {
     const activeId = this.deepestVisiblePathId(this.nodesData || [], path)
     this.setActiveId(activeId)
 
-    this.openChat(state)
+    if (syncChat) this.openChat(state)
   }
 
   setActiveId(id) {

--- a/engines/collavre/app/javascript/controllers/workspace_tree_controller.js
+++ b/engines/collavre/app/javascript/controllers/workspace_tree_controller.js
@@ -13,6 +13,8 @@ export default class extends Controller {
 
   connect() {
     this.invalidatedCreativeIds = new Set()
+    this.destroyedCreativeIds = new Set()
+    this.invalidationGeneration = 0
     this.handleFrameLoad = this.handleFrameLoad.bind(this)
     this.handleTurboRender = this.handleTurboRender.bind(this)
     this.queueRefresh = this.queueRefresh.bind(this)
@@ -41,6 +43,7 @@ export default class extends Controller {
   async load({ preserveState = false, showLoading = true, syncChat = true } = {}) {
     this.loadAbortController?.abort()
     this.loadAbortController = new AbortController()
+    const invalidationGeneration = this.invalidationGeneration
     this.preservedBranchState = preserveState ? this.branchState() : new Map()
     if (showLoading) this.showStatus(this.loadingTextValue)
 
@@ -52,7 +55,9 @@ export default class extends Controller {
       if (!response.ok) throw new Error(`Failed to load workspace tree: ${response.status}`)
 
       const data = await response.json()
-      this.render(Array.isArray(data.creatives) ? data.creatives : [], { syncChat })
+      const nodes = Array.isArray(data.creatives) ? data.creatives : []
+      if (invalidationGeneration === this.invalidationGeneration) this.restoreReadableCreativeIds(nodes)
+      this.render(nodes, { syncChat })
     } catch (error) {
       if (error.name === 'AbortError') return
       console.error(error)
@@ -303,7 +308,22 @@ export default class extends Controller {
 
   rememberInvalidatedCreativeIds(event) {
     const creativeIds = event?.detail?.creativeIds || []
-    creativeIds.forEach((id) => this.invalidatedCreativeIds.add(String(id)))
+    if (creativeIds.length > 0) this.invalidationGeneration += 1
+    creativeIds.forEach((id) => {
+      const creativeId = String(id)
+      this.invalidatedCreativeIds.add(creativeId)
+      if (event?.type === 'creative-destroyed') this.destroyedCreativeIds.add(creativeId)
+    })
+  }
+
+  restoreReadableCreativeIds(nodes) {
+    const remaining = [...nodes]
+    while (remaining.length > 0) {
+      const node = remaining.pop()
+      const creativeId = String(node.id)
+      if (!this.destroyedCreativeIds.has(creativeId)) this.invalidatedCreativeIds.delete(creativeId)
+      if (Array.isArray(node.children)) remaining.push(...node.children)
+    }
   }
 
   parsePath(value) {

--- a/engines/collavre/app/javascript/controllers/workspace_tree_controller.js
+++ b/engines/collavre/app/javascript/controllers/workspace_tree_controller.js
@@ -1,5 +1,11 @@
 import { Controller } from '@hotwired/stimulus'
 
+// Module-scoped: a history restore replaces the whole body, swapping this
+// controller's instance mid-visit. The instance that observes turbo:visit is
+// not necessarily the one that observes the subsequent turbo:render, so the
+// visit action must outlive any single instance.
+let lastVisitAction = null
+
 export default class extends Controller {
   static targets = ['tree', 'panelToggle']
 
@@ -18,7 +24,11 @@ export default class extends Controller {
     this.handleFrameLoad = this.handleFrameLoad.bind(this)
     this.handleFrameRequest = this.handleFrameRequest.bind(this)
     this.handleTurboRender = this.handleTurboRender.bind(this)
+    this.handleVisitStart = this.handleVisitStart.bind(this)
+    this.handlePopState = this.handlePopState.bind(this)
     this.queueRefresh = this.queueRefresh.bind(this)
+    window.addEventListener('popstate', this.handlePopState)
+    document.addEventListener('turbo:visit', this.handleVisitStart)
     document.addEventListener('turbo:before-fetch-request', this.handleFrameRequest)
     document.addEventListener('turbo:frame-load', this.handleFrameLoad)
     document.addEventListener('turbo:frame-render', this.handleFrameLoad)
@@ -27,6 +37,15 @@ export default class extends Controller {
     document.addEventListener('creative-destroyed', this.queueRefresh)
     window.addEventListener('collavre:creative-drop-complete', this.queueRefresh)
     this.observeWorkspaceFrame()
+    // A restore render may reconnect this controller after turbo:render has
+    // already fired on the previous, now-disconnected instance's listeners.
+    // Re-check the action when the frame callback runs: a newer visit may
+    // have started in between and supersedes the restore.
+    if (lastVisitAction === 'restore') {
+      requestAnimationFrame(() => {
+        if (lastVisitAction === 'restore') this.ensureFrameMatchesLocation()
+      })
+    }
     this.load({ syncChat: false })
   }
 
@@ -34,6 +53,9 @@ export default class extends Controller {
     this.loadAbortController?.abort()
     this.frameObserver?.disconnect()
     if (this.refreshTimeout) window.clearTimeout(this.refreshTimeout)
+    if (this.popStateSyncTimer) window.clearTimeout(this.popStateSyncTimer)
+    window.removeEventListener('popstate', this.handlePopState)
+    document.removeEventListener('turbo:visit', this.handleVisitStart)
     document.removeEventListener('turbo:before-fetch-request', this.handleFrameRequest)
     document.removeEventListener('turbo:frame-load', this.handleFrameLoad)
     document.removeEventListener('turbo:frame-render', this.handleFrameLoad)
@@ -187,10 +209,54 @@ export default class extends Controller {
     this.frameRequestGeneration = this.invalidationGeneration
   }
 
+  handleVisitStart(event) {
+    lastVisitAction = event.detail?.action
+  }
+
+  // Turbo only performs a restore visit when the popped entry still carries
+  // its own history state; entries whose state was overwritten (or dropped)
+  // pop with the URL changing but nothing re-rendering. Watch popstate
+  // directly and, once no Turbo visit is processing the traversal, converge
+  // the frame onto the URL.
+  handlePopState() {
+    if (this.popStateSyncTimer) window.clearTimeout(this.popStateSyncTimer)
+    this.popStateSyncTimer = window.setTimeout(() => {
+      this.popStateSyncTimer = null
+      if (window.Turbo?.navigator?.currentVisit) return
+      this.ensureFrameMatchesLocation()
+    }, 150)
+  }
+
   handleTurboRender() {
     requestAnimationFrame(() => {
+      // The restore check must run even from an instance the render just
+      // disconnected — it only reads the current document and URL.
+      if (lastVisitAction === 'restore') this.ensureFrameMatchesLocation()
       if (this.element.isConnected) this.syncFromWorkspaceFrame()
     })
+  }
+
+  // History restore visits render a cached page snapshot. The snapshot can
+  // predate the workspace frame's final content for that history entry, so a
+  // back/forward restore may leave the center frame showing a different
+  // creative than the URL. Reload the frame from the URL as the source of
+  // truth; the resulting authoritative turbo:frame-load resynchronizes the
+  // tree and docked chat.
+  ensureFrameMatchesLocation() {
+    const frame = document.getElementById('creative-workspace-content')
+    if (!frame) return
+
+    const state = frame.querySelector('[data-workspace-navigation-state]')
+    const stateCreativeId = state?.dataset?.creativeId || null
+    const locationCreativeId = this.creativeIdFromLocation() || null
+    if (state && stateCreativeId === locationCreativeId) return
+
+    const target = window.location.href
+    if (frame.src === target && typeof frame.reload === 'function') {
+      frame.reload()
+    } else {
+      frame.src = target
+    }
   }
 
   observeWorkspaceFrame() {

--- a/engines/collavre/app/javascript/controllers/workspace_tree_controller.js
+++ b/engines/collavre/app/javascript/controllers/workspace_tree_controller.js
@@ -233,7 +233,7 @@ export default class extends Controller {
 
   openChat(link) {
     document.dispatchEvent(new CustomEvent('creative-comments-click', {
-      detail: { button: link, creativeId: link.dataset.creativeId },
+      detail: { button: link, creativeId: link.dataset.creativeId, workspaceSync: true },
     }))
   }
 

--- a/engines/collavre/app/javascript/controllers/workspace_tree_controller.js
+++ b/engines/collavre/app/javascript/controllers/workspace_tree_controller.js
@@ -12,6 +12,7 @@ export default class extends Controller {
   }
 
   connect() {
+    this.invalidatedCreativeIds = new Set()
     this.handleFrameLoad = this.handleFrameLoad.bind(this)
     this.handleTurboRender = this.handleTurboRender.bind(this)
     this.queueRefresh = this.queueRefresh.bind(this)
@@ -157,6 +158,10 @@ export default class extends Controller {
     if (!this.isUnmodifiedPrimaryClick(event)) return
 
     const link = event.currentTarget
+    if (this.invalidatedCreativeIds.has(String(link.dataset.creativeId))) {
+      this.closePanel()
+      return
+    }
     this.setActiveId(link.dataset.creativeId)
     this.closePanel()
     this.openChat(link)
@@ -184,7 +189,8 @@ export default class extends Controller {
     this.frameObserver.observe(frame, { childList: true })
   }
 
-  queueRefresh() {
+  queueRefresh(event) {
+    this.rememberInvalidatedCreativeIds(event)
     if (this.refreshTimeout) window.clearTimeout(this.refreshTimeout)
     this.refreshTimeout = window.setTimeout(() => {
       this.refreshTimeout = null
@@ -209,6 +215,11 @@ export default class extends Controller {
       return
     }
     if (!stateCreativeId || (!authoritative && stateCreativeId !== locationCreativeId)) return
+    if (this.invalidatedCreativeIds.has(String(stateCreativeId))) {
+      this.setActiveId(null)
+      this.openChat(this.rootState())
+      return
+    }
 
     const path = this.parsePath(state.dataset.creativePath)
     const activeId = this.deepestVisiblePathId(this.nodesData || [], path)
@@ -268,6 +279,11 @@ export default class extends Controller {
       this.rootNavigationState.dataset.workspaceNavigationState = 'true'
     }
     return this.rootNavigationState
+  }
+
+  rememberInvalidatedCreativeIds(event) {
+    const creativeIds = event?.detail?.creativeIds || []
+    creativeIds.forEach((id) => this.invalidatedCreativeIds.add(String(id)))
   }
 
   parsePath(value) {

--- a/engines/collavre/app/javascript/controllers/workspace_tree_controller.js
+++ b/engines/collavre/app/javascript/controllers/workspace_tree_controller.js
@@ -16,8 +16,10 @@ export default class extends Controller {
     this.destroyedCreativeIds = new Set()
     this.invalidationGeneration = 0
     this.handleFrameLoad = this.handleFrameLoad.bind(this)
+    this.handleFrameRequest = this.handleFrameRequest.bind(this)
     this.handleTurboRender = this.handleTurboRender.bind(this)
     this.queueRefresh = this.queueRefresh.bind(this)
+    document.addEventListener('turbo:before-fetch-request', this.handleFrameRequest)
     document.addEventListener('turbo:frame-load', this.handleFrameLoad)
     document.addEventListener('turbo:frame-render', this.handleFrameLoad)
     document.addEventListener('turbo:render', this.handleTurboRender)
@@ -32,6 +34,7 @@ export default class extends Controller {
     this.loadAbortController?.abort()
     this.frameObserver?.disconnect()
     if (this.refreshTimeout) window.clearTimeout(this.refreshTimeout)
+    document.removeEventListener('turbo:before-fetch-request', this.handleFrameRequest)
     document.removeEventListener('turbo:frame-load', this.handleFrameLoad)
     document.removeEventListener('turbo:frame-render', this.handleFrameLoad)
     document.removeEventListener('turbo:render', this.handleTurboRender)
@@ -178,6 +181,12 @@ export default class extends Controller {
     this.syncFromWorkspaceFrame(event.target, { authoritative: event.type === 'turbo:frame-load' })
   }
 
+  handleFrameRequest(event) {
+    if (event.target.id !== 'creative-workspace-content') return
+
+    this.frameRequestGeneration = this.invalidationGeneration
+  }
+
   handleTurboRender() {
     requestAnimationFrame(() => {
       if (this.element.isConnected) this.syncFromWorkspaceFrame()
@@ -220,6 +229,7 @@ export default class extends Controller {
       return
     }
     if (!stateCreativeId || (!authoritative && stateCreativeId !== locationCreativeId)) return
+    if (authoritative) this.restoreCreativeIdFromFrameResponse(stateCreativeId)
     if (this.invalidatedCreativeIds.has(String(stateCreativeId))) {
       this.setActiveId(null)
       if (syncChat) this.openChat(this.rootState())
@@ -314,6 +324,16 @@ export default class extends Controller {
       this.invalidatedCreativeIds.add(creativeId)
       if (event?.type === 'creative-destroyed') this.destroyedCreativeIds.add(creativeId)
     })
+  }
+
+  restoreCreativeIdFromFrameResponse(creativeId) {
+    const id = String(creativeId)
+    if (this.destroyedCreativeIds.has(id)) return
+    // Only a frame request started after the latest invalidation proves current access;
+    // leaf creatives never appear in the workspace tree payload, so this is their only restore path.
+    if (this.frameRequestGeneration !== this.invalidationGeneration) return
+
+    this.invalidatedCreativeIds.delete(id)
   }
 
   restoreReadableCreativeIds(nodes) {

--- a/engines/collavre/app/javascript/lib/__tests__/turbo_stream_actions.test.js
+++ b/engines/collavre/app/javascript/lib/__tests__/turbo_stream_actions.test.js
@@ -1,0 +1,54 @@
+/**
+ * @jest-environment jsdom
+ */
+import { jest } from '@jest/globals'
+
+const fakeTurbo = { StreamActions: {} }
+
+jest.unstable_mockModule('@hotwired/turbo-rails', () => ({ Turbo: fakeTurbo }))
+jest.unstable_mockModule('../../creatives/tree_renderer', () => ({
+  createRow: jest.fn(),
+  applyRowProperties: jest.fn(),
+}))
+
+await import('../turbo_stream_actions')
+
+function dispatchCreativeTreeStream(payload) {
+  fakeTurbo.StreamActions.refresh_creative_tree.call({
+    getAttribute: (name) => name === 'data' ? JSON.stringify(payload) : null,
+  })
+}
+
+afterEach(() => {
+  document.body.innerHTML = ''
+  jest.restoreAllMocks()
+})
+
+test('remote destroyed streams notify chat even when no tree row is visible', () => {
+  const destroyedEvents = []
+  const invalidatedEvents = []
+  document.addEventListener('creative-destroyed', (event) => destroyedEvents.push(event.detail), { once: true })
+  document.addEventListener('workspace-tree:invalidate', (event) => invalidatedEvents.push(event), { once: true })
+
+  dispatchCreativeTreeStream({
+    action: 'destroyed',
+    creative: { id: 123, linked_id: 456, parent_id: 42 },
+  })
+
+  expect(destroyedEvents).toEqual([{ creativeIds: ['456', '123'] }])
+  expect(invalidatedEvents).toHaveLength(1)
+})
+
+test('remote destroyed streams deduplicate identical effective and origin IDs', () => {
+  const listener = jest.fn()
+  document.addEventListener('creative-destroyed', listener, { once: true })
+
+  dispatchCreativeTreeStream({
+    action: 'destroyed',
+    creative: { id: 123 },
+  })
+
+  expect(listener).toHaveBeenCalledWith(expect.objectContaining({
+    detail: { creativeIds: ['123'] },
+  }))
+})

--- a/engines/collavre/app/javascript/lib/api/__tests__/creatives.test.js
+++ b/engines/collavre/app/javascript/lib/api/__tests__/creatives.test.js
@@ -1,0 +1,39 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { jest } from '@jest/globals'
+
+const csrfFetch = jest.fn()
+
+jest.unstable_mockModule('../csrf_fetch', () => ({ default: csrfFetch }))
+
+const creativesApi = await import('../creatives')
+
+describe('creatives API workspace invalidation', () => {
+  afterEach(() => {
+    csrfFetch.mockReset()
+  })
+
+  test('invalidates the workspace tree after a successful mutation', async () => {
+    const listener = jest.fn()
+    document.addEventListener('workspace-tree:invalidate', listener)
+    csrfFetch.mockResolvedValue({ ok: true })
+
+    await creativesApi.destroy(42)
+
+    expect(listener).toHaveBeenCalledTimes(1)
+    document.removeEventListener('workspace-tree:invalidate', listener)
+  })
+
+  test('does not invalidate the workspace tree after a failed mutation', async () => {
+    const listener = jest.fn()
+    document.addEventListener('workspace-tree:invalidate', listener)
+    csrfFetch.mockResolvedValue({ ok: false })
+
+    await creativesApi.archive(42)
+
+    expect(listener).not.toHaveBeenCalled()
+    document.removeEventListener('workspace-tree:invalidate', listener)
+  })
+})

--- a/engines/collavre/app/javascript/lib/api/creatives.js
+++ b/engines/collavre/app/javascript/lib/api/creatives.js
@@ -2,6 +2,13 @@ import csrfFetch from './csrf_fetch'
 
 const JSON_HEADERS = { Accept: 'application/json' }
 
+function invalidateWorkspaceTreeOnSuccess(response) {
+  if (response.ok && typeof document !== 'undefined') {
+    document.dispatchEvent(new CustomEvent('workspace-tree:invalidate'))
+  }
+  return response
+}
+
 export function get(id) {
   return csrfFetch(`/creatives/${id}.json`, {
     headers: JSON_HEADERS,
@@ -48,7 +55,7 @@ export function save(action, method, form) {
     method,
     headers: JSON_HEADERS,
     body: new FormData(form),
-  })
+  }).then(invalidateWorkspaceTreeOnSuccess)
 }
 
 export function linkExisting(parentId, originId) {
@@ -60,33 +67,33 @@ export function linkExisting(parentId, originId) {
     method: 'POST',
     headers: JSON_HEADERS,
     body,
-  })
+  }).then(invalidateWorkspaceTreeOnSuccess)
 }
 
 export function destroy(id, withChildren = false) {
   const query = withChildren ? '?delete_with_children=true' : ''
   return csrfFetch(`/creatives/${id}${query}`, {
     method: 'DELETE',
-  })
+  }).then(invalidateWorkspaceTreeOnSuccess)
 }
 
 export function archive(id) {
   return csrfFetch(`/creatives/${id}/archive`, {
     method: 'PATCH',
-  })
+  }).then(invalidateWorkspaceTreeOnSuccess)
 }
 
 export function unarchive(id) {
   return csrfFetch(`/creatives/${id}/unarchive`, {
     method: 'PATCH',
-  })
+  }).then(invalidateWorkspaceTreeOnSuccess)
 }
 
 export function unconvert(id) {
   return csrfFetch(`/creatives/${id}/unconvert`, {
     method: 'POST',
     headers: JSON_HEADERS,
-  })
+  }).then(invalidateWorkspaceTreeOnSuccess)
 }
 
 export function updateMetadata(id, data) {

--- a/engines/collavre/app/javascript/lib/turbo_stream_actions.js
+++ b/engines/collavre/app/javascript/lib/turbo_stream_actions.js
@@ -290,6 +290,14 @@ function handleUpdated(creative) {
 }
 
 function handleDestroyed(creative) {
+    const creativeIds = [creative.id, creative.origin_id]
+        .filter((id) => id != null)
+        .map(String)
+
+    document.dispatchEvent(new CustomEvent('creative-destroyed', {
+        detail: { creativeIds: [...new Set(creativeIds)] }
+    }))
+
     const rows = findRowsForCreative(creative.id, creative.origin_id)
 
     if (rows.length === 0) return // Row not visible on this page

--- a/engines/collavre/app/javascript/lib/turbo_stream_actions.js
+++ b/engines/collavre/app/javascript/lib/turbo_stream_actions.js
@@ -48,6 +48,7 @@ registerStreamAction("refresh_creative_tree", function () {
 
     // Update ancestor progress for all actions
     updateAncestorProgress(creative.ancestors)
+    document.dispatchEvent(new CustomEvent('workspace-tree:invalidate'))
 })
 
 function handleCreated(creative) {

--- a/engines/collavre/app/javascript/modules/__tests__/creative_row_editor_delegated_clicks.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/creative_row_editor_delegated_clicks.test.js
@@ -1,0 +1,158 @@
+/**
+ * @jest-environment jsdom
+ */
+import { jest } from '@jest/globals';
+import { createListenerRegistry } from '../dom_listener_registry';
+import { createDelegatedClickHandler } from '../creative_row_editor_delegated_clicks';
+
+function session(template = document.getElementById('inline-edit-form')) {
+  return {
+    template,
+    startNew: jest.fn(),
+    hideCurrent: jest.fn(),
+    handleEditButtonClick: jest.fn(),
+  };
+}
+
+describe('createDelegatedClickHandler', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div id="creatives">
+        <div class="creative-tree" id="creative-10" data-id="10">
+          <button class="add-creative-btn"><span id="nested-add-target">Add</span></button>
+          <button class="edit-inline-btn">Edit</button>
+          <div class="creative-children" id="creative-children-10">
+            <div class="creative-tree" id="creative-11" data-id="11"></div>
+          </div>
+        </div>
+      </div>
+      <button class="add-creative-btn" data-parent-id="">Add root</button>
+      <button class="new-root-creative-btn">New root</button>
+      <button class="append-parent-btn" data-child-id="11">Append parent</button>
+      <button class="add-creative-btn" id="inline-add">Inline add</button>
+      <div id="inline-edit-form" style="display: none"></div>
+    `;
+  });
+
+  test('starts one child form with the current Turbo session after rebinding', () => {
+    const registry = createListenerRegistry();
+    const oldTemplate = document.createElement('div');
+    oldTemplate.style.display = 'block';
+    const oldSession = session(oldTemplate);
+    registry.add(document.body, 'click', createDelegatedClickHandler(oldSession));
+
+    registry.releaseAll();
+    const currentSession = session();
+    registry.add(document.body, 'click', createDelegatedClickHandler(currentSession));
+    document.getElementById('nested-add-target').click();
+
+    expect(oldSession.hideCurrent).not.toHaveBeenCalled();
+    expect(oldSession.startNew).not.toHaveBeenCalled();
+    expect(currentSession.startNew).toHaveBeenCalledTimes(1);
+    expect(currentSession.startNew).toHaveBeenCalledWith(
+      '10',
+      document.getElementById('creative-children-10'),
+      document.getElementById('creative-11'),
+      '11'
+    );
+    registry.releaseAll();
+  });
+
+  test('creates a children container when a tree has none', () => {
+    document.getElementById('creative-children-10').remove();
+    const currentSession = session();
+    document.body.addEventListener('click', createDelegatedClickHandler(currentSession), { once: true });
+
+    document.querySelector('#creative-10 .add-creative-btn').click();
+
+    const container = document.getElementById('creative-children-10');
+    expect(container).not.toBeNull();
+    expect(currentSession.startNew).toHaveBeenCalledWith('10', container, null, '');
+  });
+
+  test('uses the root container for an add button outside a tree', () => {
+    const currentSession = session();
+    const handler = createDelegatedClickHandler(currentSession);
+    const button = document.querySelector('body > .add-creative-btn');
+
+    button.addEventListener('click', handler, { once: true });
+    button.click();
+
+    expect(currentSession.startNew).toHaveBeenCalledTimes(1);
+    expect(currentSession.startNew).toHaveBeenCalledWith(
+      '',
+      document.getElementById('creatives'),
+      document.getElementById('creative-10'),
+      '10'
+    );
+  });
+
+  test('opens a new root creative before the first root', () => {
+    const currentSession = session();
+    document.body.addEventListener('click', createDelegatedClickHandler(currentSession), { once: true });
+
+    document.querySelector('.new-root-creative-btn').click();
+
+    expect(currentSession.startNew).toHaveBeenCalledWith(
+      '',
+      document.getElementById('creatives'),
+      document.getElementById('creative-10'),
+      '10'
+    );
+  });
+
+  test('closes the current form instead of opening another one', () => {
+    const currentSession = session();
+    currentSession.template.style.display = 'block';
+    document.body.addEventListener('click', createDelegatedClickHandler(currentSession), { once: true });
+
+    document.getElementById('nested-add-target').click();
+
+    expect(currentSession.hideCurrent).toHaveBeenCalledTimes(1);
+    expect(currentSession.startNew).not.toHaveBeenCalled();
+  });
+
+  test('routes edit buttons to the current session', () => {
+    const currentSession = session();
+    document.body.addEventListener('click', createDelegatedClickHandler(currentSession), { once: true });
+
+    document.querySelector('.edit-inline-btn').click();
+
+    expect(currentSession.handleEditButtonClick).toHaveBeenCalledWith(document.getElementById('creative-10'));
+  });
+
+  test('opens a parent form immediately before the selected child', () => {
+    const currentSession = session();
+    document.body.addEventListener('click', createDelegatedClickHandler(currentSession), { once: true });
+
+    document.querySelector('.append-parent-btn').click();
+
+    expect(currentSession.startNew).toHaveBeenCalledWith(
+      '10',
+      document.getElementById('creative-children-10'),
+      document.getElementById('creative-11'),
+      '11',
+      '',
+      '11'
+    );
+  });
+
+  test('does not treat inline toolbar controls as delegated add buttons', () => {
+    const currentSession = session();
+    document.body.addEventListener('click', createDelegatedClickHandler(currentSession), { once: true });
+
+    document.getElementById('inline-add').click();
+
+    expect(currentSession.startNew).not.toHaveBeenCalled();
+  });
+
+  test('does nothing when the root container is absent', () => {
+    document.getElementById('creatives').remove();
+    const currentSession = session();
+    const button = document.querySelector('body > .add-creative-btn');
+    button.addEventListener('click', createDelegatedClickHandler(currentSession), { once: true });
+
+    expect(() => button.click()).not.toThrow();
+    expect(currentSession.startNew).not.toHaveBeenCalled();
+  });
+});

--- a/engines/collavre/app/javascript/modules/__tests__/creative_row_editor_session.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/creative_row_editor_session.test.js
@@ -153,4 +153,55 @@ describe('creative row editor session lifecycle', () => {
     initializeCreativeRowEditor()
     expect(createDelegatedClickHandlerMock.mock.calls.at(-1)[0].template).toBe(template)
   })
+
+  test('stops the orphaned editing ping when a frame swap discards a session with the editor open', () => {
+    jest.useFakeTimers()
+    const stopSpy = jest.fn()
+    const startSpy = jest.fn()
+    document.addEventListener('creative-editing:stop', stopSpy)
+    document.addEventListener('creative-editing:start', startSpy)
+
+    try {
+      // Fresh session against a mounted template, same as a real workspace frame load.
+      swapCenterContent()
+      initializeCreativeRowEditor()
+      // The cached-data fast path in loadCreative() bypasses the network only when
+      // the popup is hidden; otherwise applyCreativeData() would fetch metadata.
+      document.getElementById('metadata-popup').style.display = 'none'
+
+      // A tree row with inline dataset (id/description/progress) so opening it
+      // takes the synchronous cached-data path instead of an API call.
+      const treeRow = document.createElement('creative-tree-row')
+      treeRow.dataset.descriptionRawHtml = 'hello'
+      treeRow.dataset.progressValue = '0'
+      const tree = document.createElement('div')
+      tree.className = 'creative-tree'
+      tree.id = 'creative-42'
+      tree.dataset.id = '42'
+      treeRow.appendChild(tree)
+      document.getElementById('center-frame').appendChild(treeRow)
+
+      document.dispatchEvent(new CustomEvent('creative-edit-click', { detail: { treeElement: tree } }))
+
+      expect(startSpy).toHaveBeenCalledTimes(1)
+      expect(startSpy.mock.calls[0][0].detail.creativeId).toBe(42)
+
+      // Workspace frame swap: center content is replaced wholesale and the
+      // Stimulus wrapper reconnects, without the outgoing session ever calling
+      // hideCurrent()/move() on itself.
+      swapCenterContent()
+      initializeCreativeRowEditor()
+
+      expect(stopSpy).toHaveBeenCalledTimes(1)
+      expect(stopSpy.mock.calls[0][0].detail.creativeId).toBe(42)
+
+      startSpy.mockClear()
+      jest.advanceTimersByTime(10000)
+      expect(startSpy).not.toHaveBeenCalled()
+    } finally {
+      document.removeEventListener('creative-editing:stop', stopSpy)
+      document.removeEventListener('creative-editing:start', startSpy)
+      jest.useRealTimers()
+    }
+  })
 })

--- a/engines/collavre/app/javascript/modules/__tests__/creative_row_editor_session.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/creative_row_editor_session.test.js
@@ -1,0 +1,156 @@
+/**
+ * @jest-environment jsdom
+ */
+import { jest } from '@jest/globals'
+
+// The real inline editor is a JSX module (untransformed in Jest) and the
+// delegated click handler is exercised by its own test file — both are
+// mocked here so this file can observe the session lifecycle itself.
+const createInlineEditorMock = jest.fn()
+const createDelegatedClickHandlerMock = jest.fn()
+
+jest.unstable_mockModule('../lexical_inline_editor', () => ({
+  createInlineEditor: createInlineEditorMock,
+}))
+jest.unstable_mockModule('../creative_row_editor_delegated_clicks', () => ({
+  createDelegatedClickHandler: createDelegatedClickHandlerMock,
+}))
+
+const { initializeCreativeRowEditor } = await import('../creative_row_editor')
+
+const BUTTON_IDS = [
+  'inline-metadata-btn', 'inline-toggle-markdown', 'inline-move-up', 'inline-move-down',
+  'inline-add', 'inline-level-down', 'inline-level-up', 'inline-archive', 'inline-delete',
+  'inline-delete-with-children', 'inline-link', 'inline-unconvert', 'inline-unlink',
+  'inline-close', 'inline-recommend-parent', 'metadata-popup-close', 'metadata-save-btn',
+]
+const HIDDEN_INPUT_IDS = [
+  'inline-method', 'inline-creative-description', 'inline-content-type',
+  'inline-markdown-editor', 'inline-markdown-source', 'inline-parent-id',
+  'inline-before-id', 'inline-after-id', 'inline-child-id', 'inline-origin-id',
+]
+const DIV_IDS = ['markdown-editor-wrapper', 'markdown-preview', 'inline-progress-value', 'inline-save-status', 'metadata-popup']
+
+function buildEditorDom(container) {
+  const template = document.createElement('div')
+  template.id = 'inline-edit-form'
+  template.style.display = 'none'
+
+  const form = document.createElement('form')
+  form.id = 'inline-edit-form-element'
+  template.appendChild(form)
+
+  HIDDEN_INPUT_IDS.forEach((id) => {
+    const input = document.createElement('input')
+    input.type = 'hidden'
+    input.id = id
+    form.appendChild(input)
+  })
+  const progress = document.createElement('input')
+  progress.type = 'checkbox'
+  progress.id = 'inline-creative-progress'
+  form.appendChild(progress)
+
+  const editorRoot = document.createElement('div')
+  editorRoot.id = 'lexical-inline-editor'
+  editorRoot.dataset.lexicalEditorRoot = ''
+  form.appendChild(editorRoot)
+
+  const markdownTextarea = document.createElement('textarea')
+  markdownTextarea.id = 'markdown-editor-textarea'
+  form.appendChild(markdownTextarea)
+  const metadataTextarea = document.createElement('textarea')
+  metadataTextarea.id = 'metadata-yaml-editor'
+  form.appendChild(metadataTextarea)
+  const suggestions = document.createElement('select')
+  suggestions.id = 'parent-suggestions'
+  form.appendChild(suggestions)
+
+  BUTTON_IDS.forEach((id) => {
+    const button = document.createElement('button')
+    button.type = 'button'
+    button.id = id
+    form.appendChild(button)
+  })
+  DIV_IDS.forEach((id) => {
+    const div = document.createElement('div')
+    div.id = id
+    form.appendChild(div)
+  })
+
+  container.appendChild(template)
+  return template
+}
+
+function swapCenterContent() {
+  const container = document.getElementById('center-frame')
+  container.innerHTML = ''
+  return buildEditorDom(container)
+}
+
+describe('creative row editor session lifecycle', () => {
+  beforeAll(() => {
+    document.body.innerHTML = '<div id="creatives"></div><div id="center-frame"></div>'
+    createInlineEditorMock.mockImplementation(() => ({
+      destroy: jest.fn(),
+      load: jest.fn(),
+      focus: jest.fn(),
+      getDeletedAttachments: jest.fn(() => []),
+    }))
+    createDelegatedClickHandlerMock.mockImplementation(() => jest.fn())
+  })
+
+  test('builds a session for the mounted template on first initialization', () => {
+    const template = swapCenterContent()
+
+    initializeCreativeRowEditor()
+
+    expect(createDelegatedClickHandlerMock).toHaveBeenCalledTimes(1)
+    expect(createDelegatedClickHandlerMock.mock.calls[0][0].template).toBe(template)
+  })
+
+  test('stays idempotent while the same template remains mounted', () => {
+    const calls = createDelegatedClickHandlerMock.mock.calls.length
+
+    initializeCreativeRowEditor()
+    document.dispatchEvent(new Event('turbo:load'))
+
+    expect(createDelegatedClickHandlerMock).toHaveBeenCalledTimes(calls)
+  })
+
+  test('rebuilds the session against the new template after a center frame swap', () => {
+    const previousEditor = createInlineEditorMock.mock.results.at(-1).value
+    const newTemplate = swapCenterContent()
+
+    // Non-promoted frame navigations fire no turbo:load; the Stimulus wrapper
+    // reconnecting inside the swapped frame content is the only signal.
+    initializeCreativeRowEditor()
+
+    const session = createDelegatedClickHandlerMock.mock.calls.at(-1)[0]
+    expect(session.template).toBe(newTemplate)
+    expect(previousEditor.destroy).toHaveBeenCalledTimes(1)
+  })
+
+  test('rebuilds the session from turbo:load after a full page navigation', () => {
+    const calls = createDelegatedClickHandlerMock.mock.calls.length
+    const newTemplate = swapCenterContent()
+
+    document.dispatchEvent(new Event('turbo:load'))
+
+    expect(createDelegatedClickHandlerMock).toHaveBeenCalledTimes(calls + 1)
+    expect(createDelegatedClickHandlerMock.mock.calls.at(-1)[0].template).toBe(newTemplate)
+  })
+
+  test('tears down the session when no template is mounted', () => {
+    const previousEditor = createInlineEditorMock.mock.results.at(-1).value
+    document.getElementById('center-frame').innerHTML = ''
+
+    document.dispatchEvent(new Event('turbo:load'))
+
+    expect(previousEditor.destroy).toHaveBeenCalledTimes(1)
+    // A later mount recovers with a fresh session.
+    const template = swapCenterContent()
+    initializeCreativeRowEditor()
+    expect(createDelegatedClickHandlerMock.mock.calls.at(-1)[0].template).toBe(template)
+  })
+})

--- a/engines/collavre/app/javascript/modules/__tests__/dom_listener_registry.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/dom_listener_registry.test.js
@@ -1,0 +1,67 @@
+/**
+ * @jest-environment jsdom
+ */
+import { jest } from '@jest/globals';
+import { createListenerRegistry } from '../dom_listener_registry';
+
+describe('createListenerRegistry', () => {
+  test('releases every registered listener', () => {
+    const registry = createListenerRegistry();
+    const documentHandler = jest.fn();
+    const windowHandler = jest.fn();
+    registry.add(document, 'registry-document', documentHandler);
+    registry.add(window, 'registry-window', windowHandler);
+
+    registry.releaseAll();
+    document.dispatchEvent(new Event('registry-document'));
+    window.dispatchEvent(new Event('registry-window'));
+
+    expect(documentHandler).not.toHaveBeenCalled();
+    expect(windowHandler).not.toHaveBeenCalled();
+    expect(registry.size).toBe(0);
+  });
+
+  test('rebinds a Turbo session without retaining the old handler', () => {
+    const registry = createListenerRegistry();
+    const firstSession = jest.fn();
+    const secondSession = jest.fn();
+    registry.add(document.body, 'click', firstSession);
+
+    registry.releaseAll();
+    registry.add(document.body, 'click', secondSession);
+    document.body.click();
+
+    expect(firstSession).not.toHaveBeenCalled();
+    expect(secondSession).toHaveBeenCalledTimes(1);
+    registry.releaseAll();
+  });
+
+  test('preserves listener options when removing a binding', () => {
+    const registry = createListenerRegistry();
+    const handler = jest.fn();
+    registry.add(document, 'registry-capture', handler, { capture: true });
+
+    registry.releaseAll();
+    document.dispatchEvent(new Event('registry-capture'));
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  test('ignores targets that cannot register listeners', () => {
+    const registry = createListenerRegistry();
+
+    expect(() => registry.add(null, 'click', jest.fn())).not.toThrow();
+    expect(() => registry.add({}, 'click', jest.fn())).not.toThrow();
+    expect(registry.size).toBe(0);
+  });
+
+  test('releaseAll is idempotent', () => {
+    const registry = createListenerRegistry();
+    registry.add(document, 'registry-idempotent', jest.fn());
+
+    registry.releaseAll();
+
+    expect(() => registry.releaseAll()).not.toThrow();
+    expect(registry.size).toBe(0);
+  });
+});

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -9,6 +9,8 @@ import { renderMarkdown } from '../lib/utils/markdown'
 import { reconcileMarkdownSource } from './markdown_source_reconcile'
 import { isHtmlEmpty } from './html_content_empty'
 import { CreativeSaveQueue } from './creative_save_queue'
+import { createListenerRegistry } from './dom_listener_registry'
+import { createDelegatedClickHandler } from './creative_row_editor_delegated_clicks'
 import { confirmDialog, alertDialog } from '../lib/utils/dialog'
 import { serverErrorMessage } from '../lib/api/api_error'
 import yaml from 'js-yaml'
@@ -46,8 +48,7 @@ import {
 const application = window.Stimulus
 
 let initialized = false;
-let creativeEditClickHandler = null;
-let addCreativeShortcutHandler = null;
+const globalListeners = createListenerRegistry();
 
 function deleteAttachment(signedId) {
   if (!signedId) return;
@@ -65,13 +66,14 @@ export function initializeCreativeRowEditor() {
   initialized = true;
 
   document.addEventListener('turbo:load', function () {
+    globalListeners.releaseAll();
     const template = document.getElementById('inline-edit-form');
     if (!template) return;
 
     initializeEventListeners();
 
     // Listen for attachment deletions from queue manager
-    window.addEventListener('api-queue-attachments-deleted', (event) => {
+    globalListeners.add(window, 'api-queue-attachments-deleted', (event) => {
       const attachmentIds = event.detail?.attachmentIds;
       if (attachmentIds && attachmentIds.length > 0) {
         attachmentIds.forEach(deleteAttachment);
@@ -79,7 +81,7 @@ export function initializeCreativeRowEditor() {
     });
 
     // Listen for failed requests to prevent silent data loss
-    window.addEventListener('api-queue-request-failed', (event) => {
+    globalListeners.add(window, 'api-queue-request-failed', (event) => {
       const { item, error } = event.detail;
       console.error('Queue request failed permanently:', item, error);
 
@@ -226,7 +228,7 @@ export function initializeCreativeRowEditor() {
     }
 
     // Clean up editing ping on Turbo navigation to prevent interval leak
-    document.addEventListener('turbo:before-cache', () => stopEditingPing());
+    globalListeners.add(document, 'turbo:before-cache', () => stopEditingPing());
 
     const destroyedCreativeIds = new Set();
 
@@ -575,112 +577,32 @@ export function initializeCreativeRowEditor() {
     }
 
     function initializeEventListeners() {
-      if (!creativeEditClickHandler) {
-        creativeEditClickHandler = function (e) {
-          const tree = e.detail?.treeElement || e.detail?.button?.closest('.creative-tree');
-          if (!tree) return;
-          e.preventDefault();
-          handleEditButtonClick(tree);
-        };
-        document.addEventListener('creative-edit-click', creativeEditClickHandler);
-      }
-
-      if (!addCreativeShortcutHandler) {
-        addCreativeShortcutHandler = function (event) {
-          if (event.defaultPrevented || event.isComposing) return;
-          if (event.key !== 'Enter' || event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) return;
-          const target = event.target;
-          const interactiveSelector = 'input, textarea, select, button, a, [contenteditable="true"], [data-lexical-editor-root]';
-          if (target && target.closest && target.closest(interactiveSelector)) return;
-          if (target && target.isContentEditable) return;
-          const addButton = document.querySelector('.creative-actions-row .add-creative-btn, .creative-actions-row .new-root-creative-btn');
-          if (!addButton) return;
-          event.preventDefault();
-          addButton.click();
-        };
-        document.addEventListener('keydown', addCreativeShortcutHandler);
-      }
-
-      document.body.addEventListener('click', function (e) {
-        // Delegated event for .edit-inline-btn
-        const editBtn = e.target.closest('.edit-inline-btn');
-        if (editBtn) {
-          e.preventDefault();
-          const tree = editBtn.closest('.creative-tree');
-          if (!tree) return;
-          handleEditButtonClick(tree);
-          return; // Event handled
-        }
-
-        // Delegated event for .add-creative-btn
-        const addBtn = e.target.closest('.add-creative-btn:not(#inline-add):not(#inline-level-down):not(#inline-level-up)');
-        if (addBtn) {
-          e.preventDefault();
-          if (template.style.display === 'block') {
-            hideCurrent();
-            return;
-          }
-          const tree = addBtn.closest('.creative-tree');
-          let parentId, container, insertBefore, beforeId = '';
-          if (tree) {
-            parentId = tree.dataset.id;
-            container = tree.querySelector('.creative-children');
-            if (!container) {
-              container = document.createElement('div');
-              container.className = 'creative-children';
-              container.id = 'creative-children-' + parentId;
-              tree.appendChild(container);
-            }
-            insertBefore = container.firstElementChild;
-            beforeId = insertBefore ? creativeIdFrom(insertBefore) : '';
-          } else {
-            parentId = addBtn.dataset.parentId || '';
-            const rootContainer = document.getElementById('creatives');
-            container = rootContainer;
-            insertBefore = rootContainer.firstElementChild;
-            beforeId = insertBefore ? creativeIdFrom(insertBefore) : '';
-          }
-          startNew(parentId, container, insertBefore, beforeId);
-          return; // Event handled
-        }
-
-
-        // Delegated event for .new-root-creative-btn
-        const newRootBtn = e.target.closest('.new-root-creative-btn');
-        if (newRootBtn) {
-          e.preventDefault();
-          const container = document.getElementById('creatives');
-          if (!container) return;
-
-          if (template.style.display === 'block') {
-            hideCurrent();
-            return;
-          }
-          const insertBefore = container.firstElementChild;
-          const beforeId = insertBefore ? creativeIdFrom(insertBefore) : '';
-          startNew('', container, insertBefore, beforeId);
-          return; // Event handled
-        }
-
-        // Delegated event for .append-parent-btn
-        const appendParentBtn = e.target.closest('.append-parent-btn');
-        if (appendParentBtn) {
-          e.preventDefault();
-          const targetId = appendParentBtn.dataset.childId;
-          const target = document.getElementById('creative-' + targetId);
-          if (!target) return;
-          const container = target.parentNode;
-          startNew(
-            container.id.startsWith('creative-children-') ? container.id.replace('creative-children-', '') : '',
-            container,
-            target,
-            targetId,
-            '',
-            targetId
-          );
-          return; // Event handled
-        }
+      globalListeners.add(document, 'creative-edit-click', function (event) {
+        const tree = event.detail?.treeElement || event.detail?.button?.closest('.creative-tree');
+        if (!tree) return;
+        event.preventDefault();
+        handleEditButtonClick(tree);
       });
+
+      globalListeners.add(document, 'keydown', function (event) {
+        if (event.defaultPrevented || event.isComposing) return;
+        if (event.key !== 'Enter' || event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) return;
+        const target = event.target;
+        const interactiveSelector = 'input, textarea, select, button, a, [contenteditable="true"], [data-lexical-editor-root]';
+        if (target && target.closest && target.closest(interactiveSelector)) return;
+        if (target && target.isContentEditable) return;
+        const addButton = document.querySelector('.creative-actions-row .add-creative-btn, .creative-actions-row .new-root-creative-btn');
+        if (!addButton) return;
+        event.preventDefault();
+        addButton.click();
+      });
+
+      globalListeners.add(document.body, 'click', createDelegatedClickHandler({
+        template,
+        startNew,
+        hideCurrent,
+        handleEditButtonClick,
+      }));
     }
 
     function hideRow(tree) {

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -53,10 +53,22 @@ let initialized = false;
 // must be rebuilt whenever a different template node is in the document.
 let activeTemplate = null;
 let destroyActiveEditor = null;
+// Frame-only swaps rebuild the session (see initializeCreativeRowEditor)
+// without the outgoing session ever calling hideCurrent()/move(), so the
+// editing ping interval it may have started has no other path to stop.
+let stopActiveEditingPing = null;
 const globalListeners = createListenerRegistry();
 
 function teardownEditorSession() {
   globalListeners.releaseAll();
+  if (stopActiveEditingPing) {
+    try {
+      stopActiveEditingPing();
+    } catch (e) {
+      console.error('CreativeRowEditor: Failed to stop editing ping', e);
+    }
+    stopActiveEditingPing = null;
+  }
   if (destroyActiveEditor) {
     try {
       destroyActiveEditor();
@@ -259,6 +271,21 @@ function setupEditorSession() {
 
     // Clean up editing ping on Turbo navigation to prevent interval leak
     globalListeners.add(document, 'turbo:before-cache', () => stopEditingPing());
+
+    // Registered with the module-level teardown so a workspace frame swap —
+    // which rebuilds the session without ever calling hideCurrent()/move() on
+    // the outgoing one — still stops this session's ping and reports the
+    // creative it was pinging for as no longer being edited.
+    stopActiveEditingPing = () => {
+      if (!editingPingInterval) return;
+      const editCreativeId = form.dataset.creativeId;
+      stopEditingPing();
+      if (editCreativeId) {
+        document.dispatchEvent(new CustomEvent('creative-editing:stop', {
+          detail: { creativeId: parseInt(editCreativeId, 10) }
+        }));
+      }
+    };
 
     const destroyedCreativeIds = new Set();
 

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -48,7 +48,25 @@ import {
 const application = window.Stimulus
 
 let initialized = false;
+// The template node the current editor session was built against. Workspace
+// frame swaps replace the template without firing turbo:load, so the session
+// must be rebuilt whenever a different template node is in the document.
+let activeTemplate = null;
+let destroyActiveEditor = null;
 const globalListeners = createListenerRegistry();
+
+function teardownEditorSession() {
+  globalListeners.releaseAll();
+  if (destroyActiveEditor) {
+    try {
+      destroyActiveEditor();
+    } catch (e) {
+      console.error('CreativeRowEditor: Failed to destroy inline editor', e);
+    }
+    destroyActiveEditor = null;
+  }
+  activeTemplate = null;
+}
 
 function deleteAttachment(signedId) {
   if (!signedId) return;
@@ -62,13 +80,22 @@ function deleteAttachment(signedId) {
 }
 
 export function initializeCreativeRowEditor() {
+  // Rebuild the session on every call: the Stimulus wrapper controller
+  // reconnects whenever the workspace center frame swaps its content, which
+  // is the only lifecycle signal for non-promoted frame navigations.
+  setupEditorSession();
   if (initialized) return;
   initialized = true;
 
-  document.addEventListener('turbo:load', function () {
-    globalListeners.releaseAll();
+  document.addEventListener('turbo:load', setupEditorSession);
+}
+
+function setupEditorSession() {
     const template = document.getElementById('inline-edit-form');
+    if (template && template === activeTemplate) return;
+    teardownEditorSession();
     if (!template) return;
+    activeTemplate = template;
 
     initializeEventListeners();
 
@@ -183,6 +210,9 @@ export function initializeCreativeRowEditor() {
           onEnterKey: handleEditorEnterKey,
           onUploadStateChange: handleUploadStateChange
         });
+        destroyActiveEditor = () => {
+          if (lexicalEditor && typeof lexicalEditor.destroy === 'function') lexicalEditor.destroy();
+        };
       } catch (e) {
         console.error('CreativeRowEditor: Failed to create inline editor', e);
       }
@@ -2066,5 +2096,4 @@ export function initializeCreativeRowEditor() {
         }
       });
     }
-  });
 }

--- a/engines/collavre/app/javascript/modules/creative_row_editor_delegated_clicks.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor_delegated_clicks.js
@@ -1,0 +1,87 @@
+import { creativeIdFrom } from './creative_tree_dom';
+
+export function createDelegatedClickHandler(session) {
+  return function handleDelegatedClick(event) {
+    const target = event.target;
+    if (!target || typeof target.closest !== 'function') return;
+
+    const editBtn = target.closest('.edit-inline-btn');
+    if (editBtn) {
+      event.preventDefault();
+      const tree = editBtn.closest('.creative-tree');
+      if (tree) session.handleEditButtonClick(tree);
+      return;
+    }
+
+    const addBtn = target.closest('.add-creative-btn:not(#inline-add):not(#inline-level-down):not(#inline-level-up)');
+    if (addBtn) {
+      event.preventDefault();
+      if (session.template.style.display === 'block') {
+        session.hideCurrent();
+        return;
+      }
+
+      const tree = addBtn.closest('.creative-tree');
+      let parentId;
+      let container;
+      let insertBefore;
+      let beforeId = '';
+
+      if (tree) {
+        parentId = tree.dataset.id;
+        container = tree.querySelector('.creative-children');
+        if (!container) {
+          container = document.createElement('div');
+          container.className = 'creative-children';
+          container.id = `creative-children-${parentId}`;
+          tree.appendChild(container);
+        }
+        insertBefore = container.firstElementChild;
+        beforeId = insertBefore ? creativeIdFrom(insertBefore) : '';
+      } else {
+        parentId = addBtn.dataset.parentId || '';
+        container = document.getElementById('creatives');
+        if (!container) return;
+        insertBefore = container.firstElementChild;
+        beforeId = insertBefore ? creativeIdFrom(insertBefore) : '';
+      }
+
+      session.startNew(parentId, container, insertBefore, beforeId);
+      return;
+    }
+
+    const newRootBtn = target.closest('.new-root-creative-btn');
+    if (newRootBtn) {
+      event.preventDefault();
+      const container = document.getElementById('creatives');
+      if (!container) return;
+
+      if (session.template.style.display === 'block') {
+        session.hideCurrent();
+        return;
+      }
+
+      const insertBefore = container.firstElementChild;
+      const beforeId = insertBefore ? creativeIdFrom(insertBefore) : '';
+      session.startNew('', container, insertBefore, beforeId);
+      return;
+    }
+
+    const appendParentBtn = target.closest('.append-parent-btn');
+    if (!appendParentBtn) return;
+
+    event.preventDefault();
+    const targetId = appendParentBtn.dataset.childId;
+    const targetTree = document.getElementById(`creative-${targetId}`);
+    if (!targetTree) return;
+    const container = targetTree.parentNode;
+    session.startNew(
+      container.id.startsWith('creative-children-') ? container.id.replace('creative-children-', '') : '',
+      container,
+      targetTree,
+      targetId,
+      '',
+      targetId
+    );
+  };
+}

--- a/engines/collavre/app/javascript/modules/dom_listener_registry.js
+++ b/engines/collavre/app/javascript/modules/dom_listener_registry.js
@@ -1,0 +1,23 @@
+export function createListenerRegistry() {
+  const bindings = [];
+
+  return {
+    add(target, type, handler, options) {
+      if (!target || typeof target.addEventListener !== 'function') return;
+
+      target.addEventListener(type, handler, options);
+      bindings.push({ target, type, handler, options });
+    },
+
+    releaseAll() {
+      while (bindings.length > 0) {
+        const { target, type, handler, options } = bindings.pop();
+        target.removeEventListener(type, handler, options);
+      }
+    },
+
+    get size() {
+      return bindings.length;
+    },
+  };
+}

--- a/engines/collavre/app/models/collavre/user.rb
+++ b/engines/collavre/app/models/collavre/user.rb
@@ -66,6 +66,7 @@ module Collavre
     attribute :locale, :string
     attribute :system_admin, :boolean, default: false
     attribute :searchable, :boolean, default: false
+    attribute :creative_workspace_enabled, :boolean, default: false
 
     # Typo correction (2D gating: typing-device AND input-location must both be on).
     attribute :typo_correction_enabled, :boolean, default: true

--- a/engines/collavre/app/services/collavre/creatives/workspace_path_resolver.rb
+++ b/engines/collavre/app/services/collavre/creatives/workspace_path_resolver.rb
@@ -1,0 +1,44 @@
+module Collavre
+module Creatives
+  # Resolves the IDs that the persistent workspace tree can actually render for
+  # the current creative. Shared origin paths are re-rooted through the user's
+  # linked shell, and unreadable or archived ancestors are omitted.
+  class WorkspacePathResolver
+    def initialize(creative:, user:)
+      @creative = creative
+      @user = user
+    end
+
+    def call
+      return [] unless creative
+
+      return renderable_ids(local_path_ids) if creative.origin_id?
+
+      origin_path = local_path_ids
+      reveal = RevealPathResolver.new([ creative.id ], user: user).call[creative.id]
+      return renderable_ids(origin_path) if reveal.blank?
+
+      anchor_index = origin_path.rindex { |id| reveal.key?(id) }
+      return renderable_ids(origin_path) unless anchor_index
+
+      reveal.fetch(origin_path[anchor_index]) + renderable_ids(origin_path.drop(anchor_index + 1))
+    end
+
+    private
+
+    attr_reader :creative, :user
+
+    def local_path_ids
+      creative.ancestors.reverse.pluck(:id) + [ creative.id ]
+    end
+
+    def renderable_ids(ids)
+      return [] if ids.empty?
+
+      readable = PermissionFilter.new(user: user).readable_ids(ids).to_set
+      active = Creative.where(id: ids, archived_at: nil).pluck(:id).to_set
+      ids.select { |id| readable.include?(id) && active.include?(id) }
+    end
+  end
+end
+end

--- a/engines/collavre/app/services/collavre/creatives/workspace_path_resolver.rb
+++ b/engines/collavre/app/services/collavre/creatives/workspace_path_resolver.rb
@@ -18,10 +18,16 @@ module Creatives
       reveal = RevealPathResolver.new([ creative.id ], user: user).call[creative.id]
       return renderable_ids(origin_path) if reveal.blank?
 
-      anchor_index = origin_path.rindex { |id| reveal.key?(id) }
-      return renderable_ids(origin_path) unless anchor_index
+      reveal_paths = origin_path.filter_map { |id| [ id, reveal.fetch(id) ] if reveal.key?(id) }
+      renderable_reveal_ids = renderable_ids(reveal_paths.flat_map(&:last).uniq).to_set
+      anchor = reveal_paths.reverse.find do |_id, path|
+        path.all? { |id| renderable_reveal_ids.include?(id) }
+      end
+      return renderable_ids(origin_path) unless anchor
 
-      reveal.fetch(origin_path[anchor_index]) + renderable_ids(origin_path.drop(anchor_index + 1))
+      anchor_id, reveal_path = anchor
+      anchor_index = origin_path.index(anchor_id)
+      reveal_path + renderable_ids(origin_path.drop(anchor_index + 1))
     end
 
     private

--- a/engines/collavre/app/services/collavre/creatives/workspace_tree_builder.rb
+++ b/engines/collavre/app/services/collavre/creatives/workspace_tree_builder.rb
@@ -20,7 +20,9 @@ module Collavre
           {
             id: creative.id,
             label: view_context.strip_tags(creative.effective_description).squish,
-            url: view_context.collavre.creative_path(creative),
+            snippet: creative.creative_snippet,
+            can_comment: creative.has_permission?(@user, :feedback),
+            url: view_context.collavre.creatives_path(id: creative.id),
             children: build(children_index.children_for(creative), level: level + 1)
           }
         end

--- a/engines/collavre/app/services/collavre/creatives/workspace_tree_builder.rb
+++ b/engines/collavre/app/services/collavre/creatives/workspace_tree_builder.rb
@@ -6,13 +6,14 @@ module Collavre
         @view_context = view_context
         @max_level = max_level
         @children_index = ChildrenIndex.new(user: user, show_archived: false)
+        @permission_rank = {}
       end
 
       def build(collection, level: 1)
         creatives = Array(collection)
         return [] if creatives.empty? || level > max_level
 
-        children_index.index(creatives)
+        prepare_level(creatives)
         branches = creatives.select { |creative| children_index.has_children?(creative) }
         children_index.load(branches)
 
@@ -21,7 +22,7 @@ module Collavre
             id: creative.id,
             label: view_context.strip_tags(creative.effective_description).squish,
             snippet: creative.creative_snippet,
-            can_comment: creative.has_permission?(@user, :feedback),
+            can_comment: allowed?(creative, :feedback),
             url: view_context.collavre.creatives_path(id: creative.id),
             children: build(children_index.children_for(creative), level: level + 1)
           }
@@ -30,7 +31,26 @@ module Collavre
 
       private
 
-      attr_reader :children_index, :max_level, :view_context
+      attr_reader :children_index, :max_level, :user, :view_context
+
+      def prepare_level(creatives)
+        ActiveRecord::Associations::Preloader.new(records: creatives, associations: :origin).call
+        preload_permissions(creatives)
+        children_index.index(creatives)
+      end
+
+      def preload_permissions(creatives)
+        pending = creatives.reject { |creative| @permission_rank.key?(creative.id) }
+        return if pending.empty?
+
+        ranks = PermissionFilter.new(user: user).ranks_for(pending.map(&:id))
+        pending.each { |creative| @permission_rank[creative.id] = ranks[creative.id] }
+      end
+
+      def allowed?(creative, permission)
+        rank = @permission_rank[creative.id]
+        rank.present? && rank >= CreativeShare.permissions.fetch(permission.to_s)
+      end
     end
   end
 end

--- a/engines/collavre/app/services/collavre/creatives/workspace_tree_builder.rb
+++ b/engines/collavre/app/services/collavre/creatives/workspace_tree_builder.rb
@@ -1,0 +1,34 @@
+module Collavre
+  module Creatives
+    class WorkspaceTreeBuilder
+      def initialize(user:, view_context:, max_level:)
+        @user = user
+        @view_context = view_context
+        @max_level = max_level
+        @children_index = ChildrenIndex.new(user: user, show_archived: false)
+      end
+
+      def build(collection, level: 1)
+        creatives = Array(collection)
+        return [] if creatives.empty? || level > max_level
+
+        children_index.index(creatives)
+        branches = creatives.select { |creative| children_index.has_children?(creative) }
+        children_index.load(branches)
+
+        branches.map do |creative|
+          {
+            id: creative.id,
+            label: view_context.strip_tags(creative.effective_description).squish,
+            url: view_context.collavre.creative_path(creative),
+            children: build(children_index.children_for(creative), level: level + 1)
+          }
+        end
+      end
+
+      private
+
+      attr_reader :children_index, :max_level, :view_context
+    end
+  end
+end

--- a/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
@@ -8,6 +8,7 @@
      data-docked="<%= docked %>"
      data-docked-empty-text="<%= t('collavre.creatives.workspace.select_chat') %>"
      data-default-title="<%= t('collavre.comments.comments') %>"
+     data-close-label="<%= t('collavre.comments.close') %>"
      data-collapse-docked-label="<%= t('collavre.creatives.workspace.collapse_chat') %>"
      data-expand-docked-label="<%= t('collavre.creatives.workspace.expand_chat') %>"
      <% if auto_fullscreen %>data-auto-fullscreen="true"<% end %>
@@ -129,7 +130,7 @@
           <%= svg_tag "exit-fullscreen.svg", class: "comments-popup-action-icon" %>
         </span>
       </button>
-      <button id="close-comments-btn" data-comments--popup-target="closeButton" class="popup-close-btn" type="button">&times;</button>
+      <button id="close-comments-btn" data-comments--popup-target="closeButton" class="popup-close-btn" type="button" aria-label="<%= t('collavre.comments.close') %>" title="<%= t('collavre.comments.close') %>">&times;</button>
     </div>
   </div>
   <div id="comment-contexts" data-comments--contexts-target="list" class="comment-contexts-list" style="display:none;"

--- a/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
@@ -1,14 +1,19 @@
 
 <% fullscreen = local_assigns.fetch(:fullscreen, false) %>
 <% auto_fullscreen = local_assigns.fetch(:auto_fullscreen, false) %>
+<% docked = local_assigns.fetch(:docked, false) %>
 <% creative = local_assigns[:creative] %>
 <div id="comments-popup" data-controller="comments--popup comments--list comments--form comments--presence comments--mention-menu comments--topics comments--contexts comments--drop-trigger share-modal" class="popup-box"
      data-fullscreen="<%= fullscreen %>"
+     data-docked="<%= docked %>"
+     data-docked-empty-text="<%= t('collavre.creatives.workspace.select_chat') %>"
+     data-collapse-docked-label="<%= t('collavre.creatives.workspace.collapse_chat') %>"
+     data-expand-docked-label="<%= t('collavre.creatives.workspace.expand_chat') %>"
      <% if auto_fullscreen %>data-auto-fullscreen="true"<% end %>
      data-fullscreen-label="<%= t('collavre.comments.fullscreen', default: 'Full screen') %>"
      data-exit-fullscreen-label="<%= t('collavre.comments.exit_fullscreen', default: 'Exit full screen') %>"
      <% popup_creative = creative || (@parent_creative if auto_fullscreen) %>
-     <% if (fullscreen || auto_fullscreen) && popup_creative.present? %>
+     <% if (fullscreen || auto_fullscreen || docked) && popup_creative.present? %>
      data-creative-id="<%= popup_creative.id %>"
      data-creative-snippet="<%= popup_creative.creative_snippet %>"
      data-can-comment="<%= popup_creative.has_permission?(Current.user, :feedback) %>"

--- a/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
@@ -7,6 +7,7 @@
      data-fullscreen="<%= fullscreen %>"
      data-docked="<%= docked %>"
      data-docked-empty-text="<%= t('collavre.creatives.workspace.select_chat') %>"
+     data-default-title="<%= t('collavre.comments.comments') %>"
      data-collapse-docked-label="<%= t('collavre.creatives.workspace.collapse_chat') %>"
      data-expand-docked-label="<%= t('collavre.creatives.workspace.expand_chat') %>"
      <% if auto_fullscreen %>data-auto-fullscreen="true"<% end %>

--- a/engines/collavre/app/views/collavre/creatives/_workspace_tree.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/_workspace_tree.html.erb
@@ -1,14 +1,7 @@
-<%
-  current_path_ids = if @parent_creative
-    @parent_creative.ancestors.reverse.pluck(:id) + [@parent_creative.id]
-  else
-    []
-  end
-%>
 <section class="creative-workspace-tree-region"
          data-controller="workspace-tree"
          data-workspace-tree-url-value="<%= creatives_path(format: :json, workspace_tree: 1) %>"
-         data-workspace-tree-current-path-value="<%= current_path_ids.to_json %>"
+         data-workspace-tree-current-path-value="<%= @workspace_path_ids.to_json %>"
          data-workspace-tree-loading-text-value="<%= t('app.loading') %>"
          data-workspace-tree-empty-text-value="<%= t('collavre.creatives.workspace.empty') %>"
          data-workspace-tree-error-text-value="<%= t('collavre.creatives.workspace.load_error') %>">

--- a/engines/collavre/app/views/collavre/creatives/_workspace_tree.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/_workspace_tree.html.erb
@@ -1,4 +1,3 @@
-<%= turbo_stream_from Current.user, :creative_tree %>
 <section class="creative-workspace-tree-region"
          data-controller="workspace-tree"
          data-workspace-tree-url-value="<%= creatives_path(format: :json, workspace_tree: 1) %>"
@@ -6,6 +5,10 @@
          data-workspace-tree-loading-text-value="<%= t('app.loading') %>"
          data-workspace-tree-empty-text-value="<%= t('collavre.creatives.workspace.empty') %>"
          data-workspace-tree-error-text-value="<%= t('collavre.creatives.workspace.load_error') %>">
+  <%# Keep the stream source inside the tree region: as a direct child of the
+      grid shell it would become a grid item with its own implicit row and
+      push all three columns down. %>
+  <%= turbo_stream_from Current.user, :creative_tree %>
   <button type="button"
           class="creative-workspace-tree-toggle"
           data-workspace-tree-target="panelToggle"

--- a/engines/collavre/app/views/collavre/creatives/_workspace_tree.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/_workspace_tree.html.erb
@@ -1,3 +1,4 @@
+<%= turbo_stream_from Current.user, :creative_tree %>
 <section class="creative-workspace-tree-region"
          data-controller="workspace-tree"
          data-workspace-tree-url-value="<%= creatives_path(format: :json, workspace_tree: 1) %>"

--- a/engines/collavre/app/views/collavre/creatives/_workspace_tree.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/_workspace_tree.html.erb
@@ -1,0 +1,33 @@
+<%
+  current_path_ids = if @parent_creative
+    @parent_creative.ancestors.reverse.pluck(:id) + [@parent_creative.id]
+  else
+    []
+  end
+%>
+<section class="creative-workspace-tree-region"
+         data-controller="workspace-tree"
+         data-workspace-tree-url-value="<%= creatives_path(format: :json, workspace_tree: 1) %>"
+         data-workspace-tree-current-path-value="<%= current_path_ids.to_json %>"
+         data-workspace-tree-loading-text-value="<%= t('app.loading') %>"
+         data-workspace-tree-empty-text-value="<%= t('collavre.creatives.workspace.empty') %>"
+         data-workspace-tree-error-text-value="<%= t('collavre.creatives.workspace.load_error') %>">
+  <button type="button"
+          class="creative-workspace-tree-toggle"
+          data-workspace-tree-target="panelToggle"
+          data-action="workspace-tree#togglePanel"
+          aria-expanded="false"
+          aria-controls="creative-workspace-tree"
+          aria-label="<%= t('collavre.creatives.workspace.toggle_tree') %>"
+          title="<%= t('collavre.creatives.workspace.toggle_tree') %>">
+    <%= svg_tag "chevron-right.svg", class: "creative-workspace-tree-toggle-icon", width: 18, height: 18 %>
+  </button>
+  <aside id="creative-workspace-tree" aria-label="<%= t('collavre.creatives.workspace.tree_label') %>">
+    <header class="creative-workspace-tree-header">
+      <h2><%= t('collavre.creatives.workspace.tree_title') %></h2>
+    </header>
+    <nav class="creative-workspace-tree-nav" data-workspace-tree-target="tree">
+      <p class="creative-workspace-tree-status"><%= t('app.loading') %></p>
+    </nav>
+  </aside>
+</section>

--- a/engines/collavre/app/views/collavre/creatives/index.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/index.html.erb
@@ -81,7 +81,7 @@
           </button>
         <% end %>
         <% if @parent_creative.present? %>
-          <%= button_to slide_view_creative_path(@parent_creative), method: :get, class: 'popup-menu-item' do %>
+          <%= button_to slide_view_creative_path(@parent_creative), method: :get, class: 'popup-menu-item', form: { data: { turbo_frame: '_top' } } do %>
             <span aria-hidden="true"><%= svg_tag 'slide.svg', width: 16, height: 16 %></span> <%= t('collavre.creatives.index.slide_view') %>
           <% end %>
         <% end %>
@@ -268,7 +268,7 @@
 </div>
 <% end %>
 <% if creative_workspace? %>
-  <%= turbo_frame_tag "creative-workspace-content", target: "_top" do %>
+  <%= turbo_frame_tag "creative-workspace-content" do %>
     <%= creative_index_content %>
   <% end %>
 <% else %>

--- a/engines/collavre/app/views/collavre/creatives/index.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/index.html.erb
@@ -1,14 +1,15 @@
-<%= turbo_frame_tag "creative-workspace-content",
-                    target: "_top" do %>
-<%= tag.div id: "workspace-navigation-state-#{@parent_creative&.id || 'root'}",
-            hidden: true,
-            data: {
-              workspace_navigation_state: true,
-              creative_id: @parent_creative&.id,
-              creative_path: @workspace_path_ids,
-              creative_snippet: @parent_creative&.creative_snippet,
-              can_comment: @parent_creative&.has_permission?(Current.user, :feedback)
-            } %>
+<% creative_index_content = capture do %>
+<% if creative_workspace? %>
+  <%= tag.div id: "workspace-navigation-state-#{@parent_creative&.id || 'root'}",
+              hidden: true,
+              data: {
+                workspace_navigation_state: true,
+                creative_id: @parent_creative&.id,
+                creative_path: @workspace_path_ids,
+                creative_snippet: @parent_creative&.creative_snippet,
+                can_comment: @parent_creative&.has_permission?(Current.user, :feedback)
+              } %>
+<% end %>
 <%= tag.div(flash[:alert], class: "flash-alert") if flash[:alert] %>
 <% if authenticated? %>
   <%= turbo_stream_from Current.user, :creative_tree %>
@@ -265,4 +266,11 @@
   <%= render 'integration_modals', creative: current_creative %>
 <% end %>
 </div>
+<% end %>
+<% if creative_workspace? %>
+  <%= turbo_frame_tag "creative-workspace-content", target: "_top" do %>
+    <%= creative_index_content %>
+  <% end %>
+<% else %>
+  <%= creative_index_content %>
 <% end %>

--- a/engines/collavre/app/views/collavre/creatives/index.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/index.html.erb
@@ -1,3 +1,14 @@
+<%= turbo_frame_tag "creative-workspace-content",
+                    target: "_top" do %>
+<%= tag.div id: "workspace-navigation-state-#{@parent_creative&.id || 'root'}",
+            hidden: true,
+            data: {
+              workspace_navigation_state: true,
+              creative_id: @parent_creative&.id,
+              creative_path: @workspace_path_ids,
+              creative_snippet: @parent_creative&.creative_snippet,
+              can_comment: @parent_creative&.has_permission?(Current.user, :feedback)
+            } %>
 <%= tag.div(flash[:alert], class: "flash-alert") if flash[:alert] %>
 <% if authenticated? %>
   <%= turbo_stream_from Current.user, :creative_tree %>
@@ -254,3 +265,4 @@
   <%= render 'integration_modals', creative: current_creative %>
 <% end %>
 </div>
+<% end %>

--- a/engines/collavre/app/views/collavre/creatives/index.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/index.html.erb
@@ -36,11 +36,11 @@
       <% if @parent_creative && authenticated? %>
         <span id="creative-presence-avatars" class="creative-presence-avatars"></span>
       <% end %>
-      <a href="<%= creatives_path %>" class="creative-breadcrumb-link"><%= t('collavre.creatives.index.root_breadcrumb', default: '최상위') %></a>
+      <a href="<%= creatives_path %>" class="creative-breadcrumb-link" data-turbo-action="advance"><%= t('collavre.creatives.index.root_breadcrumb', default: '최상위') %></a>
       <% if @parent_creative %>
         <% @parent_creative.ancestors.reverse.each do |ancestor| %>
           <span class="creative-breadcrumb-sep" aria-hidden="true">/</span>
-          <a href="<%= creative_path(ancestor) %>" class="creative-breadcrumb-link" title="<%= strip_tags(ancestor.effective_description) %>"><%= truncate(strip_tags(ancestor.effective_description), length: 20) %></a>
+          <a href="<%= creative_path(ancestor) %>" class="creative-breadcrumb-link" data-turbo-action="advance" title="<%= strip_tags(ancestor.effective_description) %>"><%= truncate(strip_tags(ancestor.effective_description), length: 20) %></a>
         <% end %>
         <span class="creative-breadcrumb-sep" aria-hidden="true">/</span>
         <a href="<%= creative_path(@parent_creative) %>" class="creative-breadcrumb-link creative-breadcrumb-current" data-turbo-action="replace"><%= truncate(strip_tags(@parent_creative.effective_description), length: 30) %></a>

--- a/engines/collavre/app/views/collavre/creatives/index.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/index.html.erb
@@ -11,7 +11,9 @@
               } %>
 <% end %>
 <%= tag.div(flash[:alert], class: "flash-alert") if flash[:alert] %>
-<% if authenticated? %>
+<%# In workspace mode the creative-tree stream source lives in the persistent
+    shell (_workspace_tree) so center-frame swaps never drop the subscription %>
+<% if authenticated? && !creative_workspace? %>
   <%= turbo_stream_from Current.user, :creative_tree %>
 <% end %>
 <% if @auto_fullscreen %>

--- a/engines/collavre/app/views/collavre/shared/navigation/_panels.html.erb
+++ b/engines/collavre/app/views/collavre/shared/navigation/_panels.html.erb
@@ -1,6 +1,6 @@
 <%= render_extension_slot(:navigation_panels) %>
 
-<% if Current.user %>
+<% if Current.user && !creative_workspace? %>
   <%= render 'collavre/comments/comments_popup',
              auto_fullscreen: content_for?(:comments_popup_auto_fullscreen) %>
 <% end %>

--- a/engines/collavre/app/views/collavre/users/show.html.erb
+++ b/engines/collavre/app/views/collavre/users/show.html.erb
@@ -93,12 +93,10 @@
           <%= f.check_box :notifications_enabled %>
           <%= f.label :notifications_enabled, t('collavre.users.notifications_enabled') %>
         </div>
+        <% creative_workspace_hint = t('collavre.users.creative_workspace.description') %>
         <div class="checkbox-field">
-          <%= f.check_box :creative_workspace_enabled %>
-          <span>
-            <%= f.label :creative_workspace_enabled, t('collavre.users.creative_workspace.enabled') %>
-            <small><%= t('collavre.users.creative_workspace.description') %></small>
-          </span>
+          <%= f.check_box :creative_workspace_enabled, title: creative_workspace_hint %>
+          <%= f.label :creative_workspace_enabled, t('collavre.users.creative_workspace.enabled'), title: creative_workspace_hint %>
         </div>
         <div>
           <%= f.label :locale, t('collavre.users.locale') %>

--- a/engines/collavre/app/views/collavre/users/show.html.erb
+++ b/engines/collavre/app/views/collavre/users/show.html.erb
@@ -93,6 +93,13 @@
           <%= f.check_box :notifications_enabled %>
           <%= f.label :notifications_enabled, t('collavre.users.notifications_enabled') %>
         </div>
+        <div class="checkbox-field">
+          <%= f.check_box :creative_workspace_enabled %>
+          <span>
+            <%= f.label :creative_workspace_enabled, t('collavre.users.creative_workspace.enabled') %>
+            <small><%= t('collavre.users.creative_workspace.description') %></small>
+          </span>
+        </div>
         <div>
           <%= f.label :locale, t('collavre.users.locale') %>
           <%= f.select :locale, I18n.available_locales.map { |loc| [t("collavre.users.locales.#{loc}"), loc] } %>

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -39,6 +39,7 @@ en:
       login_first: Please sign in first.
       connected: Github account connected successfully.
     comments:
+      close: Close
       reaction_invalid: Invalid reaction.
       invalid_topic: Topic does not belong to this creative.
       comments: Comments

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -39,6 +39,7 @@ ko:
       login_first: 먼저 로그인해주세요.
       connected: Github 계정이 연동되었습니다.
     comments:
+      close: 닫기
       reaction_invalid: 잘못된 리액션입니다.
       invalid_topic: 토픽이 이 크리에이티브에 속하지 않습니다.
       comments: 댓글

--- a/engines/collavre/config/locales/creatives.en.yml
+++ b/engines/collavre/config/locales/creatives.en.yml
@@ -2,6 +2,15 @@
 en:
   collavre:
     creatives:
+      workspace:
+        tree_title: Creative tree
+        tree_label: Creative navigation tree
+        toggle_tree: Toggle creative tree
+        empty: No creatives with children found.
+        load_error: Could not load the creative tree.
+        select_chat: Select a creative to view its chat.
+        collapse_chat: Collapse chat
+        expand_chat: Expand chat
       index:
         up: Up
         new_creative: Add

--- a/engines/collavre/config/locales/creatives.ko.yml
+++ b/engines/collavre/config/locales/creatives.ko.yml
@@ -2,6 +2,15 @@
 ko:
   collavre:
     creatives:
+      workspace:
+        tree_title: 크리에이티브 트리
+        tree_label: 크리에이티브 탐색 트리
+        toggle_tree: 크리에이티브 트리 열기/닫기
+        empty: 하위 항목이 있는 크리에이티브가 없습니다.
+        load_error: 크리에이티브 트리를 불러오지 못했습니다.
+        select_chat: 채팅을 볼 크리에이티브를 선택하세요.
+        collapse_chat: 채팅 접기
+        expand_chat: 채팅 펼치기
       index:
         up: 위로
         new_creative: 추가

--- a/engines/collavre/config/locales/users.en.yml
+++ b/engines/collavre/config/locales/users.en.yml
@@ -119,6 +119,9 @@ en:
       theme: Theme
       calendar_id: Calendar ID
       notifications_enabled: Enable notifications
+      creative_workspace:
+        enabled: Enable three-column creative workspace
+        description: Keep the creative tree mounted on the left, update creative content without a full page refresh, and dock chat on the right.
       locale: Language
       locales:
         en: English

--- a/engines/collavre/config/locales/users.ko.yml
+++ b/engines/collavre/config/locales/users.ko.yml
@@ -113,6 +113,9 @@ ko:
       theme: 테마
       calendar_id: 캘린더 ID
       notifications_enabled: 알림 사용
+      creative_workspace:
+        enabled: 3단 크리에이티브 작업 공간 사용
+        description: 왼쪽 크리에이티브 트리를 유지하고 전체 페이지 새로고침 없이 중앙 내용을 전환하며 오른쪽에 채팅을 표시합니다.
       locale: 언어
       locales:
         en: 영어

--- a/engines/collavre/db/migrate/20260805000000_add_creative_workspace_enabled_to_users.rb
+++ b/engines/collavre/db/migrate/20260805000000_add_creative_workspace_enabled_to_users.rb
@@ -1,0 +1,5 @@
+class AddCreativeWorkspaceEnabledToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :creative_workspace_enabled, :boolean, default: false, null: false
+  end
+end

--- a/engines/collavre/test/controllers/creatives_controller_test.rb
+++ b/engines/collavre/test/controllers/creatives_controller_test.rb
@@ -48,6 +48,17 @@ class CreativesControllerTest < ActionDispatch::IntegrationTest
     assert_select "turbo-frame#creative-workspace-content #{creative_tree_stream_selector}", count: 0
   end
 
+  test "workspace breadcrumb root and ancestor links advance browser history" do
+    ancestor = creatives(:unconvert_target)
+    child = creatives(:unconvert_child_two)
+
+    get creatives_path(id: child.id)
+
+    assert_response :success
+    assert_select "a.creative-breadcrumb-link[href='#{creatives_path}'][data-turbo-action='advance']"
+    assert_select "a.creative-breadcrumb-link[href='#{creative_path(ancestor)}'][data-turbo-action='advance']"
+  end
+
   test "workspace tree JSON returns branches without leaf roots" do
     branch = Creative.create!(user: users(:one), description: "Workspace branch")
     Creative.create!(user: users(:one), parent: branch, description: "Workspace child")

--- a/engines/collavre/test/controllers/creatives_controller_test.rb
+++ b/engines/collavre/test/controllers/creatives_controller_test.rb
@@ -30,7 +30,8 @@ class CreativesControllerTest < ActionDispatch::IntegrationTest
     assert_select "body.creative-workspace"
     assert_select ".creative-workspace-shell"
     assert_select "#creative-workspace-tree"
-    assert_select "turbo-frame#creative-workspace-content[target='_top'] [data-workspace-navigation-state][data-creative-id='#{creative.id}']"
+    assert_select "turbo-frame#creative-workspace-content:not([target]) [data-workspace-navigation-state][data-creative-id='#{creative.id}']"
+    assert_select "form[data-turbo-frame='_top'][action='#{slide_view_creative_path(creative)}']"
     assert_select "#comments-popup[data-docked='true'][data-creative-id='#{creative.id}']"
   end
 

--- a/engines/collavre/test/controllers/creatives_controller_test.rb
+++ b/engines/collavre/test/controllers/creatives_controller_test.rb
@@ -40,6 +40,11 @@ class CreativesControllerTest < ActionDispatch::IntegrationTest
     assert_select "form[data-turbo-frame='_top'][action='#{slide_view_creative_path(creative)}']"
     assert_select "#comments-popup[data-docked='true'][data-creative-id='#{creative.id}']"
     assert_select ".creative-workspace-shell #{creative_tree_stream_selector}", count: 1
+    # The stream source must not be a direct grid child of the shell: grid
+    # auto-placement would give it its own implicit row and push all three
+    # columns down, leaving a blank band under the top nav.
+    assert_select ".creative-workspace-shell > #{creative_tree_stream_selector}", count: 0
+    assert_select ".creative-workspace-tree-region #{creative_tree_stream_selector}", count: 1
     assert_select "turbo-frame#creative-workspace-content #{creative_tree_stream_selector}", count: 0
   end
 

--- a/engines/collavre/test/controllers/creatives_controller_test.rb
+++ b/engines/collavre/test/controllers/creatives_controller_test.rb
@@ -6,6 +6,11 @@ class CreativesControllerTest < ActionDispatch::IntegrationTest
     sign_in_as(users(:one), password: "password")
   end
 
+  def creative_tree_stream_selector
+    signed_name = Turbo::StreamsChannel.signed_stream_name([ users(:one), :creative_tree ])
+    "turbo-cable-stream-source[signed-stream-name='#{signed_name}']"
+  end
+
   test "creative workspace is disabled by default" do
     users(:one).update!(creative_workspace_enabled: false)
     creative = creatives(:root_parent)
@@ -19,6 +24,7 @@ class CreativesControllerTest < ActionDispatch::IntegrationTest
     assert_select "turbo-frame#creative-workspace-content", count: 0
     assert_select "[data-workspace-navigation-state]", count: 0
     assert_select "#comments-popup[data-docked='false']", count: 1
+    assert_select creative_tree_stream_selector, count: 1
   end
 
   test "creative pages render the three-column workspace shell" do
@@ -33,6 +39,8 @@ class CreativesControllerTest < ActionDispatch::IntegrationTest
     assert_select "turbo-frame#creative-workspace-content:not([target]) [data-workspace-navigation-state][data-creative-id='#{creative.id}']"
     assert_select "form[data-turbo-frame='_top'][action='#{slide_view_creative_path(creative)}']"
     assert_select "#comments-popup[data-docked='true'][data-creative-id='#{creative.id}']"
+    assert_select ".creative-workspace-shell #{creative_tree_stream_selector}", count: 1
+    assert_select "turbo-frame#creative-workspace-content #{creative_tree_stream_selector}", count: 0
   end
 
   test "workspace tree JSON returns branches without leaf roots" do
@@ -62,6 +70,7 @@ class CreativesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select "turbo-frame#creative-workspace-content [data-workspace-navigation-state][data-creative-id='#{creative.id}']"
     assert_select ".creative-workspace-shell", count: 0
+    assert_select creative_tree_stream_selector, count: 0
   end
 
   test "workspace frame falls back to root without exposing an inaccessible creative" do

--- a/engines/collavre/test/controllers/creatives_controller_test.rb
+++ b/engines/collavre/test/controllers/creatives_controller_test.rb
@@ -2,7 +2,23 @@ require "test_helper"
 
 class CreativesControllerTest < ActionDispatch::IntegrationTest
   setup do
+    users(:one).update!(creative_workspace_enabled: true)
     sign_in_as(users(:one), password: "password")
+  end
+
+  test "creative workspace is disabled by default" do
+    users(:one).update!(creative_workspace_enabled: false)
+    creative = creatives(:root_parent)
+
+    get creatives_path(id: creative.id)
+
+    assert_response :success
+    assert_select "body.creative-workspace", count: 0
+    assert_select ".creative-workspace-shell", count: 0
+    assert_select "#creative-workspace-tree", count: 0
+    assert_select "turbo-frame#creative-workspace-content", count: 0
+    assert_select "[data-workspace-navigation-state]", count: 0
+    assert_select "#comments-popup[data-docked='false']", count: 1
   end
 
   test "creative pages render the three-column workspace shell" do

--- a/engines/collavre/test/controllers/creatives_controller_test.rb
+++ b/engines/collavre/test/controllers/creatives_controller_test.rb
@@ -14,6 +14,7 @@ class CreativesControllerTest < ActionDispatch::IntegrationTest
     assert_select "body.creative-workspace"
     assert_select ".creative-workspace-shell"
     assert_select "#creative-workspace-tree"
+    assert_select "turbo-frame#creative-workspace-content[target='_top'] [data-workspace-navigation-state][data-creative-id='#{creative.id}']"
     assert_select "#comments-popup[data-docked='true'][data-creative-id='#{creative.id}']"
   end
 
@@ -29,7 +30,32 @@ class CreativesControllerTest < ActionDispatch::IntegrationTest
     ids = payload.fetch("creatives").pluck("id")
     assert_includes ids, branch.id
     refute_includes ids, leaf.id
+    branch_payload = payload.fetch("creatives").find { |node| node.fetch("id") == branch.id }
+    assert_equal creatives_path(id: branch.id), branch_payload.fetch("url")
+    assert_equal branch.creative_snippet, branch_payload.fetch("snippet")
+    assert branch_payload.fetch("can_comment")
     assert_equal "no-cache", response.headers["Cache-Control"]
+  end
+
+  test "workspace frame requests render only the replaceable creative content" do
+    creative = creatives(:root_parent)
+
+    get creatives_path(id: creative.id), headers: { "Turbo-Frame" => "creative-workspace-content" }
+
+    assert_response :success
+    assert_select "turbo-frame#creative-workspace-content [data-workspace-navigation-state][data-creative-id='#{creative.id}']"
+    assert_select ".creative-workspace-shell", count: 0
+  end
+
+  test "workspace frame falls back to root without exposing an inaccessible creative" do
+    inaccessible = Creative.create!(user: users(:two), description: "Private workspace creative")
+
+    get creatives_path(id: inaccessible.id), headers: { "Turbo-Frame" => "creative-workspace-content" }
+
+    assert_response :success
+    assert_select "turbo-frame#creative-workspace-content [data-workspace-navigation-state]:not([data-creative-id])"
+    assert_select "[data-workspace-navigation-state][data-creative-path='[]']"
+    assert_not_includes response.body, inaccessible.description
   end
 
   test "title row emits markdown editor flag so cached rich rows reopen in Lexical" do

--- a/engines/collavre/test/controllers/creatives_controller_test.rb
+++ b/engines/collavre/test/controllers/creatives_controller_test.rb
@@ -5,6 +5,33 @@ class CreativesControllerTest < ActionDispatch::IntegrationTest
     sign_in_as(users(:one), password: "password")
   end
 
+  test "creative pages render the three-column workspace shell" do
+    creative = creatives(:root_parent)
+
+    get creatives_path(id: creative.id)
+
+    assert_response :success
+    assert_select "body.creative-workspace"
+    assert_select ".creative-workspace-shell"
+    assert_select "#creative-workspace-tree"
+    assert_select "#comments-popup[data-docked='true'][data-creative-id='#{creative.id}']"
+  end
+
+  test "workspace tree JSON returns branches without leaf roots" do
+    branch = Creative.create!(user: users(:one), description: "Workspace branch")
+    Creative.create!(user: users(:one), parent: branch, description: "Workspace child")
+    leaf = Creative.create!(user: users(:one), description: "Workspace leaf")
+
+    get creatives_path(format: :json, workspace_tree: 1)
+
+    assert_response :success
+    payload = JSON.parse(response.body)
+    ids = payload.fetch("creatives").pluck("id")
+    assert_includes ids, branch.id
+    refute_includes ids, leaf.id
+    assert_equal "no-cache", response.headers["Cache-Control"]
+  end
+
   test "title row emits markdown editor flag so cached rich rows reopen in Lexical" do
     rich = Creative.create!(
       user: users(:one), content_type_input: "markdown", markdown_editor: "rich", markdown_source: "# hi"

--- a/engines/collavre/test/controllers/users_controller_test.rb
+++ b/engines/collavre/test/controllers/users_controller_test.rb
@@ -517,6 +517,28 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_select "a[href=?]", collavre.typo_correction_user_path(@regular_user)
   end
 
+  test "profile controls the creative workspace preference which defaults off" do
+    sign_in_as(@regular_user, password: "password")
+
+    get collavre.user_path(@regular_user)
+
+    assert_response :success
+    assert_select "input[name=?][type='checkbox']:not([checked])", "user[creative_workspace_enabled]"
+
+    patch collavre.user_path(@regular_user), params: {
+      user: { creative_workspace_enabled: "1" }
+    }
+
+    assert_redirected_to collavre.user_path(@regular_user)
+    assert_predicate @regular_user.reload, :creative_workspace_enabled?
+
+    patch collavre.user_path(@regular_user), params: {
+      user: { creative_workspace_enabled: "0" }
+    }
+
+    assert_not @regular_user.reload.creative_workspace_enabled?
+  end
+
   test "admin link appears in profile for system admin" do
     sign_in_as(@admin, password: "password")
     get collavre.user_path(@admin)

--- a/engines/collavre/test/controllers/users_controller_test.rb
+++ b/engines/collavre/test/controllers/users_controller_test.rb
@@ -539,6 +539,21 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_not @regular_user.reload.creative_workspace_enabled?
   end
 
+  test "profile shows the creative workspace explanation as a tooltip instead of inline text" do
+    sign_in_as(@regular_user, password: "password")
+
+    get collavre.user_path(@regular_user)
+
+    assert_response :success
+
+    description = I18n.t("collavre.users.creative_workspace.description")
+
+    assert_select "input[name=?][type='checkbox'][title=?]",
+                  "user[creative_workspace_enabled]", description
+    assert_select "label[for='user_creative_workspace_enabled'][title=?]", description
+    assert_select "small", text: description, count: 0
+  end
+
   test "admin link appears in profile for system admin" do
     sign_in_as(@admin, password: "password")
     get collavre.user_path(@admin)

--- a/engines/collavre/test/services/creatives/workspace_path_resolver_test.rb
+++ b/engines/collavre/test/services/creatives/workspace_path_resolver_test.rb
@@ -1,0 +1,66 @@
+require "test_helper"
+
+module Creatives
+  class WorkspacePathResolverTest < ActiveSupport::TestCase
+    setup do
+      @user = users(:one)
+    end
+
+    test "returns the visible path in the user's own tree" do
+      root = Creative.create!(user: @user, description: "Workspace root")
+      branch = Creative.create!(user: @user, parent: root, description: "Workspace branch")
+      leaf = Creative.create!(user: @user, parent: branch, description: "Workspace leaf")
+
+      assert_equal [ root.id, branch.id, leaf.id ], resolve(leaf)
+    end
+
+    test "re-roots a shared origin path through the user's linked shell" do
+      origin = Creative.create!(user: users(:two), description: "Shared origin")
+      branch = Creative.create!(user: users(:two), parent: origin, description: "Shared branch")
+      leaf = Creative.create!(user: users(:two), parent: branch, description: "Shared leaf")
+      CreativeShare.create!(creative: origin, user: @user, permission: :read)
+      origin.create_linked_creative_for_user(@user)
+
+      shell = Creative.find_by!(user: @user, origin: origin)
+      folder = Creative.create!(user: @user, description: "Local folder")
+      shell.update!(parent: folder)
+
+      assert_equal [ folder.id, shell.id, branch.id, leaf.id ], resolve(leaf)
+    end
+
+    test "never exposes an unreadable ancestor id" do
+      restricted = Creative.create!(user: users(:two), description: "Restricted ancestor")
+      shared_leaf = Creative.create!(user: users(:two), parent: restricted, description: "Shared leaf")
+      CreativeShare.create!(creative: shared_leaf, user: @user, permission: :read)
+      shared_leaf.create_linked_creative_for_user(@user)
+      shell = Creative.find_by!(user: @user, origin: shared_leaf)
+
+      path = resolve(shared_leaf)
+
+      assert_equal [ shell.id ], path
+      assert_not_includes path, restricted.id
+      assert path.all? { |id| Creative.find(id).has_permission?(@user, :read) }
+    end
+
+    test "uses the deepest linked shell when several origin ancestors are linked" do
+      origin = Creative.create!(user: users(:two), description: "Shared origin")
+      branch = Creative.create!(user: users(:two), parent: origin, description: "Shared branch")
+      leaf = Creative.create!(user: users(:two), parent: branch, description: "Shared leaf")
+      CreativeShare.create!(creative: origin, user: @user, permission: :read)
+      origin.create_linked_creative_for_user(@user)
+
+      root_folder = Creative.create!(user: @user, description: "Root shell folder")
+      Creative.find_by!(user: @user, origin: origin).update!(parent: root_folder)
+      branch_folder = Creative.create!(user: @user, description: "Branch shell folder")
+      branch_shell = Creative.create!(user: @user, origin: branch, parent: branch_folder)
+
+      assert_equal [ branch_folder.id, branch_shell.id, leaf.id ], resolve(leaf)
+    end
+
+    private
+
+    def resolve(creative)
+      Collavre::Creatives::WorkspacePathResolver.new(creative: creative, user: @user).call
+    end
+  end
+end

--- a/engines/collavre/test/services/creatives/workspace_path_resolver_test.rb
+++ b/engines/collavre/test/services/creatives/workspace_path_resolver_test.rb
@@ -57,6 +57,21 @@ module Creatives
       assert_equal [ branch_folder.id, branch_shell.id, leaf.id ], resolve(leaf)
     end
 
+    test "rejects a reveal path through a linked shell whose origin is no longer readable" do
+      restricted = Creative.create!(user: users(:two), description: "Revoked origin")
+      shared_leaf = Creative.create!(user: users(:two), parent: restricted, description: "Directly shared leaf")
+      ancestor_share = CreativeShare.create!(creative: restricted, user: @user, permission: :read)
+      restricted.create_linked_creative_for_user(@user)
+      stale_shell = Creative.find_by!(user: @user, origin: restricted)
+      ancestor_share.destroy!
+      CreativeShare.create!(creative: shared_leaf, user: @user, permission: :read)
+
+      path = resolve(shared_leaf)
+
+      assert_equal [ shared_leaf.id ], path
+      assert_not_includes path, stale_shell.id
+    end
+
     private
 
     def resolve(creative)

--- a/engines/collavre/test/services/creatives/workspace_tree_builder_test.rb
+++ b/engines/collavre/test/services/creatives/workspace_tree_builder_test.rb
@@ -7,8 +7,8 @@ module Creatives
         ActionController::Base.helpers.strip_tags(value)
       end
 
-      def creative_path(creative)
-        "/creatives/#{creative.id}"
+      def creatives_path(id:)
+        "/creatives?id=#{id}"
       end
 
       def collavre
@@ -31,7 +31,9 @@ module Creatives
 
       assert_equal [ root.id ], nodes.pluck(:id)
       assert_equal "Root", nodes.first[:label]
-      assert_equal "/creatives/#{root.id}", nodes.first[:url]
+      assert_equal root.creative_snippet, nodes.first[:snippet]
+      assert nodes.first[:can_comment]
+      assert_equal "/creatives?id=#{root.id}", nodes.first[:url]
       assert_equal [ branch.id ], nodes.first[:children].pluck(:id)
       assert_empty nodes.first[:children].first[:children]
     end

--- a/engines/collavre/test/services/creatives/workspace_tree_builder_test.rb
+++ b/engines/collavre/test/services/creatives/workspace_tree_builder_test.rb
@@ -1,0 +1,67 @@
+require "test_helper"
+
+module Creatives
+  class WorkspaceTreeBuilderTest < ActiveSupport::TestCase
+    class FakeViewContext
+      def strip_tags(value)
+        ActionController::Base.helpers.strip_tags(value)
+      end
+
+      def creative_path(creative)
+        "/creatives/#{creative.id}"
+      end
+
+      def collavre
+        self
+      end
+    end
+
+    setup do
+      @user = users(:one)
+      @view_context = FakeViewContext.new
+    end
+
+    test "returns only readable creatives that have children" do
+      root = Creative.create!(user: @user, description: "<strong>Root</strong>")
+      branch = Creative.create!(user: @user, parent: root, description: "Branch")
+      Creative.create!(user: @user, parent: branch, description: "Leaf")
+      Creative.create!(user: @user, description: "Root leaf")
+
+      nodes = build_tree([ root ] + Creative.where(description: "Root leaf").to_a)
+
+      assert_equal [ root.id ], nodes.pluck(:id)
+      assert_equal "Root", nodes.first[:label]
+      assert_equal "/creatives/#{root.id}", nodes.first[:url]
+      assert_equal [ branch.id ], nodes.first[:children].pluck(:id)
+      assert_empty nodes.first[:children].first[:children]
+    end
+
+    test "hides a branch whose children are not readable" do
+      root = Creative.create!(user: @user, description: "Private child root")
+      Creative.create!(user: users(:two), parent: root, description: "Foreign child")
+
+      assert_empty build_tree([ root ])
+    end
+
+    test "stops recursion at the configured display level" do
+      root = Creative.create!(user: @user, description: "Level 1")
+      branch = Creative.create!(user: @user, parent: root, description: "Level 2")
+      Creative.create!(user: @user, parent: branch, description: "Level 3")
+
+      nodes = build_tree([ root ], max_level: 1)
+
+      assert_equal [ root.id ], nodes.pluck(:id)
+      assert_empty nodes.first[:children]
+    end
+
+    private
+
+    def build_tree(creatives, max_level: 6)
+      Collavre::Creatives::WorkspaceTreeBuilder.new(
+        user: @user,
+        view_context: @view_context,
+        max_level: max_level
+      ).build(creatives)
+    end
+  end
+end

--- a/engines/collavre/test/services/creatives/workspace_tree_builder_test.rb
+++ b/engines/collavre/test/services/creatives/workspace_tree_builder_test.rb
@@ -56,6 +56,30 @@ module Creatives
       assert_empty nodes.first[:children]
     end
 
+    test "batches linked origins and permission ranks for each level" do
+      shells = 4.times.map do |index|
+        origin = Creative.create!(user: users(:two), description: "Shared root #{index}")
+        Creative.create!(user: users(:two), parent: origin, description: "Shared child #{index}")
+        CreativeShare.create!(creative: origin, user: @user, permission: :feedback)
+        origin.create_linked_creative_for_user(@user)
+        Creative.find_by!(user: @user, origin: origin)
+      end
+      shell_ids = shells.map(&:id)
+      fresh_shells = Creative.where(id: shell_ids).order(:id).to_a
+      queries = []
+      callback = lambda do |_name, _start, _finish, _id, payload|
+        sql = payload[:sql]
+        queries << sql unless payload[:cached] || payload[:name] == "SCHEMA"
+      end
+
+      ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
+        build_tree(fresh_shells)
+      end
+
+      per_node_queries = queries.grep(/(?:collavre_creatives|creative_shares_cache).*LIMIT 1/i)
+      assert_empty per_node_queries, "expected batched workspace tree reads, got:\n#{per_node_queries.join("\n")}"
+    end
+
     private
 
     def build_tree(creatives, max_level: 6)

--- a/engines/collavre/test/system/inline_scripts_test.rb
+++ b/engines/collavre/test/system/inline_scripts_test.rb
@@ -7,7 +7,8 @@ class InlineScriptsTest < ApplicationSystemTestCase
       password: SystemHelpers::PASSWORD,
       name: "TestUser",
       email_verified_at: Time.current,
-      notifications_enabled: false
+      notifications_enabled: false,
+      creative_workspace_enabled: true
     )
 
     resize_window_to
@@ -120,6 +121,33 @@ class InlineScriptsTest < ApplicationSystemTestCase
 
   public
 
+  test "profile toggles the creative workspace from its default off state" do
+    @user.update!(creative_workspace_enabled: false)
+
+    visit root_path
+    assert_no_selector ".creative-workspace-shell"
+    assert_selector "#comments-popup[data-docked='false']", visible: :all
+
+    visit collavre.user_path(@user)
+    workspace_toggle = find("#user_creative_workspace_enabled")
+    assert_not workspace_toggle.checked?
+    workspace_toggle.check
+    click_button I18n.t("collavre.users.update_profile")
+
+    assert_text I18n.t("collavre.users.profile_updated")
+    visit root_path
+    assert_selector ".creative-workspace-shell"
+    assert_selector "#comments-popup[data-docked='true']", visible: :visible
+
+    visit collavre.user_path(@user)
+    find("#user_creative_workspace_enabled").uncheck
+    click_button I18n.t("collavre.users.update_profile")
+
+    visit root_path
+    assert_no_selector ".creative-workspace-shell"
+    assert_selector "#comments-popup[data-docked='false']", visible: :all
+  end
+
   test "plans menu opens and loads plans on click" do
     creative = Creative.create!(user: @user, description: "Test Creative for Plans")
     Plan.create!(creative: creative, target_date: Date.current + 7.days)
@@ -201,6 +229,7 @@ class InlineScriptsTest < ApplicationSystemTestCase
     assert_current_path collavre.creatives_path(id: other_branch.id)
     assert_selector "#creative-workspace-content [data-workspace-navigation-state][data-creative-id='#{other_branch.id}']",
                     visible: :all, wait: 10
+    assert_eventually { page.evaluate_script("window.Turbo?.navigator?.currentVisit == null") }
 
     page.go_back
 
@@ -215,10 +244,13 @@ class InlineScriptsTest < ApplicationSystemTestCase
     assert_current_path collavre.creatives_path(id: other_branch.id)
     assert_selector "#creative-workspace-content [data-workspace-navigation-state][data-creative-id='#{other_branch.id}']",
                     visible: :all, wait: 10
+    assert_eventually { page.evaluate_script("window.Turbo?.navigator?.currentVisit == null") }
 
     page.go_back
 
-    assert_selector "#creative-workspace-content [data-workspace-navigation-state]", visible: :all, wait: 10
+    assert_current_path collavre.creatives_path
+    assert_selector "#creative-workspace-content [data-workspace-navigation-state]:not([data-creative-id])",
+                    visible: :all, wait: 10
     assert_selector "#comments-popup[data-creative-id='']", visible: :visible, wait: 10
     assert_text I18n.t("collavre.creatives.workspace.select_chat")
   end

--- a/engines/collavre/test/system/inline_scripts_test.rb
+++ b/engines/collavre/test/system/inline_scripts_test.rb
@@ -326,6 +326,29 @@ class InlineScriptsTest < ApplicationSystemTestCase
     assert_text I18n.t("collavre.creatives.workspace.select_chat")
   end
 
+  test "workspace frame reloads the docked chat for a same-creative comment link" do
+    resize_window_to(1440, 900)
+    creative = Creative.create!(user: @user, description: "Workspace comment link creative")
+    Comment.create!(creative: creative, user: @user, content: "Earlier workspace comment")
+    target_comment = Comment.create!(creative: creative, user: @user, content: "Target workspace comment")
+
+    visit collavre.creatives_path(id: creative.id)
+    assert_selector "#comments-popup[data-creative-id='#{creative.id}']", visible: :visible, wait: 10
+    page.execute_script(<<~JS)
+      document.querySelector('[data-controller="workspace-tree"]')
+        .dataset.persistenceMarker = 'comment-link-mounted';
+      window.Turbo.visit(#{collavre.creative_comment_path(creative, target_comment).to_json}, {
+        action: 'advance',
+        frame: 'creative-workspace-content'
+      });
+    JS
+
+    assert_selector "#creative-workspace-content [data-workspace-navigation-state][data-creative-id='#{creative.id}']",
+                    visible: :all, wait: 10
+    assert_selector "#comment_#{target_comment.id}[data-highlighted='true']", wait: 10
+    assert_equal "comment-link-mounted", find("[data-controller='workspace-tree']")["data-persistence-marker"]
+  end
+
   test "workspace frame clears persistent navigation after an inaccessible selection" do
     resize_window_to(1440, 900)
     branch = Creative.create!(user: @user, description: "Visible workspace branch")

--- a/engines/collavre/test/system/inline_scripts_test.rb
+++ b/engines/collavre/test/system/inline_scripts_test.rb
@@ -355,6 +355,27 @@ class InlineScriptsTest < ApplicationSystemTestCase
     assert_no_selector ".creative-workspace-tree-link[data-creative-id='#{changing_creative.id}']", wait: 10
   end
 
+  test "workspace tree refresh does not reopen a destroyed creative chat" do
+    resize_window_to(1440, 900)
+    branch = Creative.create!(user: @user, description: "Destroyed chat branch")
+    leaf = Creative.create!(user: @user, parent: branch, description: "Destroyed chat leaf")
+
+    visit collavre.creatives_path(id: leaf.id)
+    assert_equal leaf.id.to_s, find("#comments-popup", visible: :visible)["data-creative-id"]
+
+    leaf.destroy!
+    page.execute_script(<<~JS)
+      document.dispatchEvent(new CustomEvent('creative-destroyed', {
+        detail: { creativeIds: ['#{leaf.id}'] }
+      }));
+      document.dispatchEvent(new CustomEvent('workspace-tree:invalidate'));
+    JS
+
+    assert_selector "#comments-popup[data-creative-id='']", visible: :visible, wait: 10
+    assert_no_selector ".creative-workspace-tree-link[data-creative-id='#{branch.id}']", wait: 10
+    assert_text I18n.t("collavre.creatives.workspace.select_chat")
+  end
+
   test "creative guide popover shows on help button click" do
     # Clear help_menu_link setting to ensure popover shows instead of redirect
     SystemSetting.find_by(key: "help_menu_link")&.destroy

--- a/engines/collavre/test/system/inline_scripts_test.rb
+++ b/engines/collavre/test/system/inline_scripts_test.rb
@@ -213,6 +213,32 @@ class InlineScriptsTest < ApplicationSystemTestCase
     assert_equal first_branch.id.to_s, find("#comments-popup", visible: :visible)["data-creative-id"]
   end
 
+  test "workspace navigation does not auto-open floating chat on mobile" do
+    resize_window_to(600, 900)
+    first_creative = Creative.create!(user: @user, description: "First mobile creative")
+    second_creative = Creative.create!(user: @user, description: "Second mobile creative")
+
+    visit collavre.creatives_path(id: first_creative.id)
+    assert_selector "#creative-workspace-content [data-workspace-navigation-state][data-creative-id='#{first_creative.id}']",
+                    visible: :all, wait: 10
+    assert_no_selector "#comments-popup", visible: :visible
+
+    page.execute_script(<<~JS)
+      const link = document.createElement('a');
+      link.id = 'mobile-workspace-link';
+      link.href = '#{collavre.creatives_path(id: second_creative.id)}';
+      link.dataset.turboFrame = 'creative-workspace-content';
+      link.dataset.turboAction = 'advance';
+      link.textContent = 'Second mobile creative';
+      document.body.appendChild(link);
+    JS
+    find("#mobile-workspace-link").click
+
+    assert_selector "#creative-workspace-content [data-workspace-navigation-state][data-creative-id='#{second_creative.id}']",
+                    visible: :all, wait: 10
+    assert_no_selector "#comments-popup", visible: :visible
+  end
+
   test "workspace frame history synchronizes leaf and root chat states" do
     resize_window_to(1440, 900)
     branch = Creative.create!(user: @user, description: "Leaf parent branch")

--- a/engines/collavre/test/system/inline_scripts_test.rb
+++ b/engines/collavre/test/system/inline_scripts_test.rb
@@ -239,6 +239,32 @@ class InlineScriptsTest < ApplicationSystemTestCase
     assert_no_selector "#comments-popup", visible: :visible
   end
 
+  test "workspace breadcrumb and center rows preserve the mounted shell" do
+    resize_window_to(1440, 900)
+    branch = Creative.create!(user: @user, description: "Center navigation branch")
+    Creative.create!(user: @user, parent: branch, description: "Center navigation child")
+
+    visit collavre.creatives_path(id: branch.id)
+    assert_selector "#creative-workspace-content [data-workspace-navigation-state][data-creative-id='#{branch.id}']",
+                    visible: :all, wait: 10
+    page.execute_script(<<~JS)
+      document.querySelector('[data-controller="workspace-tree"]')
+        .dataset.persistenceMarker = 'center-mounted';
+    JS
+
+    find(".creative-breadcrumb-link", text: I18n.t("collavre.creatives.index.root_breadcrumb")).click
+
+    assert_selector "#creative-workspace-content [data-workspace-navigation-state]:not([data-creative-id])",
+                    visible: :all, wait: 10
+    assert_equal "center-mounted", find("[data-controller='workspace-tree']")["data-persistence-marker"]
+
+    find("creative-tree-row[creative-id='#{branch.id}'] .creative-content").click
+
+    assert_selector "#creative-workspace-content [data-workspace-navigation-state][data-creative-id='#{branch.id}']",
+                    visible: :all, wait: 10
+    assert_equal "center-mounted", find("[data-controller='workspace-tree']")["data-persistence-marker"]
+  end
+
   test "workspace frame history synchronizes leaf and root chat states" do
     resize_window_to(1440, 900)
     branch = Creative.create!(user: @user, description: "Leaf parent branch")

--- a/engines/collavre/test/system/inline_scripts_test.rb
+++ b/engines/collavre/test/system/inline_scripts_test.rb
@@ -154,6 +154,123 @@ class InlineScriptsTest < ApplicationSystemTestCase
     assert_equal inbox.id.to_s, find("#comments-popup", visible: :visible)["data-creative-id"]
   end
 
+  test "workspace tree navigation preserves the mounted tree and replaces only center content" do
+    resize_window_to(1440, 900)
+    first_branch = Creative.create!(user: @user, description: "First workspace branch")
+    Creative.create!(user: @user, parent: first_branch, description: "First child")
+    second_branch = Creative.create!(user: @user, description: "Second workspace branch")
+    Creative.create!(user: @user, parent: second_branch, description: "Second child")
+
+    visit collavre.creatives_path(id: first_branch.id)
+    assert_selector ".creative-workspace-tree-link[data-creative-id='#{second_branch.id}']", wait: 10
+    page.execute_script(<<~JS)
+      document.querySelector('[data-controller="workspace-tree"]')
+        .dataset.persistenceMarker = 'mounted';
+    JS
+
+    find(".creative-workspace-tree-link[data-creative-id='#{second_branch.id}']").click
+
+    assert_selector "#creative-workspace-content [data-workspace-navigation-state][data-creative-id='#{second_branch.id}']",
+                    visible: :all, wait: 10
+    assert_selector ".creative-workspace-tree-link[data-creative-id='#{second_branch.id}'].is-current"
+    assert_equal "mounted", find("[data-controller='workspace-tree']")["data-persistence-marker"]
+    assert_equal second_branch.id.to_s, find("#comments-popup", visible: :visible)["data-creative-id"]
+
+    page.go_back
+
+    assert_selector "#creative-workspace-content [data-workspace-navigation-state][data-creative-id='#{first_branch.id}']",
+                    visible: :all, wait: 10
+    assert_selector ".creative-workspace-tree-link[data-creative-id='#{first_branch.id}'].is-current"
+    assert_equal "mounted", find("[data-controller='workspace-tree']")["data-persistence-marker"]
+    assert_equal first_branch.id.to_s, find("#comments-popup", visible: :visible)["data-creative-id"]
+  end
+
+  test "workspace frame history synchronizes leaf and root chat states" do
+    resize_window_to(1440, 900)
+    branch = Creative.create!(user: @user, description: "Leaf parent branch")
+    leaf = Creative.create!(user: @user, parent: branch, description: "Leaf workspace creative")
+    other_branch = Creative.create!(user: @user, description: "Other workspace branch")
+    Creative.create!(user: @user, parent: other_branch, description: "Other child")
+
+    visit collavre.creatives_path(id: leaf.id)
+    assert_selector ".creative-workspace-tree-link[data-creative-id='#{other_branch.id}']", wait: 10
+    assert_equal leaf.id.to_s, find("#comments-popup", visible: :visible)["data-creative-id"]
+
+    find(".creative-workspace-tree-link[data-creative-id='#{other_branch.id}']").click
+    assert_equal other_branch.id.to_s, find("#comments-popup", visible: :visible)["data-creative-id"]
+    assert_current_path collavre.creatives_path(id: other_branch.id)
+    assert_selector "#creative-workspace-content [data-workspace-navigation-state][data-creative-id='#{other_branch.id}']",
+                    visible: :all, wait: 10
+
+    page.go_back
+
+    assert_selector "#creative-workspace-content [data-workspace-navigation-state][data-creative-id='#{leaf.id}']",
+                    visible: :all, wait: 10
+    assert_selector ".creative-workspace-tree-link[data-creative-id='#{branch.id}'].is-current"
+    assert_equal leaf.id.to_s, find("#comments-popup", visible: :visible)["data-creative-id"]
+
+    visit collavre.creatives_path
+    assert_selector ".creative-workspace-tree-link[data-creative-id='#{other_branch.id}']", wait: 10
+    find(".creative-workspace-tree-link[data-creative-id='#{other_branch.id}']").click
+    assert_current_path collavre.creatives_path(id: other_branch.id)
+    assert_selector "#creative-workspace-content [data-workspace-navigation-state][data-creative-id='#{other_branch.id}']",
+                    visible: :all, wait: 10
+
+    page.go_back
+
+    assert_selector "#creative-workspace-content [data-workspace-navigation-state]", visible: :all, wait: 10
+    assert_selector "#comments-popup[data-creative-id='']", visible: :visible, wait: 10
+    assert_text I18n.t("collavre.creatives.workspace.select_chat")
+  end
+
+  test "workspace frame clears persistent navigation after an inaccessible selection" do
+    resize_window_to(1440, 900)
+    branch = Creative.create!(user: @user, description: "Visible workspace branch")
+    Creative.create!(user: @user, parent: branch, description: "Visible child")
+    inaccessible = Creative.create!(user: users(:two), description: "Private workspace creative")
+
+    visit collavre.creatives_path(id: branch.id)
+    assert_selector ".creative-workspace-tree-link[data-creative-id='#{branch.id}'].is-current", wait: 10
+    page.execute_script(<<~JS)
+      const link = document.createElement('a');
+      link.id = 'inaccessible-workspace-link';
+      link.href = '#{collavre.creatives_path(id: inaccessible.id)}';
+      link.dataset.turboFrame = 'creative-workspace-content';
+      link.dataset.turboAction = 'advance';
+      link.textContent = 'Private target';
+      document.body.appendChild(link);
+    JS
+
+    find("#inaccessible-workspace-link").click
+
+    assert_selector "#creative-workspace-content [data-workspace-navigation-state]:not([data-creative-id])",
+                    visible: :all, wait: 10
+    assert_no_selector ".creative-workspace-tree-link.is-current"
+    assert_selector "#comments-popup[data-creative-id='']", visible: :visible, wait: 10
+    assert_text I18n.t("collavre.creatives.workspace.select_chat")
+  end
+
+  test "workspace tree refreshes first-child and last-child structural changes" do
+    resize_window_to(1440, 900)
+    stable_branch = Creative.create!(user: @user, description: "Stable workspace branch")
+    Creative.create!(user: @user, parent: stable_branch, description: "Stable child")
+    changing_creative = Creative.create!(user: @user, description: "Changing workspace creative")
+
+    visit collavre.creatives_path(id: stable_branch.id)
+    assert_selector ".creative-workspace-tree-link[data-creative-id='#{stable_branch.id}']", wait: 10
+    assert_no_selector ".creative-workspace-tree-link[data-creative-id='#{changing_creative.id}']"
+
+    child = Creative.create!(user: @user, parent: changing_creative, description: "Temporary child")
+    page.execute_script("document.dispatchEvent(new CustomEvent('workspace-tree:invalidate'))")
+
+    assert_selector ".creative-workspace-tree-link[data-creative-id='#{changing_creative.id}']", wait: 10
+
+    child.destroy!
+    page.execute_script("document.dispatchEvent(new CustomEvent('workspace-tree:invalidate'))")
+
+    assert_no_selector ".creative-workspace-tree-link[data-creative-id='#{changing_creative.id}']", wait: 10
+  end
+
   test "creative guide popover shows on help button click" do
     # Clear help_menu_link setting to ensure popover shows instead of redirect
     SystemSetting.find_by(key: "help_menu_link")&.destroy

--- a/engines/collavre/test/system/inline_scripts_test.rb
+++ b/engines/collavre/test/system/inline_scripts_test.rb
@@ -182,6 +182,25 @@ class InlineScriptsTest < ApplicationSystemTestCase
     assert_equal inbox.id.to_s, find("#comments-popup", visible: :visible)["data-creative-id"]
   end
 
+  test "workspace tree refresh preserves an explicitly opened inbox chat" do
+    resize_window_to(1440, 900)
+    inbox = Creative.inbox_for(@user)
+    center_branch = Creative.create!(user: @user, description: "Workspace center branch")
+    Creative.create!(user: @user, parent: center_branch, description: "Workspace center child")
+
+    visit collavre.creatives_path(id: center_branch.id)
+    assert_selector ".creative-workspace-tree-link[data-creative-id='#{center_branch.id}']", wait: 10
+    find(".inbox-menu-btn", match: :first).click
+    assert_equal inbox.id.to_s, find("#comments-popup", visible: :visible)["data-creative-id"]
+
+    refreshed_branch = Creative.create!(user: @user, description: "Refreshed workspace branch")
+    Creative.create!(user: @user, parent: refreshed_branch, description: "Refreshed workspace child")
+    page.execute_script("document.dispatchEvent(new CustomEvent('workspace-tree:invalidate'))")
+
+    assert_selector ".creative-workspace-tree-link[data-creative-id='#{refreshed_branch.id}']", wait: 10
+    assert_equal inbox.id.to_s, find("#comments-popup", visible: :visible)["data-creative-id"]
+  end
+
   test "workspace tree navigation preserves the mounted tree and replaces only center content" do
     resize_window_to(1440, 900)
     first_branch = Creative.create!(user: @user, description: "First workspace branch")

--- a/engines/collavre/test/system/inline_scripts_test.rb
+++ b/engines/collavre/test/system/inline_scripts_test.rb
@@ -145,7 +145,8 @@ class InlineScriptsTest < ApplicationSystemTestCase
 
     visit root_path
 
-    assert_no_selector "#comments-popup", visible: :visible
+    assert_selector "#comments-popup[data-docked='true']", visible: :visible
+    assert_text I18n.t("collavre.creatives.workspace.select_chat")
 
     find(".inbox-menu-btn", match: :first).click
 
@@ -449,7 +450,7 @@ class InlineScriptsTest < ApplicationSystemTestCase
     end
   end
 
-  test "inbox button can toggle comments popup without duplicate bindings" do
+  test "inbox button keeps docked comments open without duplicate bindings" do
     inbox = Creative.inbox_for(@user)
 
     visit root_path
@@ -459,7 +460,8 @@ class InlineScriptsTest < ApplicationSystemTestCase
     assert_equal inbox.id.to_s, find("#comments-popup", visible: :visible)["data-creative-id"]
 
     find(".inbox-menu-btn", match: :first).click
-    assert_no_selector "#comments-popup", visible: :visible, wait: 5
+    assert_selector "#comments-popup", visible: :visible, wait: 5
+    assert_equal inbox.id.to_s, find("#comments-popup", visible: :visible)["data-creative-id"]
 
     find(".inbox-menu-btn", match: :first).click
     assert_selector "#comments-popup", visible: :visible, wait: 5

--- a/package-lock.json
+++ b/package-lock.json
@@ -2196,9 +2196,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3044,12 +3044,12 @@
       }
     },
     "node_modules/@mermaid-js/parser": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.1.1.tgz",
-      "integrity": "sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.2.0.tgz",
+      "integrity": "sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==",
       "license": "MIT",
       "dependencies": {
-        "@chevrotain/types": "~11.1.1"
+        "@chevrotain/types": "~11.1.2"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -4320,9 +4320,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4692,9 +4692,9 @@
       }
     },
     "node_modules/cytoscape": {
-      "version": "3.33.2",
-      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.2.tgz",
-      "integrity": "sha512-sj4HXd3DokGhzZAdjDejGvTPLqlt84vNFN8m7bGsOzDY5DyVcxIb2ejIXat2Iy7HxWhdT/N1oKyheJ5YdpsGuw==",
+      "version": "3.34.0",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.34.0.tgz",
+      "integrity": "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10"
@@ -5547,9 +5547,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -7604,9 +7604,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",
@@ -8002,26 +8002,26 @@
       }
     },
     "node_modules/mermaid": {
-      "version": "11.15.0",
-      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.15.0.tgz",
-      "integrity": "sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw==",
+      "version": "11.16.1",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.16.1.tgz",
+      "integrity": "sha512-TQsq6u22fAn3rek5VOubrhKPo1g5hwC3FXUN9hiyupTckcYiGuuKGkNQrKYwGJkXUxZdojwRG46gsSCFZMDp4g==",
       "license": "MIT",
       "dependencies": {
-        "@braintree/sanitize-url": "^7.1.1",
+        "@braintree/sanitize-url": "^7.1.2",
         "@iconify/utils": "^3.0.2",
-        "@mermaid-js/parser": "^1.1.1",
+        "@mermaid-js/parser": "^1.2.0",
         "@types/d3": "^7.4.3",
         "@upsetjs/venn.js": "^2.0.0",
-        "cytoscape": "^3.33.1",
+        "cytoscape": "^3.33.3",
         "cytoscape-cose-bilkent": "^4.1.0",
         "cytoscape-fcose": "^2.2.0",
         "d3": "^7.9.0",
         "d3-sankey": "^0.12.3",
         "dagre-d3-es": "7.0.14",
-        "dayjs": "^1.11.19",
-        "dompurify": "^3.3.1",
+        "dayjs": "^1.11.20",
+        "dompurify": "^3.3.3",
         "es-toolkit": "^1.45.1",
-        "katex": "^0.16.25",
+        "katex": "^0.16.45",
         "khroma": "^2.1.0",
         "marked": "^16.3.0",
         "roughjs": "^4.6.6",
@@ -8081,16 +8081,16 @@
       }
     },
     "node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/minipass": {
@@ -9540,9 +9540,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary

- add a responsive three-column creative workspace with a global tree, center content, and docked chat
- keep the left tree mounted while Turbo Frame navigation replaces only the center creative content
- synchronize active tree state, URL history, and docked chat across branch, leaf, root, and inaccessible responses
- refresh workspace tree data after creative mutations while preserving branch expansion state
- resolve shared creative paths through permission-safe linked-shell routes
- clear docked chat state immediately when access is revoked
- add a profile preference for the creative workspace, defaulting to off for new and existing users

## User impact

The existing creative page remains the default. Users can opt into the three-column workspace from their profile settings. When enabled, the left tree keeps its expansion and scroll state, the center content transitions in place, and the right chat follows the selected creative.

## Validation

- `./bin/rubocop`: 1,131 files, 0 offenses
- `npm test -- --runInBand`: 63 suites, 739 tests passed
- profile and creative controller tests: 54 runs, 307 assertions, 0 failures
- workspace system tests: 5 runs, 45 assertions, 0 failures
- system suite excluding the external SSE test: 49 runs, 270 assertions, 0 failures, 2 skips
- isolated repository-order failures: 37 runs, 148 assertions, 0 failures

## Known repository test issues

- the aggregate host run reports 11 existing Active Record encryption configuration errors after cross-test global state is reset; those 11 tests pass independently
- the aggregate core-engine run reports existing unmocked external-request errors caused by cross-test state; representative affected files pass independently
- the external SSE system test remains excluded because it depends on an external session and can leave browser/database processes behind
