### PR TITLE
feat: preserve PowerPoint slide structure in HTML

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,7 @@ PATH
       nokogiri
       rails (>= 8.0)
       ruby_llm
+      rubyzip (< 4.0)
       stimulus-rails
       turbo-rails
       view_component

--- a/engines/collavre/app/assets/stylesheets/collavre/creatives.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/creatives.css
@@ -1051,4 +1051,184 @@ creative-tree-row.is-being-edited .creative-tree {
     justify-content: center;
     box-shadow: var(--shadow-2);
 }
+/* ─── Imported PowerPoint slide ─── */
 
+.ppt-slide {
+    width: 100%;
+    max-width: 960px;
+    margin: var(--space-3, 12px) 0;
+    overflow: hidden;
+    border: var(--border-1, 1px) solid var(--border-color);
+    border-radius: var(--radius-2, 8px);
+    background: var(--surface-section);
+    color: var(--text-primary);
+}
+
+.ppt-slide--wide { aspect-ratio: 16 / 9; }
+.ppt-slide--standard { aspect-ratio: 4 / 3; }
+.ppt-slide--square { aspect-ratio: 1 / 1; }
+.ppt-slide--portrait { aspect-ratio: 3 / 4; }
+
+.ppt-slide-layout,
+.ppt-slide-group {
+    display: grid;
+    grid-template-columns: repeat(24, minmax(0, 1fr));
+    grid-template-rows: repeat(24, minmax(0, 1fr));
+    width: 100%;
+    height: 100%;
+}
+
+.ppt-slide-element {
+    min-width: 0;
+    min-height: 0;
+    overflow: hidden;
+}
+
+.ppt-slide-text,
+.ppt-slide-title {
+    padding: 0.2em;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+}
+
+.ppt-slide-text p,
+.ppt-slide-title p {
+    margin: 0;
+}
+
+.ppt-slide-title {
+    font-size: 1.35em;
+    font-weight: 700;
+}
+
+.ppt-slide-image img {
+    display: block;
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+}
+
+.ppt-slide-table,
+.ppt-slide-chart table {
+    width: 100%;
+    height: 100%;
+    border-collapse: collapse;
+    table-layout: fixed;
+}
+
+.ppt-slide-table td,
+.ppt-slide-chart th,
+.ppt-slide-chart td {
+    border: var(--border-1, 1px) solid var(--border-color);
+    padding: 0.2em;
+    overflow-wrap: anywhere;
+}
+
+.ppt-slide-chart h3,
+.ppt-slide-notes h3 {
+    margin: 0 0 var(--space-2, 8px);
+}
+
+.ppt-slide-notes {
+    max-width: 960px;
+    margin-top: var(--space-2, 8px);
+    padding: var(--space-3, 12px);
+    border-left: var(--border-3, 3px) solid var(--border-color);
+}
+
+.ppt-col-1 { grid-column-start: 1; }
+.ppt-col-span-1 { grid-column-end: span 1; }
+.ppt-row-1 { grid-row-start: 1; }
+.ppt-row-span-1 { grid-row-end: span 1; }
+.ppt-col-2 { grid-column-start: 2; }
+.ppt-col-span-2 { grid-column-end: span 2; }
+.ppt-row-2 { grid-row-start: 2; }
+.ppt-row-span-2 { grid-row-end: span 2; }
+.ppt-col-3 { grid-column-start: 3; }
+.ppt-col-span-3 { grid-column-end: span 3; }
+.ppt-row-3 { grid-row-start: 3; }
+.ppt-row-span-3 { grid-row-end: span 3; }
+.ppt-col-4 { grid-column-start: 4; }
+.ppt-col-span-4 { grid-column-end: span 4; }
+.ppt-row-4 { grid-row-start: 4; }
+.ppt-row-span-4 { grid-row-end: span 4; }
+.ppt-col-5 { grid-column-start: 5; }
+.ppt-col-span-5 { grid-column-end: span 5; }
+.ppt-row-5 { grid-row-start: 5; }
+.ppt-row-span-5 { grid-row-end: span 5; }
+.ppt-col-6 { grid-column-start: 6; }
+.ppt-col-span-6 { grid-column-end: span 6; }
+.ppt-row-6 { grid-row-start: 6; }
+.ppt-row-span-6 { grid-row-end: span 6; }
+.ppt-col-7 { grid-column-start: 7; }
+.ppt-col-span-7 { grid-column-end: span 7; }
+.ppt-row-7 { grid-row-start: 7; }
+.ppt-row-span-7 { grid-row-end: span 7; }
+.ppt-col-8 { grid-column-start: 8; }
+.ppt-col-span-8 { grid-column-end: span 8; }
+.ppt-row-8 { grid-row-start: 8; }
+.ppt-row-span-8 { grid-row-end: span 8; }
+.ppt-col-9 { grid-column-start: 9; }
+.ppt-col-span-9 { grid-column-end: span 9; }
+.ppt-row-9 { grid-row-start: 9; }
+.ppt-row-span-9 { grid-row-end: span 9; }
+.ppt-col-10 { grid-column-start: 10; }
+.ppt-col-span-10 { grid-column-end: span 10; }
+.ppt-row-10 { grid-row-start: 10; }
+.ppt-row-span-10 { grid-row-end: span 10; }
+.ppt-col-11 { grid-column-start: 11; }
+.ppt-col-span-11 { grid-column-end: span 11; }
+.ppt-row-11 { grid-row-start: 11; }
+.ppt-row-span-11 { grid-row-end: span 11; }
+.ppt-col-12 { grid-column-start: 12; }
+.ppt-col-span-12 { grid-column-end: span 12; }
+.ppt-row-12 { grid-row-start: 12; }
+.ppt-row-span-12 { grid-row-end: span 12; }
+.ppt-col-13 { grid-column-start: 13; }
+.ppt-col-span-13 { grid-column-end: span 13; }
+.ppt-row-13 { grid-row-start: 13; }
+.ppt-row-span-13 { grid-row-end: span 13; }
+.ppt-col-14 { grid-column-start: 14; }
+.ppt-col-span-14 { grid-column-end: span 14; }
+.ppt-row-14 { grid-row-start: 14; }
+.ppt-row-span-14 { grid-row-end: span 14; }
+.ppt-col-15 { grid-column-start: 15; }
+.ppt-col-span-15 { grid-column-end: span 15; }
+.ppt-row-15 { grid-row-start: 15; }
+.ppt-row-span-15 { grid-row-end: span 15; }
+.ppt-col-16 { grid-column-start: 16; }
+.ppt-col-span-16 { grid-column-end: span 16; }
+.ppt-row-16 { grid-row-start: 16; }
+.ppt-row-span-16 { grid-row-end: span 16; }
+.ppt-col-17 { grid-column-start: 17; }
+.ppt-col-span-17 { grid-column-end: span 17; }
+.ppt-row-17 { grid-row-start: 17; }
+.ppt-row-span-17 { grid-row-end: span 17; }
+.ppt-col-18 { grid-column-start: 18; }
+.ppt-col-span-18 { grid-column-end: span 18; }
+.ppt-row-18 { grid-row-start: 18; }
+.ppt-row-span-18 { grid-row-end: span 18; }
+.ppt-col-19 { grid-column-start: 19; }
+.ppt-col-span-19 { grid-column-end: span 19; }
+.ppt-row-19 { grid-row-start: 19; }
+.ppt-row-span-19 { grid-row-end: span 19; }
+.ppt-col-20 { grid-column-start: 20; }
+.ppt-col-span-20 { grid-column-end: span 20; }
+.ppt-row-20 { grid-row-start: 20; }
+.ppt-row-span-20 { grid-row-end: span 20; }
+.ppt-col-21 { grid-column-start: 21; }
+.ppt-col-span-21 { grid-column-end: span 21; }
+.ppt-row-21 { grid-row-start: 21; }
+.ppt-row-span-21 { grid-row-end: span 21; }
+.ppt-col-22 { grid-column-start: 22; }
+.ppt-col-span-22 { grid-column-end: span 22; }
+.ppt-row-22 { grid-row-start: 22; }
+.ppt-row-span-22 { grid-row-end: span 22; }
+.ppt-col-23 { grid-column-start: 23; }
+.ppt-col-span-23 { grid-column-end: span 23; }
+.ppt-row-23 { grid-row-start: 23; }
+.ppt-row-span-23 { grid-row-end: span 23; }
+.ppt-col-24 { grid-column-start: 24; }
+.ppt-col-span-24 { grid-column-end: span 24; }
+.ppt-row-24 { grid-row-start: 24; }
+.ppt-row-span-24 { grid-row-end: span 24; }

--- a/engines/collavre/app/javascript/controllers/creatives/import_controller.js
+++ b/engines/collavre/app/javascript/controllers/creatives/import_controller.js
@@ -64,7 +64,7 @@ export default class extends Controller {
   async handleFile(file) {
     const lower = file.name.toLowerCase()
     const isMarkdown = lower.endsWith('.md')
-    const isPpt = lower.endsWith('.ppt') || lower.endsWith('.pptx')
+    const isPpt = lower.endsWith('.pptx')
 
     if (!isMarkdown && !isPpt) {
       alertDialog(this.onlyMarkdownValue)

--- a/engines/collavre/app/models/collavre/creative/describable.rb
+++ b/engines/collavre/app/models/collavre/creative/describable.rb
@@ -184,6 +184,7 @@ module Collavre
         task_list_attrs = %w[type disabled checked]
         media_tags = %w[video source]
         media_attrs = %w[controls src preload width height poster]
+        ppt_attrs = %w[data-ppt-slide data-ppt-width data-ppt-height]
 
         # GFM task list checkboxes (`- [ ]` / `- [x]`) render as
         # <input type="checkbox" disabled> via Commonmarker's tasklist
@@ -206,7 +207,7 @@ module Collavre
         self.description = ActionController::Base.helpers.sanitize(
           scrubbed.to_html,
           tags: Rails::HTML5::SafeListSanitizer.allowed_tags.to_a + table_tags + media_tags + %w[input],
-          attributes: Rails::HTML5::SafeListSanitizer.allowed_attributes.to_a + table_attrs + attachment_attrs + task_list_attrs + media_attrs + %w[data-lexical style]
+          attributes: Rails::HTML5::SafeListSanitizer.allowed_attributes.to_a + table_attrs + attachment_attrs + task_list_attrs + media_attrs + ppt_attrs + %w[data-lexical style]
         )
       end
 

--- a/engines/collavre/app/services/collavre/creatives/importer.rb
+++ b/engines/collavre/app/services/collavre/creatives/importer.rb
@@ -5,9 +5,9 @@ module Creatives
     class UnsupportedFile < Error; end
 
     MARKDOWN_MIME_TYPES = %w[text/markdown text/x-markdown application/octet-stream].freeze
-    PPT_MIME_TYPES = %w[
-      application/vnd.ms-powerpoint
+    PPTX_MIME_TYPES = %w[
       application/vnd.openxmlformats-officedocument.presentationml.presentation
+      application/octet-stream
     ].freeze
 
     def initialize(file:, user:, parent: nil)
@@ -19,11 +19,15 @@ module Creatives
     def call
       raise Error, "File required" if file.blank?
 
-      case mime_type
-      when *MARKDOWN_MIME_TYPES
+      case extension
+      when ".md"
+        raise UnsupportedFile, "Invalid file type" unless MARKDOWN_MIME_TYPES.include?(mime_type)
+
         content = read_file_content
         MarkdownImporter.import(content, parent: parent, user: user, create_root: true)
-      when *PPT_MIME_TYPES
+      when ".pptx"
+        raise UnsupportedFile, "Invalid file type" unless PPTX_MIME_TYPES.include?(mime_type)
+
         PptImporter.import(file.tempfile, parent: parent, user: user, create_root: true, filename: file.original_filename)
       else
         raise UnsupportedFile, "Invalid file type"
@@ -33,6 +37,10 @@ module Creatives
     private
 
     attr_reader :file, :user, :parent
+
+    def extension
+      File.extname(file.original_filename.to_s).downcase
+    end
 
     def mime_type
       file.content_type.presence || Rack::Mime.mime_type(File.extname(file.original_filename.to_s))

--- a/engines/collavre/app/services/collavre/ppt_importer.rb
+++ b/engines/collavre/app/services/collavre/ppt_importer.rb
@@ -1,76 +1,393 @@
+require "erb"
+require "nokogiri"
+require "pathname"
+require "stringio"
+require "zip"
+
 module Collavre
   class PptImporter
-    # Import each slide from a PowerPoint file as HTML and create Creatives.
-    def self.import(file, parent:, user:, create_root: false, filename: nil)
-      require "zip"
-      require "nokogiri"
-      require "base64"
-      require "pathname"
-      require "erb"
+    GRID_SIZE = 24
+    DEFAULT_SLIDE_SIZE = [ 12_192_000, 6_858_000 ].freeze
 
+    class << self
+      # Imports one PPTX slide per Creative. The generated HTML keeps the slide,
+      # shape/group, text, image, table, and chart hierarchy while a small CSS
+      # grid approximates the original coordinates responsively.
+      def import(file, parent:, user:, create_root: false, filename: nil)
+        new(file, parent: parent, user: user, create_root: create_root, filename: filename).import
+      end
+    end
+
+    def initialize(file, parent:, user:, create_root:, filename:)
+      @file = file
+      @parent = parent
+      @user = user
+      @create_root = create_root
+      @filename = filename
+      @blob_cache = {}
+    end
+
+    def import
       created = []
-      root = parent
-      if create_root
-        title = filename ? File.basename(filename, File.extname(filename)) : "Presentation"
-        root = Creative.create(user: user, parent: parent, description: ERB::Util.html_escape(title))
-        created << root
-      end
 
-      Zip::File.open(file) do |zip|
-        slide_entries = zip.glob("ppt/slides/slide*.xml").sort_by do |entry|
-          entry.name[/slide(\d+)/, 1].to_i
-        end
+      Zip::File.open(@file) do |zip|
+        @zip = zip
+        @slide_size = presentation_slide_size
+        root = create_import_root(created)
+        sequence = next_sequence(root)
 
-        slide_entries.each do |entry|
-          slide_number = entry.name[/slide(\d+)/, 1]
-          xml = Nokogiri::XML(entry.get_input_stream.read)
-          ns = xml.collect_namespaces
-          html_fragments = []
+        ordered_slide_paths.each_with_index do |slide_path, index|
+          slide = xml_document(slide_path)
+          next unless slide
 
-          # Extract paragraphs as HTML
-          xml.xpath("//p:sp//a:p", ns).each do |p_node|
-            text = p_node.xpath(".//a:t", ns).map(&:text).join
-            next if text.strip.empty?
-            html_fragments << "<p>#{ERB::Util.html_escape(text)}</p>"
-          end
-
-          # Map relationship IDs to targets for image lookup
-          rels_name = "ppt/slides/_rels/slide#{slide_number}.xml.rels"
-          relationships = {}
-          if (rels_entry = zip.find_entry(rels_name))
-            rel_xml = Nokogiri::XML(rels_entry.get_input_stream.read)
-            rel_xml.xpath("//xmlns:Relationship").each do |rel|
-              relationships[rel["Id"]] = rel["Target"]
-            end
-          end
-
-          # Extract images and embed as base64 data URLs
-          xml.xpath("//p:pic", ns).each do |pic|
-            blip = pic.at_xpath(".//a:blip", ns)
-            next unless blip
-            embed_id = blip["r:embed"]
-            target = relationships[embed_id]
-            next unless target
-            img_path = Pathname.new("ppt/slides").join(target).cleanpath.to_s
-            img_entry = zip.find_entry(img_path)
-            next unless img_entry
-            data = img_entry.get_input_stream.read
-            mime = case File.extname(img_path).downcase
-            when ".png" then "image/png"
-            when ".jpg", ".jpeg" then "image/jpeg"
-            when ".gif" then "image/gif"
-            else "application/octet-stream"
-            end
-            base64 = Base64.strict_encode64(data)
-            html_fragments << "<img src=\"data:#{mime};base64,#{base64}\" />"
-          end
-
-          c = Creative.create(user: user, parent: root, description: html_fragments.join)
-          created << c
+          html = render_slide(slide, slide_path, index + 1)
+          creative = Creative.create!(
+            user: @user,
+            parent: root,
+            description: html,
+            sequence: sequence
+          )
+          created << creative
+          sequence += 1
         end
       end
 
+      Creative::RealtimeBroadcastable.broadcast_batch_created(created)
       created
+    end
+
+    private
+
+    def create_import_root(created)
+      return @parent unless @create_root
+
+      title = @filename ? File.basename(@filename, File.extname(@filename)) : "Presentation"
+      root = Creative.create!(
+        user: @user,
+        parent: @parent,
+        description: ERB::Util.html_escape(title),
+        sequence: next_sequence(@parent)
+      )
+      created << root
+      root
+    end
+
+    def next_sequence(parent)
+      siblings = parent ? parent.children : Creative.roots
+      (siblings.maximum(:sequence) || -1) + 1
+    end
+
+    # slideN.xml filenames do not necessarily reflect presentation order after
+    # users reorder slides. Follow presentation.xml relationships first.
+    def ordered_slide_paths
+      presentation = xml_document("ppt/presentation.xml")
+      if presentation
+        relationships = relationships_for("ppt/presentation.xml")
+        paths = presentation.xpath("//*[local-name()='sldId']").filter_map do |slide_id|
+          relationship = relationships[relationship_id(slide_id)]
+          relationship&.fetch(:path, nil) if relationship&.fetch(:type, "")&.end_with?("/slide")
+        end
+        return paths if paths.any?
+      end
+
+      @zip.glob("ppt/slides/slide*.xml")
+        .sort_by { |entry| entry.name[/slide(\d+)/, 1].to_i }
+        .map(&:name)
+    end
+
+    def presentation_slide_size
+      presentation = xml_document("ppt/presentation.xml")
+      size = presentation&.at_xpath("//*[local-name()='sldSz']")
+      width = size&.[]("cx").to_i
+      height = size&.[]("cy").to_i
+      return DEFAULT_SLIDE_SIZE if width <= 0 || height <= 0
+
+      [ width, height ]
+    end
+
+    def render_slide(slide, slide_path, slide_number)
+      namespaces = slide.collect_namespaces
+      relationships = relationships_for(slide_path)
+      shape_tree = slide.at_xpath("//p:cSld/p:spTree", namespaces)
+      elements = shape_tree ? render_nodes(shape_tree.element_children, namespaces, relationships, @slide_size) : ""
+      notes = render_notes(relationships)
+      ratio_class = slide_ratio_class(*@slide_size)
+
+      <<~HTML.squish
+        <div class="ppt-slide #{ratio_class}" data-ppt-slide="#{slide_number}"
+             data-ppt-width="#{@slide_size.first}" data-ppt-height="#{@slide_size.last}">
+          <div class="ppt-slide-layout">#{elements}</div>
+        </div>
+        #{notes}
+      HTML
+    end
+
+    def render_nodes(nodes, namespaces, relationships, bounds)
+      nodes.filter_map do |node|
+        case node.name
+        when "sp"
+          render_text_shape(node, namespaces, bounds)
+        when "pic"
+          render_picture(node, namespaces, relationships, bounds)
+        when "graphicFrame"
+          render_graphic_frame(node, namespaces, relationships, bounds)
+        when "grpSp"
+          render_group(node, namespaces, relationships, bounds)
+        end
+      end.join
+    end
+
+    def render_text_shape(shape, namespaces, bounds)
+      paragraphs = shape.xpath("./p:txBody/a:p", namespaces).filter_map do |paragraph|
+        render_paragraph(paragraph, namespaces)
+      end
+      return if paragraphs.empty?
+
+      placeholder = shape.at_xpath("./p:nvSpPr/p:nvPr/p:ph", namespaces)&.[]("type")
+      kind = %w[title ctrTitle subTitle].include?(placeholder) ? "title" : "text"
+      classes = element_classes("ppt-slide-#{kind}", transform_for(shape, namespaces), bounds)
+      %(<div class="#{classes}">#{paragraphs.join}</div>)
+    end
+
+    def render_paragraph(paragraph, namespaces)
+      content = paragraph.element_children.filter_map do |child|
+        case child.name
+        when "r", "fld"
+          render_text_run(child, namespaces)
+        when "br"
+          "<br>"
+        end
+      end.join
+      content = ERB::Util.html_escape(paragraph.xpath(".//a:t", namespaces).map(&:text).join) if content.empty?
+      return if ActionController::Base.helpers.strip_tags(content).strip.empty? && !content.include?("<br>")
+
+      "<p>#{content}</p>"
+    end
+
+    def render_text_run(run, namespaces)
+      text = ERB::Util.html_escape(run.xpath(".//a:t", namespaces).map(&:text).join)
+      properties = run.at_xpath("./a:rPr", namespaces)
+      text = "<strong>#{text}</strong>" if truthy_xml_attribute?(properties&.[]("b"))
+      text = "<em>#{text}</em>" if truthy_xml_attribute?(properties&.[]("i"))
+      text = "<u>#{text}</u>" if properties&.[]("u").present? && properties["u"] != "none"
+      text
+    end
+
+    def render_picture(picture, namespaces, relationships, bounds)
+      blip = picture.at_xpath(".//a:blip", namespaces)
+      relationship = relationships[relationship_id(blip, "embed")]
+      return unless relationship
+
+      entry = @zip.find_entry(relationship[:path])
+      return unless entry
+
+      blob = blob_for(entry)
+      metadata = picture.at_xpath("./p:nvPicPr/p:cNvPr", namespaces)
+      alt = metadata&.[]("descr").presence || metadata&.[]("name").presence || blob.filename.to_s
+      classes = element_classes("ppt-slide-image", transform_for(picture, namespaces), bounds)
+      src = "/public-assets/blobs/#{blob.signed_id}/#{blob.filename.sanitized}"
+      %(<div class="#{classes}"><img src="#{src}" alt="#{ERB::Util.html_escape(alt)}"></div>)
+    end
+
+    def blob_for(entry)
+      @blob_cache[entry.name] ||= begin
+        filename = File.basename(entry.name)
+        content_type = Marcel::MimeType.for(name: filename) || "application/octet-stream"
+        ActiveStorage::Blob.create_and_upload!(
+          io: StringIO.new(entry.get_input_stream.read),
+          filename: filename,
+          content_type: content_type
+        )
+      end
+    end
+
+    def render_graphic_frame(frame, namespaces, relationships, bounds)
+      content = if frame.at_xpath(".//*[local-name()='tbl']")
+        render_table(frame.at_xpath(".//*[local-name()='tbl']"), namespaces)
+      elsif (chart = frame.at_xpath(".//*[local-name()='chart']"))
+        render_chart(relationships[relationship_id(chart)])
+      end
+      return if content.blank?
+
+      classes = element_classes("ppt-slide-graphic", transform_for(frame, namespaces), bounds)
+      %(<div class="#{classes}">#{content}</div>)
+    end
+
+    def render_table(table, namespaces)
+      rows = table.xpath("./a:tr", namespaces).map do |row|
+        cells = row.xpath("./a:tc", namespaces).map do |cell|
+          content = cell.xpath("./a:txBody/a:p", namespaces).filter_map do |paragraph|
+            render_paragraph(paragraph, namespaces)
+          end.join
+          span = cell.at_xpath("./a:tcPr/a:gridSpan", namespaces)&.[]("val").to_i
+          colspan = span > 1 ? %( colspan="#{span}") : ""
+          "<td#{colspan}>#{content}</td>"
+        end
+        "<tr>#{cells.join}</tr>"
+      end
+      %(<table class="ppt-slide-table"><tbody>#{rows.join}</tbody></table>)
+    end
+
+    def render_chart(relationship)
+      chart = relationship && xml_document(relationship[:path])
+      return unless chart
+
+      title = chart.xpath("//*[local-name()='title']//*[local-name()='t']").map(&:text).join(" ").strip
+      series = chart.xpath("//*[local-name()='ser']").filter_map do |item|
+        name = item.xpath("./*[local-name()='tx']//*[local-name()='v']").map(&:text).join(" ").strip
+        categories = indexed_chart_values(item, "cat")
+        values = indexed_chart_values(item, "val")
+        next if name.blank? && categories.empty? && values.empty?
+
+        [ name, categories, values ]
+      end
+      return if title.blank? && series.empty?
+
+      caption = title.presence || I18n.t("collavre.creatives.index.imported_chart")
+      rows = series.map do |name, categories, values|
+        pairs = [ categories.length, values.length ].max.times.map do |index|
+          [ categories[index], values[index] ].compact.join(": ")
+        end
+        "<tr><th>#{ERB::Util.html_escape(name)}</th><td>#{ERB::Util.html_escape(pairs.join(", "))}</td></tr>"
+      end
+      %(<div class="ppt-slide-chart"><h3>#{ERB::Util.html_escape(caption)}</h3><table><tbody>#{rows.join}</tbody></table></div>)
+    end
+
+    def indexed_chart_values(series, axis)
+      points = series.xpath("./*[local-name()='#{axis}']//*[local-name()='pt']")
+      points.sort_by { |point| point["idx"].to_i }.map do |point|
+        point.at_xpath("./*[local-name()='v']")&.text.to_s
+      end
+    end
+
+    def render_group(group, namespaces, relationships, bounds)
+      transform = transform_for(group, namespaces)
+      children = render_nodes(group.element_children, namespaces, relationships, group_child_bounds(group, namespaces))
+      return if children.blank?
+
+      classes = element_classes("ppt-slide-group", transform, bounds)
+      %(<div class="#{classes}">#{children}</div>)
+    end
+
+    def render_notes(relationships)
+      relationship = relationships.values.find { |item| item[:type].end_with?("/notesSlide") }
+      notes = relationship && xml_document(relationship[:path])
+      return "" unless notes
+
+      namespaces = notes.collect_namespaces
+      paragraphs = notes.xpath("//p:sp", namespaces).filter_map do |shape|
+        type = shape.at_xpath("./p:nvSpPr/p:nvPr/p:ph", namespaces)&.[]("type")
+        next unless type.nil? || type == "body"
+
+        shape.xpath("./p:txBody/a:p", namespaces).filter_map do |paragraph|
+          render_paragraph(paragraph, namespaces)
+        end.join.presence
+      end
+      return "" if paragraphs.empty?
+
+      title = ERB::Util.html_escape(I18n.t("collavre.creatives.index.imported_speaker_notes"))
+      %(<div class="ppt-slide-notes"><h3>#{title}</h3>#{paragraphs.join}</div>)
+    end
+
+    def transform_for(node, namespaces)
+      transform = case node.name
+      when "graphicFrame"
+        node.at_xpath("./p:xfrm", namespaces)
+      when "grpSp"
+        node.at_xpath("./p:grpSpPr/a:xfrm", namespaces)
+      else
+        node.at_xpath("./p:spPr/a:xfrm", namespaces)
+      end
+      return unless transform
+
+      offset = transform.at_xpath("./a:off", namespaces)
+      extent = transform.at_xpath("./a:ext", namespaces)
+      return unless offset && extent
+
+      [ offset["x"].to_i, offset["y"].to_i, extent["cx"].to_i, extent["cy"].to_i ]
+    end
+
+    def group_child_bounds(group, namespaces)
+      transform = group.at_xpath("./p:grpSpPr/a:xfrm", namespaces)
+      extent = transform&.at_xpath("./a:chExt", namespaces)
+      width = extent&.[]("cx").to_i
+      height = extent&.[]("cy").to_i
+      width.positive? && height.positive? ? [ width, height ] : @slide_size
+    end
+
+    def element_classes(kind, transform, bounds)
+      classes = [ "ppt-slide-element", kind ]
+      return classes.join(" ") unless transform
+
+      x, y, width, height = transform
+      bound_width, bound_height = bounds
+      column = grid_start(x, bound_width)
+      row = grid_start(y, bound_height)
+      classes.concat([
+        "ppt-col-#{column}",
+        "ppt-col-span-#{grid_span(width, bound_width, column)}",
+        "ppt-row-#{row}",
+        "ppt-row-span-#{grid_span(height, bound_height, row)}"
+      ])
+      classes.join(" ")
+    end
+
+    def grid_start(offset, total)
+      return 1 unless total.positive?
+
+      ((offset.to_f / total) * GRID_SIZE).floor.clamp(0, GRID_SIZE - 1) + 1
+    end
+
+    def grid_span(length, total, start)
+      return 1 unless total.positive?
+
+      ((length.to_f / total) * GRID_SIZE).round.clamp(1, GRID_SIZE - start + 1)
+    end
+
+    def slide_ratio_class(width, height)
+      ratio = width.to_f / height
+      return "ppt-slide--portrait" if ratio < 0.9
+      return "ppt-slide--square" if ratio < 1.2
+      return "ppt-slide--standard" if ratio < 1.55
+
+      "ppt-slide--wide"
+    end
+
+    def relationships_for(part_path)
+      directory = File.dirname(part_path)
+      relationships_path = File.join(directory, "_rels", "#{File.basename(part_path)}.rels")
+      document = xml_document(relationships_path)
+      return {} unless document
+
+      document.xpath("//*[local-name()='Relationship']").to_h do |relationship|
+        target = relationship["Target"].to_s
+        [ relationship["Id"], {
+          path: normalize_part_path(part_path, target),
+          type: relationship["Type"].to_s
+        } ]
+      end
+    end
+
+    def normalize_part_path(part_path, target)
+      return target.delete_prefix("/") if target.start_with?("/")
+
+      Pathname.new(File.dirname(part_path)).join(target).cleanpath.to_s
+    end
+
+    def relationship_id(node, attribute = "id")
+      return unless node
+
+      node.attribute_with_ns(attribute, "http://schemas.openxmlformats.org/officeDocument/2006/relationships")&.value ||
+        node["r:#{attribute}"]
+    end
+
+    def xml_document(path)
+      entry = @zip.find_entry(path)
+      Nokogiri::XML(entry.get_input_stream.read) if entry
+    end
+
+    def truthy_xml_attribute?(value)
+      %w[1 true on].include?(value.to_s.downcase)
     end
   end
 end

--- a/engines/collavre/app/views/collavre/creatives/_import_upload_zone.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/_import_upload_zone.html.erb
@@ -4,7 +4,7 @@
     data-creatives--import-target="dropzone"
     data-action="dragover->creatives--import#dragOver dragleave->creatives--import#dragLeave drop->creatives--import#drop click->creatives--import#pickFile">
     <%= t('collavre.creatives.index.drop_or_click_markdown') %>
-    <input type="file" id="import-markdown-input" accept=".md,.ppt,.pptx" style="display:none;" data-creatives--import-target="input" data-action="change->creatives--import#fileChanged" />
+    <input type="file" id="import-markdown-input" accept=".md,.pptx" style="display:none;" data-creatives--import-target="input" data-action="change->creatives--import#fileChanged" />
     <div id="import-markdown-progress" style="margin-top:1em;color:#0074d9;display:none;" data-creatives--import-target="progress"></div>
   </div>
 </div>

--- a/engines/collavre/collavre.gemspec
+++ b/engines/collavre/collavre.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
 
   # Markdown rendering
   spec.add_dependency "commonmarker"           # GitHub-flavored Markdown to HTML
+  spec.add_dependency "rubyzip", "< 4.0"        # PPTX archive parsing
 
   # Integrations
   spec.add_dependency "httparty"               # HTTP client for link previews and APIs
@@ -51,6 +52,4 @@ Gem::Specification.new do |spec|
   # GitHub integration:
   #   gem "octokit"
   #
-  # PPT/PPTX import:
-  #   gem "rubyzip"
 end

--- a/engines/collavre/config/locales/creatives.en.yml
+++ b/engines/collavre/config/locales/creatives.en.yml
@@ -51,6 +51,8 @@ en:
         import_uploading: Uploading...
         import_success: Import successful! Reloading...
         import_failed: Import failed.
+        imported_chart: Chart
+        imported_speaker_notes: Speaker notes
         export_markdown: Export to Markdown
         export_failed: Failed to export
         only_markdown: Only markdown (.md) or PowerPoint (.pptx) files are allowed.

--- a/engines/collavre/config/locales/creatives.ko.yml
+++ b/engines/collavre/config/locales/creatives.ko.yml
@@ -46,6 +46,8 @@ ko:
         import_uploading: 업로드 중...
         import_success: 가져오기 성공! 새로고침 중...
         import_failed: 가져오기 실패
+        imported_chart: 차트
+        imported_speaker_notes: 발표자 노트
         export_markdown: 마크다운 내보내기
         export_failed: 내보내기에 실패했습니다
         only_markdown: 마크다운(.md) 또는 파워포인트(.pptx) 파일만 가능합니다.

--- a/engines/collavre/test/controllers/creative_imports_controller_test.rb
+++ b/engines/collavre/test/controllers/creative_imports_controller_test.rb
@@ -31,6 +31,21 @@ class CreativeImportsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Invalid file type", json["error"]
   end
 
+  test "rejects legacy binary PowerPoint files" do
+    file = Rack::Test::UploadedFile.new(
+      file_fixture("invalid.txt"),
+      "application/vnd.ms-powerpoint",
+      original_filename: "legacy.ppt"
+    )
+
+    assert_no_difference("Creative.count") do
+      post collavre.creative_imports_path, params: { markdown: file }
+    end
+
+    assert_response :unprocessable_entity
+    assert_equal "Invalid file type", JSON.parse(response.body)["error"]
+  end
+
   test "returns unauthorized when user not signed in" do
     delete session_path
 

--- a/engines/collavre/test/services/ppt_importer_test.rb
+++ b/engines/collavre/test/services/ppt_importer_test.rb
@@ -1,84 +1,229 @@
 require "test_helper"
-require "zip"
 require "base64"
+require "zip"
 
 class PptImporterTest < ActiveSupport::TestCase
   SAMPLE_IMAGE = Base64.decode64("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAMAASsJTYQAAAAASUVORK5CYII=")
 
-  test "creates creatives with html for each slide" do
-    user = User.create!(email: "ppt@example.com", password: "password", name: "Presenter")
+  test "preserves presentation order and slide structure as responsive html" do
+    user = users(:one)
     parent = Creative.create!(user: user, description: "Root")
+    Creative.create!(user: user, parent: parent, description: "Existing", sequence: 4)
+    broadcasted = nil
 
     Tempfile.create([ "sample", ".pptx" ]) do |tmp|
       build_sample_pptx(tmp)
       tmp.rewind
 
-      created = PptImporter.import(tmp, parent: parent, user: user, create_root: false)
-
-      assert_equal 2, created.length
-      slide1_html = created.first.description
-      slide2_html = created.second.description
-
-      assert_includes slide1_html, "<p>Slide 1</p>"
-      assert_includes slide1_html, "img src=\"data:image/png;base64"
-      assert_includes slide2_html, "<p>Slide 2</p>"
+      Creative::RealtimeBroadcastable.stub(:broadcast_batch_created, ->(items) { broadcasted = items }) do
+        assert_difference -> { ActiveStorage::Blob.count }, +1 do
+          @created = PptImporter.import(tmp, parent: parent, user: user, create_root: false)
+        end
+      end
     end
+
+    assert_equal 2, @created.length
+    assert_equal [ 5, 6 ], @created.map(&:sequence)
+    assert_equal @created, broadcasted
+
+    # presentation.xml orders slide2 before slide1, independent of filenames.
+    assert_includes @created.first.description, "Second slide"
+
+    structured = @created.second.reload
+    html = Nokogiri::HTML.fragment(structured.description)
+    slide = html.at_css(".ppt-slide")
+    assert_equal "2", slide["data-ppt-slide"]
+    assert_equal "12192000", slide["data-ppt-width"]
+    assert slide["class"].include?("ppt-slide--wide")
+    assert html.at_css(".ppt-slide-title.ppt-col-2.ppt-row-2")
+    assert_equal "Title & intro", html.at_css(".ppt-slide-title").text.strip
+    assert html.at_css(".ppt-slide-group .ppt-slide-text"), "group hierarchy should remain nested"
+
+    image = html.at_css(".ppt-slide-image img")
+    assert_match(%r{\A/public-assets/blobs/}, image["src"])
+    assert_equal "Product screenshot", image["alt"]
+    assert_no_match(/data:image/, structured.description)
+    assert_equal 1, structured.files.count
+
+    assert_equal %w[Alpha Beta], html.css(".ppt-slide-table td").map { |cell| cell.text.strip }
+    assert_equal "Revenue", html.at_css(".ppt-slide-chart h3").text.strip
+    assert_includes html.at_css(".ppt-slide-chart").text, "Q1: 10"
+    assert_equal "Speaker notes", html.at_css(".ppt-slide-notes h3").text.strip
+    assert_includes html.at_css(".ppt-slide-notes").text, "Remember the demo"
+  end
+
+  test "creates an escaped root and broadcasts it before its slides" do
+    user = users(:one)
+    parent = Creative.create!(user: user, description: "Root")
+    broadcasted = nil
+
+    Tempfile.create([ "sample", ".pptx" ]) do |tmp|
+      build_minimal_pptx(tmp)
+      tmp.rewind
+
+      Creative::RealtimeBroadcastable.stub(:broadcast_batch_created, ->(items) { broadcasted = items }) do
+        @created = PptImporter.import(
+          tmp,
+          parent: parent,
+          user: user,
+          create_root: true,
+          filename: "<Quarterly>.pptx"
+        )
+      end
+    end
+
+    root, slide = @created
+    assert_equal "&lt;Quarterly&gt;", root.description
+    assert_equal root, slide.parent
+    assert_equal [ root, slide ], broadcasted
+  end
+
+  test "falls back to numeric slide filenames when presentation metadata is absent" do
+    user = users(:one)
+    parent = Creative.create!(user: user, description: "Root")
+
+    Tempfile.create([ "sample", ".pptx" ]) do |tmp|
+      Zip::OutputStream.open(tmp.path) do |zip|
+        write_entry(zip, "ppt/slides/slide10.xml", slide_xml("Ten"))
+        write_entry(zip, "ppt/slides/slide2.xml", slide_xml("Two"))
+      end
+      tmp.rewind
+
+      Creative::RealtimeBroadcastable.stub(:broadcast_batch_created, nil) do
+        @created = PptImporter.import(tmp, parent: parent, user: user)
+      end
+    end
+
+    assert_equal [ "Two", "Ten" ], @created.map { |creative| Nokogiri::HTML.fragment(creative.description).text.strip }
   end
 
   private
 
   def build_sample_pptx(tmp)
     Zip::OutputStream.open(tmp.path) do |zip|
-      slide1_xml = <<~XML
-        <p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
-               xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
-               xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
-          <p:cSld>
-            <p:spTree>
-              <p:sp>
-                <p:txBody>
-                  <a:p><a:r><a:t>Slide 1</a:t></a:r></a:p>
-                </p:txBody>
-              </p:sp>
-              <p:pic>
-                <p:blipFill>
-                  <a:blip r:embed="rId1"/>
-                </p:blipFill>
-              </p:pic>
-            </p:spTree>
-          </p:cSld>
-        </p:sld>
-      XML
-      zip.put_next_entry("ppt/slides/slide1.xml")
-      zip.write(slide1_xml)
-
-      rels1_xml = <<~XML
-        <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
-          <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="../media/image1.png"/>
-        </Relationships>
-      XML
-      zip.put_next_entry("ppt/slides/_rels/slide1.xml.rels")
-      zip.write(rels1_xml)
-
-      zip.put_next_entry("ppt/media/image1.png")
-      zip.write(SAMPLE_IMAGE)
-
-      slide2_xml = <<~XML
-        <p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
-               xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
-          <p:cSld>
-            <p:spTree>
-              <p:sp>
-                <p:txBody>
-                  <a:p><a:r><a:t>Slide 2</a:t></a:r></a:p>
-                </p:txBody>
-              </p:sp>
-            </p:spTree>
-          </p:cSld>
-        </p:sld>
-      XML
-      zip.put_next_entry("ppt/slides/slide2.xml")
-      zip.write(slide2_xml)
+      write_entry(zip, "ppt/presentation.xml", presentation_xml)
+      write_entry(zip, "ppt/_rels/presentation.xml.rels", presentation_relationships_xml)
+      write_entry(zip, "ppt/slides/slide1.xml", rich_slide_xml)
+      write_entry(zip, "ppt/slides/_rels/slide1.xml.rels", rich_slide_relationships_xml)
+      write_entry(zip, "ppt/slides/slide2.xml", slide_xml("Second slide"))
+      write_entry(zip, "ppt/media/image1.png", SAMPLE_IMAGE)
+      write_entry(zip, "ppt/charts/chart1.xml", chart_xml)
+      write_entry(zip, "ppt/notesSlides/notesSlide1.xml", notes_xml)
     end
+  end
+
+  def build_minimal_pptx(tmp)
+    Zip::OutputStream.open(tmp.path) do |zip|
+      write_entry(zip, "ppt/slides/slide1.xml", slide_xml("Only slide"))
+    end
+  end
+
+  def write_entry(zip, path, content)
+    zip.put_next_entry(path)
+    zip.write(content)
+  end
+
+  def presentation_xml
+    <<~XML
+      <p:presentation xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+                      xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+        <p:sldIdLst>
+          <p:sldId id="257" r:id="rId2"/>
+          <p:sldId id="256" r:id="rId1"/>
+        </p:sldIdLst>
+        <p:sldSz cx="12192000" cy="6858000"/>
+      </p:presentation>
+    XML
+  end
+
+  def presentation_relationships_xml
+    <<~XML
+      <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+        <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide1.xml"/>
+        <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide2.xml"/>
+      </Relationships>
+    XML
+  end
+
+  def slide_xml(text)
+    <<~XML
+      <p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+             xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+        <p:cSld><p:spTree><p:sp><p:txBody><a:p><a:r><a:t>#{text}</a:t></a:r></a:p></p:txBody></p:sp></p:spTree></p:cSld>
+      </p:sld>
+    XML
+  end
+
+  def rich_slide_xml
+    <<~XML
+      <p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+             xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+             xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+             xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+        <p:cSld><p:spTree>
+          <p:sp>
+            <p:nvSpPr><p:nvPr><p:ph type="title"/></p:nvPr></p:nvSpPr>
+            <p:spPr><a:xfrm><a:off x="609600" y="342900"/><a:ext cx="5486400" cy="685800"/></a:xfrm></p:spPr>
+            <p:txBody><a:p><a:r><a:rPr b="1"/><a:t>Title &amp; intro</a:t></a:r></a:p></p:txBody>
+          </p:sp>
+          <p:pic>
+            <p:nvPicPr><p:cNvPr name="Screenshot" descr="Product screenshot"/></p:nvPicPr>
+            <p:blipFill><a:blip r:embed="rIdImage"/></p:blipFill>
+            <p:spPr><a:xfrm><a:off x="6096000" y="342900"/><a:ext cx="5486400" cy="2743200"/></a:xfrm></p:spPr>
+          </p:pic>
+          <p:graphicFrame>
+            <p:xfrm><a:off x="609600" y="1714500"/><a:ext cx="4876800" cy="1371600"/></p:xfrm>
+            <a:graphic><a:graphicData><a:tbl>
+              <a:tr><a:tc><a:txBody><a:p><a:r><a:t>Alpha</a:t></a:r></a:p></a:txBody></a:tc>
+                    <a:tc><a:txBody><a:p><a:r><a:t>Beta</a:t></a:r></a:p></a:txBody></a:tc></a:tr>
+            </a:tbl></a:graphicData></a:graphic>
+          </p:graphicFrame>
+          <p:graphicFrame>
+            <p:xfrm><a:off x="609600" y="3429000"/><a:ext cx="4876800" cy="1714500"/></p:xfrm>
+            <a:graphic><a:graphicData><c:chart r:id="rIdChart"/></a:graphicData></a:graphic>
+          </p:graphicFrame>
+          <p:grpSp>
+            <p:grpSpPr><a:xfrm><a:off x="6096000" y="3429000"/><a:ext cx="4876800" cy="1714500"/><a:chOff x="0" y="0"/><a:chExt cx="4876800" cy="1714500"/></a:xfrm></p:grpSpPr>
+            <p:sp><p:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="2438400" cy="857250"/></a:xfrm></p:spPr>
+              <p:txBody><a:p><a:r><a:t>Grouped text</a:t></a:r></a:p></p:txBody></p:sp>
+          </p:grpSp>
+        </p:spTree></p:cSld>
+      </p:sld>
+    XML
+  end
+
+  def rich_slide_relationships_xml
+    <<~XML
+      <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+        <Relationship Id="rIdImage" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="../media/image1.png"/>
+        <Relationship Id="rIdChart" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart" Target="../charts/chart1.xml"/>
+        <Relationship Id="rIdNotes" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/notesSlide" Target="../notesSlides/notesSlide1.xml"/>
+      </Relationships>
+    XML
+  end
+
+  def chart_xml
+    <<~XML
+      <c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"
+                    xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+        <c:chart><c:title><c:tx><c:rich><a:p><a:r><a:t>Revenue</a:t></a:r></a:p></c:rich></c:tx></c:title>
+          <c:plotArea><c:barChart><c:ser><c:tx><c:v>Sales</c:v></c:tx>
+            <c:cat><c:strRef><c:strCache><c:pt idx="0"><c:v>Q1</c:v></c:pt></c:strCache></c:strRef></c:cat>
+            <c:val><c:numRef><c:numCache><c:pt idx="0"><c:v>10</c:v></c:pt></c:numCache></c:numRef></c:val>
+          </c:ser></c:barChart></c:plotArea>
+        </c:chart>
+      </c:chartSpace>
+    XML
+  end
+
+  def notes_xml
+    <<~XML
+      <p:notes xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+               xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+        <p:cSld><p:spTree><p:sp><p:nvSpPr><p:nvPr><p:ph type="body"/></p:nvPr></p:nvSpPr>
+          <p:txBody><a:p><a:r><a:t>Remember the demo</a:t></a:r></a:p></p:txBody>
+        </p:sp></p:spTree></p:cSld>
+      </p:notes>
+    XML
   end
 end


### PR DESCRIPTION
## Summary

- preserve PPTX presentation order and map slide coordinates onto responsive HTML grids
- import text formatting, grouped shapes, images, tables, charts, and speaker notes into each slide Creative
- store imported images in Active Storage instead of inline base64 data URIs
- assign deterministic Creative sequences and broadcast imported trees as one ordered batch
- make `rubyzip` a production dependency and reject unsupported legacy `.ppt` files

## User impact

Imported PPTX slides now retain their hierarchy and approximate layout as editable/renderable HTML. Images use the normal attachment lifecycle, and slides appear in the same order as the source presentation.

## Validation

- `bin/rails test engines/collavre/test/services/ppt_importer_test.rb engines/collavre/test/controllers/creative_imports_controller_test.rb engines/collavre/test/models/creative_test.rb`
- `bin/rubocop engines/collavre/app/services/collavre/ppt_importer.rb engines/collavre/test/services/ppt_importer_test.rb engines/collavre/app/services/collavre/creatives/importer.rb engines/collavre/app/models/collavre/creative/describable.rb engines/collavre/test/controllers/creative_imports_controller_test.rb engines/collavre/collavre.gemspec`
- `npm run build`

## Known check status

The repository-wide CSS lint still reports pre-existing violations in unchanged lines and files. The newly added PPT slide styles introduce no additional CSS lint findings.
