### PR TITLE
feat: add actionable empty state to creative tree view

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/creatives.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/creatives.css
@@ -1052,3 +1052,219 @@ creative-tree-row.is-being-edited .creative-tree {
     box-shadow: var(--shadow-2);
 }
 
+/* ============================================================================
+ * Creative tree — actionable empty state
+ * engines/collavre/app/views/collavre/creatives/_empty_state.html.erb
+ * Uses semantic tokens only, so dark mode (body.dark-mode) is automatic.
+ * ============================================================================ */
+.creative-empty-state {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    padding: var(--space-7) var(--space-3) var(--space-8);
+}
+
+.creative-empty-state-icon {
+    width: 56px;
+    height: 56px;
+    border-radius: var(--radius-round);
+    background: var(--surface-btn);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-bottom: var(--space-3);
+    color: var(--text-muted);
+}
+
+.creative-empty-state-icon svg {
+    width: 28px;
+    height: 28px;
+}
+
+.creative-empty-state-heading {
+    font-size: var(--text-1);
+    font-weight: var(--weight-6);
+    color: var(--text-primary);
+    margin: 0 0 var(--space-4);
+}
+
+/* --- Concept card: "what's a creative?" --- */
+.creative-empty-state-concept {
+    margin: 0 0 var(--space-4);
+    padding: var(--space-3) var(--space-4) var(--space-4);
+    border: 1px solid var(--border-color);
+    background: var(--surface-bg);
+    border-radius: 8px;
+    max-width: 560px;
+    width: 100%;
+}
+
+.creative-empty-state-concept-title {
+    font-size: var(--text-0);
+    font-weight: var(--weight-6);
+    color: var(--text-primary);
+    margin-bottom: var(--space-3);
+}
+
+.creative-empty-state-concept-diagram {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--space-2);
+    flex-wrap: wrap;
+}
+
+.creative-empty-state-facet {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 5px;
+    width: 84px;
+}
+
+.creative-empty-state-facet-chip {
+    width: 44px;
+    height: 44px;
+    border-radius: 10px;
+    border: 1px solid var(--border-color);
+    background: var(--surface-section);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-muted);
+}
+
+.creative-empty-state-facet-chip svg {
+    width: 20px;
+    height: 20px;
+}
+
+.creative-empty-state-facet-label {
+    font-size: var(--text-00);
+    color: var(--text-muted);
+    line-height: 1.3;
+    text-align: center;
+}
+
+.creative-empty-state-op {
+    color: var(--text-muted);
+    font-weight: var(--weight-6);
+    font-size: var(--text-1);
+    padding: 0 2px;
+    align-self: flex-start;
+    margin-top: 12px;
+}
+
+.creative-empty-state-block {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 5px;
+    border: 1.5px solid var(--color-active);
+    border-radius: 10px;
+    padding: 8px 12px;
+    background: var(--surface-section);
+}
+
+.creative-empty-state-block-icons {
+    display: flex;
+    gap: 6px;
+    color: var(--color-active);
+}
+
+.creative-empty-state-block-icons svg {
+    width: 15px;
+    height: 15px;
+}
+
+.creative-empty-state-block-label {
+    font-size: var(--text-00);
+    font-weight: var(--weight-6);
+    color: var(--text-primary);
+}
+
+.creative-empty-state-concept-caption {
+    font-size: var(--text-0);
+    color: var(--text-muted);
+    line-height: 1.55;
+    margin: var(--space-3) 0 0;
+    text-align: center;
+}
+
+/* --- Writable CTAs --- */
+.creative-empty-state-actions-row {
+    display: flex;
+    gap: var(--space-2);
+    flex-wrap: wrap;
+    justify-content: center;
+}
+
+.add-creative-btn--cta {
+    gap: 6px;
+}
+
+.add-creative-btn--cta svg {
+    width: 14px;
+    height: 14px;
+}
+
+.add-creative-btn-kbd {
+    font-family: inherit;
+    font-size: 10px;
+    background: rgba(255, 255, 255, 0.22);
+    border-radius: 3px;
+    padding: 1px 5px;
+    margin-left: 2px;
+}
+
+/* --- Read-only variant: write-access request --- */
+.creative-empty-state-readonly {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--space-2);
+}
+
+.creative-empty-state-readonly-message {
+    font-size: var(--text-0);
+    color: var(--text-muted);
+    margin: 0;
+    max-width: 340px;
+}
+
+/* Author-origin `display` beats the UA stylesheet's `[hidden] { display: none }`
+   regardless of selector specificity, so the [hidden] overrides below are
+   required or these elements would always render even while hidden — the
+   request button carries the global `.btn` class (display: inline-flex from
+   dark_mode.css), and the pending pill sets its own inline-flex below. */
+.creative-empty-state-readonly .btn[hidden],
+.creative-empty-state-request-pending[hidden] {
+    display: none;
+}
+
+.creative-empty-state-request-pending {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: var(--text-0);
+    color: var(--text-muted);
+    border: 1px solid var(--border-color);
+    border-radius: 999px;
+    padding: 6px 14px;
+    background: var(--surface-btn);
+}
+
+.creative-empty-state-request-pending-dot {
+    width: 7px;
+    height: 7px;
+    border-radius: var(--radius-round);
+    background: var(--color-brand);
+    animation: creative-empty-state-pulse 1.6s ease-in-out infinite;
+}
+
+@keyframes creative-empty-state-pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.35; }
+}
+

--- a/engines/collavre/app/assets/stylesheets/collavre/creatives.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/creatives.css
@@ -1268,3 +1268,18 @@ creative-tree-row.is-being-edited .creative-tree {
     50% { opacity: 0.35; }
 }
 
+/* --- Unauthenticated variant: sign up / log in --- */
+.creative-empty-state-loggedout {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--space-2);
+}
+
+.creative-empty-state-loggedout-message {
+    font-size: var(--text-0);
+    color: var(--text-muted);
+    margin: 0;
+    max-width: 340px;
+}
+

--- a/engines/collavre/app/controllers/collavre/concerns/shareable.rb
+++ b/engines/collavre/app/controllers/collavre/concerns/shareable.rb
@@ -5,7 +5,7 @@ module Collavre
 
       def request_permission
         creative = @creative.effective_origin
-        if creative.user == Current.user || creative.has_permission?(Current.user, :read)
+        if creative.user == Current.user || creative.has_permission?(Current.user, :write)
           return head :unprocessable_entity
         end
 

--- a/engines/collavre/app/controllers/collavre/concerns/shareable.rb
+++ b/engines/collavre/app/controllers/collavre/concerns/shareable.rb
@@ -9,14 +9,20 @@ module Collavre
           return head :unprocessable_entity
         end
 
+        # A requester who already has some access (read or feedback) is
+        # specifically asking for a write upgrade — distinguish that from a
+        # from-zero access request so the owner knows which one it is.
+        already_has_read_access = creative.has_permission?(Current.user, :read)
+
         short_title = helpers.strip_tags(creative.effective_origin.description).truncate(10)
         creative_path = Collavre::Engine.routes.url_helpers.creative_path(creative, open_comments: true)
         creative_link = "[#{short_title}](#{creative_path})"
 
         inbox_creative = Creative.inbox_for(creative.user)
         system_topic = inbox_creative.system_topic(fallback_user: creative.user)
+        i18n_key = already_has_read_access ? "inbox.write_permission_requested" : "inbox.permission_requested"
         msg = I18n.t(
-          "inbox.permission_requested",
+          i18n_key,
           user: Current.user.display_name,
           short_title: creative_link,
           locale: creative.user.locale || "en"

--- a/engines/collavre/app/controllers/collavre/creatives_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creatives_controller.rb
@@ -577,6 +577,8 @@ module Collavre
         ).to_h
       end
 
+      helper_method :any_filter_active?
+
       def any_filter_active?
         params[:tags].present? ||
           params[:min_progress].present? ||

--- a/engines/collavre/app/javascript/controllers/creatives/__tests__/tree_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/creatives/__tests__/tree_controller.test.js
@@ -598,4 +598,64 @@ describe('CreativesTreeController requestReload', () => {
 
     application.stop()
   })
+
+  // Switching rows is a stop immediately followed by a start, so a refetch drained
+  // on the stop is still sitting in the 300ms debounce when the next row opens.
+  // Checking _editing only at requestReload() time would let that timer fire and
+  // re-render the tree out from under the newly opened editor, taking the row it
+  // is attached to — and the draft inside it — out of the document.
+  test('keeps the deferred reload pending across a row switch', async () => {
+    const { application, controller, load } = await installConnected()
+
+    document.dispatchEvent(new CustomEvent('creative-editing:start'))
+    controller.requestReload()
+
+    // The switch: the outgoing row stops, the incoming row starts, both well
+    // inside the debounce window.
+    document.dispatchEvent(new CustomEvent('creative-editing:stop'))
+    document.dispatchEvent(new CustomEvent('creative-editing:start'))
+    jest.advanceTimersByTime(5000)
+
+    expect(load).not.toHaveBeenCalled()
+
+    application.stop()
+  })
+
+  test('runs the reload once the row opened by the switch is closed', async () => {
+    const { application, controller, load } = await installConnected()
+
+    document.dispatchEvent(new CustomEvent('creative-editing:start'))
+    controller.requestReload()
+    document.dispatchEvent(new CustomEvent('creative-editing:stop'))
+    document.dispatchEvent(new CustomEvent('creative-editing:start'))
+    jest.advanceTimersByTime(5000)
+    expect(load).not.toHaveBeenCalled()
+
+    document.dispatchEvent(new CustomEvent('creative-editing:stop'))
+    jest.advanceTimersByTime(300)
+
+    // Still exactly once: re-pending must not double-book the refetch.
+    expect(load).toHaveBeenCalledTimes(1)
+
+    application.stop()
+  })
+
+  // The re-check must not swallow the request: an editor that opens after the
+  // timer has already fired is a separate matter, but one that opens during the
+  // window has to leave the refetch queued rather than cancelled.
+  test('re-arms the pending flag when the timer fires mid-edit', async () => {
+    const { application, controller, load } = await installConnected()
+
+    controller.requestReload()
+    document.dispatchEvent(new CustomEvent('creative-editing:start'))
+    jest.advanceTimersByTime(300)
+    expect(load).not.toHaveBeenCalled()
+
+    document.dispatchEvent(new CustomEvent('creative-editing:stop'))
+    jest.advanceTimersByTime(300)
+
+    expect(load).toHaveBeenCalledTimes(1)
+
+    application.stop()
+  })
 })

--- a/engines/collavre/app/javascript/controllers/creatives/__tests__/tree_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/creatives/__tests__/tree_controller.test.js
@@ -268,3 +268,94 @@ describe('CreativesTreeController Chats pagination (load more)', () => {
     application.stop()
   })
 })
+
+describe('CreativesTreeController error state vs genuine-empty state', () => {
+  let originalFetch
+
+  const installControllerWithStates = () => {
+    const container = document.createElement('div')
+    container.setAttribute('data-controller', 'creatives--tree')
+    container.setAttribute('data-creatives--tree-url-value', '/creatives?format=json&id=991')
+    container.setAttribute(
+      'data-creatives--tree-empty-html-value',
+      '<div class="creative-empty-state"><button class="new-root-creative-btn">Add</button></div>'
+    )
+    container.setAttribute(
+      'data-creatives--tree-error-html-value',
+      '<p class="creative-tree-error">Could not load the creative tree.</p>'
+    )
+    document.body.appendChild(container)
+
+    const application = Application.start()
+    application.register('creatives--tree', TreeController)
+
+    return { container, application }
+  }
+
+  beforeEach(() => {
+    originalFetch = global.fetch
+  })
+
+  afterEach(() => {
+    global.fetch = originalFetch
+    document.body.innerHTML = ''
+    jest.restoreAllMocks()
+  })
+
+  test('a non-2xx response renders the distinct error state, not the actionable empty-state CTAs', async () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {})
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({}),
+    })
+
+    const { container, application } = installControllerWithStates()
+    await flush()
+    await flush()
+    await flush()
+
+    expect(container.querySelector('.creative-tree-error')).not.toBeNull()
+    expect(container.querySelector('.creative-empty-state')).toBeNull()
+    expect(container.querySelector('.new-root-creative-btn')).toBeNull()
+
+    application.stop()
+  })
+
+  test('a JSON parse failure renders the distinct error state, not the actionable empty-state CTAs', async () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {})
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => {
+        throw new SyntaxError('Unexpected token in JSON')
+      },
+    })
+
+    const { container, application } = installControllerWithStates()
+    await flush()
+    await flush()
+    await flush()
+
+    expect(container.querySelector('.creative-tree-error')).not.toBeNull()
+    expect(container.querySelector('.creative-empty-state')).toBeNull()
+    expect(container.querySelector('.new-root-creative-btn')).toBeNull()
+
+    application.stop()
+  })
+
+  test('a genuinely empty tree (successful response, zero creatives) still shows the actionable empty state', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ creatives: [] }),
+    })
+
+    const { container, application } = installControllerWithStates()
+    await flush()
+    await flush()
+
+    expect(container.querySelector('.new-root-creative-btn')).not.toBeNull()
+    expect(container.querySelector('.creative-tree-error')).toBeNull()
+
+    application.stop()
+  })
+})

--- a/engines/collavre/app/javascript/controllers/creatives/__tests__/tree_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/creatives/__tests__/tree_controller.test.js
@@ -658,4 +658,42 @@ describe('CreativesTreeController requestReload', () => {
 
     application.stop()
   })
+
+  test('keeps a pending reload held after editing stops until the operation finishes', async () => {
+    const { application, controller, load } = await installConnected()
+
+    document.dispatchEvent(new CustomEvent('creative-editing:start'))
+    controller.beginReloadHold()
+    controller.requestReload()
+    document.dispatchEvent(new CustomEvent('creative-editing:stop'))
+    jest.advanceTimersByTime(5000)
+
+    expect(load).not.toHaveBeenCalled()
+
+    controller.endReloadHold()
+    jest.advanceTimersByTime(300)
+
+    expect(load).toHaveBeenCalledTimes(1)
+
+    application.stop()
+  })
+
+  test('coalesces reloads across overlapping operation holds', async () => {
+    const { application, controller, load } = await installConnected()
+
+    controller.beginReloadHold()
+    controller.beginReloadHold()
+    controller.requestReload()
+    jest.advanceTimersByTime(5000)
+
+    controller.endReloadHold()
+    jest.advanceTimersByTime(5000)
+    expect(load).not.toHaveBeenCalled()
+
+    controller.endReloadHold()
+    jest.advanceTimersByTime(300)
+    expect(load).toHaveBeenCalledTimes(1)
+
+    application.stop()
+  })
 })

--- a/engines/collavre/app/javascript/controllers/creatives/__tests__/tree_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/creatives/__tests__/tree_controller.test.js
@@ -513,3 +513,89 @@ describe('CreativesTreeController error state vs genuine-empty state', () => {
     application.stop()
   })
 })
+
+// A reload replaces the whole container, so it takes the row an open editor is
+// attached to out of the document — along with the unsaved draft inside it.
+// Callers that reload in response to a request they fired earlier (archive /
+// unarchive, delete-with-promoted-children) can land at any moment, including
+// while the user has moved on and is editing a different row, so they go through
+// requestReload() rather than load().
+describe('CreativesTreeController requestReload', () => {
+  let originalFetch
+
+  // Stimulus connects asynchronously, so the controller instance only exists after
+  // a turn of the real event loop — hence fake timers are switched on afterwards,
+  // once connect()'s own initial load() is out of the way and can be stubbed out.
+  const installConnected = async () => {
+    const { container, application } = installController()
+    await flush()
+    const controller = application.getControllerForElementAndIdentifier(container, 'creatives--tree')
+    const load = jest.spyOn(controller, 'load').mockImplementation(() => {})
+    jest.useFakeTimers()
+    return { container, application, controller, load }
+  }
+
+  beforeEach(() => {
+    originalFetch = global.fetch
+    global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ creatives: [] }) })
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+    global.fetch = originalFetch
+    document.body.innerHTML = ''
+    jest.restoreAllMocks()
+  })
+
+  test('reloads when no editor is open', async () => {
+    const { application, controller, load } = await installConnected()
+
+    controller.requestReload()
+    jest.advanceTimersByTime(300)
+
+    expect(load).toHaveBeenCalledTimes(1)
+
+    application.stop()
+  })
+
+  test('defers the reload while a row is being edited', async () => {
+    const { application, controller, load } = await installConnected()
+
+    document.dispatchEvent(new CustomEvent('creative-editing:start'))
+    controller.requestReload()
+    jest.advanceTimersByTime(5000)
+
+    expect(load).not.toHaveBeenCalled()
+
+    application.stop()
+  })
+
+  test('runs the deferred reload once editing stops', async () => {
+    const { application, controller, load } = await installConnected()
+
+    document.dispatchEvent(new CustomEvent('creative-editing:start'))
+    controller.requestReload()
+    jest.advanceTimersByTime(5000)
+    expect(load).not.toHaveBeenCalled()
+
+    document.dispatchEvent(new CustomEvent('creative-editing:stop'))
+    jest.advanceTimersByTime(300)
+
+    expect(load).toHaveBeenCalledTimes(1)
+
+    application.stop()
+  })
+
+  test('does not reload on editing:stop when nothing was requested', async () => {
+    const { application, controller, load } = await installConnected()
+
+    document.dispatchEvent(new CustomEvent('creative-editing:start'))
+    document.dispatchEvent(new CustomEvent('creative-editing:stop'))
+    jest.advanceTimersByTime(5000)
+
+    expect(load).not.toHaveBeenCalled()
+    expect(controller).toBeDefined()
+
+    application.stop()
+  })
+})

--- a/engines/collavre/app/javascript/controllers/creatives/__tests__/write_access_request_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/creatives/__tests__/write_access_request_controller.test.js
@@ -78,4 +78,28 @@ describe('CreativesWriteAccessRequestController', () => {
     expect(button.hidden).toBe(false)
     expect(button.disabled).toBe(false)
   })
+
+  test('on a followed redirect to the sign-in page (expired session), navigates there instead of showing pending', async () => {
+    // fetch() follows redirects by default, so when the session has expired,
+    // Authentication#request_authentication redirects to the sign-in page and
+    // the browser lands on a 200 OK response for the login form itself. `ok`
+    // is therefore true even though no permission request was ever created —
+    // `redirected` is what actually distinguishes this from a real success.
+    const redirectSpy = jest
+      .spyOn(WriteAccessRequestController.prototype, 'redirectToSignIn')
+      .mockImplementation(() => {})
+
+    csrfFetch.mockResolvedValue({ ok: true, redirected: true, url: 'http://localhost/session/new' })
+
+    button.click()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(redirectSpy).toHaveBeenCalledWith('http://localhost/session/new')
+    expect(button.hidden).toBe(false)
+    const pending = container.querySelector('[data-creatives--write-access-request-target="pending"]')
+    expect(pending.hidden).toBe(true)
+
+    redirectSpy.mockRestore()
+  })
 })

--- a/engines/collavre/app/javascript/controllers/creatives/__tests__/write_access_request_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/creatives/__tests__/write_access_request_controller.test.js
@@ -5,22 +5,27 @@
 import { jest } from '@jest/globals'
 
 const csrfFetch = jest.fn()
+const alertDialog = jest.fn(() => Promise.resolve())
 
 jest.unstable_mockModule('../../../lib/api/csrf_fetch', () => ({
   default: csrfFetch,
+}))
+jest.unstable_mockModule('../../../lib/utils/dialog', () => ({
+  alertDialog,
 }))
 
 const { Application } = await import('@hotwired/stimulus')
 const WriteAccessRequestController = (await import('../write_access_request_controller')).default
 
 describe('CreativesWriteAccessRequestController', () => {
+  const failureMessage = '권한을 요청하지 못했습니다.'
   let application
   let container
   let button
 
   function markup() {
     return `
-      <div data-controller="creatives--write-access-request" data-creatives--write-access-request-url-value="/creatives/1/request_permission">
+      <div data-controller="creatives--write-access-request" data-creatives--write-access-request-url-value="/creatives/1/request_permission" data-creatives--write-access-request-failure-message-value="${failureMessage}">
         <button type="button" data-creatives--write-access-request-target="button" data-action="click->creatives--write-access-request#request">Request write access</button>
         <span data-creatives--write-access-request-target="pending" hidden>Access requested</span>
       </div>
@@ -29,6 +34,7 @@ describe('CreativesWriteAccessRequestController', () => {
 
   beforeEach(() => {
     csrfFetch.mockReset()
+    alertDialog.mockClear()
     document.body.innerHTML = markup()
     container = document.querySelector('[data-controller="creatives--write-access-request"]')
     button = container.querySelector('[data-creatives--write-access-request-target="button"]')
@@ -66,6 +72,7 @@ describe('CreativesWriteAccessRequestController', () => {
     expect(button.disabled).toBe(false)
     const pending = container.querySelector('[data-creatives--write-access-request-target="pending"]')
     expect(pending.hidden).toBe(true)
+    expect(alertDialog).toHaveBeenCalledWith(failureMessage)
   })
 
   test('on network error, re-enables the button', async () => {
@@ -77,6 +84,19 @@ describe('CreativesWriteAccessRequestController', () => {
 
     expect(button.hidden).toBe(false)
     expect(button.disabled).toBe(false)
+    expect(alertDialog).toHaveBeenCalledWith(failureMessage)
+  })
+
+  test('does not fall back to hardcoded copy when no localized failure message is rendered', async () => {
+    container.removeAttribute('data-creatives--write-access-request-failure-message-value')
+    csrfFetch.mockResolvedValue({ ok: false })
+
+    button.click()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(button.disabled).toBe(false)
+    expect(alertDialog).not.toHaveBeenCalled()
   })
 
   test('on a followed redirect to the sign-in page (expired session), navigates there instead of showing pending', async () => {

--- a/engines/collavre/app/javascript/controllers/creatives/__tests__/write_access_request_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/creatives/__tests__/write_access_request_controller.test.js
@@ -1,0 +1,81 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { jest } from '@jest/globals'
+
+const csrfFetch = jest.fn()
+
+jest.unstable_mockModule('../../../lib/api/csrf_fetch', () => ({
+  default: csrfFetch,
+}))
+
+const { Application } = await import('@hotwired/stimulus')
+const WriteAccessRequestController = (await import('../write_access_request_controller')).default
+
+describe('CreativesWriteAccessRequestController', () => {
+  let application
+  let container
+  let button
+
+  function markup() {
+    return `
+      <div data-controller="creatives--write-access-request" data-creatives--write-access-request-url-value="/creatives/1/request_permission">
+        <button type="button" data-creatives--write-access-request-target="button" data-action="click->creatives--write-access-request#request">Request write access</button>
+        <span data-creatives--write-access-request-target="pending" hidden>Access requested</span>
+      </div>
+    `
+  }
+
+  beforeEach(() => {
+    csrfFetch.mockReset()
+    document.body.innerHTML = markup()
+    container = document.querySelector('[data-controller="creatives--write-access-request"]')
+    button = container.querySelector('[data-creatives--write-access-request-target="button"]')
+
+    application = Application.start()
+    application.register('creatives--write-access-request', WriteAccessRequestController)
+  })
+
+  afterEach(() => {
+    application.stop()
+    document.body.innerHTML = ''
+  })
+
+  test('on success, hides the button and shows the pending pill', async () => {
+    csrfFetch.mockResolvedValue({ ok: true })
+
+    button.click()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(csrfFetch).toHaveBeenCalledWith('/creatives/1/request_permission', { method: 'POST' })
+    expect(button.hidden).toBe(true)
+    const pending = container.querySelector('[data-creatives--write-access-request-target="pending"]')
+    expect(pending.hidden).toBe(false)
+  })
+
+  test('on non-ok response, re-enables the button and does not show the pending pill', async () => {
+    csrfFetch.mockResolvedValue({ ok: false })
+
+    button.click()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(button.hidden).toBe(false)
+    expect(button.disabled).toBe(false)
+    const pending = container.querySelector('[data-creatives--write-access-request-target="pending"]')
+    expect(pending.hidden).toBe(true)
+  })
+
+  test('on network error, re-enables the button', async () => {
+    csrfFetch.mockRejectedValue(new Error('network down'))
+
+    button.click()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(button.hidden).toBe(false)
+    expect(button.disabled).toBe(false)
+  })
+})

--- a/engines/collavre/app/javascript/controllers/creatives/tree_controller.js
+++ b/engines/collavre/app/javascript/controllers/creatives/tree_controller.js
@@ -8,6 +8,7 @@ export default class extends Controller {
   static values = {
     url: String,
     emptyHtml: String,
+    errorHtml: String,
   }
 
   connect() {
@@ -187,7 +188,7 @@ export default class extends Controller {
         }
         console.error(error)
         this.hideLoadingIndicator()
-        this.showEmptyState()
+        this.showErrorState()
       })
   }
 
@@ -341,6 +342,19 @@ export default class extends Controller {
 
   showEmptyState() {
     const html = this.hasEmptyHtmlValue ? this.emptyHtmlValue : ''
+    this.element.innerHTML = html
+    this.markContentLoaded()
+    document.documentElement.classList.add('creative-alignment-ready')
+  }
+
+  // Distinct from showEmptyState(): used when the tree fetch itself fails
+  // (non-2xx, JSON parse failure, or a non-transient network error after
+  // retries are exhausted). The request never actually confirmed the tree is
+  // empty, so this must NOT render the Add/Import creation CTAs — a workspace
+  // that genuinely has creatives would otherwise look empty and invite
+  // duplicate creation.
+  showErrorState() {
+    const html = this.hasErrorHtmlValue ? this.errorHtmlValue : ''
     this.element.innerHTML = html
     this.markContentLoaded()
     document.documentElement.classList.add('creative-alignment-ready')

--- a/engines/collavre/app/javascript/controllers/creatives/tree_controller.js
+++ b/engines/collavre/app/javascript/controllers/creatives/tree_controller.js
@@ -51,13 +51,7 @@ export default class extends Controller {
     this.element.addEventListener('creative-tree:updated', this.handleTreeUpdated)
     document.addEventListener('creative-editing:start', this._handleEditStart)
     document.addEventListener('creative-editing:stop', this._handleEditStop)
-    this._handleSyncRefetch = () => {
-      if (this._editing) {
-        this._pendingRefetch = true
-        return
-      }
-      this.debouncedLoad()
-    }
+    this._handleSyncRefetch = () => this.requestReload()
     document.addEventListener('creative-sync:refetch', this._handleSyncRefetch)
     this._setupArchiveToggle()
   }
@@ -152,6 +146,25 @@ export default class extends Controller {
   debouncedLoad() {
     if (this._debouncedLoadTimer) clearTimeout(this._debouncedLoadTimer)
     this._debouncedLoadTimer = setTimeout(() => this.load(), 300)
+  }
+
+  // Editing-aware reload — the entry point for anything that wants the tree
+  // refetched in response to something that already happened elsewhere (the sync
+  // channel, an archive/unarchive that landed, a delete that promoted children to
+  // the root). load() replaces the whole container, which takes the row an open
+  // editor is attached to out of the document along with the unsaved draft inside
+  // it; those callers can land at any moment, including long after the user has
+  // moved on to editing a different row. So the reload waits for
+  // `creative-editing:stop`, which _handleEditStop drains.
+  //
+  // Call load() directly only for reloads the user just asked for and is waiting
+  // on (filter change, archive toggle), where re-rendering is the point.
+  requestReload() {
+    if (this._editing) {
+      this._pendingRefetch = true
+      return
+    }
+    this.debouncedLoad()
   }
 
   load() {

--- a/engines/collavre/app/javascript/controllers/creatives/tree_controller.js
+++ b/engines/collavre/app/javascript/controllers/creatives/tree_controller.js
@@ -24,6 +24,7 @@ export default class extends Controller {
     this.abortController = null
     this.loadingIndicator = null
     this._editing = false
+    this._reloadHoldCount = 0
     this._pagination = null
     this._sentinel = null
     this._sentinelObserver = null
@@ -37,10 +38,7 @@ export default class extends Controller {
       this._editing = false
       // Apply any pending sync data that was deferred while editing
       this._applyPendingSyncData()
-      if (this._pendingRefetch) {
-        this._pendingRefetch = false
-        this.debouncedLoad()
-      }
+      this._drainPendingReload()
     }
     document.documentElement.classList.remove('creative-alignment-ready')
     if (!this.hasCachedContent()) {
@@ -153,7 +151,7 @@ export default class extends Controller {
       // replaces the whole container, which would take that row, the editor
       // attached inside it and the unsaved draft out of the document. Re-pend
       // instead of dropping it: the reload is still owed, just not yet safe.
-      if (this._editing) {
+      if (this._editing || this._reloadHoldCount > 0) {
         this._pendingRefetch = true
         return
       }
@@ -173,10 +171,28 @@ export default class extends Controller {
   // Call load() directly only for reloads the user just asked for and is waiting
   // on (filter change, archive toggle), where re-rendering is the point.
   requestReload() {
-    if (this._editing) {
+    if (this._editing || this._reloadHoldCount > 0) {
       this._pendingRefetch = true
       return
     }
+    this.debouncedLoad()
+  }
+
+  // Keep editing-aware reloads pending while an operation is between its local
+  // edit flush and its server response. The counter makes overlapping requests
+  // release independently without allowing an early reload between them.
+  beginReloadHold() {
+    this._reloadHoldCount += 1
+  }
+
+  endReloadHold() {
+    if (this._reloadHoldCount > 0) this._reloadHoldCount -= 1
+    this._drainPendingReload()
+  }
+
+  _drainPendingReload() {
+    if (!this._pendingRefetch || this._editing || this._reloadHoldCount > 0) return
+    this._pendingRefetch = false
     this.debouncedLoad()
   }
 

--- a/engines/collavre/app/javascript/controllers/creatives/tree_controller.js
+++ b/engines/collavre/app/javascript/controllers/creatives/tree_controller.js
@@ -145,7 +145,20 @@ export default class extends Controller {
 
   debouncedLoad() {
     if (this._debouncedLoadTimer) clearTimeout(this._debouncedLoadTimer)
-    this._debouncedLoadTimer = setTimeout(() => this.load(), 300)
+    this._debouncedLoadTimer = setTimeout(() => {
+      // Re-check rather than trusting the check requestReload() already made.
+      // Switching rows is a `creative-editing:stop` immediately followed by a
+      // `creative-editing:start`, so a refetch drained on the stop is still
+      // sitting in this debounce window when the next row opens — and load()
+      // replaces the whole container, which would take that row, the editor
+      // attached inside it and the unsaved draft out of the document. Re-pend
+      // instead of dropping it: the reload is still owed, just not yet safe.
+      if (this._editing) {
+        this._pendingRefetch = true
+        return
+      }
+      this.load()
+    }, 300)
   }
 
   // Editing-aware reload — the entry point for anything that wants the tree

--- a/engines/collavre/app/javascript/controllers/creatives/write_access_request_controller.js
+++ b/engines/collavre/app/javascript/controllers/creatives/write_access_request_controller.js
@@ -1,5 +1,6 @@
 import { Controller } from '@hotwired/stimulus'
 import csrfFetch from '../../lib/api/csrf_fetch'
+import { alertDialog } from '../../lib/utils/dialog'
 
 // Powers the "Request write access" CTA in the creative tree's empty state
 // (see engines/collavre/app/views/collavre/creatives/_empty_state.html.erb).
@@ -13,7 +14,7 @@ import csrfFetch from '../../lib/api/csrf_fetch'
 // see the PR description for the alternatives considered.
 export default class extends Controller {
   static targets = ['button', 'pending']
-  static values = { url: String }
+  static values = { url: String, failureMessage: String }
 
   async request(event) {
     event.preventDefault()
@@ -32,11 +33,16 @@ export default class extends Controller {
       } else if (response.ok) {
         this.showPending()
       } else {
-        this.buttonTarget.disabled = false
+        this.reportFailure()
       }
     } catch {
-      this.buttonTarget.disabled = false
+      this.reportFailure()
     }
+  }
+
+  reportFailure() {
+    this.buttonTarget.disabled = false
+    if (this.hasFailureMessageValue) alertDialog(this.failureMessageValue)
   }
 
   showPending() {

--- a/engines/collavre/app/javascript/controllers/creatives/write_access_request_controller.js
+++ b/engines/collavre/app/javascript/controllers/creatives/write_access_request_controller.js
@@ -22,7 +22,14 @@ export default class extends Controller {
     this.buttonTarget.disabled = true
     try {
       const response = await csrfFetch(this.urlValue, { method: 'POST' })
-      if (response.ok) {
+      if (response.redirected) {
+        // fetch() follows redirects by default, so an expired session sends
+        // this POST to the sign-in page instead of the permission endpoint —
+        // the final response is a 200 for the login form, not a request
+        // confirmation. Send the browser to the page it actually landed on
+        // rather than claiming the request went through.
+        this.redirectToSignIn(response.url)
+      } else if (response.ok) {
         this.showPending()
       } else {
         this.buttonTarget.disabled = false
@@ -37,5 +44,9 @@ export default class extends Controller {
     if (this.hasPendingTarget) {
       this.pendingTarget.hidden = false
     }
+  }
+
+  redirectToSignIn(url) {
+    window.location.href = url
   }
 }

--- a/engines/collavre/app/javascript/controllers/creatives/write_access_request_controller.js
+++ b/engines/collavre/app/javascript/controllers/creatives/write_access_request_controller.js
@@ -1,0 +1,41 @@
+import { Controller } from '@hotwired/stimulus'
+import csrfFetch from '../../lib/api/csrf_fetch'
+
+// Powers the "Request write access" CTA in the creative tree's empty state
+// (see engines/collavre/app/views/collavre/creatives/_empty_state.html.erb).
+//
+// There is no backend concept of a "pending request" — Collavre::Concerns::Shareable#request_permission
+// just fires a one-off inbox notification to the owner, it doesn't persist request
+// state anywhere. So the "pending" pill here is a purely client-side, one-time
+// confirmation that the click went through: it swaps in immediately after a
+// successful POST and does NOT survive a page reload (a reload has no way to
+// know a request is outstanding). That's an intentional, honest scope cut —
+// see the PR description for the alternatives considered.
+export default class extends Controller {
+  static targets = ['button', 'pending']
+  static values = { url: String }
+
+  async request(event) {
+    event.preventDefault()
+    if (!this.hasUrlValue || !this.hasButtonTarget) return
+
+    this.buttonTarget.disabled = true
+    try {
+      const response = await csrfFetch(this.urlValue, { method: 'POST' })
+      if (response.ok) {
+        this.showPending()
+      } else {
+        this.buttonTarget.disabled = false
+      }
+    } catch {
+      this.buttonTarget.disabled = false
+    }
+  }
+
+  showPending() {
+    this.buttonTarget.hidden = true
+    if (this.hasPendingTarget) {
+      this.pendingTarget.hidden = false
+    }
+  }
+}

--- a/engines/collavre/app/javascript/controllers/index.js
+++ b/engines/collavre/app/javascript/controllers/index.js
@@ -10,6 +10,7 @@ import CreativesExpansionController from "./creatives/expansion_controller"
 import CreativesRowEditorController from "./creatives/row_editor_controller"
 import CreativesTreeController from "./creatives/tree_controller"
 import CreativesSyncController from "./creatives/sync_controller"
+import CreativesWriteAccessRequestController from "./creatives/write_access_request_controller"
 import CommentsListController from "./comments/list_controller"
 import CommentsFormController from "./comments/form_controller"
 import CommentsPresenceController from "./comments/presence_controller"
@@ -88,6 +89,7 @@ export function registerControllers(application) {
   application.register("creatives--row-editor", CreativesRowEditorController)
   application.register("creatives--tree", CreativesTreeController)
   application.register("creatives--sync", CreativesSyncController)
+  application.register("creatives--write-access-request", CreativesWriteAccessRequestController)
   application.register("comments--list", CommentsListController)
   application.register("comments--form", CommentsFormController)
   application.register("comments--presence", CommentsPresenceController)

--- a/engines/collavre/app/javascript/modules/__tests__/creative_row_editor_archive.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/creative_row_editor_archive.test.js
@@ -277,6 +277,81 @@ test('shows no alert when the localized archive failure message is absent', asyn
   expect(container().querySelectorAll('creative-tree-row')).toHaveLength(1)
 })
 
+// The pre-flush closes the editor before the request goes out, and the row stays
+// on screen and clickable while it is in flight. Nothing stops the user reopening
+// that very row and typing again — and the editor template is attached *inside*
+// the row, so removing the row on success takes the newer draft out of the
+// document with no flush and no feedback.
+test('does not remove the archived row when the editor was reopened on it', async () => {
+  const template = renderTree(['42'])
+  const { requestReload } = stubTreeController()
+  let settleArchive
+  archive.mockReturnValueOnce(new Promise((resolve) => { settleArchive = resolve }))
+
+  await archiveCreative('42')
+  expect(archive).toHaveBeenCalledWith('42')
+
+  // Still in flight: the user reopens the same row and starts a new draft.
+  openEditorWithPendingEdit('42')
+
+  settleArchive({ ok: true })
+  await flush()
+  await flush()
+
+  expect(container().querySelector('creative-tree-row[creative-id="42"]')).not.toBeNull()
+  expect(template.style.display).toBe('block')
+  // Handed to the editing-aware reload instead, which holds the re-render until
+  // the user closes the editor.
+  expect(requestReload).toHaveBeenCalledTimes(1)
+})
+
+// The guard is about the draft, not about archiving being slow: an editor sitting
+// on some other row is unaffected by removing this one, so that still happens
+// immediately rather than waiting for the user to finish an unrelated edit.
+test('still removes the archived row when the editor was reopened elsewhere', async () => {
+  renderTree(['42', '43'])
+  const { requestReload } = stubTreeController()
+  let settleArchive
+  archive.mockReturnValueOnce(new Promise((resolve) => { settleArchive = resolve }))
+
+  await archiveCreative('42')
+  openEditorWithPendingEdit('43')
+
+  settleArchive({ ok: true })
+  await flush()
+  await flush()
+
+  expect(container().querySelector('creative-tree-row[creative-id="42"]')).toBeNull()
+  expect(container().querySelector('creative-tree-row[creative-id="43"]')).not.toBeNull()
+  expect(requestReload).not.toHaveBeenCalled()
+})
+
+// Archiving a parent drops its children container too, so an editor reopened on a
+// child row is in exactly the same danger as one on the row itself.
+test('does not remove the archived subtree when the editor was reopened on a child', async () => {
+  renderTree(['42'])
+  container().insertAdjacentHTML('beforeend',
+    `<div class="creative-children" id="creative-children-42">${
+      '<creative-tree-row creative-id="99" data-description-raw-html="hi" data-progress-value="0">' +
+      '<div class="creative-tree" id="creative-99" data-id="99" data-level="2"></div>' +
+      '</creative-tree-row>'
+    }</div>`)
+  const { requestReload } = stubTreeController()
+  let settleArchive
+  archive.mockReturnValueOnce(new Promise((resolve) => { settleArchive = resolve }))
+
+  await archiveCreative('42')
+  openEditorWithPendingEdit('99')
+
+  settleArchive({ ok: true })
+  await flush()
+  await flush()
+
+  expect(document.getElementById('creative-children-42')).not.toBeNull()
+  expect(container().querySelector('creative-tree-row[creative-id="42"]')).not.toBeNull()
+  expect(requestReload).toHaveBeenCalledTimes(1)
+})
+
 test('declining the archive confirmation leaves the row in place', async () => {
   confirmDialog.mockResolvedValueOnce(false)
   renderTree(['42'])

--- a/engines/collavre/app/javascript/modules/__tests__/creative_row_editor_archive.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/creative_row_editor_archive.test.js
@@ -144,22 +144,51 @@ test('archiving one of several rows leaves the placeholder off the page', async 
   expect(placeholder()).toBeNull()
 })
 
-test('restoring an archived row reloads the tree instead of removing it', async () => {
+// Stimulus renders `data-controller="creatives--tree creatives--sync"` on #creatives,
+// so the fixture carries both identifiers: an exact-match attribute selector for the
+// first one alone does not match that, which is how the reload came to be skipped
+// entirely in the browser.
+function stubTreeController() {
+  const treeEl = container()
+  treeEl.setAttribute('data-controller', 'creatives--tree creatives--sync')
+  treeEl.dataset.loaded = 'true'
+  const requestReload = jest.fn()
+  const load = jest.fn()
+  window.Stimulus = {
+    getControllerForElementAndIdentifier: jest.fn((el, identifier) =>
+      el === treeEl && identifier === 'creatives--tree' ? { requestReload, load } : null,
+    ),
+  }
+  return { treeEl, requestReload, load }
+}
+
+test('restoring an archived row asks the tree controller for an editing-aware reload', async () => {
   renderTree(['42'])
   document.querySelector('creative-tree-row[creative-id="42"]').setAttribute('archived', '')
-  const treeEl = container()
-  treeEl.setAttribute('data-controller', 'creatives--tree')
-  treeEl.dataset.loaded = 'true'
-  const load = jest.fn()
-  window.Stimulus = { getControllerForElementAndIdentifier: jest.fn(() => ({ load })) }
+  const { requestReload, load } = stubTreeController()
 
   await archiveCreative('42')
 
   expect(unarchive).toHaveBeenCalledWith('42')
   expect(archive).not.toHaveBeenCalled()
-  expect(load).toHaveBeenCalledTimes(1)
-  expect(treeEl.dataset.loaded).toBeUndefined()
-  expect(treeEl.innerHTML).toBe('')
+  expect(requestReload).toHaveBeenCalledTimes(1)
+  // load() bypasses the controller's `_editing` guard, so it must not be used here.
+  expect(load).not.toHaveBeenCalled()
+})
+
+// The unarchive request is in flight for an unbounded time, so the user can open
+// another row and start typing before it lands. Wiping the container here would
+// take that row — and the editor attached inside it — out of the document, losing
+// the newer draft. Deciding when it is safe to re-render is the controller's job.
+test('restoring an archived row does not wipe the tree itself', async () => {
+  renderTree(['42'])
+  document.querySelector('creative-tree-row[creative-id="42"]').setAttribute('archived', '')
+  const { treeEl } = stubTreeController()
+
+  await archiveCreative('42')
+
+  expect(treeEl.querySelector('creative-tree-row')).not.toBeNull()
+  expect(treeEl.dataset.loaded).toBe('true')
 })
 
 test('flushes a pending edit before dropping the archived row', async () => {
@@ -226,16 +255,12 @@ test('alerts and leaves the row alone when the archive request rejects', async (
 test('alerts with the restore message and skips the reload when unarchive fails', async () => {
   renderTree(['42'])
   document.querySelector('creative-tree-row[creative-id="42"]').setAttribute('archived', '')
-  const treeEl = container()
-  treeEl.setAttribute('data-controller', 'creatives--tree')
-  treeEl.dataset.loaded = 'true'
-  const load = jest.fn()
-  window.Stimulus = { getControllerForElementAndIdentifier: jest.fn(() => ({ load })) }
+  const { treeEl, requestReload } = stubTreeController()
   unarchive.mockResolvedValueOnce({ ok: false })
 
   await archiveCreative('42')
 
-  expect(load).not.toHaveBeenCalled()
+  expect(requestReload).not.toHaveBeenCalled()
   expect(treeEl.dataset.loaded).toBe('true')
   expect(alertDialog).toHaveBeenCalledWith(RESTORE_FAILED_MESSAGE)
 })

--- a/engines/collavre/app/javascript/modules/__tests__/creative_row_editor_archive.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/creative_row_editor_archive.test.js
@@ -168,16 +168,13 @@ test('flushes a pending edit before dropping the archived row', async () => {
   expect(placeholder()).not.toBeNull()
 })
 
-// The archive request has already landed on the server by the time the editor is
-// flushed, and an update_all archive broadcasts no destroy, so a failed flush must
-// not leave the archived row on screen with nothing to repair it.
-//
-// A failed flush no longer rejects — saveForm() surfaces it through the save status
-// and an alert rather than rethrowing (rethrowing only stranded an unhandled
-// rejection and aborted the caller mid-switch). So the feedback to assert on here is
-// the alert, not a console.error; and because the row is about to be detached, the
-// editor must end up closed rather than re-opened on it by the recovery path.
-test('still removes the archived row when the pending save fails', async () => {
+// The pending edit is flushed before the archive request goes out, so a failed
+// flush aborts the whole action while the server is still untouched. That is what
+// makes the alert honest: it tells the user their edits are still open, and they
+// are — the row stays, the editor stays on it with the draft, and nothing was
+// archived. Doing it the other way round forced a choice between stranding the
+// archived row on screen and silently discarding the draft.
+test('does not archive when the pending save fails, and keeps the draft', async () => {
   const template = renderTree(['42'])
   save.mockRejectedValueOnce(new Error('network down'))
   openEditorWithPendingEdit('42')
@@ -185,11 +182,11 @@ test('still removes the archived row when the pending save fails', async () => {
   await archiveCreative('42')
 
   expect(save).toHaveBeenCalledTimes(1)
-  expect(container().querySelector('creative-tree-row')).toBeNull()
-  expect(placeholder()).not.toBeNull()
-  expect(placeholder().hidden).toBe(false)
+  expect(archive).not.toHaveBeenCalled()
+  expect(container().querySelector('creative-tree-row')).not.toBeNull()
   expect(alertDialog).toHaveBeenCalledWith(SAVE_FAILED_MESSAGE)
-  expect(template.style.display).toBe('none')
+  // The editor is still open on the row, holding the rejected draft.
+  expect(template.style.display).toBe('block')
 })
 
 test('declining the archive confirmation leaves the row in place', async () => {

--- a/engines/collavre/app/javascript/modules/__tests__/creative_row_editor_archive.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/creative_row_editor_archive.test.js
@@ -154,12 +154,16 @@ function stubTreeController() {
   treeEl.dataset.loaded = 'true'
   const requestReload = jest.fn()
   const load = jest.fn()
+  const beginReloadHold = jest.fn()
+  const endReloadHold = jest.fn()
   window.Stimulus = {
     getControllerForElementAndIdentifier: jest.fn((el, identifier) =>
-      el === treeEl && identifier === 'creatives--tree' ? { requestReload, load } : null,
+      el === treeEl && identifier === 'creatives--tree'
+        ? { requestReload, load, beginReloadHold, endReloadHold }
+        : null,
     ),
   }
-  return { treeEl, requestReload, load }
+  return { treeEl, requestReload, load, beginReloadHold, endReloadHold }
 }
 
 test('restoring an archived row asks the tree controller for an editing-aware reload', async () => {
@@ -202,6 +206,26 @@ test('flushes a pending edit before dropping the archived row', async () => {
   expect(placeholder()).not.toBeNull()
 })
 
+test('holds deferred tree reloads until the archive response is applied', async () => {
+  renderTree(['42'])
+  openEditorWithPendingEdit('42')
+  const { beginReloadHold, endReloadHold } = stubTreeController()
+  let settleArchive
+  archive.mockReturnValueOnce(new Promise((resolve) => { settleArchive = resolve }))
+
+  await archiveCreative('42')
+
+  expect(beginReloadHold).toHaveBeenCalledTimes(1)
+  expect(archive).toHaveBeenCalledWith('42')
+  expect(endReloadHold).not.toHaveBeenCalled()
+
+  settleArchive({ ok: true })
+  await flush()
+  await flush()
+
+  expect(endReloadHold).toHaveBeenCalledTimes(1)
+})
+
 // The pending edit is flushed before the archive request goes out, so a failed
 // flush aborts the whole action while the server is still untouched. That is what
 // makes the alert honest: it tells the user their edits are still open, and they
@@ -210,6 +234,7 @@ test('flushes a pending edit before dropping the archived row', async () => {
 // archived row on screen and silently discarding the draft.
 test('does not archive when the pending save fails, and keeps the draft', async () => {
   const template = renderTree(['42'])
+  const { beginReloadHold, endReloadHold } = stubTreeController()
   save.mockRejectedValueOnce(new Error('network down'))
   openEditorWithPendingEdit('42')
 
@@ -219,6 +244,8 @@ test('does not archive when the pending save fails, and keeps the draft', async 
   expect(archive).not.toHaveBeenCalled()
   expect(container().querySelector('creative-tree-row')).not.toBeNull()
   expect(alertDialog).toHaveBeenCalledWith(SAVE_FAILED_MESSAGE)
+  expect(beginReloadHold).toHaveBeenCalledTimes(1)
+  expect(endReloadHold).toHaveBeenCalledTimes(1)
   // The editor is still open on the row, holding the rejected draft.
   expect(template.style.display).toBe('block')
 })

--- a/engines/collavre/app/javascript/modules/__tests__/creative_row_editor_archive.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/creative_row_editor_archive.test.js
@@ -53,6 +53,8 @@ const EMPTY_HTML = '<div data-creatives-empty-state=""><p>No sub-creatives found
 
 // Non-English on purpose: a literal baked into the module would fail the assertion.
 const SAVE_FAILED_MESSAGE = '저장하지 못했습니다.'
+const ARCHIVE_FAILED_MESSAGE = '아카이브하지 못했습니다.'
+const RESTORE_FAILED_MESSAGE = '복원하지 못했습니다.'
 
 const flush = () => new Promise((resolve) => setTimeout(resolve, 0))
 
@@ -68,7 +70,7 @@ function rowMarkup(id) {
 
 // Post-client-render state: tree_controller wiped #creatives and rendered rows
 // into it, so only the out-of-container template holds a pristine placeholder.
-function renderTree(rowIds) {
+function renderTree(rowIds, editorOverrides = {}) {
   document.body.innerHTML = `
     <template id="creatives-empty-state-template">${EMPTY_HTML}</template>
     <div id="creatives">${rowIds.map(rowMarkup).join('')}</div>
@@ -76,6 +78,9 @@ function renderTree(rowIds) {
   `
   const template = buildEditorDom(document.getElementById('center-frame'), {
     saveFailedMessage: SAVE_FAILED_MESSAGE,
+    archiveFailedMessage: ARCHIVE_FAILED_MESSAGE,
+    restoreFailedMessage: RESTORE_FAILED_MESSAGE,
+    ...editorOverrides,
   })
   initializeCreativeRowEditor()
   return template
@@ -187,6 +192,64 @@ test('does not archive when the pending save fails, and keeps the draft', async 
   expect(alertDialog).toHaveBeenCalledWith(SAVE_FAILED_MESSAGE)
   // The editor is still open on the row, holding the rejected draft.
   expect(template.style.display).toBe('block')
+})
+
+// The flush happens before the request, so by the time the request itself fails
+// the editor is already closed and currentTree cleared. The row is untouched and
+// the draft is safely on the server, but the handler used to `return` on a non-OK
+// response and had no rejection handler at all, so the action just evaporated:
+// editor unexpectedly closed, row still unarchived, nothing said.
+test('alerts and leaves the row alone when the archive request returns non-OK', async () => {
+  renderTree(['42'])
+  archive.mockResolvedValueOnce({ ok: false })
+
+  await archiveCreative('42')
+
+  expect(archive).toHaveBeenCalledWith('42')
+  expect(container().querySelectorAll('creative-tree-row')).toHaveLength(1)
+  expect(placeholder()).toBeNull()
+  expect(alertDialog).toHaveBeenCalledWith(ARCHIVE_FAILED_MESSAGE)
+})
+
+// An unhandled rejection here fails the test run, which is the other half of
+// what this covers.
+test('alerts and leaves the row alone when the archive request rejects', async () => {
+  renderTree(['42'])
+  archive.mockRejectedValueOnce(new Error('network down'))
+
+  await archiveCreative('42')
+
+  expect(container().querySelectorAll('creative-tree-row')).toHaveLength(1)
+  expect(alertDialog).toHaveBeenCalledWith(ARCHIVE_FAILED_MESSAGE)
+})
+
+test('alerts with the restore message and skips the reload when unarchive fails', async () => {
+  renderTree(['42'])
+  document.querySelector('creative-tree-row[creative-id="42"]').setAttribute('archived', '')
+  const treeEl = container()
+  treeEl.setAttribute('data-controller', 'creatives--tree')
+  treeEl.dataset.loaded = 'true'
+  const load = jest.fn()
+  window.Stimulus = { getControllerForElementAndIdentifier: jest.fn(() => ({ load })) }
+  unarchive.mockResolvedValueOnce({ ok: false })
+
+  await archiveCreative('42')
+
+  expect(load).not.toHaveBeenCalled()
+  expect(treeEl.dataset.loaded).toBe('true')
+  expect(alertDialog).toHaveBeenCalledWith(RESTORE_FAILED_MESSAGE)
+})
+
+// Mirrors the save-failure alert: the string only exists in the ERB, so nothing
+// is shown when the attribute is missing rather than falling back to a literal.
+test('shows no alert when the localized archive failure message is absent', async () => {
+  renderTree(['42'], { archiveFailedMessage: undefined, restoreFailedMessage: undefined })
+  archive.mockResolvedValueOnce({ ok: false })
+
+  await archiveCreative('42')
+
+  expect(alertDialog).not.toHaveBeenCalled()
+  expect(container().querySelectorAll('creative-tree-row')).toHaveLength(1)
 })
 
 test('declining the archive confirmation leaves the row in place', async () => {

--- a/engines/collavre/app/javascript/modules/__tests__/creative_row_editor_delegated_clicks.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/creative_row_editor_delegated_clicks.test.js
@@ -11,6 +11,7 @@ function session(template = document.getElementById('inline-edit-form')) {
     startNew: jest.fn(),
     hideCurrent: jest.fn(),
     handleEditButtonClick: jest.fn(),
+    hideRootEmptyState: jest.fn(() => false),
   };
 }
 
@@ -99,6 +100,30 @@ describe('createDelegatedClickHandler', () => {
       document.getElementById('creative-10'),
       '10'
     );
+  });
+
+  test('inserts at the end when the root empty state is hidden by the session', () => {
+    const currentSession = session();
+    currentSession.hideRootEmptyState.mockReturnValue(true);
+    document.body.addEventListener('click', createDelegatedClickHandler(currentSession), { once: true });
+
+    document.querySelector('.new-root-creative-btn').click();
+
+    expect(currentSession.hideRootEmptyState).toHaveBeenCalledWith(document.getElementById('creatives'));
+    expect(currentSession.startNew).toHaveBeenCalledWith('', document.getElementById('creatives'), null, '');
+  });
+
+  test('uses the root container for an add button outside a tree when the empty state is hidden', () => {
+    const currentSession = session();
+    currentSession.hideRootEmptyState.mockReturnValue(true);
+    const handler = createDelegatedClickHandler(currentSession);
+    const button = document.querySelector('body > .add-creative-btn');
+
+    button.addEventListener('click', handler, { once: true });
+    button.click();
+
+    expect(currentSession.hideRootEmptyState).toHaveBeenCalledWith(document.getElementById('creatives'));
+    expect(currentSession.startNew).toHaveBeenCalledWith('', document.getElementById('creatives'), null, '');
   });
 
   test('closes the current form instead of opening another one', () => {

--- a/engines/collavre/app/javascript/modules/__tests__/creative_row_editor_empty_state_recovery.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/creative_row_editor_empty_state_recovery.test.js
@@ -286,12 +286,17 @@ describe('empty-state recovery when the first inline save fails', () => {
     expect(alertDialogMock).not.toHaveBeenCalled()
   })
 
-  // hideCurrent() announces that editing stopped before it flushes the save.
-  // When the flush fails the editor is put back on the row, so that
-  // announcement is now wrong: collaborators would be told the row is free
-  // while the rejected draft is still open in it, and a concurrent edit could
-  // overwrite it.
-  describe('editing presence after a recovered save failure', () => {
+  // hideCurrent() has to announce that editing stopped, but *when* decides
+  // whether the draft survives. It used to announce it up front, before
+  // awaiting the save it is about to flush. Everything that defers work while a
+  // row is being edited — the tree controller holds a reload and drains it on
+  // that stop, then waits out a 300ms debounce — therefore got the all-clear
+  // while the editor was still holding the user's text. A save slower than that
+  // debounce let the reload replace the whole container, taking the row and the
+  // editor attached inside it out of the document; recoverFromFailedSave() then
+  // re-attached the editor to a row that was no longer in the page. The row is
+  // released only once the flush has actually succeeded.
+  describe('editing presence across the flush', () => {
     function recordPresence() {
       const events = []
       const record = (event) => events.push(`${event.type}:${event.detail?.creativeId}`)
@@ -306,12 +311,80 @@ describe('empty-state recovery when the first inline save fails', () => {
       }
     }
 
-    test('re-announces the row as being edited', async () => {
-      saveMock.mockImplementation(() => Promise.reject(new Error('network down')))
-      const { tree } = appendExistingRow(42)
+    async function closeRowWithEdit(id = 42) {
+      const { tree } = appendExistingRow(id)
+      document.dispatchEvent(new CustomEvent('creative-edit-click', { detail: { treeElement: tree } }))
+      await flush()
+
+      const textarea = document.getElementById('markdown-editor-textarea')
+      textarea.value = 'edited'
+      textarea.dispatchEvent(new Event('input'))
+
+      document.getElementById('inline-close').click()
+      await flush()
+      return tree
+    }
+
+    test('holds the stop until an in-flight flush settles', async () => {
+      let settleSave
+      saveMock.mockImplementation(() => new Promise((resolve) => { settleSave = resolve }))
       const presence = recordPresence()
 
       try {
+        await closeRowWithEdit()
+
+        // The save is still in flight and the editor still owns the row, so
+        // nothing may act on "editing stopped" yet.
+        expect(presence.events).toEqual(['creative-editing:start:42'])
+
+        settleSave({ ok: true, text: () => Promise.resolve('{}') })
+        await flush()
+
+        expect(presence.events).toEqual([
+          'creative-editing:start:42',
+          'creative-editing:stop:42',
+        ])
+      } finally {
+        presence.stop()
+      }
+    })
+
+    test('never announces the stop when the flush is rejected', async () => {
+      saveMock.mockImplementation(() => Promise.reject(new Error('network down')))
+      const presence = recordPresence()
+
+      try {
+        await closeRowWithEdit()
+
+        // The editor is back on the row with the rejected draft, so the row was
+        // never released — announcing a stop here would both tell collaborators
+        // it is free and let a deferred reload delete what is still open in it.
+        expect(presence.events).toEqual(['creative-editing:start:42'])
+      } finally {
+        presence.stop()
+      }
+    })
+
+    test('never announces the stop when the flush comes back non-OK', async () => {
+      saveMock.mockImplementation(() => Promise.resolve({ ok: false, status: 500 }))
+      const presence = recordPresence()
+
+      try {
+        await closeRowWithEdit()
+
+        expect(presence.events).toEqual(['creative-editing:start:42'])
+      } finally {
+        presence.stop()
+      }
+    })
+
+    test('holds the stop when the flush is reached through the add button', async () => {
+      let settleSave
+      saveMock.mockImplementation(() => new Promise((resolve) => { settleSave = resolve }))
+      const presence = recordPresence()
+
+      try {
+        const { tree } = appendExistingRow(42)
         document.dispatchEvent(new CustomEvent('creative-edit-click', { detail: { treeElement: tree } }))
         await flush()
 
@@ -319,20 +392,44 @@ describe('empty-state recovery when the first inline save fails', () => {
         textarea.value = 'edited'
         textarea.dispatchEvent(new Event('input'))
 
-        document.getElementById('inline-close').click()
+        // addNew() used to announce the stop itself, before handing the flush to
+        // startNew() → hideCurrent(), which reopened the very window this closes.
+        document.getElementById('inline-add').click()
         await flush()
 
-        expect(presence.events).toEqual([
+        expect(presence.events).toEqual(['creative-editing:start:42'])
+
+        settleSave({ ok: true, text: () => Promise.resolve('{}') })
+        await flush()
+
+        expect(presence.events.slice(0, 2)).toEqual([
           'creative-editing:start:42',
           'creative-editing:stop:42',
-          'creative-editing:start:42',
         ])
       } finally {
         presence.stop()
       }
     })
 
-    test('restarts the periodic ping so presence does not lapse', async () => {
+    test('keeps a never-persisted draft announced as being edited', async () => {
+      saveMock.mockImplementation(() => Promise.reject(new Error('network down')))
+      const presence = recordPresence()
+
+      try {
+        await startFirstRowWithContent()
+        document.getElementById('inline-close').click()
+        await flush()
+
+        // startNew() announces the row with a null id and there is nothing to
+        // ping for, so a stop here could never be taken back: the deferred
+        // reload would fire on a draft that only exists in the editor.
+        expect(presence.events).toEqual(['creative-editing:start:null'])
+      } finally {
+        presence.stop()
+      }
+    })
+
+    test('keeps the periodic ping running through a failed flush', async () => {
       jest.useFakeTimers()
       saveMock.mockImplementation(() => Promise.reject(new Error('network down')))
       const { tree } = appendExistingRow(42)

--- a/engines/collavre/app/javascript/modules/__tests__/creative_row_editor_empty_state_recovery.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/creative_row_editor_empty_state_recovery.test.js
@@ -1,0 +1,222 @@
+/**
+ * @jest-environment jsdom
+ */
+import { jest } from '@jest/globals'
+
+// The real inline editor is a JSX module (untransformed in Jest), so it is
+// stubbed. The delegated click handler stays REAL here: the empty-state Add
+// button reaches startNew() through it, and hiding the empty-state card is part
+// of that path.
+const createInlineEditorMock = jest.fn()
+const saveMock = jest.fn()
+
+jest.unstable_mockModule('../lexical_inline_editor', () => ({
+  createInlineEditor: createInlineEditorMock,
+}))
+jest.unstable_mockModule('../../lib/api/creatives', () => ({
+  default: {
+    save: saveMock,
+    get: jest.fn(() => Promise.resolve({})),
+    children: jest.fn(() => Promise.resolve([])),
+  },
+}))
+
+const { initializeCreativeRowEditor } = await import('../creative_row_editor')
+
+const BUTTON_IDS = [
+  'inline-metadata-btn', 'inline-toggle-markdown', 'inline-move-up', 'inline-move-down',
+  'inline-add', 'inline-level-down', 'inline-level-up', 'inline-archive', 'inline-delete',
+  'inline-delete-with-children', 'inline-link', 'inline-unconvert', 'inline-unlink',
+  'inline-close', 'inline-recommend-parent', 'metadata-popup-close', 'metadata-save-btn',
+]
+const HIDDEN_INPUT_IDS = [
+  'inline-method', 'inline-creative-description', 'inline-content-type',
+  'inline-markdown-editor', 'inline-markdown-source', 'inline-parent-id',
+  'inline-before-id', 'inline-after-id', 'inline-child-id', 'inline-origin-id',
+]
+const DIV_IDS = ['markdown-editor-wrapper', 'markdown-preview', 'inline-progress-value', 'inline-save-status', 'metadata-popup']
+
+function buildEditorDom(container) {
+  const template = document.createElement('div')
+  template.id = 'inline-edit-form'
+  template.style.display = 'none'
+
+  const form = document.createElement('form')
+  form.id = 'inline-edit-form-element'
+  form.action = '/creatives'
+  template.appendChild(form)
+
+  HIDDEN_INPUT_IDS.forEach((id) => {
+    const input = document.createElement('input')
+    input.type = 'hidden'
+    input.id = id
+    form.appendChild(input)
+  })
+  const progress = document.createElement('input')
+  progress.type = 'checkbox'
+  progress.id = 'inline-creative-progress'
+  form.appendChild(progress)
+
+  const editorRoot = document.createElement('div')
+  editorRoot.id = 'lexical-inline-editor'
+  editorRoot.dataset.lexicalEditorRoot = ''
+  form.appendChild(editorRoot)
+
+  const markdownTextarea = document.createElement('textarea')
+  markdownTextarea.id = 'markdown-editor-textarea'
+  form.appendChild(markdownTextarea)
+  const metadataTextarea = document.createElement('textarea')
+  metadataTextarea.id = 'metadata-yaml-editor'
+  form.appendChild(metadataTextarea)
+  const suggestions = document.createElement('select')
+  suggestions.id = 'parent-suggestions'
+  form.appendChild(suggestions)
+
+  BUTTON_IDS.forEach((id) => {
+    const button = document.createElement('button')
+    button.type = 'button'
+    button.id = id
+    form.appendChild(button)
+  })
+  DIV_IDS.forEach((id) => {
+    const div = document.createElement('div')
+    div.id = id
+    form.appendChild(div)
+  })
+  container.appendChild(template)
+  return template
+}
+
+// The real <creative-tree-row> is a Lit component; startNew() only needs it to
+// expose a `.creative-tree` child, which is what the browser component renders.
+// A brand-new row has no `.creative-row` yet — that markup only appears after a
+// successful save inserts it — so the stub deliberately omits it.
+function defineTreeRowStub() {
+  if (customElements.get('creative-tree-row')) return
+  customElements.define('creative-tree-row', class extends HTMLElement {
+    connectedCallback() {
+      if (this.querySelector('.creative-tree')) return
+      const tree = document.createElement('div')
+      tree.className = 'creative-tree'
+      this.appendChild(tree)
+    }
+  })
+}
+
+function renderEmptyState() {
+  const creatives = document.getElementById('creatives')
+  creatives.innerHTML = `
+    <div class="creative-empty-state">
+      <button type="button" class="new-root-creative-btn">Add</button>
+    </div>
+  `
+  return creatives.querySelector('.creative-empty-state')
+}
+
+// Lets queued microtasks and the rAF-deferred finalizeSetup() in startNew() run.
+function flush() {
+  return new Promise((resolve) => {
+    requestAnimationFrame(() => setTimeout(resolve, 0))
+  })
+}
+
+describe('empty-state recovery when the first inline save fails', () => {
+  beforeAll(() => {
+    defineTreeRowStub()
+    createInlineEditorMock.mockImplementation(() => ({
+      destroy: jest.fn(),
+      load: jest.fn(),
+      focus: jest.fn(),
+      reset: jest.fn(),
+      getDeletedAttachments: jest.fn(() => []),
+    }))
+  })
+
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="creatives"></div><div id="center-frame"></div>'
+    saveMock.mockReset()
+    buildEditorDom(document.getElementById('center-frame'))
+    initializeCreativeRowEditor()
+    document.getElementById('metadata-popup').style.display = 'none'
+  })
+
+  async function startFirstRowWithContent() {
+    const emptyState = renderEmptyState()
+    emptyState.querySelector('.new-root-creative-btn').click()
+    await flush()
+
+    // Typing marks the buffer dirty so hideCurrent() actually attempts a save.
+    const description = document.getElementById('inline-creative-description')
+    description.value = '<p>first creative</p>'
+    const textarea = document.getElementById('markdown-editor-textarea')
+    textarea.value = 'first creative'
+    textarea.dispatchEvent(new Event('input'))
+
+    return emptyState
+  }
+
+  test('hides the empty state while the first inline row is being created', async () => {
+    const emptyState = await startFirstRowWithContent()
+
+    expect(emptyState.style.display).toBe('none')
+    expect(document.querySelectorAll('#creatives creative-tree-row')).toHaveLength(1)
+  })
+
+  test('restores the empty state when the first save rejects', async () => {
+    saveMock.mockImplementation(() => Promise.reject(new Error('network down')))
+    const emptyState = await startFirstRowWithContent()
+
+    document.getElementById('inline-close').click()
+    await flush()
+
+    expect(saveMock).toHaveBeenCalledTimes(1)
+    // Without recovery both the card and the unsaved row are invisible, leaving
+    // the tree blank with no way back.
+    expect(emptyState.style.display).toBe('')
+    expect(document.querySelectorAll('#creatives creative-tree-row')).toHaveLength(0)
+  })
+
+  test('still restores the empty state when the blank first row is cancelled', async () => {
+    const emptyState = renderEmptyState()
+    emptyState.querySelector('.new-root-creative-btn').click()
+    await flush()
+
+    document.getElementById('inline-close').click()
+    await flush()
+
+    expect(saveMock).not.toHaveBeenCalled()
+    expect(emptyState.style.display).toBe('')
+    expect(document.querySelectorAll('#creatives creative-tree-row')).toHaveLength(0)
+  })
+
+  test('brings an existing row back into view when its save rejects', async () => {
+    saveMock.mockImplementation(() => Promise.reject(new Error('network down')))
+
+    const rowComponent = document.createElement('creative-tree-row')
+    rowComponent.dataset.descriptionRawHtml = '<p>existing</p>'
+    rowComponent.dataset.progressValue = '0'
+    // The stub only renders its .creative-tree child once connected.
+    document.getElementById('creatives').appendChild(rowComponent)
+    const tree = rowComponent.querySelector('.creative-tree')
+    tree.id = 'creative-42'
+    tree.dataset.id = '42'
+    const row = document.createElement('div')
+    row.className = 'creative-row'
+    tree.appendChild(row)
+
+    document.dispatchEvent(new CustomEvent('creative-edit-click', { detail: { treeElement: tree } }))
+    await flush()
+    expect(row.style.display).toBe('none')
+
+    const textarea = document.getElementById('markdown-editor-textarea')
+    textarea.value = 'edited'
+    textarea.dispatchEvent(new Event('input'))
+
+    document.getElementById('inline-close').click()
+    await flush()
+
+    expect(saveMock).toHaveBeenCalledTimes(1)
+    expect(document.getElementById('creative-42')).not.toBeNull()
+    expect(row.style.display).toBe('')
+  })
+})

--- a/engines/collavre/app/javascript/modules/__tests__/creative_row_editor_empty_state_recovery.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/creative_row_editor_empty_state_recovery.test.js
@@ -44,6 +44,10 @@ const HIDDEN_INPUT_IDS = [
 ]
 const DIV_IDS = ['markdown-editor-wrapper', 'markdown-preview', 'inline-progress-value', 'inline-save-status', 'metadata-popup']
 
+// Stands in for t('collavre.creatives.index.save_failed_alert'); deliberately
+// not English so a hardcoded literal in the module would fail the assertion.
+const SAVE_FAILED_MESSAGE = '저장하지 못했습니다'
+
 function buildEditorDom(container) {
   const template = document.createElement('div')
   template.id = 'inline-edit-form'
@@ -52,6 +56,9 @@ function buildEditorDom(container) {
   const form = document.createElement('form')
   form.id = 'inline-edit-form-element'
   form.action = '/creatives'
+  // Mirrors the ERB: plain JS can't call `t()`, so the localized save-failure
+  // message rides on the form's data-* attribute.
+  form.dataset.saveFailedMessage = SAVE_FAILED_MESSAGE
   template.appendChild(form)
 
   HIDDEN_INPUT_IDS.forEach((id) => {
@@ -248,29 +255,106 @@ describe('empty-state recovery when the first inline save fails', () => {
     expect(saveMock).toHaveBeenCalledTimes(2)
   })
 
-  test('drops the row but alerts the user when the first save fails while switching rows', async () => {
+  test('abandons the row switch and keeps the draft when the first save fails', async () => {
     saveMock.mockImplementation(() => Promise.reject(new Error('network down')))
     const emptyState = await startFirstRowWithContent()
     const { tree: existingTree, row: existingRow } = appendExistingRow(42)
 
-    // Switching reassigns currentTree and moves the shared template onto the
-    // other row right after the await, so the draft cannot be kept on screen.
-    // It must at least not disappear silently.
     document.dispatchEvent(new CustomEvent('creative-edit-click', { detail: { treeElement: existingTree } }))
     await flush()
 
     expect(saveMock).toHaveBeenCalledTimes(1)
-    expect(unsavedRowTree()).toBeNull()
-    expect(document.querySelectorAll('#creatives creative-tree-row')).toHaveLength(1)
-    expect(alertDialogMock).toHaveBeenCalledTimes(1)
-    expect(alertDialogMock.mock.calls[0][0]).toMatch(/failed to save/i)
+    // The switch must not go through: opening the other row would run
+    // loadCreative() over the shared form buffer, destroying the draft.
+    const draftTree = unsavedRowTree()
+    expect(draftTree).not.toBeNull()
+    const template = document.getElementById('inline-edit-form')
+    expect(template.style.display).toBe('block')
+    expect(template.parentElement).toBe(draftTree)
+    expect(saveStatus()).toBe('error')
+    // The row the user clicked stays untouched — still rendered, not edited.
+    expect(existingRow.style.display).toBe('')
+    expect(existingTree.contains(template)).toBe(false)
     // Real rows remain, so the empty-state card must stay hidden.
     expect(emptyState.style.display).toBe('none')
+    // The aborted click would otherwise look like it did nothing.
+    expect(alertDialogMock).toHaveBeenCalledTimes(1)
+    expect(alertDialogMock.mock.calls[0][0]).toBe(SAVE_FAILED_MESSAGE)
+  })
 
+  test('abandons the switch and keeps an existing row edit when its save fails', async () => {
+    const { tree: firstTree, row: firstRow } = appendExistingRow(42)
+    const { tree: secondTree, row: secondRow } = appendExistingRow(43)
+
+    document.dispatchEvent(new CustomEvent('creative-edit-click', { detail: { treeElement: firstTree } }))
+    await flush()
+
+    const textarea = document.getElementById('markdown-editor-textarea')
+    textarea.value = 'edited but never persisted'
+    textarea.dispatchEvent(new Event('input'))
+
+    saveMock.mockImplementation(() => Promise.reject(new Error('network down')))
+    document.dispatchEvent(new CustomEvent('creative-edit-click', { detail: { treeElement: secondTree } }))
+    await flush()
+
+    expect(saveMock).toHaveBeenCalledTimes(1)
+    // The rejected PATCH means the server still holds the old copy; the buffer
+    // is the only place the user's edit exists, so the editor must stay on the
+    // outgoing row instead of loading creative 43 over it.
+    const template = document.getElementById('inline-edit-form')
+    expect(template.style.display).toBe('block')
+    expect(template.parentElement).toBe(firstTree)
+    expect(firstRow.style.display).toBe('none')
+    expect(secondRow.style.display).toBe('')
+    expect(saveStatus()).toBe('error')
+    expect(alertDialogMock).toHaveBeenCalledTimes(1)
+    expect(alertDialogMock.mock.calls[0][0]).toBe(SAVE_FAILED_MESSAGE)
+  })
+
+  test('does not start another new row when the outgoing draft fails to save', async () => {
+    const { tree: existingTree } = appendExistingRow(42)
+    // `.append-parent-btn` is the route into startNew() that does not
+    // toggle-close the editor first — the add buttons return early when the
+    // template is already open, so they never reach the switching flush.
+    const appendBtn = document.createElement('button')
+    appendBtn.type = 'button'
+    appendBtn.className = 'append-parent-btn'
+    appendBtn.dataset.childId = '42'
+    document.body.appendChild(appendBtn)
+
+    document.dispatchEvent(new CustomEvent('creative-edit-click', { detail: { treeElement: existingTree } }))
+    await flush()
+    const textarea = document.getElementById('markdown-editor-textarea')
+    textarea.value = 'edited but never persisted'
+    textarea.dispatchEvent(new Event('input'))
+
+    saveMock.mockImplementation(() => Promise.reject(new Error('network down')))
+    appendBtn.click()
+    await flush()
+
+    expect(saveMock).toHaveBeenCalledTimes(1)
+    // No second row: startNew() aborted instead of moving the shared template
+    // onto a brand-new row and stranding the rejected draft.
+    expect(document.querySelectorAll('#creatives creative-tree-row')).toHaveLength(1)
     const template = document.getElementById('inline-edit-form')
     expect(template.style.display).toBe('block')
     expect(template.parentElement).toBe(existingTree)
-    expect(existingRow.style.display).toBe('none')
+    expect(saveStatus()).toBe('error')
+    expect(alertDialogMock.mock.calls[0][0]).toBe(SAVE_FAILED_MESSAGE)
+  })
+
+  test('omits the alert when no localized message is available', async () => {
+    delete document.getElementById('inline-edit-form-element').dataset.saveFailedMessage
+    saveMock.mockImplementation(() => Promise.reject(new Error('network down')))
+    await startFirstRowWithContent()
+    const { tree: existingTree } = appendExistingRow(42)
+
+    document.dispatchEvent(new CustomEvent('creative-edit-click', { detail: { treeElement: existingTree } }))
+    await flush()
+
+    // No English fallback baked into the module.
+    expect(alertDialogMock).not.toHaveBeenCalled()
+    expect(saveStatus()).toBe('error')
   })
 
   test('still restores the empty state when the blank first row is cancelled', async () => {
@@ -286,20 +370,9 @@ describe('empty-state recovery when the first inline save fails', () => {
     expect(document.querySelectorAll('#creatives creative-tree-row')).toHaveLength(0)
   })
 
-  test('brings an existing row back into view when its save rejects', async () => {
+  test('keeps an existing row in the editor when closing it fails to save', async () => {
     saveMock.mockImplementation(() => Promise.reject(new Error('network down')))
-
-    const rowComponent = document.createElement('creative-tree-row')
-    rowComponent.dataset.descriptionRawHtml = '<p>existing</p>'
-    rowComponent.dataset.progressValue = '0'
-    // The stub only renders its .creative-tree child once connected.
-    document.getElementById('creatives').appendChild(rowComponent)
-    const tree = rowComponent.querySelector('.creative-tree')
-    tree.id = 'creative-42'
-    tree.dataset.id = '42'
-    const row = document.createElement('div')
-    row.className = 'creative-row'
-    tree.appendChild(row)
+    const { tree, row } = appendExistingRow(42)
 
     document.dispatchEvent(new CustomEvent('creative-edit-click', { detail: { treeElement: tree } }))
     await flush()
@@ -314,6 +387,15 @@ describe('empty-state recovery when the first inline save fails', () => {
 
     expect(saveMock).toHaveBeenCalledTimes(1)
     expect(document.getElementById('creative-42')).not.toBeNull()
-    expect(row.style.display).toBe('')
+    // Closing must not discard the rejected edit either: the editor stays open
+    // on the row (so the rendered row stays hidden underneath) with the save
+    // re-armed, rather than reverting to the stale server copy.
+    const template = document.getElementById('inline-edit-form')
+    expect(template.style.display).toBe('block')
+    expect(template.parentElement).toBe(tree)
+    expect(row.style.display).toBe('none')
+    expect(saveStatus()).toBe('error')
+    // Not a switch — the visible error status is the feedback, no modal.
+    expect(alertDialogMock).not.toHaveBeenCalled()
   })
 })

--- a/engines/collavre/app/javascript/modules/__tests__/creative_row_editor_empty_state_recovery.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/creative_row_editor_empty_state_recovery.test.js
@@ -9,6 +9,7 @@ import { jest } from '@jest/globals'
 // of that path.
 const createInlineEditorMock = jest.fn()
 const saveMock = jest.fn()
+const alertDialogMock = jest.fn(() => Promise.resolve())
 
 jest.unstable_mockModule('../lexical_inline_editor', () => ({
   createInlineEditor: createInlineEditorMock,
@@ -19,6 +20,13 @@ jest.unstable_mockModule('../../lib/api/creatives', () => ({
     get: jest.fn(() => Promise.resolve({})),
     children: jest.fn(() => Promise.resolve([])),
   },
+}))
+// creativesApi.save bypasses the api queue, so a failure here can only be
+// surfaced by an explicit alertDialog() call from the editor.
+jest.unstable_mockModule('../../lib/utils/dialog', () => ({
+  alertDialog: alertDialogMock,
+  confirmDialog: jest.fn(() => Promise.resolve(true)),
+  promptDialog: jest.fn(() => Promise.resolve(null)),
 }))
 
 const { initializeCreativeRowEditor } = await import('../creative_row_editor')
@@ -135,6 +143,7 @@ describe('empty-state recovery when the first inline save fails', () => {
   beforeEach(() => {
     document.body.innerHTML = '<div id="creatives"></div><div id="center-frame"></div>'
     saveMock.mockReset()
+    alertDialogMock.mockClear()
     buildEditorDom(document.getElementById('center-frame'))
     initializeCreativeRowEditor()
     document.getElementById('metadata-popup').style.display = 'none'
@@ -155,6 +164,33 @@ describe('empty-state recovery when the first inline save fails', () => {
     return emptyState
   }
 
+  // A row that already exists on the server, i.e. one that renders a
+  // `.creative-row` and carries a creative id.
+  function appendExistingRow(id) {
+    const rowComponent = document.createElement('creative-tree-row')
+    rowComponent.dataset.descriptionRawHtml = '<p>existing</p>'
+    rowComponent.dataset.progressValue = '0'
+    // The stub only renders its .creative-tree child once connected.
+    document.getElementById('creatives').appendChild(rowComponent)
+    const tree = rowComponent.querySelector('.creative-tree')
+    tree.id = `creative-${id}`
+    tree.dataset.id = String(id)
+    const row = document.createElement('div')
+    row.className = 'creative-row'
+    tree.appendChild(row)
+    return { tree, row }
+  }
+
+  function unsavedRowTree() {
+    const rows = Array.from(document.querySelectorAll('#creatives creative-tree-row'))
+    const unsaved = rows.find((el) => !el.querySelector('.creative-row'))
+    return unsaved ? unsaved.querySelector('.creative-tree') : null
+  }
+
+  function saveStatus() {
+    return document.getElementById('inline-save-status').dataset.state
+  }
+
   test('hides the empty state while the first inline row is being created', async () => {
     const emptyState = await startFirstRowWithContent()
 
@@ -162,7 +198,7 @@ describe('empty-state recovery when the first inline save fails', () => {
     expect(document.querySelectorAll('#creatives creative-tree-row')).toHaveLength(1)
   })
 
-  test('restores the empty state when the first save rejects', async () => {
+  test('keeps the failed first draft and its editor open when the save rejects on close', async () => {
     saveMock.mockImplementation(() => Promise.reject(new Error('network down')))
     const emptyState = await startFirstRowWithContent()
 
@@ -170,10 +206,71 @@ describe('empty-state recovery when the first inline save fails', () => {
     await flush()
 
     expect(saveMock).toHaveBeenCalledTimes(1)
-    // Without recovery both the card and the unsaved row are invisible, leaving
-    // the tree blank with no way back.
-    expect(emptyState.style.display).toBe('')
-    expect(document.querySelectorAll('#creatives creative-tree-row')).toHaveLength(0)
+    // The draft is the user's only copy of what they typed, so it must survive
+    // the failure. The row therefore stays and the empty-state card stays hidden
+    // behind it — the editor is visible on top of it, so nothing is blank.
+    expect(document.querySelectorAll('#creatives creative-tree-row')).toHaveLength(1)
+    expect(emptyState.style.display).toBe('none')
+
+    const template = document.getElementById('inline-edit-form')
+    expect(template.style.display).toBe('block')
+    expect(template.parentElement).toBe(unsavedRowTree())
+    expect(saveStatus()).toBe('error')
+  })
+
+  test('keeps the failed first draft when the save resolves with a non-ok response', async () => {
+    saveMock.mockImplementation(() => Promise.resolve({ ok: false, status: 500 }))
+    const emptyState = await startFirstRowWithContent()
+
+    document.getElementById('inline-close').click()
+    await flush()
+
+    expect(saveMock).toHaveBeenCalledTimes(1)
+    expect(document.querySelectorAll('#creatives creative-tree-row')).toHaveLength(1)
+    expect(emptyState.style.display).toBe('none')
+
+    const template = document.getElementById('inline-edit-form')
+    expect(template.style.display).toBe('block')
+    expect(template.parentElement).toBe(unsavedRowTree())
+    expect(saveStatus()).toBe('error')
+  })
+
+  test('re-arms the pending save so closing again retries the failed first draft', async () => {
+    saveMock.mockImplementation(() => Promise.reject(new Error('network down')))
+    await startFirstRowWithContent()
+
+    document.getElementById('inline-close').click()
+    await flush()
+    expect(saveMock).toHaveBeenCalledTimes(1)
+
+    document.getElementById('inline-close').click()
+    await flush()
+    expect(saveMock).toHaveBeenCalledTimes(2)
+  })
+
+  test('drops the row but alerts the user when the first save fails while switching rows', async () => {
+    saveMock.mockImplementation(() => Promise.reject(new Error('network down')))
+    const emptyState = await startFirstRowWithContent()
+    const { tree: existingTree, row: existingRow } = appendExistingRow(42)
+
+    // Switching reassigns currentTree and moves the shared template onto the
+    // other row right after the await, so the draft cannot be kept on screen.
+    // It must at least not disappear silently.
+    document.dispatchEvent(new CustomEvent('creative-edit-click', { detail: { treeElement: existingTree } }))
+    await flush()
+
+    expect(saveMock).toHaveBeenCalledTimes(1)
+    expect(unsavedRowTree()).toBeNull()
+    expect(document.querySelectorAll('#creatives creative-tree-row')).toHaveLength(1)
+    expect(alertDialogMock).toHaveBeenCalledTimes(1)
+    expect(alertDialogMock.mock.calls[0][0]).toMatch(/failed to save/i)
+    // Real rows remain, so the empty-state card must stay hidden.
+    expect(emptyState.style.display).toBe('none')
+
+    const template = document.getElementById('inline-edit-form')
+    expect(template.style.display).toBe('block')
+    expect(template.parentElement).toBe(existingTree)
+    expect(existingRow.style.display).toBe('none')
   })
 
   test('still restores the empty state when the blank first row is cancelled', async () => {

--- a/engines/collavre/app/javascript/modules/__tests__/creative_row_editor_empty_state_recovery.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/creative_row_editor_empty_state_recovery.test.js
@@ -31,109 +31,13 @@ jest.unstable_mockModule('../../lib/utils/dialog', () => ({
 
 const { initializeCreativeRowEditor } = await import('../creative_row_editor')
 
-const BUTTON_IDS = [
-  'inline-metadata-btn', 'inline-toggle-markdown', 'inline-move-up', 'inline-move-down',
-  'inline-add', 'inline-level-down', 'inline-level-up', 'inline-archive', 'inline-delete',
-  'inline-delete-with-children', 'inline-link', 'inline-unconvert', 'inline-unlink',
-  'inline-close', 'inline-recommend-parent', 'metadata-popup-close', 'metadata-save-btn',
-]
-const HIDDEN_INPUT_IDS = [
-  'inline-method', 'inline-creative-description', 'inline-content-type',
-  'inline-markdown-editor', 'inline-markdown-source', 'inline-parent-id',
-  'inline-before-id', 'inline-after-id', 'inline-child-id', 'inline-origin-id',
-]
-const DIV_IDS = ['markdown-editor-wrapper', 'markdown-preview', 'inline-progress-value', 'inline-save-status', 'metadata-popup']
+const {
+  buildEditorDom, defineTreeRowStub, renderEmptyState, appendExistingRow, flush,
+} = await import('./support/inline_editor_dom')
 
 // Stands in for t('collavre.creatives.index.save_failed_alert'); deliberately
 // not English so a hardcoded literal in the module would fail the assertion.
 const SAVE_FAILED_MESSAGE = '저장하지 못했습니다'
-
-function buildEditorDom(container) {
-  const template = document.createElement('div')
-  template.id = 'inline-edit-form'
-  template.style.display = 'none'
-
-  const form = document.createElement('form')
-  form.id = 'inline-edit-form-element'
-  form.action = '/creatives'
-  // Mirrors the ERB: plain JS can't call `t()`, so the localized save-failure
-  // message rides on the form's data-* attribute.
-  form.dataset.saveFailedMessage = SAVE_FAILED_MESSAGE
-  template.appendChild(form)
-
-  HIDDEN_INPUT_IDS.forEach((id) => {
-    const input = document.createElement('input')
-    input.type = 'hidden'
-    input.id = id
-    form.appendChild(input)
-  })
-  const progress = document.createElement('input')
-  progress.type = 'checkbox'
-  progress.id = 'inline-creative-progress'
-  form.appendChild(progress)
-
-  const editorRoot = document.createElement('div')
-  editorRoot.id = 'lexical-inline-editor'
-  editorRoot.dataset.lexicalEditorRoot = ''
-  form.appendChild(editorRoot)
-
-  const markdownTextarea = document.createElement('textarea')
-  markdownTextarea.id = 'markdown-editor-textarea'
-  form.appendChild(markdownTextarea)
-  const metadataTextarea = document.createElement('textarea')
-  metadataTextarea.id = 'metadata-yaml-editor'
-  form.appendChild(metadataTextarea)
-  const suggestions = document.createElement('select')
-  suggestions.id = 'parent-suggestions'
-  form.appendChild(suggestions)
-
-  BUTTON_IDS.forEach((id) => {
-    const button = document.createElement('button')
-    button.type = 'button'
-    button.id = id
-    form.appendChild(button)
-  })
-  DIV_IDS.forEach((id) => {
-    const div = document.createElement('div')
-    div.id = id
-    form.appendChild(div)
-  })
-  container.appendChild(template)
-  return template
-}
-
-// The real <creative-tree-row> is a Lit component; startNew() only needs it to
-// expose a `.creative-tree` child, which is what the browser component renders.
-// A brand-new row has no `.creative-row` yet — that markup only appears after a
-// successful save inserts it — so the stub deliberately omits it.
-function defineTreeRowStub() {
-  if (customElements.get('creative-tree-row')) return
-  customElements.define('creative-tree-row', class extends HTMLElement {
-    connectedCallback() {
-      if (this.querySelector('.creative-tree')) return
-      const tree = document.createElement('div')
-      tree.className = 'creative-tree'
-      this.appendChild(tree)
-    }
-  })
-}
-
-function renderEmptyState() {
-  const creatives = document.getElementById('creatives')
-  creatives.innerHTML = `
-    <div class="creative-empty-state">
-      <button type="button" class="new-root-creative-btn">Add</button>
-    </div>
-  `
-  return creatives.querySelector('.creative-empty-state')
-}
-
-// Lets queued microtasks and the rAF-deferred finalizeSetup() in startNew() run.
-function flush() {
-  return new Promise((resolve) => {
-    requestAnimationFrame(() => setTimeout(resolve, 0))
-  })
-}
 
 describe('empty-state recovery when the first inline save fails', () => {
   beforeAll(() => {
@@ -151,7 +55,7 @@ describe('empty-state recovery when the first inline save fails', () => {
     document.body.innerHTML = '<div id="creatives"></div><div id="center-frame"></div>'
     saveMock.mockReset()
     alertDialogMock.mockClear()
-    buildEditorDom(document.getElementById('center-frame'))
+    buildEditorDom(document.getElementById('center-frame'), { saveFailedMessage: SAVE_FAILED_MESSAGE })
     initializeCreativeRowEditor()
     document.getElementById('metadata-popup').style.display = 'none'
   })
@@ -169,23 +73,6 @@ describe('empty-state recovery when the first inline save fails', () => {
     textarea.dispatchEvent(new Event('input'))
 
     return emptyState
-  }
-
-  // A row that already exists on the server, i.e. one that renders a
-  // `.creative-row` and carries a creative id.
-  function appendExistingRow(id) {
-    const rowComponent = document.createElement('creative-tree-row')
-    rowComponent.dataset.descriptionRawHtml = '<p>existing</p>'
-    rowComponent.dataset.progressValue = '0'
-    // The stub only renders its .creative-tree child once connected.
-    document.getElementById('creatives').appendChild(rowComponent)
-    const tree = rowComponent.querySelector('.creative-tree')
-    tree.id = `creative-${id}`
-    tree.dataset.id = String(id)
-    const row = document.createElement('div')
-    row.className = 'creative-row'
-    tree.appendChild(row)
-    return { tree, row }
   }
 
   function unsavedRowTree() {
@@ -397,5 +284,78 @@ describe('empty-state recovery when the first inline save fails', () => {
     expect(saveStatus()).toBe('error')
     // Not a switch — the visible error status is the feedback, no modal.
     expect(alertDialogMock).not.toHaveBeenCalled()
+  })
+
+  // hideCurrent() announces that editing stopped before it flushes the save.
+  // When the flush fails the editor is put back on the row, so that
+  // announcement is now wrong: collaborators would be told the row is free
+  // while the rejected draft is still open in it, and a concurrent edit could
+  // overwrite it.
+  describe('editing presence after a recovered save failure', () => {
+    function recordPresence() {
+      const events = []
+      const record = (event) => events.push(`${event.type}:${event.detail?.creativeId}`)
+      document.addEventListener('creative-editing:start', record)
+      document.addEventListener('creative-editing:stop', record)
+      return {
+        events,
+        stop: () => {
+          document.removeEventListener('creative-editing:start', record)
+          document.removeEventListener('creative-editing:stop', record)
+        },
+      }
+    }
+
+    test('re-announces the row as being edited', async () => {
+      saveMock.mockImplementation(() => Promise.reject(new Error('network down')))
+      const { tree } = appendExistingRow(42)
+      const presence = recordPresence()
+
+      try {
+        document.dispatchEvent(new CustomEvent('creative-edit-click', { detail: { treeElement: tree } }))
+        await flush()
+
+        const textarea = document.getElementById('markdown-editor-textarea')
+        textarea.value = 'edited'
+        textarea.dispatchEvent(new Event('input'))
+
+        document.getElementById('inline-close').click()
+        await flush()
+
+        expect(presence.events).toEqual([
+          'creative-editing:start:42',
+          'creative-editing:stop:42',
+          'creative-editing:start:42',
+        ])
+      } finally {
+        presence.stop()
+      }
+    })
+
+    test('restarts the periodic ping so presence does not lapse', async () => {
+      jest.useFakeTimers()
+      saveMock.mockImplementation(() => Promise.reject(new Error('network down')))
+      const { tree } = appendExistingRow(42)
+      const presence = recordPresence()
+
+      try {
+        document.dispatchEvent(new CustomEvent('creative-edit-click', { detail: { treeElement: tree } }))
+        await jest.advanceTimersByTimeAsync(20)
+
+        const textarea = document.getElementById('markdown-editor-textarea')
+        textarea.value = 'edited'
+        textarea.dispatchEvent(new Event('input'))
+
+        document.getElementById('inline-close').click()
+        await jest.advanceTimersByTimeAsync(20)
+
+        const beforeTick = presence.events.length
+        await jest.advanceTimersByTimeAsync(3100)
+        expect(presence.events.slice(beforeTick)).toEqual(['creative-editing:start:42'])
+      } finally {
+        presence.stop()
+        jest.useRealTimers()
+      }
+    })
   })
 })

--- a/engines/collavre/app/javascript/modules/__tests__/creative_row_editor_empty_state_recovery.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/creative_row_editor_empty_state_recovery.test.js
@@ -349,6 +349,67 @@ describe('empty-state recovery when the first inline save fails', () => {
       }
     })
 
+    test('blocks opening another row while the close flush is in flight', async () => {
+      let rejectSave
+      saveMock.mockImplementation(() => new Promise((_, reject) => { rejectSave = reject }))
+      const { tree: firstTree } = appendExistingRow(42)
+      const { tree: secondTree, row: secondRow } = appendExistingRow(43)
+
+      document.dispatchEvent(new CustomEvent('creative-edit-click', { detail: { treeElement: firstTree } }))
+      await flush()
+      document.getElementById('inline-creative-description').value = '<p>outgoing draft</p>'
+      const textarea = document.getElementById('markdown-editor-textarea')
+      textarea.value = 'outgoing draft'
+      textarea.dispatchEvent(new Event('input'))
+
+      document.getElementById('inline-close').click()
+      await flush()
+      document.dispatchEvent(new CustomEvent('creative-edit-click', { detail: { treeElement: secondTree } }))
+      await flush()
+
+      const template = document.getElementById('inline-edit-form')
+      expect(template.parentElement).toBe(firstTree)
+      expect(template.style.display).toBe('none')
+      expect(secondRow.style.display).toBe('')
+
+      rejectSave(new Error('network down'))
+      await flush()
+
+      expect(template.parentElement).toBe(firstTree)
+      expect(template.style.display).toBe('block')
+      expect(document.getElementById('inline-creative-description').value).toBe('<p>outgoing draft</p>')
+    })
+
+    test('blocks starting a new row while the close flush is in flight', async () => {
+      let settleSave
+      saveMock.mockImplementation(() => new Promise((resolve) => { settleSave = resolve }))
+      const { tree } = appendExistingRow(42)
+      const addButton = document.createElement('button')
+      addButton.type = 'button'
+      addButton.className = 'new-root-creative-btn'
+      document.body.appendChild(addButton)
+
+      document.dispatchEvent(new CustomEvent('creative-edit-click', { detail: { treeElement: tree } }))
+      await flush()
+      document.getElementById('inline-creative-description').value = '<p>outgoing draft</p>'
+      const textarea = document.getElementById('markdown-editor-textarea')
+      textarea.value = 'outgoing draft'
+      textarea.dispatchEvent(new Event('input'))
+
+      document.getElementById('inline-close').click()
+      await flush()
+      addButton.click()
+      await flush()
+
+      expect(document.querySelectorAll('#creatives creative-tree-row')).toHaveLength(1)
+
+      settleSave({ ok: true, text: () => Promise.resolve('{}') })
+      await flush()
+
+      expect(document.querySelectorAll('#creatives creative-tree-row')).toHaveLength(1)
+      expect(document.getElementById('inline-edit-form').style.display).toBe('none')
+    })
+
     test('never announces the stop when the flush is rejected', async () => {
       saveMock.mockImplementation(() => Promise.reject(new Error('network down')))
       const presence = recordPresence()

--- a/engines/collavre/app/javascript/modules/__tests__/creative_row_editor_empty_state_removal.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/creative_row_editor_empty_state_removal.test.js
@@ -35,13 +35,28 @@ const {
   buildEditorDom, defineTreeRowStub, renderEmptyState, appendExistingRow, flush,
 } = await import('./support/inline_editor_dom')
 
-// Stands in for the `data-creatives--tree-empty-html-value` the ERB puts on
-// #creatives: the same markup the tree controller re-renders for a
-// server-confirmed-empty response.
+// The markup the real creatives--tree controller writes in showEmptyState(),
+// rendered from its emptyHtmlValue. Deliberately not English so a literal
+// baked into the module would fail the assertion.
 const EMPTY_HTML = '<div class="creative-empty-state"><button type="button" class="new-root-creative-btn">추가</button></div>'
 
-function setEmptyHtmlValue(html = EMPTY_HTML) {
-  document.getElementById('creatives').setAttribute('data-creatives--tree-empty-html-value', html)
+// Stands in for the connected creatives--tree Stimulus controller. The editor
+// must hand the empty state back to it rather than assembling the markup
+// itself, so this records that it was asked to.
+function stubTreeController() {
+  const calls = { showEmptyState: 0 }
+  const controller = {
+    showEmptyState() {
+      calls.showEmptyState += 1
+      document.getElementById('creatives').innerHTML = EMPTY_HTML
+    },
+  }
+  window.Stimulus = {
+    getControllerForElementAndIdentifier: (element, identifier) => (
+      element === document.getElementById('creatives') && identifier === 'creatives--tree' ? controller : null
+    ),
+  }
+  return calls
 }
 
 async function openEditorOn(tree) {
@@ -63,6 +78,7 @@ describe('empty state after the last creative is removed', () => {
 
   beforeEach(() => {
     document.body.innerHTML = '<div id="creatives"></div><div id="center-frame"></div>'
+    delete window.Stimulus
     destroyMock.mockReset()
     destroyMock.mockImplementation(() => Promise.resolve({ ok: true }))
     archiveMock.mockReset()
@@ -104,24 +120,24 @@ describe('empty state after the last creative is removed', () => {
     expect(emptyState.style.display).toBe('')
   })
 
-  test('renders the empty state from the tree markup when no card is in the DOM', async () => {
+  test('asks the tree controller to render the empty state when no card is in the DOM', async () => {
     // A workspace that loaded with rows never had the card rendered — the tree
     // controller replaced the server-rendered empty HTML with the real tree.
-    setEmptyHtmlValue()
+    const calls = stubTreeController()
     const { tree } = appendExistingRow(42)
 
     await openEditorOn(tree)
     document.getElementById('inline-delete').click()
     await flush()
 
+    expect(calls.showEmptyState).toBe(1)
     const restored = document.querySelector('#creatives .creative-empty-state')
     expect(restored).not.toBeNull()
-    expect(restored.style.display).toBe('')
     expect(restored.querySelector('.new-root-creative-btn').textContent).toBe('추가')
   })
 
   test('leaves the tree alone while other rows remain', async () => {
-    setEmptyHtmlValue()
+    const calls = stubTreeController()
     const { tree } = appendExistingRow(42)
     appendExistingRow(43)
 
@@ -130,11 +146,12 @@ describe('empty state after the last creative is removed', () => {
     await flush()
 
     expect(document.querySelectorAll('#creatives creative-tree-row')).toHaveLength(1)
+    expect(calls.showEmptyState).toBe(0)
     expect(document.querySelector('#creatives .creative-empty-state')).toBeNull()
   })
 
   test('does not re-render the empty state when the archive request fails', async () => {
-    setEmptyHtmlValue()
+    const calls = stubTreeController()
     archiveMock.mockImplementation(() => Promise.resolve({ ok: false, status: 500 }))
     const { tree } = appendExistingRow(42)
 
@@ -144,6 +161,7 @@ describe('empty state after the last creative is removed', () => {
 
     // The row is still there, so there is nothing to replace it with.
     expect(document.querySelectorAll('#creatives creative-tree-row')).toHaveLength(1)
+    expect(calls.showEmptyState).toBe(0)
     expect(document.querySelector('#creatives .creative-empty-state')).toBeNull()
   })
 })

--- a/engines/collavre/app/javascript/modules/__tests__/creative_row_editor_empty_state_removal.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/creative_row_editor_empty_state_removal.test.js
@@ -1,0 +1,149 @@
+/**
+ * @jest-environment jsdom
+ */
+import { jest } from '@jest/globals'
+
+// The real inline editor is a JSX module (untransformed in Jest), so it is
+// stubbed. Everything else — the delete/archive button handlers, the empty
+// state bookkeeping — is the real module.
+const createInlineEditorMock = jest.fn()
+const destroyMock = jest.fn()
+const archiveMock = jest.fn()
+const unarchiveMock = jest.fn()
+
+jest.unstable_mockModule('../lexical_inline_editor', () => ({
+  createInlineEditor: createInlineEditorMock,
+}))
+jest.unstable_mockModule('../../lib/api/creatives', () => ({
+  default: {
+    save: jest.fn(() => Promise.resolve({ ok: true })),
+    get: jest.fn(() => Promise.resolve({})),
+    children: jest.fn(() => Promise.resolve([])),
+    destroy: destroyMock,
+    archive: archiveMock,
+    unarchive: unarchiveMock,
+  },
+}))
+jest.unstable_mockModule('../../lib/utils/dialog', () => ({
+  alertDialog: jest.fn(() => Promise.resolve()),
+  confirmDialog: jest.fn(() => Promise.resolve(true)),
+  promptDialog: jest.fn(() => Promise.resolve(null)),
+}))
+
+const { initializeCreativeRowEditor } = await import('../creative_row_editor')
+const {
+  buildEditorDom, defineTreeRowStub, renderEmptyState, appendExistingRow, flush,
+} = await import('./support/inline_editor_dom')
+
+// Stands in for the `data-creatives--tree-empty-html-value` the ERB puts on
+// #creatives: the same markup the tree controller re-renders for a
+// server-confirmed-empty response.
+const EMPTY_HTML = '<div class="creative-empty-state"><button type="button" class="new-root-creative-btn">추가</button></div>'
+
+function setEmptyHtmlValue(html = EMPTY_HTML) {
+  document.getElementById('creatives').setAttribute('data-creatives--tree-empty-html-value', html)
+}
+
+async function openEditorOn(tree) {
+  document.dispatchEvent(new CustomEvent('creative-edit-click', { detail: { treeElement: tree } }))
+  await flush()
+}
+
+describe('empty state after the last creative is removed', () => {
+  beforeAll(() => {
+    defineTreeRowStub()
+    createInlineEditorMock.mockImplementation(() => ({
+      destroy: jest.fn(),
+      load: jest.fn(),
+      focus: jest.fn(),
+      reset: jest.fn(),
+      getDeletedAttachments: jest.fn(() => []),
+    }))
+  })
+
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="creatives"></div><div id="center-frame"></div>'
+    destroyMock.mockReset()
+    destroyMock.mockImplementation(() => Promise.resolve({ ok: true }))
+    archiveMock.mockReset()
+    archiveMock.mockImplementation(() => Promise.resolve({ ok: true }))
+    unarchiveMock.mockReset()
+    unarchiveMock.mockImplementation(() => Promise.resolve({ ok: true }))
+    buildEditorDom(document.getElementById('center-frame'))
+    initializeCreativeRowEditor()
+    document.getElementById('metadata-popup').style.display = 'none'
+  })
+
+  test('restores the hidden card when the first creative is deleted again', async () => {
+    // The card is still in #creatives, hidden by the inline-create flow that
+    // produced this creative in the first place.
+    const emptyState = renderEmptyState()
+    emptyState.style.display = 'none'
+    const { tree } = appendExistingRow(42)
+
+    await openEditorOn(tree)
+    document.getElementById('inline-delete').click()
+    await flush()
+
+    expect(destroyMock).toHaveBeenCalledWith('42', false)
+    expect(document.querySelectorAll('#creatives creative-tree-row')).toHaveLength(0)
+    expect(emptyState.style.display).toBe('')
+  })
+
+  test('restores the hidden card when the last creative is archived', async () => {
+    const emptyState = renderEmptyState()
+    emptyState.style.display = 'none'
+    const { tree } = appendExistingRow(42)
+
+    await openEditorOn(tree)
+    document.getElementById('inline-archive').click()
+    await flush()
+
+    expect(archiveMock).toHaveBeenCalledWith('42')
+    expect(document.querySelectorAll('#creatives creative-tree-row')).toHaveLength(0)
+    expect(emptyState.style.display).toBe('')
+  })
+
+  test('renders the empty state from the tree markup when no card is in the DOM', async () => {
+    // A workspace that loaded with rows never had the card rendered — the tree
+    // controller replaced the server-rendered empty HTML with the real tree.
+    setEmptyHtmlValue()
+    const { tree } = appendExistingRow(42)
+
+    await openEditorOn(tree)
+    document.getElementById('inline-delete').click()
+    await flush()
+
+    const restored = document.querySelector('#creatives .creative-empty-state')
+    expect(restored).not.toBeNull()
+    expect(restored.style.display).toBe('')
+    expect(restored.querySelector('.new-root-creative-btn').textContent).toBe('추가')
+  })
+
+  test('leaves the tree alone while other rows remain', async () => {
+    setEmptyHtmlValue()
+    const { tree } = appendExistingRow(42)
+    appendExistingRow(43)
+
+    await openEditorOn(tree)
+    document.getElementById('inline-delete').click()
+    await flush()
+
+    expect(document.querySelectorAll('#creatives creative-tree-row')).toHaveLength(1)
+    expect(document.querySelector('#creatives .creative-empty-state')).toBeNull()
+  })
+
+  test('does not re-render the empty state when the archive request fails', async () => {
+    setEmptyHtmlValue()
+    archiveMock.mockImplementation(() => Promise.resolve({ ok: false, status: 500 }))
+    const { tree } = appendExistingRow(42)
+
+    await openEditorOn(tree)
+    document.getElementById('inline-archive').click()
+    await flush()
+
+    // The row is still there, so there is nothing to replace it with.
+    expect(document.querySelectorAll('#creatives creative-tree-row')).toHaveLength(1)
+    expect(document.querySelector('#creatives .creative-empty-state')).toBeNull()
+  })
+})

--- a/engines/collavre/app/javascript/modules/__tests__/creative_row_editor_empty_state_removal.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/creative_row_editor_empty_state_removal.test.js
@@ -68,17 +68,42 @@ function stubTreeController() {
   return calls
 }
 
-// A child row nested under `parentId`, in the children container the delete path
-// inspects.
-function appendChildRow(parentId, childId) {
+// The children container for `parentId`, plus the `has-children` flag the server
+// puts on the row itself. TreeBuilder emits both together: the flag records that
+// children exist, the container is where they render.
+function childrenContainerFor(parentId) {
+  const rowComponent = document.getElementById(`creative-${parentId}`).closest('creative-tree-row')
+  rowComponent.hasChildren = true
+  rowComponent.setAttribute('has-children', '')
+
   let children = document.getElementById(`creative-children-${parentId}`)
   if (!children) {
     children = document.createElement('div')
     children.className = 'creative-children'
     children.id = `creative-children-${parentId}`
+    children.dataset.expanded = 'true'
+    children.dataset.loaded = 'true'
     document.getElementById(`creative-${parentId}`).appendChild(children)
   }
-  return appendExistingRow(childId, children)
+  return children
+}
+
+// A child row nested under `parentId`, in the children container the delete path
+// inspects.
+function appendChildRow(parentId, childId) {
+  return appendExistingRow(childId, childrenContainerFor(parentId))
+}
+
+// What TreeBuilder#children_container_payload emits for a row whose children have
+// never been expanded: `has-children` on the row, but a container with
+// `loaded: false` and no rows inside it yet.
+function appendCollapsedChildren(parentId) {
+  const children = childrenContainerFor(parentId)
+  children.dataset.expanded = 'false'
+  children.dataset.loaded = 'false'
+  children.dataset.loadUrl = `/creatives/${parentId}/children`
+  children.style.display = 'none'
+  return children
 }
 
 async function openEditorOn(tree) {
@@ -241,6 +266,27 @@ describe('empty state after the last creative is removed', () => {
     expect(calls.load).toBe(0)
   })
 
+  test('refetches the root tree when the promoted children were never expanded', async () => {
+    // A collapsed row still gets a children container, but TreeBuilder marks it
+    // `loaded: false` and leaves it empty — the children only arrive when the user
+    // expands it. The relationship is recorded on the row's `has-children` flag
+    // instead, so that is what the delete path has to consult. Looking for a
+    // rendered `creative-tree-row` sees nothing here and would skip the refetch,
+    // leaving the actionable empty card over children the server just promoted.
+    renderEmptyState()
+    const calls = stubTreeController()
+    const { tree } = appendExistingRow(42)
+    appendCollapsedChildren(42)
+
+    await openEditorOn(tree)
+    document.getElementById('inline-delete').click()
+    await flush()
+
+    expect(destroyMock).toHaveBeenCalledWith('42', false)
+    expect(calls.requestReload).toBe(1)
+    expect(calls.load).toBe(0)
+  })
+
   test('does not refetch when the deleted row has no children to promote', async () => {
     renderEmptyState()
     const calls = stubTreeController()
@@ -259,6 +305,23 @@ describe('empty state after the last creative is removed', () => {
     const calls = stubTreeController()
     const { tree } = appendExistingRow(42)
     appendChildRow(42, 43)
+
+    await openEditorOn(tree)
+    document.getElementById('inline-delete-with-children').click()
+    await flush()
+
+    expect(destroyMock).toHaveBeenCalledWith('42', true)
+    expect(calls.requestReload).toBe(0)
+  })
+
+  test('does not refetch when "delete with children" removes collapsed children', async () => {
+    // Same as above, but reached through the `has-children` flag rather than
+    // rendered rows: the flag must not pull the refetch into a branch that has
+    // nothing to preserve.
+    renderEmptyState()
+    const calls = stubTreeController()
+    const { tree } = appendExistingRow(42)
+    appendCollapsedChildren(42)
 
     await openEditorOn(tree)
     document.getElementById('inline-delete-with-children').click()

--- a/engines/collavre/app/javascript/modules/__tests__/creative_row_editor_empty_state_removal.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/creative_row_editor_empty_state_removal.test.js
@@ -55,8 +55,11 @@ function installTemplateOnly() {
 // can be observed. Resolved through window.Stimulus on each call, as the archive
 // handler does.
 function stubTreeController() {
-  const calls = { load: 0 }
-  const controller = { load() { calls.load += 1 } }
+  const calls = { load: 0, requestReload: 0 }
+  const controller = {
+    load() { calls.load += 1 },
+    requestReload() { calls.requestReload += 1 },
+  }
   window.Stimulus = {
     getControllerForElementAndIdentifier: (element, identifier) => (
       element === document.getElementById('creatives') && identifier === 'creatives--tree' ? controller : null
@@ -232,7 +235,10 @@ describe('empty state after the last creative is removed', () => {
     await flush()
 
     expect(destroyMock).toHaveBeenCalledWith('42', false)
-    expect(calls.load).toBe(1)
+    // requestReload(), not load(): move(1) has just put the editor on the next
+    // row, so an unconditional re-render would detach it mid-edit.
+    expect(calls.requestReload).toBe(1)
+    expect(calls.load).toBe(0)
   })
 
   test('does not refetch when the deleted row has no children to promote', async () => {
@@ -244,7 +250,7 @@ describe('empty state after the last creative is removed', () => {
     document.getElementById('inline-delete').click()
     await flush()
 
-    expect(calls.load).toBe(0)
+    expect(calls.requestReload).toBe(0)
   })
 
   test('does not refetch when "delete with children" removes them too', async () => {
@@ -259,7 +265,7 @@ describe('empty state after the last creative is removed', () => {
     await flush()
 
     expect(destroyMock).toHaveBeenCalledWith('42', true)
-    expect(calls.load).toBe(0)
+    expect(calls.requestReload).toBe(0)
   })
 
   test('keeps the editor open on the next row when one remains', async () => {

--- a/engines/collavre/app/javascript/modules/__tests__/support/inline_editor_dom.js
+++ b/engines/collavre/app/javascript/modules/__tests__/support/inline_editor_dom.js
@@ -1,0 +1,135 @@
+// Shared DOM scaffolding for the inline row editor tests.
+//
+// initializeCreativeRowEditor() walks a large, fixed set of element ids that
+// the ERB renders (see _inline_edit_form.html.erb) and bails out on the first
+// missing one, so every suite that drives the real module needs the same
+// skeleton. It lives here rather than in one of the suites so the empty-state
+// recovery and removal tests stay in sync with each other.
+//
+// Not matched by jest's testMatch (`**/__tests__/**/*.test.js`), so it is not
+// collected as a suite of its own.
+
+export const BUTTON_IDS = [
+  'inline-metadata-btn', 'inline-toggle-markdown', 'inline-move-up', 'inline-move-down',
+  'inline-add', 'inline-level-down', 'inline-level-up', 'inline-archive', 'inline-delete',
+  'inline-delete-with-children', 'inline-link', 'inline-unconvert', 'inline-unlink',
+  'inline-close', 'inline-recommend-parent', 'metadata-popup-close', 'metadata-save-btn',
+]
+
+export const HIDDEN_INPUT_IDS = [
+  'inline-method', 'inline-creative-description', 'inline-content-type',
+  'inline-markdown-editor', 'inline-markdown-source', 'inline-parent-id',
+  'inline-before-id', 'inline-after-id', 'inline-child-id', 'inline-origin-id',
+]
+
+export const DIV_IDS = [
+  'markdown-editor-wrapper', 'markdown-preview', 'inline-progress-value',
+  'inline-save-status', 'metadata-popup',
+]
+
+export function buildEditorDom(container, { saveFailedMessage } = {}) {
+  const template = document.createElement('div')
+  template.id = 'inline-edit-form'
+  template.style.display = 'none'
+
+  const form = document.createElement('form')
+  form.id = 'inline-edit-form-element'
+  form.action = '/creatives'
+  // Mirrors the ERB: plain JS can't call `t()`, so the localized save-failure
+  // message rides on the form's data-* attribute.
+  if (saveFailedMessage) form.dataset.saveFailedMessage = saveFailedMessage
+  template.appendChild(form)
+
+  HIDDEN_INPUT_IDS.forEach((id) => {
+    const input = document.createElement('input')
+    input.type = 'hidden'
+    input.id = id
+    form.appendChild(input)
+  })
+  const progress = document.createElement('input')
+  progress.type = 'checkbox'
+  progress.id = 'inline-creative-progress'
+  form.appendChild(progress)
+
+  const editorRoot = document.createElement('div')
+  editorRoot.id = 'lexical-inline-editor'
+  editorRoot.dataset.lexicalEditorRoot = ''
+  form.appendChild(editorRoot)
+
+  const markdownTextarea = document.createElement('textarea')
+  markdownTextarea.id = 'markdown-editor-textarea'
+  form.appendChild(markdownTextarea)
+  const metadataTextarea = document.createElement('textarea')
+  metadataTextarea.id = 'metadata-yaml-editor'
+  form.appendChild(metadataTextarea)
+  const suggestions = document.createElement('select')
+  suggestions.id = 'parent-suggestions'
+  form.appendChild(suggestions)
+
+  BUTTON_IDS.forEach((id) => {
+    const button = document.createElement('button')
+    button.type = 'button'
+    button.id = id
+    form.appendChild(button)
+  })
+  DIV_IDS.forEach((id) => {
+    const div = document.createElement('div')
+    div.id = id
+    form.appendChild(div)
+  })
+  container.appendChild(template)
+  return template
+}
+
+// The real <creative-tree-row> is a Lit component; the module only needs it to
+// expose a `.creative-tree` child, which is what the browser component renders.
+// A brand-new row has no `.creative-row` yet — that markup only appears after a
+// successful save inserts it — so the stub deliberately omits it.
+export function defineTreeRowStub() {
+  if (customElements.get('creative-tree-row')) return
+  customElements.define('creative-tree-row', class extends HTMLElement {
+    connectedCallback() {
+      if (this.querySelector('.creative-tree')) return
+      const tree = document.createElement('div')
+      tree.className = 'creative-tree'
+      this.appendChild(tree)
+    }
+  })
+}
+
+// The markup `_empty_state.html.erb` renders as the sole child of #creatives,
+// reduced to the parts the editor interacts with.
+export function renderEmptyState() {
+  const creatives = document.getElementById('creatives')
+  creatives.innerHTML = `
+    <div class="creative-empty-state">
+      <button type="button" class="new-root-creative-btn">Add</button>
+    </div>
+  `
+  return creatives.querySelector('.creative-empty-state')
+}
+
+// A row that already exists on the server, i.e. one that renders a
+// `.creative-row` and carries a creative id.
+export function appendExistingRow(id, container = document.getElementById('creatives')) {
+  const rowComponent = document.createElement('creative-tree-row')
+  rowComponent.setAttribute('creative-id', String(id))
+  rowComponent.dataset.descriptionRawHtml = '<p>existing</p>'
+  rowComponent.dataset.progressValue = '0'
+  // The stub only renders its .creative-tree child once connected.
+  container.appendChild(rowComponent)
+  const tree = rowComponent.querySelector('.creative-tree')
+  tree.id = `creative-${id}`
+  tree.dataset.id = String(id)
+  const row = document.createElement('div')
+  row.className = 'creative-row'
+  tree.appendChild(row)
+  return { rowComponent, tree, row }
+}
+
+// Lets queued microtasks and the rAF-deferred finalizeSetup() in startNew() run.
+export function flush() {
+  return new Promise((resolve) => {
+    requestAnimationFrame(() => setTimeout(resolve, 0))
+  })
+}

--- a/engines/collavre/app/javascript/modules/__tests__/support/inline_editor_dom.js
+++ b/engines/collavre/app/javascript/modules/__tests__/support/inline_editor_dom.js
@@ -27,7 +27,11 @@ export const DIV_IDS = [
   'inline-save-status', 'metadata-popup',
 ]
 
-export function buildEditorDom(container, { saveFailedMessage } = {}) {
+export function buildEditorDom(container, {
+  saveFailedMessage,
+  archiveFailedMessage,
+  restoreFailedMessage,
+} = {}) {
   const template = document.createElement('div')
   template.id = 'inline-edit-form'
   template.style.display = 'none'
@@ -70,6 +74,12 @@ export function buildEditorDom(container, { saveFailedMessage } = {}) {
     const button = document.createElement('button')
     button.type = 'button'
     button.id = id
+    if (id === 'inline-archive') {
+      // Same reason as saveFailedMessage above: the archive/restore failure
+      // strings are localized in the ERB and read back off the button.
+      if (archiveFailedMessage) button.dataset.failureMessage = archiveFailedMessage
+      if (restoreFailedMessage) button.dataset.restoreFailureMessage = restoreFailedMessage
+    }
     form.appendChild(button)
   })
   DIV_IDS.forEach((id) => {

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -637,7 +637,7 @@ export function initializeCreativeRowEditor() {
             parentId = addBtn.dataset.parentId || '';
             const rootContainer = document.getElementById('creatives');
             container = rootContainer;
-            insertBefore = rootContainer.firstElementChild;
+            insertBefore = hideRootEmptyState(rootContainer) ? null : rootContainer.firstElementChild;
             beforeId = insertBefore ? creativeIdFrom(insertBefore) : '';
           }
           startNew(parentId, container, insertBefore, beforeId);
@@ -656,7 +656,7 @@ export function initializeCreativeRowEditor() {
             hideCurrent();
             return;
           }
-          const insertBefore = container.firstElementChild;
+          const insertBefore = hideRootEmptyState(container) ? null : container.firstElementChild;
           const beforeId = insertBefore ? creativeIdFrom(insertBefore) : '';
           startNew('', container, insertBefore, beforeId);
           return; // Event handled
@@ -912,6 +912,28 @@ export function initializeCreativeRowEditor() {
       });
     }
 
+    // The empty-state card (see _empty_state.html.erb) is rendered as the sole
+    // child of #creatives when there are zero real rows. Starting an inline
+    // "new creative" editor there must hide that card — otherwise it stays
+    // visible underneath the editor — and appending the new row is equivalent
+    // to inserting before it once it's hidden, since it's always the sole child.
+    function hideRootEmptyState(rootContainer) {
+      const emptyState = rootContainer?.firstElementChild;
+      if (!emptyState || !emptyState.classList?.contains('creative-empty-state')) return false;
+      emptyState.style.display = 'none';
+      return true;
+    }
+
+    // Restores the empty-state card once the last unsaved new row is cancelled
+    // and no real rows remain under #creatives.
+    function restoreEmptyStateIfEmpty() {
+      const rootContainer = document.getElementById('creatives');
+      const emptyState = rootContainer?.querySelector('.creative-empty-state');
+      if (emptyState && !rootContainer.querySelector('creative-tree-row')) {
+        emptyState.style.display = '';
+      }
+    }
+
     function hideCurrent(event) {
       if (event?.preventDefault) {
         event.preventDefault();
@@ -939,6 +961,7 @@ export function initializeCreativeRowEditor() {
         return p.then(() => {
           if (wasNew && !form.dataset.creativeId) {
             removeTreeElement(tree);
+            restoreEmptyStateIfEmpty();
           } else if (!tree.querySelector('.creative-row')) {
             const parentTree = parentId ? document.getElementById(`creative-${parentId}`) : null;
             if (parentTree) {

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -605,7 +605,7 @@ function setupEditorSession() {
         return;
       }
       if (currentTree) {
-        await hideCurrent(false);
+        await hideCurrent(false, { switching: true });
       }
       currentTree = tree;
       currentRowElement = treeRowElement(tree);
@@ -914,7 +914,22 @@ function setupEditorSession() {
       }
     }
 
-    function hideCurrent(event) {
+    // The save request resolves with the raw Response (see creativesApi.save),
+    // so an HTTP error arrives on the *fulfilled* path with `ok === false` — it
+    // is just as much a failure as a rejection. Everything else that reaches
+    // here is a success: performSave returns null for empty content and
+    // finalizeHide substitutes Promise.resolve() when no save was needed, both
+    // of which settle as undefined.
+    function isFailedSaveResult(result) {
+      return !!result && typeof result === 'object' && result.ok === false;
+    }
+
+    // `switching` marks the calls that immediately open another row: the caller
+    // reassigns currentTree and moves the shared template as soon as the
+    // returned promise settles. It is deliberately a separate option rather
+    // than another meaning for the `event === false` argument, which only
+    // suppresses preventDefault().
+    function hideCurrent(event, { switching = false } = {}) {
       if (event?.preventDefault) {
         event.preventDefault();
       }
@@ -935,10 +950,58 @@ function setupEditorSession() {
       tree.draggable = true;
       updateActionButtonStates();
 
+      // A failed save leaves the editor hidden and currentTree cleared, so the
+      // DOM has to be reconciled here. For a row that was never persisted the
+      // buffer in the editor is the user's only copy of what they typed, and
+      // dropping the row would destroy it — silently, because saveForm's own
+      // 'error' status is gated on `tree === currentTree` (already null by now)
+      // and creativesApi.save calls csrfFetch directly, bypassing the api queue
+      // whose 'api-queue-request-failed' listener is what normally alerts the
+      // user. So: keep the draft, or if that is impossible, say so out loud.
+      const recoverFromFailedSave = function () {
+        if (!(wasNew && !form.dataset.creativeId)) {
+          // Persisted rows still hold their content server-side; just make the
+          // row visible again so the tree isn't left blank.
+          if (tree.querySelector('.creative-row')) showRow(tree);
+          return;
+        }
+
+        if (switching) {
+          // The caller reassigns currentTree and reattaches the shared template
+          // to another row the moment this settles, so re-showing the editor
+          // here would only leave an invisible phantom row behind: a
+          // <creative-tree-row> with no .creative-row (that markup is inserted
+          // on a successful save) and no editor, with the empty-state card
+          // hidden behind it. Drop the row as before, but surface the loss.
+          removeTreeElement(tree);
+          restoreEmptyStateIfEmpty();
+          alertDialog('Failed to save changes. Please check your connection and try again.');
+          return;
+        }
+
+        // Not switching: nothing else is about to claim the editor, so re-bind
+        // it to the row the draft was typed in and re-arm the save so the next
+        // close (or any other flush) retries instead of discarding it. Mirrors
+        // what the api-queue failure listener does for queued requests.
+        currentTree = tree;
+        currentRowElement = treeRowElement(tree) || currentRowElement;
+        tree.draggable = false;
+        attachTemplate(tree);
+        template.style.display = 'block';
+        isDirty = true;
+        pendingSave = true;
+        setSaveStatus('error');
+        updateActionButtonStates();
+      };
+
       const finalizeHide = function () {
         template.style.display = 'none';
         const p = (pendingSave || saveQueue.saving) ? saveForm(tree, parentId) : Promise.resolve();
-        return p.then(() => {
+        return p.then((result) => {
+          if (isFailedSaveResult(result)) {
+            recoverFromFailedSave();
+            return;
+          }
           if (wasNew && !form.dataset.creativeId) {
             removeTreeElement(tree);
             restoreEmptyStateIfEmpty();
@@ -952,22 +1015,10 @@ function setupEditorSession() {
             refreshRow(tree);
           }
         }, () => {
-          // A rejected save (network failure) still leaves the editor hidden and
-          // currentTree cleared, so the DOM has to be reconciled here too. Without
-          // this an unsaved first row stays in #creatives — invisible, since its
-          // .creative-row is only inserted on a successful save — while the
-          // empty-state card stays hidden behind it, blanking the tree with no way
-          // back. The failure itself is already surfaced by saveForm's 'error'
-          // save status and the api queue's failure listener, and every
-          // hideCurrent() caller is fire-and-forget, so rethrowing here would only
-          // strand an unhandled rejection and abort the row switch in
+          // Every hideCurrent() caller is fire-and-forget, so rethrowing here
+          // would only strand an unhandled rejection and abort the row switch in
           // handleEditButtonClick().
-          if (wasNew && !form.dataset.creativeId) {
-            removeTreeElement(tree);
-            restoreEmptyStateIfEmpty();
-          } else if (tree.querySelector('.creative-row')) {
-            showRow(tree);
-          }
+          recoverFromFailedSave();
         });
       };
 
@@ -1692,7 +1743,7 @@ function setupEditorSession() {
       };
 
       if (currentTree) {
-        return Promise.resolve(hideCurrent(false)).then(performStart);
+        return Promise.resolve(hideCurrent(false, { switching: true })).then(performStart);
       }
 
       return performStart();

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -1594,13 +1594,28 @@ function setupEditorSession() {
     // detaches whichever row the editor is currently sitting on together with the
     // unsaved draft in it. The controller knows whether a row is being edited and
     // holds the refetch until it is not.
-    function reloadCreativeTree() {
+    function creativeTreeController() {
       const container = document.getElementById('creatives');
-      if (!container) return false;
-      const controller = window.Stimulus?.getControllerForElementAndIdentifier?.(container, 'creatives--tree');
+      if (!container) return null;
+      return window.Stimulus?.getControllerForElementAndIdentifier?.(container, 'creatives--tree') || null;
+    }
+
+    function reloadCreativeTree() {
+      const controller = creativeTreeController();
       if (typeof controller?.requestReload !== 'function') return false;
       controller.requestReload();
       return true;
+    }
+
+    // A successful close releases any pending tree reload, but archive still has
+    // to land before that reload is safe: otherwise it can render the pre-archive
+    // server state and replace the row reference the response handler later removes.
+    function holdCreativeTreeReload() {
+      const controller = creativeTreeController();
+      if (typeof controller?.beginReloadHold !== 'function' ||
+          typeof controller?.endReloadHold !== 'function') return function () {};
+      controller.beginReloadHold();
+      return function () { controller.endReloadHold(); };
     }
 
     function deleteCurrent(withChildren) {
@@ -2055,6 +2070,7 @@ function setupEditorSession() {
         const confirmMsg = isArchived ? archiveBtn.dataset.restoreConfirm : archiveBtn.dataset.confirm;
 
         if (await confirmDialog(confirmMsg)) {
+          const releaseTreeReload = holdCreativeTreeReload();
           // Flush the editor BEFORE the archive request goes out, not after it has
           // landed. The row is about to be removed (or the tree re-rendered), so a
           // failed flush has nowhere safe to leave the draft once the server-side
@@ -2071,7 +2087,10 @@ function setupEditorSession() {
             console.error('CreativeRowEditor: Failed to flush the editor before archiving', err);
             return SAVE_FAILED;
           });
-          if (flushed === SAVE_FAILED) return;
+          if (flushed === SAVE_FAILED) {
+            releaseTreeReload();
+            return;
+          }
 
           // The flush above already closed the editor, so a failed request has to
           // say so: the row is still there unarchived, the editor is unexpectedly
@@ -2151,7 +2170,7 @@ function setupEditorSession() {
             // The pending edit was already flushed and the editor closed above, so
             // the view can just follow the server.
             applyToView();
-          }, reportFailure);
+          }, reportFailure).finally(releaseTreeReload);
         }
       });
     }

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -273,8 +273,7 @@ function setupEditorSession() {
     // Announces that a creative is being edited and keeps re-announcing it: the
     // sync controller expires the lock when the pings stop, so a single event
     // is not enough. Every path that puts the editor on a persisted row must go
-    // through this — including recoverFromFailedSave(), which reopens it after
-    // hideCurrent() has already announced the stop.
+    // through this.
     function startEditingPresence(creativeId) {
       const parsedId = parseInt(creativeId, 10);
       if (Number.isNaN(parsedId)) return;
@@ -935,12 +934,26 @@ function setupEditorSession() {
       const parentId = parentInput.value;
       const wasNew = !form.dataset.creativeId;
 
-      // Notify sync controller that editing stopped
-      stopEditingPing();
       const editCreativeId = form.dataset.creativeId;
-      document.dispatchEvent(new CustomEvent('creative-editing:stop', {
-        detail: { creativeId: editCreativeId ? parseInt(editCreativeId, 10) : null }
-      }));
+
+      // Announcing "editing stopped" is what releases the row to everything
+      // that defers work while it is being edited — the sync controller's lock,
+      // and the tree controller, which holds a pending reload and drains it into
+      // a 300ms debounce on this event. So it must not be said until the row is
+      // genuinely released, which is only once the flush below has succeeded.
+      // Saying it up front (as this used to) handed out the all-clear while the
+      // editor still held the user's text: a save slower than that debounce let
+      // the deferred reload replace the whole container, taking the row and the
+      // editor attached inside it out of the document, and
+      // recoverFromFailedSave() then re-attached the editor to a detached row.
+      // On failure it is never announced at all — the editor stays open on the
+      // row, so presence was never interrupted and there is nothing to restore.
+      const releaseEditingPresence = function () {
+        stopEditingPing();
+        document.dispatchEvent(new CustomEvent('creative-editing:stop', {
+          detail: { creativeId: editCreativeId ? parseInt(editCreativeId, 10) : null }
+        }));
+      };
 
       currentTree = null;
       currentRowElement = null;
@@ -972,11 +985,10 @@ function setupEditorSession() {
         pendingSave = true;
         setSaveStatus('error');
         updateActionButtonStates();
-        // The row is being edited again, but hideCurrent() already announced
-        // the stop and killed the ping before the flush ran. Leaving it that
-        // way would tell collaborators the row is free while the rejected draft
-        // is still open in it, inviting a concurrent edit that overwrites it.
-        startEditingPresence(form.dataset.creativeId);
+        // Nothing to do about presence here: releaseEditingPresence() is only
+        // called on the success path, so the ping never stopped and the row was
+        // never announced as free. That also covers a never-persisted draft,
+        // which has no id to re-announce with.
 
         if (switching) {
           // The caller was about to open another row; it aborts on this result,
@@ -997,6 +1009,7 @@ function setupEditorSession() {
             recoverFromFailedSave();
             return SAVE_FAILED;
           }
+          releaseEditingPresence();
           if (wasNew && !form.dataset.creativeId) {
             // removeTreeElement() restores the placeholder when this leaves the
             // tree empty — see creative_tree_dom.js.
@@ -1383,14 +1396,14 @@ function setupEditorSession() {
         }
       }
 
-      // Notify editing stopped on previous creative
-      stopEditingPing();
-      const prevEditId = prev.dataset?.id || form.dataset?.creativeId;
-      if (prevEditId) {
-        document.dispatchEvent(new CustomEvent('creative-editing:stop', {
-          detail: { creativeId: parseInt(prevEditId, 10) }
-        }));
-      }
+      // Editing is NOT announced as stopped here. Both branches below end in
+      // startNew(), which flushes the previous row through hideCurrent() and
+      // announces the stop itself once that flush succeeds. Doing it here as
+      // well released the row while the flush was still in flight — the same
+      // window that let a deferred tree reload delete the open editor — and,
+      // for a row that had never been persisted, said nothing at all because
+      // there was no id to report. addChild() has always relied on hideCurrent()
+      // for this.
 
       const handleAddNew = () => {
         const prevCreativeId = prev.dataset.id;

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -2029,9 +2029,32 @@ function setupEditorSession() {
           });
           if (flushed === SAVE_FAILED) return;
 
+          // The flush above already closed the editor, so a failed request has to
+          // say so: the row is still there unarchived, the editor is unexpectedly
+          // gone, and nothing else reports it — creativesApi goes straight to
+          // csrfFetch, bypassing the api queue whose failure listener would
+          // otherwise alert. The draft is not at risk (the flush persisted it), so
+          // this reports rather than recovers. Reopening the editor was considered
+          // and rejected: the request is in flight for an unbounded time, and the
+          // user may well have opened another row by the time it fails — stealing
+          // the shared editor back would then discard a newer draft to undo a
+          // cosmetic surprise.
+          const reportFailure = function (err) {
+            if (err) console.error('CreativeRowEditor: archive request failed', err);
+            // Localized in the ERB and carried on the button, like data-confirm.
+            // No literal fallback here, deliberately: an English string baked into
+            // the module is exactly what this project's i18n rule forbids.
+            const message = isArchived
+              ? archiveBtn.dataset.restoreFailureMessage
+              : archiveBtn.dataset.failureMessage;
+            if (message) alertDialog(message);
+          };
+
           const apiCall = isArchived ? creativesApi.unarchive(creativeId) : creativesApi.archive(creativeId);
           apiCall.then(res => {
-            if (!res.ok) return;
+            // csrfFetch resolves for any HTTP status, so a non-OK response is a
+            // failure that arrives on the fulfilled path.
+            if (!res || !res.ok) return reportFailure();
             const applyToView = function () {
               if (!isArchived) {
                 // Archiving: remove from view. Creative#archive! is an update_all,
@@ -2054,7 +2077,7 @@ function setupEditorSession() {
             // The pending edit was already flushed and the editor closed above, so
             // the view can just follow the server.
             applyToView();
-          });
+          }, reportFailure);
         }
       });
     }

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -1563,12 +1563,17 @@ function setupEditorSession() {
     // `application`, which is captured at import time and so is undefined whenever
     // this module is loaded before the host app starts Stimulus. The archive handler
     // resolves its controller the same way.
+    //
+    // requestReload(), not load(): a reload replaces the whole container, so it
+    // detaches whichever row the editor is currently sitting on together with the
+    // unsaved draft in it. The controller knows whether a row is being edited and
+    // holds the refetch until it is not.
     function reloadCreativeTree() {
       const container = document.getElementById('creatives');
       if (!container) return false;
       const controller = window.Stimulus?.getControllerForElementAndIdentifier?.(container, 'creatives--tree');
-      if (typeof controller?.load !== 'function') return false;
-      controller.load();
+      if (typeof controller?.requestReload !== 'function') return false;
+      controller.requestReload();
       return true;
     }
 
@@ -2064,14 +2069,17 @@ function setupEditorSession() {
                 if (childrenContainer) childrenContainer.remove();
                 removeTreeElement(row);
               } else {
-                // Restoring: reload tree to show updated state
-                const treeEl = document.querySelector('[data-controller="creatives--tree"]');
-                if (treeEl) {
-                  treeEl.innerHTML = '';
-                  delete treeEl.dataset.loaded;
-                  const ctrl = window.Stimulus?.getControllerForElementAndIdentifier(treeEl, 'creatives--tree');
-                  if (ctrl) ctrl.load();
-                }
+                // Restoring: only the server knows where the row belongs in the
+                // tree now, so refetch. Nothing is cleared here on the way: this
+                // request has been in flight for an unbounded time and the user
+                // may well have opened another row and started typing, and wiping
+                // the container would take that row — and the editor attached
+                // inside it — out of the document, discarding the newer draft.
+                // reloadCreativeTree() hands the timing to the tree controller,
+                // which defers the re-render until editing stops; load() then
+                // replaces the container itself, so clearing it first was only
+                // ever a blank flash.
+                reloadCreativeTree();
               }
             };
             // The pending edit was already flushed and the editor closed above, so

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -605,7 +605,10 @@ function setupEditorSession() {
         return;
       }
       if (currentTree) {
-        await hideCurrent(false, { switching: true });
+        // A failed save keeps the editor on the outgoing row with the draft the
+        // server rejected; loadCreative() below would replace the shared form
+        // buffer and destroy it, so the switch is abandoned instead.
+        if (await hideCurrent(false, { switching: true }) === SAVE_FAILED) return;
       }
       currentTree = tree;
       currentRowElement = treeRowElement(tree);
@@ -924,11 +927,17 @@ function setupEditorSession() {
       return !!result && typeof result === 'object' && result.ok === false;
     }
 
+    // Resolved by hideCurrent() when the flush-on-close save failed and the
+    // editor was left open on the outgoing row with the user's draft.
+    const SAVE_FAILED = 'save-failed';
+
     // `switching` marks the calls that immediately open another row: the caller
     // reassigns currentTree and moves the shared template as soon as the
     // returned promise settles. It is deliberately a separate option rather
     // than another meaning for the `event === false` argument, which only
-    // suppresses preventDefault().
+    // suppresses preventDefault(). Those callers MUST abort when hideCurrent
+    // resolves with SAVE_FAILED — the editor is still bound to the outgoing row
+    // holding the unsaved draft, and switching anyway would overwrite it.
     function hideCurrent(event, { switching = false } = {}) {
       if (event?.preventDefault) {
         event.preventDefault();
@@ -951,47 +960,40 @@ function setupEditorSession() {
       updateActionButtonStates();
 
       // A failed save leaves the editor hidden and currentTree cleared, so the
-      // DOM has to be reconciled here. For a row that was never persisted the
-      // buffer in the editor is the user's only copy of what they typed, and
-      // dropping the row would destroy it — silently, because saveForm's own
-      // 'error' status is gated on `tree === currentTree` (already null by now)
-      // and creativesApi.save calls csrfFetch directly, bypassing the api queue
-      // whose 'api-queue-request-failed' listener is what normally alerts the
-      // user. So: keep the draft, or if that is impossible, say so out loud.
+      // DOM has to be reconciled here. The buffer in the editor is the user's
+      // only copy of what they typed — the server rejected it, and for an
+      // existing row loadCreative() would overwrite the buffer with the stored
+      // copy the moment another row is opened. Losing it would also be silent,
+      // because saveForm's own 'error' status is gated on `tree === currentTree`
+      // (already null by now) and creativesApi.save calls csrfFetch directly,
+      // bypassing the api queue whose 'api-queue-request-failed' listener is
+      // what normally alerts the user. So the draft is always kept: the editor
+      // is re-bound to the row it was typed in, whether or not that row was ever
+      // persisted, and the save is re-armed so the next close retries it.
       const recoverFromFailedSave = function () {
-        if (!(wasNew && !form.dataset.creativeId)) {
-          // Persisted rows still hold their content server-side; just make the
-          // row visible again so the tree isn't left blank.
-          if (tree.querySelector('.creative-row')) showRow(tree);
-          return;
-        }
-
-        if (switching) {
-          // The caller reassigns currentTree and reattaches the shared template
-          // to another row the moment this settles, so re-showing the editor
-          // here would only leave an invisible phantom row behind: a
-          // <creative-tree-row> with no .creative-row (that markup is inserted
-          // on a successful save) and no editor, with the empty-state card
-          // hidden behind it. Drop the row as before, but surface the loss.
-          removeTreeElement(tree);
-          restoreEmptyStateIfEmpty();
-          alertDialog('Failed to save changes. Please check your connection and try again.');
-          return;
-        }
-
-        // Not switching: nothing else is about to claim the editor, so re-bind
-        // it to the row the draft was typed in and re-arm the save so the next
-        // close (or any other flush) retries instead of discarding it. Mirrors
-        // what the api-queue failure listener does for queued requests.
         currentTree = tree;
         currentRowElement = treeRowElement(tree) || currentRowElement;
         tree.draggable = false;
         attachTemplate(tree);
         template.style.display = 'block';
+        // The rendered row stays hidden underneath, as it is while editing —
+        // the editor is visible on top of it, so nothing is blank. The
+        // empty-state card likewise stays hidden: the row still exists.
+        hideRow(tree);
         isDirty = true;
         pendingSave = true;
         setSaveStatus('error');
         updateActionButtonStates();
+
+        if (switching) {
+          // The caller was about to open another row; it aborts on this result,
+          // so the editor keeps the draft. Without an alert that click would
+          // look like it did nothing, so say why out loud. The localized string
+          // is carried on the form's data-* attribute (set in the ERB) because
+          // plain JS can't call the i18n `t()` helper.
+          const message = form.dataset.saveFailedMessage;
+          if (message) alertDialog(message);
+        }
       };
 
       const finalizeHide = function () {
@@ -1000,7 +1002,7 @@ function setupEditorSession() {
         return p.then((result) => {
           if (isFailedSaveResult(result)) {
             recoverFromFailedSave();
-            return;
+            return SAVE_FAILED;
           }
           if (wasNew && !form.dataset.creativeId) {
             removeTreeElement(tree);
@@ -1015,10 +1017,11 @@ function setupEditorSession() {
             refreshRow(tree);
           }
         }, () => {
-          // Every hideCurrent() caller is fire-and-forget, so rethrowing here
-          // would only strand an unhandled rejection and abort the row switch in
-          // handleEditButtonClick().
+          // Rethrowing here would only strand an unhandled rejection: the
+          // callers that must react to a failed save read the resolved value
+          // instead, and the rest are fire-and-forget.
           recoverFromFailedSave();
+          return SAVE_FAILED;
         });
       };
 
@@ -1743,7 +1746,10 @@ function setupEditorSession() {
       };
 
       if (currentTree) {
-        return Promise.resolve(hideCurrent(false, { switching: true })).then(performStart);
+        // Same as handleEditButtonClick: don't strand the rejected draft by
+        // moving the editor onto a brand-new row.
+        return Promise.resolve(hideCurrent(false, { switching: true }))
+          .then((result) => (result === SAVE_FAILED ? undefined : performStart()));
       }
 
       return performStart();

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -341,10 +341,16 @@ function setupEditorSession() {
       }
     }
 
+    // The server's answer, carried on the row by TreeBuilder's `has_children`. It is
+    // set whether or not the children have been fetched, so it is the only reliable
+    // source for a collapsed node — its children container is rendered empty with
+    // `data-loaded="false"` until the user expands it.
+    function rowFlagHasChildren(row) {
+      return !!(row && (row.hasChildren || row.getAttribute?.('has-children')));
+    }
+
     function currentRowHasChildren() {
-      const row = currentRowElement || (currentTree ? treeRowElement(currentTree) : null);
-      if (!row) return false;
-      return !!(row.hasChildren || row.getAttribute?.('has-children'));
+      return rowFlagHasChildren(currentRowElement || (currentTree ? treeRowElement(currentTree) : null));
     }
 
     function activateMarkdownMode(source) {
@@ -1619,8 +1625,17 @@ function setupEditorSession() {
         // would leave the tree looking empty, and hand restoreTreeEmptyState() an empty
         // container to put the "no creatives yet" card into, while the server still holds
         // the promoted rows. Refetch the root tree instead.
+        //
+        // Whether there are children to promote is the server's answer, carried on
+        // the row's `has-children` flag — not "does the DOM hold a child row". A
+        // collapsed node gets a children container that TreeBuilder marks
+        // `loaded: false` and leaves empty until the user expands it, so asking the
+        // container would say "no children" for every tree the user never opened.
+        // The container is still consulted as well, because a child inserted
+        // client-side is in the DOM before any flag round-trips.
         const promotesChildrenToRoot = !withChildren && !parentTree &&
-          !!childrenTree?.querySelector('creative-tree-row');
+          (rowFlagHasChildren(treeRowElement(tree)) ||
+            !!childrenTree?.querySelector('creative-tree-row'));
         if (!withChildren && childrenTree && parentTree) {
           refreshChildren(parentTree).then(() => {
             if (parentTree) refreshRow(parentTree);

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -2075,11 +2075,38 @@ function setupEditorSession() {
             // csrfFetch resolves for any HTTP status, so a non-OK response is a
             // failure that arrives on the fulfilled path.
             if (!res || !res.ok) return reportFailure();
+            // The pre-flush closed the editor before the request went out, but it
+            // left the row on screen and clickable, and the request is in flight
+            // for an unbounded time. So the user can reopen that row — or one of
+            // its children — and start typing again before this lands. The editor
+            // template is attached *inside* the row it is bound to, so dropping
+            // this subtree would take that newer draft out of the document with
+            // no flush and no feedback, which is the same silent loss the
+            // pre-flush was introduced to stop.
+            const editorIsInsideArchivedSubtree = function () {
+              if (!currentTree) return false;
+              const editedRow = treeRowElement(currentTree) || currentTree;
+              if (row && (row === editedRow || row.contains(editedRow))) return true;
+              const childrenContainer = document.getElementById(`creative-children-${creativeId}`);
+              return !!childrenContainer?.contains(editedRow);
+            };
+
             const applyToView = function () {
               if (!isArchived) {
                 // Archiving: remove from view. Creative#archive! is an update_all,
                 // so it fires no destroy broadcast — this is the only chance to
                 // bring the empty-state placeholder back when the last row goes.
+                if (editorIsInsideArchivedSubtree()) {
+                  // Hand the timing to the tree controller instead of removing
+                  // anything here: it holds the refetch until editing stops, so
+                  // the draft stays in the editor and the archived row goes away
+                  // once the user is done with it. If there is no controller to
+                  // ask, the row is deliberately left in place anyway — a stale
+                  // row that the next reload corrects is a far smaller failure
+                  // than deleting what the user is typing.
+                  reloadCreativeTree();
+                  return;
+                }
                 const childrenContainer = document.getElementById(`creative-children-${creativeId}`);
                 if (childrenContainer) childrenContainer.remove();
                 removeTreeElement(row);

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -256,6 +256,11 @@ function setupEditorSession() {
     let uploadCompletionPromise = null;
     let resolveUploadCompletion = null;
     let addNewInProgress = false;
+    // hideCurrent() clears currentTree and hides the shared form before its
+    // close save settles. Without a separate transition guard, that temporary
+    // "no editor" state lets another row or Add reuse the form while the old
+    // save still owns its completion and recovery callbacks.
+    let closeSaveInProgress = false;
     let originalContent = '';
     let originalProgress = 0;
     let originalOriginId = '';
@@ -621,6 +626,10 @@ function setupEditorSession() {
 
     async function handleEditButtonClick(tree) {
       if (!tree) return;
+      // Do not let a second session take over the shared form while an earlier
+      // close still owns it. The initiating switch continues below after its
+      // own hideCurrent() resolves; only later, competing clicks are ignored.
+      if (closeSaveInProgress) return;
 
       if (currentTree === tree) {
         await hideCurrent();
@@ -933,6 +942,7 @@ function setupEditorSession() {
       const tree = currentTree;
       const parentId = parentInput.value;
       const wasNew = !form.dataset.creativeId;
+      closeSaveInProgress = true;
 
       const editCreativeId = form.dataset.creativeId;
 
@@ -1032,11 +1042,8 @@ function setupEditorSession() {
         });
       };
 
-      if (uploadsPending) {
-        return waitForUploads().then(finalizeHide);
-      }
-
-      return finalizeHide();
+      const closePromise = uploadsPending ? waitForUploads().then(finalizeHide) : finalizeHide();
+      return Promise.resolve(closePromise).finally(() => { closeSaveInProgress = false; });
     }
 
     // Tears the session down for a row that is already gone from the DOM, so
@@ -1700,6 +1707,10 @@ function setupEditorSession() {
     }
 
     function startNew(parentId, container, insertBefore, beforeId = '', afterId = '', childId = '') {
+      // The close save still owns the shared form and may need to recover it on
+      // failure. Starting a new row here would replace that buffer and let the
+      // stale completion mutate the newer session.
+      if (closeSaveInProgress) return;
       resetOriginTracking();
       const performStart = () => {
         let targetContainer = container || document.getElementById('creatives');

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -2011,6 +2011,24 @@ function setupEditorSession() {
         const confirmMsg = isArchived ? archiveBtn.dataset.restoreConfirm : archiveBtn.dataset.confirm;
 
         if (await confirmDialog(confirmMsg)) {
+          // Flush the editor BEFORE the archive request goes out, not after it has
+          // landed. The row is about to be removed (or the tree re-rendered), so a
+          // failed flush has nowhere safe to leave the draft once the server-side
+          // change is done — the previous ordering had to choose between stranding
+          // the archived row on screen and discarding the user's unsaved edits.
+          // Flushing first makes the failure recoverable: nothing has changed on the
+          // server yet, so the whole action is simply abandoned.
+          //
+          // `switching: true` because the editor cannot just stay quietly open here:
+          // the user asked for something that is now not happening, so they get the
+          // alert. recoverFromFailedSave() keeps the draft in the editor on this row,
+          // which is what that alert promises — and, because we abort, stays true.
+          const flushed = await hideCurrent(undefined, { switching: true }).catch(err => {
+            console.error('CreativeRowEditor: Failed to flush the editor before archiving', err);
+            return SAVE_FAILED;
+          });
+          if (flushed === SAVE_FAILED) return;
+
           const apiCall = isArchived ? creativesApi.unarchive(creativeId) : creativesApi.archive(creativeId);
           apiCall.then(res => {
             if (!res.ok) return;
@@ -2033,29 +2051,9 @@ function setupEditorSession() {
                 }
               }
             };
-            // The editor is bound to the row this action is about to drop (or to a
-            // tree about to be re-rendered), so close it first. This used to call a
-            // `closeEditor()` that exists nowhere in the module: it threw a
-            // ReferenceError and left the editor open over the archived row.
-            //
-            // The server-side change has already landed here, so the view has to
-            // follow even when that close fails: letting a failure break the chain
-            // would strand the archived row on screen with nothing to repair it,
-            // since an update_all archive broadcasts no destroy either.
-            //
-            // `switching: true` because this behaves like a row switch rather than
-            // a plain close — the row the editor is bound to is about to be
-            // detached, so a failed flush cannot simply leave the draft open on it.
-            // It gets the user the alert; SAVE_FAILED then means the recovery
-            // re-opened the editor on that doomed row, so close it back down before
-            // applyToView() removes the row out from under it.
-            return Promise.resolve()
-              .then(() => hideCurrent(undefined, { switching: true }))
-              .then(result => { if (result === SAVE_FAILED) closeEditor(); })
-              .catch(err => {
-                console.error('CreativeRowEditor: Failed to flush the editor before archiving', err);
-              })
-              .then(applyToView);
+            // The pending edit was already flushed and the editor closed above, so
+            // the view can just follow the server.
+            applyToView();
           });
         }
       });

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -269,6 +269,22 @@ function setupEditorSession() {
       }
     }
 
+    // Announces that a creative is being edited and keeps re-announcing it: the
+    // sync controller expires the lock when the pings stop, so a single event
+    // is not enough. Every path that puts the editor on a persisted row must go
+    // through this — including recoverFromFailedSave(), which reopens it after
+    // hideCurrent() has already announced the stop.
+    function startEditingPresence(creativeId) {
+      const parsedId = parseInt(creativeId, 10);
+      if (Number.isNaN(parsedId)) return;
+      const announce = () => document.dispatchEvent(new CustomEvent('creative-editing:start', {
+        detail: { creativeId: parsedId }
+      }));
+      announce();
+      stopEditingPing();
+      editingPingInterval = setInterval(announce, 3000);
+    }
+
     // Clean up editing ping on Turbo navigation to prevent interval leak
     globalListeners.add(document, 'turbo:before-cache', () => stopEditingPing());
 
@@ -621,19 +637,7 @@ function setupEditorSession() {
       updateActionButtonStates();
 
       // Notify sync controller that editing started + periodic ping
-      const editCreativeId = form.dataset.creativeId || currentRowElement?.getAttribute('creative-id');
-      if (editCreativeId) {
-        const parsedId = parseInt(editCreativeId, 10);
-        document.dispatchEvent(new CustomEvent('creative-editing:start', {
-          detail: { creativeId: parsedId }
-        }));
-        if (editingPingInterval) clearInterval(editingPingInterval);
-        editingPingInterval = setInterval(() => {
-          document.dispatchEvent(new CustomEvent('creative-editing:start', {
-            detail: { creativeId: parsedId }
-          }));
-        }, 3000);
-      }
+      startEditingPresence(form.dataset.creativeId || currentRowElement?.getAttribute('creative-id'));
     }
 
     function initializeEventListeners() {
@@ -907,14 +911,28 @@ function setupEditorSession() {
       return true;
     }
 
-    // Restores the empty-state card once the last unsaved new row is cancelled
-    // and no real rows remain under #creatives.
+    // Brings the empty state back whenever a removal leaves no rows under
+    // #creatives — a cancelled first draft, but also deleting or archiving the
+    // last remaining creative. Without this the container is left holding
+    // nothing but the display:none card (or nothing at all) and the page reads
+    // as broken rather than empty.
     function restoreEmptyStateIfEmpty() {
       const rootContainer = document.getElementById('creatives');
-      const emptyState = rootContainer?.querySelector('.creative-empty-state');
-      if (emptyState && !rootContainer.querySelector('creative-tree-row')) {
+      if (!rootContainer || rootContainer.querySelector('creative-tree-row')) return;
+
+      const emptyState = rootContainer.querySelector('.creative-empty-state');
+      if (emptyState) {
         emptyState.style.display = '';
+        return;
       }
+      // The card is only in the DOM when the page was rendered for an empty
+      // tree; once the tree controller renders real rows it is gone. Re-render
+      // it from the same markup that controller uses for a server-confirmed
+      // empty response, which the ERB carries on the container. Reading the
+      // attribute directly rather than via dataset: the Stimulus value name
+      // contains `--`, which does not survive the dataset camelization.
+      const html = rootContainer.getAttribute('data-creatives--tree-empty-html-value');
+      if (html) rootContainer.insertAdjacentHTML('beforeend', html);
     }
 
     // The save request resolves with the raw Response (see creativesApi.save),
@@ -984,6 +1002,11 @@ function setupEditorSession() {
         pendingSave = true;
         setSaveStatus('error');
         updateActionButtonStates();
+        // The row is being edited again, but hideCurrent() already announced
+        // the stop and killed the ping before the flush ran. Leaving it that
+        // way would tell collaborators the row is free while the rejected draft
+        // is still open in it, inviting a concurrent edit that overwrites it.
+        startEditingPresence(form.dataset.creativeId);
 
         if (switching) {
           // The caller was about to open another row; it aborts on this result,
@@ -1030,6 +1053,28 @@ function setupEditorSession() {
       }
 
       return finalizeHide();
+    }
+
+    // Tears the session down for a row that is already gone from the DOM, so
+    // hideCurrent() is not usable: its flush would try to save — and then
+    // re-show and refresh — a detached row. The archive handler has always
+    // called this, but it was never defined anywhere in the module, so
+    // archiving threw a ReferenceError inside its .then() and silently left the
+    // editor bound to the removed row.
+    function closeEditor() {
+      isDirty = false;
+      pendingSave = null;
+      stopEditingPing();
+      const editCreativeId = form.dataset.creativeId;
+      if (editCreativeId) {
+        document.dispatchEvent(new CustomEvent('creative-editing:stop', {
+          detail: { creativeId: parseInt(editCreativeId, 10) }
+        }));
+      }
+      currentTree = null;
+      currentRowElement = null;
+      template.style.display = 'none';
+      updateActionButtonStates();
     }
 
     function loadCreative(tree) {
@@ -1328,19 +1373,7 @@ function setupEditorSession() {
           loadCreative(target);
           focusAfterMove();
           // Notify editing started on new creative + start ping
-          const newCreativeId = target.dataset?.id || currentRowElement?.getAttribute('creative-id');
-          if (newCreativeId) {
-            const parsedNewId = parseInt(newCreativeId, 10);
-            document.dispatchEvent(new CustomEvent('creative-editing:start', {
-              detail: { creativeId: parsedNewId }
-            }));
-            stopEditingPing();
-            editingPingInterval = setInterval(() => {
-              document.dispatchEvent(new CustomEvent('creative-editing:start', {
-                detail: { creativeId: parsedNewId }
-              }));
-            }, 3000);
-          }
+          startEditingPresence(target.dataset?.id || currentRowElement?.getAttribute('creative-id'));
         });
       } else {
         // For existing creatives, show the row and refresh if needed
@@ -1350,19 +1383,7 @@ function setupEditorSession() {
         loadCreative(target);
         focusAfterMove();
         // Notify editing started on new creative + start ping
-        const newCreativeId = target.dataset?.id || currentRowElement?.getAttribute('creative-id');
-        if (newCreativeId) {
-          const parsedNewId = parseInt(newCreativeId, 10);
-          document.dispatchEvent(new CustomEvent('creative-editing:start', {
-            detail: { creativeId: parsedNewId }
-          }));
-          stopEditingPing();
-          editingPingInterval = setInterval(() => {
-            document.dispatchEvent(new CustomEvent('creative-editing:start', {
-              detail: { creativeId: parsedNewId }
-            }));
-          }, 3000);
-        }
+        startEditingPresence(target.dataset?.id || currentRowElement?.getAttribute('creative-id'));
       }
       updateActionButtonStates();
     }
@@ -1606,6 +1627,7 @@ function setupEditorSession() {
         pendingSave = null;
         move(1);
         removeTreeElement(tree);
+        restoreEmptyStateIfEmpty();
       });
     }
 
@@ -1981,6 +2003,7 @@ function setupEditorSession() {
                 const childrenContainer = document.getElementById(`creative-children-${creativeId}`);
                 if (childrenContainer) childrenContainer.remove();
                 if (row) row.remove();
+                restoreEmptyStateIfEmpty();
               } else {
                 // Restoring: reload tree to show updated state
                 const treeEl = document.querySelector('[data-controller="creatives--tree"]');

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -951,6 +951,23 @@ function setupEditorSession() {
             showRow(tree);
             refreshRow(tree);
           }
+        }, () => {
+          // A rejected save (network failure) still leaves the editor hidden and
+          // currentTree cleared, so the DOM has to be reconciled here too. Without
+          // this an unsaved first row stays in #creatives — invisible, since its
+          // .creative-row is only inserted on a successful save — while the
+          // empty-state card stays hidden behind it, blanking the tree with no way
+          // back. The failure itself is already surfaced by saveForm's 'error'
+          // save status and the api queue's failure listener, and every
+          // hideCurrent() caller is fire-and-forget, so rethrowing here would only
+          // strand an unhandled rejection and abort the row switch in
+          // handleEditButtonClick().
+          if (wasNew && !form.dataset.creativeId) {
+            removeTreeElement(tree);
+            restoreEmptyStateIfEmpty();
+          } else if (tree.querySelector('.creative-row')) {
+            showRow(tree);
+          }
         });
       };
 

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -926,13 +926,13 @@ function setupEditorSession() {
         return;
       }
       // The card is only in the DOM when the page was rendered for an empty
-      // tree; once the tree controller renders real rows it is gone. Re-render
-      // it from the same markup that controller uses for a server-confirmed
-      // empty response, which the ERB carries on the container. Reading the
-      // attribute directly rather than via dataset: the Stimulus value name
-      // contains `--`, which does not survive the dataset camelization.
-      const html = rootContainer.getAttribute('data-creatives--tree-empty-html-value');
-      if (html) rootContainer.insertAdjacentHTML('beforeend', html);
+      // tree; once the tree controller has rendered real rows it is gone. Hand
+      // back to that controller rather than re-rendering its markup here: it
+      // owns the empty state for a server-confirmed-empty response, so this
+      // stays in step with it (including the "no results" variant it renders
+      // under an active filter) and no HTML is assembled in this module.
+      const treeController = window.Stimulus?.getControllerForElementAndIdentifier?.(rootContainer, 'creatives--tree');
+      treeController?.showEmptyState?.();
     }
 
     // The save request resolves with the raw Response (see creativesApi.save),

--- a/engines/collavre/app/views/collavre/creatives/_add_button.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/_add_button.html.erb
@@ -1,20 +1,18 @@
-<% if @parent_creative %>
-  <%= button_tag(
-        type: 'button',
-        class: 'creative-header-outline-btn add-creative-btn',
-        data: { parent_id: @parent_creative.id },
-        aria: { label: t('collavre.creatives.index.new_creative') },
-        title: t('collavre.creatives.index.new_creative_shortcut')
-      ) do %>
-    <span aria-hidden="true"><%= svg_tag 'add.svg', class: 'icon-add', width: 16, height: 16 %></span>
-  <% end %>
-<% else %>
-  <%= button_tag(
-        type: 'button',
-        class: 'creative-header-outline-btn new-root-creative-btn',
-        aria: { label: t('collavre.creatives.index.new_creative') },
-        title: t('collavre.creatives.index.new_creative_shortcut')
-      ) do %>
-    <span aria-hidden="true"><%= svg_tag 'add.svg', class: 'icon-add', width: 16, height: 16 %></span>
-  <% end %>
+<%
+  label = local_assigns[:label]
+  shortcut_hint = local_assigns[:shortcut_hint]
+  base_class = @parent_creative ? 'add-creative-btn' : 'new-root-creative-btn'
+  css_class = label ? "btn btn-primary #{base_class} add-creative-btn--cta" : "creative-header-outline-btn #{base_class}"
+  data_attrs = @parent_creative ? { parent_id: @parent_creative.id } : {}
+%>
+<%= button_tag(
+      type: 'button',
+      class: css_class,
+      data: data_attrs,
+      aria: { label: t('collavre.creatives.index.new_creative') },
+      title: t('collavre.creatives.index.new_creative_shortcut')
+    ) do %>
+  <span aria-hidden="true"><%= svg_tag 'add.svg', class: 'icon-add', width: 16, height: 16 %></span>
+  <% if label %><span class="add-creative-btn-label"><%= label %></span><% end %>
+  <% if shortcut_hint %><kbd class="add-creative-btn-kbd"><%= shortcut_hint %></kbd><% end %>
 <% end %>

--- a/engines/collavre/app/views/collavre/creatives/_empty_state.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/_empty_state.html.erb
@@ -1,0 +1,85 @@
+<%
+  # Locals:
+  #   root:     Boolean — true for the root-level "no creatives" case, false for a
+  #             specific parent's "no sub-creatives" case.
+  #   can_add:  Boolean — same write-gate used for the header Add/Import controls
+  #             (see index.html.erb). Decides whether the writable CTAs or the
+  #             read-only "request write access" variant is shown.
+  #   creative: The Collavre::Creative to request write access on (nil at root,
+  #             where can_add is always true for authenticated users so this
+  #             branch never needs it).
+  heading = root ? t('collavre.creatives.index.empty_state_heading_root') : t('collavre.creatives.index.empty_state_heading_sub')
+  add_label = root ? t('collavre.creatives.index.empty_state_add_creative') : t('collavre.creatives.index.empty_state_add_sub_creative')
+%>
+<div class="creative-empty-state">
+  <div class="creative-empty-state-icon" aria-hidden="true">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+      <rect x="3" y="3" width="7" height="5" rx="1"/>
+      <rect x="14" y="10" width="7" height="5" rx="1"/>
+      <rect x="14" y="17.5" width="7" height="5" rx="1" opacity="0.45"/>
+      <path d="M6.5 8v9a2 2 0 0 0 2 2H14M6.5 10.5V12.5"/>
+      <path d="M6.5 8v2.5a2 2 0 0 0 2 2H14"/>
+    </svg>
+  </div>
+  <h3 class="creative-empty-state-heading"><%= heading %></h3>
+
+  <div class="creative-empty-state-concept">
+    <div class="creative-empty-state-concept-title"><%= t('collavre.creatives.index.empty_state_concept_title') %></div>
+    <div class="creative-empty-state-concept-diagram">
+      <div class="creative-empty-state-facet">
+        <div class="creative-empty-state-facet-chip" aria-hidden="true">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6"/><path d="M8 13h8M8 17h5"/></svg>
+        </div>
+        <div class="creative-empty-state-facet-label"><%= t('collavre.creatives.index.empty_state_facet_doc') %></div>
+      </div>
+      <span class="creative-empty-state-op" aria-hidden="true">+</span>
+      <div class="creative-empty-state-facet">
+        <div class="creative-empty-state-facet-chip" aria-hidden="true">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="3"/><path d="M8 12l3 3 5-6"/></svg>
+        </div>
+        <div class="creative-empty-state-facet-label"><%= t('collavre.creatives.index.empty_state_facet_task') %></div>
+      </div>
+      <span class="creative-empty-state-op" aria-hidden="true">+</span>
+      <div class="creative-empty-state-facet">
+        <div class="creative-empty-state-facet-chip" aria-hidden="true">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M21 11.5a8.38 8.38 0 0 1-8.5 8.3 8.9 8.9 0 0 1-3.9-.9L3 20l1.1-4.4a8.1 8.1 0 0 1-1-3.9A8.38 8.38 0 0 1 11.6 3.4a8.38 8.38 0 0 1 9.4 8.1z"/></svg>
+        </div>
+        <div class="creative-empty-state-facet-label"><%= t('collavre.creatives.index.empty_state_facet_chat') %></div>
+      </div>
+      <span class="creative-empty-state-op" aria-hidden="true">=</span>
+      <div class="creative-empty-state-block">
+        <div class="creative-empty-state-block-icons" aria-hidden="true">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6"/><path d="M8 13h8M8 17h5"/></svg>
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="3"/><path d="M8 12l3 3 5-6"/></svg>
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M21 11.5a8.38 8.38 0 0 1-8.5 8.3 8.9 8.9 0 0 1-3.9-.9L3 20l1.1-4.4a8.1 8.1 0 0 1-1-3.9A8.38 8.38 0 0 1 11.6 3.4a8.38 8.38 0 0 1 9.4 8.1z"/></svg>
+        </div>
+        <div class="creative-empty-state-block-label"><%= t('collavre.creatives.index.empty_state_block_label') %></div>
+      </div>
+    </div>
+    <p class="creative-empty-state-concept-caption"><%= t('collavre.creatives.index.empty_state_concept_caption') %></p>
+  </div>
+
+  <% if can_add %>
+    <div class="creative-empty-state-actions">
+      <div class="creative-empty-state-actions-row">
+        <%= render 'add_button', label: add_label, shortcut_hint: 'Enter' %>
+        <button type="button" class="btn btn-secondary" data-action="click->creatives--import#toggle">
+          <span aria-hidden="true"><%= svg_tag 'arrow-down.svg', width: 14, height: 14 %></span>
+          <%= t('collavre.creatives.index.import_markdown') %>
+        </button>
+      </div>
+    </div>
+  <% elsif authenticated? && creative %>
+    <div class="creative-empty-state-readonly" data-controller="creatives--write-access-request" data-creatives--write-access-request-url-value="<%= request_permission_creative_path(creative) %>">
+      <p class="creative-empty-state-readonly-message"><%= t('collavre.creatives.index.empty_state_readonly_message') %></p>
+      <button type="button" class="btn btn-primary" data-creatives--write-access-request-target="button" data-action="click->creatives--write-access-request#request">
+        <span aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="10" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg></span>
+        <%= t('collavre.creatives.index.request_permission') %>
+      </button>
+      <span class="creative-empty-state-request-pending" data-creatives--write-access-request-target="pending" hidden>
+        <span class="creative-empty-state-request-pending-dot" aria-hidden="true"></span>
+        <%= t('collavre.creatives.index.empty_state_request_pending') %>
+      </span>
+    </div>
+  <% end %>
+</div>

--- a/engines/collavre/app/views/collavre/creatives/_empty_state.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/_empty_state.html.erb
@@ -62,7 +62,7 @@
   <% if can_add %>
     <div class="creative-empty-state-actions">
       <div class="creative-empty-state-actions-row">
-        <%= render 'add_button', label: add_label, shortcut_hint: 'Enter' %>
+        <%= render 'add_button', label: add_label, shortcut_hint: t('collavre.creatives.index.empty_state_add_shortcut') %>
         <button type="button" class="btn btn-secondary" data-action="click->creatives--import#toggle">
           <span aria-hidden="true"><%= svg_tag 'arrow-down.svg', width: 14, height: 14 %></span>
           <%= t('collavre.creatives.index.import_markdown') %>

--- a/engines/collavre/app/views/collavre/creatives/_empty_state.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/_empty_state.html.erb
@@ -69,7 +69,15 @@
         </button>
       </div>
     </div>
-  <% elsif authenticated? && creative %>
+  <% elsif !authenticated? %>
+    <div class="creative-empty-state-loggedout">
+      <p class="creative-empty-state-loggedout-message"><%= t('collavre.creatives.index.empty_state_loggedout_message') %></p>
+      <div class="creative-empty-state-actions-row">
+        <%= link_to t('collavre.users.new.sign_up'), collavre.new_user_path, class: 'btn btn-primary' %>
+        <%= link_to t('app.sign_in'), collavre.new_session_path, class: 'btn btn-secondary' %>
+      </div>
+    </div>
+  <% elsif creative %>
     <div class="creative-empty-state-readonly" data-controller="creatives--write-access-request" data-creatives--write-access-request-url-value="<%= request_permission_creative_path(creative) %>">
       <p class="creative-empty-state-readonly-message"><%= t('collavre.creatives.index.empty_state_readonly_message') %></p>
       <button type="button" class="btn btn-primary" data-creatives--write-access-request-target="button" data-action="click->creatives--write-access-request#request">

--- a/engines/collavre/app/views/collavre/creatives/_empty_state.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/_empty_state.html.erb
@@ -78,7 +78,7 @@
       </div>
     </div>
   <% elsif creative %>
-    <div class="creative-empty-state-readonly" data-controller="creatives--write-access-request" data-creatives--write-access-request-url-value="<%= request_permission_creative_path(creative) %>">
+    <div class="creative-empty-state-readonly" data-controller="creatives--write-access-request" data-creatives--write-access-request-url-value="<%= request_permission_creative_path(creative) %>" data-creatives--write-access-request-failure-message-value="<%= t('collavre.creatives.index.empty_state_request_failed') %>">
       <p class="creative-empty-state-readonly-message"><%= t('collavre.creatives.index.empty_state_readonly_message') %></p>
       <button type="button" class="btn btn-primary" data-creatives--write-access-request-target="button" data-action="click->creatives--write-access-request#request">
         <span aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="10" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg></span>

--- a/engines/collavre/app/views/collavre/creatives/_inline_edit_form.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/_inline_edit_form.html.erb
@@ -95,7 +95,9 @@
                   data-confirm="<%= t('collavre.creatives.index.archive_confirm') %>"
                   data-archive-label="<%= t('collavre.creatives.index.archive') %>"
                   data-restore-label="<%= t('collavre.creatives.index.unarchive') %>"
-                  data-restore-confirm="<%= t('collavre.creatives.index.unarchive_confirm', default: 'Restore this creative?') %>">
+                  data-restore-confirm="<%= t('collavre.creatives.index.unarchive_confirm', default: 'Restore this creative?') %>"
+                  data-failure-message="<%= t('collavre.creatives.index.archive_failed_alert') %>"
+                  data-restore-failure-message="<%= t('collavre.creatives.index.unarchive_failed_alert') %>">
             <%= t('collavre.creatives.index.archive') %>
           </button>
           <button type="button"

--- a/engines/collavre/app/views/collavre/creatives/_inline_edit_form.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/_inline_edit_form.html.erb
@@ -1,5 +1,6 @@
 <div id="inline-edit-form" class="inline-edit-form-shell" style="display:none;">
-  <form id="inline-edit-form-element" method="post">
+  <form id="inline-edit-form-element" method="post"
+        data-save-failed-message="<%= t('collavre.creatives.index.save_failed_alert') %>">
     <input type="hidden" id="inline-method" name="_method" value="patch" />
     <input type="hidden" name="authenticity_token" value="<%= form_authenticity_token %>" />
     <input type="hidden" id="inline-creative-description" name="creative[description]" />

--- a/engines/collavre/app/views/collavre/creatives/index.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/index.html.erb
@@ -240,6 +240,12 @@
       empty_html = render('empty_state', root: params[:id].blank?, can_add: can_add, creative: @parent_creative)
     end
   end
+  # Distinct fallback for when the async tree fetch itself fails (non-2xx,
+  # JSON parse failure, or a non-transient network error after retries are
+  # exhausted). Must NOT include Add/Import CTAs: the request never actually
+  # confirmed the tree is empty, so offering creation actions here would
+  # mislead a user whose workspace already has creatives.
+  error_html = content_tag(:p, t('.load_error'), class: 'creative-tree-error', style: 'text-align: center;')
   # Only pass filter parameters to avoid unnecessary params in URL
   tree_params = params.to_unsafe_h.slice(
     "id", "tags", "min_progress", "max_progress", "search", "comment",
@@ -256,6 +262,7 @@
         controller: 'creatives--tree creatives--sync',
         'creatives--tree-url-value': tree_url,
         'creatives--tree-empty-html-value': empty_html.to_s,
+        'creatives--tree-error-html-value': error_html.to_s,
         'creatives--sync-root-id-value': @parent_creative&.effective_origin&.id,
         'creatives--sync-current-user-id-value': Current.user&.id,
         edit_icon_html: svg_tag("edit.svg", className: "icon-edit"),

--- a/engines/collavre/app/views/collavre/creatives/index.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/index.html.erb
@@ -15,6 +15,10 @@
      data-creatives--import-dragover-class="dragover">
   <% current_creative = @parent_creative || @creative %>
   <% can_manage_integrations = current_creative&.has_permission?(Current.user, :admin) %>
+  <%# Reused for the header Add button, the Import menu item, and the empty-state
+      CTAs: root level is always addable for authenticated users; a nested level
+      additionally requires write permission on @parent_creative. %>
+  <% can_add = authenticated? && (!params[:id] || (@parent_creative && @parent_creative.has_permission?(Current.user, :write))) %>
 
   <div class="creative-actions-row">
     <%# Left: breadcrumb ancestry %>
@@ -36,7 +40,7 @@
     <%# Right: primary actions + overflow %>
     <div class="creative-header-actions">
       <%# Add button (always visible) %>
-      <%= render 'add_button' if authenticated? && (!params[:id] || (@parent_creative && @parent_creative.has_permission?(Current.user, :write))) %>
+      <%= render 'add_button' if can_add %>
 
       <%# Expand/collapse toggle (always visible) %>
       <button id="expand-all-btn" class="creative-header-outline-btn" title="<%= t('app.expand_all') %>" data-expand-text="<%= t('app.expand_all') %>" data-collapse-text="<%= t('app.collapse_all') %>" data-action="click->creatives--expansion#toggleAll" data-creatives--expansion-target="expand">
@@ -74,7 +78,7 @@
           <% end %>
         <% end %>
         <div class="creative-overflow-divider"></div>
-        <% if authenticated? && (!params[:id] || (@parent_creative && @parent_creative.has_permission?(Current.user, :write))) %>
+        <% if can_add %>
           <button type="button" id="import-markdown-btn" class="popup-menu-item" data-action="click->creatives--import#toggle" data-creatives--import-target="toggle">
             <span aria-hidden="true"><%= svg_tag 'arrow-down.svg', width: 16, height: 16 %></span> <%= t('.import_markdown') %>
           </button>
@@ -219,8 +223,7 @@
       action = content_tag(:div, button_to(t('.request_permission'), request_permission_creative_path(@creative), method: :post), style: 'text-align: center;')
       empty_html = message + action
     else
-      text = params[:id] ? t('.no_sub_creatives') : t('.no_creatives')
-      empty_html = content_tag(:p, text, style: 'text-align: center;')
+      empty_html = render('empty_state', root: params[:id].blank?, can_add: can_add, creative: @parent_creative)
     end
   end
   # Only pass filter parameters to avoid unnecessary params in URL

--- a/engines/collavre/app/views/collavre/creatives/index.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/index.html.erb
@@ -216,7 +216,7 @@
 <%
   empty_html = nil
   if (@creatives || []).blank?
-    if params[:search].present?
+    if any_filter_active?
       empty_html = content_tag(:p, t('.no_search_results'), style: 'text-align: center;')
     elsif params[:id] && @creative && !@creative.has_permission?(Current.user, :read)
       message = content_tag(:p, t('.no_permission'), style: 'text-align: center;')

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -270,6 +270,7 @@ en:
       creative_shared: '%{user} shared "%{short_title}".'
       user_mentioned: '%{user} mentioned you in "%{creative}": "%{comment}"'
       permission_requested: '%{user} requested access to "%{short_title}".'
+      write_permission_requested: '%{user} requested write access to "%{short_title}".'
       comment_deleted_by_admin: '%{admin_name} deleted your comment in "%{creative_snippet}":
         %{comment_content}'
       comment_content_unavailable: "(comment unavailable)"

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -267,6 +267,7 @@ ko:
       creative_shared: '%{user} 가 "%{short_title}" 을 공유했습니다.'
       user_mentioned: '%{user} 님이 "%{creative}" 에서 당신을 언급했습니다: "%{comment}"'
       permission_requested: '%{user} 이 크리에이티브 "%{short_title}" 에 대한 권한 요청을 했습니다.'
+      write_permission_requested: '%{user} 이 크리에이티브 "%{short_title}" 에 대한 쓰기 권한 요청을 했습니다.'
       comment_deleted_by_admin: '%{admin_name} 님이 "%{creative_snippet}" 에서 당신의 댓글을
         삭제했습니다: %{comment_content}'
       comment_content_unavailable: "(삭제된 댓글 내용을 표시할 수 없습니다)"

--- a/engines/collavre/config/locales/creatives.en.yml
+++ b/engines/collavre/config/locales/creatives.en.yml
@@ -56,6 +56,7 @@ en:
         empty_state_add_sub_creative: Add sub-creative
         empty_state_readonly_message: You don't have write access to add sub-creatives here.
         empty_state_request_pending: Access requested · awaiting owner approval
+        empty_state_loggedout_message: Sign up or log in to add sub-creatives.
         link_loading: Loading…
         link_expand: Expand
         search_placeholder: Search creatives...

--- a/engines/collavre/config/locales/creatives.en.yml
+++ b/engines/collavre/config/locales/creatives.en.yml
@@ -54,6 +54,7 @@ en:
         empty_state_concept_caption: One block plays all three roles — document, task, and conversation. Stacked as a tree, it becomes a document-shaped project with automatic progress rollup.
         empty_state_add_creative: Add creative
         empty_state_add_sub_creative: Add sub-creative
+        empty_state_add_shortcut: Enter
         empty_state_readonly_message: You don't have write access to add sub-creatives here.
         empty_state_request_pending: Access requested · awaiting owner approval
         empty_state_loggedout_message: Sign up or log in to add sub-creatives.

--- a/engines/collavre/config/locales/creatives.en.yml
+++ b/engines/collavre/config/locales/creatives.en.yml
@@ -44,6 +44,18 @@ en:
         no_creatives: No creatives found.
         no_sub_creatives: No sub-creatives found.
         no_search_results: No creatives match your search.
+        empty_state_heading_root: No creatives yet
+        empty_state_heading_sub: No sub-creatives yet
+        empty_state_concept_title: "💡 What's a creative?"
+        empty_state_facet_doc: Tree-structured document piece
+        empty_state_facet_task: Actionable task (progress)
+        empty_state_facet_chat: Discussion channel
+        empty_state_block_label: One creative block
+        empty_state_concept_caption: One block plays all three roles — document, task, and conversation. Stacked as a tree, it becomes a document-shaped project with automatic progress rollup.
+        empty_state_add_creative: Add creative
+        empty_state_add_sub_creative: Add sub-creative
+        empty_state_readonly_message: You don't have write access to add sub-creatives here.
+        empty_state_request_pending: Access requested · awaiting owner approval
         link_loading: Loading…
         link_expand: Expand
         search_placeholder: Search creatives...

--- a/engines/collavre/config/locales/creatives.en.yml
+++ b/engines/collavre/config/locales/creatives.en.yml
@@ -142,6 +142,7 @@ en:
         progress_complete: Complete
         progress_incomplete: Incomplete
         progress_complete_children_alert: Marking this creative complete will also mark all child creatives complete.
+        save_failed_alert: Failed to save changes. Your edits are still open in the editor. Please check your connection and try again.
         mark_complete: Mark as complete
         mark_incomplete: Mark as incomplete
         set_plan_title: Set Plan for Selected Creative

--- a/engines/collavre/config/locales/creatives.en.yml
+++ b/engines/collavre/config/locales/creatives.en.yml
@@ -53,6 +53,7 @@ en:
         no_creatives: No creatives found.
         no_sub_creatives: No sub-creatives found.
         no_search_results: No creatives match your search.
+        load_error: Could not load the creative tree.
         empty_state_heading_root: No creatives yet
         empty_state_heading_sub: No sub-creatives yet
         empty_state_concept_title: "💡 What's a creative?"

--- a/engines/collavre/config/locales/creatives.en.yml
+++ b/engines/collavre/config/locales/creatives.en.yml
@@ -143,6 +143,8 @@ en:
         progress_incomplete: Incomplete
         progress_complete_children_alert: Marking this creative complete will also mark all child creatives complete.
         save_failed_alert: Failed to save changes. Your edits are still open in the editor. Please check your connection and try again.
+        archive_failed_alert: Failed to archive this creative. Nothing was changed. Please check your connection and try again.
+        unarchive_failed_alert: Failed to restore this creative. Nothing was changed. Please check your connection and try again.
         mark_complete: Mark as complete
         mark_incomplete: Mark as incomplete
         set_plan_title: Set Plan for Selected Creative

--- a/engines/collavre/config/locales/creatives.en.yml
+++ b/engines/collavre/config/locales/creatives.en.yml
@@ -67,6 +67,7 @@ en:
         empty_state_add_shortcut: Enter
         empty_state_readonly_message: You don't have write access to add sub-creatives here.
         empty_state_request_pending: Access requested · awaiting owner approval
+        empty_state_request_failed: Could not request access. Please try again.
         empty_state_loggedout_message: Sign up or log in to add sub-creatives.
         link_loading: Loading…
         link_expand: Expand

--- a/engines/collavre/config/locales/creatives.ko.yml
+++ b/engines/collavre/config/locales/creatives.ko.yml
@@ -130,6 +130,7 @@ ko:
         progress_complete: 완료
         progress_incomplete: 미완료
         progress_complete_children_alert: 하위 크리에이티브도 모두 완료로 표시됩니다.
+        save_failed_alert: 변경사항을 저장하지 못했습니다. 수정한 내용은 편집기에 그대로 남아 있습니다. 연결 상태를 확인한 뒤 다시 시도해 주세요.
         mark_complete: 완료로 표시
         mark_incomplete: 미완료로 표시
         set_plan_title: 선택된 크리에이티브에 대한 계획 설정

--- a/engines/collavre/config/locales/creatives.ko.yml
+++ b/engines/collavre/config/locales/creatives.ko.yml
@@ -131,6 +131,8 @@ ko:
         progress_incomplete: 미완료
         progress_complete_children_alert: 하위 크리에이티브도 모두 완료로 표시됩니다.
         save_failed_alert: 변경사항을 저장하지 못했습니다. 수정한 내용은 편집기에 그대로 남아 있습니다. 연결 상태를 확인한 뒤 다시 시도해 주세요.
+        archive_failed_alert: 아카이브하지 못했습니다. 변경된 내용은 없습니다. 연결 상태를 확인한 뒤 다시 시도해 주세요.
+        unarchive_failed_alert: 복원하지 못했습니다. 변경된 내용은 없습니다. 연결 상태를 확인한 뒤 다시 시도해 주세요.
         mark_complete: 완료로 표시
         mark_incomplete: 미완료로 표시
         set_plan_title: 선택된 크리에이티브에 대한 계획 설정

--- a/engines/collavre/config/locales/creatives.ko.yml
+++ b/engines/collavre/config/locales/creatives.ko.yml
@@ -50,6 +50,7 @@ ko:
         empty_state_concept_caption: 하나의 블록이 문서·작업·대화 역할을 동시에 합니다. 트리로 쌓으면 진행률이 자동 집계되는 문서형 프로젝트가 됩니다.
         empty_state_add_creative: 크리에이티브 추가
         empty_state_add_sub_creative: 하위 크리에이티브 추가
+        empty_state_add_shortcut: Enter
         empty_state_readonly_message: 이 크리에이티브에 쓰기 권한이 없어 하위 항목을 추가할 수 없습니다.
         empty_state_request_pending: 권한 요청됨 · 소유자 승인 대기 중
         empty_state_loggedout_message: 하위 크리에이티브를 추가하려면 회원가입 또는 로그인하세요.

--- a/engines/collavre/config/locales/creatives.ko.yml
+++ b/engines/collavre/config/locales/creatives.ko.yml
@@ -49,6 +49,7 @@ ko:
         no_creatives: 크리에이티브가 없습니다.
         no_sub_creatives: 하위 크리에이티브가 없습니다.
         no_search_results: 검색 결과가 없습니다.
+        load_error: 크리에이티브 트리를 불러오지 못했습니다.
         empty_state_heading_root: 크리에이티브가 없습니다
         empty_state_heading_sub: 아직 하위 크리에이티브가 없습니다
         empty_state_concept_title: "💡 크리에이티브란?"

--- a/engines/collavre/config/locales/creatives.ko.yml
+++ b/engines/collavre/config/locales/creatives.ko.yml
@@ -63,6 +63,7 @@ ko:
         empty_state_add_shortcut: Enter
         empty_state_readonly_message: 이 크리에이티브에 쓰기 권한이 없어 하위 항목을 추가할 수 없습니다.
         empty_state_request_pending: 권한 요청됨 · 소유자 승인 대기 중
+        empty_state_request_failed: 권한을 요청하지 못했습니다. 다시 시도해 주세요.
         empty_state_loggedout_message: 하위 크리에이티브를 추가하려면 회원가입 또는 로그인하세요.
         link_loading: 불러오는 중…
         link_expand: 펼치기

--- a/engines/collavre/config/locales/creatives.ko.yml
+++ b/engines/collavre/config/locales/creatives.ko.yml
@@ -52,6 +52,7 @@ ko:
         empty_state_add_sub_creative: 하위 크리에이티브 추가
         empty_state_readonly_message: 이 크리에이티브에 쓰기 권한이 없어 하위 항목을 추가할 수 없습니다.
         empty_state_request_pending: 권한 요청됨 · 소유자 승인 대기 중
+        empty_state_loggedout_message: 하위 크리에이티브를 추가하려면 회원가입 또는 로그인하세요.
         link_loading: 불러오는 중…
         link_expand: 펼치기
         recommend_parent: 카테고리 추천

--- a/engines/collavre/config/locales/creatives.ko.yml
+++ b/engines/collavre/config/locales/creatives.ko.yml
@@ -40,6 +40,18 @@ ko:
         no_creatives: 크리에이티브가 없습니다.
         no_sub_creatives: 하위 크리에이티브가 없습니다.
         no_search_results: 검색 결과가 없습니다.
+        empty_state_heading_root: 크리에이티브가 없습니다
+        empty_state_heading_sub: 아직 하위 크리에이티브가 없습니다
+        empty_state_concept_title: "💡 크리에이티브란?"
+        empty_state_facet_doc: 트리 구조 문서 조각
+        empty_state_facet_task: 실행 가능한 작업 (진행률)
+        empty_state_facet_chat: 관련 대화 채널
+        empty_state_block_label: 크리에이티브 1블록
+        empty_state_concept_caption: 하나의 블록이 문서·작업·대화 역할을 동시에 합니다. 트리로 쌓으면 진행률이 자동 집계되는 문서형 프로젝트가 됩니다.
+        empty_state_add_creative: 크리에이티브 추가
+        empty_state_add_sub_creative: 하위 크리에이티브 추가
+        empty_state_readonly_message: 이 크리에이티브에 쓰기 권한이 없어 하위 항목을 추가할 수 없습니다.
+        empty_state_request_pending: 권한 요청됨 · 소유자 승인 대기 중
         link_loading: 불러오는 중…
         link_expand: 펼치기
         recommend_parent: 카테고리 추천

--- a/engines/collavre/test/controllers/creatives_controller_empty_state_test.rb
+++ b/engines/collavre/test/controllers/creatives_controller_empty_state_test.rb
@@ -71,6 +71,28 @@ class CreativesControllerEmptyStateTest < ActionDispatch::IntegrationTest
     refute_includes response.body, html_t("collavre.creatives.index.empty_state_concept_title")
   end
 
+  test "non-search filter with zero results shows no-results message, not the actionable empty state" do
+    sign_in_as(users(:one), password: "password")
+
+    get creatives_path(min_progress: 101)
+
+    assert_response :success
+    assert_includes response.body, html_t("collavre.creatives.index.no_search_results")
+    refute_includes response.body, html_t("collavre.creatives.index.empty_state_heading_root")
+    refute_includes response.body, html_t("collavre.creatives.index.empty_state_concept_title")
+  end
+
+  test "assignee_id filter with zero results shows no-results message, not the actionable empty state" do
+    sign_in_as(users(:one), password: "password")
+
+    get creatives_path(assignee_id: users(:one).id)
+
+    assert_response :success
+    assert_includes response.body, html_t("collavre.creatives.index.no_search_results")
+    refute_includes response.body, html_t("collavre.creatives.index.empty_state_heading_root")
+    refute_includes response.body, html_t("collavre.creatives.index.empty_state_concept_title")
+  end
+
   test "requesting an unreadable or nonexistent id still renders the generic sub-creatives text without crashing" do
     sign_in_as(users(:one), password: "password")
 
@@ -80,6 +102,16 @@ class CreativesControllerEmptyStateTest < ActionDispatch::IntegrationTest
     assert_includes response.body, html_t("collavre.creatives.index.empty_state_heading_sub")
     refute_includes response.body, html_t("collavre.creatives.index.empty_state_readonly_message")
     refute_includes response.body, html_t("collavre.creatives.index.request_permission")
+  end
+
+  test "root empty state sources the Add button's kbd shortcut hint from i18n, not a hardcoded literal" do
+    sign_in_as(users(:one), password: "password")
+    I18n.backend.store_translations(:en, collavre: { creatives: { index: { empty_state_add_shortcut: "TestShortcut" } } })
+
+    get creatives_path
+
+    assert_response :success
+    assert_includes response.body, "<kbd class=\"add-creative-btn-kbd\">TestShortcut</kbd>"
   end
 
   test "unauthenticated visitor at root sees sign up / log in CTAs" do

--- a/engines/collavre/test/controllers/creatives_controller_empty_state_test.rb
+++ b/engines/collavre/test/controllers/creatives_controller_empty_state_test.rb
@@ -56,6 +56,7 @@ class CreativesControllerEmptyStateTest < ActionDispatch::IntegrationTest
     assert_includes response.body, html_t("collavre.creatives.index.empty_state_readonly_message")
     assert_includes response.body, html_t("collavre.creatives.index.request_permission")
     assert_includes response.body, request_permission_creative_path(creative)
+    assert_includes response.body, "data-creatives--write-access-request-failure-message-value=\"#{html_t('collavre.creatives.index.empty_state_request_failed')}\""
     refute_includes response.body, html_t("collavre.creatives.index.empty_state_add_sub_creative")
     refute_match(/add-creative-btn--cta/, response.body)
   end

--- a/engines/collavre/test/controllers/creatives_controller_empty_state_test.rb
+++ b/engines/collavre/test/controllers/creatives_controller_empty_state_test.rb
@@ -82,7 +82,7 @@ class CreativesControllerEmptyStateTest < ActionDispatch::IntegrationTest
     refute_includes response.body, html_t("collavre.creatives.index.request_permission")
   end
 
-  test "unauthenticated visitor at root sees no CTAs" do
+  test "unauthenticated visitor at root sees sign up / log in CTAs" do
     sign_out
 
     get creatives_path
@@ -90,9 +90,15 @@ class CreativesControllerEmptyStateTest < ActionDispatch::IntegrationTest
     assert_response :success
     refute_match(/class="[^"]*\bnew-root-creative-btn\b/, response.body)
     refute_includes response.body, html_t("collavre.creatives.index.empty_state_add_creative")
+    refute_includes response.body, html_t("collavre.creatives.index.empty_state_readonly_message")
+    assert_includes response.body, html_t("collavre.creatives.index.empty_state_loggedout_message")
+    assert_includes response.body, html_t("collavre.users.new.sign_up")
+    assert_includes response.body, html_t("app.sign_in")
+    assert_includes response.body, new_user_path
+    assert_includes response.body, new_session_path
   end
 
-  test "unauthenticated visitor on a publicly-shared childless creative sees no CTAs" do
+  test "unauthenticated visitor on a publicly-shared childless creative sees sign up / log in CTAs" do
     creative = creatives(:childless_creative)
     perform_enqueued_jobs do
       Collavre::CreativeShare.create!(creative: creative, user: nil, permission: :read)
@@ -106,5 +112,10 @@ class CreativesControllerEmptyStateTest < ActionDispatch::IntegrationTest
     refute_includes response.body, html_t("collavre.creatives.index.empty_state_readonly_message")
     refute_includes response.body, html_t("collavre.creatives.index.empty_state_add_sub_creative")
     refute_match(/add-creative-btn--cta/, response.body)
+    assert_includes response.body, html_t("collavre.creatives.index.empty_state_loggedout_message")
+    assert_includes response.body, html_t("collavre.users.new.sign_up")
+    assert_includes response.body, html_t("app.sign_in")
+    assert_includes response.body, new_user_path
+    assert_includes response.body, new_session_path
   end
 end

--- a/engines/collavre/test/controllers/creatives_controller_empty_state_test.rb
+++ b/engines/collavre/test/controllers/creatives_controller_empty_state_test.rb
@@ -1,0 +1,110 @@
+require "test_helper"
+
+class CreativesControllerEmptyStateTest < ActionDispatch::IntegrationTest
+  # The HTML branch of CreativesController#index always renders with
+  # @creatives = [] (real data streams in via a separate JSON fetch), so the
+  # empty-state markup built in index.html.erb is present on every initial
+  # HTML page load regardless of whether the tree actually has children.
+
+  # Translations are rendered through `<%= t(...) %>`, so HTML-sensitive
+  # characters (e.g. the apostrophe in "What's a creative?") come back
+  # entity-escaped in the response body.
+  def html_t(key)
+    ERB::Util.html_escape(I18n.t(key))
+  end
+
+  test "root empty state shows writable CTAs for an authenticated user" do
+    sign_in_as(users(:one), password: "password")
+
+    get creatives_path
+
+    assert_response :success
+    assert_includes response.body, html_t("collavre.creatives.index.empty_state_heading_root")
+    assert_includes response.body, html_t("collavre.creatives.index.empty_state_concept_title")
+    assert_match(/class="[^"]*\bnew-root-creative-btn\b[^"]*"/, response.body)
+    assert_includes response.body, html_t("collavre.creatives.index.empty_state_add_creative")
+    assert_includes response.body, 'data-action="click->creatives--import#toggle"'
+    assert_includes response.body, html_t("collavre.creatives.index.import_markdown")
+    refute_includes response.body, html_t("collavre.creatives.index.empty_state_readonly_message")
+  end
+
+  test "nested empty state shows writable CTAs when the user has write permission" do
+    creative = creatives(:childless_creative)
+    sign_in_as(users(:one), password: "password")
+
+    get creatives_path(id: creative.id)
+
+    assert_response :success
+    assert_includes response.body, html_t("collavre.creatives.index.empty_state_heading_sub")
+    assert_match(/class="[^"]*\badd-creative-btn--cta\b[^"]*"[^>]*data-parent-id="#{creative.id}"/, response.body)
+    assert_includes response.body, html_t("collavre.creatives.index.empty_state_add_sub_creative")
+    assert_includes response.body, html_t("collavre.creatives.index.import_markdown")
+    refute_includes response.body, html_t("collavre.creatives.index.empty_state_readonly_message")
+  end
+
+  test "nested empty state shows the write-access request CTA when the user only has read permission" do
+    creative = creatives(:childless_creative)
+    perform_enqueued_jobs do
+      Collavre::CreativeShare.create!(creative: creative, user: users(:two), permission: :read)
+    end
+    sign_in_as(users(:two), password: "password")
+
+    get creatives_path(id: creative.id)
+
+    assert_response :success
+    assert_includes response.body, html_t("collavre.creatives.index.empty_state_heading_sub")
+    assert_includes response.body, html_t("collavre.creatives.index.empty_state_readonly_message")
+    assert_includes response.body, html_t("collavre.creatives.index.request_permission")
+    assert_includes response.body, request_permission_creative_path(creative)
+    refute_includes response.body, html_t("collavre.creatives.index.empty_state_add_sub_creative")
+    refute_match(/add-creative-btn--cta/, response.body)
+  end
+
+  test "search-no-results branch is unaffected by the empty-state change" do
+    sign_in_as(users(:one), password: "password")
+
+    get creatives_path(search: "no-such-creative-zzz")
+
+    assert_response :success
+    assert_includes response.body, html_t("collavre.creatives.index.no_search_results")
+    refute_includes response.body, html_t("collavre.creatives.index.empty_state_heading_root")
+    refute_includes response.body, html_t("collavre.creatives.index.empty_state_concept_title")
+  end
+
+  test "requesting an unreadable or nonexistent id still renders the generic sub-creatives text without crashing" do
+    sign_in_as(users(:one), password: "password")
+
+    get creatives_path(id: 0)
+
+    assert_response :success
+    assert_includes response.body, html_t("collavre.creatives.index.empty_state_heading_sub")
+    refute_includes response.body, html_t("collavre.creatives.index.empty_state_readonly_message")
+    refute_includes response.body, html_t("collavre.creatives.index.request_permission")
+  end
+
+  test "unauthenticated visitor at root sees no CTAs" do
+    sign_out
+
+    get creatives_path
+
+    assert_response :success
+    refute_match(/class="[^"]*\bnew-root-creative-btn\b/, response.body)
+    refute_includes response.body, html_t("collavre.creatives.index.empty_state_add_creative")
+  end
+
+  test "unauthenticated visitor on a publicly-shared childless creative sees no CTAs" do
+    creative = creatives(:childless_creative)
+    perform_enqueued_jobs do
+      Collavre::CreativeShare.create!(creative: creative, user: nil, permission: :read)
+    end
+    sign_out
+
+    get creatives_path(id: creative.id)
+
+    assert_response :success
+    assert_includes response.body, html_t("collavre.creatives.index.empty_state_heading_sub")
+    refute_includes response.body, html_t("collavre.creatives.index.empty_state_readonly_message")
+    refute_includes response.body, html_t("collavre.creatives.index.empty_state_add_sub_creative")
+    refute_match(/add-creative-btn--cta/, response.body)
+  end
+end

--- a/engines/collavre/test/controllers/creatives_controller_request_permission_test.rb
+++ b/engines/collavre/test/controllers/creatives_controller_request_permission_test.rb
@@ -43,7 +43,7 @@ class CreativesControllerRequestPermissionTest < ActionDispatch::IntegrationTest
     expected_short_title = ApplicationController.helpers.strip_tags(creative.effective_origin.description).truncate(10)
     expected_link = "[#{expected_short_title}](#{Collavre::Engine.routes.url_helpers.creative_path(creative, open_comments: true)})"
     expected_message = I18n.t(
-      "inbox.permission_requested",
+      "inbox.write_permission_requested",
       user: users(:two).display_name,
       short_title: expected_link,
       locale: users(:one).locale || "en"
@@ -64,6 +64,17 @@ class CreativesControllerRequestPermissionTest < ActionDispatch::IntegrationTest
     end
 
     assert_response :success
+
+    comment = Comment.order(:created_at).last
+    expected_short_title = ApplicationController.helpers.strip_tags(creative.effective_origin.description).truncate(10)
+    expected_link = "[#{expected_short_title}](#{Collavre::Engine.routes.url_helpers.creative_path(creative, open_comments: true)})"
+    expected_message = I18n.t(
+      "inbox.write_permission_requested",
+      user: users(:two).display_name,
+      short_title: expected_link,
+      locale: users(:one).locale || "en"
+    )
+    assert_equal expected_message, comment.content
   end
 
   test "requester with zero access can still request permission (existing behavior preserved)" do
@@ -75,5 +86,16 @@ class CreativesControllerRequestPermissionTest < ActionDispatch::IntegrationTest
     end
 
     assert_response :success
+
+    comment = Comment.order(:created_at).last
+    expected_short_title = ApplicationController.helpers.strip_tags(creative.effective_origin.description).truncate(10)
+    expected_link = "[#{expected_short_title}](#{Collavre::Engine.routes.url_helpers.creative_path(creative, open_comments: true)})"
+    expected_message = I18n.t(
+      "inbox.permission_requested",
+      user: users(:two).display_name,
+      short_title: expected_link,
+      locale: users(:one).locale || "en"
+    )
+    assert_equal expected_message, comment.content
   end
 end

--- a/engines/collavre/test/controllers/creatives_controller_request_permission_test.rb
+++ b/engines/collavre/test/controllers/creatives_controller_request_permission_test.rb
@@ -1,0 +1,79 @@
+require "test_helper"
+
+class CreativesControllerRequestPermissionTest < ActionDispatch::IntegrationTest
+  test "owner requesting their own creative is rejected without sending anything" do
+    creative = creatives(:childless_creative)
+    sign_in_as(users(:one), password: "password")
+
+    assert_no_difference -> { Comment.count } do
+      post request_permission_creative_path(creative)
+    end
+
+    assert_response :unprocessable_entity
+  end
+
+  test "requester who already has write permission is rejected without sending anything" do
+    creative = creatives(:childless_creative)
+    perform_enqueued_jobs do
+      Collavre::CreativeShare.create!(creative: creative, user: users(:two), permission: :write)
+    end
+    sign_in_as(users(:two), password: "password")
+
+    assert_no_difference -> { Comment.count } do
+      post request_permission_creative_path(creative)
+    end
+
+    assert_response :unprocessable_entity
+  end
+
+  test "requester with read-only permission can request write access" do
+    creative = creatives(:childless_creative)
+    perform_enqueued_jobs do
+      Collavre::CreativeShare.create!(creative: creative, user: users(:two), permission: :read)
+    end
+    sign_in_as(users(:two), password: "password")
+
+    assert_difference -> { Comment.count }, 1 do
+      post request_permission_creative_path(creative)
+    end
+
+    assert_response :success
+
+    comment = Comment.order(:created_at).last
+    expected_short_title = ApplicationController.helpers.strip_tags(creative.effective_origin.description).truncate(10)
+    expected_link = "[#{expected_short_title}](#{Collavre::Engine.routes.url_helpers.creative_path(creative, open_comments: true)})"
+    expected_message = I18n.t(
+      "inbox.permission_requested",
+      user: users(:two).display_name,
+      short_title: expected_link,
+      locale: users(:one).locale || "en"
+    )
+    assert_equal expected_message, comment.content
+    assert_equal Creative.inbox_for(users(:one)), comment.creative
+  end
+
+  test "requester with feedback permission (below write) can request write access" do
+    creative = creatives(:childless_creative)
+    perform_enqueued_jobs do
+      Collavre::CreativeShare.create!(creative: creative, user: users(:two), permission: :feedback)
+    end
+    sign_in_as(users(:two), password: "password")
+
+    assert_difference -> { Comment.count }, 1 do
+      post request_permission_creative_path(creative)
+    end
+
+    assert_response :success
+  end
+
+  test "requester with zero access can still request permission (existing behavior preserved)" do
+    creative = creatives(:childless_creative)
+    sign_in_as(users(:two), password: "password")
+
+    assert_difference -> { Comment.count }, 1 do
+      post request_permission_creative_path(creative)
+    end
+
+    assert_response :success
+  end
+end

--- a/engines/collavre/test/system/creative_empty_state_inline_add_test.rb
+++ b/engines/collavre/test/system/creative_empty_state_inline_add_test.rb
@@ -1,0 +1,39 @@
+require_relative "../application_system_test_case"
+
+# Regression coverage for Codex review finding on PR #1485
+# (engines/collavre/app/views/collavre/creatives/_empty_state.html.erb:65):
+# clicking the empty-state's Add button starts the inline "new creative"
+# editor but left the big empty-state card visible underneath it, and
+# cancelling never brought it back.
+class CreativeEmptyStateInlineAddTest < ApplicationSystemTestCase
+  setup do
+    @user = User.create!(
+      email: "user@example.com",
+      password: SystemHelpers::PASSWORD,
+      name: "User",
+      email_verified_at: Time.current,
+      notifications_enabled: false
+    )
+    @parent_creative = Creative.create!(description: "Parent", user: @user)
+
+    resize_window_to
+    sign_in_via_ui(@user)
+    visit collavre.creative_path(@parent_creative)
+  end
+
+  test "hides the empty-state card while creating the first sub-creative inline, and restores it on cancel" do
+    wait_for_network_idle(timeout: 10)
+    assert_selector ".creative-empty-state", visible: true, wait: 5
+
+    find(".creative-empty-state .add-creative-btn", wait: 5).click
+
+    assert_selector "#inline-edit-form-element", wait: 5
+    assert_no_selector ".creative-empty-state", visible: true, wait: 5
+
+    find("#inline-close", wait: 5).click
+    assert_no_selector ".lexical-content-editable", visible: true, wait: 5
+    wait_for_network_idle(timeout: 10)
+
+    assert_selector ".creative-empty-state", visible: true, wait: 5
+  end
+end

--- a/engines/collavre/test/system/creative_empty_state_inline_add_test.rb
+++ b/engines/collavre/test/system/creative_empty_state_inline_add_test.rb
@@ -36,4 +36,64 @@ class CreativeEmptyStateInlineAddTest < ApplicationSystemTestCase
 
     assert_selector ".creative-empty-state", visible: true, wait: 5
   end
+
+  # End-to-end coverage for the second Codex finding on this partial: removing
+  # the last creative left #creatives holding nothing but the display:none card.
+  #
+  # These two are flow coverage, NOT discriminating regression tests: with the
+  # fix reverted they still pass, because the sync channel repaints the tree
+  # (tree_controller#showEmptyState) a moment after the removal and masks the
+  # local DOM state. The regression tests that fail without the fix are the
+  # Jest ones in creative_row_editor_empty_state_removal.test.js, which drive
+  # the real module with the network stubbed out — i.e. the case where that
+  # repaint never arrives.
+  test "restores the empty-state card after the only sub-creative is deleted" do
+    child = create_only_child
+    open_inline_editor_on(child)
+
+    find("#inline-delete-popup-toggle", wait: 5).click
+    find("#inline-delete", wait: 5).click
+    find(".modal-dialog-btn-danger", wait: 5).click
+
+    assert_no_selector row_selector(child), wait: 5
+    assert_selector ".creative-empty-state", visible: true, wait: 5
+  end
+
+  # Archiving additionally exercises the editor's closeEditor() call, which was
+  # an undefined reference until this change and threw inside the .then() rather
+  # than closing the editor.
+  test "restores the empty-state card after the only sub-creative is archived" do
+    child = create_only_child
+    open_inline_editor_on(child)
+
+    find("#inline-delete-popup-toggle", wait: 5).click
+    find("#inline-archive", wait: 5).click
+    find(".modal-dialog-btn-primary", wait: 5).click
+
+    assert_no_selector row_selector(child), wait: 5
+    assert_selector ".creative-empty-state", visible: true, wait: 5
+  end
+
+  private
+
+  def row_selector(creative)
+    "creative-tree-row[dom-id='creative-#{creative.id}']"
+  end
+
+  def create_only_child
+    child = Creative.create!(description: "Only child", user: @user, parent: @parent_creative)
+    visit collavre.creative_path(@parent_creative)
+    wait_for_network_idle(timeout: 10)
+    assert_selector row_selector(child), wait: 5
+    assert_no_selector ".creative-empty-state", visible: true
+    child
+  end
+
+  # The editor's destructive actions live behind the trash popup menu, which is
+  # only reachable once the row is open in the inline editor.
+  def open_inline_editor_on(creative)
+    find("#{row_selector(creative)} .creative-row", visible: :visible).hover
+    within(:css, row_selector(creative)) { find(".edit-inline-btn").click }
+    assert_selector "#inline-edit-form-element", visible: :visible, wait: 5
+  end
 end


### PR DESCRIPTION
## Summary

Replaces the creative tree's bare empty message with an actionable, localized empty state and hardens the inline-editor/tree lifecycle around the new actions.

The empty state now explains what a creative is and presents the action appropriate to the current user:

- **Writable:** Add a creative/sub-creative inline or import Markdown/PPT.
- **Read-only:** Request write access without leaving the page.
- **Signed out:** Sign up or log in.
- **Loading failure:** Show a distinct error state instead of actionable empty-state controls.

The UI supports English and Korean, uses the existing design tokens for light/dark mode, and preserves the existing search/no-permission branches.

## What changed

### Actionable empty state

- Added a reusable `_empty_state.html.erb` partial for root and nested trees.
- Reused the existing inline-add and import actions instead of introducing parallel flows.
- Extended `_add_button.html.erb` with optional label and shortcut locals; the displayed shortcut is `Enter`, matching the application behavior.
- Added responsive styles using existing design tokens, including reliable `[hidden]` behavior for buttons and status pills.
- Hide the empty-state card while the first inline creative is being created, restore it when that save fails, and restore it when the final visible creative is removed.
- Keep search-result and load-error states distinct from the true-empty state.

### Write-access request flow

- Broadened `Shareable#request_permission`'s guard from existing `:read` access to existing `:write` access, allowing read-only collaborators to request an upgrade while preserving the zero-access flow.
- Added `creatives--write-access-request` to submit the request asynchronously and replace the CTA with a pending indicator on success.
- Redirect expired sessions to sign-in instead of showing a false pending state.
- Surface non-OK and network failures with localized EN/KO feedback and re-enable the CTA for retry.

The pending indicator is intentionally client-side only because permission requests are notifications and have no persisted pending-request model; reloading shows the request button again.

### Inline editor and tree consistency

Review testing exposed several races in the existing shared inline editor. This PR now:

- Preserves rejected drafts and aborts row switches, archive/restore actions, and first-inline-save transitions when a save fails.
- Keeps editing presence and its periodic ping active until the closing save succeeds.
- Blocks a second editor session from reusing the shared form while a close save is in flight.
- Reports archive and restore request failures with localized feedback.
- Restores the actionable empty state after deleting or archiving the final row.
- Refetches promoted children after “Delete only this,” including children that were never expanded and therefore were not present in the DOM.
- Defers tree replacement while another editor is active, across row switches, and throughout archive/restore requests.
- Uses a counted reload hold so overlapping operations coalesce safely and release independently after their responses are applied.
- Avoids removing an archived subtree when a newer draft is open inside it; the editing-aware reload applies the server state after the draft is safely closed.

## Main files

- `engines/collavre/app/views/collavre/creatives/_empty_state.html.erb`
- `engines/collavre/app/views/collavre/creatives/index.html.erb`
- `engines/collavre/app/javascript/controllers/creatives/write_access_request_controller.js`
- `engines/collavre/app/javascript/controllers/creatives/tree_controller.js`
- `engines/collavre/app/javascript/modules/creative_row_editor.js`
- `engines/collavre/app/controllers/collavre/concerns/shareable.rb`
- `engines/collavre/config/locales/creatives.{en,ko}.yml`
- Focused controller, Jest, and system-test coverage for the behaviors above.

## Test plan

- [x] Full Jest suite: **905/905 passing**.
- [x] Empty-state inline-add system tests: **3/3 passing**.
- [x] Relevant Rails controller and i18n completeness tests passing.
- [x] RuboCop, Stylelint, schema load, security scan, CodeQL, and Codecov patch checks passing.
- [x] Manual browser QA: root/nested writable states, nested read-only access request, signed-out CTA, inline add/import, dark mode, and Korean locale.

Ready for review and squash merge per project convention.
