### PR TITLE
fix(creatives): clear empty-state placeholder when a sub-creative is added

### DIFF
--- a/engines/collavre/app/javascript/controllers/creatives/__tests__/select_mode_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/creatives/__tests__/select_mode_controller.test.js
@@ -1,0 +1,139 @@
+/**
+ * @jest-environment jsdom
+ */
+import { jest } from '@jest/globals'
+
+// Batch delete is DOM-repaired entirely client-side: the destroy broadcast
+// excludes the initiating user, so nothing comes back to fix this window.
+const csrfFetch = jest.fn(() => Promise.resolve({ ok: true }))
+const confirmDialog = jest.fn(() => Promise.resolve(true))
+
+jest.unstable_mockModule('../../../lib/api/csrf_fetch', () => ({
+  default: csrfFetch,
+  updateCsrfTokenFromResponse: jest.fn(),
+  refreshCsrfToken: jest.fn(),
+}))
+jest.unstable_mockModule('../../../lib/utils/confirm_dialog', () => ({
+  default: confirmDialog,
+  confirmDialog,
+}))
+
+const { Application } = await import('@hotwired/stimulus')
+const SelectModeController = (await import('../select_mode_controller')).default
+
+const EMPTY_HTML = '<div data-creatives-empty-state=""><p>No sub-creatives found.</p></div>'
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0))
+
+function rowMarkup(id) {
+  return `
+    <creative-tree-row creative-id="${id}">
+      <div class="creative-tree" id="creative-${id}" data-id="${id}" data-level="1">
+        <div class="creative-row" data-creatives--select-mode-target="row">
+          <input type="checkbox" class="select-creative-checkbox" value="${id}"
+                 data-creatives--select-mode-target="checkbox" />
+        </div>
+      </div>
+    </creative-tree-row>
+  `
+}
+
+// Post-client-render state: tree_controller wiped #creatives and rendered the rows
+// into it, so the placeholder only survives in the out-of-container template. Rows
+// are injected after the controller connects, as they are in the real app — the
+// server always ships #creatives empty and the tree fetch fills it in.
+async function mount(rowIds) {
+  document.body.innerHTML = `
+    <template id="creatives-empty-state-template">${EMPTY_HTML}</template>
+    <div data-controller="creatives--select-mode">
+      <button id="delete-selection-btn" data-confirm="Are you sure?"
+              data-creatives--select-mode-target="deleteButton"></button>
+      <div id="creatives"></div>
+    </div>
+  `
+
+  const application = Application.start()
+  application.register('creatives--select-mode', SelectModeController)
+  await flush()
+
+  container().innerHTML = rowIds.map(rowMarkup).join('')
+  await flush()
+  return application
+}
+
+function controllerFor(application) {
+  return application.getControllerForElementAndIdentifier(
+    document.querySelector('[data-controller="creatives--select-mode"]'),
+    'creatives--select-mode'
+  )
+}
+
+function container() {
+  return document.getElementById('creatives')
+}
+
+function placeholder() {
+  return container().querySelector('[data-creatives-empty-state]')
+}
+
+async function deleteSelected(application, ids) {
+  ids.forEach((id) => {
+    container().querySelector(`.select-creative-checkbox[value="${id}"]`).checked = true
+  })
+  await controllerFor(application).deleteSelected(new Event('click'))
+  await flush()
+}
+
+let application
+
+afterEach(() => {
+  application?.stop()
+  application = undefined
+  jest.clearAllMocks()
+  document.body.innerHTML = ''
+})
+
+test('deleting every selected row restores the empty-state placeholder', async () => {
+  application = await mount(['7', '8'])
+
+  await deleteSelected(application, ['7', '8'])
+
+  expect(csrfFetch).toHaveBeenCalledTimes(2)
+  expect(csrfFetch.mock.calls.map((call) => call[0])).toEqual([
+    '/creatives/7?delete_with_children=false',
+    '/creatives/8?delete_with_children=false',
+  ])
+  expect(placeholder()).not.toBeNull()
+  expect(placeholder().hidden).toBe(false)
+  expect(placeholder().textContent).toContain('No sub-creatives found.')
+})
+
+test('deleting a row takes its <creative-tree-row> wrapper with it', async () => {
+  application = await mount(['7', '8'])
+
+  await deleteSelected(application, ['7'])
+
+  // An emptied-but-present wrapper would read as "tree still populated" and
+  // suppress the placeholder forever.
+  expect(container().querySelectorAll('creative-tree-row')).toHaveLength(1)
+  expect(container().querySelector('creative-tree-row').getAttribute('creative-id')).toBe('8')
+})
+
+test('the placeholder stays away while rows remain', async () => {
+  application = await mount(['7', '8'])
+
+  await deleteSelected(application, ['7'])
+
+  expect(placeholder()).toBeNull()
+})
+
+test('declining the confirmation deletes nothing', async () => {
+  confirmDialog.mockResolvedValueOnce(false)
+  application = await mount(['7'])
+
+  await deleteSelected(application, ['7'])
+
+  expect(csrfFetch).not.toHaveBeenCalled()
+  expect(container().querySelectorAll('creative-tree-row')).toHaveLength(1)
+  expect(placeholder()).toBeNull()
+})

--- a/engines/collavre/app/javascript/controllers/creatives/__tests__/tree_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/creatives/__tests__/tree_controller.test.js
@@ -18,6 +18,7 @@ jest.unstable_mockModule('../../../utils/emoji_parser', () => ({
 const { Application } = await import('@hotwired/stimulus')
 const TreeController = (await import('../tree_controller')).default
 const { appendCreativeNodes } = await import('../../../creatives/tree_renderer')
+const { restoreTreeEmptyState } = await import('../../../modules/creative_tree_empty_state')
 
 const TRANSIENT_RETRY_DELAYS = [200, 600]
 
@@ -266,5 +267,130 @@ describe('CreativesTreeController Chats pagination (load more)', () => {
     expect(appendCreativeNodes).not.toHaveBeenCalled()
 
     application.stop()
+  })
+
+  // Deleting every row that is currently on screen does not mean the feed is
+  // empty when further pages are still queued behind the sentinel. Restoring the
+  // placeholder there both lies and outlives the append, leaving "No creatives
+  // found." sitting above the rows the next page brings in.
+  describe('empty-state placeholder vs. queued pages', () => {
+    const installEmptyStateTemplate = () => {
+      const template = document.createElement('template')
+      template.id = 'creatives-empty-state-template'
+      template.innerHTML = '<p data-creatives-empty-state>No creatives found.</p>'
+      document.body.appendChild(template)
+      return template
+    }
+
+    test('suppresses the placeholder while the feed has more pages queued', async () => {
+      installEmptyStateTemplate()
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ creatives: [{ id: 1 }], pagination: { has_more: true, next_page: 2 } }),
+      })
+
+      const { container, application } = installController()
+      await flush()
+      await flush()
+
+      expect(container.hasAttribute('data-creatives-pagination-pending')).toBe(true)
+
+      // The user batch-deletes every rendered row; removeTreeElement asks for the
+      // placeholder back.
+      restoreTreeEmptyState(container)
+
+      expect(container.querySelector('[data-creatives-empty-state]')).toBeNull()
+
+      application.stop()
+    })
+
+    test('restores the placeholder once the last page lands and nothing is left', async () => {
+      installEmptyStateTemplate()
+      global.fetch = jest
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ creatives: [{ id: 1 }], pagination: { has_more: true, next_page: 2 } }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ creatives: [], pagination: { has_more: false, next_page: null } }),
+        })
+
+      const { container, application } = installController()
+      await flush()
+      await flush()
+
+      restoreTreeEmptyState(container)
+      expect(container.querySelector('[data-creatives-empty-state]')).toBeNull()
+
+      MockIntersectionObserver.instances[0].triggerIntersect()
+      await flush()
+      await flush()
+
+      expect(container.hasAttribute('data-creatives-pagination-pending')).toBe(false)
+      const placeholder = container.querySelector('[data-creatives-empty-state]')
+      expect(placeholder).not.toBeNull()
+      expect(placeholder.hidden).toBe(false)
+
+      application.stop()
+    })
+
+    test('hides a placeholder that is on screen when the next page is appended', async () => {
+      installEmptyStateTemplate()
+      global.fetch = jest
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ creatives: [{ id: 1 }], pagination: { has_more: true, next_page: 2 } }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ creatives: [{ id: 2 }], pagination: { has_more: true, next_page: 3 } }),
+        })
+
+      const { container, application } = installController()
+      await flush()
+      await flush()
+
+      // Belt and braces: a placeholder that got in anyway (a path that predates
+      // the pending marker) must not survive the append.
+      const stray = document.createElement('p')
+      stray.setAttribute('data-creatives-empty-state', '')
+      container.appendChild(stray)
+
+      MockIntersectionObserver.instances[0].triggerIntersect()
+      await flush()
+      await flush()
+
+      expect(appendCreativeNodes).toHaveBeenCalledTimes(1)
+      expect(stray.hidden).toBe(true)
+
+      application.stop()
+    })
+
+    test('clears the pending marker when a fresh load tears pagination down', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ creatives: [{ id: 1 }], pagination: { has_more: true, next_page: 2 } }),
+      })
+
+      const { container, application } = installController()
+      await flush()
+      await flush()
+      expect(container.hasAttribute('data-creatives-pagination-pending')).toBe(true)
+
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ creatives: [{ id: 9 }] }),
+      })
+      application.getControllerForElementAndIdentifier(container, 'creatives--tree').load()
+      await flush()
+      await flush()
+
+      expect(container.hasAttribute('data-creatives-pagination-pending')).toBe(false)
+
+      application.stop()
+    })
   })
 })

--- a/engines/collavre/app/javascript/controllers/creatives/select_mode_controller.js
+++ b/engines/collavre/app/javascript/controllers/creatives/select_mode_controller.js
@@ -1,6 +1,7 @@
 import { Controller } from '@hotwired/stimulus'
 import csrfFetch from '../../lib/api/csrf_fetch'
 import { confirmDialog } from '../../lib/utils/confirm_dialog'
+import { removeTreeElement } from '../../modules/creative_tree_dom'
 
 export default class extends Controller {
   static targets = [
@@ -102,9 +103,13 @@ export default class extends Controller {
       detail: { creativeIds: ids.map(String) }
     }))
 
+    // Route through the shared helper: it drops the enclosing <creative-tree-row>
+    // wrapper (removing only the inner .creative-tree left an empty wrapper behind,
+    // which reads as "still populated") and restores the empty-state placeholder
+    // once the last row is gone. The destroy broadcast excludes the initiating
+    // user, so nothing else repairs this window's DOM.
     ids.forEach((id) => {
-      const tree = document.getElementById(`creative-${id}`)
-      if (tree) tree.remove()
+      removeTreeElement(document.getElementById(`creative-${id}`))
     })
 
     this.clearSelection()

--- a/engines/collavre/app/javascript/controllers/creatives/tree_controller.js
+++ b/engines/collavre/app/javascript/controllers/creatives/tree_controller.js
@@ -1,13 +1,13 @@
 import { Controller } from '@hotwired/stimulus'
 import { renderCreativeTree, appendCreativeNodes, dispatchCreativeTreeUpdated } from '../../creatives/tree_renderer'
 import { parseEmojis } from '../../utils/emoji_parser'
+import { restoreTreeEmptyState } from '../../modules/creative_tree_empty_state'
 
 const TREE_RETRY_DELAYS_MS = [200, 600]
 
 export default class extends Controller {
   static values = {
     url: String,
-    emptyHtml: String,
   }
 
   connect() {
@@ -340,8 +340,11 @@ export default class extends Controller {
   }
 
   showEmptyState() {
-    const html = this.hasEmptyHtmlValue ? this.emptyHtmlValue : ''
-    this.element.innerHTML = html
+    // The placeholder comes from the server-rendered <template> rather than an
+    // HTML string on a data attribute: no innerHTML sink, and the button_to CSRF
+    // token in the "request permission" variant survives.
+    this.element.replaceChildren()
+    restoreTreeEmptyState(this.element)
     this.markContentLoaded()
     document.documentElement.classList.add('creative-alignment-ready')
   }

--- a/engines/collavre/app/javascript/controllers/creatives/tree_controller.js
+++ b/engines/collavre/app/javascript/controllers/creatives/tree_controller.js
@@ -1,7 +1,11 @@
 import { Controller } from '@hotwired/stimulus'
 import { renderCreativeTree, appendCreativeNodes, dispatchCreativeTreeUpdated } from '../../creatives/tree_renderer'
 import { parseEmojis } from '../../utils/emoji_parser'
-import { restoreTreeEmptyState } from '../../modules/creative_tree_empty_state'
+import {
+  hideTreeEmptyState,
+  restoreTreeEmptyState,
+  PAGINATION_PENDING_ATTRIBUTE,
+} from '../../modules/creative_tree_empty_state'
 
 const TREE_RETRY_DELAYS_MS = [200, 600]
 
@@ -221,6 +225,9 @@ export default class extends Controller {
     this._pagination = pagination || null
     if (!this._pagination || !this._pagination.has_more) return
     if (typeof IntersectionObserver === 'undefined') return
+    // Deleting every rendered row does not empty the feed while further pages are
+    // queued, so suppress the empty-state placeholder until the last page lands.
+    this.element.setAttribute(PAGINATION_PENDING_ATTRIBUTE, 'true')
     this._createSentinel()
   }
 
@@ -266,6 +273,9 @@ export default class extends Controller {
         this._hideLoadMoreIndicator()
         const nodes = Array.isArray(data?.creatives) ? data.creatives : []
         if (nodes.length > 0) {
+          // Belt and braces alongside the pagination-pending guard: a placeholder
+          // that slipped through must never sit above the rows being appended.
+          hideTreeEmptyState(this.element)
           appendCreativeNodes(this.element, nodes)
           dispatchCreativeTreeUpdated(this.element)
           this.queueAlignmentUpdate()
@@ -276,6 +286,10 @@ export default class extends Controller {
           this._repositionSentinel()
         } else {
           this._teardownPagination()
+          // Last page in, and the rows that were on screen when it was requested
+          // may since have been deleted. Nothing is pending any more, so an empty
+          // container now genuinely is an empty feed.
+          restoreTreeEmptyState(this.element)
         }
       })
       .catch((error) => {
@@ -298,6 +312,7 @@ export default class extends Controller {
   }
 
   _teardownPagination() {
+    this.element.removeAttribute(PAGINATION_PENDING_ATTRIBUTE)
     if (this._loadMoreAbort) {
       this._loadMoreAbort.abort()
       this._loadMoreAbort = null

--- a/engines/collavre/app/javascript/creatives/drag_drop/__tests__/drop_completion_empty_state.test.js
+++ b/engines/collavre/app/javascript/creatives/drag_drop/__tests__/drop_completion_empty_state.test.js
@@ -1,0 +1,98 @@
+/**
+ * @jest-environment jsdom
+ */
+
+// Dragging a row into another window removes it from *this* window's tree without
+// any destroy happening, so no broadcast comes back to repair the DOM: the source
+// window has to bring the empty-state placeholder back itself.
+const { addGlobalListeners, removeGlobalListeners } = await import('../event_handlers')
+
+const DROP_COMPLETED_EVENT = 'collavre:creative-drop-complete'
+const WINDOW_ID_SESSION_KEY = 'collavre.dragWindowId'
+const WINDOW_ID = 'window-under-test'
+
+const EMPTY_HTML = '<div data-creatives-empty-state=""><p>No sub-creatives found.</p></div>'
+
+function rowMarkup(id) {
+  return `
+    <creative-tree-row creative-id="${id}">
+      <div class="creative-tree" id="creative-${id}" data-id="${id}" data-level="1">
+        <div class="creative-row"></div>
+      </div>
+    </creative-tree-row>
+  `
+}
+
+function mount(rowIds) {
+  document.body.innerHTML = `
+    <template id="creatives-empty-state-template">${EMPTY_HTML}</template>
+    <div id="creatives">${rowIds.map(rowMarkup).join('')}</div>
+  `
+}
+
+function container() {
+  return document.getElementById('creatives')
+}
+
+function placeholder() {
+  return container().querySelector('[data-creatives-empty-state]')
+}
+
+// No `direction` / `targetTreeId`: the source window could not resolve a local
+// target, which is the branch that simply drops the row from this tree.
+function dispatchDropCompleted(id) {
+  window.dispatchEvent(new CustomEvent(DROP_COMPLETED_EVENT, {
+    detail: {
+      creativeId: id,
+      treeId: `creative-${id}`,
+      sourceWindowId: WINDOW_ID,
+      context: 'source',
+    },
+  }))
+}
+
+beforeEach(() => {
+  window.sessionStorage.setItem(WINDOW_ID_SESSION_KEY, WINDOW_ID)
+  addGlobalListeners()
+})
+
+afterEach(() => {
+  removeGlobalListeners()
+  window.sessionStorage.clear()
+  document.body.innerHTML = ''
+})
+
+test('dropping the last row into another window restores the placeholder', () => {
+  mount(['7'])
+
+  dispatchDropCompleted('7')
+
+  expect(container().querySelector('creative-tree-row')).toBeNull()
+  expect(placeholder()).not.toBeNull()
+  expect(placeholder().hidden).toBe(false)
+})
+
+test('dropping one of several rows leaves the placeholder off the page', () => {
+  mount(['7', '8'])
+
+  dispatchDropCompleted('7')
+
+  expect(container().querySelectorAll('creative-tree-row')).toHaveLength(1)
+  expect(placeholder()).toBeNull()
+})
+
+test('a drop signalled for another window is ignored', () => {
+  mount(['7'])
+
+  window.dispatchEvent(new CustomEvent(DROP_COMPLETED_EVENT, {
+    detail: {
+      creativeId: '7',
+      treeId: 'creative-7',
+      sourceWindowId: 'some-other-window',
+      context: 'source',
+    },
+  }))
+
+  expect(container().querySelectorAll('creative-tree-row')).toHaveLength(1)
+  expect(placeholder()).toBeNull()
+})

--- a/engines/collavre/app/javascript/creatives/drag_drop/event_handlers.js
+++ b/engines/collavre/app/javascript/creatives/drag_drop/event_handlers.js
@@ -28,6 +28,7 @@ import { sendNewOrder, sendLinkedCreative, sendTopicMove } from '../../lib/api/d
 import { initIndicator, showLinkHover, hideLinkHover } from './indicator';
 import { showMissingMembersPopup } from '../topic_move_members_popup';
 import { alertDialog } from '../../lib/utils/dialog';
+import { restoreTreeEmptyState } from '../../modules/creative_tree_empty_state';
 
 const childZoneRatio = 0.3;
 const coordPrecision = 5;
@@ -367,6 +368,9 @@ function removeDroppedCreative({ creativeId, treeId }) {
   targetRow.remove();
 
   syncParentHasChildren(parentId);
+  // Dropping the last row into another window empties this tree, and the move
+  // is not a destroy — no broadcast repairs the placeholder here.
+  restoreTreeEmptyState();
 }
 
 function syncSourceWindowDrop(detail) {

--- a/engines/collavre/app/javascript/lib/__tests__/turbo_stream_actions.test.js
+++ b/engines/collavre/app/javascript/lib/__tests__/turbo_stream_actions.test.js
@@ -12,6 +12,27 @@ jest.unstable_mockModule('../../creatives/tree_renderer', () => ({
 }))
 
 await import('../turbo_stream_actions')
+const { createRow } = await import('../../creatives/tree_renderer')
+
+const EMPTY_HTML = '<div data-creatives-empty-state=""><p>No sub-creatives found.</p></div>'
+
+// Mirrors creatives/index.html.erb: title row above the tree container, the
+// server-rendered placeholder inside it, and the markup cached as a Stimulus value.
+function renderEmptyTreeForParent(parentId) {
+  document.body.innerHTML = `
+    <creative-tree-row is-title creative-id="${parentId}"></creative-tree-row>
+    <div id="creatives" data-creatives--tree-empty-html-value='${EMPTY_HTML}'>
+      ${EMPTY_HTML}
+    </div>
+  `
+  createRow.mockImplementation((creative) => {
+    const row = document.createElement('creative-tree-row')
+    row.setAttribute('creative-id', String(creative.id))
+    row.setAttribute('parent-id', String(creative.parent_id))
+    return row
+  })
+  return document.getElementById('creatives')
+}
 
 function dispatchCreativeTreeStream(payload) {
   fakeTurbo.StreamActions.refresh_creative_tree.call({
@@ -51,4 +72,52 @@ test('remote destroyed streams deduplicate identical effective and origin IDs', 
   expect(listener).toHaveBeenCalledWith(expect.objectContaining({
     detail: { creativeIds: ['123'] },
   }))
+})
+
+test('remote created streams clear the empty-state placeholder', () => {
+  const container = renderEmptyTreeForParent(42)
+
+  dispatchCreativeTreeStream({
+    action: 'created',
+    creative: { id: 7, parent_id: 42, level: 2, sequence: 0 },
+  })
+
+  expect(container.querySelector('creative-tree-row[creative-id="7"]')).not.toBeNull()
+  expect(container.querySelector('[data-creatives-empty-state]')).toBeNull()
+})
+
+test('remote destroyed streams restore the empty-state placeholder for the last row', () => {
+  const container = renderEmptyTreeForParent(42)
+  dispatchCreativeTreeStream({
+    action: 'created',
+    creative: { id: 7, parent_id: 42, level: 2, sequence: 0 },
+  })
+
+  dispatchCreativeTreeStream({
+    action: 'destroyed',
+    creative: { id: 7, parent_id: 42 },
+  })
+
+  expect(container.querySelector('creative-tree-row')).toBeNull()
+  expect(container.querySelector('[data-creatives-empty-state]')).not.toBeNull()
+})
+
+test('remote destroyed streams keep the placeholder hidden while rows remain', () => {
+  const container = renderEmptyTreeForParent(42)
+  dispatchCreativeTreeStream({
+    action: 'created',
+    creative: { id: 7, parent_id: 42, level: 2, sequence: 0 },
+  })
+  dispatchCreativeTreeStream({
+    action: 'created',
+    creative: { id: 8, parent_id: 42, level: 2, sequence: 1 },
+  })
+
+  dispatchCreativeTreeStream({
+    action: 'destroyed',
+    creative: { id: 7, parent_id: 42 },
+  })
+
+  expect(container.querySelector('creative-tree-row[creative-id="8"]')).not.toBeNull()
+  expect(container.querySelector('[data-creatives-empty-state]')).toBeNull()
 })

--- a/engines/collavre/app/javascript/lib/__tests__/turbo_stream_actions.test.js
+++ b/engines/collavre/app/javascript/lib/__tests__/turbo_stream_actions.test.js
@@ -16,14 +16,12 @@ const { createRow } = await import('../../creatives/tree_renderer')
 
 const EMPTY_HTML = '<div data-creatives-empty-state=""><p>No sub-creatives found.</p></div>'
 
-// Mirrors creatives/index.html.erb: title row above the tree container, the
-// server-rendered placeholder inside it, and the markup cached as a Stimulus value.
+// Mirrors creatives/index.html.erb: title row above the tree container with the
+// server-rendered placeholder inside it.
 function renderEmptyTreeForParent(parentId) {
   document.body.innerHTML = `
     <creative-tree-row is-title creative-id="${parentId}"></creative-tree-row>
-    <div id="creatives" data-creatives--tree-empty-html-value='${EMPTY_HTML}'>
-      ${EMPTY_HTML}
-    </div>
+    <div id="creatives">${EMPTY_HTML}</div>
   `
   createRow.mockImplementation((creative) => {
     const row = document.createElement('creative-tree-row')
@@ -83,7 +81,7 @@ test('remote created streams clear the empty-state placeholder', () => {
   })
 
   expect(container.querySelector('creative-tree-row[creative-id="7"]')).not.toBeNull()
-  expect(container.querySelector('[data-creatives-empty-state]')).toBeNull()
+  expect(container.querySelector('[data-creatives-empty-state]').hidden).toBe(true)
 })
 
 test('remote destroyed streams restore the empty-state placeholder for the last row', () => {
@@ -99,7 +97,7 @@ test('remote destroyed streams restore the empty-state placeholder for the last 
   })
 
   expect(container.querySelector('creative-tree-row')).toBeNull()
-  expect(container.querySelector('[data-creatives-empty-state]')).not.toBeNull()
+  expect(container.querySelector('[data-creatives-empty-state]').hidden).toBe(false)
 })
 
 test('remote destroyed streams keep the placeholder hidden while rows remain', () => {
@@ -119,5 +117,5 @@ test('remote destroyed streams keep the placeholder hidden while rows remain', (
   })
 
   expect(container.querySelector('creative-tree-row[creative-id="8"]')).not.toBeNull()
-  expect(container.querySelector('[data-creatives-empty-state]')).toBeNull()
+  expect(container.querySelector('[data-creatives-empty-state]').hidden).toBe(true)
 })

--- a/engines/collavre/app/javascript/lib/turbo_stream_actions.js
+++ b/engines/collavre/app/javascript/lib/turbo_stream_actions.js
@@ -1,5 +1,6 @@
 import { Turbo } from "@hotwired/turbo-rails"
 import { createRow, applyRowProperties } from "../creatives/tree_renderer"
+import { hideTreeEmptyState, restoreTreeEmptyState } from "../modules/creative_tree_empty_state"
 
 // Register custom actions on both the imported Turbo and the global window.Turbo
 function registerStreamAction(name, handler) {
@@ -84,6 +85,8 @@ function handleCreated(creative) {
 
         const newRow = createRow(adjustedCreative)
         insertAtCorrectPosition(newRow, adjustedCreative, targetContainer)
+        // The tree is no longer empty — drop the "no sub-creatives" placeholder.
+        hideTreeEmptyState(treeContainer)
     }
     // If no targetContainer found, the creative is relevant but we can't determine
     // the exact insertion point — it will appear on next page load.
@@ -324,6 +327,8 @@ function handleDestroyed(creative) {
         }
     }
 
+    // Last row gone — bring the placeholder back.
+    restoreTreeEmptyState()
 }
 
 function updateProgressForRow(row, progress, progressText) {

--- a/engines/collavre/app/javascript/modules/__tests__/creative_row_editor_archive.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/creative_row_editor_archive.test.js
@@ -9,15 +9,23 @@ import { jest } from '@jest/globals'
 // the archived row was the last one.
 const archive = jest.fn(() => Promise.resolve({ ok: true }))
 const unarchive = jest.fn(() => Promise.resolve({ ok: true }))
+const save = jest.fn(() => Promise.resolve({ ok: true, text: () => Promise.resolve('{}') }))
 const confirmDialog = jest.fn(() => Promise.resolve(true))
 
+// Captured so a test can drive the editor's onChange callback directly and leave
+// the session with a pending save, the way typing into Lexical would.
+let editorOptions = null
+
 jest.unstable_mockModule('../lexical_inline_editor', () => ({
-  createInlineEditor: jest.fn(() => ({
-    destroy: jest.fn(),
-    load: jest.fn(),
-    focus: jest.fn(),
-    getDeletedAttachments: jest.fn(() => []),
-  })),
+  createInlineEditor: jest.fn((_container, options) => {
+    editorOptions = options
+    return {
+      destroy: jest.fn(),
+      load: jest.fn(),
+      focus: jest.fn(),
+      getDeletedAttachments: jest.fn(() => []),
+    }
+  }),
 }))
 jest.unstable_mockModule('../creative_row_editor_delegated_clicks', () => ({
   createDelegatedClickHandler: jest.fn(() => jest.fn()),
@@ -26,6 +34,7 @@ jest.unstable_mockModule('../../lib/api/creatives', () => ({
   default: {
     archive,
     unarchive,
+    save,
     get: jest.fn(() => Promise.resolve({})),
   },
 }))
@@ -43,9 +52,11 @@ const EMPTY_HTML = '<div data-creatives-empty-state=""><p>No sub-creatives found
 
 const flush = () => new Promise((resolve) => setTimeout(resolve, 0))
 
+// data-description-raw-html / data-progress-value put openEditor() on
+// loadCreative()'s synchronous cached-data path instead of an API fetch.
 function rowMarkup(id) {
   return `
-    <creative-tree-row creative-id="${id}">
+    <creative-tree-row creative-id="${id}" data-description-raw-html="hello" data-progress-value="0">
       <div class="creative-tree" id="creative-${id}" data-id="${id}" data-level="1"></div>
     </creative-tree-row>
   `
@@ -62,6 +73,19 @@ function renderTree(rowIds) {
   const template = buildEditorDom(document.getElementById('center-frame'))
   initializeCreativeRowEditor()
   return template
+}
+
+// Binds the editor session to the row (currentTree) and leaves it dirty with a
+// pending save, so archiving has to flush that save before dropping the row.
+function openEditorWithPendingEdit(id) {
+  document.getElementById('metadata-popup').style.display = 'none'
+  const form = document.getElementById('inline-edit-form-element')
+  form.action = `/creatives/${id}`
+  document.getElementById('inline-method').value = 'patch'
+  document.dispatchEvent(new CustomEvent('creative-edit-click', {
+    detail: { treeElement: document.getElementById(`creative-${id}`) },
+  }))
+  editorOptions.onChange({ html: '<p>edited</p>', markdown: 'edited' })
 }
 
 async function archiveCreative(id) {
@@ -83,6 +107,7 @@ afterEach(() => {
   jest.clearAllMocks()
   delete window.Stimulus
   document.body.innerHTML = ''
+  editorOptions = null
 })
 
 // Also a regression test for the `closeEditor()` ReferenceError that used to abort
@@ -124,6 +149,36 @@ test('restoring an archived row reloads the tree instead of removing it', async 
   expect(load).toHaveBeenCalledTimes(1)
   expect(treeEl.dataset.loaded).toBeUndefined()
   expect(treeEl.innerHTML).toBe('')
+})
+
+test('flushes a pending edit before dropping the archived row', async () => {
+  renderTree(['42'])
+  openEditorWithPendingEdit('42')
+
+  await archiveCreative('42')
+
+  expect(save).toHaveBeenCalledTimes(1)
+  expect(container().querySelector('creative-tree-row')).toBeNull()
+  expect(placeholder()).not.toBeNull()
+})
+
+// The archive request has already landed on the server by the time the editor is
+// flushed, and an update_all archive broadcasts no destroy, so a failed flush must
+// not leave the archived row on screen with nothing to repair it.
+test('still removes the archived row when the pending save fails', async () => {
+  const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
+  save.mockRejectedValueOnce(new Error('network down'))
+  renderTree(['42'])
+  openEditorWithPendingEdit('42')
+
+  await archiveCreative('42')
+
+  expect(save).toHaveBeenCalledTimes(1)
+  expect(container().querySelector('creative-tree-row')).toBeNull()
+  expect(placeholder()).not.toBeNull()
+  expect(placeholder().hidden).toBe(false)
+  expect(consoleError).toHaveBeenCalled()
+  consoleError.mockRestore()
 })
 
 test('declining the archive confirmation leaves the row in place', async () => {

--- a/engines/collavre/app/javascript/modules/__tests__/creative_row_editor_archive.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/creative_row_editor_archive.test.js
@@ -1,0 +1,138 @@
+/**
+ * @jest-environment jsdom
+ */
+import { jest } from '@jest/globals'
+
+// Archiving is the one removal path with no server echo: Creative#archive! is an
+// `update_all`, so it fires no destroy broadcast and the initiating window has to
+// repair its own DOM — including bringing the empty-state placeholder back when
+// the archived row was the last one.
+const archive = jest.fn(() => Promise.resolve({ ok: true }))
+const unarchive = jest.fn(() => Promise.resolve({ ok: true }))
+const confirmDialog = jest.fn(() => Promise.resolve(true))
+
+jest.unstable_mockModule('../lexical_inline_editor', () => ({
+  createInlineEditor: jest.fn(() => ({
+    destroy: jest.fn(),
+    load: jest.fn(),
+    focus: jest.fn(),
+    getDeletedAttachments: jest.fn(() => []),
+  })),
+}))
+jest.unstable_mockModule('../creative_row_editor_delegated_clicks', () => ({
+  createDelegatedClickHandler: jest.fn(() => jest.fn()),
+}))
+jest.unstable_mockModule('../../lib/api/creatives', () => ({
+  default: {
+    archive,
+    unarchive,
+    get: jest.fn(() => Promise.resolve({})),
+  },
+}))
+jest.unstable_mockModule('../../lib/utils/dialog', () => ({
+  default: confirmDialog,
+  confirmDialog,
+  alertDialog: jest.fn(),
+  promptDialog: jest.fn(),
+}))
+
+const { initializeCreativeRowEditor } = await import('../creative_row_editor')
+const { buildEditorDom } = await import('./support/inline_editor_dom')
+
+const EMPTY_HTML = '<div data-creatives-empty-state=""><p>No sub-creatives found.</p></div>'
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0))
+
+function rowMarkup(id) {
+  return `
+    <creative-tree-row creative-id="${id}">
+      <div class="creative-tree" id="creative-${id}" data-id="${id}" data-level="1"></div>
+    </creative-tree-row>
+  `
+}
+
+// Post-client-render state: tree_controller wiped #creatives and rendered rows
+// into it, so only the out-of-container template holds a pristine placeholder.
+function renderTree(rowIds) {
+  document.body.innerHTML = `
+    <template id="creatives-empty-state-template">${EMPTY_HTML}</template>
+    <div id="creatives">${rowIds.map(rowMarkup).join('')}</div>
+    <div id="center-frame"></div>
+  `
+  const template = buildEditorDom(document.getElementById('center-frame'))
+  initializeCreativeRowEditor()
+  return template
+}
+
+async function archiveCreative(id) {
+  document.getElementById('inline-edit-form-element').dataset.creativeId = String(id)
+  document.getElementById('inline-archive').click()
+  await flush()
+  await flush()
+}
+
+function container() {
+  return document.getElementById('creatives')
+}
+
+function placeholder() {
+  return container().querySelector('[data-creatives-empty-state]')
+}
+
+afterEach(() => {
+  jest.clearAllMocks()
+  delete window.Stimulus
+  document.body.innerHTML = ''
+})
+
+// Also a regression test for the `closeEditor()` ReferenceError that used to abort
+// this handler: an unhandled rejection in the click promise fails the test.
+test('archiving the last row brings the empty-state placeholder back', async () => {
+  renderTree(['42'])
+
+  await archiveCreative('42')
+
+  expect(archive).toHaveBeenCalledWith('42')
+  expect(container().querySelector('creative-tree-row')).toBeNull()
+  expect(placeholder()).not.toBeNull()
+  expect(placeholder().hidden).toBe(false)
+  expect(placeholder().textContent).toContain('No sub-creatives found.')
+})
+
+test('archiving one of several rows leaves the placeholder off the page', async () => {
+  renderTree(['42', '43'])
+
+  await archiveCreative('42')
+
+  expect(container().querySelectorAll('creative-tree-row')).toHaveLength(1)
+  expect(placeholder()).toBeNull()
+})
+
+test('restoring an archived row reloads the tree instead of removing it', async () => {
+  renderTree(['42'])
+  document.querySelector('creative-tree-row[creative-id="42"]').setAttribute('archived', '')
+  const treeEl = container()
+  treeEl.setAttribute('data-controller', 'creatives--tree')
+  treeEl.dataset.loaded = 'true'
+  const load = jest.fn()
+  window.Stimulus = { getControllerForElementAndIdentifier: jest.fn(() => ({ load })) }
+
+  await archiveCreative('42')
+
+  expect(unarchive).toHaveBeenCalledWith('42')
+  expect(archive).not.toHaveBeenCalled()
+  expect(load).toHaveBeenCalledTimes(1)
+  expect(treeEl.dataset.loaded).toBeUndefined()
+  expect(treeEl.innerHTML).toBe('')
+})
+
+test('declining the archive confirmation leaves the row in place', async () => {
+  confirmDialog.mockResolvedValueOnce(false)
+  renderTree(['42'])
+
+  await archiveCreative('42')
+
+  expect(archive).not.toHaveBeenCalled()
+  expect(container().querySelectorAll('creative-tree-row')).toHaveLength(1)
+  expect(placeholder()).toBeNull()
+})

--- a/engines/collavre/app/javascript/modules/__tests__/creative_row_editor_session.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/creative_row_editor_session.test.js
@@ -17,70 +17,7 @@ jest.unstable_mockModule('../creative_row_editor_delegated_clicks', () => ({
 }))
 
 const { initializeCreativeRowEditor } = await import('../creative_row_editor')
-
-const BUTTON_IDS = [
-  'inline-metadata-btn', 'inline-toggle-markdown', 'inline-move-up', 'inline-move-down',
-  'inline-add', 'inline-level-down', 'inline-level-up', 'inline-archive', 'inline-delete',
-  'inline-delete-with-children', 'inline-link', 'inline-unconvert', 'inline-unlink',
-  'inline-close', 'inline-recommend-parent', 'metadata-popup-close', 'metadata-save-btn',
-]
-const HIDDEN_INPUT_IDS = [
-  'inline-method', 'inline-creative-description', 'inline-content-type',
-  'inline-markdown-editor', 'inline-markdown-source', 'inline-parent-id',
-  'inline-before-id', 'inline-after-id', 'inline-child-id', 'inline-origin-id',
-]
-const DIV_IDS = ['markdown-editor-wrapper', 'markdown-preview', 'inline-progress-value', 'inline-save-status', 'metadata-popup']
-
-function buildEditorDom(container) {
-  const template = document.createElement('div')
-  template.id = 'inline-edit-form'
-  template.style.display = 'none'
-
-  const form = document.createElement('form')
-  form.id = 'inline-edit-form-element'
-  template.appendChild(form)
-
-  HIDDEN_INPUT_IDS.forEach((id) => {
-    const input = document.createElement('input')
-    input.type = 'hidden'
-    input.id = id
-    form.appendChild(input)
-  })
-  const progress = document.createElement('input')
-  progress.type = 'checkbox'
-  progress.id = 'inline-creative-progress'
-  form.appendChild(progress)
-
-  const editorRoot = document.createElement('div')
-  editorRoot.id = 'lexical-inline-editor'
-  editorRoot.dataset.lexicalEditorRoot = ''
-  form.appendChild(editorRoot)
-
-  const markdownTextarea = document.createElement('textarea')
-  markdownTextarea.id = 'markdown-editor-textarea'
-  form.appendChild(markdownTextarea)
-  const metadataTextarea = document.createElement('textarea')
-  metadataTextarea.id = 'metadata-yaml-editor'
-  form.appendChild(metadataTextarea)
-  const suggestions = document.createElement('select')
-  suggestions.id = 'parent-suggestions'
-  form.appendChild(suggestions)
-
-  BUTTON_IDS.forEach((id) => {
-    const button = document.createElement('button')
-    button.type = 'button'
-    button.id = id
-    form.appendChild(button)
-  })
-  DIV_IDS.forEach((id) => {
-    const div = document.createElement('div')
-    div.id = id
-    form.appendChild(div)
-  })
-
-  container.appendChild(template)
-  return template
-}
+const { buildEditorDom } = await import('./support/inline_editor_dom')
 
 function swapCenterContent() {
   const container = document.getElementById('center-frame')

--- a/engines/collavre/app/javascript/modules/__tests__/creative_tree_dom.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/creative_tree_dom.test.js
@@ -423,20 +423,26 @@ describe('removeTreeElement', () => {
     expect(() => removeTreeElement(null)).not.toThrow();
   });
 
+  function addHiddenEmptyState() {
+    root.insertAdjacentHTML(
+      'beforeend',
+      '<div data-creatives-empty-state="" hidden><p>No sub-creatives found.</p></div>'
+    );
+    return root.querySelector('[data-creatives-empty-state]');
+  }
+
   test('restores the empty-state placeholder once the last row is gone', () => {
-    const emptyHtml = '<div data-creatives-empty-state=""><p>No sub-creatives found.</p></div>';
-    root.setAttribute('data-creatives--tree-empty-html-value', emptyHtml);
+    const placeholder = addHiddenEmptyState();
     const { row, tree } = makeRow(1);
     root.appendChild(row);
 
     removeTreeElement(tree);
 
-    expect(root.querySelector('[data-creatives-empty-state]')).not.toBeNull();
+    expect(placeholder.hidden).toBe(false);
   });
 
-  test('leaves the placeholder off while other rows remain', () => {
-    const emptyHtml = '<div data-creatives-empty-state=""><p>No sub-creatives found.</p></div>';
-    root.setAttribute('data-creatives--tree-empty-html-value', emptyHtml);
+  test('leaves the placeholder hidden while other rows remain', () => {
+    const placeholder = addHiddenEmptyState();
     const { row: first, tree } = makeRow(1);
     const { row: second } = makeRow(2);
     root.appendChild(first);
@@ -444,6 +450,6 @@ describe('removeTreeElement', () => {
 
     removeTreeElement(tree);
 
-    expect(root.querySelector('[data-creatives-empty-state]')).toBeNull();
+    expect(placeholder.hidden).toBe(true);
   });
 });

--- a/engines/collavre/app/javascript/modules/__tests__/creative_tree_dom.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/creative_tree_dom.test.js
@@ -422,4 +422,28 @@ describe('removeTreeElement', () => {
   test('no-ops on nullish tree', () => {
     expect(() => removeTreeElement(null)).not.toThrow();
   });
+
+  test('restores the empty-state placeholder once the last row is gone', () => {
+    const emptyHtml = '<div data-creatives-empty-state=""><p>No sub-creatives found.</p></div>';
+    root.setAttribute('data-creatives--tree-empty-html-value', emptyHtml);
+    const { row, tree } = makeRow(1);
+    root.appendChild(row);
+
+    removeTreeElement(tree);
+
+    expect(root.querySelector('[data-creatives-empty-state]')).not.toBeNull();
+  });
+
+  test('leaves the placeholder off while other rows remain', () => {
+    const emptyHtml = '<div data-creatives-empty-state=""><p>No sub-creatives found.</p></div>';
+    root.setAttribute('data-creatives--tree-empty-html-value', emptyHtml);
+    const { row: first, tree } = makeRow(1);
+    const { row: second } = makeRow(2);
+    root.appendChild(first);
+    root.appendChild(second);
+
+    removeTreeElement(tree);
+
+    expect(root.querySelector('[data-creatives-empty-state]')).toBeNull();
+  });
 });

--- a/engines/collavre/app/javascript/modules/__tests__/creative_tree_empty_state.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/creative_tree_empty_state.test.js
@@ -9,8 +9,17 @@ import {
 
 const EMPTY_HTML = '<div data-creatives-empty-state=""><p>No sub-creatives found.</p></div>'
 
+const EMPTY_TEMPLATE = `<template id="creatives-empty-state-template">${EMPTY_HTML}</template>`
+
 function renderEmptyTree() {
   document.body.innerHTML = `<div id="creatives">${EMPTY_HTML}</div>`
+  return document.getElementById('creatives')
+}
+
+// The state after a client-side tree render: rows replaced the whole container,
+// so the server-rendered placeholder is gone and only the template survives.
+function renderRenderedTree(innerHtml = '') {
+  document.body.innerHTML = `${EMPTY_TEMPLATE}<div id="creatives">${innerHtml}</div>`
   return document.getElementById('creatives')
 }
 
@@ -84,13 +93,56 @@ test('restoreTreeEmptyState does not duplicate the placeholder', () => {
   expect(container.querySelectorAll('[data-creatives-empty-state]')).toHaveLength(1)
 })
 
-test('restoreTreeEmptyState is a no-op when the tree has no placeholder', () => {
+test('restoreTreeEmptyState is a no-op when neither placeholder nor template exists', () => {
   document.body.innerHTML = '<div id="creatives"></div>'
   const container = document.getElementById('creatives')
 
   restoreTreeEmptyState(container)
 
   expect(container.innerHTML).toBe('')
+})
+
+test('restoreTreeEmptyState clones the template when the tree render wiped the container', () => {
+  const container = renderRenderedTree()
+
+  restoreTreeEmptyState(container)
+
+  const restored = placeholder(container)
+  expect(restored).not.toBeNull()
+  expect(restored.hidden).toBe(false)
+  expect(restored.textContent).toContain('No sub-creatives found.')
+})
+
+test('restoreTreeEmptyState does not clone the template while rows remain', () => {
+  const container = renderRenderedTree('<creative-tree-row creative-id="7"></creative-tree-row>')
+
+  restoreTreeEmptyState(container)
+
+  expect(placeholder(container)).toBeNull()
+})
+
+test('restoreTreeEmptyState does not clone the template when a placeholder is already present', () => {
+  document.body.innerHTML = `${EMPTY_TEMPLATE}<div id="creatives">${EMPTY_HTML}</div>`
+  const container = document.getElementById('creatives')
+  hideTreeEmptyState(container)
+
+  restoreTreeEmptyState(container)
+
+  expect(container.querySelectorAll('[data-creatives-empty-state]')).toHaveLength(1)
+  expect(placeholder(container).hidden).toBe(false)
+})
+
+test('cloning the template leaves the template itself untouched', () => {
+  const container = renderRenderedTree()
+
+  restoreTreeEmptyState(container)
+  hideTreeEmptyState(container)
+  container.replaceChildren()
+  restoreTreeEmptyState(container)
+
+  // A second restore after a second wipe must still produce a visible placeholder:
+  // hideTreeEmptyState() must not have mutated the template's own copy.
+  expect(placeholder(container).hidden).toBe(false)
 })
 
 test('restoreTreeEmptyState is a no-op without a tree container', () => {

--- a/engines/collavre/app/javascript/modules/__tests__/creative_tree_empty_state.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/creative_tree_empty_state.test.js
@@ -1,0 +1,95 @@
+/**
+ * @jest-environment jsdom
+ */
+import {
+  creativeTreeContainer,
+  hideTreeEmptyState,
+  restoreTreeEmptyState,
+} from '../creative_tree_empty_state'
+
+const EMPTY_HTML = '<div data-creatives-empty-state=""><p>No sub-creatives found.</p></div>'
+
+function renderEmptyTree() {
+  document.body.innerHTML = `
+    <div id="creatives" data-creatives--tree-empty-html-value='${EMPTY_HTML}'>
+      ${EMPTY_HTML}
+    </div>
+  `
+  return document.getElementById('creatives')
+}
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+test('creativeTreeContainer resolves the tree container', () => {
+  const container = renderEmptyTree()
+  expect(creativeTreeContainer()).toBe(container)
+})
+
+test('creativeTreeContainer returns null when the tree is not on the page', () => {
+  document.body.innerHTML = ''
+  expect(creativeTreeContainer()).toBeNull()
+})
+
+test('hideTreeEmptyState removes the placeholder', () => {
+  const container = renderEmptyTree()
+  hideTreeEmptyState(container)
+  expect(container.querySelector('[data-creatives-empty-state]')).toBeNull()
+})
+
+test('hideTreeEmptyState defaults to #creatives when no container is passed', () => {
+  const container = renderEmptyTree()
+  hideTreeEmptyState()
+  expect(container.querySelector('[data-creatives-empty-state]')).toBeNull()
+})
+
+test('hideTreeEmptyState is a no-op without a tree container', () => {
+  document.body.innerHTML = ''
+  expect(() => hideTreeEmptyState()).not.toThrow()
+  expect(() => hideTreeEmptyState(null)).not.toThrow()
+})
+
+test('restoreTreeEmptyState re-renders the placeholder once the tree is empty', () => {
+  const container = renderEmptyTree()
+  hideTreeEmptyState(container)
+
+  restoreTreeEmptyState(container)
+
+  const placeholder = container.querySelector('[data-creatives-empty-state]')
+  expect(placeholder).not.toBeNull()
+  expect(placeholder.textContent).toContain('No sub-creatives found.')
+})
+
+test('restoreTreeEmptyState does nothing while rows remain', () => {
+  const container = renderEmptyTree()
+  hideTreeEmptyState(container)
+  container.innerHTML = '<creative-tree-row creative-id="7"></creative-tree-row>'
+
+  restoreTreeEmptyState(container)
+
+  expect(container.querySelector('[data-creatives-empty-state]')).toBeNull()
+})
+
+test('restoreTreeEmptyState does not duplicate an existing placeholder', () => {
+  const container = renderEmptyTree()
+
+  restoreTreeEmptyState(container)
+
+  expect(container.querySelectorAll('[data-creatives-empty-state]')).toHaveLength(1)
+})
+
+test('restoreTreeEmptyState is a no-op when no cached markup exists', () => {
+  document.body.innerHTML = '<div id="creatives"></div>'
+  const container = document.getElementById('creatives')
+
+  restoreTreeEmptyState(container)
+
+  expect(container.innerHTML).toBe('')
+})
+
+test('restoreTreeEmptyState is a no-op without a tree container', () => {
+  document.body.innerHTML = ''
+  expect(() => restoreTreeEmptyState()).not.toThrow()
+  expect(() => restoreTreeEmptyState(null)).not.toThrow()
+})

--- a/engines/collavre/app/javascript/modules/__tests__/creative_tree_empty_state.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/creative_tree_empty_state.test.js
@@ -10,12 +10,12 @@ import {
 const EMPTY_HTML = '<div data-creatives-empty-state=""><p>No sub-creatives found.</p></div>'
 
 function renderEmptyTree() {
-  document.body.innerHTML = `
-    <div id="creatives" data-creatives--tree-empty-html-value='${EMPTY_HTML}'>
-      ${EMPTY_HTML}
-    </div>
-  `
+  document.body.innerHTML = `<div id="creatives">${EMPTY_HTML}</div>`
   return document.getElementById('creatives')
+}
+
+function placeholder(container) {
+  return container.querySelector('[data-creatives-empty-state]')
 }
 
 afterEach(() => {
@@ -32,16 +32,21 @@ test('creativeTreeContainer returns null when the tree is not on the page', () =
   expect(creativeTreeContainer()).toBeNull()
 })
 
-test('hideTreeEmptyState removes the placeholder', () => {
+test('hideTreeEmptyState hides the placeholder', () => {
   const container = renderEmptyTree()
+
   hideTreeEmptyState(container)
-  expect(container.querySelector('[data-creatives-empty-state]')).toBeNull()
+
+  expect(placeholder(container).hidden).toBe(true)
+  expect(placeholder(container).style.display).toBe('none')
 })
 
 test('hideTreeEmptyState defaults to #creatives when no container is passed', () => {
   const container = renderEmptyTree()
+
   hideTreeEmptyState()
-  expect(container.querySelector('[data-creatives-empty-state]')).toBeNull()
+
+  expect(placeholder(container).hidden).toBe(true)
 })
 
 test('hideTreeEmptyState is a no-op without a tree container', () => {
@@ -50,28 +55,28 @@ test('hideTreeEmptyState is a no-op without a tree container', () => {
   expect(() => hideTreeEmptyState(null)).not.toThrow()
 })
 
-test('restoreTreeEmptyState re-renders the placeholder once the tree is empty', () => {
+test('restoreTreeEmptyState shows the placeholder again once the tree is empty', () => {
   const container = renderEmptyTree()
   hideTreeEmptyState(container)
 
   restoreTreeEmptyState(container)
 
-  const placeholder = container.querySelector('[data-creatives-empty-state]')
-  expect(placeholder).not.toBeNull()
-  expect(placeholder.textContent).toContain('No sub-creatives found.')
+  expect(placeholder(container).hidden).toBe(false)
+  expect(placeholder(container).style.display).toBe('')
+  expect(placeholder(container).textContent).toContain('No sub-creatives found.')
 })
 
-test('restoreTreeEmptyState does nothing while rows remain', () => {
+test('restoreTreeEmptyState keeps the placeholder hidden while rows remain', () => {
   const container = renderEmptyTree()
   hideTreeEmptyState(container)
-  container.innerHTML = '<creative-tree-row creative-id="7"></creative-tree-row>'
+  container.insertAdjacentHTML('beforeend', '<creative-tree-row creative-id="7"></creative-tree-row>')
 
   restoreTreeEmptyState(container)
 
-  expect(container.querySelector('[data-creatives-empty-state]')).toBeNull()
+  expect(placeholder(container).hidden).toBe(true)
 })
 
-test('restoreTreeEmptyState does not duplicate an existing placeholder', () => {
+test('restoreTreeEmptyState does not duplicate the placeholder', () => {
   const container = renderEmptyTree()
 
   restoreTreeEmptyState(container)
@@ -79,7 +84,7 @@ test('restoreTreeEmptyState does not duplicate an existing placeholder', () => {
   expect(container.querySelectorAll('[data-creatives-empty-state]')).toHaveLength(1)
 })
 
-test('restoreTreeEmptyState is a no-op when no cached markup exists', () => {
+test('restoreTreeEmptyState is a no-op when the tree has no placeholder', () => {
   document.body.innerHTML = '<div id="creatives"></div>'
   const container = document.getElementById('creatives')
 

--- a/engines/collavre/app/javascript/modules/__tests__/creative_tree_empty_state.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/creative_tree_empty_state.test.js
@@ -5,6 +5,7 @@ import {
   creativeTreeContainer,
   hideTreeEmptyState,
   restoreTreeEmptyState,
+  PAGINATION_PENDING_ATTRIBUTE,
 } from '../creative_tree_empty_state'
 
 const EMPTY_HTML = '<div data-creatives-empty-state=""><p>No sub-creatives found.</p></div>'
@@ -149,4 +150,37 @@ test('restoreTreeEmptyState is a no-op without a tree container', () => {
   document.body.innerHTML = ''
   expect(() => restoreTreeEmptyState()).not.toThrow()
   expect(() => restoreTreeEmptyState(null)).not.toThrow()
+})
+
+// Paginated "Chats" feed: an empty container is not an empty result set while the
+// load-more sentinel still has pages to fetch.
+test('restoreTreeEmptyState stays out of the way while more pages are queued', () => {
+  const container = renderRenderedTree()
+  container.setAttribute(PAGINATION_PENDING_ATTRIBUTE, 'true')
+
+  restoreTreeEmptyState(container)
+
+  expect(placeholder(container)).toBeNull()
+})
+
+test('restoreTreeEmptyState leaves an existing placeholder hidden while more pages are queued', () => {
+  const container = renderEmptyTree()
+  hideTreeEmptyState(container)
+  container.setAttribute(PAGINATION_PENDING_ATTRIBUTE, 'true')
+
+  restoreTreeEmptyState(container)
+
+  expect(placeholder(container).hidden).toBe(true)
+})
+
+test('restoreTreeEmptyState restores once the pending-pages marker is cleared', () => {
+  const container = renderRenderedTree()
+  container.setAttribute(PAGINATION_PENDING_ATTRIBUTE, 'true')
+  restoreTreeEmptyState(container)
+  container.removeAttribute(PAGINATION_PENDING_ATTRIBUTE)
+
+  restoreTreeEmptyState(container)
+
+  expect(placeholder(container)).not.toBeNull()
+  expect(placeholder(container).hidden).toBe(false)
 })

--- a/engines/collavre/app/javascript/modules/__tests__/support/inline_editor_dom.js
+++ b/engines/collavre/app/javascript/modules/__tests__/support/inline_editor_dom.js
@@ -1,0 +1,69 @@
+// Minimal stand-in for the server-rendered inline-editor template
+// (collavre/creatives/_inline_edit_form.html.erb). initializeCreativeRowEditor()
+// looks every one of these nodes up by id and binds to whichever ones exist, so
+// any test that needs a live editor session has to put them on the page first.
+//
+// Not a *.test.js file, so Jest's testMatch skips it.
+const BUTTON_IDS = [
+  'inline-metadata-btn', 'inline-toggle-markdown', 'inline-move-up', 'inline-move-down',
+  'inline-add', 'inline-level-down', 'inline-level-up', 'inline-archive', 'inline-delete',
+  'inline-delete-with-children', 'inline-link', 'inline-unconvert', 'inline-unlink',
+  'inline-close', 'inline-recommend-parent', 'metadata-popup-close', 'metadata-save-btn',
+]
+const HIDDEN_INPUT_IDS = [
+  'inline-method', 'inline-creative-description', 'inline-content-type',
+  'inline-markdown-editor', 'inline-markdown-source', 'inline-parent-id',
+  'inline-before-id', 'inline-after-id', 'inline-child-id', 'inline-origin-id',
+]
+const DIV_IDS = ['markdown-editor-wrapper', 'markdown-preview', 'inline-progress-value', 'inline-save-status', 'metadata-popup']
+
+export function buildEditorDom(container) {
+  const template = document.createElement('div')
+  template.id = 'inline-edit-form'
+  template.style.display = 'none'
+
+  const form = document.createElement('form')
+  form.id = 'inline-edit-form-element'
+  template.appendChild(form)
+
+  HIDDEN_INPUT_IDS.forEach((id) => {
+    const input = document.createElement('input')
+    input.type = 'hidden'
+    input.id = id
+    form.appendChild(input)
+  })
+  const progress = document.createElement('input')
+  progress.type = 'checkbox'
+  progress.id = 'inline-creative-progress'
+  form.appendChild(progress)
+
+  const editorRoot = document.createElement('div')
+  editorRoot.id = 'lexical-inline-editor'
+  editorRoot.dataset.lexicalEditorRoot = ''
+  form.appendChild(editorRoot)
+
+  const markdownTextarea = document.createElement('textarea')
+  markdownTextarea.id = 'markdown-editor-textarea'
+  form.appendChild(markdownTextarea)
+  const metadataTextarea = document.createElement('textarea')
+  metadataTextarea.id = 'metadata-yaml-editor'
+  form.appendChild(metadataTextarea)
+  const suggestions = document.createElement('select')
+  suggestions.id = 'parent-suggestions'
+  form.appendChild(suggestions)
+
+  BUTTON_IDS.forEach((id) => {
+    const button = document.createElement('button')
+    button.type = 'button'
+    button.id = id
+    form.appendChild(button)
+  })
+  DIV_IDS.forEach((id) => {
+    const div = document.createElement('div')
+    div.id = id
+    form.appendChild(div)
+  })
+
+  container.appendChild(template)
+  return template
+}

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -44,6 +44,7 @@ import {
   updateRowFromData,
   inlinePayloadFromTree,
 } from './creative_inline_payload'
+import { hideTreeEmptyState } from './creative_tree_empty_state'
 // Import Stimulus application from the global window (set by host app)
 const application = window.Stimulus
 
@@ -1592,6 +1593,8 @@ function setupEditorSession() {
         } else {
           targetContainer.appendChild(rowComponent);
         }
+        // A row now occupies the tree — the "no sub-creatives" placeholder must go.
+        hideTreeEmptyState();
 
         const finalizeSetup = () => {
           const newTree = rowComponent.querySelector('.creative-tree');

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -1880,12 +1880,19 @@ function setupEditorSession() {
         if (await confirmDialog(confirmMsg)) {
           const apiCall = isArchived ? creativesApi.unarchive(creativeId) : creativesApi.archive(creativeId);
           apiCall.then(res => {
-            if (res.ok) {
+            if (!res.ok) return;
+            // The editor is bound to the row this action is about to drop (or to a
+            // tree about to be re-rendered), so close it first. This used to call a
+            // `closeEditor()` that exists nowhere in the module: it threw a
+            // ReferenceError and left the editor open over the archived row.
+            return Promise.resolve(hideCurrent()).then(() => {
               if (!isArchived) {
-                // Archiving: remove from view
+                // Archiving: remove from view. Creative#archive! is an update_all,
+                // so it fires no destroy broadcast — this is the only chance to
+                // bring the empty-state placeholder back when the last row goes.
                 const childrenContainer = document.getElementById(`creative-children-${creativeId}`);
                 if (childrenContainer) childrenContainer.remove();
-                if (row) row.remove();
+                removeTreeElement(row);
               } else {
                 // Restoring: reload tree to show updated state
                 const treeEl = document.querySelector('[data-controller="creatives--tree"]');
@@ -1896,8 +1903,7 @@ function setupEditorSession() {
                   if (ctrl) ctrl.load();
                 }
               }
-              closeEditor();
-            }
+            });
           });
         }
       });

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -1881,11 +1881,7 @@ function setupEditorSession() {
           const apiCall = isArchived ? creativesApi.unarchive(creativeId) : creativesApi.archive(creativeId);
           apiCall.then(res => {
             if (!res.ok) return;
-            // The editor is bound to the row this action is about to drop (or to a
-            // tree about to be re-rendered), so close it first. This used to call a
-            // `closeEditor()` that exists nowhere in the module: it threw a
-            // ReferenceError and left the editor open over the archived row.
-            return Promise.resolve(hideCurrent()).then(() => {
+            const applyToView = function () {
               if (!isArchived) {
                 // Archiving: remove from view. Creative#archive! is an update_all,
                 // so it fires no destroy broadcast — this is the only chance to
@@ -1903,7 +1899,23 @@ function setupEditorSession() {
                   if (ctrl) ctrl.load();
                 }
               }
-            });
+            };
+            // The editor is bound to the row this action is about to drop (or to a
+            // tree about to be re-rendered), so close it first. This used to call a
+            // `closeEditor()` that exists nowhere in the module: it threw a
+            // ReferenceError and left the editor open over the archived row.
+            //
+            // The server-side change has already landed here, so the view has to
+            // follow even when that close fails. hideCurrent() flushes a pending
+            // edit through saveForm(), which rethrows when the request fails (a
+            // dropped connection, say); letting that rejection break the chain
+            // would strand the archived row on screen with nothing to repair it,
+            // since an update_all archive broadcasts no destroy either. It hides
+            // the template and clears currentTree before the save is awaited, so
+            // the editor is already closed on this path.
+            return Promise.resolve().then(hideCurrent).catch(err => {
+              console.error('CreativeRowEditor: Failed to flush the editor before archiving', err);
+            }).then(applyToView);
           });
         }
       });

--- a/engines/collavre/app/javascript/modules/creative_tree_dom.js
+++ b/engines/collavre/app/javascript/modules/creative_tree_dom.js
@@ -21,6 +21,7 @@
 // apply here. The only DOM writes are element mutations (insertBefore, appendChild,
 // setAttribute, dataset, style, requestUpdate) invoked on the passed nodes.
 import { treeRowElement, readRowLevel, buildChildrenLoadUrl } from './creative_row_editor_helpers';
+import { restoreTreeEmptyState } from './creative_tree_empty_state';
 
 export function creativeTreeElement(node) {
   if (!node) return null;
@@ -257,4 +258,7 @@ export function removeTreeElement(tree) {
   } else if (tree.remove) {
     tree.remove();
   }
+  // Covers every editor-side removal: abandoned new row, delete, level moves that
+  // empty the tree. No-op while any row remains.
+  restoreTreeEmptyState();
 }

--- a/engines/collavre/app/javascript/modules/creative_tree_empty_state.js
+++ b/engines/collavre/app/javascript/modules/creative_tree_empty_state.js
@@ -22,8 +22,15 @@
 // pristine copy outside the container; restoreTreeEmptyState() clones it when the
 // tree empties out and nothing is left to un-hide. Cloning a <template> is not an
 // HTML sink — the browser parsed the markup at page load, server-side-escaped.
+//
+// One more wrinkle: the "Chats" feed is paginated, so an empty container does not
+// mean an empty result set — there may be further pages waiting behind the
+// load-more sentinel. tree_controller marks the container with
+// data-creatives-pagination-pending while that is the case, and restoreTreeEmptyState()
+// stays out of the way until the last page has landed.
 const EMPTY_STATE_SELECTOR = '[data-creatives-empty-state]';
 const EMPTY_STATE_TEMPLATE_ID = 'creatives-empty-state-template';
+export const PAGINATION_PENDING_ATTRIBUTE = 'data-creatives-pagination-pending';
 
 export function creativeTreeContainer() {
   return document.getElementById('creatives');
@@ -53,6 +60,10 @@ export function restoreTreeEmptyState(container = creativeTreeContainer()) {
   if (!container || !container.querySelector) return;
   // Still populated — the placeholder stays hidden.
   if (container.querySelector('creative-tree-row')) return;
+  // Rendered rows are gone but the feed has further pages queued: the list is not
+  // empty, it is just between pages. Showing "No creatives found." here would both
+  // lie and survive the append, sitting above the rows the next page brings in.
+  if (container.hasAttribute && container.hasAttribute(PAGINATION_PENDING_ATTRIBUTE)) return;
 
   const existing = emptyStateElements(container);
   if (existing.length > 0) {

--- a/engines/collavre/app/javascript/modules/creative_tree_empty_state.js
+++ b/engines/collavre/app/javascript/modules/creative_tree_empty_state.js
@@ -1,0 +1,38 @@
+// Empty-state placeholder ("No sub-creatives found." / "No creatives found.")
+// lifecycle for the creative tree.
+//
+// The placeholder is server-rendered inside #creatives (see creatives/index.html.erb)
+// and marked with data-creatives-empty-state. Rows, however, are inserted into that
+// same container purely client-side — by the inline row editor (local add) and by the
+// websocket broadcast handler (another user / MCP add). Neither path re-renders the
+// container, so without an explicit hook the placeholder stays visible next to the
+// freshly created row.
+//
+// hideTreeEmptyState() drops the placeholder as soon as a row lands; restoreTreeEmptyState()
+// puts it back when the last row leaves (abandoned new row, delete, broadcast destroy)
+// using the original markup cached on the container by the tree controller value.
+const EMPTY_STATE_SELECTOR = '[data-creatives-empty-state]';
+// Stimulus value attribute on #creatives (creatives--tree controller, emptyHtml value).
+// Read via getAttribute because the `creatives--tree` identifier does not survive the
+// dataset camelCase mapping in a usable form.
+const EMPTY_HTML_ATTRIBUTE = 'data-creatives--tree-empty-html-value';
+
+export function creativeTreeContainer() {
+  return document.getElementById('creatives');
+}
+
+export function hideTreeEmptyState(container = creativeTreeContainer()) {
+  if (!container || !container.querySelectorAll) return;
+  container.querySelectorAll(EMPTY_STATE_SELECTOR).forEach((element) => element.remove());
+}
+
+export function restoreTreeEmptyState(container = creativeTreeContainer()) {
+  if (!container || !container.querySelector) return;
+  // Still populated (or the placeholder is already back) — nothing to restore.
+  if (container.querySelector('creative-tree-row')) return;
+  if (container.querySelector(EMPTY_STATE_SELECTOR)) return;
+
+  const html = container.getAttribute(EMPTY_HTML_ATTRIBUTE);
+  if (!html) return;
+  container.insertAdjacentHTML('beforeend', html);
+}

--- a/engines/collavre/app/javascript/modules/creative_tree_empty_state.js
+++ b/engines/collavre/app/javascript/modules/creative_tree_empty_state.js
@@ -8,31 +8,40 @@
 // container, so without an explicit hook the placeholder stays visible next to the
 // freshly created row.
 //
-// hideTreeEmptyState() drops the placeholder as soon as a row lands; restoreTreeEmptyState()
-// puts it back when the last row leaves (abandoned new row, delete, broadcast destroy)
-// using the original markup cached on the container by the tree controller value.
+// hideTreeEmptyState() hides the placeholder as soon as a row lands;
+// restoreTreeEmptyState() shows it again when the last row leaves.
+//
+// The placeholder is toggled rather than removed and re-created: keeping the original
+// node means no markup has to be cached and re-parsed as HTML (which would both
+// re-introduce an HTML sink and lose the server-rendered button_to CSRF token in the
+// "request permission" variant of the placeholder).
 const EMPTY_STATE_SELECTOR = '[data-creatives-empty-state]';
-// Stimulus value attribute on #creatives (creatives--tree controller, emptyHtml value).
-// Read via getAttribute because the `creatives--tree` identifier does not survive the
-// dataset camelCase mapping in a usable form.
-const EMPTY_HTML_ATTRIBUTE = 'data-creatives--tree-empty-html-value';
 
 export function creativeTreeContainer() {
   return document.getElementById('creatives');
 }
 
+function emptyStateElements(container) {
+  if (!container || !container.querySelectorAll) return [];
+  return Array.from(container.querySelectorAll(EMPTY_STATE_SELECTOR));
+}
+
 export function hideTreeEmptyState(container = creativeTreeContainer()) {
-  if (!container || !container.querySelectorAll) return;
-  container.querySelectorAll(EMPTY_STATE_SELECTOR).forEach((element) => element.remove());
+  emptyStateElements(container).forEach((element) => {
+    element.hidden = true;
+    // Belt and braces: `hidden` is a UA-stylesheet rule that any `display` rule
+    // on the element would win over.
+    element.style.display = 'none';
+  });
 }
 
 export function restoreTreeEmptyState(container = creativeTreeContainer()) {
   if (!container || !container.querySelector) return;
-  // Still populated (or the placeholder is already back) — nothing to restore.
+  // Still populated — the placeholder stays hidden.
   if (container.querySelector('creative-tree-row')) return;
-  if (container.querySelector(EMPTY_STATE_SELECTOR)) return;
 
-  const html = container.getAttribute(EMPTY_HTML_ATTRIBUTE);
-  if (!html) return;
-  container.insertAdjacentHTML('beforeend', html);
+  emptyStateElements(container).forEach((element) => {
+    element.hidden = false;
+    element.style.removeProperty('display');
+  });
 }

--- a/engines/collavre/app/javascript/modules/creative_tree_empty_state.js
+++ b/engines/collavre/app/javascript/modules/creative_tree_empty_state.js
@@ -15,7 +15,15 @@
 // node means no markup has to be cached and re-parsed as HTML (which would both
 // re-introduce an HTML sink and lose the server-rendered button_to CSRF token in the
 // "request permission" variant of the placeholder).
+//
+// The container itself is wiped on every client-side tree load (tree_controller's
+// showLoadingIndicator / renderCreativeTree), so on a populated tree the placeholder
+// is gone by the time the rows arrive. #creatives-empty-state-template holds a
+// pristine copy outside the container; restoreTreeEmptyState() clones it when the
+// tree empties out and nothing is left to un-hide. Cloning a <template> is not an
+// HTML sink — the browser parsed the markup at page load, server-side-escaped.
 const EMPTY_STATE_SELECTOR = '[data-creatives-empty-state]';
+const EMPTY_STATE_TEMPLATE_ID = 'creatives-empty-state-template';
 
 export function creativeTreeContainer() {
   return document.getElementById('creatives');
@@ -35,13 +43,27 @@ export function hideTreeEmptyState(container = creativeTreeContainer()) {
   });
 }
 
+function clonedEmptyStatePlaceholder() {
+  const template = document.getElementById(EMPTY_STATE_TEMPLATE_ID);
+  if (!template || !template.content) return null;
+  return template.content.cloneNode(true).querySelector(EMPTY_STATE_SELECTOR);
+}
+
 export function restoreTreeEmptyState(container = creativeTreeContainer()) {
   if (!container || !container.querySelector) return;
   // Still populated — the placeholder stays hidden.
   if (container.querySelector('creative-tree-row')) return;
 
-  emptyStateElements(container).forEach((element) => {
-    element.hidden = false;
-    element.style.removeProperty('display');
-  });
+  const existing = emptyStateElements(container);
+  if (existing.length > 0) {
+    existing.forEach((element) => {
+      element.hidden = false;
+      element.style.removeProperty('display');
+    });
+    return;
+  }
+
+  // Nothing to un-hide — the tree render wiped the container. Re-attach a copy.
+  const placeholder = clonedEmptyStatePlaceholder();
+  if (placeholder) container.appendChild(placeholder);
 }

--- a/engines/collavre/app/views/collavre/creatives/index.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/index.html.erb
@@ -224,25 +224,22 @@
 <% end %>
 
 <%
-  empty_html = nil
-  if (@creatives || []).blank?
-    empty_body =
-      if params[:search].present?
-        content_tag(:p, t('.no_search_results'), style: 'text-align: center;')
-      elsif params[:id] && @creative && !@creative.has_permission?(Current.user, :read)
-        message = content_tag(:p, t('.no_permission'), style: 'text-align: center;')
-        action = content_tag(:div, button_to(t('.request_permission'), request_permission_creative_path(@creative), method: :post), style: 'text-align: center;')
-        message + action
-      else
-        text = params[:id] ? t('.no_sub_creatives') : t('.no_creatives')
-        content_tag(:p, text, style: 'text-align: center;')
-      end
-    # data-creatives-empty-state marks the placeholder so client-side row insertion
-    # (inline editor / websocket broadcast) can hide it as soon as the tree is no
-    # longer empty, and show it again when the last row is removed.
-    # See app/javascript/modules/creative_tree_empty_state.js.
-    empty_html = content_tag(:div, empty_body, data: { creatives_empty_state: '' })
-  end
+  empty_body =
+    if params[:search].present?
+      content_tag(:p, t('.no_search_results'), style: 'text-align: center;')
+    elsif params[:id] && @creative && !@creative.has_permission?(Current.user, :read)
+      message = content_tag(:p, t('.no_permission'), style: 'text-align: center;')
+      action = content_tag(:div, button_to(t('.request_permission'), request_permission_creative_path(@creative), method: :post), style: 'text-align: center;')
+      message + action
+    else
+      text = params[:id] ? t('.no_sub_creatives') : t('.no_creatives')
+      content_tag(:p, text, style: 'text-align: center;')
+    end
+  # data-creatives-empty-state marks the placeholder so client-side row insertion
+  # (inline editor / websocket broadcast) can hide it as soon as the tree is no
+  # longer empty, and show it again when the last row is removed.
+  # See app/javascript/modules/creative_tree_empty_state.js.
+  empty_html = content_tag(:div, empty_body, data: { creatives_empty_state: '' })
   # Only pass filter parameters to avoid unnecessary params in URL
   tree_params = params.to_unsafe_h.slice(
     "id", "tags", "min_progress", "max_progress", "search", "comment",
@@ -252,13 +249,20 @@
   tree_url = creatives_path(tree_params)
 %>
 
+<%# The tree is client-rendered: every load() wipes #creatives, so the placeholder
+    rendered inside it below cannot survive the first fetch. This template keeps a
+    pristine copy outside the container, letting the client re-attach the placeholder
+    when the tree turns out to be — or becomes — empty. A <template> is cloned, never
+    parsed from a string, so no HTML sink is involved and the button_to CSRF token
+    stays intact. %>
+<%= tag.template(empty_html, id: 'creatives-empty-state-template') %>
+
 <%= tag.div(
       empty_html,
       id: 'creatives',
       data: {
         controller: 'creatives--tree creatives--sync',
         'creatives--tree-url-value': tree_url,
-        'creatives--tree-empty-html-value': empty_html.to_s,
         'creatives--sync-root-id-value': @parent_creative&.effective_origin&.id,
         'creatives--sync-current-user-id-value': Current.user&.id,
         edit_icon_html: svg_tag("edit.svg", className: "icon-edit"),

--- a/engines/collavre/app/views/collavre/creatives/index.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/index.html.erb
@@ -226,16 +226,21 @@
 <%
   empty_html = nil
   if (@creatives || []).blank?
-    if params[:search].present?
-      empty_html = content_tag(:p, t('.no_search_results'), style: 'text-align: center;')
-    elsif params[:id] && @creative && !@creative.has_permission?(Current.user, :read)
-      message = content_tag(:p, t('.no_permission'), style: 'text-align: center;')
-      action = content_tag(:div, button_to(t('.request_permission'), request_permission_creative_path(@creative), method: :post), style: 'text-align: center;')
-      empty_html = message + action
-    else
-      text = params[:id] ? t('.no_sub_creatives') : t('.no_creatives')
-      empty_html = content_tag(:p, text, style: 'text-align: center;')
-    end
+    empty_body =
+      if params[:search].present?
+        content_tag(:p, t('.no_search_results'), style: 'text-align: center;')
+      elsif params[:id] && @creative && !@creative.has_permission?(Current.user, :read)
+        message = content_tag(:p, t('.no_permission'), style: 'text-align: center;')
+        action = content_tag(:div, button_to(t('.request_permission'), request_permission_creative_path(@creative), method: :post), style: 'text-align: center;')
+        message + action
+      else
+        text = params[:id] ? t('.no_sub_creatives') : t('.no_creatives')
+        content_tag(:p, text, style: 'text-align: center;')
+      end
+    # data-creatives-empty-state marks the placeholder so client-side row insertion
+    # (inline editor / websocket broadcast) can drop it as soon as the tree is no
+    # longer empty, and restore it when the last row is removed.
+    empty_html = content_tag(:div, empty_body, data: { creatives_empty_state: '' })
   end
   # Only pass filter parameters to avoid unnecessary params in URL
   tree_params = params.to_unsafe_h.slice(

--- a/engines/collavre/app/views/collavre/creatives/index.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/index.html.erb
@@ -238,8 +238,9 @@
         content_tag(:p, text, style: 'text-align: center;')
       end
     # data-creatives-empty-state marks the placeholder so client-side row insertion
-    # (inline editor / websocket broadcast) can drop it as soon as the tree is no
-    # longer empty, and restore it when the last row is removed.
+    # (inline editor / websocket broadcast) can hide it as soon as the tree is no
+    # longer empty, and show it again when the last row is removed.
+    # See app/javascript/modules/creative_tree_empty_state.js.
     empty_html = content_tag(:div, empty_body, data: { creatives_empty_state: '' })
   end
   # Only pass filter parameters to avoid unnecessary params in URL

--- a/engines/collavre/test/controllers/creatives_controller_test.rb
+++ b/engines/collavre/test/controllers/creatives_controller_test.rb
@@ -382,6 +382,36 @@ class CreativesControllerTest < ActionDispatch::IntegrationTest
       "New child should not have been in first response"
   end
 
+  test "index renders the empty-state placeholder marked for client-side toggling" do
+    get creatives_path(id: creatives(:childless_creative).id)
+
+    assert_response :success
+    assert_select "#creatives > div[data-creatives-empty-state]", count: 1 do
+      assert_select "p", text: I18n.t("collavre.creatives.index.no_sub_creatives")
+    end
+  end
+
+  test "index renders an empty-state template outside the client-rendered tree" do
+    # The tree is client-rendered and every load wipes #creatives, so the
+    # placeholder inside it cannot survive the first fetch. The template is the
+    # copy restoreTreeEmptyState() clones from when the tree empties out.
+    get creatives_path(id: creatives(:root_parent).id)
+
+    assert_response :success
+    assert_select "template#creatives-empty-state-template", count: 1
+    assert_select "#creatives template#creatives-empty-state-template", count: 0
+    template = css_select("template#creatives-empty-state-template").first
+    assert_includes template.to_html, "data-creatives-empty-state"
+    assert_includes template.to_html, I18n.t("collavre.creatives.index.no_sub_creatives")
+  end
+
+  test "index no longer passes empty-state markup as a controller value" do
+    get creatives_path(id: creatives(:root_parent).id)
+
+    assert_response :success
+    assert_nil css_select("#creatives").first["data-creatives--tree-empty-html-value"]
+  end
+
   test "index allows public access by default" do
     sign_out
     get creatives_path

--- a/engines/collavre/test/system/creative_inline_edit_test.rb
+++ b/engines/collavre/test/system/creative_inline_edit_test.rb
@@ -187,6 +187,19 @@ class CreativeInlineEditTest < ApplicationSystemTestCase
     assert_no_selector "#creatives [data-creatives-empty-state]"
   end
 
+  test "keeps the empty state template available after the tree renders rows" do
+    Creative.create!(description: "Existing child", user: @user, parent: @root_creative)
+
+    visit collavre.creative_path(@root_creative)
+
+    assert_selector "#creatives > creative-tree-row .creative-row", text: "Existing child", wait: 5
+    assert_no_selector "#creatives [data-creatives-empty-state]"
+    # Rendering the tree wipes #creatives, so the placeholder inside it is gone by
+    # now. The template sits outside the container and survives, which is what
+    # restoreTreeEmptyState() clones from when the last row is removed.
+    assert_selector "template#creatives-empty-state-template", visible: :all, count: 1
+  end
+
   test "does not duplicate attachments when re-editing inline creative" do
     fixture_path = Rails.root.join("test/fixtures/files/small.png")
 

--- a/engines/collavre/test/system/creative_inline_edit_test.rb
+++ b/engines/collavre/test/system/creative_inline_edit_test.rb
@@ -174,6 +174,19 @@ class CreativeInlineEditTest < ApplicationSystemTestCase
     assert_selector "#creatives > creative-tree-row:nth-of-type(2) .creative-row", text: ActionController::Base.helpers.strip_tags(existing_child.description)
   end
 
+  test "hides the empty state placeholder once a sub-creative is added" do
+    visit collavre.creative_path(@root_creative)
+
+    assert_selector "#creatives [data-creatives-empty-state]", wait: 5
+
+    find(".creative-actions-row .add-creative-btn").click
+    fill_inline_editor("First child")
+    close_inline_editor
+
+    assert_selector "#creatives > creative-tree-row .creative-row", text: "First child", wait: 5
+    assert_no_selector "#creatives [data-creatives-empty-state]"
+  end
+
   test "does not duplicate attachments when re-editing inline creative" do
     fixture_path = Rails.root.join("test/fixtures/files/small.png")
 


### PR DESCRIPTION
## Problem

On a creative page with no children, the tree shows the "No sub-creatives found."
placeholder. Adding a sub-creative inserts the new row but leaves the placeholder
visible right under it, until a full page reload.

## Root cause

The placeholder is server-rendered as a plain `<p>` inside `#creatives`
(`creatives/index.html.erb`). Rows, however, are inserted into that same container
purely client-side, and neither insertion path knew about the placeholder:

- local add — `performStart()` in `modules/creative_row_editor.js`
- remote / MCP add — `handleCreated()` in `lib/turbo_stream_actions.js`

Nothing identified the placeholder element, so nothing could remove it.

## Fix

- Wrap the placeholder in a `data-creatives-empty-state` marker element.
- New shared module `modules/creative_tree_empty_state.js`:
  - `hideTreeEmptyState()` — hides the placeholder when a row lands.
  - `restoreTreeEmptyState()` — shows it again once the last row is gone; no-op
    while any row remains.
  - The node is toggled (`hidden` + `display:none`) rather than removed and
    re-created from cached markup: no HTML re-parse (CodeQL `js/xss-through-dom`),
    and the "request permission" variant keeps its server-rendered `button_to`
    CSRF token.
- Hooked into both creation paths, and into both removal choke points
  (`removeTreeElement()` for editor-side removals — abandoned new row, delete —
  and `handleDestroyed()` for broadcasts), so the placeholder comes back instead
  of leaving an empty tree with no message.

## Tests

- `modules/__tests__/creative_tree_empty_state.test.js` — new module (hide,
  restore, guards for missing container / missing placeholder / no duplicates).
- `lib/__tests__/turbo_stream_actions.test.js` — broadcast `created` hides the
  placeholder, `destroyed` restores it for the last row and leaves it hidden
  while siblings remain.
- `modules/__tests__/creative_tree_dom.test.js` — `removeTreeElement` restore
  behavior.
- `test/system/creative_inline_edit_test.rb` — end-to-end: empty parent page,
  add button, placeholder gone.

Verified red/green: the system test fails against the pre-fix bundle
(placeholder still rendered next to the new row) and passes after the change.
All 770 engine JS tests and all 9 tests in `creative_inline_edit_test.rb` pass
locally; the full CI `test` job passed on the first commit.