### PR TITLE
fix: decode HTML character references in plain-text creative labels

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -87,9 +87,7 @@ module ApplicationHelper
   def creative_title_for_display(creative, length: 12)
     return "" unless creative
 
-    description_body = creative.effective_origin.description
-    title = description_body ? strip_tags(description_body) : ""
-    title.strip.truncate(length, omission: "...")
+    Collavre::HtmlText.truncated_label(creative.effective_origin.description, length)
   end
 
   def render_contact_creatives(creatives)

--- a/engines/collavre/app/controllers/collavre/comments_controller.rb
+++ b/engines/collavre/app/controllers/collavre/comments_controller.rb
@@ -213,7 +213,7 @@ module Collavre
         if (is_admin || is_creative_owner) && !is_owner && @comment.user.present? && !@comment.user.ai_user?
           inbox_creative = Creative.inbox_for(@comment.user)
           creative_path = Collavre::Engine.routes.url_helpers.creative_path(@creative, open_comments: true)
-          creative_link = "[#{@creative.creative_snippet}](#{creative_path})"
+          creative_link = "[#{@creative.creative_snippet_markdown}](#{creative_path})"
           msg = I18n.t(
             "inbox.comment_deleted_by_admin",
             admin_name: Current.user.name,

--- a/engines/collavre/app/controllers/collavre/concerns/shareable.rb
+++ b/engines/collavre/app/controllers/collavre/concerns/shareable.rb
@@ -9,7 +9,7 @@ module Collavre
           return head :unprocessable_entity
         end
 
-        short_title = helpers.strip_tags(creative.effective_origin.description).truncate(10)
+        short_title = Collavre::HtmlText.truncated_label(creative.effective_origin.description, 10)
         creative_path = Collavre::Engine.routes.url_helpers.creative_path(creative, open_comments: true)
         creative_link = "[#{short_title}](#{creative_path})"
 

--- a/engines/collavre/app/controllers/collavre/concerns/shareable.rb
+++ b/engines/collavre/app/controllers/collavre/concerns/shareable.rb
@@ -9,7 +9,7 @@ module Collavre
           return head :unprocessable_entity
         end
 
-        short_title = Collavre::HtmlText.truncated_label(creative.effective_origin.description, 10)
+        short_title = Collavre::HtmlText.markdown_label(creative.effective_origin.description, 10)
         creative_path = Collavre::Engine.routes.url_helpers.creative_path(creative, open_comments: true)
         creative_link = "[#{short_title}](#{creative_path})"
 

--- a/engines/collavre/app/controllers/concerns/collavre/comments/conversion.rb
+++ b/engines/collavre/app/controllers/concerns/collavre/comments/conversion.rb
@@ -36,7 +36,7 @@ module Collavre
       end
 
       def build_convert_system_message(creative)
-        title = Collavre::HtmlText.label(creative.description)
+        title = Collavre::HtmlText.markdown_label(creative.description)
         title = I18n.t("collavre.comments.convert_system_message_default_title") if title.blank?
         url = creative_path(creative)
         I18n.t("collavre.comments.convert_system_message", title: title, url: url)

--- a/engines/collavre/app/controllers/concerns/collavre/comments/conversion.rb
+++ b/engines/collavre/app/controllers/concerns/collavre/comments/conversion.rb
@@ -36,7 +36,7 @@ module Collavre
       end
 
       def build_convert_system_message(creative)
-        title = helpers.strip_tags(creative.description).to_s.strip
+        title = Collavre::HtmlText.label(creative.description)
         title = I18n.t("collavre.comments.convert_system_message_default_title") if title.blank?
         url = creative_path(creative)
         I18n.t("collavre.comments.convert_system_message", title: title, url: url)

--- a/engines/collavre/app/javascript/lib/utils/__tests__/markdown.test.js
+++ b/engines/collavre/app/javascript/lib/utils/__tests__/markdown.test.js
@@ -151,3 +151,47 @@ describe("highlightCodeBlocks", () => {
     expect(el.querySelector("pre code").innerHTML).toBe(first)
   })
 })
+
+// Server-generated inbox/system comments embed a creative's plain-text label in
+// a markdown link: `[#{label}](#{path})`. Collavre::HtmlText.markdown_label
+// backslash-escapes the label before that interpolation; these cases pin down
+// what those escapes have to survive on the rendering side.
+describe("generated creative links tolerate hostile labels once escaped", () => {
+  const link = (label) => renderCommentMarkdown(`[${label}](/creatives/1)`)
+  const hrefOf = (html) => {
+    const el = document.createElement("div")
+    el.innerHTML = html
+    return el.querySelector("a")?.getAttribute("href")
+  }
+  const textOf = (html) => {
+    const el = document.createElement("div")
+    el.innerHTML = html
+    return el.querySelector("a")?.textContent
+  }
+
+  it("keeps an unescaped angle-bracket label from being dropped once escaped", () => {
+    // Raw `<x>` reaches marked as inline HTML and the sanitizer deletes it.
+    expect(textOf(link("A <x> tag"))).toBe("A  tag")
+    // `\<x\>` renders the brackets as literal text instead.
+    expect(textOf(link("A \\<x\\> tag"))).toBe("A <x> tag")
+  })
+
+  it("keeps a bracket-injecting label from hijacking the link destination", () => {
+    // Unescaped, the label closes the link early and supplies its own href.
+    expect(hrefOf(link("x](https://evil.example)"))).toBe("https://evil.example")
+    // Escaped, the destination stays the creative path and the label is literal.
+    const safe = link("x\\]\\(https://evil.example\\)")
+    expect(hrefOf(safe)).toBe("/creatives/1")
+    expect(textOf(safe)).toBe("x](https://evil.example)")
+  })
+
+  it("renders escaped emphasis and code characters as literal label text", () => {
+    expect(textOf(link("a\\*b\\*c \\_d\\_ \\`e\\` \\~f\\~"))).toBe("a*b*c _d_ `e` ~f~")
+  })
+
+  it("leaves an ordinary label untouched", () => {
+    const html = link("버그: 채팅 컨텍스트 라벨")
+    expect(hrefOf(html)).toBe("/creatives/1")
+    expect(textOf(html)).toBe("버그: 채팅 컨텍스트 라벨")
+  })
+})

--- a/engines/collavre/app/models/collavre/comment/notifiable.rb
+++ b/engines/collavre/app/models/collavre/comment/notifiable.rb
@@ -151,7 +151,7 @@ module Collavre
 
       def creative_markdown_link(target_creative = creative)
         path = Collavre::Engine.routes.url_helpers.creative_path(target_creative, open_comments: true)
-        "[#{target_creative.creative_snippet}](#{path})"
+        "[#{target_creative.creative_snippet_markdown}](#{path})"
       end
 
       def inbox_comment_link

--- a/engines/collavre/app/models/collavre/creative/describable.rb
+++ b/engines/collavre/app/models/collavre/creative/describable.rb
@@ -42,12 +42,12 @@ module Collavre
         if html
           description_val&.to_s || ""
         else
-          ActionController::Base.helpers.strip_tags(description_val&.to_s || "")
+          Collavre::HtmlText.plain(description_val)
         end
       end
 
       def creative_snippet
-        CGI.unescapeHTML(ActionController::Base.helpers.strip_tags(effective_origin.description || "")).truncate(24, omission: "...")
+        Collavre::HtmlText.truncated_label(effective_origin.description, 24)
       end
 
       # Read-only-source creatives reject any description change

--- a/engines/collavre/app/models/collavre/creative/describable.rb
+++ b/engines/collavre/app/models/collavre/creative/describable.rb
@@ -50,6 +50,12 @@ module Collavre
         Collavre::HtmlText.truncated_label(effective_origin.description, 24)
       end
 
+      # `creative_snippet` for callers that interpolate it into generated
+      # markdown, typically as the text of a `[snippet](path)` link.
+      def creative_snippet_markdown
+        Collavre::HtmlText.escape_markdown(creative_snippet)
+      end
+
       # Read-only-source creatives reject any description change
       # (description_cannot_change_if_read_only_source), so embedding would raise
       # and orphan the blob. Callers MUST check this before creating the blob.

--- a/engines/collavre/app/models/collavre/creative_share.rb
+++ b/engines/collavre/app/models/collavre/creative_share.rb
@@ -87,10 +87,7 @@ module Collavre
       return unless Current.user && user
       return if user.ai_user?
       inbox_creative = Creative.inbox_for(user)
-      short_title = ActionController::Base.helpers.truncate(
-        ActionController::Base.helpers.strip_tags(creative.effective_description),
-        length: 30
-      )
+      short_title = Collavre::HtmlText.truncated_label(creative.effective_description, 30)
       creative_path = Collavre::Engine.routes.url_helpers.creative_path(creative, open_comments: true)
       creative_link = "[#{short_title}](#{creative_path})"
       msg = I18n.t(

--- a/engines/collavre/app/models/collavre/creative_share.rb
+++ b/engines/collavre/app/models/collavre/creative_share.rb
@@ -87,7 +87,7 @@ module Collavre
       return unless Current.user && user
       return if user.ai_user?
       inbox_creative = Creative.inbox_for(user)
-      short_title = Collavre::HtmlText.truncated_label(creative.effective_description, 30)
+      short_title = Collavre::HtmlText.markdown_label(creative.effective_description, 30)
       creative_path = Collavre::Engine.routes.url_helpers.creative_path(creative, open_comments: true)
       creative_link = "[#{short_title}](#{creative_path})"
       msg = I18n.t(

--- a/engines/collavre/app/services/collavre/creatives/breadcrumb_resolver.rb
+++ b/engines/collavre/app/services/collavre/creatives/breadcrumb_resolver.rb
@@ -84,7 +84,7 @@ module Creatives
     end
 
     def ancestor_label(creative)
-      creative.effective_description(nil, false).to_s.gsub(/\s+/, " ").strip
+      Collavre::HtmlText.label(creative.effective_description(nil, true))
     end
   end
 end

--- a/engines/collavre/app/services/collavre/creatives/tree_formatter.rb
+++ b/engines/collavre/app/services/collavre/creatives/tree_formatter.rb
@@ -34,10 +34,10 @@ module Collavre
         lines.join("\n")
       end
 
-      # Extract plain text description from a creative (shared helper)
+      # Extract plain text description from a creative (shared helper).
+      # One creative must occupy exactly one row, so this collapses newlines.
       def self.plain_description(creative)
-        raw = creative.effective_description(nil, true)
-        ActionView::Base.full_sanitizer.sanitize(raw).strip
+        Collavre::HtmlText.label(creative.effective_description(nil, true))
       end
 
       private
@@ -53,7 +53,7 @@ module Collavre
 
         if @include_comments
           node.comments.order(created_at: :desc).limit(3).reverse_each do |comment|
-            comment_text = ActionView::Base.full_sanitizer.sanitize(comment.content).strip.truncate(100)
+            comment_text = Collavre::HtmlText.truncated_label(comment.content, 100)
             lines << "#{indent}    > #{comment_text}"
           end
         end

--- a/engines/collavre/app/services/collavre/creatives/workspace_tree_builder.rb
+++ b/engines/collavre/app/services/collavre/creatives/workspace_tree_builder.rb
@@ -20,7 +20,7 @@ module Collavre
         branches.map do |creative|
           {
             id: creative.id,
-            label: view_context.strip_tags(creative.effective_description).squish,
+            label: Collavre::HtmlText.label(creative.effective_description),
             snippet: creative.creative_snippet,
             can_comment: allowed?(creative, :feedback),
             url: view_context.collavre.creatives_path(id: creative.id),

--- a/engines/collavre/app/services/collavre/html_text.rb
+++ b/engines/collavre/app/services/collavre/html_text.rb
@@ -1,0 +1,39 @@
+module Collavre
+  # Single source of truth for rendering stored HTML (creative descriptions,
+  # comment bodies) as plain text for titles, labels, snippets and AI prompts.
+  #
+  # Every caller used to hand-roll `strip_tags` and, at best, pair it with
+  # `CGI.unescapeHTML`. That pair is broken: `strip_tags` runs
+  # Rails::HTML5::FullSanitizer, whose HTML5 serializer re-encodes U+00A0 as the
+  # named reference `&nbsp;`, while `CGI.unescapeHTML` only decodes the five XML
+  # entities plus numeric references. The literal six-character string `&nbsp;`
+  # therefore survived into labels (and got re-escaped to `&amp;nbsp;` on
+  # render, so users saw `&nbsp;` on screen) and counted against truncation
+  # limits. Re-parsing the stripped output as an HTML fragment decodes every
+  # named reference instead.
+  module HtmlText
+    module_function
+
+    # Tags stripped, character references decoded exactly once. Whitespace is
+    # preserved as authored, so U+00A0 stays U+00A0 — use `label` for anything
+    # rendered on a single line.
+    def plain(html)
+      stripped = ActionController::Base.helpers.strip_tags(html.to_s)
+      return "" if stripped.empty?
+
+      Nokogiri::HTML5.fragment(stripped).text
+    end
+
+    # Single-line plain text for titles, labels and breadcrumbs. `squish`
+    # collapses every run of Unicode whitespace — U+00A0 included — into one
+    # ASCII space.
+    def label(html)
+      plain(html).squish
+    end
+
+    # `label` capped at `length`, matching String#truncate semantics.
+    def truncated_label(html, length, omission: "...")
+      label(html).truncate(length, omission: omission)
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/html_text.rb
+++ b/engines/collavre/app/services/collavre/html_text.rb
@@ -35,5 +35,30 @@ module Collavre
     def truncated_label(html, length, omission: "...")
       label(html).truncate(length, omission: omission)
     end
+
+    # Characters that would start a markdown construct where a label gets
+    # interpolated. `]` and `)` let a title close the generated link early and
+    # supply its own destination; `<` and `>` make marked emit inline HTML that
+    # the client sanitizer then deletes; the rest turn a label into emphasis, a
+    # code span or strikethrough.
+    MARKDOWN_SPECIAL = /[\\`*_\[\]()<>~]/
+    private_constant :MARKDOWN_SPECIAL
+
+    # Backslash-escapes markdown constructs so `text` renders as the literal
+    # characters the author typed. One pass over the string, so the backslashes
+    # this adds are never themselves escaped.
+    def escape_markdown(text)
+      text.to_s.gsub(MARKDOWN_SPECIAL) { |char| "\\#{char}" }
+    end
+
+    # `label` (optionally capped at `length`) escaped for interpolation into
+    # generated markdown, as in `"[#{markdown_label(html, 30)}](#{path})"`.
+    #
+    # Truncation happens before escaping so `length` counts the characters a
+    # reader sees, and a cut can never land inside a backslash escape.
+    def markdown_label(html, length = nil, omission: "...")
+      text = length ? truncated_label(html, length, omission: omission) : label(html)
+      escape_markdown(text)
+    end
   end
 end

--- a/engines/collavre/app/services/collavre/tools/creative_retrieval_service.rb
+++ b/engines/collavre/app/services/collavre/tools/creative_retrieval_service.rb
@@ -177,7 +177,7 @@ module Tools
       if include_comments
         result[:recent_comments] = creative.comments.order(created_at: :desc).limit(3).map do |comment|
           {
-            content: ActionView::Base.full_sanitizer.sanitize(comment.content).strip.truncate(200),
+            content: Collavre::HtmlText.plain(comment.content).strip.truncate(200),
             user: comment.user&.display_name || comment.user&.name,
             created_at: comment.created_at&.iso8601
           }

--- a/engines/collavre/app/views/collavre/creatives/index.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/index.html.erb
@@ -40,10 +40,10 @@
       <% if @parent_creative %>
         <% @parent_creative.ancestors.reverse.each do |ancestor| %>
           <span class="creative-breadcrumb-sep" aria-hidden="true">/</span>
-          <a href="<%= creative_path(ancestor) %>" class="creative-breadcrumb-link" data-turbo-action="advance" title="<%= strip_tags(ancestor.effective_description) %>"><%= truncate(strip_tags(ancestor.effective_description), length: 20) %></a>
+          <a href="<%= creative_path(ancestor) %>" class="creative-breadcrumb-link" data-turbo-action="advance" title="<%= Collavre::HtmlText.label(ancestor.effective_description) %>"><%= Collavre::HtmlText.truncated_label(ancestor.effective_description, 20) %></a>
         <% end %>
         <span class="creative-breadcrumb-sep" aria-hidden="true">/</span>
-        <a href="<%= creative_path(@parent_creative) %>" class="creative-breadcrumb-link creative-breadcrumb-current" data-turbo-action="replace"><%= truncate(strip_tags(@parent_creative.effective_description), length: 30) %></a>
+        <a href="<%= creative_path(@parent_creative) %>" class="creative-breadcrumb-link creative-breadcrumb-current" data-turbo-action="replace"><%= Collavre::HtmlText.truncated_label(@parent_creative.effective_description, 30) %></a>
       <% end %>
     </div>
 
@@ -158,7 +158,7 @@
 
 <% if @parent_creative %>
   <% content_for :head do %>
-    <meta property="og:title" content="<%= strip_tags(@parent_creative.effective_origin.description) %>">
+    <meta property="og:title" content="<%= Collavre::HtmlText.label(@parent_creative.effective_origin.description) %>">
   <% end %>
   <% title_templates = [
         content_tag(:template, data: { part: "description" }) { sanitize @parent_creative.effective_description },

--- a/engines/collavre/app/views/collavre/invitation_mailer/invite.html.erb
+++ b/engines/collavre/app/views/collavre/invitation_mailer/invite.html.erb
@@ -1,5 +1,5 @@
 <p>
   <%= t('collavre.invitation_mailer.invite.message_html',
-         creative: strip_tags(@invitation.creative.effective_origin.description),
+         creative: Collavre::HtmlText.label(@invitation.creative.effective_origin.description),
          link: link_to(t('app.here'), collavre.invite_url(token: @invitation.generate_token_for(:invite)))) %>
 </p>

--- a/engines/collavre/app/views/collavre/invitation_mailer/invite.text.erb
+++ b/engines/collavre/app/views/collavre/invitation_mailer/invite.text.erb
@@ -1,3 +1,3 @@
 <%= t('collavre.invitation_mailer.invite.message_text',
-       creative: strip_tags(@invitation.creative.effective_origin.description),
+       creative: Collavre::HtmlText.label(@invitation.creative.effective_origin.description),
        link: collavre.invite_url(token: @invitation.generate_token_for(:invite))) %>

--- a/engines/collavre/app/views/collavre/invites/show.html.erb
+++ b/engines/collavre/app/views/collavre/invites/show.html.erb
@@ -1,4 +1,4 @@
-<% creative_title = CGI.unescapeHTML(strip_tags(@invitation.creative.effective_origin.description).to_s).squish %>
+<% creative_title = Collavre::HtmlText.label(@invitation.creative.effective_origin.description) %>
 <% meta_title = t(".meta.title", creative: creative_title) %>
 <% content_for :title, meta_title %>
 <% content_for :head do %>
@@ -12,7 +12,7 @@
 <% end %>
 
 <h1 class="no-top-margin"><%= t('.title') %></h1>
-<p><%= t('collavre.invites.show.invited_by', inviter: @invitation.inviter.display_name, email: @invitation.inviter.email, creative: strip_tags(@invitation.creative.effective_origin.description)) %></p>
+<p><%= t('collavre.invites.show.invited_by', inviter: @invitation.inviter.display_name, email: @invitation.inviter.email, creative: creative_title) %></p>
 <p><%= t('collavre.invites.show.prompt') %></p>
 <p>
   <%= link_to t('collavre.invites.show.login'), new_session_path(invite_token: params[:token]) %> |

--- a/engines/collavre/app/views/collavre/users/_org_chart_node.html.erb
+++ b/engines/collavre/app/views/collavre/users/_org_chart_node.html.erb
@@ -8,7 +8,7 @@
 <details class="org-chart-group" <%= 'open' if depth == 0 %>>
   <summary class="org-chart-creative-row <%= 'org-chart-depth-0' if depth == 0 %>" style="--depth: <%= depth %>">
     <span class="org-chart-creative-icon"><%= depth == 0 ? '📂' : '📁' %></span>
-    <%= link_to strip_tags(creative.effective_description.to_s).truncate(60),
+    <%= link_to Collavre::HtmlText.truncated_label(creative.effective_description, 60),
         collavre.creative_path(creative),
         class: "org-chart-creative-link" %>
     <% if effective.user_id == Current.user.id %>

--- a/engines/collavre/app/views/collavre/users/new.html.erb
+++ b/engines/collavre/app/views/collavre/users/new.html.erb
@@ -3,7 +3,7 @@
 <% if defined?(@invitation) && @invitation.present? %>
   <p>
     <strong><%= t('collavre.creatives.index.share_creative') %>:</strong>
-    <%= strip_tags(@invitation.creative.effective_origin.description) %>
+    <%= Collavre::HtmlText.label(@invitation.creative.effective_origin.description) %>
   </p>
 <% end %>
 

--- a/engines/collavre/test/models/creative_share_test.rb
+++ b/engines/collavre/test/models/creative_share_test.rb
@@ -23,6 +23,46 @@ class CreativeShareTest < ActiveSupport::TestCase
     Current.reset
   end
 
+  test "share notification escapes a link-hijacking creative title" do
+    sharer = users(:one)
+    recipient = users(:two)
+    Current.session = OpenStruct.new(user: sharer)
+
+    creative = Creative.create!(user: sharer, description: "<p>x](https://evil.example)</p>")
+    inbox = Collavre::Creative.inbox_for(recipient)
+
+    perform_enqueued_jobs do
+      CreativeShare.create!(creative: creative, user: recipient, permission: :read)
+    end
+
+    content = inbox.comments.reload.order(:id).last.content
+
+    # The title must not be able to close the generated link early and supply
+    # its own destination.
+    refute_includes content, "](https://evil.example)"
+    assert_includes content, "x\\]\\(https://evil.example\\)"
+    assert_includes content, Collavre::Engine.routes.url_helpers.creative_path(creative, open_comments: true)
+
+    Current.reset
+  end
+
+  test "share notification escapes angle brackets so the label survives rendering" do
+    sharer = users(:one)
+    recipient = users(:two)
+    Current.session = OpenStruct.new(user: sharer)
+
+    creative = Creative.create!(user: sharer, description: "<p>A &lt;x&gt; tag</p>")
+    inbox = Collavre::Creative.inbox_for(recipient)
+
+    perform_enqueued_jobs do
+      CreativeShare.create!(creative: creative, user: recipient, permission: :read)
+    end
+
+    assert_includes inbox.comments.reload.order(:id).last.content, "A \\<x\\> tag"
+
+    Current.reset
+  end
+
   test "descendant no_access share removes read permission" do
     owner = User.create!(email: "share-owner@example.com", password: TEST_PASSWORD, name: "Owner")
     shared_user = User.create!(email: "share-shared@example.com", password: TEST_PASSWORD, name: "Shared")

--- a/engines/collavre/test/models/creative_test.rb
+++ b/engines/collavre/test/models/creative_test.rb
@@ -144,6 +144,55 @@ class CreativeTest < ActiveSupport::TestCase
     assert_equal "Hello world", plain_text.strip
   end
 
+  test "effective_description decodes character references when html flag is false" do
+    creative = Creative.new(description: "<p>A &amp; B &lt;x&gt; and more</p>")
+
+    plain_text = creative.effective_description(nil, false)
+
+    refute_includes plain_text, "&nbsp;"
+    refute_includes plain_text, "&amp;"
+    assert_equal "A & B <x> and more", plain_text
+  end
+
+  test "creative_snippet decodes the nbsp reference emitted by tag stripping" do
+    creative = Creative.new(description: "<p>label shows</p>")
+
+    snippet = creative.creative_snippet
+
+    refute_includes snippet, "&nbsp;"
+    assert_equal "label shows", snippet
+  end
+
+  test "creative_snippet decodes ampersands and angle brackets" do
+    creative = Creative.new(description: "<p>A &amp; B &lt;x&gt;</p>")
+
+    assert_equal "A & B <x>", creative.creative_snippet
+  end
+
+  test "creative_snippet counts decoded characters against the 24 char cap" do
+    # 15 visible characters, but the three separators are non-breaking spaces
+    # that tag stripping re-encodes as the 6-character `&nbsp;` — 30 characters
+    # encoded. Counting the encoded form truncates a title that comfortably fits.
+    creative = Creative.new(description: "<p>#{Array.new(4) { |i| "ab#{i}" }.join(" ")}</p>")
+
+    snippet = creative.creative_snippet
+
+    refute_includes snippet, "..."
+    assert_equal "ab0 ab1 ab2 ab3", snippet
+  end
+
+  test "creative_snippet collapses newlines into single spaces" do
+    creative = Creative.new(description: "<p>first</p>\n<p>second</p>")
+
+    assert_equal "first second", creative.creative_snippet
+  end
+
+  test "creative_snippet truncates long descriptions to 24 characters" do
+    creative = Creative.new(description: "<p>#{'x' * 100}</p>")
+
+    assert_equal "#{'x' * 21}...", creative.creative_snippet
+  end
+
   test "assigns parent user when parent present" do
     owner = User.create!(email: "creative-owner@example.com", password: TEST_PASSWORD, name: "Owner")
     Current.session = Struct.new(:user).new(owner)

--- a/engines/collavre/test/models/creative_test.rb
+++ b/engines/collavre/test/models/creative_test.rb
@@ -193,6 +193,25 @@ class CreativeTest < ActiveSupport::TestCase
     assert_equal "#{'x' * 21}...", creative.creative_snippet
   end
 
+  test "creative_snippet_markdown escapes a link-hijacking title" do
+    creative = Creative.new(description: "<p>x](https://evil.example)</p>")
+
+    assert_equal "x](https://evil.example)", creative.creative_snippet
+    assert_equal "x\\]\\(https://evil.example\\)", creative.creative_snippet_markdown
+  end
+
+  test "creative_snippet_markdown escapes decoded angle brackets" do
+    creative = Creative.new(description: "<p>A &lt;x&gt; tag</p>")
+
+    assert_equal "A \\<x\\> tag", creative.creative_snippet_markdown
+  end
+
+  test "creative_snippet_markdown applies the same 24 char cap as creative_snippet" do
+    creative = Creative.new(description: "<p>#{'x' * 100}</p>")
+
+    assert_equal "#{'x' * 21}...", creative.creative_snippet_markdown
+  end
+
   test "assigns parent user when parent present" do
     owner = User.create!(email: "creative-owner@example.com", password: TEST_PASSWORD, name: "Owner")
     Current.session = Struct.new(:user).new(owner)

--- a/engines/collavre/test/services/collavre/html_text_test.rb
+++ b/engines/collavre/test/services/collavre/html_text_test.rb
@@ -1,0 +1,90 @@
+require "test_helper"
+
+module Collavre
+  class HtmlTextTest < ActiveSupport::TestCase
+    NBSP = " ".freeze
+
+    # --- plain -------------------------------------------------------------
+
+    test "plain strips tags and keeps inner text" do
+      assert_equal "Hello world", HtmlText.plain("<p>Hello <strong>world</strong></p>")
+    end
+
+    test "plain returns empty string for nil and blank input" do
+      assert_equal "", HtmlText.plain(nil)
+      assert_equal "", HtmlText.plain("")
+      assert_equal "", HtmlText.plain("<p></p>")
+    end
+
+    test "plain decodes the nbsp named reference that strip_tags re-encodes" do
+      html = "<p>label#{NBSP}shows</p>"
+
+      # Guard the premise: the HTML5 full sanitizer really does emit `&nbsp;`.
+      assert_includes ActionController::Base.helpers.strip_tags(html), "&nbsp;"
+
+      result = HtmlText.plain(html)
+      refute_includes result, "&nbsp;"
+      assert_equal "label#{NBSP}shows", result
+    end
+
+    test "plain decodes named references CGI.unescapeHTML cannot" do
+      assert_equal "a…b", HtmlText.plain("<p>a&hellip;b</p>")
+      assert_equal "a—b", HtmlText.plain("<p>a&mdash;b</p>")
+      assert_equal "50 € now", HtmlText.plain("<p>50 &euro; now</p>")
+    end
+
+    test "plain decodes the basic xml entities and numeric references" do
+      assert_equal %(A & B <x> "q" 'a'), HtmlText.plain("<p>A &amp; B &lt;x&gt; &quot;q&quot; &#39;a&#39;</p>")
+      assert_equal "a#{NBSP}b", HtmlText.plain("<p>a&#160;b</p>")
+    end
+
+    test "plain decodes exactly once so escaped markup stays escaped" do
+      assert_equal "a &lt; b", HtmlText.plain("<p>a &amp;lt; b</p>")
+      assert_equal "&nbsp;", HtmlText.plain("<p>&amp;nbsp;</p>")
+    end
+
+    test "plain does not reintroduce markup from escaped input" do
+      assert_equal "<script>alert(1)</script>", HtmlText.plain("<p>&lt;script&gt;alert(1)&lt;/script&gt;</p>")
+    end
+
+    test "plain preserves authored whitespace including nbsp" do
+      assert_equal "a\nb  c#{NBSP}d", HtmlText.plain("a\nb  c#{NBSP}d")
+    end
+
+    # --- label -------------------------------------------------------------
+
+    test "label collapses newlines and repeated spaces into single spaces" do
+      assert_equal "a b c", HtmlText.label("<p>a\n  b</p><p>   c   </p>")
+    end
+
+    test "label collapses nbsp into a plain space" do
+      assert_equal "label shows", HtmlText.label("<p>label#{NBSP}shows</p>")
+      refute_includes HtmlText.label("<p>label#{NBSP}shows</p>"), NBSP
+    end
+
+    test "label returns empty string for blank input" do
+      assert_equal "", HtmlText.label(nil)
+      assert_equal "", HtmlText.label("<p>#{NBSP}</p>")
+    end
+
+    # --- truncated_label ---------------------------------------------------
+
+    test "truncated_label caps length with the default omission" do
+      assert_equal "abcdefg...", HtmlText.truncated_label("<p>#{'abcdefghij' * 3}</p>", 10)
+    end
+
+    test "truncated_label accepts a custom omission" do
+      assert_equal "abcdefghi…", HtmlText.truncated_label("<p>#{'abcdefghij' * 3}</p>", 10, omission: "…")
+    end
+
+    test "truncated_label counts a decoded nbsp as one character" do
+      # `a&nbsp;b` is 8 characters undecoded but 3 once decoded, so a 5-char cap
+      # must keep the whole string rather than truncate it.
+      assert_equal "a b", HtmlText.truncated_label("<p>a#{NBSP}b</p>", 5)
+    end
+
+    test "truncated_label leaves short text untouched" do
+      assert_equal "short", HtmlText.truncated_label("<p>short</p>", 24)
+    end
+  end
+end

--- a/engines/collavre/test/services/collavre/html_text_test.rb
+++ b/engines/collavre/test/services/collavre/html_text_test.rb
@@ -86,5 +86,72 @@ module Collavre
     test "truncated_label leaves short text untouched" do
       assert_equal "short", HtmlText.truncated_label("<p>short</p>", 24)
     end
+
+    # --- escape_markdown ---------------------------------------------------
+
+    test "escape_markdown backslash-escapes every construct-forming character" do
+      assert_equal "a\\\\b", HtmlText.escape_markdown("a\\b")
+      assert_equal "a\\`b", HtmlText.escape_markdown("a`b")
+      assert_equal "a\\*b", HtmlText.escape_markdown("a*b")
+      assert_equal "a\\_b", HtmlText.escape_markdown("a_b")
+      assert_equal "a\\[b\\]", HtmlText.escape_markdown("a[b]")
+      assert_equal "a\\(b\\)", HtmlText.escape_markdown("a(b)")
+      assert_equal "a\\<b\\>", HtmlText.escape_markdown("a<b>")
+      assert_equal "a\\~b", HtmlText.escape_markdown("a~b")
+    end
+
+    test "escape_markdown escapes a backslash exactly once" do
+      # A naive two-pass gsub would turn `\*` into `\\\*` and render a literal
+      # backslash next to the asterisk.
+      assert_equal "\\\\\\*", HtmlText.escape_markdown("\\*")
+    end
+
+    test "escape_markdown leaves ordinary text alone" do
+      assert_equal "버그: 채팅 컨텍스트 & 라벨", HtmlText.escape_markdown("버그: 채팅 컨텍스트 & 라벨")
+      assert_equal "", HtmlText.escape_markdown(nil)
+    end
+
+    # --- markdown_label ----------------------------------------------------
+
+    test "markdown_label neutralises a link-hijacking title" do
+      # A creative described as `x](https://evil.example)` is stored verbatim by
+      # comrak, so `"[#{label}](#{path})"` would otherwise close the generated
+      # link early and point it at an attacker-chosen destination.
+      html = "<p>x](<a href=\"https://evil.example\">https://evil.example</a>)</p>"
+
+      assert_equal "x](https://evil.example)", HtmlText.label(html)
+      assert_equal "x\\]\\(https://evil.example\\)", HtmlText.markdown_label(html)
+    end
+
+    test "markdown_label keeps decoded angle brackets visible instead of letting them be dropped" do
+      # The rich editor stores a typed `<x>` as `&lt;x&gt;`; decoding it to a raw
+      # `<x>` inside markdown makes marked emit inline HTML that the sanitizer
+      # then deletes, silently corrupting the label.
+      html = "<p>A &lt;x&gt; tag</p>"
+
+      assert_equal "A <x> tag", HtmlText.label(html)
+      assert_equal "A \\<x\\> tag", HtmlText.markdown_label(html)
+    end
+
+    test "markdown_label truncates before escaping so the cap counts visible characters" do
+      html = "<p>#{'ab' * 20}</p>"
+
+      assert_equal "abababab...", HtmlText.markdown_label(html, 11)
+    end
+
+    test "markdown_label never truncates in the middle of an escape sequence" do
+      # `*` lands exactly on the 5-character boundary; escaping afterwards keeps
+      # its backslash attached instead of leaving a dangling `\`.
+      assert_equal "abcd\\*", HtmlText.markdown_label("<p>abcd*efgh</p>", 5, omission: "")
+    end
+
+    test "markdown_label collapses nbsp like label does" do
+      assert_equal "label shows", HtmlText.markdown_label("<p>label#{NBSP}shows</p>")
+    end
+
+    test "markdown_label returns empty string for blank input" do
+      assert_equal "", HtmlText.markdown_label(nil)
+      assert_equal "", HtmlText.markdown_label("<p>#{NBSP}</p>")
+    end
   end
 end

--- a/engines/collavre/test/services/creatives/tree_formatter_test.rb
+++ b/engines/collavre/test/services/creatives/tree_formatter_test.rb
@@ -114,5 +114,46 @@ module Creatives
       result = Creatives::TreeFormatter.plain_description(creative)
       assert_equal "Bold text", result
     end
+
+    test "plain_description decodes the nbsp reference emitted by tag stripping" do
+      creative = Creative.new(description: "<p>label shows</p>")
+
+      result = Creatives::TreeFormatter.plain_description(creative)
+
+      refute_includes result, "&nbsp;"
+      assert_equal "label shows", result
+    end
+
+    test "plain_description decodes ampersands and angle brackets" do
+      creative = Creative.new(description: "<p>A &amp; B &lt;x&gt;</p>")
+
+      assert_equal "A & B <x>", Creatives::TreeFormatter.plain_description(creative)
+    end
+
+    test "plain_description keeps a node on one line" do
+      # One creative must render as exactly one tree row; a description whose
+      # paragraphs are separated by newlines would otherwise corrupt the format.
+      creative = Creative.new(id: 1, description: "<p>first</p>\n<p>second</p>", progress: 0.0)
+      creative.association(:children).target = []
+
+      formatter = Creatives::TreeFormatter.new(include_header: false, use_permissions: false)
+
+      assert_equal "- [1] first second (0%)", formatter.format(creative)
+    end
+
+    test "include_comments decodes comment bodies and keeps each on one line" do
+      user = users(:one)
+      Current.session = OpenStruct.new(user: user)
+      creative = Creative.create!(user: user, description: "Root", progress: 0.0)
+      Comment.create!(creative: creative, user: user, content: "<p>hi there &amp; bye</p>")
+
+      formatter = Creatives::TreeFormatter.new(include_header: false, use_permissions: false, include_comments: true)
+      result = formatter.format(creative.reload)
+
+      refute_includes result, "&nbsp;"
+      assert_includes result, "    > hi there & bye"
+    ensure
+      Current.reset
+    end
   end
 end

--- a/engines/collavre_notion/app/controllers/collavre_notion/creatives/notion_integrations_controller.rb
+++ b/engines/collavre_notion/app/controllers/collavre_notion/creatives/notion_integrations_controller.rb
@@ -16,7 +16,7 @@ module CollavreNotion
 
         render json: {
           connected: account.present?,
-          creative_title: helpers.strip_tags(@creative.effective_origin.description.to_s).strip.presence || "Untitled Creative",
+          creative_title: Collavre::HtmlText.label(@creative.effective_origin.description).presence || "Untitled Creative",
           account: account && {
             workspace_name: account.workspace_name,
             workspace_id: account.workspace_id,

--- a/engines/collavre_notion/app/jobs/collavre_notion/notion_sync_job.rb
+++ b/engines/collavre_notion/app/jobs/collavre_notion/notion_sync_job.rb
@@ -19,7 +19,7 @@ module CollavreNotion
         end
 
         # Update the existing Notion page with children as blocks
-        title = ActionController::Base.helpers.strip_tags(creative.description).strip.presence || "Untitled Creative"
+        title = Collavre::HtmlText.label(creative.description).presence || "Untitled Creative"
         children = creative.children.to_a
         Rails.logger.info("NotionSyncJob: Syncing creative #{creative.id} as page title with #{children.count} children as blocks")
         blocks = children.any? ? NotionCreativeExporter.new(creative).export_tree_blocks(children, 1, 0) : []

--- a/engines/collavre_notion/app/services/collavre_notion/notion_creative_exporter.rb
+++ b/engines/collavre_notion/app/services/collavre_notion/notion_creative_exporter.rb
@@ -185,8 +185,8 @@ module CollavreNotion
     end
 
     def extract_text_content(html)
-      # Remove HTML tags and get plain text
-      ActionView::Base.full_sanitizer.sanitize(html).strip
+      # Remove HTML tags and decode character references
+      Collavre::HtmlText.plain(html).strip
     end
 
     def create_heading_block(text, level)

--- a/engines/collavre_notion/app/services/collavre_notion/notion_service.rb
+++ b/engines/collavre_notion/app/services/collavre_notion/notion_service.rb
@@ -92,7 +92,7 @@ module CollavreNotion
     end
 
     def create_creative_page(creative, notion_link, parent_page_id)
-      title = ActionController::Base.helpers.strip_tags(creative.description).strip.presence || "Untitled Creative"
+      title = Collavre::HtmlText.label(creative.description).presence || "Untitled Creative"
 
       # Export only the children - the page title serves as the root creative
       children = creative.children.to_a
@@ -123,7 +123,7 @@ module CollavreNotion
     end
 
     def update_creative_page(creative, notion_link)
-      title = ActionController::Base.helpers.strip_tags(creative.description).strip.presence || "Untitled Creative"
+      title = Collavre::HtmlText.label(creative.description).presence || "Untitled Creative"
 
       # Update with only the children - page title serves as the root creative
       children = creative.children.to_a


### PR DESCRIPTION
Fixes the bug tracked in Creative 17318: context chips and other creative labels rendered a literal `&nbsp;` on screen.

## Root cause

`Creative#creative_snippet` combined two steps that do not compose:

```ruby
CGI.unescapeHTML(ActionController::Base.helpers.strip_tags(description)).truncate(24, ...)
```

1. `strip_tags` runs `Rails::HTML5::FullSanitizer`. Its HTML5 serializer re-encodes `U+00A0` as the **named** reference `&nbsp;`. (The HTML4 sanitizer left `U+00A0` alone, which is why this went unnoticed.)
2. `CGI.unescapeHTML` decodes only `&amp; &lt; &gt; &quot; &apos;` and numeric references such as `&#160;`. It does **not** decode named references.

The six-character string `&nbsp;` therefore survived into the snippet, and the ERB/JS escaping layer turned its `&` into `&amp;`, so users saw `&nbsp;`. It also counted as 6 characters against `truncate(24)`, clipping titles earlier than intended.

The stored data is correct — `U+00A0` legitimately enters via the Lexical editor and via comrak decoding markdown `&nbsp;` per CommonMark. Only the plain-text extraction step was wrong.

## Fix

New `Collavre::HtmlText` is the single source of truth for rendering stored HTML as plain text. It re-parses the stripped output as an HTML fragment, which decodes every named reference (not just five of them) exactly once:

| Method | Behaviour |
| --- | --- |
| `plain(html)` | Tags stripped, character references decoded once. Whitespace preserved as authored. |
| `label(html)` | `plain` squished to one line — `U+00A0` collapses to a plain space. For titles, labels, breadcrumbs. |
| `truncated_label(html, length, omission:)` | `label` capped at `length`, `String#truncate` semantics. |

Every hand-rolled `strip_tags` / `full_sanitizer.sanitize` call site now routes through it, so the same input yields the same label everywhere:

- `Creative#creative_snippet`, `Creative#effective_description`
- `Creatives::TreeFormatter` (both node descriptions and comment bodies) — this is what made MCP `get` return literal `&nbsp;`
- `Creatives::BreadcrumbResolver`, `Creatives::WorkspaceTreeBuilder`
- `Tools::CreativeRetrievalService`
- `CreativeShare`, `Concerns::Shareable`, `Comments::Conversion`
- `ApplicationHelper#creative_title_for_display`
- Views: creatives index (breadcrumbs + `og:title`), invites, users/new, org chart node, invitation mailer (html + text)
- Notion engine: exporter, service, sync job, integrations controller

`TreeFormatter.plain_description` previously did no unescaping at all, so it also leaked raw `&amp;` and `&lt;` into MCP responses and AI prompts. Now fixed by the same change.

### Intentionally left alone

`InboxItem#localized_message` keeps its `gsub("&nbsp;", " ")`. New rows can no longer contain the encoded form, but rows persisted before this fix still carry it in `message_params`, and removing the gsub would regress their display.

## Tests

`engines/collavre/test/services/collavre/html_text_test.rb` is new (15 tests) and covers the full contract, including:

- the premise guard that `strip_tags` really does emit `&nbsp;` — so the test fails loudly if Rails ever changes sanitizer behaviour
- named references `CGI.unescapeHTML` cannot decode (`&hellip;`, `&mdash;`, `&euro;`)
- **exactly-once** decoding, so `&amp;nbsp;` stays `&nbsp;` and `&lt;script&gt;` does not become markup again
- truncation counting decoded characters, not encoded ones

Regression tests added at the call sites in `creative_test.rb` (6) and `tree_formatter_test.rb` (4), including one that pins a creative to exactly one tree row.

All were confirmed **red** against the old implementation before the fix landed.

```
html_text_test + creative_test + tree_formatter_test                 47 runs, 111 assertions, 0 failures
existing tests at every touched call site (breadcrumb, workspace tree,
retrieval, share, inbox, helpers, org chart, invitations, shares)     92 runs, 472 assertions, 0 failures
notion exporter + integrations controller                            14 runs,  52 assertions, 0 failures
rubocop (17 changed files)                                           no offenses
```