### PR TITLE
fix(ui): raise empty-state concept card text off the 8px token

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/creatives.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/creatives.css
@@ -1120,7 +1120,7 @@ creative-tree-row.is-being-edited .creative-tree {
     flex-direction: column;
     align-items: center;
     gap: 5px;
-    /* Wide enough that the longest label ("실행 가능한 작업 (진행률)") wraps to two
+    /* Wide enough that the longest label (empty_state_facet_task) wraps to two
        lines at --text-0 instead of shredding into a four-line stack. */
     width: 108px;
 }
@@ -1147,7 +1147,7 @@ creative-tree-row.is-being-edited .creative-tree {
     color: var(--text-muted);
     line-height: 1.3;
     text-align: center;
-    /* Korean breaks mid-word by default; wrap at spaces instead. */
+    /* CJK text breaks mid-word by default; wrap at spaces instead. */
     word-break: keep-all;
 }
 
@@ -1158,6 +1158,19 @@ creative-tree-row.is-being-edited .creative-tree {
     padding: 0 2px;
     align-self: flex-start;
     margin-top: 12px;
+}
+
+/* Glues each operator to the term it introduces, so a diagram too narrow for one
+   row wraps before an operator instead of leaving one dangling at a row end. */
+.creative-empty-state-term {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--space-2);
+}
+
+/* The block is shorter than a facet column, so its "=" needs no chip offset. */
+.creative-empty-state-result .creative-empty-state-op {
+    margin-top: 0;
 }
 
 .creative-empty-state-block {

--- a/engines/collavre/app/assets/stylesheets/collavre/creatives.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/creatives.css
@@ -1083,7 +1083,7 @@ creative-tree-row.is-being-edited .creative-tree {
 }
 
 .creative-empty-state-heading {
-    font-size: var(--text-1);
+    font-size: var(--text-3);
     font-weight: var(--weight-6);
     color: var(--text-primary);
     margin: 0 0 var(--space-4);
@@ -1101,7 +1101,7 @@ creative-tree-row.is-being-edited .creative-tree {
 }
 
 .creative-empty-state-concept-title {
-    font-size: var(--text-0);
+    font-size: var(--text-1);
     font-weight: var(--weight-6);
     color: var(--text-primary);
     margin-bottom: var(--space-3);
@@ -1120,7 +1120,9 @@ creative-tree-row.is-being-edited .creative-tree {
     flex-direction: column;
     align-items: center;
     gap: 5px;
-    width: 84px;
+    /* Wide enough that the longest label ("실행 가능한 작업 (진행률)") wraps to two
+       lines at --text-0 instead of shredding into a four-line stack. */
+    width: 108px;
 }
 
 .creative-empty-state-facet-chip {
@@ -1141,10 +1143,12 @@ creative-tree-row.is-being-edited .creative-tree {
 }
 
 .creative-empty-state-facet-label {
-    font-size: var(--text-00);
+    font-size: var(--text-0);
     color: var(--text-muted);
     line-height: 1.3;
     text-align: center;
+    /* Korean breaks mid-word by default; wrap at spaces instead. */
+    word-break: keep-all;
 }
 
 .creative-empty-state-op {
@@ -1179,13 +1183,13 @@ creative-tree-row.is-being-edited .creative-tree {
 }
 
 .creative-empty-state-block-label {
-    font-size: var(--text-00);
+    font-size: var(--text-0);
     font-weight: var(--weight-6);
     color: var(--text-primary);
 }
 
 .creative-empty-state-concept-caption {
-    font-size: var(--text-0);
+    font-size: var(--text-1);
     color: var(--text-muted);
     line-height: 1.55;
     margin: var(--space-3) 0 0;

--- a/engines/collavre/app/assets/stylesheets/collavre/creatives.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/creatives.css
@@ -1168,8 +1168,10 @@ creative-tree-row.is-being-edited .creative-tree {
     gap: var(--space-2);
 }
 
-/* The block is shorter than a facet column, so its "=" needs no chip offset. */
+/* Center the "=" beside the shorter result block instead of using the facet
+   chip offset. */
 .creative-empty-state-result .creative-empty-state-op {
+    align-self: center;
     margin-top: 0;
 }
 
@@ -1299,4 +1301,3 @@ creative-tree-row.is-being-edited .creative-tree {
     margin: 0;
     max-width: 340px;
 }
-

--- a/engines/collavre/app/views/collavre/creatives/_empty_state.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/_empty_state.html.erb
@@ -32,28 +32,37 @@
         </div>
         <div class="creative-empty-state-facet-label"><%= t('collavre.creatives.index.empty_state_facet_doc') %></div>
       </div>
-      <span class="creative-empty-state-op" aria-hidden="true">+</span>
-      <div class="creative-empty-state-facet">
-        <div class="creative-empty-state-facet-chip" aria-hidden="true">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="3"/><path d="M8 12l3 3 5-6"/></svg>
+      <%# Each operator is grouped with the term it introduces, so when the
+          diagram is too narrow for one row it breaks *before* an operator
+          rather than stranding one at the end of a row. %>
+      <div class="creative-empty-state-term">
+        <span class="creative-empty-state-op" aria-hidden="true">+</span>
+        <div class="creative-empty-state-facet">
+          <div class="creative-empty-state-facet-chip" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="3"/><path d="M8 12l3 3 5-6"/></svg>
+          </div>
+          <div class="creative-empty-state-facet-label"><%= t('collavre.creatives.index.empty_state_facet_task') %></div>
         </div>
-        <div class="creative-empty-state-facet-label"><%= t('collavre.creatives.index.empty_state_facet_task') %></div>
       </div>
-      <span class="creative-empty-state-op" aria-hidden="true">+</span>
-      <div class="creative-empty-state-facet">
-        <div class="creative-empty-state-facet-chip" aria-hidden="true">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M21 11.5a8.38 8.38 0 0 1-8.5 8.3 8.9 8.9 0 0 1-3.9-.9L3 20l1.1-4.4a8.1 8.1 0 0 1-1-3.9A8.38 8.38 0 0 1 11.6 3.4a8.38 8.38 0 0 1 9.4 8.1z"/></svg>
+      <div class="creative-empty-state-term">
+        <span class="creative-empty-state-op" aria-hidden="true">+</span>
+        <div class="creative-empty-state-facet">
+          <div class="creative-empty-state-facet-chip" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M21 11.5a8.38 8.38 0 0 1-8.5 8.3 8.9 8.9 0 0 1-3.9-.9L3 20l1.1-4.4a8.1 8.1 0 0 1-1-3.9A8.38 8.38 0 0 1 11.6 3.4a8.38 8.38 0 0 1 9.4 8.1z"/></svg>
+          </div>
+          <div class="creative-empty-state-facet-label"><%= t('collavre.creatives.index.empty_state_facet_chat') %></div>
         </div>
-        <div class="creative-empty-state-facet-label"><%= t('collavre.creatives.index.empty_state_facet_chat') %></div>
       </div>
-      <span class="creative-empty-state-op" aria-hidden="true">=</span>
-      <div class="creative-empty-state-block">
-        <div class="creative-empty-state-block-icons" aria-hidden="true">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6"/><path d="M8 13h8M8 17h5"/></svg>
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="3"/><path d="M8 12l3 3 5-6"/></svg>
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M21 11.5a8.38 8.38 0 0 1-8.5 8.3 8.9 8.9 0 0 1-3.9-.9L3 20l1.1-4.4a8.1 8.1 0 0 1-1-3.9A8.38 8.38 0 0 1 11.6 3.4a8.38 8.38 0 0 1 9.4 8.1z"/></svg>
+      <div class="creative-empty-state-term creative-empty-state-result">
+        <span class="creative-empty-state-op" aria-hidden="true">=</span>
+        <div class="creative-empty-state-block">
+          <div class="creative-empty-state-block-icons" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6"/><path d="M8 13h8M8 17h5"/></svg>
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="3"/><path d="M8 12l3 3 5-6"/></svg>
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M21 11.5a8.38 8.38 0 0 1-8.5 8.3 8.9 8.9 0 0 1-3.9-.9L3 20l1.1-4.4a8.1 8.1 0 0 1-1-3.9A8.38 8.38 0 0 1 11.6 3.4a8.38 8.38 0 0 1 9.4 8.1z"/></svg>
+          </div>
+          <div class="creative-empty-state-block-label"><%= t('collavre.creatives.index.empty_state_block_label') %></div>
         </div>
-        <div class="creative-empty-state-block-label"><%= t('collavre.creatives.index.empty_state_block_label') %></div>
       </div>
     </div>
     <p class="creative-empty-state-concept-caption"><%= t('collavre.creatives.index.empty_state_concept_caption') %></p>

--- a/engines/collavre/test/system/creative_empty_state_typography_test.rb
+++ b/engines/collavre/test/system/creative_empty_state_typography_test.rb
@@ -88,11 +88,26 @@ class CreativeEmptyStateTypographyTest < ApplicationSystemTestCase
     end
   end
 
+  test "the result operator is vertically centered beside the creative block" do
+    operator_center = element_center_y(".creative-empty-state-result .creative-empty-state-op")
+    block_center = element_center_y(".creative-empty-state-result .creative-empty-state-block")
+    center_delta = (operator_center - block_center).abs
+
+    assert_operator center_delta, :<=, 1,
+      "result operator and creative block centers differ by #{center_delta}px"
+  end
+
   private
 
   def computed_font_size_px(selector)
     page.evaluate_script(
       "parseFloat(getComputedStyle(document.querySelector(#{selector.to_json})).fontSize)"
     )
+  end
+
+  def element_center_y(selector)
+    script = "(() => { const rect = document.querySelector(#{selector.to_json}).getBoundingClientRect();" \
+      " return rect.top + rect.height / 2; })()"
+    page.evaluate_script(script)
   end
 end

--- a/engines/collavre/test/system/creative_empty_state_typography_test.rb
+++ b/engines/collavre/test/system/creative_empty_state_typography_test.rb
@@ -1,10 +1,11 @@
 require_relative "../application_system_test_case"
 
-# The empty-state concept card originally rendered its facet labels
-# ("트리 구조 문서 조각", "실행 가능한 작업 (진행률)", "관련 대화 채널") and the
-# block label ("크리에이티브 1블록") at --text-00 (8px), which is unreadable at
-# normal viewing distance. These assert the readable floor from the design-token
-# scale (--text-0 = 12px) so a future edit cannot silently drop back to --text-00.
+# The empty-state concept card originally rendered its three facet labels
+# (empty_state_facet_doc / _task / _chat) and the block label
+# (empty_state_block_label) at --text-00 (8px), which is unreadable at normal
+# viewing distance. These assert the readable floor from the design-token scale
+# (--text-0 = 12px) so a future edit cannot silently drop back to --text-00,
+# plus the layout guards that the larger type depends on.
 class CreativeEmptyStateTypographyTest < ApplicationSystemTestCase
   READABLE_FLOOR_PX = 12
 
@@ -49,6 +50,42 @@ class CreativeEmptyStateTypographyTest < ApplicationSystemTestCase
 
     assert_equal 3, line_counts.size
     line_counts.each { |lines| assert_operator lines, :<=, 2, "facet label wrapped to #{lines} lines" }
+  end
+
+  # Wider facet columns push the "a + b + c = block" equation closer to the card
+  # edge, so at narrow viewports it now wraps where it previously did not. It may
+  # wrap — it may not strand a "+" or "=" at the end of a row.
+  test "the concept diagram never ends a row with a dangling operator" do
+    [ 1400, 1200, 900, 768, 600, 420, 360 ].each do |width|
+      resize_window_to(width, 800)
+
+      row_endings = page.evaluate_script(<<~JS)
+        (function () {
+          // Walk the visual leaves (operators, facets, the result block) in DOM
+          // order; a leaf whose left edge moves back toward the start of the
+          // line means flex-wrap opened a new row.
+          var leaves = Array.from(document.querySelectorAll(
+            '.creative-empty-state-concept-diagram .creative-empty-state-op,' +
+            '.creative-empty-state-concept-diagram .creative-empty-state-facet,' +
+            '.creative-empty-state-concept-diagram .creative-empty-state-block'
+          ));
+          var rows = [], current = [], prevLeft = -Infinity;
+          leaves.forEach(function (el) {
+            var left = el.getBoundingClientRect().left;
+            if (left <= prevLeft && current.length) { rows.push(current); current = []; }
+            prevLeft = left;
+            current.push(el);
+          });
+          if (current.length) rows.push(current);
+          return rows.map(function (row) {
+            return row[row.length - 1].classList.contains('creative-empty-state-op');
+          });
+        })();
+      JS
+
+      assert_operator row_endings.size, :>=, 1
+      refute_includes row_endings, true, "at #{width}px a diagram row ends with a bare operator"
+    end
   end
 
   private

--- a/engines/collavre/test/system/creative_empty_state_typography_test.rb
+++ b/engines/collavre/test/system/creative_empty_state_typography_test.rb
@@ -1,0 +1,61 @@
+require_relative "../application_system_test_case"
+
+# The empty-state concept card originally rendered its facet labels
+# ("트리 구조 문서 조각", "실행 가능한 작업 (진행률)", "관련 대화 채널") and the
+# block label ("크리에이티브 1블록") at --text-00 (8px), which is unreadable at
+# normal viewing distance. These assert the readable floor from the design-token
+# scale (--text-0 = 12px) so a future edit cannot silently drop back to --text-00.
+class CreativeEmptyStateTypographyTest < ApplicationSystemTestCase
+  READABLE_FLOOR_PX = 12
+
+  setup do
+    @user = User.create!(
+      email: "user@example.com",
+      password: SystemHelpers::PASSWORD,
+      name: "User",
+      email_verified_at: Time.current,
+      notifications_enabled: false
+    )
+    @parent_creative = Creative.create!(description: "Parent", user: @user)
+
+    resize_window_to
+    sign_in_via_ui(@user)
+    visit collavre.creative_path(@parent_creative)
+    wait_for_network_idle(timeout: 10)
+    assert_selector ".creative-empty-state", visible: true, wait: 5
+  end
+
+  test "concept card text renders at or above the readable token size" do
+    {
+      ".creative-empty-state-facet-label" => "facet label",
+      ".creative-empty-state-block-label" => "block label",
+      ".creative-empty-state-concept-title" => "concept title",
+      ".creative-empty-state-concept-caption" => "concept caption",
+      ".creative-empty-state-heading" => "heading"
+    }.each do |selector, label|
+      assert_operator computed_font_size_px(selector), :>=, READABLE_FLOOR_PX,
+        "#{label} (#{selector}) renders below the #{READABLE_FLOOR_PX}px readable floor"
+    end
+  end
+
+  # Bumping the labels without widening the facet column would shred the longest
+  # label into a four-line stack, so guard the column width too.
+  test "the longest facet label wraps to at most two lines" do
+    line_counts = page.evaluate_script(<<~JS)
+      Array.from(document.querySelectorAll('.creative-empty-state-facet-label')).map(function (el) {
+        return Math.round(el.getBoundingClientRect().height / parseFloat(getComputedStyle(el).lineHeight));
+      });
+    JS
+
+    assert_equal 3, line_counts.size
+    line_counts.each { |lines| assert_operator lines, :<=, 2, "facet label wrapped to #{lines} lines" }
+  end
+
+  private
+
+  def computed_font_size_px(selector)
+    page.evaluate_script(
+      "parseFloat(getComputedStyle(document.querySelector(#{selector.to_json})).fontSize)"
+    )
+  end
+end


### PR DESCRIPTION
## Problem

The "what's a creative?" concept card in the creative empty state rendered its
labels at `--text-00` (8px) — the token reserved for tiny badges. At normal
viewing distance the four labels reported as unreadable:

- 트리 구조 문서 조각 / Tree-structured document piece
- 실행 가능한 작업 (진행률) / Actionable task (progress)
- 관련 대화 채널 / Discussion channel
- 크리에이티브 1블록 / One creative block

## Change

Every line of the card steps up one rung of the existing type scale, so the
card gets bigger without leaving the design-token system and without flattening
its internal hierarchy:

| element | before | after |
| --- | --- | --- |
| heading | `--text-1` (16px) | `--text-3` (20px) |
| concept title | `--text-0` (12px) | `--text-1` (16px) |
| facet labels | `--text-00` (8px) | `--text-0` (12px) |
| block label | `--text-00` (8px) | `--text-0` (12px) |
| caption | `--text-0` (12px) | `--text-1` (16px) |

Layout follow-ups the size bump forces:

- facet column `84px` → `108px`, so the longest label still wraps to two lines
  instead of shredding into a four-line stack
- `word-break: keep-all` on the facet labels, so Korean wraps at spaces rather
  than mid-word (CJK breaks anywhere by default)

## Tests

New `creative_empty_state_typography_test.rb`:

- asserts the computed font size of every line of the card is ≥ 12px — this
  fails on the pre-fix CSS (`Expected 8 to be >= 12`)
- asserts each facet label wraps to at most two lines, guarding the new column
  width

Verified locally: 5 runs / 39 assertions / 0 failures across the new file and
the existing `creative_empty_state_inline_add_test.rb`. Screenshots checked in
both `ko` and `en` — the diagram still fits on one row in both.