### PR TITLE
fix(ui): stop flashing the empty state before the creative tree loads

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/creatives.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/creatives.css
@@ -430,6 +430,30 @@ creative-tree-row.show-edit .creative-row {
     color: var(--text-muted);
     font-size: 1.2em;
     letter-spacing: 2px;
+
+    /*
+     * Hold the dots back for the first ~180ms. Most tree fetches resolve well
+     * inside that window, and an indicator that appears and vanishes again is
+     * itself the flicker we are trying to remove; a slow fetch still gets
+     * feedback.
+     *
+     * Deliberately animated *up* from transparent rather than declaring
+     * `opacity: 0` on the element: where animations are suppressed
+     * (reduced-motion overrides, headless test harnesses) the placeholder falls
+     * back to fully visible instead of disappearing altogether.
+     */
+    animation: creative-tree-loading-fade-in 300ms ease-out;
+}
+
+@keyframes creative-tree-loading-fade-in {
+    0%,
+    60% {
+        opacity: 0;
+    }
+
+    100% {
+        opacity: 1;
+    }
 }
 
 .creative-tree-loading-placeholder .creative-loading-indicator {

--- a/engines/collavre/app/javascript/controllers/creatives/__tests__/tree_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/creatives/__tests__/tree_controller.test.js
@@ -33,6 +33,7 @@ const installController = () => {
   const container = document.createElement('div')
   container.setAttribute('data-controller', 'creatives--tree')
   container.setAttribute('data-creatives--tree-url-value', '/creatives?format=json&id=991')
+  container.setAttribute('data-creatives--tree-loading-text-value', 'Loading creatives')
   document.body.appendChild(container)
 
   const application = Application.start()
@@ -412,6 +413,7 @@ describe('CreativesTreeController error state vs genuine-empty state', () => {
     const container = document.createElement('div')
     container.setAttribute('data-controller', 'creatives--tree')
     container.setAttribute('data-creatives--tree-url-value', '/creatives?format=json&id=991')
+    container.setAttribute('data-creatives--tree-loading-text-value', 'Loading creatives')
     container.setAttribute(
       'data-creatives--tree-error-text-value',
       'Could not load the creative tree.'
@@ -645,7 +647,7 @@ describe('CreativesTreeController server-rendered loading placeholder', () => {
     application.stop()
   })
 
-  test('falls back to an English label when no loading text value is supplied', async () => {
+  test('requires a translated label when no server placeholder is available', async () => {
     let resolveFetch
     global.fetch = jest.fn(() => new Promise((resolve) => { resolveFetch = resolve }))
 
@@ -655,10 +657,10 @@ describe('CreativesTreeController server-rendered loading placeholder', () => {
     container.replaceChildren()
     const controller = application.getControllerForElementAndIdentifier(container, 'creatives--tree')
     controller.loadingIndicator = null
-    controller.showLoadingIndicator()
-
-    expect(container.querySelector('[data-creatives-tree-loading]').getAttribute('aria-label'))
-      .toBe('Loading creatives')
+    expect(() => controller.showLoadingIndicator()).toThrow(
+      'creatives--tree requires a translated loadingText value when no server loading placeholder is present',
+    )
+    expect(container.querySelector('[data-creatives-tree-loading]')).toBeNull()
 
     resolveFetch({ ok: true, json: async () => ({ creatives: [] }) })
     application.stop()

--- a/engines/collavre/app/javascript/controllers/creatives/__tests__/tree_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/creatives/__tests__/tree_controller.test.js
@@ -514,6 +514,180 @@ describe('CreativesTreeController error state vs genuine-empty state', () => {
   })
 })
 
+// The empty state used to be server-rendered inside #creatives, so the browser
+// painted "No sub-creatives yet" the moment the HTML landed — before Stimulus had
+// booted, let alone before the tree fetch had confirmed anything. index.html.erb
+// now renders the loading placeholder there instead, and the controller adopts
+// that node rather than replacing it.
+describe('CreativesTreeController server-rendered loading placeholder', () => {
+  let originalFetch
+
+  const SERVER_PLACEHOLDER_HTML =
+    '<div class="creative-tree-loading-placeholder" data-creatives-tree-loading role="status"' +
+    ' aria-live="polite" aria-label="크리에이티브를 불러오는 중">' +
+    '<span class="creative-loading-indicator" aria-hidden="true">' +
+    '<span class="creative-loading-dot">.</span>' +
+    '<span class="creative-loading-dot">.</span>' +
+    '<span class="creative-loading-dot">.</span>' +
+    '</span></div>'
+
+  const installWithServerPlaceholder = ({ placeholder = true } = {}) => {
+    const template = document.createElement('template')
+    template.id = 'creatives-empty-state-template'
+    template.innerHTML =
+      '<div data-creatives-empty-state><div class="creative-empty-state">' +
+      '<button class="new-root-creative-btn">Add</button></div></div>'
+    document.body.appendChild(template)
+
+    const container = document.createElement('div')
+    container.setAttribute('data-controller', 'creatives--tree')
+    container.setAttribute('data-creatives--tree-url-value', '/creatives?format=json&id=991')
+    container.setAttribute('data-creatives--tree-loading-text-value', '크리에이티브를 불러오는 중')
+    if (placeholder) container.innerHTML = SERVER_PLACEHOLDER_HTML
+    document.body.appendChild(container)
+
+    const serverNode = container.querySelector('[data-creatives-tree-loading]')
+
+    const application = Application.start()
+    application.register('creatives--tree', TreeController)
+
+    return { container, application, serverNode }
+  }
+
+  beforeEach(() => {
+    originalFetch = global.fetch
+  })
+
+  afterEach(() => {
+    global.fetch = originalFetch
+    document.body.innerHTML = ''
+    jest.restoreAllMocks()
+  })
+
+  test('adopts the server-rendered placeholder instead of rebuilding it', async () => {
+    let resolveFetch
+    global.fetch = jest.fn(() => new Promise((resolve) => { resolveFetch = resolve }))
+
+    const { container, application, serverNode } = installWithServerPlaceholder()
+    await flush()
+
+    const live = container.querySelector('[data-creatives-tree-loading]')
+    // Same node, still attached: rebuilding would blank the container for a frame,
+    // which is precisely the flicker this arrangement removes.
+    expect(live).toBe(serverNode)
+    expect(container.children).toHaveLength(1)
+
+    resolveFetch({ ok: true, json: async () => ({ creatives: [] }) })
+    application.stop()
+  })
+
+  test('does not paint the empty state before the fetch resolves', async () => {
+    let resolveFetch
+    global.fetch = jest.fn(() => new Promise((resolve) => { resolveFetch = resolve }))
+
+    const { container, application } = installWithServerPlaceholder()
+    await flush()
+
+    expect(container.querySelector('[data-creatives-empty-state]')).toBeNull()
+    expect(container.querySelector('.new-root-creative-btn')).toBeNull()
+    expect(container.querySelector('[data-creatives-tree-loading]')).not.toBeNull()
+
+    resolveFetch({ ok: true, json: async () => ({ creatives: [] }) })
+    application.stop()
+  })
+
+  test('swaps the placeholder for the empty state only once zero rows are confirmed', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ creatives: [] }) })
+
+    const { container, application } = installWithServerPlaceholder()
+    await flush()
+    await flush()
+
+    expect(container.querySelector('[data-creatives-tree-loading]')).toBeNull()
+    expect(container.querySelector('.new-root-creative-btn')).not.toBeNull()
+
+    application.stop()
+  })
+
+  test('re-attaches the adopted placeholder on a later reload', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ creatives: [] }) })
+
+    const { container, application, serverNode } = installWithServerPlaceholder()
+    await flush()
+    await flush()
+    expect(container.querySelector('[data-creatives-tree-loading]')).toBeNull()
+
+    let resolveSecond
+    global.fetch = jest.fn(() => new Promise((resolve) => { resolveSecond = resolve }))
+    const controller = application.getControllerForElementAndIdentifier(container, 'creatives--tree')
+    controller.load()
+
+    expect(container.querySelector('[data-creatives-tree-loading]')).toBe(serverNode)
+    expect(container.querySelector('.new-root-creative-btn')).toBeNull()
+
+    resolveSecond({ ok: true, json: async () => ({ creatives: [] }) })
+    application.stop()
+  })
+
+  test('builds its own placeholder when the container has none, labelled from i18n', async () => {
+    let resolveFetch
+    global.fetch = jest.fn(() => new Promise((resolve) => { resolveFetch = resolve }))
+
+    const { container, application } = installWithServerPlaceholder({ placeholder: false })
+    await flush()
+
+    const built = container.querySelector('[data-creatives-tree-loading]')
+    expect(built).not.toBeNull()
+    expect(built.getAttribute('aria-label')).toBe('크리에이티브를 불러오는 중')
+    expect(built.querySelectorAll('.creative-loading-dot')).toHaveLength(3)
+
+    resolveFetch({ ok: true, json: async () => ({ creatives: [] }) })
+    application.stop()
+  })
+
+  test('falls back to an English label when no loading text value is supplied', async () => {
+    let resolveFetch
+    global.fetch = jest.fn(() => new Promise((resolve) => { resolveFetch = resolve }))
+
+    const { container, application } = installWithServerPlaceholder({ placeholder: false })
+    await flush()
+    container.removeAttribute('data-creatives--tree-loading-text-value')
+    container.replaceChildren()
+    const controller = application.getControllerForElementAndIdentifier(container, 'creatives--tree')
+    controller.loadingIndicator = null
+    controller.showLoadingIndicator()
+
+    expect(container.querySelector('[data-creatives-tree-loading]').getAttribute('aria-label'))
+      .toBe('Loading creatives')
+
+    resolveFetch({ ok: true, json: async () => ({ creatives: [] }) })
+    application.stop()
+  })
+
+  test('never adopts the load-more indicator as the tree placeholder', async () => {
+    let resolveFetch
+    global.fetch = jest.fn(() => new Promise((resolve) => { resolveFetch = resolve }))
+
+    const { container, application } = installWithServerPlaceholder({ placeholder: false })
+    await flush()
+    // The paginated "Chats" feed appends its own .creative-tree-loading-placeholder;
+    // it carries no data-creatives-tree-loading, so the selector must miss it.
+    const loadMore = document.createElement('div')
+    loadMore.className = 'creative-tree-loading-placeholder creative-chats-load-more'
+    container.replaceChildren(loadMore)
+
+    const controller = application.getControllerForElementAndIdentifier(container, 'creatives--tree')
+    controller.loadingIndicator = null
+    controller.showLoadingIndicator()
+
+    expect(controller.loadingIndicator).not.toBe(loadMore)
+    expect(container.contains(loadMore)).toBe(false)
+
+    resolveFetch({ ok: true, json: async () => ({ creatives: [] }) })
+    application.stop()
+  })
+})
+
 // A reload replaces the whole container, so it takes the row an open editor is
 // attached to out of the document — along with the unsaved draft inside it.
 // Callers that reload in response to a request they fired earlier (archive /

--- a/engines/collavre/app/javascript/controllers/creatives/tree_controller.js
+++ b/engines/collavre/app/javascript/controllers/creatives/tree_controller.js
@@ -18,6 +18,10 @@ export default class extends Controller {
     // out of a data attribute and assigning it is an innerHTML sink as far as
     // CodeQL (js/xss-through-dom) is concerned, and neither needs to be one.
     errorText: String,
+    // Accessible name for the loading placeholder. Server-supplied so it is
+    // translated like everything else; the literal below is only a fallback for
+    // contexts that render the controller without the value (tests, extensions).
+    loadingText: String,
   }
 
   connect() {
@@ -433,24 +437,42 @@ export default class extends Controller {
 
   showLoadingIndicator() {
     if (!this.loadingIndicator) {
-      const indicator = document.createElement('div')
-      indicator.className = 'creative-tree-loading-placeholder'
-      indicator.setAttribute('role', 'status')
-      indicator.setAttribute('aria-live', 'polite')
-      indicator.setAttribute('aria-label', 'Loading creatives')
-      indicator.innerHTML = `
-        <span class="creative-loading-indicator" aria-hidden="true">
-          <span class="creative-loading-dot">.</span>
-          <span class="creative-loading-dot">.</span>
-          <span class="creative-loading-dot">.</span>
-        </span>
-      `
-      this.loadingIndicator = indicator
+      // The first load's placeholder is already in the DOM: index.html.erb renders
+      // it inside #creatives so the initial paint says "loading" rather than
+      // flashing the empty state until Stimulus boots. Adopt that node instead of
+      // building a replacement — swapping it out would blank the container for a
+      // frame, which is the flicker this whole arrangement exists to avoid.
+      this.loadingIndicator =
+        this.element.querySelector(':scope > [data-creatives-tree-loading]') || this.buildLoadingIndicator()
     }
     this.clearLoadedState()
-    this.element.innerHTML = ''
-    this.element.appendChild(this.loadingIndicator)
+    // replaceChildren over `innerHTML = ''` + appendChild: the adopted placeholder
+    // is a child of the container, so wiping first would detach the very node
+    // being re-inserted.
+    this.element.replaceChildren(this.loadingIndicator)
     this.startAnimation()
+  }
+
+  buildLoadingIndicator() {
+    const indicator = document.createElement('div')
+    indicator.className = 'creative-tree-loading-placeholder'
+    indicator.setAttribute('data-creatives-tree-loading', '')
+    indicator.setAttribute('role', 'status')
+    indicator.setAttribute('aria-live', 'polite')
+    indicator.setAttribute('aria-label', this.loadingLabel())
+    indicator.innerHTML = `
+      <span class="creative-loading-indicator" aria-hidden="true">
+        <span class="creative-loading-dot">.</span>
+        <span class="creative-loading-dot">.</span>
+        <span class="creative-loading-dot">.</span>
+      </span>
+    `
+    return indicator
+  }
+
+  loadingLabel() {
+    if (this.hasLoadingTextValue && this.loadingTextValue) return this.loadingTextValue
+    return 'Loading creatives'
   }
 
   hideLoadingIndicator() {

--- a/engines/collavre/app/javascript/controllers/creatives/tree_controller.js
+++ b/engines/collavre/app/javascript/controllers/creatives/tree_controller.js
@@ -18,9 +18,9 @@ export default class extends Controller {
     // out of a data attribute and assigning it is an innerHTML sink as far as
     // CodeQL (js/xss-through-dom) is concerned, and neither needs to be one.
     errorText: String,
-    // Accessible name for the loading placeholder. Server-supplied so it is
-    // translated like everything else; the literal below is only a fallback for
-    // contexts that render the controller without the value (tests, extensions).
+    // Accessible name for a loading placeholder built by this controller.
+    // Renderers that do not provide a translated server placeholder must pass
+    // this value so extensions cannot expose a hardcoded label in another locale.
     loadingText: String,
   }
 
@@ -472,7 +472,9 @@ export default class extends Controller {
 
   loadingLabel() {
     if (this.hasLoadingTextValue && this.loadingTextValue) return this.loadingTextValue
-    return 'Loading creatives'
+    throw new Error(
+      'creatives--tree requires a translated loadingText value when no server loading placeholder is present',
+    )
   }
 
   hideLoadingIndicator() {

--- a/engines/collavre/app/views/collavre/creatives/_tree_loading_placeholder.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/_tree_loading_placeholder.html.erb
@@ -1,0 +1,16 @@
+<%# Server-rendered twin of tree_controller#showLoadingIndicator's markup.
+    Rendered inside #creatives so the very first paint already shows "loading"
+    instead of the empty state; tree_controller adopts this exact node when it
+    boots (see data-creatives-tree-loading), so nothing is torn down and
+    rebuilt. Keep the markup in sync with showLoadingIndicator(). %>
+<%= tag.div(
+      tag.span(
+        safe_join(Array.new(3) { tag.span('.', class: 'creative-loading-dot') }),
+        class: 'creative-loading-indicator',
+        aria: { hidden: true }
+      ),
+      class: 'creative-tree-loading-placeholder',
+      role: 'status',
+      aria: { live: 'polite', label: t('collavre.creatives.index.loading_creatives') },
+      data: { creatives_tree_loading: '' }
+    ) %>

--- a/engines/collavre/app/views/collavre/creatives/index.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/index.html.erb
@@ -259,21 +259,24 @@
   tree_url = creatives_path(tree_params)
 %>
 
-<%# The tree is client-rendered: every load() wipes #creatives, so the placeholder
-    rendered inside it below cannot survive the first fetch. This template keeps a
-    pristine copy outside the container, letting the client re-attach the placeholder
-    when the tree turns out to be — or becomes — empty. A <template> is cloned, never
-    parsed from a string, so no HTML sink is involved and the button_to CSRF token
-    stays intact. %>
+<%# The tree is client-rendered, so the empty state lives *only* in this template.
+    Rendering it inside #creatives would paint "No sub-creatives yet" on the very
+    first frame — before Stimulus has even booted, let alone confirmed the tree is
+    empty — which reads as a false empty state on every page load. #creatives gets
+    a loading placeholder instead, and the client clones this template once the
+    fetch actually reports zero rows (or the last row is removed). A <template> is
+    cloned, never parsed from a string, so no HTML sink is involved and the
+    button_to CSRF token stays intact. %>
 <%= tag.template(empty_html, id: 'creatives-empty-state-template') %>
 
 <%= tag.div(
-      empty_html,
+      render('tree_loading_placeholder'),
       id: 'creatives',
       data: {
         controller: 'creatives--tree creatives--sync',
         'creatives--tree-url-value': tree_url,
         'creatives--tree-error-text-value': error_text,
+        'creatives--tree-loading-text-value': t('.loading_creatives'),
         'creatives--sync-root-id-value': @parent_creative&.effective_origin&.id,
         'creatives--sync-current-user-id-value': Current.user&.id,
         edit_icon_html: svg_tag("edit.svg", className: "icon-edit"),

--- a/engines/collavre/config/locales/creatives.en.yml
+++ b/engines/collavre/config/locales/creatives.en.yml
@@ -54,6 +54,7 @@ en:
         no_sub_creatives: No sub-creatives found.
         no_search_results: No creatives match your search.
         load_error: Could not load the creative tree.
+        loading_creatives: Loading creatives
         empty_state_heading_root: No creatives yet
         empty_state_heading_sub: No sub-creatives yet
         empty_state_concept_title: "💡 What's a creative?"

--- a/engines/collavre/config/locales/creatives.ko.yml
+++ b/engines/collavre/config/locales/creatives.ko.yml
@@ -50,6 +50,7 @@ ko:
         no_sub_creatives: 하위 크리에이티브가 없습니다.
         no_search_results: 검색 결과가 없습니다.
         load_error: 크리에이티브 트리를 불러오지 못했습니다.
+        loading_creatives: 크리에이티브를 불러오는 중
         empty_state_heading_root: 크리에이티브가 없습니다
         empty_state_heading_sub: 아직 하위 크리에이티브가 없습니다
         empty_state_concept_title: "💡 크리에이티브란?"

--- a/engines/collavre/test/controllers/creatives_controller_empty_state_test.rb
+++ b/engines/collavre/test/controllers/creatives_controller_empty_state_test.rb
@@ -5,6 +5,11 @@ class CreativesControllerEmptyStateTest < ActionDispatch::IntegrationTest
   # @creatives = [] (real data streams in via a separate JSON fetch), so the
   # empty-state markup built in index.html.erb is present on every initial
   # HTML page load regardless of whether the tree actually has children.
+  #
+  # It is present in the #creatives-empty-state-template only, though — never in
+  # #creatives itself, which would flash a false empty state before the fetch
+  # resolves. The body assertions below therefore describe the template's
+  # contents; see the dedicated test at the bottom of this file.
 
   # Translations are rendered through `<%= t(...) %>`, so HTML-sensitive
   # characters (e.g. the apostrophe in "What's a creative?") come back
@@ -150,5 +155,27 @@ class CreativesControllerEmptyStateTest < ActionDispatch::IntegrationTest
     assert_includes response.body, html_t("app.sign_in")
     assert_includes response.body, new_user_path
     assert_includes response.body, new_session_path
+  end
+
+  test "the read-only request-access variant lives in the template, not in the tree container" do
+    creative = creatives(:childless_creative)
+    perform_enqueued_jobs do
+      Collavre::CreativeShare.create!(creative: creative, user: users(:two), permission: :read)
+    end
+    sign_in_as(users(:two), password: "password")
+
+    get creatives_path(id: creative.id)
+
+    assert_response :success
+    template = css_select("template#creatives-empty-state-template").first
+    assert_not_nil template
+    # The CSRF-bearing button_to form must survive in the template: the client
+    # clones the node rather than re-parsing markup, so the token stays valid.
+    assert_includes template.to_html, html_t("collavre.creatives.index.request_permission")
+    assert_includes template.to_html, request_permission_creative_path(creative)
+    # ...and must NOT be pre-painted into the container, where it would show up
+    # before the fetch has confirmed the tree is actually empty.
+    assert_select "#creatives div[data-creatives-empty-state]", count: 0
+    assert_select "#creatives > div[data-creatives-tree-loading]", count: 1
   end
 end

--- a/engines/collavre/test/controllers/creatives_controller_test.rb
+++ b/engines/collavre/test/controllers/creatives_controller_test.rb
@@ -382,23 +382,39 @@ class CreativesControllerTest < ActionDispatch::IntegrationTest
       "New child should not have been in first response"
   end
 
-  test "index renders the empty-state placeholder marked for client-side toggling" do
+  test "index paints a loading placeholder inside the tree, never the empty state" do
     get creatives_path(id: creatives(:childless_creative).id)
 
     assert_response :success
-    # The wrapper is what creative_tree_empty_state.js hides and restores; the
-    # empty-state card (with its Add/Import CTAs) is what it now wraps, in place
-    # of the plain "no sub-creatives" sentence.
-    assert_select "#creatives > div[data-creatives-empty-state]", count: 1 do
-      assert_select ".creative-empty-state-heading",
-        text: I18n.t("collavre.creatives.index.empty_state_heading_sub")
+    # The tree is client-rendered, so the server cannot know yet whether it is
+    # empty. Rendering the empty state here would flash "No sub-creatives yet" on
+    # the first paint of every load, before Stimulus has even booted. The loading
+    # placeholder is what belongs in the container; the empty state waits in the
+    # <template> until the fetch actually reports zero rows.
+    assert_select "#creatives > div[data-creatives-tree-loading]", count: 1 do
+      assert_select "span.creative-loading-dot", count: 3
     end
+    assert_select "#creatives div[data-creatives-empty-state]", count: 0
+  end
+
+  test "index labels the loading placeholder through i18n" do
+    get creatives_path(id: creatives(:childless_creative).id)
+
+    assert_response :success
+    placeholder = css_select("#creatives > div[data-creatives-tree-loading]").first
+    assert_equal I18n.t("collavre.creatives.index.loading_creatives"), placeholder["aria-label"]
+    assert_equal "status", placeholder["role"]
+    # tree_controller reuses the same string when it builds the indicator for
+    # later reloads, so the accessible name does not switch languages mid-session.
+    assert_equal I18n.t("collavre.creatives.index.loading_creatives"),
+      css_select("#creatives").first["data-creatives--tree-loading-text-value"]
   end
 
   test "index renders an empty-state template outside the client-rendered tree" do
-    # The tree is client-rendered and every load wipes #creatives, so the
-    # placeholder inside it cannot survive the first fetch. The template is the
-    # copy restoreTreeEmptyState() clones from when the tree empties out.
+    # The tree is client-rendered and every load wipes #creatives, so the empty
+    # state cannot be server-rendered into the container. The template is the copy
+    # showEmptyState() / restoreTreeEmptyState() clone from once the tree is known
+    # to be empty.
     get creatives_path(id: creatives(:root_parent).id)
 
     assert_response :success


### PR DESCRIPTION
## Problem

The creative tree is client-rendered, but `index.html.erb` server-rendered the empty state ("No sub-creatives yet" / "No creatives yet") **inside** `#creatives`:

```erb
<%= tag.template(empty_html, id: 'creatives-empty-state-template') %>
<%= tag.div(empty_html, id: 'creatives', data: { controller: 'creatives--tree ...' }) %>
```

Timeline on every page load:

1. HTML lands → the browser immediately paints the empty-state card
2. JS bundle parses → Stimulus boots → `tree_controller#connect`
3. `load()` → `showLoadingIndicator()` wipes the container and shows the loading dots
4. Fetch resolves → rows render

Steps 1–3 are the flash. The gap is **JS boot time, not fetch time**, so the false empty state showed up regardless of how fast the server or the JSON endpoint was — including on creatives that have plenty of children. The existing `html.creative-alignment-ready` CSS gating only covers `.page-title` and `.creative-actions-row`, so it never masked `#creatives`.

## Fix

`#creatives` now server-renders a **loading placeholder** instead of the empty state. The empty state lives only in `#creatives-empty-state-template` and is cloned once the fetch actually reports zero rows — so it can no longer claim "empty" before anything has been checked.

- **New partial** `_tree_loading_placeholder.html.erb` mirrors `showLoadingIndicator()`'s markup, marked with `data-creatives-tree-loading`.
- **`showLoadingIndicator()` adopts** that node instead of rebuilding one. Rebuilding would blank the container for a frame, reintroducing the very flicker being removed. It also switches from `innerHTML = '' ` + `appendChild` to `replaceChildren()`, so the adopted node is never detached mid-swap.
- **`data-creatives-tree-loading`** (not the shared `.creative-tree-loading-placeholder` class) is the adoption hook, so the paginated Chats feed's own load-more indicator can never be mistaken for the tree placeholder.
- **i18n**: the indicator's accessible name moves to `loading_creatives` (en/ko) and is passed through a `loading_text` Stimulus value, so the server-rendered and JS-built copies stay in the same language. Renderers without a translated server placeholder must provide the localized `loadingText` value; a missing value fails fast with a developer-facing error instead of exposing untranslated screen-reader UI.
- **CSS**: the dots fade in after ~180ms. Most fetches resolve inside that window, and an indicator that appears and vanishes is its own flicker. It animates *up* from transparent rather than declaring `opacity: 0`, so a suppressed animation (reduced-motion override, headless harness) degrades to fully visible rather than invisible.

No change to the empty-state or error-state paths: `showEmptyState()` and `restoreTreeEmptyState()` already cloned the `<template>`, and the `button_to` CSRF token in the request-permission variant is still cloned rather than re-parsed.

## Approach not taken

Server-side `exists?` to decide whether to render the empty state up front would duplicate the filter (`tags`, `search`, `min/max_progress`, `comment`, `show_archived`, …) and permission-scope logic that the tree JSON query already owns. The moment the two drift, false empty states return — and it still wouldn't cover the JS-boot gap on a genuinely empty tree.

## Tests

- `creatives_controller_test.rb`: the old assertion (`#creatives > div[data-creatives-empty-state]`, count 1) is inverted — the container must hold the loading placeholder and **zero** empty-state nodes. Added a test pinning the placeholder's i18n `aria-label`, `role="status"`, and the controller value.
- `creatives_controller_empty_state_test.rb`: new test proving the CSRF-bearing request-access variant survives in the template while being absent from the container.
- `tree_controller.test.js`: 7 new tests — adopts the server node (identity check), no empty state before the fetch resolves, swap only after zero rows are confirmed, re-attach on reload, self-built fallback with the i18n label, fail-fast enforcement when the localized value is missing, and never adopting the load-more indicator.

### Results

| Suite | Result |
|---|---|
| `jest` (full) | 83 suites, 954 tests passed |
| `creatives_controller_test.rb` | 28 runs, 166 assertions, 0 failures |
| `creatives_controller_empty_state_test.rb` | 11 runs, 128 assertions, 0 failures |
| `creative_inline_edit_test.rb` (system) | 10 runs, 61 assertions, 0 failures |
| `creative_empty_state_{typography,inline_add}_test.rb` (system) | 7 runs, 73 assertions, 0 failures |
| `i18n_completeness_test.rb` | 2 runs, 0 failures |
| `stylelint` (creatives.css) | no new offenses |
| `rubocop` (changed files) | no offenses |