### PR TITLE
feat: add creative links to inline editors

### DIFF
--- a/engines/collavre/app/javascript/components/InlineLexicalEditor.jsx
+++ b/engines/collavre/app/javascript/components/InlineLexicalEditor.jsx
@@ -19,7 +19,7 @@ import {
   registerCodeHighlighting
 } from "@lexical/code"
 import { ListItemNode, ListNode, $isListItemNode, $isListNode, INSERT_ORDERED_LIST_COMMAND, INSERT_UNORDERED_LIST_COMMAND } from "@lexical/list"
-import { $createLinkNode, LinkNode, AutoLinkNode } from "@lexical/link"
+import { LinkNode, AutoLinkNode } from "@lexical/link"
 import { TableNode, TableRowNode, TableCellNode, INSERT_TABLE_COMMAND } from "@lexical/table"
 import { TablePlugin } from "@lexical/react/LexicalTablePlugin"
 import TableHoverActionsPlugin from "./plugins/table_hover_actions_plugin"
@@ -70,6 +70,7 @@ import { CODE_TOKEN_THEME } from "../lib/editor/code_token_theme"
 import { detectCodeLanguage, normalizeFenceLang, bridgeCodeFenceLanguages, markLanguageResolved, isLanguageResolved, clearLanguageResolved } from "../lib/editor/code_languages"
 import { CreativeLinkNode } from "../lib/lexical/creative_link_node"
 import { registerCreativeLinkTrigger } from "../lib/lexical/creative_link_trigger"
+import { $createToolbarLinkNode, $findLinkNode } from "../lib/lexical/link_toolbar"
 
 const URL_MATCHERS = [
   createLinkMatcherWithRegExp(/https?:\/\/[^\s<]+/gi, (text) => text)
@@ -579,7 +580,6 @@ function Toolbar() {
   }, [editor])
 
   const toggleLink = useCallback(() => {
-    let hasLink = false
     let selectionText = ""
     let isRange = false
     let url = ""
@@ -591,17 +591,10 @@ function Toolbar() {
       isRange = true
       selectionText = selection.getTextContent()
 
-      const nodes = selection.getNodes()
-      const nodeWithLink = nodes.find((node) => {
-        if (node.getType() === "link") return true
-        const parent = node.getParent()
-        return parent?.getType() === "link"
-      })
+      const nodeWithLink = $findLinkNode(selection.getNodes())
 
       if (nodeWithLink) {
-        hasLink = true
-        const linkNode = nodeWithLink.getType() === "link" ? nodeWithLink : nodeWithLink.getParent()
-        url = linkNode.getURL()
+        url = nodeWithLink.getURL()
       }
     })
 
@@ -880,23 +873,17 @@ function Toolbar() {
               if (!selection) return
 
               // Check if we are editing an existing link
-              const nodes = selection.getNodes()
-              const nodeWithLink = nodes.find((node) => {
-                if (node.getType() === "link") return true
-                const parent = node.getParent()
-                return parent?.getType() === "link"
-              })
+              const nodeWithLink = $findLinkNode(selection.getNodes())
 
               if (nodeWithLink) {
                 // UPDATE MODE
-                const linkNode = nodeWithLink.getType() === "link" ? nodeWithLink : nodeWithLink.getParent()
-                const newLink = $createLinkNode(finalUrl)
+                const newLink = $createToolbarLinkNode(finalUrl)
                 newLink.append($createTextNode(finalLabel))
-                linkNode.replace(newLink)
+                nodeWithLink.replace(newLink)
                 newLink.select()
               } else {
                 // CREATE MODE
-                const newLink = $createLinkNode(finalUrl)
+                const newLink = $createToolbarLinkNode(finalUrl)
                 newLink.append($createTextNode(finalLabel))
 
                 if ($isRangeSelection(selection) && !selection.isCollapsed()) {

--- a/engines/collavre/app/javascript/components/InlineLexicalEditor.jsx
+++ b/engines/collavre/app/javascript/components/InlineLexicalEditor.jsx
@@ -19,7 +19,7 @@ import {
   registerCodeHighlighting
 } from "@lexical/code"
 import { ListItemNode, ListNode, $isListItemNode, $isListNode, INSERT_ORDERED_LIST_COMMAND, INSERT_UNORDERED_LIST_COMMAND } from "@lexical/list"
-import { $createLinkNode, LinkNode, AutoLinkNode, TOGGLE_LINK_COMMAND } from "@lexical/link"
+import { $createLinkNode, LinkNode, AutoLinkNode } from "@lexical/link"
 import { TableNode, TableRowNode, TableCellNode, INSERT_TABLE_COMMAND } from "@lexical/table"
 import { TablePlugin } from "@lexical/react/LexicalTablePlugin"
 import TableHoverActionsPlugin from "./plugins/table_hover_actions_plugin"
@@ -68,6 +68,8 @@ import { $convertToMarkdownString } from "@lexical/markdown"
 import { updateResponsiveImages } from "../lib/responsive_images"
 import { CODE_TOKEN_THEME } from "../lib/editor/code_token_theme"
 import { detectCodeLanguage, normalizeFenceLang, bridgeCodeFenceLanguages, markLanguageResolved, isLanguageResolved, clearLanguageResolved } from "../lib/editor/code_languages"
+import { CreativeLinkNode } from "../lib/lexical/creative_link_node"
+import { registerCreativeLinkTrigger } from "../lib/lexical/creative_link_trigger"
 
 const URL_MATCHERS = [
   createLinkMatcherWithRegExp(/https?:\/\/[^\s<]+/gi, (text) => text)
@@ -288,6 +290,24 @@ function LinkAttributesPlugin() {
       })
     })
   }, [editor])
+
+  return null
+}
+
+function CreativeLinkTriggerPlugin() {
+  const [editor] = useLexicalComposerContext()
+
+  useEffect(() => registerCreativeLinkTrigger(editor, ({ anchorRect, onSelect, onClose }) => {
+    const modal = document.getElementById("link-creative-modal")
+    const controller = modal && window.Stimulus?.getControllerForElementAndIdentifier(
+      modal,
+      "link-creative"
+    )
+    if (!controller) return false
+
+    controller.open(anchorRect, onSelect, onClose, { allowCreate: true })
+    return true
+  }), [editor])
 
   return null
 }
@@ -1013,6 +1033,7 @@ function EditorInner({
         <TrailingParagraphPlugin />
         <InitialContentPlugin html={initialHtml} />
         <LinkAttributesPlugin />
+        <CreativeLinkTriggerPlugin />
         <ReadyPlugin onReady={onReady} />
         <FileUploadPlugin
           onUploadStateChange={onUploadStateChange}
@@ -1081,6 +1102,7 @@ export default function InlineLexicalEditor({
         ListNode,
         LinkNode,
         AutoLinkNode,
+        CreativeLinkNode,
         ImageNode,
         AttachmentNode,
         VideoNode,

--- a/engines/collavre/app/javascript/controllers/__tests__/link_creative_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/link_creative_controller.test.js
@@ -6,11 +6,13 @@ import { jest } from '@jest/globals'
 
 const browse = jest.fn()
 const search = jest.fn()
+const createFromTitle = jest.fn()
 
 jest.unstable_mockModule('../../lib/api/creatives', () => ({
-  default: { browse, search },
+  default: { browse, search, createFromTitle },
   browse,
   search,
+  createFromTitle,
 }))
 
 const { Application } = await import('@hotwired/stimulus')
@@ -24,7 +26,10 @@ const installController = async () => {
          data-link-creative-loading-text="Loading…"
          data-link-creative-no-results-text="No results"
          data-link-creative-empty-text="Empty"
-         data-link-creative-expand-text="Expand">
+         data-link-creative-expand-text="Expand"
+         data-link-creative-create-text="Create “%{query}”"
+         data-link-creative-creating-text="Creating…"
+         data-link-creative-create-failed-text="Create failed">
       <button type="button" class="popup-close-btn" data-link-creative-target="close">&times;</button>
       <input type="text" data-link-creative-target="input">
       <ul class="common-popup-list link-creative-list" data-popup-list data-link-creative-target="list"></ul>
@@ -150,6 +155,82 @@ describe('LinkCreativeController picker', () => {
     const crumbs = result.querySelectorAll('.link-crumb')
     expect(Array.from(crumbs).map((c) => c.textContent)).toEqual(['Root', 'Mid'])
 
+    application.stop()
+  })
+
+  test('creates a creative from a non-matching query when creation is enabled', async () => {
+    browse.mockResolvedValue([])
+    search.mockResolvedValue([])
+    createFromTitle.mockResolvedValue({ id: 23 })
+    const onSelect = jest.fn()
+
+    const { application, controller } = await installController()
+    controller.open(rect, onSelect, jest.fn(), { allowCreate: true })
+    await flush()
+
+    controller.inputTarget.value = 'Missing page'
+    controller.search()
+    await flush()
+
+    const createItem = document.querySelector('.link-create-item')
+    expect(createItem.textContent).toBe('Create “Missing page”')
+    createItem.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flush()
+
+    expect(createFromTitle).toHaveBeenCalledWith('Missing page')
+    expect(onSelect).toHaveBeenCalledWith({ id: 23, label: 'Missing page' })
+    application.stop()
+  })
+
+  test('does not offer creation for an exact case-insensitive match', async () => {
+    browse.mockResolvedValue([])
+    search.mockResolvedValue([{ id: 9, description: 'Existing Page', path: [] }])
+
+    const { application, controller } = await installController()
+    controller.open(rect, jest.fn(), jest.fn(), { allowCreate: true })
+    await flush()
+
+    controller.inputTarget.value = 'existing page'
+    controller.search()
+    await flush()
+
+    expect(document.querySelector('.link-create-item')).toBeNull()
+    application.stop()
+  })
+
+  test('keeps creation disabled for existing picker consumers', async () => {
+    browse.mockResolvedValue([])
+    search.mockResolvedValue([])
+
+    const { application, controller } = await installController()
+    controller.open(rect, jest.fn(), jest.fn())
+    await flush()
+
+    controller.inputTarget.value = 'Missing page'
+    controller.search()
+    await flush()
+
+    expect(document.querySelector('.link-create-item')).toBeNull()
+    expect(document.querySelector('.link-popup-message').textContent).toBe('No results')
+    application.stop()
+  })
+
+  test('shows the localized failure message when creation fails', async () => {
+    browse.mockResolvedValue([])
+    search.mockResolvedValue([])
+    createFromTitle.mockRejectedValue(new Error('network down'))
+
+    const { application, controller } = await installController()
+    controller.open(rect, jest.fn(), jest.fn(), { allowCreate: true })
+    await flush()
+
+    controller.inputTarget.value = 'Missing page'
+    controller.search()
+    await flush()
+    document.querySelector('.link-create-item').click()
+    await flush()
+
+    expect(document.querySelector('.link-popup-message').textContent).toBe('Create failed')
     application.stop()
   })
 

--- a/engines/collavre/app/javascript/controllers/__tests__/link_creative_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/link_creative_controller.test.js
@@ -234,6 +234,36 @@ describe('LinkCreativeController picker', () => {
     application.stop()
   })
 
+  test('ignores a stale creation response after the picker is reopened', async () => {
+    browse.mockResolvedValue([])
+    search.mockResolvedValue([])
+    let resolveCreation
+    createFromTitle.mockReturnValue(new Promise((resolve) => {
+      resolveCreation = resolve
+    }))
+    const firstOnSelect = jest.fn()
+    const secondOnSelect = jest.fn()
+
+    const { application, controller } = await installController()
+    controller.open(rect, firstOnSelect, jest.fn(), { allowCreate: true })
+    await flush()
+    controller.inputTarget.value = 'First page'
+    controller.search()
+    await flush()
+    document.querySelector('.link-create-item').click()
+
+    controller.close()
+    controller.open(rect, secondOnSelect, jest.fn(), { allowCreate: true })
+    await flush()
+    resolveCreation({ id: 23 })
+    await flush()
+
+    expect(firstOnSelect).not.toHaveBeenCalled()
+    expect(secondOnSelect).not.toHaveBeenCalled()
+    expect(controller.popup.isOpen()).toBe(true)
+    application.stop()
+  })
+
   test('masks restricted ancestors in the breadcrumb and keeps them non-clickable', async () => {
     browse.mockResolvedValue([])
     search.mockResolvedValue([

--- a/engines/collavre/app/javascript/controllers/link_creative_controller.js
+++ b/engines/collavre/app/javascript/controllers/link_creative_controller.js
@@ -39,9 +39,11 @@ export default class extends CommonPopupController {
         super.disconnect()
     }
 
-    open(anchorRect, onSelectCallback, onCloseCallback) {
+    open(anchorRect, onSelectCallback, onCloseCallback, { allowCreate = false } = {}) {
         this.onSelectCallback = onSelectCallback
         this.onCloseCallback = onCloseCallback
+        this._allowCreate = allowCreate
+        this._creating = false
         this._mode = 'tree'
         this._rootNodes = null
         this._activeEl = null
@@ -295,12 +297,11 @@ export default class extends CommonPopupController {
 
     _renderSearchResults(results) {
         this.listTarget.innerHTML = ''
-        if (!results || results.length === 0) {
-            this._renderMessage(this._text('noResultsText'))
-            return
-        }
+        const query = this.inputTarget.value.trim()
+        const list = Array.isArray(results) ? results : []
+        if (list.length === 0) this._appendMessage(this._text('noResultsText'))
 
-        results.forEach((result) => {
+        list.forEach((result) => {
             const li = document.createElement('li')
             li.className = 'link-result-item'
             li.setAttribute('data-pick-row', '')
@@ -321,7 +322,32 @@ export default class extends CommonPopupController {
 
             this.listTarget.appendChild(li)
         })
+
+        const exactMatch = list.some((result) =>
+            String(result.description || '').trim().toLocaleLowerCase() === query.toLocaleLowerCase()
+        )
+        if (this._allowCreate && query && !exactMatch) {
+            this.listTarget.appendChild(this._buildCreateItem(query))
+        }
         this._resetActive()
+    }
+
+    _buildCreateItem(query) {
+        const li = document.createElement('li')
+        li.className = 'link-result-item link-create-item'
+        li.setAttribute('data-pick-row', '')
+        li.dataset.create = 'true'
+        li.dataset.query = query
+
+        const label = document.createElement('div')
+        label.className = 'link-result-label'
+        label.textContent = this._text('createText').replace('%{query}', query)
+        li.appendChild(label)
+
+        li.addEventListener('mouseenter', () => this._setActive(li))
+        li.addEventListener('mousedown', (event) => event.preventDefault())
+        li.addEventListener('click', () => this._activateRow(li))
+        return li
     }
 
     _buildBreadcrumb(result) {
@@ -446,6 +472,10 @@ export default class extends CommonPopupController {
 
     _activateRow(row) {
         if (!row || !row.hasAttribute('data-pick-row')) return
+        if (row.dataset.create === 'true') {
+            this._createCreative(row.dataset.query)
+            return
+        }
         // For a linked-creative shell row, emit the effective origin id, not the
         // shell id: consumers use the selected id as the new link's origin, and
         // linking to the shell (rather than the real shared creative) would make
@@ -456,6 +486,22 @@ export default class extends CommonPopupController {
         const labelEl = row.querySelector('.link-tree-label, .link-result-label')
         const label = labelEl ? labelEl.textContent : ''
         this.select({ id, label })
+    }
+
+    _createCreative(query) {
+        if (this._creating || !query) return
+        this._creating = true
+        this._renderMessage(this._text('creatingText'))
+
+        creativesApi.createFromTitle(query)
+            .then((creative) => {
+                if (!creative?.id) throw new Error('Creative creation returned no id')
+                this.select({ id: creative.id, label: query })
+            })
+            .catch(() => {
+                this._creating = false
+                this._renderMessage(this._text('createFailedText'))
+            })
     }
 
     // Override select to invoke callback
@@ -500,11 +546,15 @@ export default class extends CommonPopupController {
 
     _renderMessage(text) {
         this.listTarget.innerHTML = ''
+        this._appendMessage(text)
+        this._activeEl = null
+    }
+
+    _appendMessage(text) {
         const li = document.createElement('li')
         li.className = 'link-popup-message'
         li.textContent = text
         this.listTarget.appendChild(li)
-        this._activeEl = null
     }
 
     _text(key) {
@@ -513,6 +563,9 @@ export default class extends CommonPopupController {
             noResultsText: this.element.dataset.linkCreativeNoResultsText,
             emptyText: this.element.dataset.linkCreativeEmptyText,
             expandText: this.element.dataset.linkCreativeExpandText,
+            createText: this.element.dataset.linkCreativeCreateText,
+            creatingText: this.element.dataset.linkCreativeCreatingText,
+            createFailedText: this.element.dataset.linkCreativeCreateFailedText,
         }
         return map[key] || ''
     }

--- a/engines/collavre/app/javascript/controllers/link_creative_controller.js
+++ b/engines/collavre/app/javascript/controllers/link_creative_controller.js
@@ -19,6 +19,7 @@ export default class extends CommonPopupController {
         super.connect()
         this._debounceTimer = null
         this._searchToken = 0
+        this._openGeneration = 0
         this._mode = 'tree'
         this._rootNodes = null
         this._activeEl = null
@@ -40,6 +41,7 @@ export default class extends CommonPopupController {
     }
 
     open(anchorRect, onSelectCallback, onCloseCallback, { allowCreate = false } = {}) {
+        this._openGeneration++
         this.onSelectCallback = onSelectCallback
         this.onCloseCallback = onCloseCallback
         this._allowCreate = allowCreate
@@ -60,6 +62,7 @@ export default class extends CommonPopupController {
     }
 
     close() {
+        this._openGeneration++
         this._clearDebounce()
         super.close()
     }
@@ -491,14 +494,17 @@ export default class extends CommonPopupController {
     _createCreative(query) {
         if (this._creating || !query) return
         this._creating = true
+        const openGeneration = this._openGeneration
         this._renderMessage(this._text('creatingText'))
 
         creativesApi.createFromTitle(query)
             .then((creative) => {
+                if (openGeneration !== this._openGeneration) return
                 if (!creative?.id) throw new Error('Creative creation returned no id')
                 this.select({ id: creative.id, label: query })
             })
             .catch(() => {
+                if (openGeneration !== this._openGeneration) return
                 this._creating = false
                 this._renderMessage(this._text('createFailedText'))
             })

--- a/engines/collavre/app/javascript/lib/api/__tests__/creatives.test.js
+++ b/engines/collavre/app/javascript/lib/api/__tests__/creatives.test.js
@@ -36,4 +36,33 @@ describe('creatives API workspace invalidation', () => {
     expect(listener).not.toHaveBeenCalled()
     document.removeEventListener('workspace-tree:invalidate', listener)
   })
+
+  test('creates a rich-authored Markdown creative from a picker title', async () => {
+    const listener = jest.fn()
+    document.addEventListener('workspace-tree:invalidate', listener)
+    csrfFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({ id: 17 }) })
+
+    await expect(creativesApi.createFromTitle('New page')).resolves.toEqual({ id: 17 })
+
+    const [, options] = csrfFetch.mock.calls[0]
+    expect(csrfFetch.mock.calls[0][0]).toBe('/creatives')
+    expect(options.method).toBe('POST')
+    expect(options.body.get('creative[markdown_source]')).toBe('New page')
+    expect(options.body.get('creative[content_type_input]')).toBe('markdown')
+    expect(options.body.get('creative[markdown_editor]')).toBe('rich')
+    expect(listener).toHaveBeenCalledTimes(1)
+    document.removeEventListener('workspace-tree:invalidate', listener)
+  })
+
+  test('rejects a failed picker creation without invalidating the workspace tree', async () => {
+    const listener = jest.fn()
+    document.addEventListener('workspace-tree:invalidate', listener)
+    csrfFetch.mockResolvedValue({ ok: false, status: 422 })
+
+    await expect(creativesApi.createFromTitle('Invalid')).rejects.toThrow(
+      'Failed to create creative: 422',
+    )
+    expect(listener).not.toHaveBeenCalled()
+    document.removeEventListener('workspace-tree:invalidate', listener)
+  })
 })

--- a/engines/collavre/app/javascript/lib/api/creatives.js
+++ b/engines/collavre/app/javascript/lib/api/creatives.js
@@ -50,6 +50,24 @@ export function search(query, { simple = false } = {}) {
   }).then((response) => response.json())
 }
 
+export function createFromTitle(title) {
+  const body = new FormData()
+  body.append('creative[description]', title)
+  body.append('creative[content_type_input]', 'markdown')
+  body.append('creative[markdown_source]', title)
+  body.append('creative[markdown_editor]', 'rich')
+
+  return csrfFetch('/creatives', {
+    method: 'POST',
+    headers: JSON_HEADERS,
+    body,
+  }).then((response) => {
+    if (!response.ok) throw new Error(`Failed to create creative: ${response.status}`)
+    invalidateWorkspaceTreeOnSuccess(response)
+    return response.json()
+  })
+}
+
 export function save(action, method, form) {
   return csrfFetch(action, {
     method,
@@ -113,6 +131,7 @@ const creativesApi = {
   loadChildren,
   browse,
   search,
+  createFromTitle,
   save,
   linkExisting,
   destroy,

--- a/engines/collavre/app/javascript/lib/lexical/__tests__/creative_link_node.test.js
+++ b/engines/collavre/app/javascript/lib/lexical/__tests__/creative_link_node.test.js
@@ -12,6 +12,7 @@ import { LinkNode } from '@lexical/link'
 import { $generateHtmlFromNodes, $generateNodesFromDOM } from '@lexical/html'
 import {
   $createCreativeLinkNode,
+  $isCreativeLinkNode,
   CreativeLinkNode,
   creativeIdFromUrl,
 } from '../creative_link_node'
@@ -76,5 +77,86 @@ describe('CreativeLinkNode', () => {
     })
     expect(importedType).toBe('creative-link')
     expect(importedCreativeId).toBe(77)
+  })
+
+  test('imports serialized nodes and preserves link attributes when cloned', () => {
+    const editor = createTestEditor()
+    let imported = null
+    let cloned = null
+
+    editor.update(() => {
+      imported = CreativeLinkNode.importJSON({
+        type: 'creative-link',
+        version: 1,
+        url: '/creatives/51',
+        creativeId: 51,
+        rel: 'nofollow',
+        target: '_blank',
+        title: 'Imported page',
+      })
+      imported.append($createTextNode('Imported'))
+      const paragraph = $createParagraphNode()
+      paragraph.append(imported)
+      $getRoot().append(paragraph)
+      cloned = CreativeLinkNode.clone(imported)
+    }, { discrete: true })
+
+    editor.getEditorState().read(() => {
+      expect(imported.exportJSON()).toMatchObject({
+        type: 'creative-link',
+        creativeId: 51,
+        url: '/creatives/51',
+        rel: 'nofollow',
+        target: '_blank',
+        title: 'Imported page',
+      })
+      expect($isCreativeLinkNode(imported)).toBe(true)
+    })
+    expect(cloned.__url).toBe('/creatives/51')
+    expect(cloned.__creativeId).toBe(51)
+    expect(cloned.__rel).toBe('nofollow')
+    expect($isCreativeLinkNode({})).toBe(false)
+  })
+
+  test('updates and removes the DOM creative id with the node state', () => {
+    const editor = createTestEditor()
+
+    editor.update(() => {
+      const paragraph = $createParagraphNode()
+      const linked = $createCreativeLinkNode('/creatives/61', 61)
+      const unlinked = $createCreativeLinkNode('/other', null)
+      paragraph.append(linked, unlinked)
+      $getRoot().append(paragraph)
+
+      const element = document.createElement('a')
+      linked.updateDOM(linked, element, {})
+      expect(element.dataset.creativeId).toBe('61')
+
+      unlinked.updateDOM(linked, element, {})
+      expect(element.hasAttribute('data-creative-id')).toBe(false)
+    }, { discrete: true })
+  })
+
+  test('imports data-creative-id without an href and keeps link attributes', () => {
+    const editor = createTestEditor()
+    let imported = null
+
+    editor.update(() => {
+      const doc = new DOMParser().parseFromString(
+        '<p><a data-creative-id="88" rel="nofollow" target="_blank" title="Page">Existing</a></p>',
+        'text/html',
+      )
+      const nodes = $generateNodesFromDOM(editor, doc.body)
+      nodes.forEach((node) => $getRoot().append(node))
+      imported = $getRoot().getFirstChild().getFirstChild()
+    }, { discrete: true })
+
+    editor.getEditorState().read(() => {
+      expect(imported.getURL()).toBe('/creatives/88')
+      expect(imported.getCreativeId()).toBe(88)
+      expect(imported.getRel()).toBe('nofollow')
+      expect(imported.getTarget()).toBe('_blank')
+      expect(imported.getTitle()).toBe('Page')
+    })
   })
 })

--- a/engines/collavre/app/javascript/lib/lexical/__tests__/creative_link_node.test.js
+++ b/engines/collavre/app/javascript/lib/lexical/__tests__/creative_link_node.test.js
@@ -1,0 +1,80 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  createEditor,
+} from 'lexical'
+import { LinkNode } from '@lexical/link'
+import { $generateHtmlFromNodes, $generateNodesFromDOM } from '@lexical/html'
+import {
+  $createCreativeLinkNode,
+  CreativeLinkNode,
+  creativeIdFromUrl,
+} from '../creative_link_node'
+import { lexicalToMarkdown } from '../markdown_serialize'
+
+function createTestEditor() {
+  return createEditor({
+    namespace: 'creative-link-test',
+    nodes: [LinkNode, CreativeLinkNode],
+    onError(error) {
+      throw error
+    },
+  })
+}
+
+describe('CreativeLinkNode', () => {
+  test('extracts creative ids only from canonical internal paths', () => {
+    expect(creativeIdFromUrl('/creatives/42')).toBe(42)
+    expect(creativeIdFromUrl('/creatives/42?topic_id=3')).toBe(42)
+    expect(creativeIdFromUrl('https://example.com/creatives/42')).toBeNull()
+    expect(creativeIdFromUrl('/creatives/not-a-number')).toBeNull()
+  })
+
+  test('exports data-creative-id while keeping canonical Markdown', () => {
+    const editor = createTestEditor()
+    editor.update(() => {
+      const paragraph = $createParagraphNode()
+      const link = $createCreativeLinkNode('/creatives/42', 42)
+      link.append($createTextNode('Internal page'))
+      paragraph.append(link)
+      $getRoot().append(paragraph)
+    }, { discrete: true })
+
+    let html = ''
+    editor.getEditorState().read(() => {
+      html = $generateHtmlFromNodes(editor)
+    })
+
+    expect(html).toContain('data-creative-id="42"')
+    expect(lexicalToMarkdown(editor)).toBe('[Internal page](/creatives/42)')
+  })
+
+  test('reconstructs the dedicated node from a canonical internal href', () => {
+    const editor = createTestEditor()
+    let imported = null
+
+    editor.update(() => {
+      const doc = new DOMParser().parseFromString(
+        '<p><a href="/creatives/77">Existing</a></p>',
+        'text/html',
+      )
+      const nodes = $generateNodesFromDOM(editor, doc.body)
+      nodes.forEach((node) => $getRoot().append(node))
+      imported = $getRoot().getFirstChild().getFirstChild()
+    }, { discrete: true })
+
+    let importedType = null
+    let importedCreativeId = null
+    editor.getEditorState().read(() => {
+      importedType = imported.getType()
+      importedCreativeId = imported.getCreativeId()
+    })
+    expect(importedType).toBe('creative-link')
+    expect(importedCreativeId).toBe(77)
+  })
+})

--- a/engines/collavre/app/javascript/lib/lexical/__tests__/creative_link_trigger.test.js
+++ b/engines/collavre/app/javascript/lib/lexical/__tests__/creative_link_trigger.test.js
@@ -99,4 +99,35 @@ describe('creative link [[ trigger', () => {
     expect(openPicker).toHaveBeenCalledTimes(1)
     unregister()
   })
+
+  test('clears a dismissed trigger after editing away and opens for a new trigger', async () => {
+    const editor = createTestEditor()
+    const openPicker = jest.fn(() => true)
+    const unregister = registerCreativeLinkTrigger(editor, openPicker)
+
+    let textNode = null
+    editor.update(() => {
+      const paragraph = $createParagraphNode()
+      textNode = $createTextNode('[[')
+      paragraph.append(textNode)
+      $getRoot().append(paragraph)
+      textNode.selectEnd()
+    }, { discrete: true })
+    await flush()
+    openPicker.mock.calls[0][0].onClose()
+
+    editor.update(() => {
+      textNode.getLatest().setTextContent('plain')
+      textNode.getLatest().selectEnd()
+    }, { discrete: true })
+    await flush()
+    editor.update(() => {
+      textNode.getLatest().setTextContent('plain [[')
+      textNode.getLatest().selectEnd()
+    }, { discrete: true })
+    await flush()
+
+    expect(openPicker).toHaveBeenCalledTimes(2)
+    unregister()
+  })
 })

--- a/engines/collavre/app/javascript/lib/lexical/__tests__/creative_link_trigger.test.js
+++ b/engines/collavre/app/javascript/lib/lexical/__tests__/creative_link_trigger.test.js
@@ -1,0 +1,102 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { jest } from '@jest/globals'
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  createEditor,
+} from 'lexical'
+import { LinkNode } from '@lexical/link'
+import { CreativeLinkNode } from '../creative_link_node'
+import { registerCreativeLinkTrigger } from '../creative_link_trigger'
+import { lexicalToMarkdown } from '../markdown_serialize'
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0))
+
+function createTestEditor() {
+  const editor = createEditor({
+    namespace: 'creative-link-trigger-test',
+    nodes: [LinkNode, CreativeLinkNode],
+    onError(error) {
+      throw error
+    },
+  })
+  const root = document.createElement('div')
+  root.contentEditable = 'true'
+  document.body.appendChild(root)
+  editor.setRootElement(root)
+  return editor
+}
+
+describe('creative link [[ trigger', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  test('opens once and replaces the trigger with a canonical creative link', async () => {
+    const editor = createTestEditor()
+    const openPicker = jest.fn(() => true)
+    const unregister = registerCreativeLinkTrigger(editor, openPicker)
+
+    editor.update(() => {
+      const paragraph = $createParagraphNode()
+      const text = $createTextNode('Before [[')
+      paragraph.append(text)
+      $getRoot().append(paragraph)
+      text.selectEnd()
+    }, { discrete: true })
+    await flush()
+
+    expect(openPicker).toHaveBeenCalledTimes(1)
+    openPicker.mock.calls[0][0].onSelect({ id: 99, label: 'Target page' })
+
+    expect(lexicalToMarkdown(editor)).toBe('Before [Target page](/creatives/99)')
+    expect(openPicker).toHaveBeenCalledTimes(1)
+    unregister()
+  })
+
+  test('keeps the trigger when the picker cannot open', async () => {
+    const editor = createTestEditor()
+    const openPicker = jest.fn(() => false)
+    const unregister = registerCreativeLinkTrigger(editor, openPicker)
+
+    editor.update(() => {
+      const paragraph = $createParagraphNode()
+      const text = $createTextNode('[[')
+      paragraph.append(text)
+      $getRoot().append(paragraph)
+      text.selectEnd()
+    }, { discrete: true })
+    await flush()
+
+    expect(openPicker).toHaveBeenCalledTimes(1)
+    expect(lexicalToMarkdown(editor)).toBe('[[')
+    unregister()
+  })
+
+  test('does not immediately reopen a dismissed trigger', async () => {
+    const editor = createTestEditor()
+    const openPicker = jest.fn(() => true)
+    const unregister = registerCreativeLinkTrigger(editor, openPicker)
+
+    let textNode = null
+    editor.update(() => {
+      const paragraph = $createParagraphNode()
+      textNode = $createTextNode('[[')
+      paragraph.append(textNode)
+      $getRoot().append(paragraph)
+      textNode.selectEnd()
+    }, { discrete: true })
+    await flush()
+
+    openPicker.mock.calls[0][0].onClose()
+    editor.update(() => textNode.getLatest().selectEnd(), { discrete: true })
+    await flush()
+
+    expect(openPicker).toHaveBeenCalledTimes(1)
+    unregister()
+  })
+})

--- a/engines/collavre/app/javascript/lib/lexical/__tests__/link_toolbar.test.js
+++ b/engines/collavre/app/javascript/lib/lexical/__tests__/link_toolbar.test.js
@@ -1,0 +1,62 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  createEditor,
+} from 'lexical'
+import { $createLinkNode, LinkNode } from '@lexical/link'
+import {
+  $createCreativeLinkNode,
+  $isCreativeLinkNode,
+  CreativeLinkNode,
+} from '../creative_link_node'
+import { $createToolbarLinkNode, $findLinkNode } from '../link_toolbar'
+
+function createTestEditor() {
+  return createEditor({
+    namespace: 'link-toolbar-test',
+    nodes: [LinkNode, CreativeLinkNode],
+    onError(error) {
+      throw error
+    },
+  })
+}
+
+describe('link toolbar helpers', () => {
+  test('finds regular and Creative links from their text children', () => {
+    const editor = createTestEditor()
+
+    editor.update(() => {
+      const paragraph = $createParagraphNode()
+      const regularText = $createTextNode('External')
+      const creativeText = $createTextNode('Creative')
+      const regularLink = $createLinkNode('https://example.com').append(regularText)
+      const creativeLink = $createCreativeLinkNode('/creatives/42', 42).append(creativeText)
+      paragraph.append(regularLink, creativeLink)
+      $getRoot().append(paragraph)
+
+      expect($findLinkNode([regularText])).toBe(regularLink)
+      expect($findLinkNode([creativeText])).toBe(creativeLink)
+      expect($findLinkNode([creativeLink])).toBe(creativeLink)
+      expect($findLinkNode([paragraph])).toBeNull()
+    }, { discrete: true })
+  })
+
+  test('preserves Creative identity for canonical URLs and converts external URLs', () => {
+    const editor = createTestEditor()
+
+    editor.update(() => {
+      const creativeLink = $createToolbarLinkNode('/creatives/73')
+      const regularLink = $createToolbarLinkNode('https://example.com')
+
+      expect($isCreativeLinkNode(creativeLink)).toBe(true)
+      expect(creativeLink.getCreativeId()).toBe(73)
+      expect($isCreativeLinkNode(regularLink)).toBe(false)
+      expect(regularLink.getType()).toBe('link')
+    }, { discrete: true })
+  })
+})

--- a/engines/collavre/app/javascript/lib/lexical/creative_link_node.js
+++ b/engines/collavre/app/javascript/lib/lexical/creative_link_node.js
@@ -1,0 +1,101 @@
+import { LinkNode } from "@lexical/link"
+import { $applyNodeReplacement } from "lexical"
+
+const CREATIVE_PATH = /^\/creatives\/(\d+)(?:[/?#]|$)/
+
+export function creativeIdFromUrl(url) {
+  const match = String(url || "").match(CREATIVE_PATH)
+  return match ? Number(match[1]) : null
+}
+
+export class CreativeLinkNode extends LinkNode {
+  __creativeId
+
+  static getType() {
+    return "creative-link"
+  }
+
+  static clone(node) {
+    return new CreativeLinkNode(
+      node.__url,
+      node.__creativeId,
+      { rel: node.__rel, target: node.__target, title: node.__title },
+      node.__key
+    )
+  }
+
+  constructor(url = "", creativeId = null, attributes = {}, key) {
+    super(url, attributes, key)
+    this.__creativeId = Number(creativeId || creativeIdFromUrl(url)) || null
+  }
+
+  createDOM(config) {
+    const element = super.createDOM(config)
+    if (this.__creativeId) element.dataset.creativeId = String(this.__creativeId)
+    return element
+  }
+
+  updateDOM(prevNode, element, config) {
+    super.updateDOM(prevNode, element, config)
+    const creativeId = this.getCreativeId()
+    if (creativeId) {
+      element.dataset.creativeId = String(creativeId)
+    } else {
+      delete element.dataset.creativeId
+    }
+    return false
+  }
+
+  static importDOM() {
+    return {
+      a: (element) => {
+        const creativeId = Number(element.dataset.creativeId) || creativeIdFromUrl(element.getAttribute("href"))
+        if (!creativeId) return null
+
+        return {
+          conversion: () => ({
+            node: $createCreativeLinkNode(
+              element.getAttribute("href") || `/creatives/${creativeId}`,
+              creativeId,
+              {
+                rel: element.getAttribute("rel"),
+                target: element.getAttribute("target"),
+                title: element.getAttribute("title")
+              }
+            )
+          }),
+          priority: 2
+        }
+      }
+    }
+  }
+
+  static importJSON(serializedNode) {
+    return $createCreativeLinkNode(
+      serializedNode.url,
+      serializedNode.creativeId,
+      serializedNode
+    ).updateFromJSON(serializedNode)
+  }
+
+  exportJSON() {
+    return {
+      ...super.exportJSON(),
+      creativeId: this.getCreativeId(),
+      type: "creative-link",
+      version: 1
+    }
+  }
+
+  getCreativeId() {
+    return this.getLatest().__creativeId
+  }
+}
+
+export function $createCreativeLinkNode(url, creativeId, attributes) {
+  return $applyNodeReplacement(new CreativeLinkNode(url, creativeId, attributes))
+}
+
+export function $isCreativeLinkNode(node) {
+  return node instanceof CreativeLinkNode
+}

--- a/engines/collavre/app/javascript/lib/lexical/creative_link_trigger.js
+++ b/engines/collavre/app/javascript/lib/lexical/creative_link_trigger.js
@@ -1,0 +1,98 @@
+import {
+  $createRangeSelection,
+  $createTextNode,
+  $getNodeByKey,
+  $getSelection,
+  $isRangeSelection,
+  $isTextNode,
+  $setSelection,
+} from "lexical"
+import { $createCreativeLinkNode } from "./creative_link_node"
+
+function currentTrigger() {
+  const selection = $getSelection()
+  if (!$isRangeSelection(selection) || !selection.isCollapsed()) return null
+
+  const node = selection.anchor.getNode()
+  if (!$isTextNode(node)) return null
+  if (["code", "link", "creative-link"].includes(node.getParent()?.getType())) return null
+
+  const offset = selection.anchor.offset
+  if (node.getTextContent().slice(0, offset).slice(-2) !== "[[") return null
+
+  return { key: node.getKey(), start: offset - 2, end: offset }
+}
+
+function selectionRect(editor) {
+  const domSelection = window.getSelection?.()
+  if (domSelection?.rangeCount) {
+    const rect = domSelection.getRangeAt(0).getBoundingClientRect?.()
+    if (rect) return rect
+  }
+  return editor.getRootElement()?.getBoundingClientRect?.() || null
+}
+
+export function insertCreativeLinkAtTrigger(editor, trigger, item) {
+  if (!trigger || !item?.id) return false
+  let inserted = false
+
+  editor.update(() => {
+    const node = $getNodeByKey(trigger.key)
+    if (!$isTextNode(node)) return
+    if (node.getTextContent().slice(trigger.start, trigger.end) !== "[[") return
+
+    const selection = $createRangeSelection()
+    selection.anchor.set(trigger.key, trigger.start, "text")
+    selection.focus.set(trigger.key, trigger.end, "text")
+    $setSelection(selection)
+
+    const link = $createCreativeLinkNode(`/creatives/${item.id}`, item.id)
+    link.append($createTextNode(item.label || String(item.id)))
+    const trailingSpace = $createTextNode(" ")
+    selection.insertNodes([link, trailingSpace])
+    trailingSpace.selectEnd()
+    inserted = true
+  }, { discrete: true })
+
+  if (inserted) editor.focus()
+  return inserted
+}
+
+export function registerCreativeLinkTrigger(editor, openPicker) {
+  let pickerOpen = false
+  let dismissedTrigger = null
+
+  return editor.registerUpdateListener(({ editorState }) => {
+    if (pickerOpen) return
+
+    let trigger = null
+    editorState.read(() => {
+      trigger = currentTrigger()
+    })
+    if (!trigger) {
+      dismissedTrigger = null
+      return
+    }
+    if (
+      dismissedTrigger &&
+      dismissedTrigger.key === trigger.key &&
+      dismissedTrigger.start === trigger.start &&
+      dismissedTrigger.end === trigger.end
+    ) return
+
+    pickerOpen = true
+    const opened = openPicker({
+      anchorRect: selectionRect(editor),
+      onSelect: (item) => {
+        insertCreativeLinkAtTrigger(editor, trigger, item)
+        pickerOpen = false
+      },
+      onClose: () => {
+        dismissedTrigger = trigger
+        pickerOpen = false
+        editor.focus()
+      }
+    })
+    if (opened === false) pickerOpen = false
+  })
+}

--- a/engines/collavre/app/javascript/lib/lexical/link_toolbar.js
+++ b/engines/collavre/app/javascript/lib/lexical/link_toolbar.js
@@ -1,0 +1,23 @@
+import { $createLinkNode, $isLinkNode } from '@lexical/link'
+import {
+  $createCreativeLinkNode,
+  creativeIdFromUrl,
+} from './creative_link_node'
+
+export function $findLinkNode(nodes) {
+  for (const node of nodes) {
+    if ($isLinkNode(node)) return node
+
+    const parent = node.getParent()
+    if ($isLinkNode(parent)) return parent
+  }
+
+  return null
+}
+
+export function $createToolbarLinkNode(url) {
+  const creativeId = creativeIdFromUrl(url)
+  return creativeId
+    ? $createCreativeLinkNode(url, creativeId)
+    : $createLinkNode(url)
+}

--- a/engines/collavre/app/javascript/modules/__tests__/command_menu_creative_picker.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/command_menu_creative_picker.test.js
@@ -1,0 +1,62 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { jest } from '@jest/globals'
+
+const openCreativeLinkPicker = jest.fn()
+
+jest.unstable_mockModule('../creative_link_picker', () => ({
+  openCreativeLinkPicker,
+}))
+
+await import('../command_menu')
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0))
+
+describe('command menu Creative picker', () => {
+  const originalFetch = global.fetch
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+    global.fetch = originalFetch
+    jest.clearAllMocks()
+  })
+
+  test('routes the /creative command through the shared picker', async () => {
+    document.body.innerHTML = `
+      <form id="new-comment-form"><textarea>/creative</textarea></form>
+      <div id="comments-popup" data-creative-id="7"></div>
+      <div id="command-menu" style="display:none">
+        <ul data-popup-list></ul>
+      </div>
+    `
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([{
+        type: 'popup',
+        popup_type: 'creative_picker',
+        name: 'creative',
+        label: '/creative',
+        aliases: [],
+      }]),
+    })
+
+    document.dispatchEvent(new Event('turbo:load'))
+    const textarea = document.querySelector('textarea')
+    textarea.setSelectionRange(9, 9)
+    textarea.dispatchEvent(new Event('input', { bubbles: true }))
+    await flush()
+    await flush()
+
+    textarea.dispatchEvent(new KeyboardEvent('keydown', {
+      key: 'Enter',
+      bubbles: true,
+      cancelable: true,
+    }))
+
+    expect(openCreativeLinkPicker).toHaveBeenCalledWith(textarea, {
+      triggerRange: { start: 0, end: 9 },
+    })
+  })
+})

--- a/engines/collavre/app/javascript/modules/__tests__/creative_link_picker.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/creative_link_picker.test.js
@@ -4,6 +4,7 @@
 
 import { jest } from '@jest/globals'
 import {
+  escapeMarkdownLabel,
   insertMarkdownCreativeLink,
   markdownCreativeCommandRange,
   openCreativeLinkPicker,
@@ -34,6 +35,17 @@ describe('creative link picker helpers', () => {
     expect(inputListener).toHaveBeenCalledTimes(1)
   })
 
+  test('escapes Markdown constructs in the selected Creative label', () => {
+    const textarea = document.createElement('textarea')
+
+    expect(escapeMarkdownLabel('a\\`*_[]()<>~b')).toBe('a\\\\\\`\\*\\_\\[\\]\\(\\)\\<\\>\\~b')
+    expect(insertMarkdownCreativeLink(textarea, {
+      id: 12,
+      label: 'x](https://evil.example)',
+    })).toBe(true)
+    expect(textarea.value).toBe('[x\\]\\(https://evil.example\\)](/creatives/12) ')
+  })
+
   test('removes the trigger and opens the shared picker with creation enabled', () => {
     document.body.innerHTML = '<div id="link-creative-modal"></div><textarea id="editor">/creative</textarea>'
     const textarea = document.getElementById('editor')
@@ -51,6 +63,10 @@ describe('creative link picker helpers', () => {
     expect(textarea.value).toBe('')
     expect(controller.open).toHaveBeenCalledTimes(1)
     expect(controller.open.mock.calls[0][3]).toEqual({ allowCreate: true })
+
+    textarea.blur()
+    controller.open.mock.calls[0][2]()
+    expect(document.activeElement).toBe(textarea)
 
     controller.open.mock.calls[0][1]({ id: 18, label: 'Created' })
     expect(textarea.value).toBe('[Created](/creatives/18) ')

--- a/engines/collavre/app/javascript/modules/__tests__/creative_link_picker.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/creative_link_picker.test.js
@@ -1,0 +1,69 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { jest } from '@jest/globals'
+import {
+  insertMarkdownCreativeLink,
+  markdownCreativeCommandRange,
+  openCreativeLinkPicker,
+} from '../creative_link_picker'
+
+describe('creative link picker helpers', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+    delete window.Stimulus
+  })
+
+  test('finds /creative only at the beginning of a Markdown line', () => {
+    expect(markdownCreativeCommandRange('/creative', 9)).toEqual({ start: 0, end: 9 })
+    expect(markdownCreativeCommandRange('first\n/creative', 15)).toEqual({ start: 6, end: 15 })
+    expect(markdownCreativeCommandRange('text /creative', 14)).toBeNull()
+    expect(markdownCreativeCommandRange('/creative later', 15)).toBeNull()
+  })
+
+  test('inserts the canonical Markdown link and notifies textarea consumers', () => {
+    const textarea = document.createElement('textarea')
+    textarea.value = 'before after'
+    textarea.setSelectionRange(7, 7)
+    const inputListener = jest.fn()
+    textarea.addEventListener('input', inputListener)
+
+    expect(insertMarkdownCreativeLink(textarea, { id: 12, label: 'Target' })).toBe(true)
+    expect(textarea.value).toBe('before [Target](/creatives/12) after')
+    expect(inputListener).toHaveBeenCalledTimes(1)
+  })
+
+  test('removes the trigger and opens the shared picker with creation enabled', () => {
+    document.body.innerHTML = '<div id="link-creative-modal"></div><textarea id="editor">/creative</textarea>'
+    const textarea = document.getElementById('editor')
+    textarea.setSelectionRange(9, 9)
+    const controller = { open: jest.fn() }
+    window.Stimulus = {
+      getControllerForElementAndIdentifier: jest.fn(() => controller),
+    }
+
+    const opened = openCreativeLinkPicker(textarea, {
+      triggerRange: { start: 0, end: 9 },
+    })
+
+    expect(opened).toBe(true)
+    expect(textarea.value).toBe('')
+    expect(controller.open).toHaveBeenCalledTimes(1)
+    expect(controller.open.mock.calls[0][3]).toEqual({ allowCreate: true })
+
+    controller.open.mock.calls[0][1]({ id: 18, label: 'Created' })
+    expect(textarea.value).toBe('[Created](/creatives/18) ')
+  })
+
+  test('does not remove the trigger when the shared picker is unavailable', () => {
+    document.body.innerHTML = '<textarea id="editor">/creative</textarea>'
+    const textarea = document.getElementById('editor')
+    textarea.setSelectionRange(9, 9)
+
+    expect(openCreativeLinkPicker(textarea, {
+      triggerRange: { start: 0, end: 9 },
+    })).toBe(false)
+    expect(textarea.value).toBe('/creative')
+  })
+})

--- a/engines/collavre/app/javascript/modules/command_menu.js
+++ b/engines/collavre/app/javascript/modules/command_menu.js
@@ -1,6 +1,7 @@
 import CommonPopup from '../lib/common_popup'
 import { getCaretClientRect } from '../utils/caret_position'
 import CommandArgsForm from './command_args_form'
+import { openCreativeLinkPicker } from './creative_link_picker'
 
 let commandMenuInitialized = false
 
@@ -175,33 +176,9 @@ if (!commandMenuInitialized) {
     }
 
     function openCreativePicker(textarea) {
-      const modal = document.getElementById('link-creative-modal')
-      if (!modal) return
-
-      const controller = window.Stimulus?.getControllerForElementAndIdentifier(modal, 'link-creative')
-      if (!controller) return
-
-      // Clear the command text (e.g. "/crea", "/creative") from textarea
-      clearCommandText()
-
-      const caretRect = getCaretClientRect(textarea) || textarea.getBoundingClientRect()
-      controller.open(
-        caretRect,
-        (item) => {
-          // Insert markdown link at cursor position
-          const link = `[${item.label}](/creatives/${item.id})`
-          const curPos = textarea.selectionStart
-          const beforeCur = textarea.value.slice(0, curPos)
-          const afterCur = textarea.value.slice(curPos)
-          textarea.value = beforeCur + link + ' ' + afterCur
-          const newPos = curPos + link.length + 1
-          textarea.setSelectionRange(newPos, newPos)
-          textarea.focus()
-        },
-        () => {
-          textarea.focus()
-        }
-      )
+      openCreativeLinkPicker(textarea, {
+        triggerRange: { start: 0, end: textarea.selectionStart },
+      })
     }
 
     textarea.addEventListener('keydown', function (event) {

--- a/engines/collavre/app/javascript/modules/creative_link_picker.js
+++ b/engines/collavre/app/javascript/modules/creative_link_picker.js
@@ -1,5 +1,11 @@
 import { getCaretClientRect } from '../utils/caret_position'
 
+const MARKDOWN_SPECIAL = /[\\`*_\[\]()<>~]/g
+
+export function escapeMarkdownLabel(label) {
+  return String(label || '').replace(MARKDOWN_SPECIAL, (character) => `\\${character}`)
+}
+
 export function markdownCreativeCommandRange(value, caretPosition) {
   const beforeCaret = String(value || '').slice(0, caretPosition)
   const match = beforeCaret.match(/(?:^|\n)(\/creative)$/)
@@ -15,7 +21,7 @@ export function insertMarkdownCreativeLink(textarea, item) {
   if (!textarea || !item?.id) return false
 
   const position = textarea.selectionStart
-  const link = `[${item.label}](/creatives/${item.id})`
+  const link = `[${escapeMarkdownLabel(item.label)}](/creatives/${item.id})`
   textarea.setRangeText(`${link} `, position, textarea.selectionEnd, 'end')
   textarea.dispatchEvent(new Event('input', { bubbles: true }))
   textarea.focus()

--- a/engines/collavre/app/javascript/modules/creative_link_picker.js
+++ b/engines/collavre/app/javascript/modules/creative_link_picker.js
@@ -1,0 +1,51 @@
+import { getCaretClientRect } from '../utils/caret_position'
+
+export function markdownCreativeCommandRange(value, caretPosition) {
+  const beforeCaret = String(value || '').slice(0, caretPosition)
+  const match = beforeCaret.match(/(?:^|\n)(\/creative)$/)
+  if (!match) return null
+
+  return {
+    start: caretPosition - match[1].length,
+    end: caretPosition,
+  }
+}
+
+export function insertMarkdownCreativeLink(textarea, item) {
+  if (!textarea || !item?.id) return false
+
+  const position = textarea.selectionStart
+  const link = `[${item.label}](/creatives/${item.id})`
+  textarea.setRangeText(`${link} `, position, textarea.selectionEnd, 'end')
+  textarea.dispatchEvent(new Event('input', { bubbles: true }))
+  textarea.focus()
+  return true
+}
+
+export function openCreativeLinkPicker(textarea, {
+  triggerRange = null,
+  allowCreate = true,
+} = {}) {
+  if (!textarea) return false
+
+  const modal = document.getElementById('link-creative-modal')
+  const controller = modal && window.Stimulus?.getControllerForElementAndIdentifier(
+    modal,
+    'link-creative'
+  )
+  if (!controller) return false
+
+  if (triggerRange) {
+    textarea.setRangeText('', triggerRange.start, triggerRange.end, 'end')
+    textarea.dispatchEvent(new Event('input', { bubbles: true }))
+  }
+
+  const caretRect = getCaretClientRect(textarea) || textarea.getBoundingClientRect()
+  controller.open(
+    caretRect,
+    (item) => insertMarkdownCreativeLink(textarea, item),
+    () => textarea.focus(),
+    { allowCreate }
+  )
+  return true
+}

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -3,6 +3,7 @@ import apiQueue from '../lib/api/queue_manager'
 import { $getSelection } from 'lexical'
 import { isSelectionAtDocumentStart, isSelectionAtDocumentEnd } from '../lib/lexical/selection_boundary'
 import { createInlineEditor } from './lexical_inline_editor'
+import { markdownCreativeCommandRange, openCreativeLinkPicker } from './creative_link_picker'
 import { renderCreativeTree, dispatchCreativeTreeUpdated } from '../creatives/tree_renderer'
 import { isProgressComplete, progressBaselineValueFrom, progressValueChangedFrom } from './creative_progress'
 import { renderMarkdown } from '../lib/utils/markdown'
@@ -1895,6 +1896,9 @@ function setupEditorSession() {
       markdownPreviewTimer = setTimeout(() => {
         if (markdownPreview) markdownPreview.innerHTML = renderMarkdown(md);
       }, 300);
+
+      const triggerRange = markdownCreativeCommandRange(md, markdownTextarea.selectionStart);
+      if (triggerRange) openCreativeLinkPicker(markdownTextarea, { triggerRange });
     }
 
     // Intercepts Shift+Enter via capture-phase keydown on Lexical's root element.

--- a/engines/collavre/app/views/collavre/shared/_link_creative_modal.html.erb
+++ b/engines/collavre/app/views/collavre/shared/_link_creative_modal.html.erb
@@ -2,7 +2,10 @@
      data-link-creative-loading-text="<%= t('collavre.creatives.index.link_loading', default: 'Loading…') %>"
      data-link-creative-no-results-text="<%= t('collavre.creatives.index.no_search_results', default: 'No creatives match your search.') %>"
      data-link-creative-empty-text="<%= t('collavre.creatives.index.no_sub_creatives', default: 'No sub-creatives found.') %>"
-     data-link-creative-expand-text="<%= t('collavre.creatives.index.link_expand', default: 'Expand') %>">
+     data-link-creative-expand-text="<%= t('collavre.creatives.index.link_expand', default: 'Expand') %>"
+     data-link-creative-create-text="<%= t('collavre.creatives.index.link_create', query: '%{query}', default: 'Create “%{query}”') %>"
+     data-link-creative-creating-text="<%= t('collavre.creatives.index.link_creating', default: 'Creating creative…') %>"
+     data-link-creative-create-failed-text="<%= t('collavre.creatives.index.link_create_failed', default: 'Could not create the creative.') %>">
   <button type="button" id="close-link-creative-modal" class="popup-close-btn" data-link-creative-target="close">&times;</button>
   <h3><%= t('collavre.creatives.index.link', default: 'Link') %></h3>
   <input type="text" id="link-creative-search" class="shared-input-surface" style="width:100%;margin-bottom:0.5em;" placeholder="<%= t('collavre.creatives.index.search_placeholder', default: 'Search creative') %>" data-link-creative-target="input">

--- a/engines/collavre/config/locales/creatives.en.yml
+++ b/engines/collavre/config/locales/creatives.en.yml
@@ -71,6 +71,9 @@ en:
         empty_state_request_failed: Could not request access. Please try again.
         empty_state_loggedout_message: Sign up or log in to add sub-creatives.
         link_loading: Loading…
+        link_create: Create “%{query}”
+        link_creating: Creating creative…
+        link_create_failed: Could not create the creative.
         link_expand: Expand
         search_placeholder: Search creatives...
         recommend_parent: Recommend Category

--- a/engines/collavre/config/locales/creatives.ko.yml
+++ b/engines/collavre/config/locales/creatives.ko.yml
@@ -67,6 +67,9 @@ ko:
         empty_state_request_failed: 권한을 요청하지 못했습니다. 다시 시도해 주세요.
         empty_state_loggedout_message: 하위 크리에이티브를 추가하려면 회원가입 또는 로그인하세요.
         link_loading: 불러오는 중…
+        link_create: “%{query}” 새로 만들기
+        link_creating: 크리에이티브를 만드는 중…
+        link_create_failed: 크리에이티브를 만들지 못했습니다.
         link_expand: 펼치기
         recommend_parent: 카테고리 추천
         import_uploading: 업로드 중...


### PR DESCRIPTION
## What changed

- add a `[[` trigger in the rich Lexical editor that opens the existing Creative picker
- add `/creative` support to the source Markdown editor and share the Markdown link insertion flow with chat
- preserve internal Creative identity with a dedicated Lexical link node while serializing to `[label](/creatives/id)`
- offer localized create-and-link behavior when no exact Creative matches the picker query
- keep create behavior opt-in so existing picker consumers are unchanged

## Why

Creative links should be discoverable from both editor surfaces without requiring users to hand-write Markdown, while remaining compatible with the existing chat command and canonical Markdown storage format.

## Validation

- `npm test -- --runInBand` — 969 tests passed
- `mise exec -- bundle exec rake test` — 3,692 runs, 12,186 assertions passed
- `mise exec -- bundle exec rake test:system` — 67 runs passed, 2 existing skips
- `mise exec -- ./bin/rubocop -a` — 1,145 files, no offenses
- `mise exec -- ruby script/check-i18n.rb`
- `npm run build`