### PR TITLE
perf: lazily load workspace tree branches

### DIFF
--- a/engines/collavre/app/controllers/collavre/creatives_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creatives_controller.rb
@@ -1,5 +1,7 @@
 module Collavre
   class CreativesController < ApplicationController
+    WORKSPACE_TREE_EXPANSION_LIMIT = 100
+
     include Collavre::Concerns::SlideViewable
     include Collavre::Concerns::Exportable
     include Collavre::Concerns::TreeManageable
@@ -67,7 +69,7 @@ module Collavre
               creatives: Collavre::Creatives::WorkspaceTreeBuilder.new(
                 user: Current.user,
                 view_context: view_context,
-                max_level: Collavre::SystemSetting.display_level
+                expanded_ids: workspace_tree_expanded_ids
               ).build(index_result.creatives)
             }
             return
@@ -593,6 +595,13 @@ module Collavre
           :assignee_id, :unassigned, :show_archived, :page, :per_page,
           tags: []
         ).to_h
+      end
+
+      def workspace_tree_expanded_ids
+        permitted = params.permit(expand: [])[:expand]
+        Array(permitted).filter_map { |id| Integer(id, exception: false) }
+          .uniq
+          .first(WORKSPACE_TREE_EXPANSION_LIMIT)
       end
 
       helper_method :any_filter_active?

--- a/engines/collavre/app/javascript/controllers/__tests__/workspace_tree_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/workspace_tree_controller.test.js
@@ -201,9 +201,31 @@ describe('WorkspaceTreeController', () => {
     controller.addExpandedPath(Array.from({ length: 101 }, (_value, index) => index + 1000))
 
     expect(controller.expandedCreativeIds.size).toBe(100)
-    expect(controller.expandedCreativeIds.has('1000')).toBe(false)
-    expect(controller.expandedCreativeIds.has('1100')).toBe(true)
     expect(new URL(controller.workspaceTreeUrl(), window.location.origin).searchParams.getAll('expand[]')).toHaveLength(100)
+  })
+
+  test('keeps a connected root prefix when the whole path exceeds the expansion bound', () => {
+    controller.currentPathValue = []
+    controller.expandedCreativeIds.clear()
+
+    const path = Array.from({ length: 101 }, (_value, index) => index + 1000)
+    controller.addExpandedPath(path)
+
+    // Lazy traversal descends only through expanded ancestors, so dropping the
+    // root would collapse the whole tree instead of showing the first 100 levels.
+    expect([...controller.expandedCreativeIds]).toEqual(path.slice(0, 100).map(String))
+  })
+
+  test('evicts unrelated branches before trimming the current path', () => {
+    controller.currentPathValue = []
+    controller.expandedCreativeIds.clear()
+    controller.expandedCreativeIds.add('9000')
+    controller.expandedCreativeIds.add('9001')
+
+    const path = Array.from({ length: 100 }, (_value, index) => index + 1000)
+    controller.addExpandedPath(path)
+
+    expect([...controller.expandedCreativeIds]).toEqual(path.map(String))
   })
 
   test('keeps the mounted tree state and switches chat while the center frame navigates', () => {

--- a/engines/collavre/app/javascript/controllers/__tests__/workspace_tree_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/workspace_tree_controller.test.js
@@ -120,6 +120,24 @@ describe('WorkspaceTreeController', () => {
     expect(panelToggle.closest('section').classList.contains('is-open')).toBe(false)
   })
 
+  test('preserves link focus across background tree refreshes', async () => {
+    let rootLink = document.querySelector('[data-creative-id="1"] > div > a')
+    rootLink.focus()
+
+    await controller.load({ showLoading: false, syncChat: false, preserveView: true })
+
+    rootLink = document.querySelector('[data-creative-id="1"] > div > a')
+    expect(document.activeElement).toBe(rootLink)
+
+    let leafLink = document.querySelector('[data-creative-id="2"] a')
+    leafLink.focus()
+
+    await controller.load({ showLoading: false, syncChat: false, preserveView: true })
+
+    leafLink = document.querySelector('[data-creative-id="2"] a')
+    expect(document.activeElement).toBe(leafLink)
+  })
+
   test('keeps the rendered branch state when a lazy reload fails', async () => {
     fetchMock.mockRejectedValueOnce(new Error('offline'))
     jest.spyOn(console, 'error').mockImplementation(() => {})

--- a/engines/collavre/app/javascript/controllers/__tests__/workspace_tree_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/workspace_tree_controller.test.js
@@ -77,11 +77,10 @@ describe('WorkspaceTreeController', () => {
   })
 
   test('renders the tree, expands the current path, and marks the deepest visible node', () => {
-    expect(fetchMock).toHaveBeenCalledWith(
-      '/creatives.json?workspace_tree=1',
-      expect.objectContaining({ headers: { Accept: 'application/json' } })
-    )
-    expect(document.querySelector('[data-creative-id="1"] > ul').hidden).toBe(false)
+    const [requestUrl, requestOptions] = fetchMock.mock.calls[0]
+    expect(new URL(requestUrl, window.location.origin).searchParams.getAll('expand[]')).toEqual(['1', '2', '3'])
+    expect(requestOptions).toEqual(expect.objectContaining({ headers: { Accept: 'application/json' } }))
+    expect(document.querySelector('[data-creative-id="1"] > ul')).not.toBeNull()
     expect(document.querySelector('[data-creative-id="2"] a').classList.contains('is-current')).toBe(true)
     expect(document.querySelector('[data-creative-id="2"] a').getAttribute('aria-current')).toBe('page')
     expect(document.querySelector('[data-creative-id="2"] a').dataset.turboFrame).toBe('creative-workspace-content')
@@ -89,11 +88,28 @@ describe('WorkspaceTreeController', () => {
     expect(document.querySelector('.creative-workspace-tree-branch-toggle').getAttribute('aria-label')).toBe('Root')
   })
 
-  test('toggles branches and the medium-width panel', () => {
-    const branchToggle = document.querySelector('.creative-workspace-tree-branch-toggle')
+  test('lazily reloads toggled branches and restores focus and scroll', async () => {
+    let branchToggle = document.querySelector('.creative-workspace-tree-branch-toggle')
+    controller.treeTarget.scrollTop = 24
     branchToggle.click()
-    expect(document.querySelector('[data-creative-id="1"] > ul').hidden).toBe(true)
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(document.querySelector('[data-creative-id="1"] > ul')).toBeNull()
+    branchToggle = document.querySelector('.creative-workspace-tree-branch-toggle')
     expect(branchToggle.getAttribute('aria-expanded')).toBe('false')
+    expect(document.activeElement).toBe(branchToggle)
+    expect(controller.treeTarget.scrollTop).toBe(24)
+    let requestUrl = fetchMock.mock.calls[1][0]
+    expect(new URL(requestUrl, window.location.origin).searchParams.getAll('expand[]')).toEqual(['2', '3'])
+
+    branchToggle.click()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    branchToggle = document.querySelector('.creative-workspace-tree-branch-toggle')
+    expect(document.querySelector('[data-creative-id="1"] > ul')).not.toBeNull()
+    expect(branchToggle.getAttribute('aria-expanded')).toBe('true')
+    expect(document.activeElement).toBe(branchToggle)
+    requestUrl = fetchMock.mock.calls[2][0]
+    expect(new URL(requestUrl, window.location.origin).searchParams.getAll('expand[]')).toEqual(['2', '3', '1'])
 
     const panelToggle = document.querySelector('[data-workspace-tree-target="panelToggle"]')
     panelToggle.click()
@@ -102,6 +118,74 @@ describe('WorkspaceTreeController', () => {
 
     document.querySelector('.creative-workspace-tree-link').click()
     expect(panelToggle.closest('section').classList.contains('is-open')).toBe(false)
+  })
+
+  test('keeps the rendered branch state when a lazy reload fails', async () => {
+    fetchMock.mockRejectedValueOnce(new Error('offline'))
+    jest.spyOn(console, 'error').mockImplementation(() => {})
+    const branchToggle = document.querySelector('.creative-workspace-tree-branch-toggle')
+
+    branchToggle.click()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(controller.expandedCreativeIds.has('1')).toBe(true)
+    expect(document.querySelector('[data-creative-id="1"] > ul')).not.toBeNull()
+    expect(branchToggle.disabled).toBe(false)
+    console.error.mockRestore()
+  })
+
+  test('ignores a stale non-abort failure after a newer tree request commits', async () => {
+    let rejectToggleRequest
+    fetchMock.mockReturnValueOnce(new Promise((_resolve, reject) => {
+      rejectToggleRequest = reject
+    }))
+    const branchToggle = document.querySelector('.creative-workspace-tree-branch-toggle')
+    branchToggle.click()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ creatives: [{ id: 1, label: 'Root', url: '/creatives?id=1', has_children: true, children: [] }] }),
+    })
+    await controller.load({ showLoading: false, syncChat: false })
+    rejectToggleRequest(new Error('stale offline failure'))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(controller.expandedCreativeIds.has('1')).toBe(false)
+    expect(controller.committedExpandedCreativeIds.has('1')).toBe(false)
+    expect(document.querySelector('[data-creative-id="1"] > ul')).toBeNull()
+  })
+
+  test('reverts an aborted toggle when the latest owner request fails', async () => {
+    let rejectToggleRequest
+    fetchMock.mockReturnValueOnce(new Promise((_resolve, reject) => {
+      rejectToggleRequest = reject
+    }))
+    jest.spyOn(console, 'error').mockImplementation(() => {})
+    document.querySelector('.creative-workspace-tree-branch-toggle').click()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    fetchMock.mockRejectedValueOnce(new Error('refresh failed'))
+    await controller.load({ showLoading: false, syncChat: false })
+    rejectToggleRequest(new DOMException('Aborted', 'AbortError'))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(controller.expandedCreativeIds.has('1')).toBe(true)
+    expect(controller.committedExpandedCreativeIds.has('1')).toBe(true)
+    expect(document.querySelector('[data-creative-id="1"] > ul')).not.toBeNull()
+    console.error.mockRestore()
+  })
+
+  test('bounds the expanded branch request state', () => {
+    controller.currentPathValue = []
+    controller.expandedCreativeIds.clear()
+
+    controller.addExpandedPath(Array.from({ length: 101 }, (_value, index) => index + 1000))
+
+    expect(controller.expandedCreativeIds.size).toBe(100)
+    expect(controller.expandedCreativeIds.has('1000')).toBe(false)
+    expect(controller.expandedCreativeIds.has('1100')).toBe(true)
+    expect(new URL(controller.workspaceTreeUrl(), window.location.origin).searchParams.getAll('expand[]')).toHaveLength(100)
   })
 
   test('keeps the mounted tree state and switches chat while the center frame navigates', () => {
@@ -236,7 +320,8 @@ describe('WorkspaceTreeController', () => {
   test('refreshes stale data while preserving explicit branch state', async () => {
     const branchToggle = document.querySelector('.creative-workspace-tree-branch-toggle')
     branchToggle.click()
-    expect(branchToggle.getAttribute('aria-expanded')).toBe('false')
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(document.querySelector('.creative-workspace-tree-branch-toggle').getAttribute('aria-expanded')).toBe('false')
 
     fetchMock.mockResolvedValueOnce({
       ok: true,
@@ -253,9 +338,78 @@ describe('WorkspaceTreeController', () => {
     await new Promise((resolve) => setTimeout(resolve, 120))
     await new Promise((resolve) => setTimeout(resolve, 0))
 
-    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(fetchMock).toHaveBeenCalledTimes(3)
     expect(document.querySelector('[data-creative-id="1"] > div > a').textContent).toBe('Renamed root')
     expect(document.querySelector('.creative-workspace-tree-branch-toggle').getAttribute('aria-expanded')).toBe('false')
+  })
+
+  test('loads a newly navigated frame path without reopening chat', async () => {
+    const chatListener = jest.fn()
+    document.addEventListener('creative-comments-click', chatListener)
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        creatives: [{
+          id: 1,
+          label: 'Root',
+          url: '/creatives?id=1',
+          has_children: true,
+          children: [{ id: 4, label: 'New branch', url: '/creatives?id=4', has_children: true, children: [] }],
+        }],
+      }),
+    })
+    const frame = document.getElementById('creative-workspace-content')
+    const state = frame.querySelector('[data-workspace-navigation-state]')
+    state.dataset.creativeId = '5'
+    state.dataset.creativePath = '[1,4,5]'
+    window.history.replaceState({}, '', '/creatives?id=5')
+
+    frame.dispatchEvent(new CustomEvent('turbo:frame-load', { bubbles: true }))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    const requestUrl = fetchMock.mock.calls[1][0]
+    expect(new URL(requestUrl, window.location.origin).searchParams.getAll('expand[]')).toEqual(['1', '2', '3', '4', '5'])
+    expect(document.querySelector('[data-creative-id="4"] a').classList.contains('is-current')).toBe(true)
+    expect(chatListener).toHaveBeenCalledTimes(1)
+    expect(chatListener).toHaveBeenCalledWith(expect.objectContaining({
+      detail: expect.objectContaining({ creativeId: '5', workspaceSync: true }),
+    }))
+    document.removeEventListener('creative-comments-click', chatListener)
+  })
+
+  test('retries an unresolved frame path on the next tree refresh', async () => {
+    fetchMock.mockRejectedValueOnce(new Error('path load failed'))
+    jest.spyOn(console, 'error').mockImplementation(() => {})
+    const frame = document.getElementById('creative-workspace-content')
+    const state = frame.querySelector('[data-workspace-navigation-state]')
+    state.dataset.creativeId = '5'
+    state.dataset.creativePath = '[1,4,5]'
+    window.history.replaceState({}, '', '/creatives?id=5')
+
+    frame.dispatchEvent(new CustomEvent('turbo:frame-load', { bubbles: true }))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(controller.pendingRevealPath).toEqual([1, 4, 5])
+    expect(controller.expandedCreativeIds.has('4')).toBe(false)
+
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        creatives: [{
+          id: 1,
+          label: 'Root',
+          url: '/creatives?id=1',
+          has_children: true,
+          children: [{ id: 4, label: 'Recovered branch', url: '/creatives?id=4', has_children: true, children: [] }],
+        }],
+      }),
+    })
+    await controller.load({ showLoading: false, syncChat: false })
+
+    const requestUrl = fetchMock.mock.calls[2][0]
+    expect(new URL(requestUrl, window.location.origin).searchParams.getAll('expand[]')).toEqual(['1', '2', '3', '4', '5'])
+    expect(controller.pendingRevealPath).toBeNull()
+    expect(document.querySelector('[data-creative-id="4"] a').classList.contains('is-current')).toBe(true)
+    console.error.mockRestore()
   })
 
   test('does not replace an explicitly opened chat during a background tree refresh', async () => {

--- a/engines/collavre/app/javascript/controllers/workspace_tree_controller.js
+++ b/engines/collavre/app/javascript/controllers/workspace_tree_controller.js
@@ -422,10 +422,21 @@ export default class extends Controller {
   }
 
   captureViewState(focusCreativeId) {
-    const focusedItem = document.activeElement?.closest?.('.creative-workspace-tree-item')
+    const focusedControl = document.activeElement?.closest?.(
+      '.creative-workspace-tree-branch-toggle, .creative-workspace-tree-link'
+    )
+    const focusedItem = focusedControl?.closest('.creative-workspace-tree-item')
+    let focusControl = null
+    if (focusCreativeId || focusedControl?.classList.contains('creative-workspace-tree-branch-toggle')) {
+      focusControl = 'toggle'
+    } else if (focusedControl) {
+      focusControl = 'link'
+    }
+
     return {
       scrollTop: this.treeTarget.scrollTop,
       focusCreativeId: focusCreativeId || focusedItem?.dataset.creativeId,
+      focusControl,
     }
   }
 
@@ -433,12 +444,15 @@ export default class extends Controller {
     if (!viewState) return
 
     this.treeTarget.scrollTop = viewState.scrollTop
-    if (!viewState.focusCreativeId) return
+    if (!viewState.focusCreativeId || !viewState.focusControl) return
 
     const item = [...this.treeTarget.querySelectorAll('.creative-workspace-tree-item[data-creative-id]')]
       .find((candidate) => candidate.dataset.creativeId === String(viewState.focusCreativeId))
-    const toggle = item?.querySelector(':scope > .creative-workspace-tree-row > .creative-workspace-tree-branch-toggle')
-    toggle?.focus({ preventScroll: true })
+    const selector = viewState.focusControl === 'toggle'
+      ? '.creative-workspace-tree-branch-toggle'
+      : '.creative-workspace-tree-link'
+    const control = item?.querySelector(`:scope > .creative-workspace-tree-row > ${selector}`)
+    control?.focus({ preventScroll: true })
   }
 
   setTreeBusy(busy) {

--- a/engines/collavre/app/javascript/controllers/workspace_tree_controller.js
+++ b/engines/collavre/app/javascript/controllers/workspace_tree_controller.js
@@ -406,15 +406,32 @@ export default class extends Controller {
       this.expandedCreativeIds.add(id)
       changed = true
     })
-    this.trimExpandedCreativeIds(new Set(path.map(String)))
+    this.trimExpandedCreativeIds(path)
     return changed
   }
 
-  trimExpandedCreativeIds(protectedIds = new Set(this.currentPathValue.map(String))) {
+  // `protectedPath` is ordered root-first. The server descends only through
+  // expanded ancestors, so once the path itself has to be trimmed the set must
+  // keep a connected root-to-descendant prefix: evicting the root would collapse
+  // the whole tree instead of leaving the first MAX_EXPANDED_BRANCHES levels.
+  trimExpandedCreativeIds(protectedPath = this.currentPathValue) {
+    const orderedProtectedIds = protectedPath.map(String)
+    const protectedIds = new Set(orderedProtectedIds)
     while (this.expandedCreativeIds.size > MAX_EXPANDED_BRANCHES) {
-      const evictedId = [...this.expandedCreativeIds].find((id) => !protectedIds.has(id))
-      this.expandedCreativeIds.delete(evictedId || this.expandedCreativeIds.values().next().value)
+      const evictedId =
+        [...this.expandedCreativeIds].find((id) => !protectedIds.has(id)) ??
+        this.deepestExpandedId(orderedProtectedIds)
+      if (!evictedId) return
+
+      this.expandedCreativeIds.delete(evictedId)
     }
+  }
+
+  deepestExpandedId(orderedIds) {
+    for (let index = orderedIds.length - 1; index >= 0; index -= 1) {
+      if (this.expandedCreativeIds.has(orderedIds[index])) return orderedIds[index]
+    }
+    return null
   }
 
   samePath(left, right) {

--- a/engines/collavre/app/javascript/controllers/workspace_tree_controller.js
+++ b/engines/collavre/app/javascript/controllers/workspace_tree_controller.js
@@ -5,6 +5,7 @@ import { Controller } from '@hotwired/stimulus'
 // not necessarily the one that observes the subsequent turbo:render, so the
 // visit action must outlive any single instance.
 let lastVisitAction = null
+const MAX_EXPANDED_BRANCHES = 100
 
 export default class extends Controller {
   static targets = ['tree', 'panelToggle']
@@ -18,6 +19,9 @@ export default class extends Controller {
   }
 
   connect() {
+    this.expandedCreativeIds = new Set()
+    this.addExpandedPath(this.currentPathValue)
+    this.committedExpandedCreativeIds = new Set(this.expandedCreativeIds)
     this.invalidatedCreativeIds = new Set()
     this.destroyedCreativeIds = new Set()
     this.invalidationGeneration = 0
@@ -65,28 +69,48 @@ export default class extends Controller {
     window.removeEventListener('collavre:creative-drop-complete', this.queueRefresh)
   }
 
-  async load({ preserveState = false, showLoading = true, syncChat = true } = {}) {
+  async load({ showLoading = true, syncChat = true, preserveView = false, focusCreativeId } = {}) {
     this.loadAbortController?.abort()
     this.loadAbortController = new AbortController()
+    if (this.pendingRevealPath) this.addExpandedPath(this.pendingRevealPath)
+    const requestId = (this.loadRequestId || 0) + 1
+    this.loadRequestId = requestId
+    const requestedExpandedIds = new Set(this.expandedCreativeIds)
+    const requestedRevealPath = this.pendingRevealPath ? [...this.pendingRevealPath] : null
     const invalidationGeneration = this.invalidationGeneration
-    this.preservedBranchState = preserveState ? this.branchState() : new Map()
+    const viewState = preserveView ? this.captureViewState(focusCreativeId) : null
     if (showLoading) this.showStatus(this.loadingTextValue)
+    this.setTreeBusy(true)
 
     try {
-      const response = await fetch(this.urlValue, {
+      const response = await fetch(this.workspaceTreeUrl(requestedExpandedIds), {
         headers: { Accept: 'application/json' },
         signal: this.loadAbortController.signal,
       })
       if (!response.ok) throw new Error(`Failed to load workspace tree: ${response.status}`)
 
       const data = await response.json()
+      if (requestId !== this.loadRequestId) return null
+
       const nodes = Array.isArray(data.creatives) ? data.creatives : []
       if (invalidationGeneration === this.invalidationGeneration) this.restoreReadableCreativeIds(nodes)
+      this.expandedCreativeIds = new Set(requestedExpandedIds)
+      this.committedExpandedCreativeIds = new Set(requestedExpandedIds)
+      if (requestedRevealPath && this.samePath(requestedRevealPath, this.pendingRevealPath || [])) {
+        this.pendingRevealPath = null
+      }
       this.render(nodes, { syncChat })
+      this.restoreViewState(viewState)
+      return true
     } catch (error) {
-      if (error.name === 'AbortError') return
+      if (error.name === 'AbortError' || requestId !== this.loadRequestId) return null
+
+      this.expandedCreativeIds = new Set(this.committedExpandedCreativeIds)
       console.error(error)
       if (showLoading) this.showStatus(this.errorTextValue)
+      return false
+    } finally {
+      if (requestId === this.loadRequestId) this.setTreeBusy(false)
     }
   }
 
@@ -120,10 +144,10 @@ export default class extends Controller {
     const row = document.createElement('div')
     row.className = 'creative-workspace-tree-row'
     const children = Array.isArray(node.children) ? node.children : []
-    const savedExpanded = this.preservedBranchState?.get(String(node.id))
-    const expanded = children.length > 0 && (savedExpanded ?? this.currentPathValue.map(String).includes(String(node.id)))
+    const hasChildren = node.has_children === true || children.length > 0
+    const expanded = hasChildren && this.expandedCreativeIds.has(String(node.id))
 
-    if (children.length > 0) {
+    if (hasChildren) {
       const toggle = document.createElement('button')
       toggle.type = 'button'
       toggle.className = 'creative-workspace-tree-branch-toggle'
@@ -156,22 +180,32 @@ export default class extends Controller {
     row.appendChild(link)
     item.appendChild(row)
 
-    if (children.length > 0) {
+    if (hasChildren && expanded) {
       const childList = this.buildList(children)
-      childList.hidden = !expanded
       item.appendChild(childList)
     }
 
     return item
   }
 
-  toggleBranch(item, toggle) {
-    const childList = item.querySelector(':scope > .creative-workspace-tree-list')
-    if (!childList) return
+  async toggleBranch(item, toggle) {
+    const creativeId = item.dataset.creativeId
+    if (!creativeId) return
 
-    childList.hidden = !childList.hidden
-    toggle.setAttribute('aria-expanded', String(!childList.hidden))
-    toggle.textContent = childList.hidden ? '▸' : '▾'
+    if (this.expandedCreativeIds.has(creativeId)) {
+      this.expandedCreativeIds.delete(creativeId)
+    } else {
+      this.expandedCreativeIds.delete(creativeId)
+      this.expandedCreativeIds.add(creativeId)
+      this.trimExpandedCreativeIds()
+    }
+
+    await this.load({
+      showLoading: false,
+      syncChat: false,
+      preserveView: true,
+      focusCreativeId: creativeId,
+    })
   }
 
   togglePanel() {
@@ -274,7 +308,7 @@ export default class extends Controller {
     if (this.refreshTimeout) window.clearTimeout(this.refreshTimeout)
     this.refreshTimeout = window.setTimeout(() => {
       this.refreshTimeout = null
-      this.load({ preserveState: true, showLoading: false, syncChat: false })
+      this.load({ showLoading: false, syncChat: false, preserveView: true })
     }, 100)
   }
 
@@ -290,6 +324,8 @@ export default class extends Controller {
     const stateCreativeId = state.dataset.creativeId
     const locationCreativeId = this.creativeIdFromLocation()
     if (!stateCreativeId && (authoritative || !locationCreativeId)) {
+      this.currentPathValue = []
+      this.pendingRevealPath = null
       this.setActiveId(null)
       if (syncChat) this.openChat(this.rootState())
       return
@@ -303,6 +339,16 @@ export default class extends Controller {
     }
 
     const path = this.parsePath(state.dataset.creativePath)
+    const pathChanged = !this.samePath(path, this.currentPathValue)
+    this.currentPathValue = path
+    if (pathChanged) {
+      if (this.addExpandedPath(path)) {
+        this.pendingRevealPath = [...path]
+        this.load({ showLoading: false, syncChat: false, preserveView: true })
+      } else {
+        this.pendingRevealPath = null
+      }
+    }
     const activeId = this.deepestVisiblePathId(this.nodesData || [], path)
     this.setActiveId(activeId)
 
@@ -345,15 +391,61 @@ export default class extends Controller {
       ?.querySelector(':scope > .creative-workspace-tree-row > .creative-workspace-tree-link')
   }
 
-  branchState() {
-    return new Map(
-      [...this.treeTarget.querySelectorAll('.creative-workspace-tree-branch-toggle')]
-        .map((toggle) => [
-          toggle.closest('.creative-workspace-tree-item')?.dataset.creativeId,
-          toggle.getAttribute('aria-expanded') === 'true',
-        ])
-        .filter(([id]) => id)
-    )
+  workspaceTreeUrl(expandedIds = this.expandedCreativeIds) {
+    const url = new URL(this.urlValue, window.location.origin)
+    url.searchParams.delete('expand[]')
+    expandedIds.forEach((id) => url.searchParams.append('expand[]', id))
+    return `${url.pathname}${url.search}${url.hash}`
+  }
+
+  addExpandedPath(path) {
+    let changed = false
+    path.map(String).forEach((id) => {
+      if (this.expandedCreativeIds.has(id)) return
+
+      this.expandedCreativeIds.add(id)
+      changed = true
+    })
+    this.trimExpandedCreativeIds(new Set(path.map(String)))
+    return changed
+  }
+
+  trimExpandedCreativeIds(protectedIds = new Set(this.currentPathValue.map(String))) {
+    while (this.expandedCreativeIds.size > MAX_EXPANDED_BRANCHES) {
+      const evictedId = [...this.expandedCreativeIds].find((id) => !protectedIds.has(id))
+      this.expandedCreativeIds.delete(evictedId || this.expandedCreativeIds.values().next().value)
+    }
+  }
+
+  samePath(left, right) {
+    return left.length === right.length && left.every((id, index) => String(id) === String(right[index]))
+  }
+
+  captureViewState(focusCreativeId) {
+    const focusedItem = document.activeElement?.closest?.('.creative-workspace-tree-item')
+    return {
+      scrollTop: this.treeTarget.scrollTop,
+      focusCreativeId: focusCreativeId || focusedItem?.dataset.creativeId,
+    }
+  }
+
+  restoreViewState(viewState) {
+    if (!viewState) return
+
+    this.treeTarget.scrollTop = viewState.scrollTop
+    if (!viewState.focusCreativeId) return
+
+    const item = [...this.treeTarget.querySelectorAll('.creative-workspace-tree-item[data-creative-id]')]
+      .find((candidate) => candidate.dataset.creativeId === String(viewState.focusCreativeId))
+    const toggle = item?.querySelector(':scope > .creative-workspace-tree-row > .creative-workspace-tree-branch-toggle')
+    toggle?.focus({ preventScroll: true })
+  }
+
+  setTreeBusy(busy) {
+    this.treeTarget.setAttribute('aria-busy', String(busy))
+    this.treeTarget.querySelectorAll('.creative-workspace-tree-branch-toggle').forEach((toggle) => {
+      toggle.disabled = busy
+    })
   }
 
   creativeIdFromLocation() {

--- a/engines/collavre/app/services/collavre/creatives/workspace_tree_builder.rb
+++ b/engines/collavre/app/services/collavre/creatives/workspace_tree_builder.rb
@@ -1,41 +1,82 @@
 module Collavre
   module Creatives
     class WorkspaceTreeBuilder
-      def initialize(user:, view_context:, max_level:)
+      def initialize(user:, view_context:, expanded_ids: [])
         @user = user
         @view_context = view_context
-        @max_level = max_level
+        @expanded_ids = expanded_ids.map(&:to_s).to_set
         @children_index = ChildrenIndex.new(user: user, show_archived: false)
         @permission_rank = {}
       end
 
-      def build(collection, level: 1)
-        creatives = Array(collection)
-        return [] if creatives.empty? || level > max_level
+      def build(collection)
+        entries = Array(collection).map { |creative| { creative: creative, ancestor_ids: Set.new } }
+        build_entries(entries)
+      end
 
+      private
+
+      attr_reader :children_index, :expanded_ids, :user, :view_context
+
+      def build_entries(entries)
+        return [] if entries.empty?
+
+        creatives = entries.map { |entry| entry.fetch(:creative) }.uniq(&:id)
         prepare_level(creatives)
-        branches = creatives.select { |creative| children_index.has_children?(creative) }
+        branch_entries = entries.select { |entry| children_index.has_children?(entry.fetch(:creative)) }
+        branches = branch_entries.map { |entry| entry.fetch(:creative) }.uniq(&:id)
         children_index.load(branches)
+        children_by_parent = branches.to_h { |creative| [ creative.id, children_index.children_for(creative) ] }
+        prepare_presence(children_by_parent.values.flatten)
+        branch_children_by_parent = children_by_parent.transform_values do |children|
+          children.select { |child| children_index.has_children?(child) }
+        end
+        child_entries_by_parent = branch_entries.to_h do |entry|
+          creative = entry.fetch(:creative)
+          children = expanded?(creative) ? acyclic_children(entry, branch_children_by_parent.fetch(creative.id)) : []
+          child_entries = children.map do |child|
+            { creative: child, ancestor_ids: entry.fetch(:ancestor_ids).dup.add(creative.id) }
+          end
+          [ entry.object_id, child_entries ]
+        end
+        child_nodes = build_entries(child_entries_by_parent.values.flatten)
+        next_child_node = child_nodes.each
 
-        branches.map do |creative|
+        branch_entries.map do |entry|
+          creative = entry.fetch(:creative)
+          visible_children = acyclic_children(entry, branch_children_by_parent.fetch(creative.id))
+          children = child_entries_by_parent.fetch(entry.object_id).map { next_child_node.next }
           {
             id: creative.id,
             label: Collavre::HtmlText.label(creative.effective_description),
             snippet: creative.creative_snippet,
             can_comment: allowed?(creative, :feedback),
             url: view_context.collavre.creatives_path(id: creative.id),
-            children: build(children_index.children_for(creative), level: level + 1)
+            has_children: visible_children.any?,
+            children: children
           }
         end
       end
 
-      private
+      def acyclic_children(entry, children)
+        visited_ids = entry.fetch(:ancestor_ids).dup.add(entry.fetch(:creative).id)
+        children.reject { |child| visited_ids.include?(child.id) }
+      end
 
-      attr_reader :children_index, :max_level, :user, :view_context
+      def expanded?(creative)
+        expanded_ids.include?(creative.id.to_s)
+      end
 
       def prepare_level(creatives)
         ActiveRecord::Associations::Preloader.new(records: creatives, associations: :origin).call
         preload_permissions(creatives)
+        children_index.index(creatives)
+      end
+
+      def prepare_presence(creatives)
+        return if creatives.empty?
+
+        ActiveRecord::Associations::Preloader.new(records: creatives, associations: :origin).call
         children_index.index(creatives)
       end
 

--- a/engines/collavre/test/controllers/creatives_controller_test.rb
+++ b/engines/collavre/test/controllers/creatives_controller_test.rb
@@ -59,9 +59,10 @@ class CreativesControllerTest < ActionDispatch::IntegrationTest
     assert_select "a.creative-breadcrumb-link[href='#{creative_path(ancestor)}'][data-turbo-action='advance']"
   end
 
-  test "workspace tree JSON returns branches without leaf roots" do
+  test "workspace tree JSON returns collapsed branches without leaf roots" do
     branch = Creative.create!(user: users(:one), description: "Workspace branch")
-    Creative.create!(user: users(:one), parent: branch, description: "Workspace child")
+    child = Creative.create!(user: users(:one), parent: branch, description: "Workspace child")
+    Creative.create!(user: users(:one), parent: child, description: "Workspace leaf")
     leaf = Creative.create!(user: users(:one), description: "Workspace leaf")
 
     get creatives_path(format: :json, workspace_tree: 1)
@@ -75,7 +76,32 @@ class CreativesControllerTest < ActionDispatch::IntegrationTest
     assert_equal creatives_path(id: branch.id), branch_payload.fetch("url")
     assert_equal branch.creative_snippet, branch_payload.fetch("snippet")
     assert branch_payload.fetch("can_comment")
+    assert branch_payload.fetch("has_children")
+    assert_empty branch_payload.fetch("children")
     assert_equal "no-cache", response.headers["Cache-Control"]
+
+    get creatives_path(format: :json, workspace_tree: 1, expand: [ branch.id ])
+
+    assert_response :success
+    expanded_branch = JSON.parse(response.body).fetch("creatives").find { |node| node.fetch("id") == branch.id }
+    assert_equal [ child.id ], expanded_branch.fetch("children").pluck("id")
+  end
+
+  test "workspace tree JSON ignores invalid and excessive expansion ids" do
+    branch = Creative.create!(user: users(:one), description: "Limited branch")
+    child = Creative.create!(user: users(:one), parent: branch, description: "Limited child")
+    Creative.create!(user: users(:one), parent: child, description: "Limited leaf")
+    excessive_ids = Array.new(Collavre::CreativesController::WORKSPACE_TREE_EXPANSION_LIMIT) { |index| 1_000_000 + index }
+
+    get creatives_path(
+      format: :json,
+      workspace_tree: 1,
+      expand: [ "invalid", *excessive_ids, branch.id ]
+    )
+
+    assert_response :success
+    branch_payload = JSON.parse(response.body).fetch("creatives").find { |node| node.fetch("id") == branch.id }
+    assert_empty branch_payload.fetch("children")
   end
 
   test "workspace frame requests render only the replaceable creative content" do

--- a/engines/collavre/test/services/creatives/workspace_tree_builder_test.rb
+++ b/engines/collavre/test/services/creatives/workspace_tree_builder_test.rb
@@ -21,20 +21,32 @@ module Creatives
       @view_context = FakeViewContext.new
     end
 
-    test "returns only readable creatives that have children" do
+    test "returns only readable branches without loading their children" do
       root = Creative.create!(user: @user, description: "<strong>Root</strong>")
       branch = Creative.create!(user: @user, parent: root, description: "Branch")
       Creative.create!(user: @user, parent: branch, description: "Leaf")
-      Creative.create!(user: @user, description: "Root leaf")
+      root_leaf = Creative.create!(user: @user, description: "Root leaf")
 
-      nodes = build_tree([ root ] + Creative.where(description: "Root leaf").to_a)
+      nodes = build_tree([ root, root_leaf ])
 
       assert_equal [ root.id ], nodes.pluck(:id)
       assert_equal "Root", nodes.first[:label]
       assert_equal root.creative_snippet, nodes.first[:snippet]
       assert nodes.first[:can_comment]
       assert_equal "/creatives?id=#{root.id}", nodes.first[:url]
+      assert nodes.first[:has_children]
+      assert_empty nodes.first[:children]
+    end
+
+    test "loads only requested branches" do
+      root = Creative.create!(user: @user, description: "Root")
+      branch = Creative.create!(user: @user, parent: root, description: "Branch")
+      Creative.create!(user: @user, parent: branch, description: "Leaf")
+
+      nodes = build_tree([ root ], expanded_ids: [ root.id ])
+
       assert_equal [ branch.id ], nodes.first[:children].pluck(:id)
+      refute nodes.first[:children].first[:has_children]
       assert_empty nodes.first[:children].first[:children]
     end
 
@@ -45,15 +57,35 @@ module Creatives
       assert_empty build_tree([ root ])
     end
 
-    test "stops recursion at the configured display level" do
+    test "expands requested paths beyond the former display level" do
       root = Creative.create!(user: @user, description: "Level 1")
-      branch = Creative.create!(user: @user, parent: root, description: "Level 2")
-      Creative.create!(user: @user, parent: branch, description: "Level 3")
+      path = [ root ]
+      6.times do |index|
+        path << Creative.create!(user: @user, parent: path.last, description: "Level #{index + 2}")
+      end
+      Creative.create!(user: @user, parent: path.last, description: "Leaf")
 
-      nodes = build_tree([ root ], max_level: 1)
+      nodes = build_tree([ root ], expanded_ids: path.map(&:id))
 
-      assert_equal [ root.id ], nodes.pluck(:id)
-      assert_empty nodes.first[:children]
+      rendered_ids = []
+      remaining = nodes
+      until remaining.empty?
+        rendered_ids << remaining.first.fetch(:id)
+        remaining = remaining.first.fetch(:children)
+      end
+      assert_equal path.map(&:id), rendered_ids
+    end
+
+    test "stops linked shell cycles without hiding the shell" do
+      origin = Creative.create!(user: @user, description: "Cyclic origin")
+      shell = Creative.create!(user: @user, parent: origin, origin: origin, description: "Cyclic shell")
+
+      nodes = build_tree([ origin ], expanded_ids: [ origin.id, shell.id ])
+
+      assert_equal [ origin.id ], nodes.pluck(:id)
+      assert_equal [ shell.id ], nodes.first.fetch(:children).pluck(:id)
+      refute nodes.first.fetch(:children).first.fetch(:has_children)
+      assert_empty nodes.first.fetch(:children).first.fetch(:children)
     end
 
     test "batches linked origins and permission ranks for each level" do
@@ -73,20 +105,22 @@ module Creatives
       end
 
       ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
-        build_tree(fresh_shells)
+        build_tree(fresh_shells, expanded_ids: shell_ids)
       end
 
-      per_node_queries = queries.grep(/(?:collavre_creatives|creative_shares_cache).*LIMIT 1/i)
+      child_scans = queries.grep(/SELECT "creatives"\."id", "creatives"\."parent_id".*WHERE "creatives"\."parent_id"/i)
+      per_node_queries = queries.grep(/(?:FROM "creatives"|creative_shares_cache).*LIMIT 1/i)
+      assert_equal 2, child_scans.size, "expected one child scan per inspected level"
       assert_empty per_node_queries, "expected batched workspace tree reads, got:\n#{per_node_queries.join("\n")}"
     end
 
     private
 
-    def build_tree(creatives, max_level: 6)
+    def build_tree(creatives, expanded_ids: [])
       Collavre::Creatives::WorkspaceTreeBuilder.new(
         user: @user,
         view_context: @view_context,
-        max_level: max_level
+        expanded_ids: expanded_ids
       ).build(creatives)
     end
   end


### PR DESCRIPTION
## Summary

- replace the eager six-level workspace-tree payload with a lightweight `expand[]` contract
- batch every visible tree level and preserve linked-shell permission behavior with cycle protection
- keep expanded branches across invalidations while restoring scroll, focus, request ownership, and failed deep-link retries
- cap expanded branch IDs at 100 on both the client and server

## Why

The persistent workspace tree built and rendered every branch up to the display-level limit on every initial load and invalidation. Its depth-first recursion also invoked batching once per node, so collapsed branches still caused hundreds of database queries and unnecessary JSON/DOM work.

## Impact

The initial request now returns root branches only, and subsequent requests return the currently visible tree in one response. A synthetic 120-node tree produced 3 nodes / 15 queries / 441 bytes initially and 9 nodes / 16 queries / 1.2 KB for one expanded path. Paths are no longer truncated at six levels.

## Validation

- Jest: 959 tests
- Rails unit/integration: 3,695 runs / 12,203 assertions
- Rails system: 67 runs / 388 assertions (2 existing skips)
- Rubocop: 1,145 files / 0 offenses
- asset build
- focused workspace system: 10 runs / 72 assertions
- Vrex review: no blocker or major findings
