### PR TITLE
feat: persist chat input drafts in localStorage

### DIFF
--- a/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_draft.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_draft.test.js
@@ -227,6 +227,26 @@ describe('FormController - draft persistence', () => {
     expect(chatDrafts.get('78')).toBeNull()
   })
 
+  test('closing an untouched linked chat before topics load preserves the canonical draft', () => {
+    chatDrafts.set('70', 'canonical draft')
+    delete popupEl.dataset.effectiveCreativeId
+
+    controller.onChatWillOpen({ creativeId: '78' })
+    expect(controller.textareaTarget.value).toBe('')
+    controller.onPopupClosed()
+
+    expect(chatDrafts.updatedAt('78')).toBeNull()
+
+    controller.onChatWillOpen({ creativeId: '78' })
+    popupEl.dataset.creativeId = '78'
+    dispatchTopicChange('70')
+    controller.onPopupOpened({ creativeId: '78', canComment: true })
+
+    expect(controller.textareaTarget.value).toBe('canonical draft')
+    expect(chatDrafts.get('70')).toBe('canonical draft')
+    expect(chatDrafts.get('78')).toBeNull()
+  })
+
   test('switching topics within the same chat does not flush the draft', () => {
     dispatchTopicChange('77', '10073')
     controller.textareaTarget.value = 'still composing'

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_draft.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_draft.test.js
@@ -214,6 +214,27 @@ describe('FormController - draft persistence', () => {
     expect(chatDrafts.get('77')).toBe('will fail')
   })
 
+  test('send completion after a chat switch clears only the submitted chat draft', async () => {
+    dispatchTopicChange('77')
+    typeInto(controller.textareaTarget, 'send from 77')
+    controller._flushDraftSave()
+
+    let finishFetch
+    global.fetch = jest.fn(() => new Promise((resolve) => { finishFetch = resolve }))
+    controller.handleSend(new Event('submit', { cancelable: true }))
+
+    dispatchTopicChange('88')
+    controller.onPopupOpened({ creativeId: '88', canComment: true })
+    typeInto(controller.textareaTarget, 'draft for 88')
+
+    finishFetch({ ok: true, status: 200, text: () => Promise.resolve('<div></div>') })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(chatDrafts.get('77')).toBeNull()
+    expect(chatDrafts.get('88')).toBe('draft for 88')
+    expect(controller.textareaTarget.value).toBe('draft for 88')
+  })
+
   test('editing a comment preserves the draft and suspends draft saving', async () => {
     dispatchTopicChange('77')
     typeInto(controller.textareaTarget, 'my draft')

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_draft.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_draft.test.js
@@ -820,6 +820,100 @@ describe('FormController - draft persistence', () => {
     expect(controller.textareaTarget.value).toBe('')
   })
 
+  test('restores a failed submission newer than an existing stored draft', async () => {
+    jest.spyOn(Date, 'now').mockReturnValue(1000)
+    chatDrafts.set('77', 'older stored draft')
+    dispatchTopicChange('77')
+    controller.onPopupOpened({ creativeId: '77', canComment: true })
+    typeInto(controller.textareaTarget, 'newer failed submission')
+
+    let failFetch
+    global.fetch = jest.fn(() => new Promise((resolve) => { failFetch = resolve }))
+    controller.handleSend(new Event('submit', { cancelable: true }))
+
+    controller.onChatWillOpen({ creativeId: '88' })
+    popupEl.dataset.creativeId = '88'
+    dispatchTopicChange('88')
+    controller.onPopupOpened({ creativeId: '88', canComment: true })
+
+    Date.now.mockReturnValue(2000)
+    failFetch({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve({ errors: ['boom'] }),
+    })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(chatDrafts.get('77')).toBe('older stored draft')
+    expect(submissionBackup('77')).toBe('newer failed submission')
+
+    controller.onChatWillOpen({ creativeId: '77' })
+    popupEl.dataset.creativeId = '77'
+    dispatchTopicChange('77')
+    controller.onPopupOpened({ creativeId: '77', canComment: true })
+
+    expect(controller.textareaTarget.value).toBe('newer failed submission')
+
+    Date.now.mockReturnValue(3000)
+    chatDrafts.set('77', 'newest draft from another tab')
+    controller.onPopupClosed()
+
+    expect(chatDrafts.get('77')).toBe('newest draft from another tab')
+  })
+
+  test('restores a regular draft newer than a failed-submission backup', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(1000)
+    chatDrafts.saveSubmissionBackup('77', 'older failed submission')
+    Date.now.mockReturnValue(2000)
+    chatDrafts.set('77', 'newer stored draft')
+
+    dispatchTopicChange('77')
+    controller.onPopupOpened({ creativeId: '77', canComment: true })
+
+    expect(controller.textareaTarget.value).toBe('newer stored draft')
+    expect(submissionBackup('77')).toBeNull()
+  })
+
+  test('prefers a regular draft saved after a backup at the same timestamp', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(1000)
+    chatDrafts.saveSubmissionBackup('77', 'failed submission')
+    chatDrafts.set('77', 'later regular draft')
+
+    dispatchTopicChange('77')
+    controller.onPopupOpened({ creativeId: '77', canComment: true })
+
+    expect(controller.textareaTarget.value).toBe('later regular draft')
+    expect(submissionBackup('77')).toBeNull()
+  })
+
+  test('does not restore a backup older than a regular draft clear', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(500)
+    chatDrafts.set('77', 'regular draft')
+    Date.now.mockReturnValue(1000)
+    chatDrafts.saveSubmissionBackup('77', 'failed submission')
+    Date.now.mockReturnValue(2000)
+    chatDrafts.clear('77')
+
+    dispatchTopicChange('77')
+    controller.onPopupOpened({ creativeId: '77', canComment: true })
+
+    expect(controller.textareaTarget.value).toBe('')
+    expect(submissionBackup('77')).toBeNull()
+  })
+
+  test('prefers a same-timestamp regular clear saved after a backup', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(1000)
+    chatDrafts.set('77', 'regular draft')
+    chatDrafts.saveSubmissionBackup('77', 'failed submission')
+    chatDrafts.clear('77')
+
+    dispatchTopicChange('77')
+    controller.onPopupOpened({ creativeId: '77', canComment: true })
+
+    expect(controller.textareaTarget.value).toBe('')
+    expect(submissionBackup('77')).toBeNull()
+  })
+
   test('pagehide does not persist an uncertain in-flight submission', async () => {
     dispatchTopicChange('77')
     typeInto(controller.textareaTarget, 'message leaving with the page')

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_draft.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_draft.test.js
@@ -341,13 +341,39 @@ describe('FormController - draft persistence', () => {
     controller.connect()
   })
 
-  test('losing comment permission flush-saves the draft', () => {
+  test('losing comment permission preserves the saved draft through close', () => {
     dispatchTopicChange('77')
     controller.textareaTarget.value = 'permission changed'
     controller.setCommentPermission(false)
     expect(chatDrafts.get('77')).toBe('permission changed')
+
+    typeInto(controller.textareaTarget, 'hidden stale text')
+    controller.onPopupClosed()
+    expect(chatDrafts.get('77')).toBe('permission changed')
+
+    dispatchTopicChange('77')
+    controller.onPopupOpened({ creativeId: '77', canComment: true })
+    expect(controller.textareaTarget.value).toBe('permission changed')
+  })
+
+  test('regaining comment permission restores the saved draft', () => {
+    dispatchTopicChange('77')
+    controller.textareaTarget.value = 'permission changed'
+    controller.setCommentPermission(false)
+
     controller.setCommentPermission(true)
     expect(controller.formTarget.style.display).toBe('')
+    expect(controller.textareaTarget.value).toBe('permission changed')
+  })
+
+  test('opening a read-only chat does not clear its saved draft on close', () => {
+    chatDrafts.set('77', 'read-only saved draft')
+    dispatchTopicChange('77')
+
+    controller.onPopupOpened({ creativeId: '77', canComment: false })
+    controller.onPopupClosed()
+
+    expect(chatDrafts.get('77')).toBe('read-only saved draft')
   })
 
   test('successful send clears the stored draft', async () => {

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_draft.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_draft.test.js
@@ -155,6 +155,28 @@ describe('FormController - draft persistence', () => {
     expect(chatDrafts.get('78')).toBeNull()
   })
 
+  test('a stale raw linked draft does not replace a newer effective draft', () => {
+    const now = Date.now()
+    window.localStorage.setItem(
+      'collavre_chat_drafts_9',
+      JSON.stringify({
+        70: { text: 'new canonical draft', updatedAt: now },
+        78: { text: 'stale raw draft', updatedAt: now - 1000 },
+      }),
+    )
+
+    controller.onChatWillOpen({ creativeId: '78' })
+    expect(controller.textareaTarget.value).toBe('stale raw draft')
+
+    popupEl.dataset.creativeId = '78'
+    dispatchTopicChange('70')
+    controller.onPopupOpened({ creativeId: '78', canComment: true })
+
+    expect(controller.textareaTarget.value).toBe('new canonical draft')
+    expect(chatDrafts.get('70')).toBe('new canonical draft')
+    expect(chatDrafts.get('78')).toBeNull()
+  })
+
   test('switching topics within the same chat does not flush the draft', () => {
     dispatchTopicChange('77', '10073')
     controller.textareaTarget.value = 'still composing'
@@ -271,6 +293,23 @@ describe('FormController - draft persistence', () => {
     expect(chatDrafts.get('77')).toBe('next message')
   })
 
+  test('successful send restores a newer stored draft for the active chat', async () => {
+    dispatchTopicChange('77')
+    typeInto(controller.textareaTarget, 'first message')
+    controller._flushDraftSave()
+
+    let finishFetch
+    global.fetch = jest.fn(() => new Promise((resolve) => { finishFetch = resolve }))
+    controller.handleSend(new Event('submit', { cancelable: true }))
+
+    chatDrafts.set('77', 'draft updated outside this form')
+    finishFetch({ ok: true, status: 200, text: () => Promise.resolve('<div></div>') })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(controller.textareaTarget.value).toBe('draft updated outside this form')
+    expect(chatDrafts.get('77')).toBe('draft updated outside this form')
+  })
+
   test('send completion after an account change does not clear the new user draft', async () => {
     dispatchTopicChange('77')
     typeInto(controller.textareaTarget, 'user 9 message')
@@ -329,6 +368,26 @@ describe('FormController - draft persistence', () => {
     expect(chatDrafts.get('77')).toBeNull()
     expect(chatDrafts.get('88')).toBe('draft for 88')
     expect(controller.textareaTarget.value).toBe('draft for 88')
+  })
+
+  test('send completion preserves newer submitted-chat text after switching away', async () => {
+    dispatchTopicChange('77')
+    typeInto(controller.textareaTarget, 'first message')
+    controller._flushDraftSave()
+
+    let finishFetch
+    global.fetch = jest.fn(() => new Promise((resolve) => { finishFetch = resolve }))
+    controller.handleSend(new Event('submit', { cancelable: true }))
+
+    typeInto(controller.textareaTarget, 'next message')
+    dispatchTopicChange('88')
+    controller.onPopupOpened({ creativeId: '88', canComment: true })
+
+    finishFetch({ ok: true, status: 200, text: () => Promise.resolve('<div></div>') })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(chatDrafts.get('77')).toBe('next message')
+    expect(controller.textareaTarget.value).toBe('')
   })
 
   test('editing a comment preserves the draft and suspends draft saving', async () => {
@@ -426,6 +485,38 @@ describe('FormController - draft persistence', () => {
     global.fetch = jest.fn(() =>
       Promise.resolve({ ok: true, status: 200, text: () => Promise.resolve('<div></div>') }),
     )
+    controller.handleSend(new Event('submit', { cancelable: true }))
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(controller.textareaTarget.value).toBe('my ordinary draft')
+    expect(chatDrafts.get('77')).toBe('my ordinary draft')
+  })
+
+  test('removing the last review quote restores the ordinary chat draft', () => {
+    dispatchTopicChange('77')
+    typeInto(controller.textareaTarget, 'my ordinary draft')
+    controller.appendReviewQuote(5, 'quoted review text')
+    typeInto(controller.textareaTarget, 'feedback for the quote')
+
+    controller.reviewQuotesContainerTarget
+      .querySelector('.review-quote-chip-remove')
+      .click()
+
+    expect(controller.textareaTarget.value).toBe('my ordinary draft')
+    expect(chatDrafts.get('77')).toBe('my ordinary draft')
+  })
+
+  test('sending the last question quote restores the ordinary chat draft', async () => {
+    dispatchTopicChange('77')
+    typeInto(controller.textareaTarget, 'my ordinary draft')
+    controller.appendReviewQuote(5, 'quoted question text')
+    controller._reviewStore.toggleType(controller._reviewStore.activeId)
+    typeInto(controller.textareaTarget, 'question feedback')
+    jest.spyOn(controller, 'renderCommentHtml').mockImplementation(() => {})
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ ok: true, status: 200, text: () => Promise.resolve('<div></div>') }),
+    )
+
     controller.handleSend(new Event('submit', { cancelable: true }))
     await new Promise((resolve) => setTimeout(resolve, 20))
 

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_draft.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_draft.test.js
@@ -1,0 +1,269 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { jest } from '@jest/globals'
+import { Application } from '@hotwired/stimulus'
+import FormController from '../form_controller'
+import chatDrafts from '../../../lib/chat_drafts'
+
+describe('FormController - draft persistence', () => {
+  let application
+  let container
+  let controller
+  let popupEl
+
+  const FIXTURE = `
+    <div id="comments-popup"
+         data-controller="comments--form"
+         data-update-comment-text="Update">
+      <form data-comments--form-target="form">
+        <input type="hidden" name="comment[quoted_comment_id]" data-comments--form-target="quotedCommentId" value="" />
+        <input type="hidden" name="comment[quoted_text]" data-comments--form-target="quotedText" value="" />
+        <div data-comments--form-target="quoteIndicator" style="display:none;">
+          <span data-comments--form-target="quoteIndicatorText"></span>
+        </div>
+        <div class="review-quotes-container" data-comments--form-target="reviewQuotesContainer" style="display:none;"></div>
+        <textarea data-comments--form-target="textarea" rows="2"></textarea>
+        <input type="checkbox" data-comments--form-target="privateCheckbox" />
+        <button type="submit" data-comments--form-target="submit">Send</button>
+        <button data-comments--form-target="cancel" style="display:none;">Cancel</button>
+        <button data-comments--form-target="searchButton" style="display:none;">Search</button>
+        <button data-comments--form-target="voiceButton" style="display:none;">Voice</button>
+        <input type="file" data-comments--form-target="imageInput" style="display:none;" />
+        <button data-comments--form-target="imageButton" style="display:none;">Image</button>
+        <div data-comments--form-target="attachmentList"></div>
+      </form>
+    </div>`
+
+  const dispatchTopicChange = (effectiveCreativeId, topicId = '10073') => {
+    popupEl.dataset.effectiveCreativeId = String(effectiveCreativeId)
+    popupEl.dispatchEvent(
+      new CustomEvent('comments--topics:change', { detail: { topicId } }),
+    )
+  }
+
+  const typeInto = (textarea, value) => {
+    textarea.value = value
+    textarea.dispatchEvent(new Event('input', { bubbles: true }))
+  }
+
+  beforeEach(async () => {
+    window.localStorage.clear()
+    document.body.dataset.currentUserId = '9'
+
+    if (typeof global.requestAnimationFrame !== 'function') {
+      global.requestAnimationFrame = (cb) => setTimeout(cb, 0)
+    }
+    if (!global.DataTransfer) {
+      global.DataTransfer = class {
+        constructor() {
+          this.files = []
+          this.items = { add: (file) => this.files.push(file) }
+        }
+      }
+    }
+    const meta = document.createElement('meta')
+    meta.name = 'csrf-token'
+    meta.content = 'test-token'
+    document.head.appendChild(meta)
+
+    container = document.createElement('div')
+    container.innerHTML = FIXTURE
+    document.body.appendChild(container)
+
+    application = Application.start()
+    application.register('comments--form', FormController)
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    popupEl = container.querySelector('#comments-popup')
+    controller = application.getControllerForElementAndIdentifier(popupEl, 'comments--form')
+    jest.spyOn(controller, 'setImageFiles').mockImplementation(() => {})
+    controller.creativeId = '77'
+  })
+
+  afterEach(() => {
+    application.stop()
+    document.body.removeChild(container)
+    document.head.querySelector('meta[name="csrf-token"]').remove()
+    delete document.body.dataset.currentUserId
+    jest.restoreAllMocks()
+  })
+
+  test('restores a saved draft when the popup opens for that chat', () => {
+    chatDrafts.set('77', 'unfinished thought')
+    dispatchTopicChange('77')
+    controller.onPopupOpened({ creativeId: '77', canComment: true })
+    expect(controller.textareaTarget.value).toBe('unfinished thought')
+  })
+
+  test('does not clobber a non-empty textarea on restore', () => {
+    chatDrafts.set('77', 'stored draft')
+    dispatchTopicChange('77')
+    controller.textareaTarget.value = 'already typing'
+    controller._restoreDraft()
+    expect(controller.textareaTarget.value).toBe('already typing')
+  })
+
+  test('typing saves the draft after the 500ms debounce', async () => {
+    dispatchTopicChange('77')
+    typeInto(controller.textareaTarget, 'saving me')
+    expect(chatDrafts.get('77')).toBeNull()
+    await new Promise((resolve) => setTimeout(resolve, 600))
+    expect(chatDrafts.get('77')).toBe('saving me')
+  })
+
+  test('switching to another chat flush-saves the previous draft under the previous key', () => {
+    dispatchTopicChange('77')
+    controller.textareaTarget.value = 'draft for 77'
+    dispatchTopicChange('88')
+    expect(chatDrafts.get('77')).toBe('draft for 77')
+    controller.onPopupOpened({ creativeId: '88', canComment: true })
+    expect(controller.textareaTarget.value).toBe('')
+  })
+
+  test('switching topics within the same chat does not flush the draft', () => {
+    dispatchTopicChange('77', '10073')
+    controller.textareaTarget.value = 'still composing'
+    dispatchTopicChange('77', '10074')
+    expect(chatDrafts.get('77')).toBeNull()
+    expect(controller._activeDraftKey).toBe('77')
+  })
+
+  test('falls back to the raw creative id until an effective id is available', () => {
+    delete popupEl.dataset.effectiveCreativeId
+    popupEl.dataset.creativeId = '66'
+    popupEl.dispatchEvent(
+      new CustomEvent('comments--topics:change', { detail: { topicId: '10073' } }),
+    )
+    expect(controller._activeDraftKey).toBe('66')
+  })
+
+  test('keeps the draft key empty when no creative id is available', () => {
+    delete popupEl.dataset.effectiveCreativeId
+    delete popupEl.dataset.creativeId
+    popupEl.dispatchEvent(
+      new CustomEvent('comments--topics:change', { detail: { topicId: '10073' } }),
+    )
+    expect(controller._activeDraftKey).toBeNull()
+  })
+
+  test('closing the popup flush-saves the draft; blank input deletes it', () => {
+    dispatchTopicChange('77')
+    controller.textareaTarget.value = 'saved on close'
+    controller.onPopupClosed()
+    expect(chatDrafts.get('77')).toBe('saved on close')
+
+    dispatchTopicChange('77')
+    controller.onPopupOpened({ creativeId: '77', canComment: true })
+    expect(controller.textareaTarget.value).toBe('saved on close')
+    controller.textareaTarget.value = ''
+    controller.onPopupClosed()
+    expect(chatDrafts.get('77')).toBeNull()
+  })
+
+  test('disconnect (Turbo navigation) flush-saves the draft', () => {
+    dispatchTopicChange('77')
+    controller.textareaTarget.value = 'leaving the page'
+    controller.disconnect()
+    expect(chatDrafts.get('77')).toBe('leaving the page')
+    controller.connect()
+  })
+
+  test('losing comment permission flush-saves the draft', () => {
+    dispatchTopicChange('77')
+    controller.textareaTarget.value = 'permission changed'
+    controller.setCommentPermission(false)
+    expect(chatDrafts.get('77')).toBe('permission changed')
+    controller.setCommentPermission(true)
+    expect(controller.formTarget.style.display).toBe('')
+  })
+
+  test('successful send clears the stored draft', async () => {
+    dispatchTopicChange('77')
+    typeInto(controller.textareaTarget, 'about to send')
+    controller._flushDraftSave()
+    expect(chatDrafts.get('77')).toBe('about to send')
+
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ ok: true, status: 200, text: () => Promise.resolve('<div></div>') }),
+    )
+    controller.textareaTarget.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true }),
+    )
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(chatDrafts.get('77')).toBeNull()
+    expect(controller.textareaTarget.value).toBe('')
+  })
+
+  test('failed send keeps the stored draft', async () => {
+    dispatchTopicChange('77')
+    typeInto(controller.textareaTarget, 'will fail')
+    controller._flushDraftSave()
+
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: false,
+        status: 500,
+        json: () => Promise.resolve({ errors: ['boom'] }),
+      }),
+    )
+    controller.textareaTarget.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true }),
+    )
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(chatDrafts.get('77')).toBe('will fail')
+  })
+
+  test('editing a comment preserves the draft and suspends draft saving', async () => {
+    dispatchTopicChange('77')
+    typeInto(controller.textareaTarget, 'my draft')
+    controller.startEditing({ id: 5, content: 'existing comment', private: false })
+    expect(chatDrafts.get('77')).toBe('my draft')
+
+    typeInto(controller.textareaTarget, 'existing comment edited')
+    await new Promise((resolve) => setTimeout(resolve, 600))
+    expect(chatDrafts.get('77')).toBe('my draft')
+
+    controller.handleCancel(new Event('click'))
+    expect(controller.textareaTarget.value).toBe('my draft')
+  })
+
+  test('successful edit restores the unsent draft', async () => {
+    dispatchTopicChange('77')
+    typeInto(controller.textareaTarget, 'my draft')
+    controller.startEditing({ id: 5, content: 'existing comment', private: false })
+    jest.spyOn(controller, 'renderCommentHtml').mockImplementation(() => {})
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ ok: true, status: 200, text: () => Promise.resolve('<div></div>') }),
+    )
+
+    controller.handleSend(new Event('submit', { cancelable: true }))
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(controller.textareaTarget.value).toBe('my draft')
+    expect(chatDrafts.get('77')).toBe('my draft')
+  })
+
+  test('a stashed slash-command draft is never replaced by the command text', async () => {
+    dispatchTopicChange('77')
+    typeInto(controller.textareaTarget, 'my draft')
+    controller.handleStashDraft(
+      new CustomEvent('comments--form:stash-draft', { detail: { draft: 'my draft' } }),
+    )
+    expect(chatDrafts.get('77')).toBe('my draft')
+
+    typeInto(controller.textareaTarget, '/calendar 2026-08-14')
+    await new Promise((resolve) => setTimeout(resolve, 600))
+    expect(chatDrafts.get('77')).toBe('my draft')
+
+    controller._restoreStashedDraft('/calendar 2026-08-14')
+    expect(controller.textareaTarget.value).toBe('my draft')
+    expect(chatDrafts.get('77')).toBe('my draft')
+  })
+
+  test('typing without an active draft key does not write to storage', async () => {
+    typeInto(controller.textareaTarget, 'orphan text')
+    await new Promise((resolve) => setTimeout(resolve, 600))
+    expect(window.localStorage.getItem('collavre_chat_drafts_9')).toBeNull()
+  })
+})

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_draft.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_draft.test.js
@@ -570,6 +570,50 @@ describe('FormController - draft persistence', () => {
     expect(chatDrafts.get('88')).toBe('draft for 88')
   })
 
+  test('reconnecting during a send does not preserve the restored submitted message', async () => {
+    dispatchTopicChange('77')
+    typeInto(controller.textareaTarget, 'send before reconnect')
+    controller._flushDraftSave()
+
+    let finishFetch
+    global.fetch = jest.fn(() => new Promise((resolve) => { finishFetch = resolve }))
+    controller.handleSend(new Event('submit', { cancelable: true }))
+
+    controller.disconnect()
+    controller.connect()
+    dispatchTopicChange('77')
+    controller.onPopupOpened({ creativeId: '77', canComment: true })
+    expect(controller.textareaTarget.value).toBe('send before reconnect')
+
+    finishFetch({ ok: true, status: 200, text: () => Promise.resolve('<div></div>') })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(controller.textareaTarget.value).toBe('')
+    expect(chatDrafts.get('77')).toBeNull()
+  })
+
+  test('reconnecting during a send preserves text typed after the reconnect', async () => {
+    dispatchTopicChange('77')
+    typeInto(controller.textareaTarget, 'send before reconnect')
+    controller._flushDraftSave()
+
+    let finishFetch
+    global.fetch = jest.fn(() => new Promise((resolve) => { finishFetch = resolve }))
+    controller.handleSend(new Event('submit', { cancelable: true }))
+
+    controller.disconnect()
+    controller.connect()
+    dispatchTopicChange('77')
+    controller.onPopupOpened({ creativeId: '77', canComment: true })
+    typeInto(controller.textareaTarget, 'next message after reconnect')
+
+    finishFetch({ ok: true, status: 200, text: () => Promise.resolve('<div></div>') })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(controller.textareaTarget.value).toBe('next message after reconnect')
+    expect(chatDrafts.get('77')).toBe('next message after reconnect')
+  })
+
   test('send completion preserves newer submitted-chat text after switching away', async () => {
     dispatchTopicChange('77')
     typeInto(controller.textareaTarget, 'first message')

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_draft.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_draft.test.js
@@ -308,6 +308,36 @@ describe('FormController - draft persistence', () => {
     controller.connect()
   })
 
+  test('Turbo reconnect keeps comment edits out of the ordinary draft', () => {
+    dispatchTopicChange('77')
+    typeInto(controller.textareaTarget, 'ordinary draft')
+    controller.startEditing({ id: '12', content: 'edited comment', private: false })
+
+    controller.disconnect()
+    controller.connect()
+    typeInto(controller.textareaTarget, 'edited after reconnect')
+    controller.disconnect()
+
+    expect(controller.editingId).toBe('12')
+    expect(chatDrafts.get('77')).toBe('ordinary draft')
+    controller.connect()
+  })
+
+  test('Turbo reconnect keeps review feedback out of the ordinary draft', () => {
+    dispatchTopicChange('77')
+    typeInto(controller.textareaTarget, 'ordinary draft')
+    controller.appendReviewQuote(5, 'quoted review text')
+    typeInto(controller.textareaTarget, 'feedback before reconnect')
+
+    controller.disconnect()
+    controller.connect()
+    typeInto(controller.textareaTarget, 'feedback after reconnect')
+    window.dispatchEvent(new Event('pagehide'))
+
+    expect(controller._reviewStore.isEmpty).toBe(false)
+    expect(chatDrafts.get('77')).toBe('ordinary draft')
+  })
+
   test('native pagehide flushes input before the debounce completes', () => {
     dispatchTopicChange('77')
     typeInto(controller.textareaTarget, 'reload-safe draft')

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_draft.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_draft.test.js
@@ -368,6 +368,78 @@ describe('FormController - draft persistence', () => {
     controller.connect()
   })
 
+  test('a cross-tab logout keeps the cleared user namespace disabled', async () => {
+    dispatchTopicChange('77')
+    typeInto(controller.textareaTarget, 'old user draft')
+
+    controller.disconnect()
+    chatDrafts.clearAll()
+    const clearSignal = window.localStorage.getItem('collavre_chat_drafts_clear')
+    window.dispatchEvent(new StorageEvent('storage', {
+      key: 'collavre_chat_drafts_clear',
+      newValue: clearSignal,
+    }))
+
+    controller.connect()
+    controller.onChatWillOpen({ creativeId: '88' })
+    popupEl.dataset.creativeId = '88'
+    dispatchTopicChange('88')
+    controller.onPopupOpened({ creativeId: '88', canComment: true })
+    expect(controller._activeDraftKey).toBeNull()
+    typeInto(controller.textareaTarget, 'must not persist for the old user')
+    controller.onPopupClosed()
+    await new Promise((resolve) => setTimeout(resolve, 600))
+
+    expect(chatDrafts.get('77')).toBeNull()
+    expect(chatDrafts.get('88')).toBeNull()
+  })
+
+  test('a missed cross-tab logout invalidates an in-flight send on reconnect', async () => {
+    dispatchTopicChange('77')
+    typeInto(controller.textareaTarget, 'old user submission')
+    let failFetch
+    global.fetch = jest.fn(() => new Promise((resolve) => { failFetch = resolve }))
+    controller.handleSend(new Event('submit', { cancelable: true }))
+
+    controller.disconnect()
+    chatDrafts.clearAll()
+    controller.connect()
+    controller.onChatWillOpen({ creativeId: '77' })
+
+    failFetch({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve({ errors: ['boom'] }),
+    })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(controller.textareaTarget.value).toBe('')
+    expect(chatDrafts.get('77')).toBeNull()
+    expect(submissionBackup('77')).toBeNull()
+  })
+
+  test('storage recovery does not treat an existing clear marker as a new logout', () => {
+    controller.disconnect()
+    chatDrafts.clearAll()
+    controller._observedDraftClearNonces.clear()
+    const storageGetter = jest.spyOn(window, 'localStorage', 'get').mockImplementation(() => {
+      throw new DOMException('denied', 'SecurityError')
+    })
+
+    controller.connect()
+    controller.disconnect()
+    storageGetter.mockRestore()
+    controller.connect()
+    controller.onChatWillOpen({ creativeId: '88' })
+    popupEl.dataset.creativeId = '88'
+    dispatchTopicChange('88')
+    controller.onPopupOpened({ creativeId: '88', canComment: true })
+    typeInto(controller.textareaTarget, 'draft after storage recovery')
+    controller._flushDraftSave()
+
+    expect(chatDrafts.get('88')).toBe('draft after storage recovery')
+  })
+
   test('a failed in-flight send cannot recreate a draft after cross-tab logout', async () => {
     dispatchTopicChange('77')
     typeInto(controller.textareaTarget, 'old user submission')

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_draft.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_draft.test.js
@@ -965,6 +965,29 @@ describe('FormController - draft persistence', () => {
     expect(chatDrafts.get('77')).toBe('next message')
   })
 
+  test('switching chats while a slash command succeeds preserves its stashed draft', async () => {
+    dispatchTopicChange('77')
+    typeInto(controller.textareaTarget, 'ordinary draft')
+    controller.handleStashDraft(
+      new CustomEvent('comments--form:stash-draft', { detail: { draft: 'ordinary draft' } }),
+    )
+    typeInto(controller.textareaTarget, '/calendar 2026-08-14')
+
+    let finishFetch
+    global.fetch = jest.fn(() => new Promise((resolve) => { finishFetch = resolve }))
+    controller.handleSend(new Event('submit', { cancelable: true }))
+
+    controller.onChatWillOpen({ creativeId: '88' })
+    dispatchTopicChange('88')
+    controller.onPopupOpened({ creativeId: '88', canComment: true })
+
+    finishFetch({ ok: true, status: 200, text: () => Promise.resolve('<div></div>') })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(chatDrafts.get('77')).toBe('ordinary draft')
+    expect(controller.textareaTarget.value).toBe('')
+  })
+
   test('review quote feedback never replaces the ordinary chat draft', async () => {
     dispatchTopicChange('77')
     typeInto(controller.textareaTarget, 'my ordinary draft')

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_draft.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_draft.test.js
@@ -370,6 +370,33 @@ describe('FormController - draft persistence', () => {
     expect(controller.textareaTarget.value).toBe('draft for 88')
   })
 
+  test('typing in another chat does not preserve a restored submitted message', async () => {
+    dispatchTopicChange('77')
+    typeInto(controller.textareaTarget, 'send from 77')
+    controller._flushDraftSave()
+
+    let finishFetch
+    global.fetch = jest.fn(() => new Promise((resolve) => { finishFetch = resolve }))
+    controller.handleSend(new Event('submit', { cancelable: true }))
+
+    controller.onChatWillOpen({ creativeId: '88' })
+    dispatchTopicChange('88')
+    controller.onPopupOpened({ creativeId: '88', canComment: true })
+    typeInto(controller.textareaTarget, 'draft for 88')
+
+    controller.onChatWillOpen({ creativeId: '77' })
+    dispatchTopicChange('77')
+    controller.onPopupOpened({ creativeId: '77', canComment: true })
+    expect(controller.textareaTarget.value).toBe('send from 77')
+
+    finishFetch({ ok: true, status: 200, text: () => Promise.resolve('<div></div>') })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(controller.textareaTarget.value).toBe('')
+    expect(chatDrafts.get('77')).toBeNull()
+    expect(chatDrafts.get('88')).toBe('draft for 88')
+  })
+
   test('send completion preserves newer submitted-chat text after switching away', async () => {
     dispatchTopicChange('77')
     typeInto(controller.textareaTarget, 'first message')

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_draft.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_draft.test.js
@@ -443,6 +443,36 @@ describe('FormController - draft persistence', () => {
     expect(chatDrafts.get('77')).toBe('same-millisecond concurrent draft')
   })
 
+  test('submission snapshots text and revision before a concurrent draft arrives', async () => {
+    dispatchTopicChange('77')
+    typeInto(controller.textareaTarget, 'first message')
+    controller._flushDraftSave()
+
+    const originalEntry = chatDrafts._entry.bind(chatDrafts)
+    let injectConcurrentDraft = true
+    jest.spyOn(chatDrafts, '_entry').mockImplementation((chatId) => {
+      const entry = originalEntry(chatId)
+      if (injectConcurrentDraft && String(chatId) === '77') {
+        injectConcurrentDraft = false
+        chatDrafts._append('77', {
+          text: 'draft saved concurrently after snapshot',
+          updatedAt: entry.updatedAt + 1,
+          version: `${entry.version}-concurrent`,
+        })
+      }
+      return entry
+    })
+
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ ok: true, status: 200, text: () => Promise.resolve('<div></div>') }),
+    )
+    controller.handleSend(new Event('submit', { cancelable: true }))
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(controller.textareaTarget.value).toBe('draft saved concurrently after snapshot')
+    expect(chatDrafts.get('77')).toBe('draft saved concurrently after snapshot')
+  })
+
   test('successful send preserves a draft another tab saved before submission', async () => {
     dispatchTopicChange('77')
     typeInto(controller.textareaTarget, 'stale message in this tab')
@@ -559,6 +589,172 @@ describe('FormController - draft persistence', () => {
     expect(controller.textareaTarget.value).toBe('draft for 88')
   })
 
+  test('send completion clears a submitted draft after raw-to-effective key migration', async () => {
+    delete popupEl.dataset.effectiveCreativeId
+    controller.onChatWillOpen({ creativeId: '78' })
+    typeInto(controller.textareaTarget, 'send before linked topics resolve')
+
+    let finishFetch
+    global.fetch = jest.fn(() => new Promise((resolve) => { finishFetch = resolve }))
+    controller.handleSend(new Event('submit', { cancelable: true }))
+
+    popupEl.dataset.creativeId = '78'
+    dispatchTopicChange('70')
+    controller.onPopupOpened({ creativeId: '78', canComment: true })
+    expect(controller.textareaTarget.value).toBe('send before linked topics resolve')
+
+    finishFetch({ ok: true, status: 200, text: () => Promise.resolve('<div></div>') })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(controller.textareaTarget.value).toBe('')
+    expect(chatDrafts.get('78')).toBeNull()
+    expect(chatDrafts.get('70')).toBeNull()
+  })
+
+  test('raw-to-effective migration preserves a newer canonical draft during submission', async () => {
+    let now = 1000
+    jest.spyOn(Date, 'now').mockImplementation(() => now)
+    delete popupEl.dataset.effectiveCreativeId
+    controller.onChatWillOpen({ creativeId: '78' })
+    typeInto(controller.textareaTarget, 'stale linked message')
+    controller._flushDraftSave()
+
+    let finishFetch
+    global.fetch = jest.fn(() => new Promise((resolve) => { finishFetch = resolve }))
+    controller.handleSend(new Event('submit', { cancelable: true }))
+
+    now += 1000
+    chatDrafts.set('70', 'newer canonical draft')
+    popupEl.dataset.creativeId = '78'
+    dispatchTopicChange('70')
+    controller.onPopupOpened({ creativeId: '78', canComment: true })
+
+    finishFetch({ ok: true, status: 200, text: () => Promise.resolve('<div></div>') })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(controller.textareaTarget.value).toBe('newer canonical draft')
+    expect(chatDrafts.get('78')).toBeNull()
+    expect(chatDrafts.get('70')).toBe('newer canonical draft')
+  })
+
+  test('a failed raw-to-effective move keeps the submission bound to the raw key', async () => {
+    delete popupEl.dataset.effectiveCreativeId
+    controller.onChatWillOpen({ creativeId: '78' })
+    typeInto(controller.textareaTarget, 'send despite migration failure')
+    controller._flushDraftSave()
+
+    let finishFetch
+    global.fetch = jest.fn(() => new Promise((resolve) => { finishFetch = resolve }))
+    controller.handleSend(new Event('submit', { cancelable: true }))
+    jest.spyOn(chatDrafts, 'move').mockReturnValue(false)
+
+    popupEl.dataset.creativeId = '78'
+    dispatchTopicChange('70')
+    controller.onPopupOpened({ creativeId: '78', canComment: true })
+    finishFetch({ ok: true, status: 200, text: () => Promise.resolve('<div></div>') })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(controller.textareaTarget.value).toBe('')
+    expect(chatDrafts.get('78')).toBeNull()
+    expect(chatDrafts.get('70')).toBeNull()
+  })
+
+  test('send completion clears a target copied before the source marker fails', async () => {
+    delete popupEl.dataset.effectiveCreativeId
+    controller.onChatWillOpen({ creativeId: '78' })
+    typeInto(controller.textareaTarget, 'send during partial migration')
+    controller._flushDraftSave()
+
+    let finishFetch
+    global.fetch = jest.fn(() => new Promise((resolve) => { finishFetch = resolve }))
+    controller.handleSend(new Event('submit', { cancelable: true }))
+    jest.spyOn(chatDrafts, 'move').mockImplementation((sourceKey, targetKey) => {
+      chatDrafts._append(String(targetKey), { ...chatDrafts._entry(String(sourceKey)) })
+    })
+
+    popupEl.dataset.creativeId = '78'
+    dispatchTopicChange('70')
+    controller.onPopupOpened({ creativeId: '78', canComment: true })
+    finishFetch({ ok: true, status: 200, text: () => Promise.resolve('<div></div>') })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(controller.textareaTarget.value).toBe('')
+    expect(chatDrafts.get('78')).toBeNull()
+    expect(chatDrafts.get('70')).toBeNull()
+  })
+
+  test('send completion rebinds when another tab already moved the submitted draft', async () => {
+    delete popupEl.dataset.effectiveCreativeId
+    controller.onChatWillOpen({ creativeId: '78' })
+    typeInto(controller.textareaTarget, 'send after another tab migrates')
+    controller._flushDraftSave()
+
+    let finishFetch
+    global.fetch = jest.fn(() => new Promise((resolve) => { finishFetch = resolve }))
+    controller.handleSend(new Event('submit', { cancelable: true }))
+    chatDrafts.move('78', '70')
+
+    popupEl.dataset.creativeId = '78'
+    dispatchTopicChange('70')
+    controller.onPopupOpened({ creativeId: '78', canComment: true })
+    finishFetch({ ok: true, status: 200, text: () => Promise.resolve('<div></div>') })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(controller.textareaTarget.value).toBe('')
+    expect(chatDrafts.get('78')).toBeNull()
+    expect(chatDrafts.get('70')).toBeNull()
+  })
+
+  test('linked-key migration preserves a stashed draft that differs from the command', async () => {
+    delete popupEl.dataset.effectiveCreativeId
+    controller.onChatWillOpen({ creativeId: '78' })
+    typeInto(controller.textareaTarget, 'ordinary draft before command')
+    controller.handleStashDraft(
+      new CustomEvent('comments--form:stash-draft', {
+        detail: { draft: 'ordinary draft before command' },
+      }),
+    )
+    typeInto(controller.textareaTarget, '/calendar 2026-08-14')
+
+    let finishFetch
+    global.fetch = jest.fn(() => new Promise((resolve) => { finishFetch = resolve }))
+    controller.handleSend(new Event('submit', { cancelable: true }))
+
+    popupEl.dataset.creativeId = '78'
+    dispatchTopicChange('70')
+    controller.onPopupOpened({ creativeId: '78', canComment: true })
+    finishFetch({ ok: true, status: 200, text: () => Promise.resolve('<div></div>') })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(controller.textareaTarget.value).toBe('ordinary draft before command')
+    expect(chatDrafts.get('78')).toBeNull()
+    expect(chatDrafts.get('70')).toBe('ordinary draft before command')
+  })
+
+  test('an unrelated linked-key migration does not rebind a pending submission', async () => {
+    dispatchTopicChange('77')
+    typeInto(controller.textareaTarget, 'send from 77')
+    controller._flushDraftSave()
+
+    let finishFetch
+    global.fetch = jest.fn(() => new Promise((resolve) => { finishFetch = resolve }))
+    controller.handleSend(new Event('submit', { cancelable: true }))
+
+    delete popupEl.dataset.effectiveCreativeId
+    controller.onChatWillOpen({ creativeId: '78' })
+    typeInto(controller.textareaTarget, 'draft for linked chat')
+    popupEl.dataset.creativeId = '78'
+    dispatchTopicChange('70')
+    controller.onPopupOpened({ creativeId: '78', canComment: true })
+
+    finishFetch({ ok: true, status: 200, text: () => Promise.resolve('<div></div>') })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(chatDrafts.get('77')).toBeNull()
+    expect(chatDrafts.get('70')).toBe('draft for linked chat')
+    expect(controller.textareaTarget.value).toBe('draft for linked chat')
+  })
+
   test('typing in another chat does not preserve a restored submitted message', async () => {
     dispatchTopicChange('77')
     typeInto(controller.textareaTarget, 'send from 77')
@@ -628,6 +824,34 @@ describe('FormController - draft persistence', () => {
 
     expect(controller.textareaTarget.value).toBe('next message after reconnect')
     expect(chatDrafts.get('77')).toBe('next message after reconnect')
+  })
+
+  test('reconnecting while linked topics load preserves migration and new input', async () => {
+    delete popupEl.dataset.effectiveCreativeId
+    controller.onChatWillOpen({ creativeId: '78' })
+    typeInto(controller.textareaTarget, 'send before reconnect')
+    controller._flushDraftSave()
+
+    let finishFetch
+    global.fetch = jest.fn(() => new Promise((resolve) => { finishFetch = resolve }))
+    controller.handleSend(new Event('submit', { cancelable: true }))
+
+    controller.disconnect()
+    controller.connect()
+    expect(controller._activeDraftKey).toBe('78')
+    expect(controller._awaitingEffectiveDraftKeyFor).toBe('78')
+    typeInto(controller.textareaTarget, 'next message after reconnect')
+
+    popupEl.dataset.creativeId = '78'
+    dispatchTopicChange('70')
+    controller.onPopupOpened({ creativeId: '78', canComment: true })
+
+    finishFetch({ ok: true, status: 200, text: () => Promise.resolve('<div></div>') })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(controller.textareaTarget.value).toBe('next message after reconnect')
+    expect(chatDrafts.get('78')).toBeNull()
+    expect(chatDrafts.get('70')).toBe('next message after reconnect')
   })
 
   test('send completion preserves newer submitted-chat text after switching away', async () => {

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_draft.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_draft.test.js
@@ -129,6 +129,19 @@ describe('FormController - draft persistence', () => {
     expect(controller._activeDraftKey).toBe('77')
   })
 
+  test('switching linked creatives flushes before resetting a shared effective draft', () => {
+    popupEl.dataset.creativeId = '77'
+    dispatchTopicChange('70', '10073')
+    typeInto(controller.textareaTarget, 'draft from linked creative 77')
+
+    popupEl.dataset.creativeId = '78'
+    dispatchTopicChange('70', '10073')
+
+    expect(chatDrafts.get('70')).toBe('draft from linked creative 77')
+    controller.onPopupOpened({ creativeId: '78', canComment: true })
+    expect(controller.textareaTarget.value).toBe('draft from linked creative 77')
+  })
+
   test('falls back to the raw creative id until an effective id is available', () => {
     delete popupEl.dataset.effectiveCreativeId
     popupEl.dataset.creativeId = '66'
@@ -263,6 +276,28 @@ describe('FormController - draft persistence', () => {
 
     expect(controller.textareaTarget.value).toBe('my draft')
     expect(chatDrafts.get('77')).toBe('my draft')
+  })
+
+  test('edit completion after a chat switch preserves the submitted chat draft', async () => {
+    dispatchTopicChange('77')
+    typeInto(controller.textareaTarget, 'my draft')
+    controller.startEditing({ id: 5, content: 'existing comment', private: false })
+    jest.spyOn(controller, 'renderCommentHtml').mockImplementation(() => {})
+
+    let finishFetch
+    global.fetch = jest.fn(() => new Promise((resolve) => { finishFetch = resolve }))
+    controller.handleSend(new Event('submit', { cancelable: true }))
+
+    dispatchTopicChange('88')
+    controller.onPopupOpened({ creativeId: '88', canComment: true })
+    typeInto(controller.textareaTarget, 'draft for 88')
+
+    finishFetch({ ok: true, status: 200, text: () => Promise.resolve('<div></div>') })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(chatDrafts.get('77')).toBe('my draft')
+    expect(chatDrafts.get('88')).toBe('draft for 88')
+    expect(controller.textareaTarget.value).toBe('draft for 88')
   })
 
   test('a stashed slash-command draft is never replaced by the command text', async () => {

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_draft.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_draft.test.js
@@ -138,6 +138,24 @@ describe('FormController - draft persistence', () => {
     expect(chatDrafts.get('88')).toBe('draft for 88')
   })
 
+  test('a slash-command stash from the outgoing chat does not suppress the incoming draft', () => {
+    dispatchTopicChange('77')
+    typeInto(controller.textareaTarget, 'draft for 77')
+    controller.handleStashDraft(
+      new CustomEvent('comments--form:stash-draft', {
+        detail: { draft: 'draft for 77' },
+      }),
+    )
+    controller.textareaTarget.value = '/calendar 2026-08-14 10:00 Sync'
+
+    controller.onChatWillOpen({ creativeId: '88' })
+    typeInto(controller.textareaTarget, 'draft for 88')
+    controller.onPopupClosed()
+
+    expect(chatDrafts.get('77')).toBe('draft for 77')
+    expect(chatDrafts.get('88')).toBe('draft for 88')
+  })
+
   test('typing during a linked chat switch migrates from raw to effective draft key', () => {
     popupEl.dataset.creativeId = '77'
     dispatchTopicChange('70')

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_draft.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_draft.test.js
@@ -121,6 +121,40 @@ describe('FormController - draft persistence', () => {
     expect(controller.textareaTarget.value).toBe('')
   })
 
+  test('typing during an asynchronous chat switch is saved under the incoming chat', () => {
+    dispatchTopicChange('77')
+    typeInto(controller.textareaTarget, 'draft for 77')
+
+    controller.onChatWillOpen({ creativeId: '88' })
+    typeInto(controller.textareaTarget, 'draft for 88')
+
+    expect(chatDrafts.get('77')).toBe('draft for 77')
+    expect(chatDrafts.get('88')).toBeNull()
+
+    dispatchTopicChange('88')
+    controller.onPopupOpened({ creativeId: '88', canComment: true })
+
+    expect(controller.textareaTarget.value).toBe('draft for 88')
+    expect(chatDrafts.get('88')).toBe('draft for 88')
+  })
+
+  test('typing during a linked chat switch migrates from raw to effective draft key', () => {
+    popupEl.dataset.creativeId = '77'
+    dispatchTopicChange('70')
+    typeInto(controller.textareaTarget, 'shared draft before switch')
+
+    controller.onChatWillOpen({ creativeId: '78' })
+    typeInto(controller.textareaTarget, 'shared draft after switch')
+
+    popupEl.dataset.creativeId = '78'
+    dispatchTopicChange('70')
+    controller.onPopupOpened({ creativeId: '78', canComment: true })
+
+    expect(controller.textareaTarget.value).toBe('shared draft after switch')
+    expect(chatDrafts.get('70')).toBe('shared draft after switch')
+    expect(chatDrafts.get('78')).toBeNull()
+  })
+
   test('switching topics within the same chat does not flush the draft', () => {
     dispatchTopicChange('77', '10073')
     controller.textareaTarget.value = 'still composing'
@@ -237,6 +271,26 @@ describe('FormController - draft persistence', () => {
     expect(chatDrafts.get('77')).toBe('next message')
   })
 
+  test('send completion after an account change does not clear the new user draft', async () => {
+    dispatchTopicChange('77')
+    typeInto(controller.textareaTarget, 'user 9 message')
+    controller._flushDraftSave()
+
+    let finishFetch
+    global.fetch = jest.fn(() => new Promise((resolve) => { finishFetch = resolve }))
+    controller.handleSend(new Event('submit', { cancelable: true }))
+
+    document.body.dataset.currentUserId = '10'
+    chatDrafts.set('77', 'user 10 draft')
+
+    finishFetch({ ok: true, status: 200, text: () => Promise.resolve('<div></div>') })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(chatDrafts.get('77')).toBe('user 10 draft')
+    document.body.dataset.currentUserId = '9'
+    expect(chatDrafts.get('77')).toBe('user 9 message')
+  })
+
   test('failed send keeps the stored draft', async () => {
     dispatchTopicChange('77')
     typeInto(controller.textareaTarget, 'will fail')
@@ -344,6 +398,39 @@ describe('FormController - draft persistence', () => {
     controller._restoreStashedDraft('/calendar 2026-08-14')
     expect(controller.textareaTarget.value).toBe('my draft')
     expect(chatDrafts.get('77')).toBe('my draft')
+  })
+
+  test('review quote feedback never replaces the ordinary chat draft', async () => {
+    dispatchTopicChange('77')
+    typeInto(controller.textareaTarget, 'my ordinary draft')
+
+    controller.appendReviewQuote(5, 'quoted review text')
+    typeInto(controller.textareaTarget, 'feedback for the quote')
+    await new Promise((resolve) => setTimeout(resolve, 600))
+
+    expect(chatDrafts.get('77')).toBe('my ordinary draft')
+
+    controller.onPopupClosed()
+    dispatchTopicChange('77')
+    controller.onPopupOpened({ creativeId: '77', canComment: true })
+    expect(controller.textareaTarget.value).toBe('my ordinary draft')
+  })
+
+  test('successful review send restores the ordinary chat draft', async () => {
+    dispatchTopicChange('77')
+    typeInto(controller.textareaTarget, 'my ordinary draft')
+    controller.appendReviewQuote(5, 'quoted review text')
+    typeInto(controller.textareaTarget, 'feedback for the quote')
+    controller._commitActiveQuote()
+
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ ok: true, status: 200, text: () => Promise.resolve('<div></div>') }),
+    )
+    controller.handleSend(new Event('submit', { cancelable: true }))
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(controller.textareaTarget.value).toBe('my ordinary draft')
+    expect(chatDrafts.get('77')).toBe('my ordinary draft')
   })
 
   test('typing without an active draft key does not write to storage', async () => {

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_draft.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_draft.test.js
@@ -328,6 +328,39 @@ describe('FormController - draft persistence', () => {
     expect(chatDrafts.get('77')).toBe('draft updated outside this form')
   })
 
+  test('successful send preserves a draft another tab saved before submission', async () => {
+    dispatchTopicChange('77')
+    typeInto(controller.textareaTarget, 'stale message in this tab')
+    controller._flushDraftSave()
+
+    chatDrafts.set('77', 'newer draft from another tab')
+
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ ok: true, status: 200, text: () => Promise.resolve('<div></div>') }),
+    )
+    controller.handleSend(new Event('submit', { cancelable: true }))
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(controller.textareaTarget.value).toBe('newer draft from another tab')
+    expect(chatDrafts.get('77')).toBe('newer draft from another tab')
+  })
+
+  test('successful send clears this tab draft changed before its debounce runs', async () => {
+    chatDrafts.set('77', 'older draft from this tab')
+    dispatchTopicChange('77')
+    controller.onPopupOpened({ creativeId: '77', canComment: true })
+    typeInto(controller.textareaTarget, 'new message sent immediately')
+
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ ok: true, status: 200, text: () => Promise.resolve('<div></div>') }),
+    )
+    controller.handleSend(new Event('submit', { cancelable: true }))
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(controller.textareaTarget.value).toBe('')
+    expect(chatDrafts.get('77')).toBeNull()
+  })
+
   test('send completion after an account change does not clear the new user draft', async () => {
     dispatchTopicChange('77')
     typeInto(controller.textareaTarget, 'user 9 message')
@@ -502,6 +535,28 @@ describe('FormController - draft persistence', () => {
     controller._restoreStashedDraft('/calendar 2026-08-14')
     expect(controller.textareaTarget.value).toBe('my draft')
     expect(chatDrafts.get('77')).toBe('my draft')
+  })
+
+  test('a message typed while a slash command is pending is saved on close', async () => {
+    dispatchTopicChange('77')
+    typeInto(controller.textareaTarget, 'my draft')
+    controller.handleStashDraft(
+      new CustomEvent('comments--form:stash-draft', { detail: { draft: 'my draft' } }),
+    )
+    typeInto(controller.textareaTarget, '/calendar 2026-08-14')
+
+    let finishFetch
+    global.fetch = jest.fn(() => new Promise((resolve) => { finishFetch = resolve }))
+    controller.handleSend(new Event('submit', { cancelable: true }))
+
+    typeInto(controller.textareaTarget, 'next message')
+    controller.onPopupClosed()
+    const savedOnClose = chatDrafts.get('77')
+
+    finishFetch({ ok: true, status: 200, text: () => Promise.resolve('<div></div>') })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    expect(savedOnClose).toBe('next message')
+    expect(chatDrafts.get('77')).toBe('next message')
   })
 
   test('review quote feedback never replaces the ordinary chat draft', async () => {

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_draft.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_draft.test.js
@@ -174,14 +174,11 @@ describe('FormController - draft persistence', () => {
   })
 
   test('a stale raw linked draft does not replace a newer effective draft', () => {
-    const now = Date.now()
-    window.localStorage.setItem(
-      'collavre_chat_drafts_9',
-      JSON.stringify({
-        70: { text: 'new canonical draft', updatedAt: now },
-        78: { text: 'stale raw draft', updatedAt: now - 1000 },
-      }),
-    )
+    let now = 1000
+    jest.spyOn(Date, 'now').mockImplementation(() => now)
+    chatDrafts.set('78', 'stale raw draft')
+    now += 1000
+    chatDrafts.set('70', 'new canonical draft')
 
     controller.onChatWillOpen({ creativeId: '78' })
     expect(controller.textareaTarget.value).toBe('stale raw draft')
@@ -198,13 +195,9 @@ describe('FormController - draft persistence', () => {
   test('clearing a raw linked draft removes an older canonical draft', () => {
     let now = 1000
     jest.spyOn(Date, 'now').mockImplementation(() => now)
-    window.localStorage.setItem(
-      'collavre_chat_drafts_9',
-      JSON.stringify({
-        70: { text: 'canonical draft', updatedAt: now },
-        78: { text: 'raw draft shown while loading', updatedAt: now - 1 },
-      }),
-    )
+    chatDrafts.set('70', 'canonical draft')
+    now += 1
+    chatDrafts.set('78', 'raw draft shown while loading')
 
     controller.onChatWillOpen({ creativeId: '78' })
     expect(controller.textareaTarget.value).toBe('raw draft shown while loading')
@@ -425,6 +418,29 @@ describe('FormController - draft persistence', () => {
 
     expect(controller.textareaTarget.value).toBe('draft updated outside this form')
     expect(chatDrafts.get('77')).toBe('draft updated outside this form')
+  })
+
+  test('successful send preserves a concurrent draft with the same timestamp', async () => {
+    jest.spyOn(Date, 'now').mockReturnValue(1000)
+    dispatchTopicChange('77')
+    typeInto(controller.textareaTarget, 'first message')
+    controller._flushDraftSave()
+
+    let finishFetch
+    global.fetch = jest.fn(() => new Promise((resolve) => { finishFetch = resolve }))
+    controller.handleSend(new Event('submit', { cancelable: true }))
+
+    const submittedRevision = chatDrafts.revision('77')
+    chatDrafts._append('77', {
+      text: 'same-millisecond concurrent draft',
+      updatedAt: chatDrafts.updatedAt('77'),
+      version: `${submittedRevision}-later`,
+    })
+    finishFetch({ ok: true, status: 200, text: () => Promise.resolve('<div></div>') })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(controller.textareaTarget.value).toBe('same-millisecond concurrent draft')
+    expect(chatDrafts.get('77')).toBe('same-millisecond concurrent draft')
   })
 
   test('successful send preserves a draft another tab saved before submission', async () => {

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_draft.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_draft.test.js
@@ -48,8 +48,17 @@ describe('FormController - draft persistence', () => {
     textarea.dispatchEvent(new Event('input', { bubbles: true }))
   }
 
+  const dismissAlert = () => {
+    document.querySelector('.modal-dialog-btn-primary')?.click()
+  }
+
+  const submissionBackup = (chatId) => (
+    chatDrafts.latestSubmissionBackup(chatId)?.text || null
+  )
+
   beforeEach(async () => {
     window.localStorage.clear()
+    window.sessionStorage.clear()
     document.body.dataset.currentUserId = '9'
 
     if (typeof global.requestAnimationFrame !== 'function') {
@@ -309,6 +318,64 @@ describe('FormController - draft persistence', () => {
     controller.connect()
   })
 
+  test('a failed in-flight send cannot recreate a draft after cross-tab logout', async () => {
+    dispatchTopicChange('77')
+    typeInto(controller.textareaTarget, 'old user submission')
+    let failFetch
+    global.fetch = jest.fn(() => new Promise((resolve) => { failFetch = resolve }))
+    controller.handleSend(new Event('submit', { cancelable: true }))
+
+    window.dispatchEvent(new StorageEvent('storage', {
+      key: 'collavre_chat_drafts_clear',
+      newValue: JSON.stringify({
+        namespace: 'collavre_chat_drafts_9',
+        nonce: 'another-tab-logout',
+      }),
+    }))
+    dispatchTopicChange('77')
+    controller.onPopupOpened({ creativeId: '77', canComment: true })
+    expect(controller.textareaTarget.value).toBe('')
+
+    failFetch({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve({ errors: ['boom'] }),
+    })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(controller.textareaTarget.value).toBe('')
+    expect(chatDrafts.get('77')).toBeNull()
+    expect(controller.sending).toBe(false)
+    dismissAlert()
+  })
+
+  test('an invalidated send success does not reset input entered after logout', async () => {
+    dispatchTopicChange('77')
+    typeInto(controller.textareaTarget, 'old user submission')
+    let finishFetch
+    global.fetch = jest.fn(() => new Promise((resolve) => { finishFetch = resolve }))
+    controller.handleSend(new Event('submit', { cancelable: true }))
+
+    window.dispatchEvent(new StorageEvent('storage', {
+      key: 'collavre_chat_drafts_clear',
+      newValue: JSON.stringify({
+        namespace: 'collavre_chat_drafts_9',
+        nonce: 'another-tab-logout',
+      }),
+    }))
+    document.body.dataset.currentUserId = '10'
+    dispatchTopicChange('77')
+    controller.onPopupOpened({ creativeId: '77', canComment: true })
+    typeInto(controller.textareaTarget, 'new input after logout')
+    controller._flushDraftSave()
+
+    finishFetch({ ok: true, status: 200, text: () => Promise.resolve('<div></div>') })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(controller.textareaTarget.value).toBe('new input after logout')
+    expect(chatDrafts.get('77')).toBe('new input after logout')
+  })
+
   test('an unrelated storage event leaves the active draft intact', () => {
     dispatchTopicChange('77')
     typeInto(controller.textareaTarget, 'still active')
@@ -334,6 +401,27 @@ describe('FormController - draft persistence', () => {
     controller.connect()
   })
 
+  test('same-tab logout invalidates an in-flight send before clearing drafts', async () => {
+    dispatchTopicChange('77')
+    typeInto(controller.textareaTarget, 'old user submission')
+    let failFetch
+    global.fetch = jest.fn(() => new Promise((resolve) => { failFetch = resolve }))
+    controller.handleSend(new Event('submit', { cancelable: true }))
+
+    controller.discardDraft()
+    chatDrafts.clearAll()
+    failFetch({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve({ errors: ['boom'] }),
+    })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(chatDrafts.get('77')).toBeNull()
+    expect(submissionBackup('77')).toBeNull()
+    expect(controller.textareaTarget.value).toBe('')
+  })
+
   test('losing comment permission preserves the saved draft through close', () => {
     dispatchTopicChange('77')
     controller.textareaTarget.value = 'permission changed'
@@ -357,6 +445,47 @@ describe('FormController - draft persistence', () => {
     controller.setCommentPermission(true)
     expect(controller.formTarget.style.display).toBe('')
     expect(controller.textareaTarget.value).toBe('permission changed')
+  })
+
+  test('permission loss preserves an undebounced submission when the send fails', async () => {
+    dispatchTopicChange('77')
+    typeInto(controller.textareaTarget, 'submission before permission loss')
+    let failFetch
+    global.fetch = jest.fn(() => new Promise((resolve) => { failFetch = resolve }))
+    controller.handleSend(new Event('submit', { cancelable: true }))
+
+    controller.setCommentPermission(false)
+    expect(chatDrafts.get('77')).toBeNull()
+    failFetch({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve({ errors: ['boom'] }),
+    })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(chatDrafts.get('77')).toBeNull()
+    expect(submissionBackup('77')).toBe('submission before permission loss')
+    controller.setCommentPermission(true)
+    expect(controller.textareaTarget.value).toBe('submission before permission loss')
+    dismissAlert()
+  })
+
+  test('permission loss preserves text entered after an in-flight submission', async () => {
+    dispatchTopicChange('77')
+    typeInto(controller.textareaTarget, 'first submitted message')
+    controller._flushDraftSave()
+    let finishFetch
+    global.fetch = jest.fn(() => new Promise((resolve) => { finishFetch = resolve }))
+    controller.handleSend(new Event('submit', { cancelable: true }))
+
+    typeInto(controller.textareaTarget, 'next message before permission loss')
+    controller.setCommentPermission(false)
+    finishFetch({ ok: true, status: 200, text: () => Promise.resolve('<div></div>') })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(chatDrafts.get('77')).toBe('next message before permission loss')
+    controller.setCommentPermission(true)
+    expect(controller.textareaTarget.value).toBe('next message before permission loss')
   })
 
   test('opening a read-only chat does not clear its saved draft on close', () => {
@@ -490,6 +619,43 @@ describe('FormController - draft persistence', () => {
     expect(chatDrafts.get('77')).toBe('newer draft from another tab')
   })
 
+  test('submission debounce does not overwrite a newer draft from another tab', async () => {
+    chatDrafts.set('77', 'shared starting draft')
+    dispatchTopicChange('77')
+    controller.onPopupOpened({ creativeId: '77', canComment: true })
+    typeInto(controller.textareaTarget, 'message submitted from this tab')
+    chatDrafts.set('77', 'newer draft from another tab')
+
+    let finishFetch
+    global.fetch = jest.fn(() => new Promise((resolve) => { finishFetch = resolve }))
+    controller.handleSend(new Event('submit', { cancelable: true }))
+    expect(chatDrafts.get('77')).toBe('newer draft from another tab')
+
+    finishFetch({ ok: true, status: 200, text: () => Promise.resolve('<div></div>') })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(controller.textareaTarget.value).toBe('newer draft from another tab')
+    expect(chatDrafts.get('77')).toBe('newer draft from another tab')
+  })
+
+  test('submission debounce preserves a same-text revision from another tab', async () => {
+    chatDrafts.set('77', 'shared starting draft')
+    dispatchTopicChange('77')
+    controller.onPopupOpened({ creativeId: '77', canComment: true })
+    typeInto(controller.textareaTarget, 'message submitted from this tab')
+    chatDrafts.set('77', 'other tab temporary change')
+    chatDrafts.set('77', 'shared starting draft')
+
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ ok: true, status: 200, text: () => Promise.resolve('<div></div>') }),
+    )
+    controller.handleSend(new Event('submit', { cancelable: true }))
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(controller.textareaTarget.value).toBe('shared starting draft')
+    expect(chatDrafts.get('77')).toBe('shared starting draft')
+  })
+
   test('an idle tab does not overwrite a draft changed by another tab on close', () => {
     chatDrafts.set('77', 'draft restored in both tabs')
     dispatchTopicChange('77')
@@ -529,6 +695,24 @@ describe('FormController - draft persistence', () => {
     expect(chatDrafts.get('77')).toBeNull()
   })
 
+  test('successful slow send does not restore the submitted text when its debounce fires', async () => {
+    dispatchTopicChange('77')
+    typeInto(controller.textareaTarget, 'message sent before debounce')
+    const saveDraft = jest.spyOn(chatDrafts, 'set')
+
+    let finishFetch
+    global.fetch = jest.fn(() => new Promise((resolve) => { finishFetch = resolve }))
+    controller.handleSend(new Event('submit', { cancelable: true }))
+
+    await new Promise((resolve) => setTimeout(resolve, 600))
+    expect(saveDraft).not.toHaveBeenCalled()
+    finishFetch({ ok: true, status: 200, text: () => Promise.resolve('<div></div>') })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(controller.textareaTarget.value).toBe('')
+    expect(chatDrafts.get('77')).toBeNull()
+  })
+
   test('send completion after an account change does not clear the new user draft', async () => {
     dispatchTopicChange('77')
     typeInto(controller.textareaTarget, 'user 9 message')
@@ -540,10 +724,13 @@ describe('FormController - draft persistence', () => {
 
     document.body.dataset.currentUserId = '10'
     chatDrafts.set('77', 'user 10 draft')
+    controller.resetForm()
+    controller._restoreDraft()
 
     finishFetch({ ok: true, status: 200, text: () => Promise.resolve('<div></div>') })
     await new Promise((resolve) => setTimeout(resolve, 20))
 
+    expect(controller.textareaTarget.value).toBe('user 10 draft')
     expect(chatDrafts.get('77')).toBe('user 10 draft')
     document.body.dataset.currentUserId = '9'
     expect(chatDrafts.get('77')).toBe('user 9 message')
@@ -566,6 +753,198 @@ describe('FormController - draft persistence', () => {
     )
     await new Promise((resolve) => setTimeout(resolve, 0))
     expect(chatDrafts.get('77')).toBe('will fail')
+  })
+
+  test('failed send persists input submitted before its debounce runs', async () => {
+    dispatchTopicChange('77')
+    typeInto(controller.textareaTarget, 'unsaved message that will fail')
+
+    const failedResponse = {
+      ok: false, status: 500, json: () => Promise.resolve({ errors: ['boom'] }),
+    }
+    global.fetch = jest.fn(() => Promise.resolve(failedResponse))
+    controller.handleSend(new Event('submit', { cancelable: true }))
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(submissionBackup('77')).toBe('unsaved message that will fail')
+  })
+
+  test('failed send replaces an older restored backup with the submitted text', async () => {
+    chatDrafts.saveSubmissionBackup('77', 'older failed submission')
+    dispatchTopicChange('77')
+    controller.onPopupOpened({ creativeId: '77', canComment: true })
+    typeInto(controller.textareaTarget, 'new submission that will fail')
+
+    const failedResponse = {
+      ok: false, status: 500, json: () => Promise.resolve({ errors: ['boom'] }),
+    }
+    global.fetch = jest.fn(() => Promise.resolve(failedResponse))
+    controller.handleSend(new Event('submit', { cancelable: true }))
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(submissionBackup('77')).toBe('new submission that will fail')
+    dismissAlert()
+
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ ok: true, status: 200, text: () => Promise.resolve('<div></div>') }),
+    )
+    controller.handleSend(new Event('submit', { cancelable: true }))
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    controller.resetForm()
+    controller._restoreDraft()
+
+    expect(submissionBackup('77')).toBeNull()
+    expect(controller.textareaTarget.value).toBe('')
+  })
+
+  test('failed send persists unsaved input after switching chats', async () => {
+    dispatchTopicChange('77')
+    typeInto(controller.textareaTarget, 'unsaved message from 77')
+
+    let failFetch
+    global.fetch = jest.fn(() => new Promise((resolve) => { failFetch = resolve }))
+    controller.handleSend(new Event('submit', { cancelable: true }))
+
+    controller.onChatWillOpen({ creativeId: '88' })
+    dispatchTopicChange('88')
+    controller.onPopupOpened({ creativeId: '88', canComment: true })
+
+    failFetch({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve({ errors: ['boom'] }),
+    })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(submissionBackup('77')).toBe('unsaved message from 77')
+    expect(controller.textareaTarget.value).toBe('')
+  })
+
+  test('pagehide does not persist an uncertain in-flight submission', async () => {
+    dispatchTopicChange('77')
+    typeInto(controller.textareaTarget, 'message leaving with the page')
+    let finishFetch
+    global.fetch = jest.fn(() => new Promise((resolve) => { finishFetch = resolve }))
+    controller.handleSend(new Event('submit', { cancelable: true }))
+
+    window.dispatchEvent(new PageTransitionEvent('pagehide'))
+
+    expect(chatDrafts.get('77')).toBeNull()
+    expect(submissionBackup('77')).toBeNull()
+    finishFetch({ ok: true, status: 200, text: () => Promise.resolve('<div></div>') })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(controller.textareaTarget.value).toBe('')
+    expect(chatDrafts.get('77')).toBeNull()
+    expect(submissionBackup('77')).toBeNull()
+  })
+
+  test('sending a restored submission backup clears its exact backup key', async () => {
+    chatDrafts.saveSubmissionBackup('77', 'restored submission')
+    dispatchTopicChange('77')
+    controller.onPopupOpened({ creativeId: '77', canComment: true })
+    expect(controller.textareaTarget.value).toBe('restored submission')
+
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ ok: true, status: 200, text: () => Promise.resolve('<div></div>') }),
+    )
+    controller.handleSend(new Event('submit', { cancelable: true }))
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(controller.textareaTarget.value).toBe('')
+    expect(submissionBackup('77')).toBeNull()
+  })
+
+  test('clearing a restored submission backup removes it permanently', () => {
+    chatDrafts.saveSubmissionBackup('77', 'failed submission to clear')
+    dispatchTopicChange('77')
+    controller.onPopupOpened({ creativeId: '77', canComment: true })
+    expect(controller.textareaTarget.value).toBe('failed submission to clear')
+
+    typeInto(controller.textareaTarget, '')
+    controller._flushDraftSave()
+    controller.resetForm()
+    controller._restoreDraft()
+
+    expect(submissionBackup('77')).toBeNull()
+    expect(controller.textareaTarget.value).toBe('')
+  })
+
+  test('pagehide does not claim a same-text draft saved by another tab', async () => {
+    chatDrafts.set('77', 'starting draft')
+    dispatchTopicChange('77')
+    controller.onPopupOpened({ creativeId: '77', canComment: true })
+    typeInto(controller.textareaTarget, 'same submitted and external text')
+
+    let finishFetch
+    global.fetch = jest.fn(() => new Promise((resolve) => { finishFetch = resolve }))
+    controller.handleSend(new Event('submit', { cancelable: true }))
+    chatDrafts.set('77', 'same submitted and external text')
+    const externalRevision = chatDrafts.revision('77')
+
+    window.dispatchEvent(new PageTransitionEvent('pagehide'))
+    finishFetch({ ok: true, status: 200, text: () => Promise.resolve('<div></div>') })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(chatDrafts.revision('77')).toBe(externalRevision)
+    expect(chatDrafts.get('77')).toBe('same submitted and external text')
+    expect(controller.textareaTarget.value).toBe('same submitted and external text')
+  })
+
+  test('pagehide does not overwrite a different draft saved by another tab', async () => {
+    chatDrafts.set('77', 'starting draft')
+    dispatchTopicChange('77')
+    controller.onPopupOpened({ creativeId: '77', canComment: true })
+    typeInto(controller.textareaTarget, 'submitted from this tab')
+
+    let finishFetch
+    global.fetch = jest.fn(() => new Promise((resolve) => { finishFetch = resolve }))
+    controller.handleSend(new Event('submit', { cancelable: true }))
+    chatDrafts.set('77', 'different draft from another tab')
+    const externalRevision = chatDrafts.revision('77')
+
+    window.dispatchEvent(new PageTransitionEvent('pagehide'))
+    finishFetch({ ok: true, status: 200, text: () => Promise.resolve('<div></div>') })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(chatDrafts.revision('77')).toBe(externalRevision)
+    expect(chatDrafts.get('77')).toBe('different draft from another tab')
+    expect(controller.textareaTarget.value).toBe('different draft from another tab')
+  })
+
+  test('successful send clears its restored backup after the user namespace changes', async () => {
+    const backupKey = chatDrafts.saveSubmissionBackup('77', 'old user submission')
+    dispatchTopicChange('77')
+    controller.onPopupOpened({ creativeId: '77', canComment: true })
+    let finishFetch
+    global.fetch = jest.fn(() => new Promise((resolve) => { finishFetch = resolve }))
+    controller.handleSend(new Event('submit', { cancelable: true }))
+
+    document.body.dataset.currentUserId = '10'
+    finishFetch({ ok: true, status: 200, text: () => Promise.resolve('<div></div>') })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(window.sessionStorage.getItem(backupKey)).toBeNull()
+  })
+
+  test('pagehide preserves an external draft detected when submission starts', async () => {
+    chatDrafts.set('77', 'starting draft')
+    dispatchTopicChange('77')
+    controller.onPopupOpened({ creativeId: '77', canComment: true })
+    typeInto(controller.textareaTarget, 'submitted from this tab')
+    chatDrafts.set('77', 'external draft present before submit')
+    const externalRevision = chatDrafts.revision('77')
+
+    let finishFetch
+    global.fetch = jest.fn(() => new Promise((resolve) => { finishFetch = resolve }))
+    controller.handleSend(new Event('submit', { cancelable: true }))
+    window.dispatchEvent(new PageTransitionEvent('pagehide'))
+    finishFetch({ ok: true, status: 200, text: () => Promise.resolve('<div></div>') })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(chatDrafts.revision('77')).toBe(externalRevision)
+    expect(chatDrafts.get('77')).toBe('external draft present before submit')
+    expect(controller.textareaTarget.value).toBe('external draft present before submit')
   })
 
   test('send completion after a chat switch clears only the submitted chat draft', async () => {
@@ -609,6 +988,71 @@ describe('FormController - draft persistence', () => {
     expect(controller.textareaTarget.value).toBe('')
     expect(chatDrafts.get('78')).toBeNull()
     expect(chatDrafts.get('70')).toBeNull()
+  })
+
+  test('linked-key migration rekeys a restored submission backup in flight', async () => {
+    delete popupEl.dataset.effectiveCreativeId
+    controller.onChatWillOpen({ creativeId: '78' })
+    chatDrafts.saveSubmissionBackup('78', 'failed submission before linked topics resolve')
+    controller.resetForm()
+    controller._restoreDraft()
+
+    let finishFetch
+    global.fetch = jest.fn(() => new Promise((resolve) => { finishFetch = resolve }))
+    controller.handleSend(new Event('submit', { cancelable: true }))
+
+    popupEl.dataset.creativeId = '78'
+    dispatchTopicChange('70')
+    controller.onPopupOpened({ creativeId: '78', canComment: true })
+    expect(submissionBackup('78')).toBeNull()
+    expect(submissionBackup('70')).toBe('failed submission before linked topics resolve')
+
+    finishFetch({ ok: true, status: 200, text: () => Promise.resolve('<div></div>') })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(controller.textareaTarget.value).toBe('')
+    expect(submissionBackup('70')).toBeNull()
+  })
+
+  test('linked-key migration moves a persisted backup without in-memory submission state', () => {
+    delete popupEl.dataset.effectiveCreativeId
+    controller.onChatWillOpen({ creativeId: '78' })
+    chatDrafts.saveSubmissionBackup('78', 'failed submission restored after reload')
+    controller._pendingDraftSubmissions.clear()
+    controller.resetForm()
+    controller._restoreDraft()
+
+    popupEl.dataset.creativeId = '78'
+    dispatchTopicChange('70')
+    controller.onPopupOpened({ creativeId: '78', canComment: true })
+
+    expect(submissionBackup('78')).toBeNull()
+    expect(submissionBackup('70')).toBe('failed submission restored after reload')
+    expect(controller.textareaTarget.value).toBe('failed submission restored after reload')
+  })
+
+  test('failed send restores an undebounced submission after linked-key migration', async () => {
+    delete popupEl.dataset.effectiveCreativeId
+    controller.onChatWillOpen({ creativeId: '78' })
+    typeInto(controller.textareaTarget, 'failed send before linked topics resolve')
+
+    let failFetch
+    global.fetch = jest.fn(() => new Promise((resolve) => { failFetch = resolve }))
+    controller.handleSend(new Event('submit', { cancelable: true }))
+
+    popupEl.dataset.creativeId = '78'
+    dispatchTopicChange('70')
+    controller.onPopupOpened({ creativeId: '78', canComment: true })
+    failFetch({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve({ errors: ['boom'] }),
+    })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(controller.textareaTarget.value).toBe('failed send before linked topics resolve')
+    expect(chatDrafts.get('78')).toBeNull()
+    expect(submissionBackup('70')).toBe('failed send before linked topics resolve')
   })
 
   test('raw-to-effective migration preserves a newer canonical draft during submission', async () => {
@@ -796,6 +1240,27 @@ describe('FormController - draft persistence', () => {
     dispatchTopicChange('77')
     controller.onPopupOpened({ creativeId: '77', canComment: true })
     expect(controller.textareaTarget.value).toBe('send before reconnect')
+
+    finishFetch({ ok: true, status: 200, text: () => Promise.resolve('<div></div>') })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(controller.textareaTarget.value).toBe('')
+    expect(chatDrafts.get('77')).toBeNull()
+  })
+
+  test('reconnecting before the submission debounce does not persist the sent message', async () => {
+    dispatchTopicChange('77')
+    typeInto(controller.textareaTarget, 'send before debounce and reconnect')
+
+    let finishFetch
+    global.fetch = jest.fn(() => new Promise((resolve) => { finishFetch = resolve }))
+    controller.handleSend(new Event('submit', { cancelable: true }))
+
+    controller.disconnect()
+    controller.connect()
+    dispatchTopicChange('77')
+    controller.onPopupOpened({ creativeId: '77', canComment: true })
+    expect(controller.textareaTarget.value).toBe('send before debounce and reconnect')
 
     finishFetch({ ok: true, status: 200, text: () => Promise.resolve('<div></div>') })
     await new Promise((resolve) => setTimeout(resolve, 20))

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_draft.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_draft.test.js
@@ -418,6 +418,29 @@ describe('FormController - draft persistence', () => {
     expect(chatDrafts.get('77')).toBe('newer draft from another tab')
   })
 
+  test('an idle tab does not overwrite a draft changed by another tab on close', () => {
+    chatDrafts.set('77', 'draft restored in both tabs')
+    dispatchTopicChange('77')
+    controller.onPopupOpened({ creativeId: '77', canComment: true })
+
+    chatDrafts.set('77', 'newer draft from another tab')
+    controller.onPopupClosed()
+
+    expect(chatDrafts.get('77')).toBe('newer draft from another tab')
+  })
+
+  test('local input after another tab change remains eligible to save', () => {
+    chatDrafts.set('77', 'draft restored in both tabs')
+    dispatchTopicChange('77')
+    controller.onPopupOpened({ creativeId: '77', canComment: true })
+
+    chatDrafts.set('77', 'draft from another tab')
+    typeInto(controller.textareaTarget, 'new local input')
+    controller.onPopupClosed()
+
+    expect(chatDrafts.get('77')).toBe('new local input')
+  })
+
   test('successful send clears this tab draft changed before its debounce runs', async () => {
     chatDrafts.set('77', 'older draft from this tab')
     dispatchTopicChange('77')

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_draft.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_draft.test.js
@@ -835,6 +835,23 @@ describe('FormController - draft persistence', () => {
     expect(chatDrafts.get('77')).toBeNull()
   })
 
+  test('successful send respects a concurrent clear instead of restoring pending text', async () => {
+    dispatchTopicChange('77')
+    typeInto(controller.textareaTarget, 'message cleared from another tab')
+    controller._flushDraftSave()
+
+    let finishFetch
+    global.fetch = jest.fn(() => new Promise((resolve) => { finishFetch = resolve }))
+    controller.handleSend(new Event('submit', { cancelable: true }))
+
+    chatDrafts.clear('77')
+    finishFetch({ ok: true, status: 200, text: () => Promise.resolve('<div></div>') })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(controller.textareaTarget.value).toBe('')
+    expect(chatDrafts.get('77')).toBeNull()
+  })
+
   test('send completion after an account change does not clear the new user draft', async () => {
     dispatchTopicChange('77')
     typeInto(controller.textareaTarget, 'user 9 message')

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_draft.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_draft.test.js
@@ -418,6 +418,57 @@ describe('FormController - draft persistence', () => {
     expect(submissionBackup('77')).toBeNull()
   })
 
+  test('a fresh controller clears submission backups from a missed logout once', async () => {
+    chatDrafts.saveSubmissionBackup('77', 'failed submission before logout')
+    window.localStorage.setItem('collavre_chat_drafts_clear', JSON.stringify({
+      namespace: 'collavre_chat_drafts_9',
+      nonce: 'missed-logout',
+    }))
+
+    controller.disconnect()
+    application.stop()
+    application = Application.start()
+    application.register('comments--form', FormController)
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    const freshController = application.getControllerForElementAndIdentifier(
+      popupEl,
+      'comments--form',
+    )
+
+    expect(freshController).not.toBe(controller)
+    expect(submissionBackup('77')).toBeNull()
+
+    chatDrafts.saveSubmissionBackup('77', 'failed submission after logout')
+    freshController.disconnect()
+    freshController.connect()
+
+    expect(submissionBackup('77')).toBe('failed submission after logout')
+    controller = freshController
+  })
+
+  test('a fresh controller retries missed logout cleanup after backup storage recovers', () => {
+    chatDrafts.saveSubmissionBackup('77', 'failed submission before logout')
+    window.localStorage.setItem('collavre_chat_drafts_clear', JSON.stringify({
+      namespace: 'collavre_chat_drafts_9',
+      nonce: 'missed-logout',
+    }))
+    controller.disconnect()
+    controller._observedDraftClearNonces.clear()
+    const storageGetter = jest.spyOn(window, 'sessionStorage', 'get').mockImplementation(() => {
+      throw new DOMException('denied', 'SecurityError')
+    })
+
+    controller.connect()
+    expect(controller._draftPersistenceDisabled()).toBe(true)
+
+    controller.disconnect()
+    storageGetter.mockRestore()
+    controller.connect()
+
+    expect(controller._draftPersistenceDisabled()).toBe(false)
+    expect(submissionBackup('77')).toBeNull()
+  })
+
   test('storage recovery does not treat an existing clear marker as a new logout', () => {
     controller.disconnect()
     chatDrafts.clearAll()

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_draft.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_draft.test.js
@@ -182,6 +182,18 @@ describe('FormController - draft persistence', () => {
     controller.connect()
   })
 
+  test('discarding drafts cancels a pending save and prevents disconnect from recreating it', async () => {
+    dispatchTopicChange('77')
+    typeInto(controller.textareaTarget, 'must be discarded')
+
+    controller.discardDraft()
+    controller.disconnect()
+    await new Promise((resolve) => setTimeout(resolve, 600))
+
+    expect(chatDrafts.get('77')).toBeNull()
+    controller.connect()
+  })
+
   test('losing comment permission flush-saves the draft', () => {
     dispatchTopicChange('77')
     controller.textareaTarget.value = 'permission changed'
@@ -206,6 +218,23 @@ describe('FormController - draft persistence', () => {
     await new Promise((resolve) => setTimeout(resolve, 0))
     expect(chatDrafts.get('77')).toBeNull()
     expect(controller.textareaTarget.value).toBe('')
+  })
+
+  test('successful send preserves newer text entered while the request is in flight', async () => {
+    dispatchTopicChange('77')
+    typeInto(controller.textareaTarget, 'first message')
+    controller._flushDraftSave()
+
+    let finishFetch
+    global.fetch = jest.fn(() => new Promise((resolve) => { finishFetch = resolve }))
+    controller.handleSend(new Event('submit', { cancelable: true }))
+
+    typeInto(controller.textareaTarget, 'next message')
+    finishFetch({ ok: true, status: 200, text: () => Promise.resolve('<div></div>') })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(controller.textareaTarget.value).toBe('next message')
+    expect(chatDrafts.get('77')).toBe('next message')
   })
 
   test('failed send keeps the stored draft', async () => {

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_draft.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_draft.test.js
@@ -374,9 +374,10 @@ describe('FormController - draft persistence', () => {
 
     controller.disconnect()
     chatDrafts.clearAll()
-    const clearSignal = window.localStorage.getItem('collavre_chat_drafts_clear')
+    const clearSignalKey = chatDrafts._clearEventKey()
+    const clearSignal = window.localStorage.getItem(clearSignalKey)
     window.dispatchEvent(new StorageEvent('storage', {
-      key: 'collavre_chat_drafts_clear',
+      key: clearSignalKey,
       newValue: clearSignal,
     }))
 
@@ -420,10 +421,13 @@ describe('FormController - draft persistence', () => {
 
   test('a fresh controller clears submission backups from a missed logout once', async () => {
     chatDrafts.saveSubmissionBackup('77', 'failed submission before logout')
-    window.localStorage.setItem('collavre_chat_drafts_clear', JSON.stringify({
+    window.localStorage.setItem(chatDrafts._clearEventKey(), JSON.stringify({
       namespace: 'collavre_chat_drafts_9',
       nonce: 'missed-logout',
     }))
+    document.body.dataset.currentUserId = '10'
+    chatDrafts.clearAll()
+    document.body.dataset.currentUserId = '9'
 
     controller.disconnect()
     application.stop()
@@ -443,6 +447,50 @@ describe('FormController - draft persistence', () => {
     freshController.connect()
 
     expect(submissionBackup('77')).toBe('failed submission after logout')
+    controller = freshController
+  })
+
+  test('a fresh controller suspends drafts until legacy marker promotion succeeds', async () => {
+    const namespace = chatDrafts.namespace()
+    const namespacedKey = chatDrafts._clearEventKey(namespace)
+    chatDrafts.saveSubmissionBackup('77', 'failed submission before logout')
+    window.localStorage.setItem(namespacedKey, JSON.stringify({
+      namespace,
+      nonce: 'logout-1',
+      legacyNamespace: namespace,
+      legacyNonce: 'logout-1',
+    }))
+    window.localStorage.setItem('collavre_chat_drafts_clear', JSON.stringify({
+      namespace,
+      nonce: 'logout-2',
+    }))
+    const originalSetItem = window.Storage.prototype.setItem
+    const setItem = jest.spyOn(window.Storage.prototype, 'setItem')
+      .mockImplementation(function(key, value) {
+	if (this === window.localStorage && key === namespacedKey) return
+	originalSetItem.call(this, key, value)
+      })
+
+    controller.disconnect()
+    application.stop()
+    application = Application.start()
+    application.register('comments--form', FormController)
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    const freshController = application.getControllerForElementAndIdentifier(
+      popupEl,
+      'comments--form',
+    )
+
+    expect(submissionBackup('77')).toBeNull()
+    expect(freshController._draftPersistenceDisabled()).toBe(true)
+    expect(freshController._observedDraftClearNonces.has(namespace)).toBe(false)
+
+    setItem.mockRestore()
+    freshController.disconnect()
+    freshController.connect()
+
+    expect(freshController._draftPersistenceDisabled()).toBe(false)
+    expect(freshController._observedDraftClearNonces.get(namespace)).toBe('logout-2')
     controller = freshController
   })
 

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_draft.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_draft.test.js
@@ -1365,6 +1365,49 @@ describe('FormController - draft persistence', () => {
     expect(chatDrafts.get('70')).toBeNull()
   })
 
+  test('an incomplete raw-to-effective move keeps the latest raw draft active', () => {
+    delete popupEl.dataset.effectiveCreativeId
+    chatDrafts.set('78', 'latest raw draft')
+    controller.onChatWillOpen({ creativeId: '78' })
+    jest.spyOn(chatDrafts, 'move').mockReturnValueOnce(false)
+
+    popupEl.dataset.creativeId = '78'
+    dispatchTopicChange('70')
+    controller.onPopupOpened({ creativeId: '78', canComment: true })
+
+    expect(controller._activeDraftKey).toBe('78')
+    expect(controller._awaitingEffectiveDraftKeyFor).toBe('78')
+    expect(controller.textareaTarget.value).toBe('latest raw draft')
+
+    dispatchTopicChange('70')
+    controller.onPopupOpened({ creativeId: '78', canComment: true })
+
+    expect(controller._activeDraftKey).toBe('70')
+    expect(controller._awaitingEffectiveDraftKeyFor).toBeNull()
+    expect(controller.textareaTarget.value).toBe('latest raw draft')
+    expect(chatDrafts.get('78')).toBeNull()
+    expect(chatDrafts.get('70')).toBe('latest raw draft')
+  })
+
+  test('an incomplete move restores a newer canonical draft', () => {
+    let now = 1000
+    jest.spyOn(Date, 'now').mockImplementation(() => now)
+    delete popupEl.dataset.effectiveCreativeId
+    chatDrafts.set('78', 'stale raw draft')
+    now += 1
+    chatDrafts.set('70', 'newer canonical draft')
+    controller.onChatWillOpen({ creativeId: '78' })
+    jest.spyOn(chatDrafts, 'move').mockReturnValue(false)
+
+    popupEl.dataset.creativeId = '78'
+    dispatchTopicChange('70')
+    controller.onPopupOpened({ creativeId: '78', canComment: true })
+
+    expect(controller._activeDraftKey).toBe('70')
+    expect(controller._awaitingEffectiveDraftKeyFor).toBeNull()
+    expect(controller.textareaTarget.value).toBe('newer canonical draft')
+  })
+
   test('send completion clears a target copied before the source marker fails', async () => {
     delete popupEl.dataset.effectiveCreativeId
     controller.onChatWillOpen({ creativeId: '78' })

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_draft.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_draft.test.js
@@ -195,6 +195,36 @@ describe('FormController - draft persistence', () => {
     expect(chatDrafts.get('78')).toBeNull()
   })
 
+  test('clearing a raw linked draft removes an older canonical draft', () => {
+    let now = 1000
+    jest.spyOn(Date, 'now').mockImplementation(() => now)
+    window.localStorage.setItem(
+      'collavre_chat_drafts_9',
+      JSON.stringify({
+        70: { text: 'canonical draft', updatedAt: now },
+        78: { text: 'raw draft shown while loading', updatedAt: now - 1 },
+      }),
+    )
+
+    controller.onChatWillOpen({ creativeId: '78' })
+    expect(controller.textareaTarget.value).toBe('raw draft shown while loading')
+
+    now += 1
+    typeInto(controller.textareaTarget, '')
+    controller._flushDraftSave()
+    const tombstoneUpdatedAt = chatDrafts.updatedAt('78')
+    controller._flushDraftSave()
+    expect(chatDrafts.updatedAt('78')).toBe(tombstoneUpdatedAt)
+
+    popupEl.dataset.creativeId = '78'
+    dispatchTopicChange('70')
+    controller.onPopupOpened({ creativeId: '78', canComment: true })
+
+    expect(controller.textareaTarget.value).toBe('')
+    expect(chatDrafts.get('70')).toBeNull()
+    expect(chatDrafts.get('78')).toBeNull()
+  })
+
   test('switching topics within the same chat does not flush the draft', () => {
     dispatchTopicChange('77', '10073')
     controller.textareaTarget.value = 'still composing'
@@ -254,6 +284,49 @@ describe('FormController - draft persistence', () => {
     controller.disconnect()
     expect(chatDrafts.get('77')).toBe('leaving the page')
     controller.connect()
+  })
+
+  test('native pagehide flushes input before the debounce completes', () => {
+    dispatchTopicChange('77')
+    typeInto(controller.textareaTarget, 'reload-safe draft')
+
+    window.dispatchEvent(new Event('pagehide'))
+
+    expect(chatDrafts.get('77')).toBe('reload-safe draft')
+  })
+
+  test('a cross-tab logout discards pending input for the signed-out user', async () => {
+    dispatchTopicChange('77')
+    chatDrafts.set('88', 'already saved in this tab')
+    typeInto(controller.textareaTarget, 'must not return after logout')
+
+    window.dispatchEvent(new StorageEvent('storage', {
+      key: 'collavre_chat_drafts_clear',
+      newValue: JSON.stringify({
+        namespace: 'collavre_chat_drafts_9',
+        nonce: 'another-tab-logout',
+      }),
+    }))
+    controller.disconnect()
+    await new Promise((resolve) => setTimeout(resolve, 600))
+
+    expect(controller.textareaTarget.value).toBe('')
+    expect(chatDrafts.get('77')).toBeNull()
+    expect(chatDrafts.get('88')).toBeNull()
+    controller.connect()
+  })
+
+  test('an unrelated storage event leaves the active draft intact', () => {
+    dispatchTopicChange('77')
+    typeInto(controller.textareaTarget, 'still active')
+
+    window.dispatchEvent(new StorageEvent('storage', {
+      key: 'unrelated',
+      newValue: 'x',
+    }))
+    window.dispatchEvent(new Event('pagehide'))
+
+    expect(chatDrafts.get('77')).toBe('still active')
   })
 
   test('discarding drafts cancels a pending save and prevents disconnect from recreating it', async () => {

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_draft.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_draft.test.js
@@ -861,6 +861,146 @@ describe('FormController - draft persistence', () => {
     expect(chatDrafts.get('77')).toBe('newest draft from another tab')
   })
 
+  test('failed send preserves newer text saved after the submission started', async () => {
+    jest.spyOn(Date, 'now').mockReturnValue(1000)
+    chatDrafts.set('77', 'older stored draft')
+    dispatchTopicChange('77')
+    controller.onPopupOpened({ creativeId: '77', canComment: true })
+    typeInto(controller.textareaTarget, 'submitted message that will fail')
+
+    let failFetch
+    global.fetch = jest.fn(() => new Promise((resolve) => { failFetch = resolve }))
+    controller.handleSend(new Event('submit', { cancelable: true }))
+
+    Date.now.mockReturnValue(2000)
+    typeInto(controller.textareaTarget, 'newer message after submission')
+    controller.onChatWillOpen({ creativeId: '88' })
+    popupEl.dataset.creativeId = '88'
+    dispatchTopicChange('88')
+    controller.onPopupOpened({ creativeId: '88', canComment: true })
+
+    Date.now.mockReturnValue(3000)
+    failFetch({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve({ errors: ['boom'] }),
+    })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(chatDrafts.get('77')).toBe('newer message after submission')
+    expect(submissionBackup('77')).toBeNull()
+
+    controller.onChatWillOpen({ creativeId: '77' })
+    popupEl.dataset.creativeId = '77'
+    dispatchTopicChange('77')
+    controller.onPopupOpened({ creativeId: '77', canComment: true })
+
+    expect(controller.textareaTarget.value).toBe('newer message after submission')
+  })
+
+  test('failed send preserves a cross-tab draft saved after submission', async () => {
+    dispatchTopicChange('77')
+    typeInto(controller.textareaTarget, 'submitted message that will fail')
+
+    let failFetch
+    global.fetch = jest.fn(() => new Promise((resolve) => { failFetch = resolve }))
+    controller.handleSend(new Event('submit', { cancelable: true }))
+
+    chatDrafts.set('77', 'newer draft from another tab')
+    controller.onChatWillOpen({ creativeId: '88' })
+    popupEl.dataset.creativeId = '88'
+    dispatchTopicChange('88')
+    controller.onPopupOpened({ creativeId: '88', canComment: true })
+
+    failFetch({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve({ errors: ['boom'] }),
+    })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(chatDrafts.get('77')).toBe('newer draft from another tab')
+    expect(submissionBackup('77')).toBeNull()
+
+    controller.onChatWillOpen({ creativeId: '77' })
+    popupEl.dataset.creativeId = '77'
+    dispatchTopicChange('77')
+    controller.onPopupOpened({ creativeId: '77', canComment: true })
+
+    expect(controller.textareaTarget.value).toBe('newer draft from another tab')
+  })
+
+  test('failed send respects a cross-tab clear after submission', async () => {
+    dispatchTopicChange('77')
+    typeInto(controller.textareaTarget, 'submitted message that will fail')
+
+    let failFetch
+    global.fetch = jest.fn(() => new Promise((resolve) => { failFetch = resolve }))
+    controller.handleSend(new Event('submit', { cancelable: true }))
+
+    chatDrafts.set('77', 'temporary draft from another tab')
+    chatDrafts.clear('77')
+    failFetch({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve({ errors: ['boom'] }),
+    })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(chatDrafts.get('77')).toBeNull()
+    expect(submissionBackup('77')).toBeNull()
+  })
+
+  test('failure backup keeps submission-time ordering across a late cross-tab write', async () => {
+    jest.spyOn(Date, 'now').mockReturnValue(1000)
+    dispatchTopicChange('77')
+    typeInto(controller.textareaTarget, 'submitted message that will fail')
+
+    const saveSubmissionBackup = chatDrafts.saveSubmissionBackup.bind(chatDrafts)
+    jest.spyOn(chatDrafts, 'saveSubmissionBackup').mockImplementation((...args) => {
+      chatDrafts.set('77', 'draft written during failure handling')
+      return saveSubmissionBackup(...args)
+    })
+    global.fetch = jest.fn(() => Promise.resolve({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve({ errors: ['boom'] }),
+    }))
+    controller.handleSend(new Event('submit', { cancelable: true }))
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    controller.resetForm()
+    controller._restoreDraft()
+
+    expect(controller.textareaTarget.value).toBe('draft written during failure handling')
+    expect(chatDrafts.get('77')).toBe('draft written during failure handling')
+    expect(submissionBackup('77')).toBeNull()
+  })
+
+  test('failed send does not mask a cross-tab draft observed at submission', async () => {
+    chatDrafts.set('77', 'shared starting draft')
+    dispatchTopicChange('77')
+    controller.onPopupOpened({ creativeId: '77', canComment: true })
+    typeInto(controller.textareaTarget, 'stale submitted message')
+    chatDrafts.set('77', 'draft from another tab before submission')
+
+    global.fetch = jest.fn(() => Promise.resolve({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve({ errors: ['boom'] }),
+    }))
+    controller.handleSend(new Event('submit', { cancelable: true }))
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(chatDrafts.get('77')).toBe('draft from another tab before submission')
+    expect(submissionBackup('77')).toBeNull()
+
+    controller.resetForm()
+    controller._restoreDraft()
+
+    expect(controller.textareaTarget.value).toBe('draft from another tab before submission')
+  })
+
   test('restores a regular draft newer than a failed-submission backup', () => {
     jest.spyOn(Date, 'now').mockReturnValue(1000)
     chatDrafts.saveSubmissionBackup('77', 'older failed submission')
@@ -1147,6 +1287,34 @@ describe('FormController - draft persistence', () => {
     expect(controller.textareaTarget.value).toBe('failed send before linked topics resolve')
     expect(chatDrafts.get('78')).toBeNull()
     expect(submissionBackup('70')).toBe('failed send before linked topics resolve')
+  })
+
+  test('failed linked send restores an edit of the migrated raw baseline', async () => {
+    delete popupEl.dataset.effectiveCreativeId
+    chatDrafts.set('78', 'stored raw baseline')
+    controller.onChatWillOpen({ creativeId: '78' })
+    expect(controller.textareaTarget.value).toBe('stored raw baseline')
+    typeInto(controller.textareaTarget, 'edited submission before debounce')
+
+    let failFetch
+    global.fetch = jest.fn(() => new Promise((resolve) => { failFetch = resolve }))
+    controller.handleSend(new Event('submit', { cancelable: true }))
+
+    popupEl.dataset.creativeId = '78'
+    dispatchTopicChange('70')
+    controller.onPopupOpened({ creativeId: '78', canComment: true })
+    failFetch({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve({ errors: ['boom'] }),
+    })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    controller.resetForm()
+    controller._restoreDraft()
+
+    expect(controller.textareaTarget.value).toBe('edited submission before debounce')
+    expect(submissionBackup('70')).toBe('edited submission before debounce')
   })
 
   test('raw-to-effective migration preserves a newer canonical draft during submission', async () => {

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/popup_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/popup_controller.test.js
@@ -13,6 +13,8 @@ describe('CommentsPopupController', () => {
     let controller
 
     beforeEach(() => {
+        window.localStorage.clear()
+        document.body.dataset.currentUserId = '9'
         container = document.createElement('div')
         container.innerHTML = `
       <div id="comments-popup" data-controller="comments--popup" data-fullscreen-url-template="/creatives/__CREATIVE_ID__/comments/fullscreen" style="width: 300px; height: 400px; position: absolute;">
@@ -24,6 +26,7 @@ describe('CommentsPopupController', () => {
         <div data-comments--popup-target="rightHandle"></div>
       </div>
       <button id="trigger-btn" data-creative-id="123" data-can-comment="true">Open</button>
+      <form id="logout-form" action="/session"></form>
     `
         document.body.appendChild(container)
 
@@ -41,6 +44,7 @@ describe('CommentsPopupController', () => {
 
     afterEach(() => {
         document.body.innerHTML = ''
+        delete document.body.dataset.currentUserId
         application.stop()
     })
 
@@ -599,6 +603,18 @@ describe('CommentsPopupController', () => {
         expect(listController.onPopupOpened).toHaveBeenCalledWith({
             creativeId: '456', highlightId: undefined, topicId: '7',
         })
+    })
+
+    test('logout submit clears popup size and chat drafts from localStorage', () => {
+        window.localStorage.setItem('commentsPopupSize', '{"w":300}')
+        window.localStorage.setItem('collavre_chat_drafts_9', '{"77":{"text":"x","updatedAt":1}}')
+
+        document.getElementById('logout-form').dispatchEvent(
+            new Event('submit', { bubbles: true, cancelable: true }),
+        )
+
+        expect(window.localStorage.getItem('commentsPopupSize')).toBeNull()
+        expect(window.localStorage.getItem('collavre_chat_drafts_9')).toBeNull()
     })
 
 })

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/popup_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/popup_controller.test.js
@@ -605,6 +605,38 @@ describe('CommentsPopupController', () => {
         })
     })
 
+    test('notifies the form of a chat switch before awaiting topics', async () => {
+        let finishTopicsLoad
+        const formController = {
+            currentTopicId: 'old-topic',
+            _mainTopicId: 'old-main',
+            onChatWillOpen: jest.fn(),
+            onPopupOpened: jest.fn(),
+        }
+        const topicsController = {
+            clearOverrideTopicId: jest.fn(),
+            currentTopicId: 'new-topic',
+            onPopupOpened: jest.fn(() => new Promise(resolve => { finishTopicsLoad = resolve })),
+        }
+        Object.defineProperty(controller, 'formController', { configurable: true, value: formController })
+        Object.defineProperty(controller, 'topicsController', { configurable: true, value: topicsController })
+
+        controller.openGeneration = 1
+        const pendingOpen = controller.notifyChildControllers({
+            creativeId: '456', canComment: true, openGeneration: 1,
+        })
+        await Promise.resolve()
+
+        expect(formController.onChatWillOpen).toHaveBeenCalledWith({ creativeId: '456' })
+        expect(formController.onPopupOpened).not.toHaveBeenCalled()
+
+        finishTopicsLoad()
+        await pendingOpen
+        expect(formController.onPopupOpened).toHaveBeenCalledWith({
+            creativeId: '456', canComment: true,
+        })
+    })
+
     test('logout submit clears popup size and chat drafts from localStorage', () => {
         window.localStorage.setItem('commentsPopupSize', '{"w":300}')
         window.localStorage.setItem('collavre_chat_drafts_9', '{"77":{"text":"x","updatedAt":1}}')

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/popup_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/popup_controller.test.js
@@ -6,6 +6,7 @@
 import { Application } from '@hotwired/stimulus'
 import { jest } from '@jest/globals'
 import CommentsPopupController from '../popup_controller'
+import chatDrafts from '../../../lib/chat_drafts'
 
 describe('CommentsPopupController', () => {
     let application
@@ -654,6 +655,30 @@ describe('CommentsPopupController', () => {
         expect(formController.discardDraft).toHaveBeenCalledTimes(1)
         expect(window.localStorage.getItem('commentsPopupSize')).toBeNull()
         expect(window.localStorage.getItem('collavre_chat_drafts_9')).toBeNull()
+    })
+
+    test('logout submit discards drafts when the localStorage getter is denied', () => {
+        const formController = { discardDraft: jest.fn() }
+        Object.defineProperty(controller, 'formController', {
+            configurable: true,
+            value: formController,
+        })
+        const storageGetter = jest.spyOn(window, 'localStorage', 'get').mockImplementation(() => {
+            throw new DOMException('Storage access denied', 'SecurityError')
+        })
+
+        try {
+            chatDrafts.set('77', 'private draft')
+
+            expect(() => document.getElementById('logout-form').dispatchEvent(
+                new Event('submit', { bubbles: true, cancelable: true }),
+            )).not.toThrow()
+
+            expect(formController.discardDraft).toHaveBeenCalledTimes(1)
+            expect(chatDrafts.get('77')).toBeNull()
+        } finally {
+            storageGetter.mockRestore()
+        }
     })
 
 })

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/popup_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/popup_controller.test.js
@@ -28,6 +28,7 @@ describe('CommentsPopupController', () => {
       </div>
       <button id="trigger-btn" data-creative-id="123" data-can-comment="true">Open</button>
       <form id="logout-form" action="/session"></form>
+      <form id="mounted-logout-form" action="/collavre/session"></form>
     `
         document.body.appendChild(container)
 
@@ -655,6 +656,23 @@ describe('CommentsPopupController', () => {
         expect(formController.discardDraft).toHaveBeenCalledTimes(1)
         expect(window.localStorage.getItem('commentsPopupSize')).toBeNull()
         expect(window.localStorage.getItem('collavre_chat_drafts_9')).toBeNull()
+    })
+
+    test('mounted logout submit clears chat drafts', () => {
+	chatDrafts.set('77', 'private draft')
+
+	const formController = { discardDraft: jest.fn() }
+	Object.defineProperty(controller, 'formController', {
+	    configurable: true,
+	    value: formController,
+	})
+
+	document.getElementById('mounted-logout-form').dispatchEvent(
+	    new Event('submit', { bubbles: true, cancelable: true }),
+	)
+
+	expect(formController.discardDraft).toHaveBeenCalledTimes(1)
+	expect(chatDrafts.get('77')).toBeNull()
     })
 
     test('logout submit discards drafts when the localStorage getter is denied', () => {

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/popup_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/popup_controller.test.js
@@ -609,10 +609,17 @@ describe('CommentsPopupController', () => {
         window.localStorage.setItem('commentsPopupSize', '{"w":300}')
         window.localStorage.setItem('collavre_chat_drafts_9', '{"77":{"text":"x","updatedAt":1}}')
 
+        const formController = { discardDraft: jest.fn() }
+        Object.defineProperty(controller, 'formController', {
+            configurable: true,
+            value: formController,
+        })
+
         document.getElementById('logout-form').dispatchEvent(
             new Event('submit', { bubbles: true, cancelable: true }),
         )
 
+        expect(formController.discardDraft).toHaveBeenCalledTimes(1)
         expect(window.localStorage.getItem('commentsPopupSize')).toBeNull()
         expect(window.localStorage.getItem('collavre_chat_drafts_9')).toBeNull()
     })

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -94,10 +94,16 @@ export default class extends Controller {
     // _activeDraftKey always identifies the chat whose text is in the textarea.
     this._activeDraftKey = null
     this._activeDraftCreativeId = null
+    this._awaitingEffectiveDraftKeyFor = null
     this._draftSaveTimer = null
     this._draftRevision = 0
     this._handleDraftInput = () => {
-      if (this.editingId || this._stashedDraft || !this._activeDraftKey) return
+      if (
+        this.editingId ||
+        this._stashedDraft ||
+        !this._reviewStore.isEmpty ||
+        !this._activeDraftKey
+      ) return
       this._draftRevision += 1
       clearTimeout(this._draftSaveTimer)
       this._draftSaveTimer = setTimeout(() => this._saveDraftNow(), 500)
@@ -140,11 +146,26 @@ export default class extends Controller {
     const draftKeyChanged = String(this._activeDraftKey || '') !== String(nextDraftKey || '')
     const creativeChanged =
       String(this._activeDraftCreativeId || '') !== String(nextCreativeId || '')
+    const resolvingIncomingDraftKey =
+      this._awaitingEffectiveDraftKeyFor &&
+      String(this._awaitingEffectiveDraftKeyFor) === String(nextCreativeId || '')
     if (draftKeyChanged || creativeChanged) {
+      const previousDraftKey = this._activeDraftKey
+      const incomingText = resolvingIncomingDraftKey ? this.textareaTarget.value : ''
       this._flushDraftSave()
       this._activeDraftKey = nextDraftKey ? String(nextDraftKey) : null
       this._activeDraftCreativeId = nextCreativeId ? String(nextCreativeId) : null
+      if (resolvingIncomingDraftKey && incomingText.trim() && this._activeDraftKey) {
+        chatDrafts.set(this._activeDraftKey, incomingText)
+        if (
+          previousDraftKey &&
+          String(previousDraftKey) !== String(this._activeDraftKey)
+        ) {
+          chatDrafts.clear(previousDraftKey)
+        }
+      }
     }
+    if (resolvingIncomingDraftKey) this._awaitingEffectiveDraftKeyFor = null
     this.currentTopicId = event.detail.topicId
     this._isInbox = event.detail.isInbox || false
     this._systemTopicId = event.detail.systemTopicId || null
@@ -198,6 +219,10 @@ export default class extends Controller {
     // so by the time we get here, currentTopicId already reflects the new
     // creative's restored topic. Do not re-clear it.
     this.formTarget.style.display = canComment ? '' : 'none'
+    // Capture input entered while topics were loading before reset clears it.
+    // Without a pending input timer, a blank textarea must not erase a draft
+    // that is waiting in storage to be restored below.
+    if (this._draftSaveTimer) this._flushDraftSave()
     this.resetForm()
     if (canComment && this.shouldAutoFocusOnOpen()) {
       requestAnimationFrame(() => this.textareaTarget.focus())
@@ -205,10 +230,29 @@ export default class extends Controller {
     this._restoreDraft()
   }
 
+  onChatWillOpen({ creativeId }) {
+    const nextCreativeId = creativeId ? String(creativeId) : null
+    if (
+      String(this._activeDraftCreativeId || '') === String(nextCreativeId || '')
+    ) return
+
+    // The popup publishes its raw creative id before awaiting topics. Flush the
+    // outgoing chat now, then give any input typed during that await a key owned
+    // by the incoming chat. The topics event replaces it with the effective id.
+    this._flushDraftSave()
+    this._activeDraftKey = nextCreativeId
+    this._activeDraftCreativeId = nextCreativeId
+    this._awaitingEffectiveDraftKeyFor = nextCreativeId
+    this.creativeId = creativeId
+    this.resetForm()
+    this._restoreDraft()
+  }
+
   onPopupClosed() {
     this._flushDraftSave()
     this._activeDraftKey = null
     this._activeDraftCreativeId = null
+    this._awaitingEffectiveDraftKeyFor = null
     this.stopSpeechRecognition()
     this.resetForm()
   }
@@ -218,6 +262,7 @@ export default class extends Controller {
     this._draftSaveTimer = null
     this._activeDraftKey = null
     this._activeDraftCreativeId = null
+    this._awaitingEffectiveDraftKeyFor = null
     this._stashedDraft = null
   }
 
@@ -317,7 +362,12 @@ export default class extends Controller {
   }
 
   _saveDraftNow() {
-    if (!this._activeDraftKey || this.editingId || this._stashedDraft) return
+    if (
+      !this._activeDraftKey ||
+      this.editingId ||
+      this._stashedDraft ||
+      !this._reviewStore.isEmpty
+    ) return
     chatDrafts.set(this._activeDraftKey, this.textareaTarget.value)
   }
 
@@ -395,8 +445,10 @@ export default class extends Controller {
     // failure that left the command text behind from text typed mid-flight.
     const submittedText = this.textareaTarget.value
     const submittedDraftKey = this._activeDraftKey
+    const submittedDraftNamespace = chatDrafts.namespace()
     const submittedEditingId = this.editingId
     const submittedDraftRevision = this._draftRevision
+    const submittedHadReview = hasQuotes
 
     const formData = new FormData(this.formTarget)
     const effectiveTopicId = this.currentTopicId || this._mainTopicId
@@ -440,12 +492,17 @@ export default class extends Controller {
         })
       })
       .then((html) => {
+        const ownsSubmittedDraftNamespace =
+          submittedDraftNamespace === chatDrafts.namespace()
         const switchedChats =
+          ownsSubmittedDraftNamespace &&
           submittedDraftKey &&
           this._activeDraftKey &&
           String(submittedDraftKey) !== String(this._activeDraftKey)
         const hasNewerDraft =
+          ownsSubmittedDraftNamespace &&
           !submittedEditingId &&
+          !submittedHadReview &&
           submittedDraftKey &&
           this._activeDraftKey &&
           String(submittedDraftKey) === String(this._activeDraftKey) &&
@@ -456,19 +513,21 @@ export default class extends Controller {
         this._draftSaveTimer = null
         this.resetForm()
         if (submittedEditingId) {
-          this._restoreDraft()
+          if (ownsSubmittedDraftNamespace) this._restoreDraft()
           // If editing, just replace the item in place
           this.renderCommentHtml(html, { replaceExisting: true })
         } else {
-          if (hasNewerDraft) {
+          if (submittedHadReview && ownsSubmittedDraftNamespace) {
+            this._restoreDraft()
+          } else if (hasNewerDraft) {
             this.textareaTarget.value = newerDraft
             this._autoResize()
             this._updateSubmitButton()
             chatDrafts.set(submittedDraftKey, newerDraft)
-          } else if (submittedDraftKey) {
+          } else if (submittedDraftKey && ownsSubmittedDraftNamespace) {
             chatDrafts.clear(submittedDraftKey)
           }
-          if (switchedChats) this._restoreDraft()
+          if (switchedChats && !submittedHadReview) this._restoreDraft()
           // New Comment:
           // 1. If we are in "History Mode" (scrolled up), sending a message should jump us to the latest.
           // 2. Ideally, we just reload the "Latest" page to ensure sync and Live Mode.
@@ -516,7 +575,11 @@ export default class extends Controller {
         inFlightSends.delete(sendKey)
         this._hasRetried = false
         this.setSendingState(false)
-        this._restoreStashedDraft(submittedText)
+        if (submittedDraftNamespace === chatDrafts.namespace()) {
+          this._restoreStashedDraft(submittedText)
+        } else {
+          this._stashedDraft = null
+        }
       })
   }
 
@@ -871,6 +934,7 @@ export default class extends Controller {
     if (!selectedText) return
 
     const store = this._reviewStore
+    if (store.isEmpty) this._flushDraftSave()
     store.saveActiveFeedback(this.textareaTarget.value)
 
     if (commentId) {

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -101,6 +101,7 @@ export default class extends Controller {
     // so its completion must keep comparing against the same draft history.
     this._draftRevisions ||= new Map()
     this._observedDrafts ||= new Map()
+    this._observedDisplayedDrafts ||= new Map()
     this._observedDraftRevisions ||= new Map()
     this._observedStoredDraftRevisions ||= new Map()
     // A linked chat can replace its temporary raw key while its request is in
@@ -455,13 +456,20 @@ export default class extends Controller {
     const observationKey = `${chatDrafts.namespace()}:${draftKey}`
     const hasObservedDraft = this._observedDrafts?.has(observationKey)
     const observedText = this._observedDrafts?.get(observationKey)
+    const hasObservedDisplayedDraft =
+      this._observedDisplayedDrafts?.has(observationKey)
+    const observedDisplayedText = hasObservedDisplayedDraft
+      ? this._observedDisplayedDrafts.get(observationKey)
+      : observedText
     const observedRevision = this._observedDraftRevisions?.get(observationKey) || 0
     const observedStoredRevision =
       this._observedStoredDraftRevisions?.get(observationKey) || null
     const currentRevision = this._draftRevisions?.get(observationKey) || 0
+    const displayedDraftChanged =
+      (hasObservedDisplayedDraft || hasObservedDraft) &&
+      (observedDisplayedText || '') !== text
     const draftChangedLocally =
-      currentRevision !== observedRevision ||
-      (hasObservedDraft && (observedText || '') !== text)
+      currentRevision !== observedRevision || displayedDraftChanged
     const storedDraftChangedOutsideController = hasObservedDraft && (
       observedText !== storedText || observedStoredRevision !== storedDraft.revision
     )
@@ -514,12 +522,22 @@ export default class extends Controller {
     if (this.textareaTarget.value.trim()) return
 
     const draft = chatDrafts.snapshot(this._activeDraftKey)
-    const backup = draft.text
-      ? null
-      : chatDrafts.latestSubmissionBackup(this._activeDraftKey)
-    this._observeDraft(this._activeDraftKey, draft.text, chatDrafts.namespace(), draft.revision)
-    if (draft.text || backup?.text) {
-      this.textareaTarget.value = draft.text || backup.text
+    const backup = chatDrafts.latestSubmissionBackup(this._activeDraftKey)
+    const restoreBackup = Boolean(
+      backup?.text &&
+      (draft.updatedAt === null || backup.updatedAt > draft.updatedAt),
+    )
+    if (backup && !restoreBackup) chatDrafts.removeSubmissionBackup(backup.key)
+    const restoredText = restoreBackup ? backup.text : draft.text
+    this._observeDraft(
+      this._activeDraftKey,
+      draft.text,
+      chatDrafts.namespace(),
+      draft.revision,
+      restoredText,
+    )
+    if (restoredText) {
+      this.textareaTarget.value = restoredText
       requestAnimationFrame(() => this._autoResize())
     } else {
       this._restorePendingSubmittedDraft()
@@ -548,6 +566,7 @@ export default class extends Controller {
     text,
     namespace = chatDrafts.namespace(),
     storedRevision,
+    displayedText,
   ) {
     if (!draftKey) return
     const storedDraft = storedRevision === undefined
@@ -555,6 +574,10 @@ export default class extends Controller {
       : { text, revision: storedRevision }
     const observationKey = `${namespace}:${draftKey}`
     this._observedDrafts?.set(observationKey, storedDraft.text)
+    this._observedDisplayedDrafts?.set(
+      observationKey,
+      displayedText === undefined ? storedDraft.text : displayedText,
+    )
     this._observedDraftRevisions?.set(
       observationKey,
       this._draftRevisions?.get(observationKey) || 0,

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -93,6 +93,7 @@ export default class extends Controller {
     // Draft persistence: debounce-save unsent input per chat.
     // _activeDraftKey always identifies the chat whose text is in the textarea.
     this._activeDraftKey = null
+    this._activeDraftCreativeId = null
     this._draftSaveTimer = null
     this._handleDraftInput = () => {
       if (this.editingId || this._stashedDraft || !this._activeDraftKey) return
@@ -133,9 +134,14 @@ export default class extends Controller {
     // textarea still contains the outgoing chat's text. Flush before re-keying.
     const nextDraftKey =
       this.element.dataset.effectiveCreativeId || this.element.dataset.creativeId || null
-    if (String(this._activeDraftKey || '') !== String(nextDraftKey || '')) {
+    const nextCreativeId = this.element.dataset.creativeId || null
+    const draftKeyChanged = String(this._activeDraftKey || '') !== String(nextDraftKey || '')
+    const creativeChanged =
+      String(this._activeDraftCreativeId || '') !== String(nextCreativeId || '')
+    if (draftKeyChanged || creativeChanged) {
       this._flushDraftSave()
       this._activeDraftKey = nextDraftKey ? String(nextDraftKey) : null
+      this._activeDraftCreativeId = nextCreativeId ? String(nextCreativeId) : null
     }
     this.currentTopicId = event.detail.topicId
     this._isInbox = event.detail.isInbox || false
@@ -200,6 +206,7 @@ export default class extends Controller {
   onPopupClosed() {
     this._flushDraftSave()
     this._activeDraftKey = null
+    this._activeDraftCreativeId = null
     this.stopSpeechRecognition()
     this.resetForm()
   }
@@ -378,6 +385,7 @@ export default class extends Controller {
     // failure that left the command text behind from text typed mid-flight.
     const submittedText = this.textareaTarget.value
     const submittedDraftKey = this._activeDraftKey
+    const submittedEditingId = this.editingId
 
     const formData = new FormData(this.formTarget)
     const effectiveTopicId = this.currentTopicId || this._mainTopicId
@@ -391,8 +399,8 @@ export default class extends Controller {
 
     let url = `/creatives/${this.creativeId}/comments`
     let method = 'POST'
-    if (this.editingId) {
-      url += `/${this.editingId}`
+    if (submittedEditingId) {
+      url += `/${submittedEditingId}`
       method = 'PATCH'
     }
 
@@ -421,14 +429,13 @@ export default class extends Controller {
         })
       })
       .then((html) => {
-        const wasEditing = this.editingId
         const switchedChats =
           submittedDraftKey &&
           this._activeDraftKey &&
           String(submittedDraftKey) !== String(this._activeDraftKey)
         if (switchedChats) this._flushDraftSave()
         this.resetForm()
-        if (wasEditing) {
+        if (submittedEditingId) {
           this._restoreDraft()
           // If editing, just replace the item in place
           this.renderCommentHtml(html, { replaceExisting: true })

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -377,6 +377,7 @@ export default class extends Controller {
     // going to the server. _restoreStashedDraft compares against it to tell a
     // failure that left the command text behind from text typed mid-flight.
     const submittedText = this.textareaTarget.value
+    const submittedDraftKey = this._activeDraftKey
 
     const formData = new FormData(this.formTarget)
     const effectiveTopicId = this.currentTopicId || this._mainTopicId
@@ -421,6 +422,11 @@ export default class extends Controller {
       })
       .then((html) => {
         const wasEditing = this.editingId
+        const switchedChats =
+          submittedDraftKey &&
+          this._activeDraftKey &&
+          String(submittedDraftKey) !== String(this._activeDraftKey)
+        if (switchedChats) this._flushDraftSave()
         this.resetForm()
         if (wasEditing) {
           this._restoreDraft()
@@ -428,7 +434,8 @@ export default class extends Controller {
           this.renderCommentHtml(html, { replaceExisting: true })
         } else {
           clearTimeout(this._draftSaveTimer)
-          if (this._activeDraftKey) chatDrafts.clear(this._activeDraftKey)
+          if (submittedDraftKey) chatDrafts.clear(submittedDraftKey)
+          if (switchedChats) this._restoreDraft()
           // New Comment:
           // 1. If we are in "History Mode" (scrolled up), sending a message should jump us to the latest.
           // 2. Ideally, we just reload the "Latest" page to ensure sync and Live Mode.

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -95,8 +95,10 @@ export default class extends Controller {
     this._activeDraftKey = null
     this._activeDraftCreativeId = null
     this._draftSaveTimer = null
+    this._draftRevision = 0
     this._handleDraftInput = () => {
       if (this.editingId || this._stashedDraft || !this._activeDraftKey) return
+      this._draftRevision += 1
       clearTimeout(this._draftSaveTimer)
       this._draftSaveTimer = setTimeout(() => this._saveDraftNow(), 500)
     }
@@ -209,6 +211,14 @@ export default class extends Controller {
     this._activeDraftCreativeId = null
     this.stopSpeechRecognition()
     this.resetForm()
+  }
+
+  discardDraft() {
+    clearTimeout(this._draftSaveTimer)
+    this._draftSaveTimer = null
+    this._activeDraftKey = null
+    this._activeDraftCreativeId = null
+    this._stashedDraft = null
   }
 
   setCommentPermission(canComment) {
@@ -386,6 +396,7 @@ export default class extends Controller {
     const submittedText = this.textareaTarget.value
     const submittedDraftKey = this._activeDraftKey
     const submittedEditingId = this.editingId
+    const submittedDraftRevision = this._draftRevision
 
     const formData = new FormData(this.formTarget)
     const effectiveTopicId = this.currentTopicId || this._mainTopicId
@@ -433,15 +444,30 @@ export default class extends Controller {
           submittedDraftKey &&
           this._activeDraftKey &&
           String(submittedDraftKey) !== String(this._activeDraftKey)
+        const hasNewerDraft =
+          !submittedEditingId &&
+          submittedDraftKey &&
+          this._activeDraftKey &&
+          String(submittedDraftKey) === String(this._activeDraftKey) &&
+          this._draftRevision !== submittedDraftRevision
+        const newerDraft = hasNewerDraft ? this.textareaTarget.value : null
         if (switchedChats) this._flushDraftSave()
+        clearTimeout(this._draftSaveTimer)
+        this._draftSaveTimer = null
         this.resetForm()
         if (submittedEditingId) {
           this._restoreDraft()
           // If editing, just replace the item in place
           this.renderCommentHtml(html, { replaceExisting: true })
         } else {
-          clearTimeout(this._draftSaveTimer)
-          if (submittedDraftKey) chatDrafts.clear(submittedDraftKey)
+          if (hasNewerDraft) {
+            this.textareaTarget.value = newerDraft
+            this._autoResize()
+            this._updateSubmitButton()
+            chatDrafts.set(submittedDraftKey, newerDraft)
+          } else if (submittedDraftKey) {
+            chatDrafts.clear(submittedDraftKey)
+          }
           if (switchedChats) this._restoreDraft()
           // New Comment:
           // 1. If we are in "History Mode" (scrolled up), sending a message should jump us to the latest.

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -462,7 +462,6 @@ export default class extends Controller {
     const draftKey = this._activeDraftKey
     const text = this.textareaTarget.value
     const blank = !text.trim()
-    const preserveBlank = blank && Boolean(this._awaitingEffectiveDraftKeyFor)
     const storedDraft = chatDrafts.snapshot(draftKey)
     const storedText = storedDraft.text
     const hasStoredEntry = chatDrafts.updatedAt(draftKey) !== null
@@ -478,11 +477,14 @@ export default class extends Controller {
     const observedStoredRevision =
       this._observedStoredDraftRevisions?.get(observationKey) || null
     const currentRevision = this._draftRevisions?.get(observationKey) || 0
+    const inputChangedLocally = currentRevision !== observedRevision
+    const preserveBlank =
+      blank && Boolean(this._awaitingEffectiveDraftKeyFor) && inputChangedLocally
     const displayedDraftChanged =
       (hasObservedDisplayedDraft || hasObservedDraft) &&
       (observedDisplayedText || '') !== text
     const draftChangedLocally =
-      currentRevision !== observedRevision || displayedDraftChanged
+      inputChangedLocally || displayedDraftChanged
     const storedDraftChangedOutsideController = hasObservedDraft && (
       observedText !== storedText || observedStoredRevision !== storedDraft.revision
     )

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -181,6 +181,7 @@ export default class extends Controller {
     const resolvingIncomingDraftKey =
       this._awaitingEffectiveDraftKeyFor &&
       String(this._awaitingEffectiveDraftKeyFor) === String(nextCreativeId || '')
+    let keepAwaitingEffectiveDraftKey = false
     if (draftKeyChanged || creativeChanged) {
       const previousDraftKey = this._activeDraftKey
       // onChatWillOpen already flushed the outgoing chat. While the effective
@@ -195,13 +196,12 @@ export default class extends Controller {
         this._activeDraftKey
       ) {
         const sourceDraft = chatDrafts.snapshot(previousDraftKey)
-        chatDrafts.move(previousDraftKey, this._activeDraftKey)
+	const moveCompleted = chatDrafts.move(previousDraftKey, this._activeDraftKey)
         const targetDraft = chatDrafts.snapshot(this._activeDraftKey)
-        const movedBackups = chatDrafts.moveSubmissionBackups(
-          previousDraftKey,
-          this._activeDraftKey,
-        )
-        if (targetDraft.revision || !sourceDraft.revision) {
+	const movedBackups = moveCompleted
+	  ? chatDrafts.moveSubmissionBackups(previousDraftKey, this._activeDraftKey)
+	  : new Map()
+	if (moveCompleted && (targetDraft.revision || !sourceDraft.revision)) {
           this._rebindPendingDraftSubmissions(
             previousDraftKey,
             this._activeDraftKey,
@@ -209,10 +209,23 @@ export default class extends Controller {
             targetDraft,
             movedBackups,
           )
+	} else if (!moveCompleted) {
+	  this._trackPartialDraftMigration(
+	    previousDraftKey,
+	    this._activeDraftKey,
+	    sourceDraft,
+	    targetDraft,
+	  )
+	  if (chatDrafts.isNewer(previousDraftKey, this._activeDraftKey)) {
+	    this._activeDraftKey = String(previousDraftKey)
+	    keepAwaitingEffectiveDraftKey = true
+	  }
         }
       }
     }
-    if (resolvingIncomingDraftKey) this._awaitingEffectiveDraftKeyFor = null
+    if (resolvingIncomingDraftKey && !keepAwaitingEffectiveDraftKey) {
+      this._awaitingEffectiveDraftKeyFor = null
+    }
     this.currentTopicId = event.detail.topicId
     this._isInbox = event.detail.isInbox || false
     this._systemTopicId = event.detail.systemTopicId || null
@@ -630,6 +643,30 @@ export default class extends Controller {
       if (submission.backupKey && movedBackups.has(submission.backupKey)) {
         submission.backupKey = movedBackups.get(submission.backupKey)
       }
+    })
+  }
+
+  _trackPartialDraftMigration(sourceKey, targetKey, sourceDraft, targetDraft) {
+    if (
+      !sourceDraft.revision ||
+      targetDraft.revision !== sourceDraft.revision
+    ) return
+
+    const namespace = chatDrafts.namespace()
+    this._pendingDraftSubmissions?.forEach((submission) => {
+      if (
+	submission.namespace !== namespace ||
+	String(submission.key) !== String(sourceKey) ||
+	submission.hadStash ||
+	submission.hadReview ||
+	submission.editing ||
+	submission.storedRevision !== sourceDraft.revision
+      ) return
+
+      submission.migratedSources.push({
+	key: String(targetKey),
+	revision: targetDraft.revision,
+      })
     })
   }
 

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -98,6 +98,16 @@ export default class extends Controller {
     this._draftSaveTimer = null
     this._draftRevisions = new Map()
     this._observedDrafts = new Map()
+    this._handlePageHide = () => {
+      if (this.element.isConnected) this._flushDraftSave()
+    }
+    this._handleDraftStorage = (event) => {
+      if (!this.element.isConnected || !chatDrafts.wasCleared(event)) return
+
+      this.discardDraft()
+      // A timer in this tab may have raced with the logout tab's first clear.
+      chatDrafts.clearAll({ broadcast: false })
+    }
     this._handleDraftInput = () => {
       if (
         this.editingId ||
@@ -111,6 +121,8 @@ export default class extends Controller {
       this._draftSaveTimer = setTimeout(() => this._saveDraftNow(), 500)
     }
     this.textareaTarget.addEventListener('input', this._handleDraftInput)
+    window.addEventListener('pagehide', this._handlePageHide)
+    window.addEventListener('storage', this._handleDraftStorage)
 
     this.textareaTarget.addEventListener('keydown', (event) => {
       if (event.key === 'Escape') {
@@ -185,6 +197,8 @@ export default class extends Controller {
   disconnect() {
     this._flushDraftSave()
     this.textareaTarget.removeEventListener('input', this._handleDraftInput)
+    window.removeEventListener('pagehide', this._handlePageHide)
+    window.removeEventListener('storage', this._handleDraftStorage)
     this.formTarget.removeEventListener('submit', this.handleSubmit)
     this.submitTarget.removeEventListener('click', this.handleSend)
     this.submitTarget.removeEventListener('pointerup', this.handlePointerSend)
@@ -266,6 +280,7 @@ export default class extends Controller {
     this._activeDraftCreativeId = null
     this._awaitingEffectiveDraftKeyFor = null
     this._stashedDraft = null
+    this.resetForm()
   }
 
   setCommentPermission(canComment) {
@@ -387,11 +402,22 @@ export default class extends Controller {
       this._shouldSuppressDraftSaveForStash() ||
       !this._reviewStore.isEmpty
     ) return
+    const draftKey = this._activeDraftKey
     const text = this.textareaTarget.value
-    if (chatDrafts.get(this._activeDraftKey) !== text) {
-      chatDrafts.set(this._activeDraftKey, text)
+    const blank = !text.trim()
+    const preserveBlank = blank && Boolean(this._awaitingEffectiveDraftKeyFor)
+    const storedText = chatDrafts.get(draftKey)
+    const hasStoredEntry = chatDrafts.updatedAt(draftKey) !== null
+    if (preserveBlank) {
+      if (storedText !== null || !hasStoredEntry) {
+        chatDrafts.set(draftKey, '', { preserveBlank: true })
+      }
+    } else if (blank) {
+      if (hasStoredEntry) chatDrafts.clear(draftKey)
+    } else if (storedText !== text) {
+      chatDrafts.set(draftKey, text)
     }
-    this._observeDraft(this._activeDraftKey, chatDrafts.get(this._activeDraftKey))
+    this._observeDraft(draftKey, chatDrafts.get(draftKey))
   }
 
   _flushDraftSave() {

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -540,8 +540,8 @@ export default class extends Controller {
     const submittedEditingId = this.editingId
     const submittedDraftKeyRevision = this._draftRevisions?.get(submittedDraftRevisionKey) || 0
     const submittedHadReview = hasQuotes
-    const submittedDraftUpdatedAt = submittedDraftKey
-      ? chatDrafts.updatedAt(submittedDraftKey)
+    const submittedDraftStoredRevision = submittedDraftKey
+      ? chatDrafts.revision(submittedDraftKey)
       : null
     if (this._stashedDraftBelongsToCurrentCreative()) {
       this._stashedDraft.submittedText = submittedText
@@ -616,7 +616,7 @@ export default class extends Controller {
             (this._draftRevisions?.get(submittedDraftRevisionKey) || 0) !==
               submittedDraftKeyRevision ||
             submittedStoredDraftChangedOutsideController ||
-            chatDrafts.updatedAt(submittedDraftKey) !== submittedDraftUpdatedAt
+            chatDrafts.revision(submittedDraftKey) !== submittedDraftStoredRevision
           )
         const hasNewerDraft = hasNewerActiveDraft || hasNewerStoredDraft
         const newerDraft = hasNewerActiveDraft ? this.textareaTarget.value : null

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -97,10 +97,11 @@ export default class extends Controller {
     this._awaitingEffectiveDraftKeyFor = null
     this._draftSaveTimer = null
     this._draftRevisions = new Map()
+    this._observedDrafts = new Map()
     this._handleDraftInput = () => {
       if (
         this.editingId ||
-        this._stashedDraftBelongsToCurrentCreative() ||
+        this._shouldSuppressDraftSaveForStash() ||
         !this._reviewStore.isEmpty ||
         !this._activeDraftKey
       ) return
@@ -327,6 +328,16 @@ export default class extends Controller {
     )
   }
 
+  _shouldSuppressDraftSaveForStash() {
+    if (!this._stashedDraftBelongsToCurrentCreative()) return false
+
+    // Before handleSend captures the command, the command-menu input event
+    // must not replace the stashed ordinary draft. Once the send starts, only
+    // the submitted command remains suppressed; later input is a new draft.
+    return !this._stashedDraft.submittedText ||
+      this.textareaTarget.value === this._stashedDraft.submittedText
+  }
+
   _restoreStashedDraft(submittedText) {
     const stashed = this._stashedDraft
     this._stashedDraft = null
@@ -373,12 +384,14 @@ export default class extends Controller {
     if (
       !this._activeDraftKey ||
       this.editingId ||
-      this._stashedDraftBelongsToCurrentCreative() ||
+      this._shouldSuppressDraftSaveForStash() ||
       !this._reviewStore.isEmpty
     ) return
     const text = this.textareaTarget.value
-    if (chatDrafts.get(this._activeDraftKey) === text) return
-    chatDrafts.set(this._activeDraftKey, text)
+    if (chatDrafts.get(this._activeDraftKey) !== text) {
+      chatDrafts.set(this._activeDraftKey, text)
+    }
+    this._observeDraft(this._activeDraftKey, chatDrafts.get(this._activeDraftKey))
   }
 
   _flushDraftSave() {
@@ -392,10 +405,17 @@ export default class extends Controller {
     if (this.textareaTarget.value.trim()) return
 
     const draft = chatDrafts.get(this._activeDraftKey)
+    this._observeDraft(this._activeDraftKey, draft)
     if (draft) {
       this.textareaTarget.value = draft
       requestAnimationFrame(() => this._autoResize())
     }
+  }
+
+  _observeDraft(draftKey, text, namespace = chatDrafts.namespace()) {
+    if (!draftKey) return
+    const observationKey = `${namespace}:${draftKey}`
+    this._observedDrafts?.set(observationKey, text)
   }
 
   setSendingState(isSending) {
@@ -457,12 +477,21 @@ export default class extends Controller {
     const submittedDraftKey = this._activeDraftKey
     const submittedDraftNamespace = chatDrafts.namespace()
     const submittedDraftRevisionKey = `${submittedDraftNamespace}:${submittedDraftKey}`
+    const submittedStoredDraftText = submittedDraftKey
+      ? chatDrafts.get(submittedDraftKey)
+      : null
+    const submittedStoredDraftChangedOutsideController =
+      this._observedDrafts?.has(submittedDraftRevisionKey) &&
+      this._observedDrafts.get(submittedDraftRevisionKey) !== submittedStoredDraftText
     const submittedEditingId = this.editingId
     const submittedDraftKeyRevision = this._draftRevisions?.get(submittedDraftRevisionKey) || 0
     const submittedHadReview = hasQuotes
     const submittedDraftUpdatedAt = submittedDraftKey
       ? chatDrafts.updatedAt(submittedDraftKey)
       : null
+    if (this._stashedDraftBelongsToCurrentCreative()) {
+      this._stashedDraft.submittedText = submittedText
+    }
 
     const formData = new FormData(this.formTarget)
     const effectiveTopicId = this.currentTopicId || this._mainTopicId
@@ -532,6 +561,7 @@ export default class extends Controller {
           (
             (this._draftRevisions?.get(submittedDraftRevisionKey) || 0) !==
               submittedDraftKeyRevision ||
+            submittedStoredDraftChangedOutsideController ||
             chatDrafts.updatedAt(submittedDraftKey) !== submittedDraftUpdatedAt
           )
         const hasNewerDraft = hasNewerActiveDraft || hasNewerStoredDraft
@@ -552,10 +582,12 @@ export default class extends Controller {
             this._autoResize()
             this._updateSubmitButton()
             chatDrafts.set(submittedDraftKey, newerDraft)
+            this._observeDraft(submittedDraftKey, newerDraft, submittedDraftNamespace)
           } else if (hasNewerStoredDraft && submittedChatStillActive) {
             this._restoreDraft()
           } else if (!hasNewerDraft && submittedDraftKey && ownsSubmittedDraftNamespace) {
             chatDrafts.clear(submittedDraftKey)
+            this._observeDraft(submittedDraftKey, null, submittedDraftNamespace)
           }
           if (switchedChats && !submittedHadReview) this._restoreDraft()
           // New Comment:

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -37,14 +37,14 @@ export default class extends Controller {
 
   connect() {
     this.creativeId = null
-    this.editingId = null
+    this.editingId ??= null
     this.sending = false
-    this._reviewStore = new ReviewQuotesStore()
+    this._reviewStore ||= new ReviewQuotesStore()
     this.cachedImageFiles = null
 
     this.handleSubmit = this.handleSubmit.bind(this)
     this.handleSend = this.handleSend.bind(this)
-    this.defaultSubmitHTML = this.submitTarget.innerHTML
+    this.defaultSubmitHTML ??= this.submitTarget.innerHTML
     this.handlePointerSend = this.handlePointerSend.bind(this)
     this.handleTouchSend = this.handleTouchSend.bind(this)
     this.handleCancel = this.handleCancel.bind(this)

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -96,6 +96,7 @@ export default class extends Controller {
     this._activeDraftCreativeId = null
     this._awaitingEffectiveDraftKeyFor = null
     this._draftSaveTimer = null
+    this._draftSaveSuspendedForPermission = false
     this._draftRevisions = new Map()
     this._observedDrafts = new Map()
     this._observedDraftRevisions = new Map()
@@ -112,6 +113,7 @@ export default class extends Controller {
     this._handleDraftInput = () => {
       if (
         this.editingId ||
+        this._draftSaveSuspendedForPermission ||
         this._shouldSuppressDraftSaveForStash() ||
         !this._reviewStore.isEmpty ||
         !this._activeDraftKey
@@ -231,6 +233,7 @@ export default class extends Controller {
   onPopupOpened({ creativeId, canComment }) {
     this.creativeId = creativeId
     this.element.dataset.creativeId = creativeId || ''
+    if (canComment) this._draftSaveSuspendedForPermission = false
     // Stale topic ids from the previous creative are cleared by the popup
     // controller BEFORE topics loadTopics() dispatches comments--topics:change,
     // so by the time we get here, currentTopicId already reflects the new
@@ -241,6 +244,7 @@ export default class extends Controller {
     // that is waiting in storage to be restored below.
     if (this._draftSaveTimer) this._flushDraftSave()
     this.resetForm()
+    this._draftSaveSuspendedForPermission = !canComment
     if (canComment && this.shouldAutoFocusOnOpen()) {
       requestAnimationFrame(() => this.textareaTarget.focus())
     }
@@ -289,11 +293,14 @@ export default class extends Controller {
 
     if (!canComment) {
       this._flushDraftSave()
+      this._draftSaveSuspendedForPermission = true
       this.stopSpeechRecognition()
       this.resetForm()
       return
     }
 
+    this._draftSaveSuspendedForPermission = false
+    this._restoreDraft()
     if (this.shouldAutoFocusOnOpen()) {
       requestAnimationFrame(() => this.textareaTarget.focus())
     }
@@ -399,6 +406,7 @@ export default class extends Controller {
   _saveDraftNow() {
     if (
       !this._activeDraftKey ||
+      this._draftSaveSuspendedForPermission ||
       this.editingId ||
       this._shouldSuppressDraftSaveForStash() ||
       !this._reviewStore.isEmpty

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -581,7 +581,7 @@ export default class extends Controller {
     if (restoredText) {
       this.textareaTarget.value = restoredText
       requestAnimationFrame(() => this._autoResize())
-    } else {
+    } else if (draft.updatedAt === null) {
       this._restorePendingSubmittedDraft()
     }
   }
@@ -898,7 +898,7 @@ export default class extends Controller {
       })
       .then((html) => {
         if (submittedDraft.backupKey) {
-          chatDrafts.removeSubmissionBackup(
+	  chatDrafts.clearSubmissionBackupsThrough(
             submittedDraft.backupKey,
             submittedDraft.namespace,
           )

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -98,6 +98,7 @@ export default class extends Controller {
     this._draftSaveTimer = null
     this._draftRevisions = new Map()
     this._observedDrafts = new Map()
+    this._observedDraftRevisions = new Map()
     this._handlePageHide = () => {
       if (this.element.isConnected) this._flushDraftSave()
     }
@@ -408,6 +409,19 @@ export default class extends Controller {
     const preserveBlank = blank && Boolean(this._awaitingEffectiveDraftKeyFor)
     const storedText = chatDrafts.get(draftKey)
     const hasStoredEntry = chatDrafts.updatedAt(draftKey) !== null
+    const observationKey = `${chatDrafts.namespace()}:${draftKey}`
+    const hasObservedDraft = this._observedDrafts?.has(observationKey)
+    const observedText = this._observedDrafts?.get(observationKey)
+    const observedRevision = this._observedDraftRevisions?.get(observationKey) || 0
+    const currentRevision = this._draftRevisions?.get(observationKey) || 0
+    const draftChangedLocally =
+      currentRevision !== observedRevision ||
+      (hasObservedDraft && (observedText || '') !== text)
+    const storedDraftChangedOutsideController =
+      hasObservedDraft && observedText !== storedText
+    // An idle tab can retain stale restored text after another tab updates the
+    // same draft. Closing or switching that idle tab must not write it back.
+    if (!draftChangedLocally && storedDraftChangedOutsideController) return
     if (preserveBlank) {
       if (storedText !== null || !hasStoredEntry) {
         chatDrafts.set(draftKey, '', { preserveBlank: true })
@@ -442,6 +456,10 @@ export default class extends Controller {
     if (!draftKey) return
     const observationKey = `${namespace}:${draftKey}`
     this._observedDrafts?.set(observationKey, text)
+    this._observedDraftRevisions?.set(
+      observationKey,
+      this._draftRevisions?.get(observationKey) || 0,
+    )
   }
 
   setSendingState(isSending) {

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -97,6 +97,10 @@ export default class extends Controller {
     this._awaitingEffectiveDraftKeyFor ??= null
     this._draftSaveTimer = null
     this._draftSaveSuspendedForPermission ??= false
+    // A cross-tab logout permanently retires the old user's namespace for this
+    // controller lifetime, including Stimulus reconnects in the stale tab.
+    this._disabledDraftNamespaces ||= new Set()
+    this._observedDraftClearNonces ||= new Map()
     // A pending send survives a Stimulus reconnect on this controller instance,
     // so its completion must keep comparing against the same draft history.
     this._draftRevisions ||= new Map()
@@ -107,6 +111,18 @@ export default class extends Controller {
     // A linked chat can replace its temporary raw key while its request is in
     // flight. Keep mutable submission state across that migration/reconnect.
     this._pendingDraftSubmissions ||= new Set()
+    const draftNamespace = chatDrafts.namespace()
+    const draftClearNonce = chatDrafts.clearNonce(draftNamespace)
+    if (
+      draftClearNonce &&
+      this._observedDraftClearNonces.has(draftNamespace) &&
+      this._observedDraftClearNonces.get(draftNamespace) !== draftClearNonce
+    ) {
+      this._disableDraftNamespace(draftNamespace)
+    }
+    if (draftClearNonce !== undefined) {
+      this._observedDraftClearNonces.set(draftNamespace, draftClearNonce)
+    }
     this._handlePageHide = () => {
       if (!this.element.isConnected) return
 
@@ -116,18 +132,12 @@ export default class extends Controller {
       if (!this.element.isConnected || !chatDrafts.wasCleared(event)) return
 
       const clearedNamespace = chatDrafts.namespace()
-      this._pendingDraftSubmissions?.forEach((submission) => {
-        if (submission.namespace !== clearedNamespace) return
-
-        submission.invalidated = true
-      })
-      this.discardDraft()
-      // A timer in this tab may have raced with the logout tab's first clear.
-      chatDrafts.clearAll({ broadcast: false })
+      this._disableDraftNamespace(clearedNamespace)
     }
     this._handleDraftInput = () => {
       if (
         this.editingId ||
+	this._draftPersistenceDisabled() ||
         this._draftSaveSuspendedForPermission ||
         this._shouldSuppressDraftSaveForStash() ||
         !this._reviewStore.isEmpty ||
@@ -172,9 +182,13 @@ export default class extends Controller {
   handleTopicChange(event) {
     // This event fires before onPopupOpened during a chat switch, while the
     // textarea still contains the outgoing chat's text. Flush before re-keying.
-    const nextDraftKey =
-      this.element.dataset.effectiveCreativeId || this.element.dataset.creativeId || null
-    const nextCreativeId = this.element.dataset.creativeId || null
+    const draftPersistenceDisabled = this._draftPersistenceDisabled()
+    const nextDraftKey = draftPersistenceDisabled
+      ? null
+      : this.element.dataset.effectiveCreativeId || this.element.dataset.creativeId || null
+    const nextCreativeId = draftPersistenceDisabled
+      ? null
+      : this.element.dataset.creativeId || null
     const draftKeyChanged = String(this._activeDraftKey || '') !== String(nextDraftKey || '')
     const creativeChanged =
       String(this._activeDraftCreativeId || '') !== String(nextCreativeId || '')
@@ -304,6 +318,14 @@ export default class extends Controller {
     // outgoing chat now, then give any input typed during that await a key owned
     // by the incoming chat. The topics event replaces it with the effective id.
     this._flushDraftSave()
+    if (this._draftPersistenceDisabled()) {
+      this._activeDraftKey = null
+      this._activeDraftCreativeId = null
+      this._awaitingEffectiveDraftKeyFor = null
+      this.creativeId = creativeId
+      this.resetForm()
+      return
+    }
     this._activeDraftKey = nextCreativeId
     this._activeDraftCreativeId = nextCreativeId
     this._awaitingEffectiveDraftKeyFor = nextCreativeId
@@ -453,6 +475,7 @@ export default class extends Controller {
   _saveDraftNow() {
     if (
       !this._activeDraftKey ||
+      this._draftPersistenceDisabled() ||
       this._draftSaveSuspendedForPermission ||
       this.editingId ||
       this._shouldSuppressDraftSaveForStash() ||
@@ -533,7 +556,11 @@ export default class extends Controller {
   }
 
   _restoreDraft() {
-    if (!this._activeDraftKey || this.editingId) return
+    if (
+      !this._activeDraftKey ||
+      this._draftPersistenceDisabled() ||
+      this.editingId
+    ) return
     if (this.textareaTarget.value.trim()) return
 
     const draft = chatDrafts.snapshot(this._activeDraftKey)
@@ -574,6 +601,17 @@ export default class extends Controller {
     this.textareaTarget.value = pending.text
     requestAnimationFrame(() => this._autoResize())
     this._updateSubmitButton()
+  }
+
+  _draftPersistenceDisabled(namespace = chatDrafts.namespace()) {
+    return this._disabledDraftNamespaces?.has(namespace) || false
+  }
+
+  _disableDraftNamespace(namespace) {
+    this._disabledDraftNamespaces.add(namespace)
+    this.discardDraft()
+    // A timer in this tab may have raced with the logout tab's first clear.
+    chatDrafts.clearAll({ broadcast: false })
   }
 
   _observeDraft(

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -97,9 +97,11 @@ export default class extends Controller {
     this._awaitingEffectiveDraftKeyFor = null
     this._draftSaveTimer = null
     this._draftSaveSuspendedForPermission = false
-    this._draftRevisions = new Map()
-    this._observedDrafts = new Map()
-    this._observedDraftRevisions = new Map()
+    // A pending send survives a Stimulus reconnect on this controller instance,
+    // so its completion must keep comparing against the same draft history.
+    this._draftRevisions ||= new Map()
+    this._observedDrafts ||= new Map()
+    this._observedDraftRevisions ||= new Map()
     this._handlePageHide = () => {
       if (this.element.isConnected) this._flushDraftSave()
     }

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -97,6 +97,7 @@ export default class extends Controller {
     this._awaitingEffectiveDraftKeyFor = null
     this._draftSaveTimer = null
     this._draftRevision = 0
+    this._draftRevisions = new Map()
     this._handleDraftInput = () => {
       if (
         this.editingId ||
@@ -105,6 +106,8 @@ export default class extends Controller {
         !this._activeDraftKey
       ) return
       this._draftRevision += 1
+      const revisionKey = `${chatDrafts.namespace()}:${this._activeDraftKey}`
+      this._draftRevisions.set(revisionKey, (this._draftRevisions.get(revisionKey) || 0) + 1)
       clearTimeout(this._draftSaveTimer)
       this._draftSaveTimer = setTimeout(() => this._saveDraftNow(), 500)
     }
@@ -151,18 +154,18 @@ export default class extends Controller {
       String(this._awaitingEffectiveDraftKeyFor) === String(nextCreativeId || '')
     if (draftKeyChanged || creativeChanged) {
       const previousDraftKey = this._activeDraftKey
-      const incomingText = resolvingIncomingDraftKey ? this.textareaTarget.value : ''
-      this._flushDraftSave()
+      // onChatWillOpen already flushed the outgoing chat. While the effective
+      // key is loading, save only actual new input; rewriting a restored raw
+      // draft here would make stale text appear newer than the canonical draft.
+      if (!resolvingIncomingDraftKey || this._draftSaveTimer) this._flushDraftSave()
       this._activeDraftKey = nextDraftKey ? String(nextDraftKey) : null
       this._activeDraftCreativeId = nextCreativeId ? String(nextCreativeId) : null
-      if (resolvingIncomingDraftKey && incomingText.trim() && this._activeDraftKey) {
-        chatDrafts.set(this._activeDraftKey, incomingText)
-        if (
-          previousDraftKey &&
-          String(previousDraftKey) !== String(this._activeDraftKey)
-        ) {
-          chatDrafts.clear(previousDraftKey)
-        }
+      if (
+        resolvingIncomingDraftKey &&
+        previousDraftKey &&
+        this._activeDraftKey
+      ) {
+        chatDrafts.move(previousDraftKey, this._activeDraftKey)
       }
     }
     if (resolvingIncomingDraftKey) this._awaitingEffectiveDraftKeyFor = null
@@ -368,7 +371,9 @@ export default class extends Controller {
       this._stashedDraft ||
       !this._reviewStore.isEmpty
     ) return
-    chatDrafts.set(this._activeDraftKey, this.textareaTarget.value)
+    const text = this.textareaTarget.value
+    if (chatDrafts.get(this._activeDraftKey) === text) return
+    chatDrafts.set(this._activeDraftKey, text)
   }
 
   _flushDraftSave() {
@@ -446,9 +451,14 @@ export default class extends Controller {
     const submittedText = this.textareaTarget.value
     const submittedDraftKey = this._activeDraftKey
     const submittedDraftNamespace = chatDrafts.namespace()
+    const submittedDraftRevisionKey = `${submittedDraftNamespace}:${submittedDraftKey}`
     const submittedEditingId = this.editingId
     const submittedDraftRevision = this._draftRevision
+    const submittedDraftKeyRevision = this._draftRevisions?.get(submittedDraftRevisionKey) || 0
     const submittedHadReview = hasQuotes
+    const submittedDraftUpdatedAt = submittedDraftKey
+      ? chatDrafts.updatedAt(submittedDraftKey)
+      : null
 
     const formData = new FormData(this.formTarget)
     const effectiveTopicId = this.currentTopicId || this._mainTopicId
@@ -499,15 +509,28 @@ export default class extends Controller {
           submittedDraftKey &&
           this._activeDraftKey &&
           String(submittedDraftKey) !== String(this._activeDraftKey)
-        const hasNewerDraft =
+        const submittedChatStillActive =
+          submittedDraftKey &&
+          this._activeDraftKey &&
+          String(submittedDraftKey) === String(this._activeDraftKey)
+        const hasNewerActiveDraft =
+          ownsSubmittedDraftNamespace &&
+          !submittedEditingId &&
+          !submittedHadReview &&
+          submittedChatStillActive &&
+          this._draftRevision !== submittedDraftRevision
+        const hasNewerStoredDraft =
           ownsSubmittedDraftNamespace &&
           !submittedEditingId &&
           !submittedHadReview &&
           submittedDraftKey &&
-          this._activeDraftKey &&
-          String(submittedDraftKey) === String(this._activeDraftKey) &&
-          this._draftRevision !== submittedDraftRevision
-        const newerDraft = hasNewerDraft ? this.textareaTarget.value : null
+          (
+            (this._draftRevisions?.get(submittedDraftRevisionKey) || 0) !==
+              submittedDraftKeyRevision ||
+            chatDrafts.updatedAt(submittedDraftKey) !== submittedDraftUpdatedAt
+          )
+        const hasNewerDraft = hasNewerActiveDraft || hasNewerStoredDraft
+        const newerDraft = hasNewerActiveDraft ? this.textareaTarget.value : null
         if (switchedChats) this._flushDraftSave()
         clearTimeout(this._draftSaveTimer)
         this._draftSaveTimer = null
@@ -519,12 +542,14 @@ export default class extends Controller {
         } else {
           if (submittedHadReview && ownsSubmittedDraftNamespace) {
             this._restoreDraft()
-          } else if (hasNewerDraft) {
+          } else if (hasNewerActiveDraft) {
             this.textareaTarget.value = newerDraft
             this._autoResize()
             this._updateSubmitButton()
             chatDrafts.set(submittedDraftKey, newerDraft)
-          } else if (submittedDraftKey && ownsSubmittedDraftNamespace) {
+          } else if (hasNewerStoredDraft && submittedChatStillActive) {
+            this._restoreDraft()
+          } else if (!hasNewerDraft && submittedDraftKey && ownsSubmittedDraftNamespace) {
             chatDrafts.clear(submittedDraftKey)
           }
           if (switchedChats && !submittedHadReview) this._restoreDraft()
@@ -973,7 +998,7 @@ export default class extends Controller {
     this.textareaTarget.value = ''
 
     if (store.isEmpty) {
-      this.textareaTarget.placeholder = this._defaultPlaceholder()
+      this._restoreOrdinaryDraft()
     } else if (!store.hasActive) {
       this.textareaTarget.placeholder = this._getI18nText('reviewSummaryPlaceholder', 'Overall comment (optional)...')
     }
@@ -1130,7 +1155,7 @@ export default class extends Controller {
         store.remove(quote.id)
         if (wasActive) this.textareaTarget.value = ''
         if (store.isEmpty) {
-          this.textareaTarget.placeholder = this._defaultPlaceholder()
+          this._restoreOrdinaryDraft()
         } else if (!store.hasActive) {
           this.textareaTarget.placeholder = this._getI18nText('reviewSummaryPlaceholder', 'Overall comment (optional)...')
         }
@@ -1163,6 +1188,12 @@ export default class extends Controller {
       'send-question': this._getI18nText('reviewSendQuestion', 'Send question'),
     }
     this.submitTarget.textContent = labels[state]
+  }
+
+  _restoreOrdinaryDraft() {
+    this.textareaTarget.value = ''
+    this.textareaTarget.placeholder = this._defaultPlaceholder()
+    this._restoreDraft()
   }
 
   _getI18nText(key, fallback) {

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -100,6 +100,7 @@ export default class extends Controller {
     // A cross-tab logout permanently retires the old user's namespace for this
     // controller lifetime, including Stimulus reconnects in the stale tab.
     this._disabledDraftNamespaces ||= new Set()
+    this._draftBackupCleanupPendingNamespaces ||= new Set()
     this._observedDraftClearNonces ||= new Map()
     // A pending send survives a Stimulus reconnect on this controller instance,
     // so its completion must keep comparing against the same draft history.
@@ -113,14 +114,27 @@ export default class extends Controller {
     this._pendingDraftSubmissions ||= new Set()
     const draftNamespace = chatDrafts.namespace()
     const draftClearNonce = chatDrafts.clearNonce(draftNamespace)
+    const observedDraftClearNonce = this._observedDraftClearNonces.has(draftNamespace)
+    let canObserveDraftClearNonce = true
+    if (draftClearNonce && !observedDraftClearNonce) {
+      canObserveDraftClearNonce = chatDrafts.clearSubmissionBackupsForClear(
+	draftNamespace,
+	draftClearNonce,
+      )
+      if (canObserveDraftClearNonce) {
+	this._draftBackupCleanupPendingNamespaces.delete(draftNamespace)
+      } else {
+	this._draftBackupCleanupPendingNamespaces.add(draftNamespace)
+      }
+    }
     if (
       draftClearNonce &&
-      this._observedDraftClearNonces.has(draftNamespace) &&
+      observedDraftClearNonce &&
       this._observedDraftClearNonces.get(draftNamespace) !== draftClearNonce
     ) {
       this._disableDraftNamespace(draftNamespace)
     }
-    if (draftClearNonce !== undefined) {
+    if (draftClearNonce !== undefined && canObserveDraftClearNonce) {
       this._observedDraftClearNonces.set(draftNamespace, draftClearNonce)
     }
     this._handlePageHide = () => {
@@ -604,7 +618,9 @@ export default class extends Controller {
   }
 
   _draftPersistenceDisabled(namespace = chatDrafts.namespace()) {
-    return this._disabledDraftNamespaces?.has(namespace) || false
+    return this._disabledDraftNamespaces?.has(namespace) ||
+      this._draftBackupCleanupPendingNamespaces?.has(namespace) ||
+      false
   }
 
   _disableDraftNamespace(namespace) {

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -100,7 +100,7 @@ export default class extends Controller {
     this._handleDraftInput = () => {
       if (
         this.editingId ||
-        this._stashedDraft ||
+        this._stashedDraftBelongsToCurrentCreative() ||
         !this._reviewStore.isEmpty ||
         !this._activeDraftKey
       ) return
@@ -320,6 +320,13 @@ export default class extends Controller {
     this._stashedDraft = draft ? { draft, creativeId: this.creativeId } : null
   }
 
+  _stashedDraftBelongsToCurrentCreative() {
+    return Boolean(
+      this._stashedDraft &&
+      String(this._stashedDraft.creativeId) === String(this.creativeId),
+    )
+  }
+
   _restoreStashedDraft(submittedText) {
     const stashed = this._stashedDraft
     this._stashedDraft = null
@@ -366,7 +373,7 @@ export default class extends Controller {
     if (
       !this._activeDraftKey ||
       this.editingId ||
-      this._stashedDraft ||
+      this._stashedDraftBelongsToCurrentCreative() ||
       !this._reviewStore.isEmpty
     ) return
     const text = this.textareaTarget.value

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -593,6 +593,7 @@ export default class extends Controller {
     const initialSubmittedDraftRevisionKey =
       `${submittedDraftNamespace}:${initialSubmittedDraftKey}`
     const initialSubmittedDraft = chatDrafts.snapshot(initialSubmittedDraftKey)
+    const submittedHadStash = this._stashedDraftBelongsToCurrentCreative()
     const submittedDraft = {
       key: initialSubmittedDraftKey,
       namespace: submittedDraftNamespace,
@@ -604,13 +605,14 @@ export default class extends Controller {
       keyRevision: this._draftRevisions?.get(initialSubmittedDraftRevisionKey) || 0,
       storedRevision: initialSubmittedDraft.revision,
       text: submittedText,
+      hadStash: submittedHadStash,
       migratedSources: [],
     }
     this._pendingDraftSubmissions ||= new Set()
     this._pendingDraftSubmissions.add(submittedDraft)
     const submittedEditingId = this.editingId
     const submittedHadReview = hasQuotes
-    if (this._stashedDraftBelongsToCurrentCreative()) {
+    if (submittedHadStash) {
       this._stashedDraft.submittedText = submittedText
     }
 
@@ -663,6 +665,7 @@ export default class extends Controller {
           storedChangedOutsideController: submittedStoredDraftChangedOutsideController,
           keyRevision: submittedDraftKeyRevision,
           storedRevision: submittedDraftStoredRevision,
+          hadStash: submittedHadStash,
         } = submittedDraft
         const ownsSubmittedDraftNamespace =
           submittedDraftNamespace === chatDrafts.namespace()
@@ -714,7 +717,12 @@ export default class extends Controller {
             this._observeDraft(submittedDraftKey, newerDraft, submittedDraftNamespace)
           } else if (hasNewerStoredDraft && submittedChatStillActive) {
             this._restoreDraft()
-          } else if (!hasNewerDraft && submittedDraftKey && ownsSubmittedDraftNamespace) {
+          } else if (
+            !submittedHadStash &&
+            !hasNewerDraft &&
+            submittedDraftKey &&
+            ownsSubmittedDraftNamespace
+          ) {
             chatDrafts.clear(submittedDraftKey)
             this._observeDraft(submittedDraftKey, null, submittedDraftNamespace)
           }

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -96,7 +96,6 @@ export default class extends Controller {
     this._activeDraftCreativeId = null
     this._awaitingEffectiveDraftKeyFor = null
     this._draftSaveTimer = null
-    this._draftRevision = 0
     this._draftRevisions = new Map()
     this._handleDraftInput = () => {
       if (
@@ -105,7 +104,6 @@ export default class extends Controller {
         !this._reviewStore.isEmpty ||
         !this._activeDraftKey
       ) return
-      this._draftRevision += 1
       const revisionKey = `${chatDrafts.namespace()}:${this._activeDraftKey}`
       this._draftRevisions.set(revisionKey, (this._draftRevisions.get(revisionKey) || 0) + 1)
       clearTimeout(this._draftSaveTimer)
@@ -453,7 +451,6 @@ export default class extends Controller {
     const submittedDraftNamespace = chatDrafts.namespace()
     const submittedDraftRevisionKey = `${submittedDraftNamespace}:${submittedDraftKey}`
     const submittedEditingId = this.editingId
-    const submittedDraftRevision = this._draftRevision
     const submittedDraftKeyRevision = this._draftRevisions?.get(submittedDraftRevisionKey) || 0
     const submittedHadReview = hasQuotes
     const submittedDraftUpdatedAt = submittedDraftKey
@@ -518,7 +515,8 @@ export default class extends Controller {
           !submittedEditingId &&
           !submittedHadReview &&
           submittedChatStillActive &&
-          this._draftRevision !== submittedDraftRevision
+          (this._draftRevisions?.get(submittedDraftRevisionKey) || 0) !==
+            submittedDraftKeyRevision
         const hasNewerStoredDraft =
           ownsSubmittedDraftNamespace &&
           !submittedEditingId &&

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -92,16 +92,19 @@ export default class extends Controller {
 
     // Draft persistence: debounce-save unsent input per chat.
     // _activeDraftKey always identifies the chat whose text is in the textarea.
-    this._activeDraftKey = null
-    this._activeDraftCreativeId = null
-    this._awaitingEffectiveDraftKeyFor = null
+    this._activeDraftKey ??= null
+    this._activeDraftCreativeId ??= null
+    this._awaitingEffectiveDraftKeyFor ??= null
     this._draftSaveTimer = null
-    this._draftSaveSuspendedForPermission = false
+    this._draftSaveSuspendedForPermission ??= false
     // A pending send survives a Stimulus reconnect on this controller instance,
     // so its completion must keep comparing against the same draft history.
     this._draftRevisions ||= new Map()
     this._observedDrafts ||= new Map()
     this._observedDraftRevisions ||= new Map()
+    // A linked chat can replace its temporary raw key while its request is in
+    // flight. Keep mutable submission state across that migration/reconnect.
+    this._pendingDraftSubmissions ||= new Set()
     this._handlePageHide = () => {
       if (this.element.isConnected) this._flushDraftSave()
     }
@@ -181,7 +184,17 @@ export default class extends Controller {
         previousDraftKey &&
         this._activeDraftKey
       ) {
+        const sourceDraft = chatDrafts.snapshot(previousDraftKey)
         chatDrafts.move(previousDraftKey, this._activeDraftKey)
+        const targetDraft = chatDrafts.snapshot(this._activeDraftKey)
+        if (targetDraft.revision) {
+          this._rebindPendingDraftSubmissions(
+            previousDraftKey,
+            this._activeDraftKey,
+            sourceDraft,
+            targetDraft,
+          )
+        }
       }
     }
     if (resolvingIncomingDraftKey) this._awaitingEffectiveDraftKeyFor = null
@@ -472,6 +485,53 @@ export default class extends Controller {
     )
   }
 
+  _rebindPendingDraftSubmissions(sourceKey, targetKey, sourceDraft, targetDraft) {
+    const namespace = chatDrafts.namespace()
+    const targetRevisionKey = `${namespace}:${targetKey}`
+
+    this._pendingDraftSubmissions?.forEach((submission) => {
+      if (
+        submission.namespace !== namespace ||
+        String(submission.key) !== String(sourceKey)
+      ) return
+
+      const submittedDraftWasMoved =
+        (
+          submission.storedRevision &&
+          targetDraft.revision === submission.storedRevision &&
+          targetDraft.text === submission.text
+        ) || (
+          sourceDraft.revision &&
+          targetDraft.revision === sourceDraft.revision &&
+          sourceDraft.text === submission.text
+        )
+      if (
+        sourceDraft.revision &&
+        sourceDraft.text === submission.text
+      ) {
+        submission.migratedSources.push({
+          key: String(sourceKey),
+          revision: sourceDraft.revision,
+        })
+      }
+      submission.key = String(targetKey)
+      submission.revisionKey = targetRevisionKey
+      submission.keyRevision = this._draftRevisions?.get(targetRevisionKey) || 0
+      submission.storedRevision = targetDraft.revision
+      submission.storedChangedOutsideController ||=
+        !submittedDraftWasMoved
+    })
+  }
+
+  _clearMigratedSubmittedSources(submission) {
+    submission.migratedSources.forEach(({ key, revision }) => {
+      if (chatDrafts.revision(key) !== revision) return
+
+      chatDrafts.clear(key)
+      this._observeDraft(key, null, submission.namespace)
+    })
+  }
+
   setSendingState(isSending) {
     if (!this.submitTarget) return
 
@@ -528,21 +588,28 @@ export default class extends Controller {
     // going to the server. _restoreStashedDraft compares against it to tell a
     // failure that left the command text behind from text typed mid-flight.
     const submittedText = this.textareaTarget.value
-    const submittedDraftKey = this._activeDraftKey
+    const initialSubmittedDraftKey = this._activeDraftKey
     const submittedDraftNamespace = chatDrafts.namespace()
-    const submittedDraftRevisionKey = `${submittedDraftNamespace}:${submittedDraftKey}`
-    const submittedStoredDraftText = submittedDraftKey
-      ? chatDrafts.get(submittedDraftKey)
-      : null
-    const submittedStoredDraftChangedOutsideController =
-      this._observedDrafts?.has(submittedDraftRevisionKey) &&
-      this._observedDrafts.get(submittedDraftRevisionKey) !== submittedStoredDraftText
+    const initialSubmittedDraftRevisionKey =
+      `${submittedDraftNamespace}:${initialSubmittedDraftKey}`
+    const initialSubmittedDraft = chatDrafts.snapshot(initialSubmittedDraftKey)
+    const submittedDraft = {
+      key: initialSubmittedDraftKey,
+      namespace: submittedDraftNamespace,
+      revisionKey: initialSubmittedDraftRevisionKey,
+      storedChangedOutsideController:
+        this._observedDrafts?.has(initialSubmittedDraftRevisionKey) &&
+        this._observedDrafts.get(initialSubmittedDraftRevisionKey) !==
+          initialSubmittedDraft.text,
+      keyRevision: this._draftRevisions?.get(initialSubmittedDraftRevisionKey) || 0,
+      storedRevision: initialSubmittedDraft.revision,
+      text: submittedText,
+      migratedSources: [],
+    }
+    this._pendingDraftSubmissions ||= new Set()
+    this._pendingDraftSubmissions.add(submittedDraft)
     const submittedEditingId = this.editingId
-    const submittedDraftKeyRevision = this._draftRevisions?.get(submittedDraftRevisionKey) || 0
     const submittedHadReview = hasQuotes
-    const submittedDraftStoredRevision = submittedDraftKey
-      ? chatDrafts.revision(submittedDraftKey)
-      : null
     if (this._stashedDraftBelongsToCurrentCreative()) {
       this._stashedDraft.submittedText = submittedText
     }
@@ -589,6 +656,14 @@ export default class extends Controller {
         })
       })
       .then((html) => {
+        const {
+          key: submittedDraftKey,
+          namespace: submittedDraftNamespace,
+          revisionKey: submittedDraftRevisionKey,
+          storedChangedOutsideController: submittedStoredDraftChangedOutsideController,
+          keyRevision: submittedDraftKeyRevision,
+          storedRevision: submittedDraftStoredRevision,
+        } = submittedDraft
         const ownsSubmittedDraftNamespace =
           submittedDraftNamespace === chatDrafts.namespace()
         const switchedChats =
@@ -643,6 +718,9 @@ export default class extends Controller {
             chatDrafts.clear(submittedDraftKey)
             this._observeDraft(submittedDraftKey, null, submittedDraftNamespace)
           }
+          if (ownsSubmittedDraftNamespace && !submittedHadReview) {
+            this._clearMigratedSubmittedSources(submittedDraft)
+          }
           if (switchedChats && !submittedHadReview) this._restoreDraft()
           // New Comment:
           // 1. If we are in "History Mode" (scrolled up), sending a message should jump us to the latest.
@@ -688,10 +766,11 @@ export default class extends Controller {
         alertDialog(error?.message || 'Failed to submit comment')
       })
       .finally(() => {
+        this._pendingDraftSubmissions.delete(submittedDraft)
         inFlightSends.delete(sendKey)
         this._hasRetried = false
         this.setSendingState(false)
-        if (submittedDraftNamespace === chatDrafts.namespace()) {
+        if (submittedDraft.namespace === chatDrafts.namespace()) {
           this._restoreStashedDraft(submittedText)
         } else {
           this._stashedDraft = null

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -601,10 +601,7 @@ export default class extends Controller {
         String(submission.key) !== String(sourceKey)
       ) return
 
-      const targetMatchesSubmission =
-        submission.storedRevision &&
-        targetDraft.revision === submission.storedRevision &&
-        targetDraft.text === submission.text
+      const targetMatchesStoredBaseline = submission.storedRevision && targetDraft.revision === submission.storedRevision
       const sourceMatchesSubmission =
         sourceDraft.revision &&
         targetDraft.revision === sourceDraft.revision &&
@@ -613,8 +610,7 @@ export default class extends Controller {
         !submission.storedRevision &&
         !sourceDraft.revision &&
         !targetDraft.revision
-      const submittedDraftWasMoved =
-        targetMatchesSubmission || sourceMatchesSubmission || submittedDraftWasUnstored
+      const submittedDraftWasMoved = targetMatchesStoredBaseline || sourceMatchesSubmission || submittedDraftWasUnstored
       if (
         sourceDraft.revision &&
         sourceDraft.text === submission.text
@@ -628,6 +624,7 @@ export default class extends Controller {
       submission.revisionKey = targetRevisionKey
       submission.keyRevision = this._draftRevisions?.get(targetRevisionKey) || 0
       submission.storedRevision = targetDraft.revision
+      submission.storedUpdatedAt = targetDraft.updatedAt
       submission.storedChangedOutsideController ||=
         !submittedDraftWasMoved
       if (submission.backupKey && movedBackups.has(submission.backupKey)) {
@@ -654,9 +651,20 @@ export default class extends Controller {
       submission.namespace !== chatDrafts.namespace()
     ) return
 
+    const currentDraft = chatDrafts.snapshot(submission.key)
+    const currentKeyRevision =
+      this._draftRevisions?.get(submission.revisionKey) || 0
+    const submittedChatAdvanced =
+      submission.storedChangedOutsideController ||
+      currentKeyRevision !== submission.keyRevision ||
+      currentDraft.revision !== submission.storedRevision ||
+      currentDraft.updatedAt !== submission.storedUpdatedAt
+    if (submittedChatAdvanced) return
+
     submission.backupKey ||= chatDrafts.saveSubmissionBackup(
       submission.key,
       submission.text,
+      { updatedAt: submission.backupUpdatedAt },
     )
   }
 
@@ -731,6 +739,10 @@ export default class extends Controller {
     const initialSubmittedDraft = chatDrafts.snapshot(initialSubmittedDraftKey)
     const submittedHadStash = this._stashedDraftBelongsToCurrentCreative()
     const submittedBackup = chatDrafts.latestSubmissionBackup(initialSubmittedDraftKey)
+    const submittedBackupUpdatedAt = Math.max(
+      Date.now(),
+      (initialSubmittedDraft.updatedAt || 0) + 1,
+    )
     const observedSubmittedText =
       this._observedDrafts?.get(initialSubmittedDraftRevisionKey)
     const observedSubmittedStoredRevision =
@@ -749,6 +761,8 @@ export default class extends Controller {
       storedChangedOutsideController: submittedStoredDraftChangedOutsideController,
       keyRevision: this._draftRevisions?.get(initialSubmittedDraftRevisionKey) || 0,
       storedRevision: initialSubmittedDraft.revision,
+      storedUpdatedAt: initialSubmittedDraft.updatedAt,
+      backupUpdatedAt: submittedBackupUpdatedAt,
       text: submittedText,
       hadStash: submittedHadStash,
       backupKey: submittedBackup?.text === submittedText ? submittedBackup.key : null,

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -114,6 +114,7 @@ export default class extends Controller {
     this._pendingDraftSubmissions ||= new Set()
     const draftNamespace = chatDrafts.namespace()
     const draftClearNonce = chatDrafts.clearNonce(draftNamespace)
+    const draftClearNoncePending = chatDrafts.clearNoncePending(draftNamespace)
     const observedDraftClearNonce = this._observedDraftClearNonces.has(draftNamespace)
     let canObserveDraftClearNonce = true
     if (draftClearNonce && !observedDraftClearNonce) {
@@ -121,7 +122,7 @@ export default class extends Controller {
 	draftNamespace,
 	draftClearNonce,
       )
-      if (canObserveDraftClearNonce) {
+      if (canObserveDraftClearNonce && !draftClearNoncePending) {
 	this._draftBackupCleanupPendingNamespaces.delete(draftNamespace)
       } else {
 	this._draftBackupCleanupPendingNamespaces.add(draftNamespace)
@@ -134,7 +135,11 @@ export default class extends Controller {
     ) {
       this._disableDraftNamespace(draftNamespace)
     }
-    if (draftClearNonce !== undefined && canObserveDraftClearNonce) {
+    if (
+      draftClearNonce !== undefined &&
+      canObserveDraftClearNonce &&
+      !draftClearNoncePending
+    ) {
       this._observedDraftClearNonces.set(draftNamespace, draftClearNonce)
     }
     this._handlePageHide = () => {

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -102,15 +102,24 @@ export default class extends Controller {
     this._draftRevisions ||= new Map()
     this._observedDrafts ||= new Map()
     this._observedDraftRevisions ||= new Map()
+    this._observedStoredDraftRevisions ||= new Map()
     // A linked chat can replace its temporary raw key while its request is in
     // flight. Keep mutable submission state across that migration/reconnect.
     this._pendingDraftSubmissions ||= new Set()
     this._handlePageHide = () => {
-      if (this.element.isConnected) this._flushDraftSave()
+      if (!this.element.isConnected) return
+
+      this._flushDraftSave()
     }
     this._handleDraftStorage = (event) => {
       if (!this.element.isConnected || !chatDrafts.wasCleared(event)) return
 
+      const clearedNamespace = chatDrafts.namespace()
+      this._pendingDraftSubmissions?.forEach((submission) => {
+        if (submission.namespace !== clearedNamespace) return
+
+        submission.invalidated = true
+      })
       this.discardDraft()
       // A timer in this tab may have raced with the logout tab's first clear.
       chatDrafts.clearAll({ broadcast: false })
@@ -187,12 +196,17 @@ export default class extends Controller {
         const sourceDraft = chatDrafts.snapshot(previousDraftKey)
         chatDrafts.move(previousDraftKey, this._activeDraftKey)
         const targetDraft = chatDrafts.snapshot(this._activeDraftKey)
-        if (targetDraft.revision) {
+        const movedBackups = chatDrafts.moveSubmissionBackups(
+          previousDraftKey,
+          this._activeDraftKey,
+        )
+        if (targetDraft.revision || !sourceDraft.revision) {
           this._rebindPendingDraftSubmissions(
             previousDraftKey,
             this._activeDraftKey,
             sourceDraft,
             targetDraft,
+            movedBackups,
           )
         }
       }
@@ -294,6 +308,10 @@ export default class extends Controller {
   }
 
   discardDraft() {
+    const namespace = chatDrafts.namespace()
+    this._pendingDraftSubmissions?.forEach((submission) => {
+      if (submission.namespace === namespace) submission.invalidated = true
+    })
     clearTimeout(this._draftSaveTimer)
     this._draftSaveTimer = null
     this._activeDraftKey = null
@@ -426,22 +444,27 @@ export default class extends Controller {
       this._shouldSuppressDraftSaveForStash() ||
       !this._reviewStore.isEmpty
     ) return
+    if (this._currentTextIsPendingSubmission()) return
     const draftKey = this._activeDraftKey
     const text = this.textareaTarget.value
     const blank = !text.trim()
     const preserveBlank = blank && Boolean(this._awaitingEffectiveDraftKeyFor)
-    const storedText = chatDrafts.get(draftKey)
+    const storedDraft = chatDrafts.snapshot(draftKey)
+    const storedText = storedDraft.text
     const hasStoredEntry = chatDrafts.updatedAt(draftKey) !== null
     const observationKey = `${chatDrafts.namespace()}:${draftKey}`
     const hasObservedDraft = this._observedDrafts?.has(observationKey)
     const observedText = this._observedDrafts?.get(observationKey)
     const observedRevision = this._observedDraftRevisions?.get(observationKey) || 0
+    const observedStoredRevision =
+      this._observedStoredDraftRevisions?.get(observationKey) || null
     const currentRevision = this._draftRevisions?.get(observationKey) || 0
     const draftChangedLocally =
       currentRevision !== observedRevision ||
       (hasObservedDraft && (observedText || '') !== text)
-    const storedDraftChangedOutsideController =
-      hasObservedDraft && observedText !== storedText
+    const storedDraftChangedOutsideController = hasObservedDraft && (
+      observedText !== storedText || observedStoredRevision !== storedDraft.revision
+    )
     // An idle tab can retain stale restored text after another tab updates the
     // same draft. Closing or switching that idle tab must not write it back.
     if (!draftChangedLocally && storedDraftChangedOutsideController) return
@@ -450,11 +473,14 @@ export default class extends Controller {
         chatDrafts.set(draftKey, '', { preserveBlank: true })
       }
     } else if (blank) {
-      if (hasStoredEntry) chatDrafts.clear(draftKey)
+      if (hasStoredEntry) {
+        chatDrafts.clear(draftKey)
+      }
     } else if (storedText !== text) {
       chatDrafts.set(draftKey, text)
     }
-    this._observeDraft(draftKey, chatDrafts.get(draftKey))
+    if (blank && draftChangedLocally) chatDrafts.clearSubmissionBackups(draftKey)
+    this._observeDraft(draftKey)
   }
 
   _flushDraftSave() {
@@ -463,29 +489,86 @@ export default class extends Controller {
     this._saveDraftNow()
   }
 
+  _currentTextIsPendingSubmission() {
+    return Boolean(this._currentPendingSubmission())
+  }
+
+  _currentPendingSubmission() {
+    const namespace = chatDrafts.namespace()
+    const key = String(this._activeDraftKey || '')
+
+    return [...(this._pendingDraftSubmissions || [])].find((submission) => (
+      !submission.invalidated &&
+      submission.namespace === namespace &&
+      String(submission.key || '') === key &&
+      !submission.hadStash &&
+      !submission.hadReview &&
+      !submission.editing &&
+      submission.text === this.textareaTarget.value &&
+      (this._draftRevisions?.get(submission.revisionKey) || 0) === submission.keyRevision
+    ))
+  }
+
   _restoreDraft() {
     if (!this._activeDraftKey || this.editingId) return
     if (this.textareaTarget.value.trim()) return
 
-    const draft = chatDrafts.get(this._activeDraftKey)
-    this._observeDraft(this._activeDraftKey, draft)
-    if (draft) {
-      this.textareaTarget.value = draft
+    const draft = chatDrafts.snapshot(this._activeDraftKey)
+    const backup = draft.text
+      ? null
+      : chatDrafts.latestSubmissionBackup(this._activeDraftKey)
+    this._observeDraft(this._activeDraftKey, draft.text, chatDrafts.namespace(), draft.revision)
+    if (draft.text || backup?.text) {
+      this.textareaTarget.value = draft.text || backup.text
       requestAnimationFrame(() => this._autoResize())
+    } else {
+      this._restorePendingSubmittedDraft()
     }
   }
 
-  _observeDraft(draftKey, text, namespace = chatDrafts.namespace()) {
+  _restorePendingSubmittedDraft() {
+    const namespace = chatDrafts.namespace()
+    const pending = [...(this._pendingDraftSubmissions || [])].find((submission) => (
+      !submission.invalidated &&
+      submission.namespace === namespace &&
+      String(submission.key || '') === String(this._activeDraftKey || '') &&
+      !submission.hadStash &&
+      !submission.hadReview &&
+      !submission.editing
+    ))
+    if (!pending) return
+
+    this.textareaTarget.value = pending.text
+    requestAnimationFrame(() => this._autoResize())
+    this._updateSubmitButton()
+  }
+
+  _observeDraft(
+    draftKey,
+    text,
+    namespace = chatDrafts.namespace(),
+    storedRevision,
+  ) {
     if (!draftKey) return
+    const storedDraft = storedRevision === undefined
+      ? chatDrafts.snapshot(draftKey)
+      : { text, revision: storedRevision }
     const observationKey = `${namespace}:${draftKey}`
-    this._observedDrafts?.set(observationKey, text)
+    this._observedDrafts?.set(observationKey, storedDraft.text)
     this._observedDraftRevisions?.set(
       observationKey,
       this._draftRevisions?.get(observationKey) || 0,
     )
+    this._observedStoredDraftRevisions?.set(observationKey, storedDraft.revision)
   }
 
-  _rebindPendingDraftSubmissions(sourceKey, targetKey, sourceDraft, targetDraft) {
+  _rebindPendingDraftSubmissions(
+    sourceKey,
+    targetKey,
+    sourceDraft,
+    targetDraft,
+    movedBackups = new Map(),
+  ) {
     const namespace = chatDrafts.namespace()
     const targetRevisionKey = `${namespace}:${targetKey}`
 
@@ -495,16 +578,20 @@ export default class extends Controller {
         String(submission.key) !== String(sourceKey)
       ) return
 
+      const targetMatchesSubmission =
+        submission.storedRevision &&
+        targetDraft.revision === submission.storedRevision &&
+        targetDraft.text === submission.text
+      const sourceMatchesSubmission =
+        sourceDraft.revision &&
+        targetDraft.revision === sourceDraft.revision &&
+        targetDraft.text === submission.text
+      const submittedDraftWasUnstored =
+        !submission.storedRevision &&
+        !sourceDraft.revision &&
+        !targetDraft.revision
       const submittedDraftWasMoved =
-        (
-          submission.storedRevision &&
-          targetDraft.revision === submission.storedRevision &&
-          targetDraft.text === submission.text
-        ) || (
-          sourceDraft.revision &&
-          targetDraft.revision === sourceDraft.revision &&
-          sourceDraft.text === submission.text
-        )
+        targetMatchesSubmission || sourceMatchesSubmission || submittedDraftWasUnstored
       if (
         sourceDraft.revision &&
         sourceDraft.text === submission.text
@@ -520,6 +607,9 @@ export default class extends Controller {
       submission.storedRevision = targetDraft.revision
       submission.storedChangedOutsideController ||=
         !submittedDraftWasMoved
+      if (submission.backupKey && movedBackups.has(submission.backupKey)) {
+        submission.backupKey = movedBackups.get(submission.backupKey)
+      }
     })
   }
 
@@ -530,6 +620,21 @@ export default class extends Controller {
       chatDrafts.clear(key)
       this._observeDraft(key, null, submission.namespace)
     })
+  }
+
+  _persistFailedSubmissionDraft(submission) {
+    if (
+      submission.invalidated ||
+      submission.hadStash ||
+      submission.hadReview ||
+      submission.editing ||
+      submission.namespace !== chatDrafts.namespace()
+    ) return
+
+    submission.backupKey ||= chatDrafts.saveSubmissionBackup(
+      submission.key,
+      submission.text,
+    )
   }
 
   setSendingState(isSending) {
@@ -575,6 +680,14 @@ export default class extends Controller {
     this.setSendingState(true)
     this.presenceController?.stoppedTyping()
 
+    // Cancel any pending input debounce before capturing the submission. A
+    // write while the request is in flight looks like a newer draft and can
+    // restore the already-sent text on success. Failures persist below.
+    if (this._draftSaveTimer) {
+      clearTimeout(this._draftSaveTimer)
+      this._draftSaveTimer = null
+    }
+
     // Build final content from review quotes + user text
     if (hasQuotes) {
       store.backup(this.textareaTarget.value)
@@ -594,24 +707,36 @@ export default class extends Controller {
       `${submittedDraftNamespace}:${initialSubmittedDraftKey}`
     const initialSubmittedDraft = chatDrafts.snapshot(initialSubmittedDraftKey)
     const submittedHadStash = this._stashedDraftBelongsToCurrentCreative()
+    const submittedBackup = chatDrafts.latestSubmissionBackup(initialSubmittedDraftKey)
+    const observedSubmittedText =
+      this._observedDrafts?.get(initialSubmittedDraftRevisionKey)
+    const observedSubmittedStoredRevision =
+      this._observedStoredDraftRevisions?.get(initialSubmittedDraftRevisionKey) || null
+    const submittedTextChangedOutsideController =
+      observedSubmittedText !== initialSubmittedDraft.text
+    const submittedRevisionChangedOutsideController =
+      observedSubmittedStoredRevision !== initialSubmittedDraft.revision
+    const submittedStoredDraftChangedOutsideController =
+      this._observedDrafts?.has(initialSubmittedDraftRevisionKey) &&
+      (submittedTextChangedOutsideController || submittedRevisionChangedOutsideController)
     const submittedDraft = {
       key: initialSubmittedDraftKey,
       namespace: submittedDraftNamespace,
       revisionKey: initialSubmittedDraftRevisionKey,
-      storedChangedOutsideController:
-        this._observedDrafts?.has(initialSubmittedDraftRevisionKey) &&
-        this._observedDrafts.get(initialSubmittedDraftRevisionKey) !==
-          initialSubmittedDraft.text,
+      storedChangedOutsideController: submittedStoredDraftChangedOutsideController,
       keyRevision: this._draftRevisions?.get(initialSubmittedDraftRevisionKey) || 0,
       storedRevision: initialSubmittedDraft.revision,
       text: submittedText,
       hadStash: submittedHadStash,
+      backupKey: submittedBackup?.text === submittedText ? submittedBackup.key : null,
       migratedSources: [],
     }
     this._pendingDraftSubmissions ||= new Set()
     this._pendingDraftSubmissions.add(submittedDraft)
     const submittedEditingId = this.editingId
     const submittedHadReview = hasQuotes
+    submittedDraft.editing = Boolean(submittedEditingId)
+    submittedDraft.hadReview = submittedHadReview
     if (submittedHadStash) {
       this._stashedDraft.submittedText = submittedText
     }
@@ -658,6 +783,18 @@ export default class extends Controller {
         })
       })
       .then((html) => {
+        if (submittedDraft.backupKey) {
+          chatDrafts.removeSubmissionBackup(
+            submittedDraft.backupKey,
+            submittedDraft.namespace,
+          )
+          submittedDraft.backupKey = null
+        }
+        if (
+          submittedDraft.invalidated ||
+          submittedDraft.namespace !== chatDrafts.namespace()
+        ) return
+
         const {
           key: submittedDraftKey,
           namespace: submittedDraftNamespace,
@@ -668,6 +805,7 @@ export default class extends Controller {
           hadStash: submittedHadStash,
         } = submittedDraft
         const ownsSubmittedDraftNamespace =
+          !submittedDraft.invalidated &&
           submittedDraftNamespace === chatDrafts.namespace()
         const switchedChats =
           ownsSubmittedDraftNamespace &&
@@ -697,7 +835,13 @@ export default class extends Controller {
             chatDrafts.revision(submittedDraftKey) !== submittedDraftStoredRevision
           )
         const hasNewerDraft = hasNewerActiveDraft || hasNewerStoredDraft
-        const newerDraft = hasNewerActiveDraft ? this.textareaTarget.value : null
+        const newerDraft = hasNewerActiveDraft
+          ? (
+            this._draftSaveSuspendedForPermission
+              ? chatDrafts.get(submittedDraftKey)
+              : this.textareaTarget.value
+          )
+          : null
         if (switchedChats) this._flushDraftSave()
         clearTimeout(this._draftSaveTimer)
         this._draftSaveTimer = null
@@ -764,6 +908,8 @@ export default class extends Controller {
         }
       })
       .catch((error) => {
+        if (submittedDraft.invalidated) return
+
         // Restore review quotes state on failure so user doesn't lose work
         if (this._reviewStore.hasBackup()) {
           const restoredText = this._reviewStore.restore()
@@ -771,6 +917,7 @@ export default class extends Controller {
           this._renderReviewQuoteChips()
           this._updateSubmitButton()
         }
+        this._persistFailedSubmissionDraft(submittedDraft)
         alertDialog(error?.message || 'Failed to submit comment')
       })
       .finally(() => {
@@ -778,7 +925,10 @@ export default class extends Controller {
         inFlightSends.delete(sendKey)
         this._hasRetried = false
         this.setSendingState(false)
-        if (submittedDraft.namespace === chatDrafts.namespace()) {
+        if (
+          !submittedDraft.invalidated &&
+          submittedDraft.namespace === chatDrafts.namespace()
+        ) {
           this._restoreStashedDraft(submittedText)
         } else {
           this._stashedDraft = null

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -4,6 +4,7 @@ import { wrapHtmlInCodeBlocks } from '../../lib/html_code_block_wrapper'
 import { refreshCsrfToken } from '../../lib/api/csrf_fetch'
 import ReviewQuotesStore from './review_quotes_store'
 import { alertDialog } from '../../lib/utils/dialog'
+import chatDrafts from '../../lib/chat_drafts'
 
 // In-flight comment sends, keyed by creative id. This lives at module scope —
 // not on the controller instance — so the duplicate-submit guard survives a
@@ -89,6 +90,17 @@ export default class extends Controller {
     }
     this.textareaTarget.addEventListener('input', this._autoResize)
 
+    // Draft persistence: debounce-save unsent input per chat.
+    // _activeDraftKey always identifies the chat whose text is in the textarea.
+    this._activeDraftKey = null
+    this._draftSaveTimer = null
+    this._handleDraftInput = () => {
+      if (this.editingId || this._stashedDraft || !this._activeDraftKey) return
+      clearTimeout(this._draftSaveTimer)
+      this._draftSaveTimer = setTimeout(() => this._saveDraftNow(), 500)
+    }
+    this.textareaTarget.addEventListener('input', this._handleDraftInput)
+
     this.textareaTarget.addEventListener('keydown', (event) => {
       if (event.key === 'Escape') {
         this.presenceController?.cancelAllAgentTasks()
@@ -117,6 +129,14 @@ export default class extends Controller {
   }
 
   handleTopicChange(event) {
+    // This event fires before onPopupOpened during a chat switch, while the
+    // textarea still contains the outgoing chat's text. Flush before re-keying.
+    const nextDraftKey =
+      this.element.dataset.effectiveCreativeId || this.element.dataset.creativeId || null
+    if (String(this._activeDraftKey || '') !== String(nextDraftKey || '')) {
+      this._flushDraftSave()
+      this._activeDraftKey = nextDraftKey ? String(nextDraftKey) : null
+    }
     this.currentTopicId = event.detail.topicId
     this._isInbox = event.detail.isInbox || false
     this._systemTopicId = event.detail.systemTopicId || null
@@ -132,6 +152,8 @@ export default class extends Controller {
   }
 
   disconnect() {
+    this._flushDraftSave()
+    this.textareaTarget.removeEventListener('input', this._handleDraftInput)
     this.formTarget.removeEventListener('submit', this.handleSubmit)
     this.submitTarget.removeEventListener('click', this.handleSend)
     this.submitTarget.removeEventListener('pointerup', this.handlePointerSend)
@@ -172,9 +194,12 @@ export default class extends Controller {
     if (canComment && this.shouldAutoFocusOnOpen()) {
       requestAnimationFrame(() => this.textareaTarget.focus())
     }
+    this._restoreDraft()
   }
 
   onPopupClosed() {
+    this._flushDraftSave()
+    this._activeDraftKey = null
     this.stopSpeechRecognition()
     this.resetForm()
   }
@@ -183,6 +208,7 @@ export default class extends Controller {
     this.formTarget.style.display = canComment ? '' : 'none'
 
     if (!canComment) {
+      this._flushDraftSave()
       this.stopSpeechRecognition()
       this.resetForm()
       return
@@ -208,6 +234,7 @@ export default class extends Controller {
   }
 
   startEditing({ id, content, private: isPrivate }) {
+    this._flushDraftSave()
     this.editingId = id
     this.textareaTarget.value = content || ''
     if (this.privateCheckboxTarget) {
@@ -223,6 +250,7 @@ export default class extends Controller {
 
   handleStashDraft(event) {
     const draft = event.detail?.draft || null
+    if (draft) this._flushDraftSave()
     // Tagged with the conversation it was typed in: the popup reuses this one
     // controller for every creative, so a stash left over from another one must
     // not be handed back here.
@@ -252,6 +280,7 @@ export default class extends Controller {
     // would re-open the command menu for a draft that starts with "/".
     this._autoResize()
     this._updateSubmitButton()
+    this._saveDraftNow()
   }
 
   resetForm() {
@@ -268,6 +297,28 @@ export default class extends Controller {
     this.textareaTarget.placeholder = this._defaultPlaceholder()
     // Reset textarea height after clearing content
     this.textareaTarget.style.height = 'auto'
+  }
+
+  _saveDraftNow() {
+    if (!this._activeDraftKey || this.editingId || this._stashedDraft) return
+    chatDrafts.set(this._activeDraftKey, this.textareaTarget.value)
+  }
+
+  _flushDraftSave() {
+    clearTimeout(this._draftSaveTimer)
+    this._draftSaveTimer = null
+    this._saveDraftNow()
+  }
+
+  _restoreDraft() {
+    if (!this._activeDraftKey || this.editingId) return
+    if (this.textareaTarget.value.trim()) return
+
+    const draft = chatDrafts.get(this._activeDraftKey)
+    if (draft) {
+      this.textareaTarget.value = draft
+      requestAnimationFrame(() => this._autoResize())
+    }
   }
 
   setSendingState(isSending) {
@@ -372,9 +423,12 @@ export default class extends Controller {
         const wasEditing = this.editingId
         this.resetForm()
         if (wasEditing) {
+          this._restoreDraft()
           // If editing, just replace the item in place
           this.renderCommentHtml(html, { replaceExisting: true })
         } else {
+          clearTimeout(this._draftSaveTimer)
+          if (this._activeDraftKey) chatDrafts.clear(this._activeDraftKey)
           // New Comment:
           // 1. If we are in "History Mode" (scrolled up), sending a message should jump us to the latest.
           // 2. Ideally, we just reload the "Latest" page to ensure sync and Live Mode.
@@ -440,6 +494,7 @@ export default class extends Controller {
   handleCancel(event) {
     event.preventDefault()
     this.resetForm()
+    this._restoreDraft()
   }
 
   handleSearch(event) {

--- a/engines/collavre/app/javascript/controllers/comments/popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_controller.js
@@ -1,5 +1,6 @@
 import { Controller } from '@hotwired/stimulus'
 import chatHistory from '../../lib/chat_history'
+import chatDrafts from '../../lib/chat_drafts'
 
 const SIZE_STORAGE_KEY = 'commentsPopupSize'
 const CREATIVE_CLICK_EVENT = 'creative-comments-click'
@@ -116,7 +117,10 @@ export default class extends Controller {
     }
 
     document.querySelectorAll('form[action="/session"]').forEach((form) => {
-      form.addEventListener('submit', () => window.localStorage.removeItem(SIZE_STORAGE_KEY))
+      form.addEventListener('submit', () => {
+        window.localStorage.removeItem(SIZE_STORAGE_KEY)
+        chatDrafts.clearAll()
+      })
     })
 
     if (this.element.dataset.autoFullscreen === 'true') {

--- a/engines/collavre/app/javascript/controllers/comments/popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_controller.js
@@ -407,6 +407,7 @@ export default class extends Controller {
     // formController.onPopupOpened, which runs after the topics await — would
     // erase the topic that restoreSelection() just restored from the server.
     if (this.formController) {
+      this.formController.onChatWillOpen?.({ creativeId })
       this.formController.currentTopicId = ''
       this.formController._mainTopicId = null
     }

--- a/engines/collavre/app/javascript/controllers/comments/popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_controller.js
@@ -119,6 +119,7 @@ export default class extends Controller {
     document.querySelectorAll('form[action="/session"]').forEach((form) => {
       form.addEventListener('submit', () => {
         window.localStorage.removeItem(SIZE_STORAGE_KEY)
+        this.formController?.discardDraft()
         chatDrafts.clearAll()
       })
     })

--- a/engines/collavre/app/javascript/controllers/comments/popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_controller.js
@@ -118,9 +118,13 @@ export default class extends Controller {
 
     document.querySelectorAll('form[action="/session"]').forEach((form) => {
       form.addEventListener('submit', () => {
-        window.localStorage.removeItem(SIZE_STORAGE_KEY)
         this.formController?.discardDraft()
         chatDrafts.clearAll()
+        try {
+          window.localStorage.removeItem(SIZE_STORAGE_KEY)
+        } catch {
+          // Storage can be unavailable on restricted origins; logout must continue.
+        }
       })
     })
 

--- a/engines/collavre/app/javascript/controllers/comments/popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_controller.js
@@ -116,7 +116,7 @@ export default class extends Controller {
       }
     }
 
-    document.querySelectorAll('form[action="/session"]').forEach((form) => {
+    document.querySelectorAll('form[action$="/session"]').forEach((form) => {
       form.addEventListener('submit', () => {
         this.formController?.discardDraft()
         chatDrafts.clearAll()

--- a/engines/collavre/app/javascript/lib/__tests__/chat_drafts.test.js
+++ b/engines/collavre/app/javascript/lib/__tests__/chat_drafts.test.js
@@ -8,6 +8,13 @@ import { ChatDrafts } from '../chat_drafts'
 describe('ChatDrafts', () => {
   let drafts
 
+  const storedValues = (prefix) => Array.from(
+    { length: window.localStorage.length },
+    (_, index) => window.localStorage.key(index),
+  )
+    .filter((key) => key.startsWith(prefix))
+    .map((key) => window.localStorage.getItem(key))
+
   beforeEach(() => {
     window.localStorage.clear()
     document.body.dataset.currentUserId = '9'
@@ -27,10 +34,126 @@ describe('ChatDrafts', () => {
     expect(drafts.get('999')).toBeNull()
   })
 
+  test('stores concurrent chats under independent keys', () => {
+    const firstTab = new ChatDrafts()
+    const otherTab = new ChatDrafts()
+
+    firstTab.set('101', 'draft from first tab')
+    otherTab.set('202', 'draft from other tab')
+
+    expect(drafts.get('101')).toBe('draft from first tab')
+    expect(drafts.get('202')).toBe('draft from other tab')
+    expect(storedValues('collavre_chat_drafts_9:101:').join()).toContain('first tab')
+    expect(storedValues('collavre_chat_drafts_9:202:').join()).toContain('other tab')
+    expect(window.localStorage.getItem('collavre_chat_drafts_9')).toBeNull()
+  })
+
+  test('uses a deterministic version tie-breaker for the same timestamp', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(1000)
+    const earlier = { text: 'earlier', updatedAt: 1000, version: '1000-a' }
+    const later = { text: 'later', updatedAt: 1000, version: '1000-b' }
+
+    expect(drafts._append('101', later)).toBe(true)
+    expect(drafts._append('101', earlier)).toBe(true)
+
+    expect(drafts.get('101')).toBe('later')
+    expect(drafts.revision('101')).toBe('1000-b')
+  })
+
+  test('a clear tombstone survives obsolete aggregate cleanup', () => {
+    let now = 1000
+    jest.spyOn(Date, 'now').mockImplementation(() => now)
+    drafts.set('101', 'clear me')
+    now += 1
+    drafts.clear('101')
+
+    window.localStorage.setItem('collavre_chat_drafts_9', JSON.stringify({
+      101: { text: 'old tab draft', updatedAt: 1000 },
+    }))
+
+    expect(drafts.get('101')).toBeNull()
+    expect(window.localStorage.getItem('collavre_chat_drafts_9')).toBeNull()
+  })
+
+  test('a conditional tombstone does not hide a newer concurrent operation', () => {
+    let now = 1000
+    jest.spyOn(Date, 'now').mockImplementation(() => now)
+    drafts.set('101', 'eviction candidate')
+    const candidate = drafts._entry('101')
+    now += 1
+    drafts.set('101', 'newer concurrent input')
+    now += 1
+    drafts._append('101', drafts._newEntry('', candidate, {
+      deleted: true,
+      deletesThrough: drafts._versionOf(candidate),
+    }))
+
+    expect(drafts.get('101')).toBe('newer concurrent input')
+    drafts._compact('101')
+    expect(drafts.get('101')).toBe('newer concurrent input')
+  })
+
+  test('compaction keeps a tombstone that blocks a delayed stale operation', () => {
+    let now = 1000
+    jest.spyOn(Date, 'now').mockImplementation(() => now)
+    drafts.set('101', 'draft to clear')
+    const stale = drafts._entry('101')
+    now += 1
+    drafts.clear('101')
+
+    expect(drafts.get('101')).toBeNull()
+    expect(drafts._append('101', stale)).toBe(true)
+    expect(drafts.get('101')).toBeNull()
+  })
+
+  test('bounds tombstones during repeated set and clear cycles', () => {
+    for (let index = 0; index < 1000; index += 1) {
+      drafts.set('101', `draft ${index}`)
+      drafts.clear('101')
+    }
+
+    expect(storedValues('collavre_chat_drafts_9:101:')).toHaveLength(1)
+  })
+
+  test('retains each chat deletion guard until TTL cleanup', () => {
+    drafts.set('victim', 'draft to clear')
+    const stale = drafts._entry('victim')
+    drafts.clear('victim')
+    for (let index = 0; index < 50; index += 1) {
+      drafts.set(`other-${index}`, `draft ${index}`)
+      drafts.clear(`other-${index}`)
+    }
+
+    drafts._append('victim', stale)
+
+    expect(drafts.get('victim')).toBeNull()
+  })
+
+  test('compaction retains only the strongest deletion guard', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(1000)
+    const ceiling = (updatedAt, version) => ({ updatedAt, version })
+    const tombstones = [
+      { text: '', updatedAt: 11, version: 't1', deleted: true, deletesThrough: ceiling(10, 'v1') },
+      { text: '', updatedAt: 31, version: 't2', deleted: true, deletesThrough: ceiling(30, 'v3') },
+      { text: '', updatedAt: 21, version: 't3', deleted: true, deletesThrough: ceiling(20, 'v2') },
+      { text: '', updatedAt: 32, version: 't4', deleted: true, deletesThrough: ceiling(30, 'v3') },
+      { text: '', updatedAt: 30, version: 't0', deleted: true, deletesThrough: ceiling(30, 'v3') },
+    ]
+    tombstones.forEach((entry) => drafts._append('101', entry))
+
+    drafts._compact('101')
+
+    expect(storedValues('collavre_chat_drafts_9:101:')).toEqual([
+      JSON.stringify(tombstones[3]),
+    ])
+  })
+
   test('exposes a monotonic update timestamp per draft', () => {
     jest.spyOn(Date, 'now').mockReturnValue(1000)
     expect(drafts.updatedAt(null)).toBeNull()
     expect(drafts.updatedAt('missing')).toBeNull()
+    expect(drafts.revision(null)).toBeNull()
+    expect(drafts.revision('missing')).toBeNull()
 
     drafts.set('101', 'same text')
     const firstUpdatedAt = drafts.updatedAt('101')
@@ -42,7 +165,7 @@ describe('ChatDrafts', () => {
 
   test('storage key is namespaced by current user id', () => {
     drafts.set('101', 'hello')
-    expect(window.localStorage.getItem('collavre_chat_drafts_9')).toContain('hello')
+    expect(storedValues('collavre_chat_drafts_9:101:').join()).toContain('hello')
   })
 
   test('recomputes the storage namespace when the current user changes', () => {
@@ -52,8 +175,8 @@ describe('ChatDrafts', () => {
     expect(drafts.get('101')).toBeNull()
     drafts.set('101', 'user 10 draft')
 
-    expect(window.localStorage.getItem('collavre_chat_drafts_9')).toContain('user 9 draft')
-    expect(window.localStorage.getItem('collavre_chat_drafts_10')).toContain('user 10 draft')
+    expect(storedValues('collavre_chat_drafts_9:101:').join()).toContain('user 9 draft')
+    expect(storedValues('collavre_chat_drafts_10:101:').join()).toContain('user 10 draft')
   })
 
   test('exposes the current namespace for asynchronous ownership checks', () => {
@@ -66,19 +189,21 @@ describe('ChatDrafts', () => {
     delete document.body.dataset.currentUserId
     const guestDrafts = new ChatDrafts()
     guestDrafts.set('101', 'guest draft')
-    expect(window.localStorage.getItem('collavre_chat_drafts_guest')).toContain('guest draft')
+    expect(storedValues('collavre_chat_drafts_guest:101:').join()).toContain('guest draft')
   })
 
-  test('blank text deletes the entry', () => {
+  test('blank text hides the entry behind a deletion tombstone', () => {
     drafts.set('101', 'hello')
     drafts.set('101', '   ')
     expect(drafts.get('101')).toBeNull()
-    expect(window.localStorage.getItem('collavre_chat_drafts_9')).not.toContain('101')
+    expect(storedValues('collavre_chat_drafts_9:101:').some((value) => (
+      JSON.parse(value).deleted === true
+    ))).toBe(true)
   })
 
   test('set with blank text on a missing entry is a no-op (no write)', () => {
     drafts.set('101', '')
-    expect(window.localStorage.getItem('collavre_chat_drafts_9')).toBeNull()
+    expect(storedValues('collavre_chat_drafts_9:101:')).toEqual([])
   })
 
   test('clear removes a single draft', () => {
@@ -96,6 +221,51 @@ describe('ChatDrafts', () => {
 
     expect(drafts.get('raw')).toBeNull()
     expect(drafts.get('effective')).toBe('loading-window draft')
+
+    drafts.move('raw', 'effective')
+    expect(drafts.get('effective')).toBe('loading-window draft')
+  })
+
+  test('retries a move when the source changes concurrently', () => {
+    drafts.set('raw', 'first source')
+    const sameEntry = drafts._sameEntry.bind(drafts)
+    let changed = false
+    jest.spyOn(drafts, '_sameEntry').mockImplementation((source, latest) => {
+      if (!changed) {
+        changed = true
+        drafts.set('raw', 'newer source')
+        return false
+      }
+      return sameEntry(source, latest)
+    })
+
+    drafts.move('raw', 'effective')
+
+    expect(drafts.get('raw')).toBeNull()
+    expect(drafts.get('effective')).toBe('newer source')
+  })
+
+  test('handles move marker write failure', () => {
+    drafts.set('raw', 'source')
+    const append = drafts._append.bind(drafts)
+    jest.spyOn(drafts, '_append').mockImplementation((id, entry) => (
+      entry.movedTo ? false : append(id, entry)
+    ))
+    expect(() => drafts.move('raw', 'effective')).not.toThrow()
+    expect(drafts.get('raw')).toBe('source')
+  })
+
+  test('keeps the source when the move target cannot be stored', () => {
+    drafts.set('raw', 'source')
+    const append = drafts._append.bind(drafts)
+    jest.spyOn(drafts, '_append').mockImplementation((id, entry) => (
+      id === 'effective' ? false : append(id, entry)
+    ))
+
+    drafts.move('raw', 'effective')
+
+    expect(drafts.get('raw')).toBe('source')
+    expect(drafts.get('effective')).toBeNull()
   })
 
   test('moves only the newer draft when the destination already exists', () => {
@@ -133,30 +303,32 @@ describe('ChatDrafts', () => {
 
     expect(drafts.get('raw')).toBeNull()
     expect(drafts.updatedAt('raw')).toBe(1001)
+    expect(drafts.revision('raw')).not.toBeNull()
 
     drafts.move('raw', 'effective')
 
     expect(drafts.get('raw')).toBeNull()
     expect(drafts.updatedAt('raw')).toBeNull()
+    expect(drafts.revision('raw')).toBeNull()
     expect(drafts.get('effective')).toBeNull()
   })
 
   test('move ignores invalid, identical, and missing source ids', () => {
     drafts.set('101', 'existing draft')
-    const stored = window.localStorage.getItem('collavre_chat_drafts_9')
+    const stored = storedValues('collavre_chat_drafts_9:101:')
 
     drafts.move(null, '102')
     drafts.move('101', null)
     drafts.move('101', '101')
     drafts.move('missing', '102')
 
-    expect(window.localStorage.getItem('collavre_chat_drafts_9')).toBe(stored)
+    expect(storedValues('collavre_chat_drafts_9:101:')).toEqual(stored)
   })
 
   test('clearAll removes the storage key', () => {
     drafts.set('101', 'a')
     drafts.clearAll()
-    expect(window.localStorage.getItem('collavre_chat_drafts_9')).toBeNull()
+    expect(storedValues('collavre_chat_drafts_9:101:')).toEqual([])
   })
 
   test('clearAll broadcasts its namespace for other tabs', () => {
@@ -186,7 +358,7 @@ describe('ChatDrafts', () => {
     drafts.set('101', 'a')
     drafts.clearAll({ broadcast: false })
 
-    expect(window.localStorage.getItem('collavre_chat_drafts_9')).toBeNull()
+    expect(storedValues('collavre_chat_drafts_9:101:')).toEqual([])
     expect(window.localStorage.getItem('collavre_chat_drafts_clear')).toBeNull()
   })
 
@@ -207,22 +379,33 @@ describe('ChatDrafts', () => {
     expect(drafts.get('chat-51')).toBe('draft 51')
   })
 
-  test('prunes entries older than the 7-day TTL on load', () => {
-    const eightDaysAgo = Date.now() - 8 * 24 * 60 * 60 * 1000
-    window.localStorage.setItem(
-      'collavre_chat_drafts_9',
-      JSON.stringify({
-        old: { text: 'stale', updatedAt: eightDaysAgo },
-        fresh: { text: 'recent', updatedAt: Date.now() },
-      }),
-    )
-    expect(drafts.get('old')).toBeNull()
+  test('discards the obsolete aggregate format on load', () => {
+    window.localStorage.setItem('collavre_chat_drafts_9', JSON.stringify({
+      old: { text: 'stale', updatedAt: Date.now() },
+      fresh: { text: 'recent', updatedAt: Date.now() },
+    }))
+
+    expect(drafts.get('fresh')).toBeNull()
+    expect(window.localStorage.getItem('collavre_chat_drafts_9')).toBeNull()
+  })
+
+  test('prunes expired independent operations while loading another chat', () => {
+    const oldKey = 'collavre_chat_drafts_9:old:expired'
+    window.localStorage.setItem(oldKey, JSON.stringify({
+      text: 'stale sensitive text',
+      updatedAt: Date.now() - 8 * 24 * 60 * 60 * 1000,
+      version: 'expired',
+    }))
+    drafts.set('fresh', 'recent')
+
     expect(drafts.get('fresh')).toBe('recent')
+    expect(window.localStorage.getItem(oldKey)).toBeNull()
   })
 
   test('survives corrupted stored JSON', () => {
     window.localStorage.setItem('collavre_chat_drafts_9', '{not json')
     expect(drafts.get('101')).toBeNull()
+    expect(window.localStorage.getItem('collavre_chat_drafts_9')).toBeNull()
     drafts.set('101', 'recovered')
     expect(drafts.get('101')).toBe('recovered')
   })
@@ -236,6 +419,7 @@ describe('ChatDrafts', () => {
     )
     expect(drafts.get('bad')).toBeNull()
     expect(drafts.get('worse')).toBeNull()
+    expect(window.localStorage.getItem('collavre_chat_drafts_9')).toBeNull()
   })
 
   test('survives a throwing storage backend', () => {
@@ -249,4 +433,124 @@ describe('ChatDrafts', () => {
     expect(brokenDrafts.get('101')).toBeNull()
     expect(() => brokenDrafts.clearAll()).not.toThrow()
   })
+
+  test('handles malformed independent entries and key enumeration failures', () => {
+    window.localStorage.setItem('collavre_chat_drafts_9:bad-json:op', '{bad')
+    window.localStorage.setItem(
+      'collavre_chat_drafts_9:bad-entry:op',
+      JSON.stringify({ text: 42, updatedAt: Date.now() }),
+    )
+    expect(drafts.get('bad-json')).toBeNull()
+    expect(drafts._entries()).toEqual([])
+
+    const unlistable = new ChatDrafts({
+      length: 1,
+      key: () => { throw new Error('denied') },
+      getItem: () => null,
+      setItem: () => {},
+      removeItem: () => {},
+    })
+    expect(unlistable._keys()).toEqual([])
+  })
+
+  test('ignores an operation removed during key enumeration', () => {
+    const disappearing = new ChatDrafts({
+      length: 1,
+      key: () => 'collavre_chat_drafts_9:101:gone',
+      getItem: () => null,
+      setItem: () => {},
+      removeItem: () => {},
+    })
+
+    expect(disappearing.get('101')).toBeNull()
+  })
+
+  test('ignores an operation removed during entry enumeration', () => {
+    let reads = 0
+    const entry = JSON.stringify({ text: 'draft', updatedAt: Date.now(), version: 'v1' })
+    const disappearing = new ChatDrafts({
+      length: 1,
+      key: () => 'collavre_chat_drafts_9:101:v1',
+      getItem: () => ((reads += 1) === 1 ? entry : null),
+      setItem: () => {},
+      removeItem: () => {},
+    })
+
+    expect(disappearing._entries()).toEqual([])
+  })
+
+  test('removes operation keys with malformed encoded chat ids', () => {
+    const key = 'collavre_chat_drafts_9:%E0%A4%A:v1'
+    window.localStorage.setItem(key, JSON.stringify({
+      text: 'draft',
+      updatedAt: Date.now(),
+      version: 'v1',
+    }))
+
+    expect(drafts._entries()).toEqual([])
+    expect(window.localStorage.getItem(key)).toBeNull()
+
+    const unremovable = new ChatDrafts({
+      length: 1,
+      key: () => key,
+      getItem: () => JSON.stringify({
+        text: 'draft',
+        updatedAt: Date.now(),
+        version: 'v1',
+      }),
+      setItem: () => {},
+      removeItem: () => { throw new Error('denied') },
+    })
+    expect(unremovable._entries()).toEqual([])
+  })
+
+  test('skips invalid operations during compaction and selects the newest operation', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(1000)
+    const older = { text: 'older', updatedAt: 1000, version: 'v1' }
+    const newer = { text: 'newer', updatedAt: 1001, version: 'v2' }
+    const stale = { text: 'stale', updatedAt: 999, version: 'v0' }
+    drafts._append('101', older)
+    drafts._append('101', newer)
+    drafts._append('101', stale)
+    window.localStorage.setItem('collavre_chat_drafts_9:101:invalid', '{bad')
+
+    expect(drafts._entries()).toEqual([{ id: '101', entry: newer }])
+    window.localStorage.setItem('collavre_chat_drafts_9:101:invalid-entry', '{bad')
+    expect(drafts._entry('101')).toEqual(newer)
+    window.localStorage.setItem('collavre_chat_drafts_9:101:invalid-again', '{bad')
+    expect(() => drafts._compact('101')).not.toThrow()
+  })
+
+  test('handles storage failures while pruning and clearing independent entries', () => {
+    const invalid = JSON.stringify({ text: 42, updatedAt: Date.now() })
+    const backend = {
+      length: 1,
+      key: () => 'collavre_chat_drafts_9:101',
+      getItem: (key) => (key.endsWith(':101') ? invalid : null),
+      setItem: () => { throw new Error('quota') },
+      removeItem: () => { throw new Error('denied') },
+    }
+    const failingDrafts = new ChatDrafts(backend)
+
+    expect(failingDrafts.get('101')).toBeNull()
+    expect(() => failingDrafts.clearAll()).not.toThrow()
+  })
+
+  test('bounds immutable append verification retries', () => {
+    const entry = { text: 'draft', updatedAt: Date.now(), version: 'v1' }
+    const noWriteStorage = {
+      getItem: () => null,
+      setItem: () => {},
+      removeItem: () => {},
+    }
+    expect(new ChatDrafts(noWriteStorage)._append('101', entry)).toBe(false)
+  })
+
+  test('compares immutable operations and exact entry identity', () => {
+    const entry = { text: 'draft', updatedAt: 1000, version: 'v1' }
+    expect(drafts._compare(entry, null)).toBe(1)
+    expect(drafts._compare(entry, { ...entry })).toBe(0)
+    expect(drafts._sameEntry(entry, { ...entry })).toBe(true)
+  })
+
 })

--- a/engines/collavre/app/javascript/lib/__tests__/chat_drafts.test.js
+++ b/engines/collavre/app/javascript/lib/__tests__/chat_drafts.test.js
@@ -138,6 +138,157 @@ describe('ChatDrafts', () => {
     expect(drafts.latestSubmissionBackup('101')?.updatedAt).toBe(999)
   })
 
+  test('does not replace a newer submission backup with a late older failure', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(2000)
+    const olderTab = new ChatDrafts()
+    const newerTab = new ChatDrafts()
+    olderTab._writerId = 'a'
+    newerTab._writerId = 'b'
+
+    const newerKey = newerTab.saveSubmissionBackup(
+      '101',
+      'later submission that failed first',
+      { updatedAt: 2000 },
+    )
+    const ignoredOlderKey = olderTab.saveSubmissionBackup(
+      '101',
+      'earlier submission that failed later',
+      { updatedAt: 1000 },
+    )
+    const ignoredTiedKey = olderTab.saveSubmissionBackup(
+      '101',
+      'same-time submission with an older version',
+      { updatedAt: 2000 },
+    )
+
+    expect(ignoredOlderKey).toBeNull()
+    expect(ignoredTiedKey).toBeNull()
+    expect(drafts.latestSubmissionBackup('101')).toMatchObject({
+      key: newerKey,
+      text: 'later submission that failed first',
+      updatedAt: 2000,
+    })
+  })
+
+  test('drops its candidate when a newer backup arrives during the write', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(3000)
+    const values = new Map()
+    let interleaved = false
+    const storage = {
+      get length() { return values.size },
+      key: (index) => [...values.keys()][index] ?? null,
+      getItem: (key) => values.get(key) ?? null,
+      setItem: (key, value) => {
+	values.set(key, value)
+	if (interleaved || !key.includes('_pending:101:')) return
+
+	interleaved = true
+	values.set(
+	  'collavre_chat_drafts_9_pending:101:3000-z-1',
+	  JSON.stringify({ text: 'concurrent newer failure', updatedAt: 3000 }),
+	)
+      },
+      removeItem: (key) => values.delete(key),
+    }
+    const interleavedDrafts = new ChatDrafts(null, storage)
+    interleavedDrafts._writerId = 'a'
+
+    const candidateKey = interleavedDrafts.saveSubmissionBackup(
+      '101',
+      'older failure being persisted',
+      { updatedAt: 2000 },
+    )
+
+    expect(candidateKey).toBeNull()
+    expect(interleavedDrafts.latestSubmissionBackup('101')?.text)
+      .toBe('concurrent newer failure')
+    expect([...values.keys()]).toHaveLength(1)
+  })
+
+  test('rolls back a new backup when an older backup cannot be removed', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(2000)
+    const values = new Map()
+    let blockedKey = null
+    const storage = {
+      get length() { return values.size },
+      key: (index) => [...values.keys()][index] ?? null,
+      getItem: (key) => values.get(key) ?? null,
+      setItem: (key, value) => values.set(key, value),
+      removeItem: (key) => {
+	if (key !== blockedKey) values.delete(key)
+      },
+    }
+    const rollbackDrafts = new ChatDrafts(null, storage)
+    const olderKey = rollbackDrafts.saveSubmissionBackup(
+      '101',
+      'older failed submission',
+      { updatedAt: 1000 },
+    )
+    blockedKey = olderKey
+
+    const rolledBackKey = rollbackDrafts.saveSubmissionBackup(
+      '101',
+      'newer failed submission',
+      { updatedAt: 2000 },
+    )
+
+    expect(rolledBackKey).toBeNull()
+    expect(rollbackDrafts.latestSubmissionBackup('101')).toMatchObject({
+      key: olderKey,
+      text: 'older failed submission',
+    })
+    expect([...values.keys()]).toEqual([olderKey])
+  })
+
+  test('tracks a candidate when rollback fails and clears only through that version', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(3000)
+    const values = new Map()
+    let removalsBlocked = true
+    const storage = {
+      get length() { return values.size },
+      key: (index) => [...values.keys()][index] ?? null,
+      getItem: (key) => values.get(key) ?? null,
+      setItem: (key, value) => values.set(key, value),
+      removeItem: (key) => {
+	if (!removalsBlocked) values.delete(key)
+      },
+    }
+    const retryDrafts = new ChatDrafts(null, storage)
+    retryDrafts._writerId = 'a'
+    const olderKey = retryDrafts.saveSubmissionBackup(
+      '101',
+      'older failed submission',
+      { updatedAt: 1000 },
+    )
+    const candidateKey = retryDrafts.saveSubmissionBackup(
+      '101',
+      'candidate whose rollback is blocked',
+      { updatedAt: 2000 },
+    )
+    retryDrafts._writerId = 'z'
+    const newerKey = retryDrafts.saveSubmissionBackup(
+      '101',
+      'newer concurrent failure',
+      { updatedAt: 3000 },
+    )
+
+    expect(candidateKey).not.toBeNull()
+    expect(newerKey).not.toBeNull()
+    removalsBlocked = false
+    expect(retryDrafts.clearSubmissionBackupsThrough(candidateKey)).toBe(true)
+
+    expect(values.has(olderKey)).toBe(false)
+    expect(values.has(candidateKey)).toBe(false)
+    expect(retryDrafts.latestSubmissionBackup('101')).toMatchObject({
+      key: newerKey,
+      text: 'newer concurrent failure',
+    })
+    expect(retryDrafts.clearSubmissionBackupsThrough('unrelated-key')).toBe(false)
+    expect(retryDrafts.clearSubmissionBackupsThrough(
+      'collavre_chat_drafts_9_pending:101:missing',
+    )).toBe(false)
+  })
+
   test('stores submission backups independently and removes exact backups', () => {
     let now = 1000
     jest.spyOn(Date, 'now').mockImplementation(() => now)

--- a/engines/collavre/app/javascript/lib/__tests__/chat_drafts.test.js
+++ b/engines/collavre/app/javascript/lib/__tests__/chat_drafts.test.js
@@ -119,6 +119,26 @@ describe('ChatDrafts', () => {
     expect(drafts.get('101')).toBe('newer concurrent input')
   })
 
+  test('clearing a draft does not hide text concurrently saved from the same revision', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(1000)
+    drafts.set('101', 'shared draft')
+
+    const clearingTab = new ChatDrafts()
+    const writingTab = new ChatDrafts()
+    clearingTab._writerId = 'z-clear'
+    writingTab._writerId = 'a-write'
+    const append = clearingTab._append.bind(clearingTab)
+    jest.spyOn(clearingTab, '_append').mockImplementation((id, entry) => {
+      if (entry.deleted) writingTab.set('101', 'concurrent new text')
+      return append(id, entry)
+    })
+
+    clearingTab.clear('101')
+
+    expect(drafts.get('101')).toBe('concurrent new text')
+    expect(drafts.revision('101')).toContain('a-write')
+  })
+
   test('compaction keeps a tombstone that blocks a delayed stale operation', () => {
     let now = 1000
     jest.spyOn(Date, 'now').mockImplementation(() => now)

--- a/engines/collavre/app/javascript/lib/__tests__/chat_drafts.test.js
+++ b/engines/collavre/app/javascript/lib/__tests__/chat_drafts.test.js
@@ -864,6 +864,31 @@ describe('ChatDrafts', () => {
     expect(() => brokenDrafts.clearAll()).not.toThrow()
   })
 
+  test('falls back when Web Storage property access is denied', () => {
+    jest.spyOn(window, 'localStorage', 'get').mockImplementation(() => {
+      throw new DOMException('denied', 'SecurityError')
+    })
+    jest.spyOn(window, 'sessionStorage', 'get').mockImplementation(() => {
+      throw new DOMException('denied', 'SecurityError')
+    })
+    const unavailableDrafts = new ChatDrafts()
+
+    expect(() => unavailableDrafts.snapshot('101')).not.toThrow()
+    expect(unavailableDrafts._backend().key(0)).toBeNull()
+    expect(unavailableDrafts._backend().getItem('missing')).toBeNull()
+    unavailableDrafts.set('101', 'ephemeral draft')
+    expect(unavailableDrafts.get('101')).toBe('ephemeral draft')
+
+    const backupKey = unavailableDrafts.saveSubmissionBackup('101', 'failed send')
+    expect(unavailableDrafts.latestSubmissionBackup('101')).toMatchObject({
+      key: backupKey,
+      text: 'failed send',
+    })
+    expect(() => unavailableDrafts.clearAll()).not.toThrow()
+    expect(unavailableDrafts.get('101')).toBeNull()
+    expect(unavailableDrafts.latestSubmissionBackup('101')).toBeNull()
+  })
+
   test('handles malformed independent entries and key enumeration failures', () => {
     window.localStorage.setItem('collavre_chat_drafts_9:bad-json:op', '{bad')
     window.localStorage.setItem(

--- a/engines/collavre/app/javascript/lib/__tests__/chat_drafts.test.js
+++ b/engines/collavre/app/javascript/lib/__tests__/chat_drafts.test.js
@@ -43,6 +43,12 @@ describe('ChatDrafts', () => {
     expect(window.localStorage.getItem('collavre_chat_drafts_10')).toContain('user 10 draft')
   })
 
+  test('exposes the current namespace for asynchronous ownership checks', () => {
+    expect(drafts.namespace()).toBe('collavre_chat_drafts_9')
+    document.body.dataset.currentUserId = '10'
+    expect(drafts.namespace()).toBe('collavre_chat_drafts_10')
+  })
+
   test('falls back to guest namespace without a current user id', () => {
     delete document.body.dataset.currentUserId
     const guestDrafts = new ChatDrafts()

--- a/engines/collavre/app/javascript/lib/__tests__/chat_drafts.test.js
+++ b/engines/collavre/app/javascript/lib/__tests__/chat_drafts.test.js
@@ -71,20 +71,51 @@ describe('ChatDrafts', () => {
     expect(drafts.snapshot('101')).toEqual({
       text: 'submitted draft',
       revision: 'v1',
+      updatedAt: 1000,
     })
     expect(entry).toHaveBeenCalledTimes(1)
-    expect(drafts.snapshot(null)).toEqual({ text: null, revision: null })
+    expect(drafts.snapshot(null)).toEqual({
+      text: null,
+      revision: null,
+      updatedAt: null,
+    })
 
     entry.mockRestore()
-    expect(drafts.snapshot('missing')).toEqual({ text: null, revision: null })
+    expect(drafts.snapshot('missing')).toEqual({
+      text: null,
+      revision: null,
+      updatedAt: null,
+    })
     drafts.set('blank', '', { preserveBlank: true })
     expect(drafts.snapshot('blank')).toEqual({
       text: null,
       revision: drafts.revision('blank'),
+      updatedAt: drafts.updatedAt('blank'),
     })
     drafts.set('raw', 'draft to move')
     drafts.move('raw', 'effective')
-    expect(drafts.snapshot('raw')).toEqual({ text: null, revision: null })
+    expect(drafts.snapshot('raw')).toEqual({
+      text: null,
+      revision: null,
+      updatedAt: null,
+    })
+
+    drafts.set('cleared', 'draft to clear')
+    drafts.clear('cleared')
+    expect(drafts.snapshot('cleared')).toEqual({
+      text: null,
+      revision: null,
+      updatedAt: drafts._entry('cleared').updatedAt,
+    })
+  })
+
+  test('orders a submission backup after the regular draft it supersedes', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(1000)
+    drafts.set('101', 'older regular draft')
+
+    drafts.saveSubmissionBackup('101', 'newer failed submission')
+
+    expect(drafts.latestSubmissionBackup('101')?.updatedAt).toBe(1001)
   })
 
   test('stores submission backups independently and removes exact backups', () => {

--- a/engines/collavre/app/javascript/lib/__tests__/chat_drafts.test.js
+++ b/engines/collavre/app/javascript/lib/__tests__/chat_drafts.test.js
@@ -617,6 +617,55 @@ describe('ChatDrafts', () => {
     expect(drafts.get('effective')).toBeNull()
   })
 
+  test('a blank migration does not hide the first concurrent destination draft', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(1000)
+    drafts._writerId = 'z-clear'
+    drafts.set('raw', '', { preserveBlank: true })
+
+    const writingTab = new ChatDrafts()
+    writingTab._writerId = 'a-write'
+    const entry = drafts._entry.bind(drafts)
+    let destinationWritten = false
+    jest.spyOn(drafts, '_entry').mockImplementation((id) => {
+      const current = entry(id)
+      if (id === 'effective' && !current && !destinationWritten) {
+        destinationWritten = true
+        writingTab.set('effective', 'first canonical draft')
+      }
+      return current
+    })
+
+    drafts.move('raw', 'effective')
+
+    expect(drafts.get('raw')).toBeNull()
+    expect(drafts.get('effective')).toBe('first canonical draft')
+    expect(drafts.revision('effective')).toContain('a-write')
+  })
+
+  test('a migrated blank does not hide text concurrently saved from the destination revision', () => {
+    let now = 1000
+    jest.spyOn(Date, 'now').mockImplementation(() => now)
+    drafts._writerId = 'z-clear'
+    drafts.set('effective', 'canonical draft')
+    now += 1
+    drafts.set('raw', '', { preserveBlank: true })
+
+    const writingTab = new ChatDrafts()
+    writingTab._writerId = 'a-write'
+    const append = drafts._append.bind(drafts)
+    jest.spyOn(drafts, '_append').mockImplementation((id, entry) => {
+      if (id === 'effective' && entry.deleted) {
+        writingTab.set('effective', 'concurrent canonical text')
+      }
+      return append(id, entry)
+    })
+
+    drafts.move('raw', 'effective')
+
+    expect(drafts.get('effective')).toBe('concurrent canonical text')
+    expect(drafts.revision('effective')).toContain('a-write')
+  })
+
   test('move ignores invalid, identical, and missing source ids', () => {
     drafts.set('101', 'existing draft')
     const stored = storedValues('collavre_chat_drafts_9:101:')

--- a/engines/collavre/app/javascript/lib/__tests__/chat_drafts.test.js
+++ b/engines/collavre/app/javascript/lib/__tests__/chat_drafts.test.js
@@ -1017,22 +1017,30 @@ describe('ChatDrafts', () => {
 
   test('clearAll broadcasts its namespace for other tabs', () => {
     drafts.clearAll()
-    const signal = window.localStorage.getItem('collavre_chat_drafts_clear')
+    const signalKey = drafts._clearEventKey()
+    const signal = window.localStorage.getItem(signalKey)
+    const legacySignal = window.localStorage.getItem('collavre_chat_drafts_clear')
 
     expect(JSON.parse(signal).namespace).toBe('collavre_chat_drafts_9')
+    expect(JSON.parse(signal)).toMatchObject(JSON.parse(legacySignal))
+    expect(JSON.parse(signal).legacyNonce).toBe(JSON.parse(legacySignal).nonce)
     expect(drafts.clearNonce()).toBe(JSON.parse(signal).nonce)
+    expect(drafts.clearNoncePending()).toBe(false)
     expect(drafts.clearNonce('collavre_chat_drafts_10')).toBeNull()
-    window.localStorage.setItem('collavre_chat_drafts_clear', JSON.stringify({
+    const signalWithoutNonce = JSON.stringify({
       namespace: 'collavre_chat_drafts_9',
-    }))
+    })
+    window.localStorage.setItem(signalKey, signalWithoutNonce)
+    window.localStorage.setItem('collavre_chat_drafts_clear', signalWithoutNonce)
     expect(drafts.clearNonce()).toBeNull()
+    window.localStorage.setItem(signalKey, signal)
     window.localStorage.setItem('collavre_chat_drafts_clear', signal)
     expect(drafts.wasCleared(new StorageEvent('storage', {
-      key: 'collavre_chat_drafts_clear',
+      key: signalKey,
       newValue: signal,
     }))).toBe(true)
     expect(drafts.wasCleared(new StorageEvent('storage', {
-      key: 'collavre_chat_drafts_clear',
+      key: drafts._clearEventKey('collavre_chat_drafts_10'),
       newValue: JSON.stringify({ namespace: 'collavre_chat_drafts_10' }),
     }))).toBe(false)
     expect(drafts.wasCleared(new StorageEvent('storage', {
@@ -1040,11 +1048,181 @@ describe('ChatDrafts', () => {
       newValue: signal,
     }))).toBe(false)
     expect(drafts.wasCleared(new StorageEvent('storage', {
-      key: 'collavre_chat_drafts_clear',
+      key: signalKey,
       newValue: '{invalid',
     }))).toBe(false)
+    window.localStorage.setItem(signalKey, '{invalid')
+    expect(drafts.clearNonce()).toBe(JSON.parse(signal).nonce)
+    window.localStorage.setItem(signalKey, '{invalid')
     window.localStorage.setItem('collavre_chat_drafts_clear', '{invalid')
-    expect(drafts.clearNonce()).toBeUndefined()
+    expect(drafts.clearNonce()).toBeNull()
+  })
+
+  test('reads and observes legacy clear signals', () => {
+    const signal = JSON.stringify({
+      namespace: 'collavre_chat_drafts_9',
+      nonce: 'legacy-logout',
+    })
+    window.localStorage.setItem('collavre_chat_drafts_clear', signal)
+
+    expect(drafts.clearNonce()).toBe('legacy-logout')
+    expect(drafts.wasCleared(new StorageEvent('storage', {
+      key: 'collavre_chat_drafts_clear',
+      newValue: signal,
+    }))).toBe(true)
+  })
+
+  test('promotes a newer legacy clear signal into its namespace marker', () => {
+    const signalKey = drafts._clearEventKey()
+    window.localStorage.setItem(signalKey, JSON.stringify({
+      namespace: 'collavre_chat_drafts_9',
+      nonce: '1000-new-client',
+      updatedAt: 1000,
+    }))
+    window.localStorage.setItem('collavre_chat_drafts_clear', JSON.stringify({
+      namespace: 'collavre_chat_drafts_9',
+      nonce: '2000-old-client',
+    }))
+
+    expect(drafts.clearNonce()).toBe('2000-old-client')
+    expect(JSON.parse(window.localStorage.getItem(signalKey)).nonce)
+      .toBe('2000-old-client')
+  })
+
+  test('treats a changed synchronized legacy signal as newer across clock rollback', () => {
+    const signalKey = drafts._clearEventKey()
+    window.localStorage.setItem(signalKey, JSON.stringify({
+      namespace: 'collavre_chat_drafts_9',
+      nonce: '2000-z-new-client',
+      updatedAt: 2000,
+      legacyNamespace: 'collavre_chat_drafts_9',
+      legacyNonce: '2000-z-new-client',
+    }))
+    window.localStorage.setItem('collavre_chat_drafts_clear', JSON.stringify({
+      namespace: 'collavre_chat_drafts_9',
+      nonce: '1000-a-old-client',
+    }))
+
+    expect(drafts.clearNonce()).toBe('1000-a-old-client')
+    expect(JSON.parse(window.localStorage.getItem(signalKey))).toMatchObject({
+      nonce: '1000-a-old-client',
+      legacyNonce: '1000-a-old-client',
+    })
+  })
+
+  test('prefers the current legacy signal when old markers lack ordering metadata', () => {
+    const namespace = 'collavre_chat_drafts_9'
+    window.localStorage.setItem(drafts._clearEventKey(namespace), JSON.stringify({
+      namespace,
+      nonce: 'new-client-marker',
+    }))
+    window.localStorage.setItem('collavre_chat_drafts_clear', JSON.stringify({
+      namespace,
+      nonce: 'old-client-logout',
+    }))
+
+    expect(drafts.clearNonce()).toBe('old-client-logout')
+  })
+
+  test('keeps a new namespaced marker when the legacy write remains stale', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(1000)
+    const namespace = 'collavre_chat_drafts_9'
+    const namespacedKey = drafts._clearEventKey(namespace)
+    const staleLegacy = JSON.stringify({
+      namespace,
+      nonce: '3000-stale-legacy',
+      updatedAt: 3000,
+    })
+    const values = new Map([['collavre_chat_drafts_clear', staleLegacy]])
+    const storage = {
+      get length() { return values.size },
+      key: (index) => [...values.keys()][index] ?? null,
+      getItem: (key) => values.get(key) ?? null,
+      setItem: (key, value) => {
+	if (key !== 'collavre_chat_drafts_clear') values.set(key, value)
+      },
+      removeItem: (key) => values.delete(key),
+    }
+    const partialDrafts = new ChatDrafts(storage)
+
+    partialDrafts.clearAll()
+
+    const namespacedSignal = JSON.parse(values.get(namespacedKey))
+    expect(namespacedSignal.legacyNonce).toBe('3000-stale-legacy')
+    expect(partialDrafts.clearNonce()).toBe(namespacedSignal.nonce)
+  })
+
+  test('does not observe a legacy promotion until its write is verified', () => {
+    const namespace = 'collavre_chat_drafts_9'
+    const namespacedKey = drafts._clearEventKey(namespace)
+    const namespacedSignal = JSON.stringify({
+      namespace,
+      nonce: 'logout-1',
+      legacyNamespace: namespace,
+      legacyNonce: 'logout-1',
+    })
+    const legacySignal = JSON.stringify({ namespace, nonce: 'logout-2' })
+    const values = new Map([
+      [namespacedKey, namespacedSignal],
+      ['collavre_chat_drafts_clear', legacySignal],
+    ])
+    let writesBlocked = true
+    const storage = {
+      get length() { return values.size },
+      key: (index) => [...values.keys()][index] ?? null,
+      getItem: (key) => values.get(key) ?? null,
+      setItem: (key, value) => {
+	if (!writesBlocked) values.set(key, value)
+      },
+      removeItem: (key) => values.delete(key),
+    }
+
+    const silentDrafts = new ChatDrafts(storage)
+    expect(silentDrafts.clearNonce(namespace)).toBe('logout-2')
+    expect(silentDrafts.clearNoncePending(namespace)).toBe(true)
+    expect(values.get(namespacedKey)).toBe(namespacedSignal)
+
+    const throwingStorage = {
+      ...storage,
+      setItem: () => { throw new Error('denied') },
+    }
+    const throwingDrafts = new ChatDrafts(throwingStorage)
+    expect(throwingDrafts.clearNonce(namespace)).toBe('logout-2')
+    expect(throwingDrafts.clearNoncePending(namespace)).toBe(true)
+
+    writesBlocked = false
+    expect(new ChatDrafts(storage).clearNonce(namespace)).toBe('logout-2')
+    expect(silentDrafts.clearNonce(namespace)).toBe('logout-2')
+    expect(silentDrafts.clearNoncePending(namespace)).toBe(false)
+  })
+
+  test('uses a valid clear marker when the other marker cannot be read', () => {
+    const namespace = 'collavre_chat_drafts_9'
+    const namespacedKey = drafts._clearEventKey(namespace)
+    const signal = JSON.stringify({ namespace, nonce: 'logout-1' })
+    const storage = {
+      length: 0,
+      key: () => null,
+      getItem: (key) => {
+	if (key === 'collavre_chat_drafts_clear') throw new Error('denied')
+	return key === namespacedKey ? signal : null
+      },
+      setItem: () => {},
+      removeItem: () => {},
+    }
+
+    expect(new ChatDrafts(storage).clearNonce(namespace)).toBe('logout-1')
+  })
+
+  test('retains clear nonces for each user namespace', () => {
+    drafts.clearAll()
+    const userNineNonce = drafts.clearNonce()
+
+    document.body.dataset.currentUserId = '10'
+    drafts.clearAll()
+
+    expect(drafts.clearNonce()).not.toBe(userNineNonce)
+    expect(drafts.clearNonce('collavre_chat_drafts_9')).toBe(userNineNonce)
   })
 
   test('clearAll can skip the cross-tab broadcast', () => {
@@ -1052,7 +1230,7 @@ describe('ChatDrafts', () => {
     drafts.clearAll({ broadcast: false })
 
     expect(storedValues('collavre_chat_drafts_9:101:')).toEqual([])
-    expect(window.localStorage.getItem('collavre_chat_drafts_clear')).toBeNull()
+    expect(window.localStorage.getItem(drafts._clearEventKey())).toBeNull()
   })
 
   test('ignores falsy chat ids', () => {

--- a/engines/collavre/app/javascript/lib/__tests__/chat_drafts.test.js
+++ b/engines/collavre/app/javascript/lib/__tests__/chat_drafts.test.js
@@ -766,6 +766,13 @@ describe('ChatDrafts', () => {
     const signal = window.localStorage.getItem('collavre_chat_drafts_clear')
 
     expect(JSON.parse(signal).namespace).toBe('collavre_chat_drafts_9')
+    expect(drafts.clearNonce()).toBe(JSON.parse(signal).nonce)
+    expect(drafts.clearNonce('collavre_chat_drafts_10')).toBeNull()
+    window.localStorage.setItem('collavre_chat_drafts_clear', JSON.stringify({
+      namespace: 'collavre_chat_drafts_9',
+    }))
+    expect(drafts.clearNonce()).toBeNull()
+    window.localStorage.setItem('collavre_chat_drafts_clear', signal)
     expect(drafts.wasCleared(new StorageEvent('storage', {
       key: 'collavre_chat_drafts_clear',
       newValue: signal,
@@ -782,6 +789,8 @@ describe('ChatDrafts', () => {
       key: 'collavre_chat_drafts_clear',
       newValue: '{invalid',
     }))).toBe(false)
+    window.localStorage.setItem('collavre_chat_drafts_clear', '{invalid')
+    expect(drafts.clearNonce()).toBeUndefined()
   })
 
   test('clearAll can skip the cross-tab broadcast', () => {
@@ -861,6 +870,7 @@ describe('ChatDrafts', () => {
     const brokenDrafts = new ChatDrafts(broken)
     expect(() => brokenDrafts.set('101', 'x')).not.toThrow()
     expect(brokenDrafts.get('101')).toBeNull()
+    expect(brokenDrafts.clearNonce()).toBeUndefined()
     expect(() => brokenDrafts.clearAll()).not.toThrow()
   })
 
@@ -874,6 +884,7 @@ describe('ChatDrafts', () => {
     const unavailableDrafts = new ChatDrafts()
 
     expect(() => unavailableDrafts.snapshot('101')).not.toThrow()
+    expect(unavailableDrafts.clearNonce()).toBeUndefined()
     expect(unavailableDrafts._backend().key(0)).toBeNull()
     expect(unavailableDrafts._backend().getItem('missing')).toBeNull()
     unavailableDrafts.set('101', 'ephemeral draft')

--- a/engines/collavre/app/javascript/lib/__tests__/chat_drafts.test.js
+++ b/engines/collavre/app/javascript/lib/__tests__/chat_drafts.test.js
@@ -118,6 +118,15 @@ describe('ChatDrafts', () => {
     expect(drafts.latestSubmissionBackup('101')?.updatedAt).toBe(1001)
   })
 
+  test('uses a captured timestamp to preserve submission-time ordering', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(1000)
+    drafts.set('101', 'regular draft written after submission')
+
+    drafts.saveSubmissionBackup('101', 'failed submission', { updatedAt: 999 })
+
+    expect(drafts.latestSubmissionBackup('101')?.updatedAt).toBe(999)
+  })
+
   test('stores submission backups independently and removes exact backups', () => {
     let now = 1000
     jest.spyOn(Date, 'now').mockImplementation(() => now)

--- a/engines/collavre/app/javascript/lib/__tests__/chat_drafts.test.js
+++ b/engines/collavre/app/javascript/lib/__tests__/chat_drafts.test.js
@@ -124,6 +124,23 @@ describe('ChatDrafts', () => {
     expect(drafts.get('effective')).toBe('newer canonical draft')
   })
 
+  test('moves a newer blank tombstone by clearing the destination', () => {
+    let now = 1000
+    jest.spyOn(Date, 'now').mockImplementation(() => now)
+    drafts.set('effective', 'canonical draft')
+    now += 1
+    drafts.set('raw', '', { preserveBlank: true })
+
+    expect(drafts.get('raw')).toBeNull()
+    expect(drafts.updatedAt('raw')).toBe(1001)
+
+    drafts.move('raw', 'effective')
+
+    expect(drafts.get('raw')).toBeNull()
+    expect(drafts.updatedAt('raw')).toBeNull()
+    expect(drafts.get('effective')).toBeNull()
+  })
+
   test('move ignores invalid, identical, and missing source ids', () => {
     drafts.set('101', 'existing draft')
     const stored = window.localStorage.getItem('collavre_chat_drafts_9')
@@ -140,6 +157,37 @@ describe('ChatDrafts', () => {
     drafts.set('101', 'a')
     drafts.clearAll()
     expect(window.localStorage.getItem('collavre_chat_drafts_9')).toBeNull()
+  })
+
+  test('clearAll broadcasts its namespace for other tabs', () => {
+    drafts.clearAll()
+    const signal = window.localStorage.getItem('collavre_chat_drafts_clear')
+
+    expect(JSON.parse(signal).namespace).toBe('collavre_chat_drafts_9')
+    expect(drafts.wasCleared(new StorageEvent('storage', {
+      key: 'collavre_chat_drafts_clear',
+      newValue: signal,
+    }))).toBe(true)
+    expect(drafts.wasCleared(new StorageEvent('storage', {
+      key: 'collavre_chat_drafts_clear',
+      newValue: JSON.stringify({ namespace: 'collavre_chat_drafts_10' }),
+    }))).toBe(false)
+    expect(drafts.wasCleared(new StorageEvent('storage', {
+      key: 'unrelated',
+      newValue: signal,
+    }))).toBe(false)
+    expect(drafts.wasCleared(new StorageEvent('storage', {
+      key: 'collavre_chat_drafts_clear',
+      newValue: '{invalid',
+    }))).toBe(false)
+  })
+
+  test('clearAll can skip the cross-tab broadcast', () => {
+    drafts.set('101', 'a')
+    drafts.clearAll({ broadcast: false })
+
+    expect(window.localStorage.getItem('collavre_chat_drafts_9')).toBeNull()
+    expect(window.localStorage.getItem('collavre_chat_drafts_clear')).toBeNull()
   })
 
   test('ignores falsy chat ids', () => {

--- a/engines/collavre/app/javascript/lib/__tests__/chat_drafts.test.js
+++ b/engines/collavre/app/javascript/lib/__tests__/chat_drafts.test.js
@@ -32,6 +32,17 @@ describe('ChatDrafts', () => {
     expect(window.localStorage.getItem('collavre_chat_drafts_9')).toContain('hello')
   })
 
+  test('recomputes the storage namespace when the current user changes', () => {
+    drafts.set('101', 'user 9 draft')
+
+    document.body.dataset.currentUserId = '10'
+    expect(drafts.get('101')).toBeNull()
+    drafts.set('101', 'user 10 draft')
+
+    expect(window.localStorage.getItem('collavre_chat_drafts_9')).toContain('user 9 draft')
+    expect(window.localStorage.getItem('collavre_chat_drafts_10')).toContain('user 10 draft')
+  })
+
   test('falls back to guest namespace without a current user id', () => {
     delete document.body.dataset.currentUserId
     const guestDrafts = new ChatDrafts()

--- a/engines/collavre/app/javascript/lib/__tests__/chat_drafts.test.js
+++ b/engines/collavre/app/javascript/lib/__tests__/chat_drafts.test.js
@@ -109,6 +109,17 @@ describe('ChatDrafts', () => {
     })
   })
 
+  test('compares resolved drafts across chat keys', () => {
+    drafts.set('raw', 'raw draft')
+    expect(drafts.isNewer('raw', 'effective')).toBe(true)
+    expect(drafts.isNewer('raw', null)).toBe(true)
+    expect(drafts.isNewer(null, 'effective')).toBe(false)
+    expect(drafts.isNewer('missing', 'effective')).toBe(false)
+
+    drafts.set('effective', 'canonical draft')
+    expect(drafts.isNewer('raw', 'effective')).toBe(false)
+  })
+
   test('orders a submission backup after the regular draft it supersedes', () => {
     jest.spyOn(Date, 'now').mockReturnValue(1000)
     drafts.set('101', 'older regular draft')
@@ -549,6 +560,72 @@ describe('ChatDrafts', () => {
     expect(drafts.get('effective')).toBe('newer source')
   })
 
+  test('retries a move when a newer source survives the move marker', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(1000)
+    drafts.set('raw', 'first source')
+
+    const writingTab = new ChatDrafts()
+    const append = drafts._append.bind(drafts)
+    let sourceWritten = false
+    const writeNewerSource = () => {
+      sourceWritten = true
+      writingTab.set('raw', 'newer source')
+    }
+    jest.spyOn(drafts, '_append').mockImplementation((id, entry) => {
+      if (id === 'raw' && entry.movedTo && !sourceWritten) writeNewerSource()
+      return append(id, entry)
+    })
+
+    drafts.move('raw', 'effective')
+
+    expect(drafts.get('raw')).toBeNull()
+    expect(drafts.get('effective')).toBe('newer source')
+  })
+
+  test('retries a move when a concurrent source clear survives the marker', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(1000)
+    drafts._writerId = 'z-marker'
+    drafts.set('raw', 'source to clear')
+
+    const clearingTab = new ChatDrafts()
+    clearingTab._writerId = 'a-clear'
+    const append = drafts._append.bind(drafts)
+    let sourceCleared = false
+    const clearSource = () => {
+      sourceCleared = true
+      clearingTab.clear('raw')
+    }
+    jest.spyOn(drafts, '_append').mockImplementation((id, entry) => {
+      if (id === 'raw' && entry.movedTo && !sourceCleared) clearSource()
+      return append(id, entry)
+    })
+
+    drafts.move('raw', 'effective')
+
+    expect(drafts.get('raw')).toBeNull()
+    expect(drafts.get('effective')).toBeNull()
+  })
+
+  test('reports an incomplete move after concurrent source writes exhaust retries', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(1000)
+    drafts.set('raw', 'first source')
+
+    const writingTab = new ChatDrafts()
+    const append = drafts._append.bind(drafts)
+    let sourceWrites = 0
+    const writeNewerSource = () => {
+      sourceWrites += 1
+      writingTab.set('raw', `newer source ${sourceWrites}`)
+    }
+    jest.spyOn(drafts, '_append').mockImplementation((id, entry) => {
+      if (id === 'raw' && entry.movedTo) writeNewerSource()
+      return append(id, entry)
+    })
+
+    expect(drafts.move('raw', 'effective')).toBe(false)
+    expect(drafts.get('raw')).toBe('newer source 3')
+  })
+
   test('handles move marker write failure', () => {
     drafts.set('raw', 'source')
     const append = drafts._append.bind(drafts)
@@ -566,7 +643,7 @@ describe('ChatDrafts', () => {
       id === 'effective' ? false : append(id, entry)
     ))
 
-    drafts.move('raw', 'effective')
+    expect(drafts.move('raw', 'effective')).toBe(false)
 
     expect(drafts.get('raw')).toBe('source')
     expect(drafts.get('effective')).toBeNull()

--- a/engines/collavre/app/javascript/lib/__tests__/chat_drafts.test.js
+++ b/engines/collavre/app/javascript/lib/__tests__/chat_drafts.test.js
@@ -17,6 +17,7 @@ describe('ChatDrafts', () => {
 
   beforeEach(() => {
     window.localStorage.clear()
+    window.sessionStorage.clear()
     document.body.dataset.currentUserId = '9'
     drafts = new ChatDrafts()
   })
@@ -84,6 +85,223 @@ describe('ChatDrafts', () => {
     drafts.set('raw', 'draft to move')
     drafts.move('raw', 'effective')
     expect(drafts.snapshot('raw')).toEqual({ text: null, revision: null })
+  })
+
+  test('stores submission backups independently and removes exact backups', () => {
+    let now = 1000
+    jest.spyOn(Date, 'now').mockImplementation(() => now)
+    expect(drafts.saveSubmissionBackup(null, 'draft')).toBeNull()
+    expect(drafts.saveSubmissionBackup('101', '  ')).toBeNull()
+    expect(drafts.latestSubmissionBackup(null)).toBeNull()
+
+    const firstKey = drafts.saveSubmissionBackup('101', 'first submission')
+    now += 1
+    const secondKey = drafts.saveSubmissionBackup('101', 'second submission')
+
+    expect(drafts.latestSubmissionBackup('101')).toEqual({
+      key: secondKey,
+      text: 'second submission',
+      updatedAt: 1001,
+    })
+    drafts.removeSubmissionBackup('unrelated-key')
+    drafts.removeSubmissionBackup(secondKey, 'collavre_chat_drafts_other')
+    expect(drafts.latestSubmissionBackup('101')?.key).toBe(secondKey)
+    drafts.removeSubmissionBackup(secondKey)
+    expect(window.sessionStorage.getItem(firstKey)).toBeNull()
+    expect(drafts.latestSubmissionBackup('101')).toBeNull()
+    drafts.clearSubmissionBackups('101')
+    drafts.clearSubmissionBackups(null)
+    expect(drafts.latestSubmissionBackup('101')).toBeNull()
+
+    now += 1
+    const tiedFirst = drafts.saveSubmissionBackup('101', 'tied first')
+    const tiedSecond = drafts.saveSubmissionBackup('101', 'tied second')
+    expect(window.sessionStorage.getItem(tiedFirst)).toBeNull()
+    expect(drafts.latestSubmissionBackup('101')?.key).toBe(tiedSecond)
+
+    const prefix = drafts._backupPrefix('tied')
+    window.sessionStorage.setItem(`${prefix}a`, JSON.stringify({ text: 'a', updatedAt: now }))
+    window.sessionStorage.setItem(`${prefix}b`, JSON.stringify({ text: 'b', updatedAt: now }))
+    expect(drafts.latestSubmissionBackup('tied')?.text).toBe('b')
+  })
+
+  test('moves submission backups without changing their ordering metadata', () => {
+    expect(drafts.moveSubmissionBackups(null, 'effective')).toEqual(new Map())
+    expect(drafts.moveSubmissionBackups('raw', 'raw')).toEqual(new Map())
+    const sourceKey = drafts.saveSubmissionBackup('raw', 'linked submission')
+    const source = drafts.latestSubmissionBackup('raw')
+
+    const moved = drafts.moveSubmissionBackups('raw', 'effective')
+
+    expect(moved.get(sourceKey)).toBe(drafts.latestSubmissionBackup('effective').key)
+    expect(drafts.latestSubmissionBackup('effective')).toMatchObject({
+      text: 'linked submission',
+      updatedAt: source.updatedAt,
+    })
+    expect(drafts.latestSubmissionBackup('raw')).toBeNull()
+  })
+
+  test('keeps the newest submission backup when linked keys converge', () => {
+    let now = 1000
+    jest.spyOn(Date, 'now').mockImplementation(() => now)
+    drafts.saveSubmissionBackup('older-raw', 'older raw')
+    now += 1
+    const newerTargetKey = drafts.saveSubmissionBackup('newer-target', 'newer target')
+
+    expect(drafts.moveSubmissionBackups('older-raw', 'newer-target')).toEqual(new Map())
+    expect(drafts.latestSubmissionBackup('newer-target')?.key).toBe(newerTargetKey)
+    expect(drafts.latestSubmissionBackup('older-raw')).toBeNull()
+
+    drafts.saveSubmissionBackup('older-target', 'older target')
+    now += 1
+    const newerSourceKey = drafts.saveSubmissionBackup('newer-raw', 'newer raw')
+    const moved = drafts.moveSubmissionBackups('newer-raw', 'older-target')
+    expect(moved.get(newerSourceKey)).toBe(drafts.latestSubmissionBackup('older-target').key)
+    expect(drafts.latestSubmissionBackup('older-target')?.text).toBe('newer raw')
+
+    const tiedSourceKey = drafts.saveSubmissionBackup('tied-raw', 'tied raw')
+    const tiedTargetKey = drafts.saveSubmissionBackup('tied-target', 'tied target')
+    expect(drafts.moveSubmissionBackups('tied-raw', 'tied-target')).toEqual(new Map())
+    expect(drafts.latestSubmissionBackup('tied-target')?.key).toBe(tiedTargetKey)
+    expect(window.sessionStorage.getItem(tiedSourceKey)).toBeNull()
+  })
+
+  test('keeps a submission backup when its move cannot be persisted', () => {
+    const storage = {
+      get length() { return window.localStorage.length },
+      key: (index) => window.localStorage.key(index),
+      getItem: (key) => window.localStorage.getItem(key),
+      setItem: (key, value) => {
+        if (key.startsWith('collavre_chat_drafts_9_pending:effective:')) {
+          throw new Error('quota')
+        }
+        window.localStorage.setItem(key, value)
+      },
+      removeItem: (key) => window.localStorage.removeItem(key),
+    }
+    const failingDrafts = new ChatDrafts(storage)
+    failingDrafts.saveSubmissionBackup('raw', 'keep at source')
+
+    expect(failingDrafts.moveSubmissionBackups('raw', 'effective')).toEqual(new Map())
+    expect(failingDrafts.latestSubmissionBackup('raw')?.text).toBe('keep at source')
+    expect(failingDrafts.latestSubmissionBackup('effective')).toBeNull()
+
+    window.localStorage.clear()
+    const droppedStorage = {
+      get length() { return window.localStorage.length },
+      key: storage.key,
+      getItem: storage.getItem,
+      setItem: (key, value) => {
+        if (!key.startsWith('collavre_chat_drafts_9_pending:effective:')) {
+          window.localStorage.setItem(key, value)
+        }
+      },
+      removeItem: storage.removeItem,
+    }
+    const droppedDrafts = new ChatDrafts(droppedStorage)
+    droppedDrafts.saveSubmissionBackup('raw', 'verify destination')
+    expect(droppedDrafts.moveSubmissionBackups('raw', 'effective')).toEqual(new Map())
+    expect(droppedDrafts.latestSubmissionBackup('raw')?.text).toBe('verify destination')
+
+    const values = new Map()
+    const stickySourceStorage = {
+      get length() { return values.size },
+      key: (index) => [...values.keys()][index] || null,
+      getItem: (key) => values.get(key) ?? null,
+      setItem: (key, value) => values.set(key, value),
+      removeItem: (key) => {
+        if (!key.startsWith('collavre_chat_drafts_9_pending:raw:')) values.delete(key)
+      },
+    }
+    const stickyDrafts = new ChatDrafts(stickySourceStorage)
+    stickyDrafts.saveSubmissionBackup('raw', 'source cannot be removed')
+    expect(stickyDrafts.moveSubmissionBackups('raw', 'effective')).toEqual(new Map())
+    expect(stickyDrafts.latestSubmissionBackup('raw')?.text).toBe('source cannot be removed')
+    expect(stickyDrafts.latestSubmissionBackup('effective')).toBeNull()
+
+    values.clear()
+    const stickyTargetStorage = {
+      get length() { return values.size },
+      key: stickySourceStorage.key,
+      getItem: stickySourceStorage.getItem,
+      setItem: stickySourceStorage.setItem,
+      removeItem: (key) => {
+        if (!key.startsWith('collavre_chat_drafts_9_pending:effective:')) values.delete(key)
+      },
+    }
+    const stickyTargetDrafts = new ChatDrafts(stickyTargetStorage)
+    let now = 1000
+    jest.spyOn(Date, 'now').mockImplementation(() => now)
+    stickyTargetDrafts.saveSubmissionBackup('effective', 'target cannot be removed')
+    now += 1
+    stickyTargetDrafts.saveSubmissionBackup('raw', 'newer source')
+    expect(stickyTargetDrafts.moveSubmissionBackups('raw', 'effective')).toEqual(new Map())
+    expect(stickyTargetDrafts.latestSubmissionBackup('effective')?.text)
+      .toBe('target cannot be removed')
+    expect(stickyTargetDrafts.latestSubmissionBackup('raw')?.text).toBe('newer source')
+  })
+
+  test('prunes expired and malformed submission backups', () => {
+    const prefix = drafts._backupPrefix('101')
+    const expiredKey = `${prefix}expired`
+    const malformedKey = `${prefix}malformed`
+    const blankKey = `${prefix}blank`
+    window.sessionStorage.setItem(expiredKey, JSON.stringify({
+      text: 'expired submission',
+      updatedAt: Date.now() - 8 * 24 * 60 * 60 * 1000,
+    }))
+    window.sessionStorage.setItem(malformedKey, '{bad')
+    window.sessionStorage.setItem(blankKey, JSON.stringify({ text: '', updatedAt: Date.now() }))
+    expect(drafts.latestSubmissionBackup('101')).toBeNull()
+    const validKey = drafts.saveSubmissionBackup('101', 'valid submission')
+
+    expect(drafts.latestSubmissionBackup('101')?.key).toBe(validKey)
+    expect(window.sessionStorage.getItem(expiredKey)).toBeNull()
+    expect(window.sessionStorage.getItem(malformedKey)).toBeNull()
+    expect(window.sessionStorage.getItem(blankKey)).toBeNull()
+
+    drafts.clearAll({ broadcast: false })
+    expect(window.sessionStorage.getItem(validKey)).toBeNull()
+  })
+
+  test('bounds submission backups to the newest fifty entries', () => {
+    let now = 1000
+    jest.spyOn(Date, 'now').mockImplementation(() => (now += 1))
+    const keys = Array.from({ length: 51 }, (_, index) => (
+      drafts.saveSubmissionBackup(`chat-${index}`, `submission ${index}`)
+    ))
+
+    expect(window.sessionStorage.getItem(keys[0])).toBeNull()
+    expect(window.sessionStorage.getItem(keys[50])).not.toBeNull()
+    expect(drafts.latestSubmissionBackup('chat-50')?.text).toBe('submission 50')
+  })
+
+  test('submission backups tolerate unavailable storage', () => {
+    const broken = {
+      length: 1,
+      key: () => 'collavre_chat_drafts_9_pending:101:backup',
+      getItem: () => { throw new Error('denied') },
+      setItem: () => { throw new Error('quota') },
+      removeItem: () => { throw new Error('denied') },
+    }
+    const brokenDrafts = new ChatDrafts(broken)
+
+    expect(brokenDrafts.saveSubmissionBackup('101', 'draft')).toBeNull()
+    expect(brokenDrafts.latestSubmissionBackup('101')).toBeNull()
+    expect(() => brokenDrafts.removeSubmissionBackup(
+      'collavre_chat_drafts_9_pending:101:backup',
+    )).not.toThrow()
+    expect(() => brokenDrafts.clearSubmissionBackups('101')).not.toThrow()
+
+    const writeOnlyFailure = {
+      length: 0,
+      key: () => null,
+      getItem: () => null,
+      setItem: () => { throw new Error('quota') },
+      removeItem: () => {},
+    }
+    expect(new ChatDrafts(null, writeOnlyFailure)
+      .saveSubmissionBackup('101', 'draft')).toBeNull()
   })
 
   test('a clear tombstone survives obsolete aggregate cleanup', () => {

--- a/engines/collavre/app/javascript/lib/__tests__/chat_drafts.test.js
+++ b/engines/collavre/app/javascript/lib/__tests__/chat_drafts.test.js
@@ -60,6 +60,32 @@ describe('ChatDrafts', () => {
     expect(drafts.revision('101')).toBe('1000-b')
   })
 
+  test('snapshots text and revision from one resolved operation', () => {
+    const resolved = { text: 'submitted draft', updatedAt: 1000, version: 'v1' }
+    const newer = { text: 'concurrent draft', updatedAt: 1001, version: 'v2' }
+    const entry = jest.spyOn(drafts, '_entry')
+      .mockImplementationOnce(() => resolved)
+      .mockImplementation(() => newer)
+
+    expect(drafts.snapshot('101')).toEqual({
+      text: 'submitted draft',
+      revision: 'v1',
+    })
+    expect(entry).toHaveBeenCalledTimes(1)
+    expect(drafts.snapshot(null)).toEqual({ text: null, revision: null })
+
+    entry.mockRestore()
+    expect(drafts.snapshot('missing')).toEqual({ text: null, revision: null })
+    drafts.set('blank', '', { preserveBlank: true })
+    expect(drafts.snapshot('blank')).toEqual({
+      text: null,
+      revision: drafts.revision('blank'),
+    })
+    drafts.set('raw', 'draft to move')
+    drafts.move('raw', 'effective')
+    expect(drafts.snapshot('raw')).toEqual({ text: null, revision: null })
+  })
+
   test('a clear tombstone survives obsolete aggregate cleanup', () => {
     let now = 1000
     jest.spyOn(Date, 'now').mockImplementation(() => now)

--- a/engines/collavre/app/javascript/lib/__tests__/chat_drafts.test.js
+++ b/engines/collavre/app/javascript/lib/__tests__/chat_drafts.test.js
@@ -327,6 +327,70 @@ describe('ChatDrafts', () => {
     expect(drafts.latestSubmissionBackup('tied')?.text).toBe('b')
   })
 
+  test('clears submission backups once for each observed logout nonce', () => {
+    drafts.saveSubmissionBackup('101', 'failed before logout')
+
+    expect(drafts.clearSubmissionBackupsForClear(null, 'logout-1')).toBe(false)
+    expect(drafts.clearSubmissionBackupsForClear(
+      'collavre_chat_drafts_9',
+      null,
+    )).toBe(false)
+    expect(drafts.clearSubmissionBackupsForClear(
+      'collavre_chat_drafts_9',
+      'logout-1',
+    )).toBe(true)
+    expect(drafts.latestSubmissionBackup('101')).toBeNull()
+
+    drafts.saveSubmissionBackup('101', 'failed after logout')
+    expect(drafts.clearSubmissionBackupsForClear(
+      'collavre_chat_drafts_9',
+      'logout-1',
+    )).toBe(true)
+    expect(drafts.latestSubmissionBackup('101')?.text).toBe('failed after logout')
+
+    expect(drafts.clearSubmissionBackupsForClear(
+      'collavre_chat_drafts_9',
+      'logout-2',
+    )).toBe(true)
+    expect(drafts.latestSubmissionBackup('101')).toBeNull()
+  })
+
+  test('retries logout backup cleanup when storage cannot complete it', () => {
+    const backupKey = 'collavre_chat_drafts_9_pending:101:backup'
+    const values = new Map([[
+      backupKey,
+      JSON.stringify({ text: 'failed submission', updatedAt: Date.now() }),
+    ]])
+    const blockedRemoval = {
+      get length() { return values.size },
+      key: (index) => [...values.keys()][index] ?? null,
+      getItem: (key) => values.get(key) ?? null,
+      setItem: (key, value) => values.set(key, value),
+      removeItem: () => {},
+    }
+    const blockedDrafts = new ChatDrafts(null, blockedRemoval)
+
+    expect(blockedDrafts.clearSubmissionBackupsForClear(
+      'collavre_chat_drafts_9',
+      'logout-1',
+    )).toBe(false)
+    expect(blockedDrafts.latestSubmissionBackup('101')?.text)
+      .toBe('failed submission')
+
+    const silentAcknowledgement = {
+      length: 0,
+      key: () => null,
+      getItem: () => null,
+      setItem: () => {},
+      removeItem: () => {},
+    }
+    expect(new ChatDrafts(null, silentAcknowledgement)
+      .clearSubmissionBackupsForClear(
+	'collavre_chat_drafts_9',
+	'logout-1',
+      )).toBe(false)
+  })
+
   test('moves submission backups without changing their ordering metadata', () => {
     expect(drafts.moveSubmissionBackups(null, 'effective')).toEqual(new Map())
     expect(drafts.moveSubmissionBackups('raw', 'raw')).toEqual(new Map())
@@ -529,6 +593,10 @@ describe('ChatDrafts', () => {
       'collavre_chat_drafts_9_pending:101:backup',
     )).not.toThrow()
     expect(() => brokenDrafts.clearSubmissionBackups('101')).not.toThrow()
+    expect(brokenDrafts.clearSubmissionBackupsForClear(
+      'collavre_chat_drafts_9',
+      'logout-1',
+    )).toBe(false)
 
     const writeOnlyFailure = {
       length: 0,
@@ -1071,6 +1139,10 @@ describe('ChatDrafts', () => {
 
     expect(() => unavailableDrafts.snapshot('101')).not.toThrow()
     expect(unavailableDrafts.clearNonce()).toBeUndefined()
+    expect(unavailableDrafts.clearSubmissionBackupsForClear(
+      'collavre_chat_drafts_9',
+      'logout-1',
+    )).toBe(false)
     expect(unavailableDrafts._backend().key(0)).toBeNull()
     expect(unavailableDrafts._backend().getItem('missing')).toBeNull()
     unavailableDrafts.set('101', 'ephemeral draft')

--- a/engines/collavre/app/javascript/lib/__tests__/chat_drafts.test.js
+++ b/engines/collavre/app/javascript/lib/__tests__/chat_drafts.test.js
@@ -1,0 +1,127 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { jest } from '@jest/globals'
+import { ChatDrafts } from '../chat_drafts'
+
+describe('ChatDrafts', () => {
+  let drafts
+
+  beforeEach(() => {
+    window.localStorage.clear()
+    document.body.dataset.currentUserId = '9'
+    drafts = new ChatDrafts()
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+    delete document.body.dataset.currentUserId
+  })
+
+  test('set + get roundtrip, keyed per chat', () => {
+    drafts.set('101', 'hello draft')
+    drafts.set(202, 'second draft')
+    expect(drafts.get('101')).toBe('hello draft')
+    expect(drafts.get('202')).toBe('second draft')
+    expect(drafts.get('999')).toBeNull()
+  })
+
+  test('storage key is namespaced by current user id', () => {
+    drafts.set('101', 'hello')
+    expect(window.localStorage.getItem('collavre_chat_drafts_9')).toContain('hello')
+  })
+
+  test('falls back to guest namespace without a current user id', () => {
+    delete document.body.dataset.currentUserId
+    const guestDrafts = new ChatDrafts()
+    guestDrafts.set('101', 'guest draft')
+    expect(window.localStorage.getItem('collavre_chat_drafts_guest')).toContain('guest draft')
+  })
+
+  test('blank text deletes the entry', () => {
+    drafts.set('101', 'hello')
+    drafts.set('101', '   ')
+    expect(drafts.get('101')).toBeNull()
+    expect(window.localStorage.getItem('collavre_chat_drafts_9')).not.toContain('101')
+  })
+
+  test('set with blank text on a missing entry is a no-op (no write)', () => {
+    drafts.set('101', '')
+    expect(window.localStorage.getItem('collavre_chat_drafts_9')).toBeNull()
+  })
+
+  test('clear removes a single draft', () => {
+    drafts.set('101', 'a')
+    drafts.set('102', 'b')
+    drafts.clear('101')
+    expect(drafts.get('101')).toBeNull()
+    expect(drafts.get('102')).toBe('b')
+  })
+
+  test('clearAll removes the storage key', () => {
+    drafts.set('101', 'a')
+    drafts.clearAll()
+    expect(window.localStorage.getItem('collavre_chat_drafts_9')).toBeNull()
+  })
+
+  test('ignores falsy chat ids', () => {
+    drafts.set(null, 'x')
+    drafts.set('', 'x')
+    expect(drafts.get(null)).toBeNull()
+    expect(drafts.get('')).toBeNull()
+    expect(window.localStorage.getItem('collavre_chat_drafts_9')).toBeNull()
+  })
+
+  test('evicts the oldest drafts beyond MAX_DRAFTS (50)', () => {
+    let now = 1_000_000
+    jest.spyOn(Date, 'now').mockImplementation(() => (now += 1000))
+    for (let i = 1; i <= 51; i++) drafts.set(`chat-${i}`, `draft ${i}`)
+    expect(drafts.get('chat-1')).toBeNull()
+    expect(drafts.get('chat-2')).toBe('draft 2')
+    expect(drafts.get('chat-51')).toBe('draft 51')
+  })
+
+  test('prunes entries older than the 7-day TTL on load', () => {
+    const eightDaysAgo = Date.now() - 8 * 24 * 60 * 60 * 1000
+    window.localStorage.setItem(
+      'collavre_chat_drafts_9',
+      JSON.stringify({
+        old: { text: 'stale', updatedAt: eightDaysAgo },
+        fresh: { text: 'recent', updatedAt: Date.now() },
+      }),
+    )
+    expect(drafts.get('old')).toBeNull()
+    expect(drafts.get('fresh')).toBe('recent')
+  })
+
+  test('survives corrupted stored JSON', () => {
+    window.localStorage.setItem('collavre_chat_drafts_9', '{not json')
+    expect(drafts.get('101')).toBeNull()
+    drafts.set('101', 'recovered')
+    expect(drafts.get('101')).toBe('recovered')
+  })
+
+  test('survives non-object stored JSON and malformed entries', () => {
+    window.localStorage.setItem('collavre_chat_drafts_9', JSON.stringify(['array']))
+    expect(drafts.get('101')).toBeNull()
+    window.localStorage.setItem(
+      'collavre_chat_drafts_9',
+      JSON.stringify({ bad: { text: 42 }, worse: null }),
+    )
+    expect(drafts.get('bad')).toBeNull()
+    expect(drafts.get('worse')).toBeNull()
+  })
+
+  test('survives a throwing storage backend', () => {
+    const broken = {
+      getItem: () => { throw new Error('denied') },
+      setItem: () => { throw new Error('quota') },
+      removeItem: () => { throw new Error('denied') },
+    }
+    const brokenDrafts = new ChatDrafts(broken)
+    expect(() => brokenDrafts.set('101', 'x')).not.toThrow()
+    expect(brokenDrafts.get('101')).toBeNull()
+    expect(() => brokenDrafts.clearAll()).not.toThrow()
+  })
+})

--- a/engines/collavre/app/javascript/lib/__tests__/chat_drafts.test.js
+++ b/engines/collavre/app/javascript/lib/__tests__/chat_drafts.test.js
@@ -27,6 +27,19 @@ describe('ChatDrafts', () => {
     expect(drafts.get('999')).toBeNull()
   })
 
+  test('exposes a monotonic update timestamp per draft', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(1000)
+    expect(drafts.updatedAt(null)).toBeNull()
+    expect(drafts.updatedAt('missing')).toBeNull()
+
+    drafts.set('101', 'same text')
+    const firstUpdatedAt = drafts.updatedAt('101')
+    drafts.set('101', 'same text')
+
+    expect(firstUpdatedAt).toBe(1000)
+    expect(drafts.updatedAt('101')).toBe(1001)
+  })
+
   test('storage key is namespaced by current user id', () => {
     drafts.set('101', 'hello')
     expect(window.localStorage.getItem('collavre_chat_drafts_9')).toContain('hello')
@@ -74,6 +87,53 @@ describe('ChatDrafts', () => {
     drafts.clear('101')
     expect(drafts.get('101')).toBeNull()
     expect(drafts.get('102')).toBe('b')
+  })
+
+  test('moves a draft to an empty destination', () => {
+    drafts.set('raw', 'loading-window draft')
+
+    drafts.move('raw', 'effective')
+
+    expect(drafts.get('raw')).toBeNull()
+    expect(drafts.get('effective')).toBe('loading-window draft')
+  })
+
+  test('moves only the newer draft when the destination already exists', () => {
+    let now = 1000
+    jest.spyOn(Date, 'now').mockImplementation(() => now)
+    drafts.set('effective', 'older canonical draft')
+    now += 1
+    drafts.set('raw', 'newer loading-window draft')
+
+    drafts.move('raw', 'effective')
+
+    expect(drafts.get('raw')).toBeNull()
+    expect(drafts.get('effective')).toBe('newer loading-window draft')
+  })
+
+  test('keeps a newer destination when removing a stale source draft', () => {
+    let now = 1000
+    jest.spyOn(Date, 'now').mockImplementation(() => now)
+    drafts.set('raw', 'stale raw draft')
+    now += 1
+    drafts.set('effective', 'newer canonical draft')
+
+    drafts.move('raw', 'effective')
+
+    expect(drafts.get('raw')).toBeNull()
+    expect(drafts.get('effective')).toBe('newer canonical draft')
+  })
+
+  test('move ignores invalid, identical, and missing source ids', () => {
+    drafts.set('101', 'existing draft')
+    const stored = window.localStorage.getItem('collavre_chat_drafts_9')
+
+    drafts.move(null, '102')
+    drafts.move('101', null)
+    drafts.move('101', '101')
+    drafts.move('missing', '102')
+
+    expect(window.localStorage.getItem('collavre_chat_drafts_9')).toBe(stored)
   })
 
   test('clearAll removes the storage key', () => {

--- a/engines/collavre/app/javascript/lib/__tests__/chat_drafts.test.js
+++ b/engines/collavre/app/javascript/lib/__tests__/chat_drafts.test.js
@@ -238,21 +238,53 @@ describe('ChatDrafts', () => {
     expect(failingDrafts.latestSubmissionBackup('effective')).toBeNull()
 
     window.localStorage.clear()
+    let rollbackNow = 1000
+    jest.spyOn(Date, 'now').mockImplementation(() => rollbackNow)
+    const rollbackStorage = {
+      get length() { return window.localStorage.length },
+      key: storage.key,
+      getItem: storage.getItem,
+      setItem: (key, value) => {
+	if (
+	  key.startsWith('collavre_chat_drafts_9_pending:effective:') &&
+	  value.includes('newer source')
+	) throw new Error('quota')
+	window.localStorage.setItem(key, value)
+      },
+      removeItem: storage.removeItem,
+    }
+    const rollbackDrafts = new ChatDrafts(rollbackStorage)
+    rollbackDrafts.saveSubmissionBackup('effective', 'older target')
+    rollbackNow += 1
+    rollbackDrafts.saveSubmissionBackup('raw', 'newer source')
+
+    expect(rollbackDrafts.moveSubmissionBackups('raw', 'effective')).toEqual(new Map())
+    expect(rollbackDrafts.latestSubmissionBackup('effective')?.text).toBe('older target')
+    expect(rollbackDrafts.latestSubmissionBackup('raw')?.text).toBe('newer source')
+
+    window.localStorage.clear()
     const droppedStorage = {
       get length() { return window.localStorage.length },
       key: storage.key,
       getItem: storage.getItem,
       setItem: (key, value) => {
-        if (!key.startsWith('collavre_chat_drafts_9_pending:effective:')) {
-          window.localStorage.setItem(key, value)
-        }
+	if (
+	  !key.startsWith('collavre_chat_drafts_9_pending:effective:') ||
+	  !value.includes('verify destination')
+	) {
+	  window.localStorage.setItem(key, value)
+	}
       },
       removeItem: storage.removeItem,
     }
     const droppedDrafts = new ChatDrafts(droppedStorage)
+    droppedDrafts.saveSubmissionBackup('effective', 'target before dropped write')
+    rollbackNow += 1
     droppedDrafts.saveSubmissionBackup('raw', 'verify destination')
     expect(droppedDrafts.moveSubmissionBackups('raw', 'effective')).toEqual(new Map())
     expect(droppedDrafts.latestSubmissionBackup('raw')?.text).toBe('verify destination')
+    expect(droppedDrafts.latestSubmissionBackup('effective')?.text)
+      .toBe('target before dropped write')
 
     const values = new Map()
     const stickySourceStorage = {
@@ -265,10 +297,13 @@ describe('ChatDrafts', () => {
       },
     }
     const stickyDrafts = new ChatDrafts(stickySourceStorage)
+    stickyDrafts.saveSubmissionBackup('effective', 'target before sticky source')
+    rollbackNow += 1
     stickyDrafts.saveSubmissionBackup('raw', 'source cannot be removed')
     expect(stickyDrafts.moveSubmissionBackups('raw', 'effective')).toEqual(new Map())
     expect(stickyDrafts.latestSubmissionBackup('raw')?.text).toBe('source cannot be removed')
-    expect(stickyDrafts.latestSubmissionBackup('effective')).toBeNull()
+    expect(stickyDrafts.latestSubmissionBackup('effective')?.text)
+      .toBe('target before sticky source')
 
     values.clear()
     const stickyTargetStorage = {

--- a/engines/collavre/app/javascript/lib/chat_drafts.js
+++ b/engines/collavre/app/javascript/lib/chat_drafts.js
@@ -53,18 +53,19 @@ class ChatDrafts {
     }
   }
 
-  saveSubmissionBackup(chatId, text) {
+  saveSubmissionBackup(chatId, text, { updatedAt = null } = {}) {
     if (!chatId || !text || !text.trim()) return null
 
     if (!this.clearSubmissionBackups(chatId)) return null
 
-    const current = this._entry(String(chatId))
-    const updatedAt = Math.max(Date.now(), (current?.updatedAt || 0) + 1)
+    const current = updatedAt === null ? this._entry(String(chatId)) : null
+    const backupUpdatedAt = updatedAt ??
+      Math.max(Date.now(), (current?.updatedAt || 0) + 1)
     this._sequence += 1
-    const version = `${updatedAt}-${this._writerId}-${this._sequence}`
+    const version = `${backupUpdatedAt}-${this._writerId}-${this._sequence}`
     const key = `${this._backupPrefix(String(chatId))}${encodeURIComponent(version)}`
     try {
-      this._backupBackend().setItem(key, JSON.stringify({ text, updatedAt }))
+      this._backupBackend().setItem(key, JSON.stringify({ text, updatedAt: backupUpdatedAt }))
       this._evictSubmissionBackups()
       return key
     } catch {

--- a/engines/collavre/app/javascript/lib/chat_drafts.js
+++ b/engines/collavre/app/javascript/lib/chat_drafts.js
@@ -156,6 +156,32 @@ class ChatDrafts {
     ))
   }
 
+  clearSubmissionBackupsForClear(namespace, nonce) {
+    if (!namespace || !nonce) return false
+
+    const backend = this._backupBackend()
+    if (
+      !this._backupStorage &&
+      !this._storage &&
+      backend === this._fallbackBackupStorage
+    ) return false
+    const acknowledgementKey = `${CLEAR_EVENT_KEY}${KEY_SEPARATOR}${encodeURIComponent(namespace)}`
+    try {
+      if (backend.getItem(acknowledgementKey) === nonce) return true
+
+      const backupsCleared = this._keys(
+	this._backupPrefix(null, namespace),
+	backend,
+      ).every((key) => this.removeSubmissionBackup(key, namespace))
+      if (!backupsCleared) return false
+
+      backend.setItem(acknowledgementKey, nonce)
+      return backend.getItem(acknowledgementKey) === nonce
+    } catch {
+      return false
+    }
+  }
+
   moveSubmissionBackups(sourceChatId, targetChatId) {
     const moved = new Map()
     if (!sourceChatId || !targetChatId) return moved

--- a/engines/collavre/app/javascript/lib/chat_drafts.js
+++ b/engines/collavre/app/javascript/lib/chat_drafts.js
@@ -275,6 +275,18 @@ class ChatDrafts {
     }
   }
 
+  clearNonce(namespace = this._key()) {
+    const backend = this._backend()
+    if (!this._storage && backend === this._fallbackStorage) return undefined
+
+    try {
+      const signal = JSON.parse(backend.getItem(CLEAR_EVENT_KEY))
+      return signal?.namespace === namespace ? signal.nonce || null : null
+    } catch {
+      return undefined
+    }
+  }
+
   namespace() {
     return this._key()
   }

--- a/engines/collavre/app/javascript/lib/chat_drafts.js
+++ b/engines/collavre/app/javascript/lib/chat_drafts.js
@@ -1,12 +1,13 @@
 const MAX_DRAFTS = 50
 const DRAFT_TTL_MS = 7 * 24 * 60 * 60 * 1000
+const CLEAR_EVENT_KEY = 'collavre_chat_drafts_clear'
 
 /**
  * Per-user persistent store for unsent chat input drafts.
  *
  * One localStorage key per user stores drafts keyed by chat id. Blank drafts
- * are removed, stale entries expire after seven days, and the oldest drafts
- * are evicted when the store grows beyond 50 entries.
+ * are removed except for temporary migration tombstones, stale entries expire
+ * after seven days, and the oldest drafts are evicted beyond 50 entries.
  */
 class ChatDrafts {
   constructor(storage = null) {
@@ -16,7 +17,7 @@ class ChatDrafts {
   get(chatId) {
     if (!chatId) return null
     const entry = this._load()[String(chatId)]
-    return entry ? entry.text : null
+    return entry?.text || null
   }
 
   updatedAt(chatId) {
@@ -25,14 +26,22 @@ class ChatDrafts {
     return entry ? entry.updatedAt : null
   }
 
-  set(chatId, text) {
+  set(chatId, text, { preserveBlank = false } = {}) {
     if (!chatId) return
 
     const id = String(chatId)
     const drafts = this._load()
     if (!text || !text.trim()) {
-      if (!(id in drafts)) return
-      delete drafts[id]
+      if (preserveBlank) {
+        // Linked creatives resolve from a raw id to a shared effective id.
+        // Keep the clear timestamp long enough for move() to win conflicts.
+        const previousUpdatedAt = drafts[id]?.updatedAt || 0
+        drafts[id] = { text: '', updatedAt: Math.max(Date.now(), previousUpdatedAt + 1) }
+        this._evict(drafts)
+      } else {
+        if (!(id in drafts)) return
+        delete drafts[id]
+      }
     } else {
       const previousUpdatedAt = drafts[id]?.updatedAt || 0
       drafts[id] = { text, updatedAt: Math.max(Date.now(), previousUpdatedAt + 1) }
@@ -57,16 +66,44 @@ class ChatDrafts {
     if (!source) return
 
     const target = drafts[targetId]
-    if (!target || source.updatedAt > target.updatedAt) drafts[targetId] = source
+    if (!target || source.updatedAt > target.updatedAt) {
+      if (source.text) {
+        drafts[targetId] = source
+      } else {
+        delete drafts[targetId]
+      }
+    }
     delete drafts[sourceId]
     this._save(drafts)
   }
 
-  clearAll() {
+  clearAll({ broadcast = true } = {}) {
+    const backend = this._backend()
+    const namespace = this._key()
     try {
-      this._backend().removeItem(this._key())
+      backend.removeItem(namespace)
     } catch {
       // Storage unavailable.
+    }
+    if (!broadcast) return
+
+    try {
+      backend.setItem(CLEAR_EVENT_KEY, JSON.stringify({
+        namespace,
+        nonce: `${Date.now()}-${Math.random()}`,
+      }))
+    } catch {
+      // Storage unavailable.
+    }
+  }
+
+  wasCleared(event) {
+    if (event?.key !== CLEAR_EVENT_KEY || !event.newValue) return false
+
+    try {
+      return JSON.parse(event.newValue)?.namespace === this._key()
+    } catch {
+      return false
     }
   }
 

--- a/engines/collavre/app/javascript/lib/chat_drafts.js
+++ b/engines/collavre/app/javascript/lib/chat_drafts.js
@@ -1,0 +1,107 @@
+const MAX_DRAFTS = 50
+const DRAFT_TTL_MS = 7 * 24 * 60 * 60 * 1000
+
+/**
+ * Per-user persistent store for unsent chat input drafts.
+ *
+ * One localStorage key per user stores drafts keyed by chat id. Blank drafts
+ * are removed, stale entries expire after seven days, and the oldest drafts
+ * are evicted when the store grows beyond 50 entries.
+ */
+class ChatDrafts {
+  constructor(storage = null) {
+    this._storage = storage
+    this._userId = null
+  }
+
+  get(chatId) {
+    if (!chatId) return null
+    const entry = this._load()[String(chatId)]
+    return entry ? entry.text : null
+  }
+
+  set(chatId, text) {
+    if (!chatId) return
+
+    const id = String(chatId)
+    const drafts = this._load()
+    if (!text || !text.trim()) {
+      if (!(id in drafts)) return
+      delete drafts[id]
+    } else {
+      drafts[id] = { text, updatedAt: Date.now() }
+      this._evict(drafts)
+    }
+    this._save(drafts)
+  }
+
+  clear(chatId) {
+    this.set(chatId, '')
+  }
+
+  clearAll() {
+    try {
+      this._backend().removeItem(this._key())
+    } catch {
+      // Storage unavailable.
+    }
+  }
+
+  _backend() {
+    return this._storage || window.localStorage
+  }
+
+  _key() {
+    if (this._userId === null) {
+      this._userId = document.body?.dataset?.currentUserId || 'guest'
+    }
+    return `collavre_chat_drafts_${this._userId}`
+  }
+
+  _evict(drafts) {
+    const ids = Object.keys(drafts)
+    if (ids.length <= MAX_DRAFTS) return
+
+    ids.sort((a, b) => drafts[a].updatedAt - drafts[b].updatedAt)
+    ids.slice(0, ids.length - MAX_DRAFTS).forEach((id) => delete drafts[id])
+  }
+
+  _load() {
+    try {
+      const raw = this._backend().getItem(this._key())
+      if (!raw) return {}
+
+      const data = JSON.parse(raw)
+      if (!data || typeof data !== 'object' || Array.isArray(data)) return {}
+
+      const cutoff = Date.now() - DRAFT_TTL_MS
+      Object.keys(data).forEach((id) => {
+        const entry = data[id]
+        if (
+          !entry ||
+          typeof entry.text !== 'string' ||
+          typeof entry.updatedAt !== 'number' ||
+          entry.updatedAt < cutoff
+        ) {
+          delete data[id]
+        }
+      })
+      return data
+    } catch {
+      return {}
+    }
+  }
+
+  _save(drafts) {
+    try {
+      this._backend().setItem(this._key(), JSON.stringify(drafts))
+    } catch {
+      // Storage quota exceeded or storage unavailable.
+    }
+  }
+}
+
+const chatDrafts = new ChatDrafts()
+
+export default chatDrafts
+export { ChatDrafts }

--- a/engines/collavre/app/javascript/lib/chat_drafts.js
+++ b/engines/collavre/app/javascript/lib/chat_drafts.js
@@ -61,7 +61,10 @@ class ChatDrafts {
       if (preserveBlank) {
         this._append(id, this._newEntry('', current, { deleted: true, migration: true }))
       } else if (current && !current.deleted) {
-        this._append(id, this._newEntry('', current, { deleted: true }))
+        this._append(id, this._newEntry('', current, {
+          deleted: true,
+          deletesThrough: this._versionOf(current),
+        }))
       } else {
         return
       }

--- a/engines/collavre/app/javascript/lib/chat_drafts.js
+++ b/engines/collavre/app/javascript/lib/chat_drafts.js
@@ -41,15 +41,15 @@ class ChatDrafts {
   }
 
   snapshot(chatId) {
-    if (!chatId) return { text: null, revision: null }
+    if (!chatId) return { text: null, revision: null, updatedAt: null }
 
     const entry = this._entry(String(chatId))
+    const hasRevision =
+      entry && !entry.movedTo && (!entry.deleted || entry.migration)
     return {
       text: entry && !entry.deleted ? entry.text : null,
-      revision:
-        entry && !entry.movedTo && (!entry.deleted || entry.migration)
-          ? entry.version
-          : null,
+      revision: hasRevision ? entry.version : null,
+      updatedAt: entry && !entry.movedTo ? entry.updatedAt : null,
     }
   }
 
@@ -58,7 +58,8 @@ class ChatDrafts {
 
     if (!this.clearSubmissionBackups(chatId)) return null
 
-    const updatedAt = Date.now()
+    const current = this._entry(String(chatId))
+    const updatedAt = Math.max(Date.now(), (current?.updatedAt || 0) + 1)
     this._sequence += 1
     const version = `${updatedAt}-${this._writerId}-${this._sequence}`
     const key = `${this._backupPrefix(String(chatId))}${encodeURIComponent(version)}`

--- a/engines/collavre/app/javascript/lib/chat_drafts.js
+++ b/engines/collavre/app/javascript/lib/chat_drafts.js
@@ -19,6 +19,12 @@ class ChatDrafts {
     return entry ? entry.text : null
   }
 
+  updatedAt(chatId) {
+    if (!chatId) return null
+    const entry = this._load()[String(chatId)]
+    return entry ? entry.updatedAt : null
+  }
+
   set(chatId, text) {
     if (!chatId) return
 
@@ -28,7 +34,8 @@ class ChatDrafts {
       if (!(id in drafts)) return
       delete drafts[id]
     } else {
-      drafts[id] = { text, updatedAt: Date.now() }
+      const previousUpdatedAt = drafts[id]?.updatedAt || 0
+      drafts[id] = { text, updatedAt: Math.max(Date.now(), previousUpdatedAt + 1) }
       this._evict(drafts)
     }
     this._save(drafts)
@@ -36,6 +43,23 @@ class ChatDrafts {
 
   clear(chatId) {
     this.set(chatId, '')
+  }
+
+  move(sourceChatId, targetChatId) {
+    if (!sourceChatId || !targetChatId) return
+
+    const sourceId = String(sourceChatId)
+    const targetId = String(targetChatId)
+    if (sourceId === targetId) return
+
+    const drafts = this._load()
+    const source = drafts[sourceId]
+    if (!source) return
+
+    const target = drafts[targetId]
+    if (!target || source.updatedAt > target.updatedAt) drafts[targetId] = source
+    delete drafts[sourceId]
+    this._save(drafts)
   }
 
   clearAll() {

--- a/engines/collavre/app/javascript/lib/chat_drafts.js
+++ b/engines/collavre/app/javascript/lib/chat_drafts.js
@@ -53,6 +53,15 @@ class ChatDrafts {
     }
   }
 
+  isNewer(sourceChatId, targetChatId) {
+    if (!sourceChatId) return false
+
+    const source = this._entry(String(sourceChatId))
+    if (!source) return false
+    const target = targetChatId ? this._entry(String(targetChatId)) : null
+    return this._compare(source, target) > 0
+  }
+
   saveSubmissionBackup(chatId, text, { updatedAt = null } = {}) {
     if (!chatId || !text || !text.trim()) return null
 
@@ -172,15 +181,15 @@ class ChatDrafts {
   }
 
   move(sourceChatId, targetChatId) {
-    if (!sourceChatId || !targetChatId) return
+    if (!sourceChatId || !targetChatId) return false
 
     const sourceId = String(sourceChatId)
     const targetId = String(targetChatId)
-    if (sourceId === targetId) return
+    if (sourceId === targetId) return true
 
     for (let attempt = 0; attempt < 3; attempt += 1) {
       const source = this._entry(sourceId)
-      if (!source || source.movedTo === targetId) return
+      if (!source || source.movedTo === targetId) return true
 
       const target = this._entry(targetId)
       const shouldCopyToTarget = target
@@ -194,7 +203,7 @@ class ChatDrafts {
           deletesThrough: source.deleted
             ? this._versionOf(target)
             : undefined,
-        })) return
+	})) return false
         this._compact(targetId)
       }
 
@@ -206,10 +215,11 @@ class ChatDrafts {
         movedTo: targetId,
         deletesThrough: this._versionOf(source),
       })
-      if (!this._append(sourceId, marker)) return
+      if (!this._append(sourceId, marker)) return false
       this._compact(sourceId)
-      return
+      if (this._sameEntry(marker, this._entry(sourceId))) return true
     }
+    return false
   }
 
   clearAll({ broadcast = true } = {}) {
@@ -442,7 +452,8 @@ class ChatDrafts {
     return sorted.find((entry) => (
       !entry.deletesThrough ||
       !operations.some((candidate) => (
-        !candidate.deletesThrough &&
+	!this._sameEntry(candidate, entry) &&
+	(entry.movedTo || !candidate.deletesThrough) &&
         this._compare(candidate, entry.deletesThrough) > 0
       ))
     )) || null

--- a/engines/collavre/app/javascript/lib/chat_drafts.js
+++ b/engines/collavre/app/javascript/lib/chat_drafts.js
@@ -46,6 +46,10 @@ class ChatDrafts {
     }
   }
 
+  namespace() {
+    return this._key()
+  }
+
   _backend() {
     return this._storage || window.localStorage
   }

--- a/engines/collavre/app/javascript/lib/chat_drafts.js
+++ b/engines/collavre/app/javascript/lib/chat_drafts.js
@@ -11,7 +11,6 @@ const DRAFT_TTL_MS = 7 * 24 * 60 * 60 * 1000
 class ChatDrafts {
   constructor(storage = null) {
     this._storage = storage
-    this._userId = null
   }
 
   get(chatId) {
@@ -52,10 +51,8 @@ class ChatDrafts {
   }
 
   _key() {
-    if (this._userId === null) {
-      this._userId = document.body?.dataset?.currentUserId || 'guest'
-    }
-    return `collavre_chat_drafts_${this._userId}`
+    const userId = document.body?.dataset?.currentUserId || 'guest'
+    return `collavre_chat_drafts_${userId}`
   }
 
   _evict(drafts) {

--- a/engines/collavre/app/javascript/lib/chat_drafts.js
+++ b/engines/collavre/app/javascript/lib/chat_drafts.js
@@ -1,53 +1,62 @@
 const MAX_DRAFTS = 50
 const DRAFT_TTL_MS = 7 * 24 * 60 * 60 * 1000
 const CLEAR_EVENT_KEY = 'collavre_chat_drafts_clear'
+const KEY_SEPARATOR = ':'
 
 /**
  * Per-user persistent store for unsent chat input drafts.
  *
- * One localStorage key per user stores drafts keyed by chat id. Blank drafts
- * are removed except for temporary migration tombstones, stale entries expire
- * after seven days, and the oldest drafts are evicted beyond 50 entries.
+ * Draft changes use immutable per-chat operation keys. Concurrent tabs can
+ * therefore append without replacing another chat's state or racing a
+ * read-modify-write snapshot. The greatest timestamp/version wins. Deletions
+ * remain as bounded tombstones until the seven-day TTL prevents stale tabs
+ * from restoring cleared text.
  */
 class ChatDrafts {
   constructor(storage = null) {
     this._storage = storage
+    this._writerId = `${Date.now()}-${Math.random()}`
+    this._sequence = 0
   }
 
   get(chatId) {
     if (!chatId) return null
-    const entry = this._load()[String(chatId)]
-    return entry?.text || null
+    const entry = this._entry(String(chatId))
+    return entry && !entry.deleted ? entry.text : null
   }
 
   updatedAt(chatId) {
     if (!chatId) return null
-    const entry = this._load()[String(chatId)]
-    return entry ? entry.updatedAt : null
+    const entry = this._entry(String(chatId))
+    if (!entry || entry.movedTo || (entry.deleted && !entry.migration)) return null
+    return entry.updatedAt
+  }
+
+  revision(chatId) {
+    if (!chatId) return null
+    const entry = this._entry(String(chatId))
+    if (!entry || entry.movedTo || (entry.deleted && !entry.migration)) return null
+    return entry.version
   }
 
   set(chatId, text, { preserveBlank = false } = {}) {
     if (!chatId) return
 
     const id = String(chatId)
-    const drafts = this._load()
+    const current = this._entry(id)
     if (!text || !text.trim()) {
       if (preserveBlank) {
-        // Linked creatives resolve from a raw id to a shared effective id.
-        // Keep the clear timestamp long enough for move() to win conflicts.
-        const previousUpdatedAt = drafts[id]?.updatedAt || 0
-        drafts[id] = { text: '', updatedAt: Math.max(Date.now(), previousUpdatedAt + 1) }
-        this._evict(drafts)
+        this._append(id, this._newEntry('', current, { deleted: true, migration: true }))
+      } else if (current && !current.deleted) {
+        this._append(id, this._newEntry('', current, { deleted: true }))
       } else {
-        if (!(id in drafts)) return
-        delete drafts[id]
+        return
       }
     } else {
-      const previousUpdatedAt = drafts[id]?.updatedAt || 0
-      drafts[id] = { text, updatedAt: Math.max(Date.now(), previousUpdatedAt + 1) }
-      this._evict(drafts)
+      this._append(id, this._newEntry(text, current))
     }
-    this._save(drafts)
+    this._compact(id)
+    this._evict()
   }
 
   clear(chatId) {
@@ -61,25 +70,44 @@ class ChatDrafts {
     const targetId = String(targetChatId)
     if (sourceId === targetId) return
 
-    const drafts = this._load()
-    const source = drafts[sourceId]
-    if (!source) return
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      const source = this._entry(sourceId)
+      if (!source || source.movedTo === targetId) return
 
-    const target = drafts[targetId]
-    if (!target || source.updatedAt > target.updatedAt) {
-      if (source.text) {
-        drafts[targetId] = source
-      } else {
-        delete drafts[targetId]
+      const target = this._entry(targetId)
+      if (!target || this._compare(source, target) > 0) {
+        if (!this._append(targetId, {
+          ...source,
+          migration: false,
+          movedTo: undefined,
+        })) return
+        this._compact(targetId)
       }
+
+      if (!this._sameEntry(source, this._entry(sourceId))) continue
+
+      const marker = this._newEntry('', source, {
+        deleted: true,
+        migration: false,
+        movedTo: targetId,
+        deletesThrough: this._versionOf(source),
+      })
+      if (!this._append(sourceId, marker)) return
+      this._compact(sourceId)
+      return
     }
-    delete drafts[sourceId]
-    this._save(drafts)
   }
 
   clearAll({ broadcast = true } = {}) {
     const backend = this._backend()
     const namespace = this._key()
+    this._keys().forEach((key) => {
+      try {
+        backend.removeItem(key)
+      } catch {
+        // Storage unavailable.
+      }
+    })
     try {
       backend.removeItem(namespace)
     } catch {
@@ -120,46 +148,232 @@ class ChatDrafts {
     return `collavre_chat_drafts_${userId}`
   }
 
-  _evict(drafts) {
-    const ids = Object.keys(drafts)
-    if (ids.length <= MAX_DRAFTS) return
-
-    ids.sort((a, b) => drafts[a].updatedAt - drafts[b].updatedAt)
-    ids.slice(0, ids.length - MAX_DRAFTS).forEach((id) => delete drafts[id])
+  _prefix() {
+    return `${this._key()}${KEY_SEPARATOR}`
   }
 
-  _load() {
+  _chatPrefix(chatId) {
+    return `${this._prefix()}${encodeURIComponent(chatId)}${KEY_SEPARATOR}`
+  }
+
+  _operationKey(chatId, version) {
+    return `${this._chatPrefix(chatId)}${encodeURIComponent(version)}`
+  }
+
+  _keys(prefix = this._prefix()) {
+    const backend = this._backend()
+    if (typeof backend.key !== 'function' || typeof backend.length !== 'number') return []
+
+    const keys = []
+    for (let index = 0; index < backend.length; index += 1) {
+      try {
+        const key = backend.key(index)
+        if (key?.startsWith(prefix)) keys.push(key)
+      } catch {
+        return keys
+      }
+    }
+    return keys
+  }
+
+  _entry(chatId) {
+    this._pruneOperations()
+    const operations = this._keys(this._chatPrefix(chatId)).flatMap((key) => {
+      const entry = this._readOperation(key)
+      return entry ? [entry] : []
+    })
+    return this._resolve(operations)
+  }
+
+  _readOperation(key) {
+    const backend = this._backend()
+    let entry
     try {
-      const raw = this._backend().getItem(this._key())
-      if (!raw) return {}
+      const raw = backend.getItem(key)
+      if (!raw) return null
+      entry = JSON.parse(raw)
+    } catch {
+      try {
+        backend.removeItem(key)
+      } catch {
+        // Storage unavailable.
+      }
+      return null
+    }
 
-      const data = JSON.parse(raw)
-      if (!data || typeof data !== 'object' || Array.isArray(data)) return {}
+    if (!this._valid(entry)) {
+      try {
+        backend.removeItem(key)
+      } catch {
+        // Storage unavailable.
+      }
+      return null
+    }
+    return entry
+  }
 
-      const cutoff = Date.now() - DRAFT_TTL_MS
-      Object.keys(data).forEach((id) => {
-        const entry = data[id]
-        if (
-          !entry ||
-          typeof entry.text !== 'string' ||
-          typeof entry.updatedAt !== 'number' ||
-          entry.updatedAt < cutoff
-        ) {
-          delete data[id]
+  _pruneOperations() {
+    try {
+      // Discard the obsolete aggregate format; current drafts use operation keys.
+      this._backend().removeItem(this._key())
+    } catch {
+      // Storage unavailable.
+    }
+    this._keys().forEach((key) => this._readOperation(key))
+  }
+
+  _valid(entry) {
+    return Boolean(
+      entry &&
+      typeof entry.text === 'string' &&
+      Number.isFinite(entry.updatedAt) &&
+      typeof entry.version === 'string' &&
+      (entry.deleted === undefined || typeof entry.deleted === 'boolean') &&
+      (entry.migration === undefined || typeof entry.migration === 'boolean') &&
+      (entry.movedTo === undefined || typeof entry.movedTo === 'string') &&
+      (
+        entry.deletesThrough === undefined ||
+        (
+          entry.deletesThrough &&
+          Number.isFinite(entry.deletesThrough.updatedAt) &&
+          typeof entry.deletesThrough.version === 'string'
+        )
+      ) &&
+      entry.updatedAt >= Date.now() - DRAFT_TTL_MS,
+    )
+  }
+
+  _newEntry(text, previous, options = {}) {
+    const updatedAt = Math.max(Date.now(), (previous?.updatedAt || 0) + 1)
+    this._sequence += 1
+    return {
+      text,
+      updatedAt,
+      version: `${updatedAt}-${this._writerId}-${this._sequence}`,
+      ...options,
+    }
+  }
+
+  _compare(left, right) {
+    if (!right) return 1
+    if (left.updatedAt !== right.updatedAt) return left.updatedAt - right.updatedAt
+    return left.version.localeCompare(right.version)
+  }
+
+  _sameEntry(left, right) {
+    return Boolean(
+      right &&
+      left.text === right.text &&
+      left.updatedAt === right.updatedAt &&
+      left.version === right.version &&
+      Boolean(left.deleted) === Boolean(right.deleted) &&
+      Boolean(left.migration) === Boolean(right.migration) &&
+      left.movedTo === right.movedTo &&
+      left.deletesThrough?.updatedAt === right.deletesThrough?.updatedAt &&
+      left.deletesThrough?.version === right.deletesThrough?.version,
+    )
+  }
+
+  _versionOf(entry) {
+    return { updatedAt: entry.updatedAt, version: entry.version }
+  }
+
+  _resolve(operations) {
+    const sorted = [...operations].sort((left, right) => this._compare(right, left))
+    return sorted.find((entry) => (
+      !entry.deletesThrough ||
+      !operations.some((candidate) => (
+        !candidate.deletesThrough &&
+        this._compare(candidate, entry.deletesThrough) > 0
+      ))
+    )) || null
+  }
+
+  _append(chatId, entry) {
+    const key = this._operationKey(chatId, entry.version)
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      try {
+        this._backend().setItem(key, JSON.stringify(entry))
+      } catch {
+        return false
+      }
+      if (this._sameEntry(entry, this._readOperation(key))) return true
+    }
+    return false
+  }
+
+  _compact(chatId) {
+    const keys = this._keys(this._chatPrefix(chatId))
+    const operations = keys.flatMap((key) => {
+      const entry = this._readOperation(key)
+      return entry ? [{ key, entry }] : []
+    })
+    if (operations.length <= 1) return
+
+    const resolved = this._resolve(operations.map(({ entry }) => entry))
+    const guard = operations.reduce((latest, operation) => {
+      if (!operation.entry.deleted) return latest
+      if (!latest) return operation
+
+      const ceilingComparison = this._compare(
+        this._deletionCeiling(operation.entry),
+        this._deletionCeiling(latest.entry),
+      )
+      if (ceilingComparison !== 0) return ceilingComparison > 0 ? operation : latest
+      return this._compare(operation.entry, latest.entry) > 0 ? operation : latest
+    }, null)
+    operations.filter(({ entry }) => (
+      !this._sameEntry(entry, resolved) &&
+      (!guard || !this._sameEntry(entry, guard.entry))
+    )).forEach(({ key }) => {
+      try {
+        this._backend().removeItem(key)
+      } catch {
+        // Storage unavailable.
+      }
+    })
+  }
+
+  _entries() {
+    this._pruneOperations()
+    const operations = new Map()
+    this._keys().forEach((key) => {
+      const entry = this._readOperation(key)
+      if (!entry) return
+      const suffix = key.slice(this._prefix().length)
+      let id
+      try {
+        id = decodeURIComponent(suffix.slice(0, suffix.indexOf(KEY_SEPARATOR)))
+      } catch {
+        try {
+          this._backend().removeItem(key)
+        } catch {
+          // Storage unavailable.
         }
+        return
+      }
+      if (!operations.has(id)) operations.set(id, [])
+      operations.get(id).push(entry)
+    })
+    return [...operations].map(([id, entries]) => ({ id, entry: this._resolve(entries) }))
+  }
+
+  _evict() {
+    const entries = this._entries().filter(({ entry }) => !entry.deleted)
+    if (entries.length > MAX_DRAFTS) {
+      entries.sort((left, right) => this._compare(left.entry, right.entry))
+      entries.slice(0, entries.length - MAX_DRAFTS).forEach(({ id, entry }) => {
+        this._append(id, this._newEntry('', entry, {
+          deleted: true,
+          deletesThrough: this._versionOf(entry),
+        }))
+        this._compact(id)
       })
-      return data
-    } catch {
-      return {}
     }
   }
 
-  _save(drafts) {
-    try {
-      this._backend().setItem(this._key(), JSON.stringify(drafts))
-    } catch {
-      // Storage quota exceeded or storage unavailable.
-    }
+  _deletionCeiling(entry) {
+    return entry.deletesThrough || this._versionOf(entry)
   }
 }
 

--- a/engines/collavre/app/javascript/lib/chat_drafts.js
+++ b/engines/collavre/app/javascript/lib/chat_drafts.js
@@ -183,11 +183,17 @@ class ChatDrafts {
       if (!source || source.movedTo === targetId) return
 
       const target = this._entry(targetId)
-      if (!target || this._compare(source, target) > 0) {
+      const shouldCopyToTarget = target
+        ? this._compare(source, target) > 0
+        : !source.deleted
+      if (shouldCopyToTarget) {
         if (!this._append(targetId, {
           ...source,
           migration: false,
           movedTo: undefined,
+          deletesThrough: source.deleted
+            ? this._versionOf(target)
+            : undefined,
         })) return
         this._compact(targetId)
       }

--- a/engines/collavre/app/javascript/lib/chat_drafts.js
+++ b/engines/collavre/app/javascript/lib/chat_drafts.js
@@ -78,16 +78,33 @@ class ChatDrafts {
   saveSubmissionBackup(chatId, text, { updatedAt = null } = {}) {
     if (!chatId || !text || !text.trim()) return null
 
-    if (!this.clearSubmissionBackups(chatId)) return null
-
-    const current = updatedAt === null ? this._entry(String(chatId)) : null
+    const id = String(chatId)
+    const current = updatedAt === null ? this._entry(id) : null
     const backupUpdatedAt = updatedAt ??
       Math.max(Date.now(), (current?.updatedAt || 0) + 1)
     this._sequence += 1
     const version = `${backupUpdatedAt}-${this._writerId}-${this._sequence}`
-    const key = `${this._backupPrefix(String(chatId))}${encodeURIComponent(version)}`
+    const key = `${this._backupPrefix(id)}${encodeURIComponent(version)}`
+    const candidate = { key, text, updatedAt: backupUpdatedAt }
+    const existing = this.latestSubmissionBackup(id)
+    if (existing && this._compareSubmissionBackups(existing, candidate) >= 0) return null
+
     try {
       this._backupBackend().setItem(key, JSON.stringify({ text, updatedAt: backupUpdatedAt }))
+      const backups = this._submissionBackups(id)
+      const latest = [...backups].sort((left, right) => (
+	this._compareSubmissionBackups(right, left)
+      ))[0]
+      if (!latest || latest.key !== key) {
+	this.removeSubmissionBackup(key)
+	return null
+      }
+      const superseded = backups.filter((backup) => (
+	backup.key !== key && this._compareSubmissionBackups(backup, candidate) < 0
+      ))
+      if (!superseded.every((backup) => this.removeSubmissionBackup(backup.key))) {
+	return this.removeSubmissionBackup(key) ? null : key
+      }
       this._evictSubmissionBackups()
       return key
     } catch {
@@ -99,7 +116,7 @@ class ChatDrafts {
     if (!chatId) return null
 
     return this._submissionBackups(String(chatId)).sort((left, right) => (
-      right.updatedAt - left.updatedAt || right.key.localeCompare(left.key)
+      this._compareSubmissionBackups(right, left)
     ))[0] || null
   }
 
@@ -120,6 +137,23 @@ class ChatDrafts {
       this._backupPrefix(String(chatId)),
       this._backupBackend(),
     ).every((key) => this.removeSubmissionBackup(key))
+  }
+
+  clearSubmissionBackupsThrough(key, namespace = this._key()) {
+    if (!key || !key.startsWith(this._backupPrefix(null, namespace))) return false
+
+    const backups = this._submissionBackups(null, namespace)
+    const candidate = backups.find((backup) => backup.key === key)
+    if (!candidate) return false
+
+    const chatPrefix = key.slice(0, key.lastIndexOf(KEY_SEPARATOR) + 1)
+    const superseded = backups.filter((backup) => (
+      backup.key.startsWith(chatPrefix) &&
+      this._compareSubmissionBackups(backup, candidate) <= 0
+    )).sort((left, right) => this._compareSubmissionBackups(left, right))
+    return superseded.every((backup) => (
+      this.removeSubmissionBackup(backup.key, namespace)
+    ))
   }
 
   moveSubmissionBackups(sourceChatId, targetChatId) {
@@ -420,8 +454,8 @@ class ChatDrafts {
     this._evictSubmissionBackups()
   }
 
-  _submissionBackups(chatId = null) {
-    const prefix = this._backupPrefix(chatId)
+  _submissionBackups(chatId = null, namespace = this._key()) {
+    const prefix = this._backupPrefix(chatId, namespace)
     const cutoff = Date.now() - DRAFT_TTL_MS
 
     const backend = this._backupBackend()
@@ -446,9 +480,13 @@ class ChatDrafts {
 
   _evictSubmissionBackups() {
     const backups = this._submissionBackups().sort((left, right) => (
-      right.updatedAt - left.updatedAt || right.key.localeCompare(left.key)
+      this._compareSubmissionBackups(right, left)
     ))
     backups.slice(MAX_DRAFTS).forEach(({ key }) => this.removeSubmissionBackup(key))
+  }
+
+  _compareSubmissionBackups(left, right) {
+    return left.updatedAt - right.updatedAt || left.key.localeCompare(right.key)
   }
 
   _valid(entry) {

--- a/engines/collavre/app/javascript/lib/chat_drafts.js
+++ b/engines/collavre/app/javascript/lib/chat_drafts.js
@@ -39,6 +39,19 @@ class ChatDrafts {
     return entry.version
   }
 
+  snapshot(chatId) {
+    if (!chatId) return { text: null, revision: null }
+
+    const entry = this._entry(String(chatId))
+    return {
+      text: entry && !entry.deleted ? entry.text : null,
+      revision:
+        entry && !entry.movedTo && (!entry.deleted || entry.migration)
+          ? entry.version
+          : null,
+    }
+  }
+
   set(chatId, text, { preserveBlank = false } = {}) {
     if (!chatId) return
 

--- a/engines/collavre/app/javascript/lib/chat_drafts.js
+++ b/engines/collavre/app/javascript/lib/chat_drafts.js
@@ -3,6 +3,17 @@ const DRAFT_TTL_MS = 7 * 24 * 60 * 60 * 1000
 const CLEAR_EVENT_KEY = 'collavre_chat_drafts_clear'
 const KEY_SEPARATOR = ':'
 
+const createMemoryStorage = () => {
+  const values = new Map()
+  return {
+    get length() { return values.size },
+    key: (index) => [...values.keys()][index] ?? null,
+    getItem: (key) => values.get(String(key)) ?? null,
+    setItem: (key, value) => values.set(String(key), String(value)),
+    removeItem: (key) => values.delete(String(key)),
+  }
+}
+
 /**
  * Per-user persistent store for unsent chat input drafts.
  *
@@ -16,6 +27,8 @@ class ChatDrafts {
   constructor(storage = null, backupStorage = null) {
     this._storage = storage
     this._backupStorage = backupStorage
+    this._fallbackStorage = createMemoryStorage()
+    this._fallbackBackupStorage = createMemoryStorage()
     this._writerId = `${Date.now()}-${Math.random()}`
     this._sequence = 0
   }
@@ -267,11 +280,24 @@ class ChatDrafts {
   }
 
   _backend() {
-    return this._storage || window.localStorage
+    if (this._storage) return this._storage
+
+    try {
+      return window.localStorage
+    } catch {
+      return this._fallbackStorage
+    }
   }
 
   _backupBackend() {
-    return this._backupStorage || this._storage || window.sessionStorage
+    if (this._backupStorage) return this._backupStorage
+    if (this._storage) return this._storage
+
+    try {
+      return window.sessionStorage
+    } catch {
+      return this._fallbackBackupStorage
+    }
   }
 
   _key() {

--- a/engines/collavre/app/javascript/lib/chat_drafts.js
+++ b/engines/collavre/app/javascript/lib/chat_drafts.js
@@ -31,6 +31,7 @@ class ChatDrafts {
     this._fallbackBackupStorage = createMemoryStorage()
     this._writerId = `${Date.now()}-${Math.random()}`
     this._sequence = 0
+    this._pendingClearNonces = new Map()
   }
 
   get(chatId) {
@@ -337,10 +338,25 @@ class ChatDrafts {
     }
     if (!broadcast) return
 
+    const updatedAt = Date.now()
+    const nonce = `${updatedAt}-${Math.random()}`
+    const signal = {
+      namespace,
+      nonce,
+      updatedAt,
+    }
+    const serializedSignal = JSON.stringify(signal)
     try {
-      backend.setItem(CLEAR_EVENT_KEY, JSON.stringify({
-        namespace,
-        nonce: `${Date.now()}-${Math.random()}`,
+      backend.setItem(CLEAR_EVENT_KEY, serializedSignal)
+    } catch {
+      // Storage unavailable.
+    }
+    const legacyResult = this._readClearSignal(backend, CLEAR_EVENT_KEY)
+    try {
+      backend.setItem(this._clearEventKey(namespace), JSON.stringify({
+	...signal,
+	legacyNamespace: legacyResult.signal?.namespace || null,
+	legacyNonce: legacyResult.signal?.nonce || null,
       }))
     } catch {
       // Storage unavailable.
@@ -348,7 +364,10 @@ class ChatDrafts {
   }
 
   wasCleared(event) {
-    if (event?.key !== CLEAR_EVENT_KEY || !event.newValue) return false
+    if (
+      !event?.newValue ||
+      ![CLEAR_EVENT_KEY, this._clearEventKey()].includes(event.key)
+    ) return false
 
     try {
       return JSON.parse(event.newValue)?.namespace === this._key()
@@ -361,12 +380,74 @@ class ChatDrafts {
     const backend = this._backend()
     if (!this._storage && backend === this._fallbackStorage) return undefined
 
-    try {
-      const signal = JSON.parse(backend.getItem(CLEAR_EVENT_KEY))
-      return signal?.namespace === namespace ? signal.nonce || null : null
-    } catch {
-      return undefined
+    const namespacedKey = this._clearEventKey(namespace)
+    const namespacedResult = this._readClearSignal(backend, namespacedKey)
+    const legacyResult = this._readClearSignal(backend, CLEAR_EVENT_KEY)
+    const namespacedSignal = namespacedResult.signal?.namespace === namespace
+      ? namespacedResult.signal
+      : null
+    const legacySignal = legacyResult.signal?.namespace === namespace
+      ? legacyResult.signal
+      : null
+    const pendingNonce = this._pendingClearNonces.get(namespace)
+    if (
+      pendingNonce &&
+      namespacedSignal?.nonce === pendingNonce &&
+      namespacedSignal.legacyNamespace === namespace &&
+      namespacedSignal.legacyNonce === pendingNonce
+    ) {
+      this._pendingClearNonces.delete(namespace)
     }
+    let signal = namespacedSignal || legacySignal
+    let promoteLegacy = false
+    if (
+      legacySignal &&
+      legacySignal.nonce !== namespacedSignal?.nonce
+    ) {
+      const hasLegacyBaseline = namespacedSignal &&
+	Object.hasOwn(namespacedSignal, 'legacyNamespace') &&
+	Object.hasOwn(namespacedSignal, 'legacyNonce')
+      const matchesLegacyBaseline = hasLegacyBaseline &&
+	namespacedSignal.legacyNamespace === legacySignal.namespace &&
+	namespacedSignal.legacyNonce === legacySignal.nonce
+      promoteLegacy = !matchesLegacyBaseline && (
+	hasLegacyBaseline ||
+	this._compareClearSignals(legacySignal, namespacedSignal) >= 0
+      )
+    }
+    if (!signal) {
+      return namespacedResult.available && legacyResult.available ? null : undefined
+    }
+    if (!signal.nonce) return null
+    if (promoteLegacy || !namespacedSignal) {
+      const promotedSignal = {
+	...legacySignal,
+	legacyNamespace: legacySignal.namespace,
+	legacyNonce: legacySignal.nonce,
+      }
+      try {
+	backend.setItem(namespacedKey, JSON.stringify(promotedSignal))
+      } catch {
+	this._pendingClearNonces.set(namespace, promotedSignal.nonce)
+	return promotedSignal.nonce
+      }
+      const promotedResult = this._readClearSignal(backend, namespacedKey)
+      if (
+	!promotedResult.available ||
+	promotedResult.signal?.nonce !== promotedSignal.nonce ||
+	promotedResult.signal?.legacyNonce !== promotedSignal.legacyNonce
+      ) {
+	this._pendingClearNonces.set(namespace, promotedSignal.nonce)
+	return promotedSignal.nonce
+      }
+      this._pendingClearNonces.delete(namespace)
+      signal = promotedSignal
+    }
+    return signal.nonce
+  }
+
+  clearNoncePending(namespace = this._key()) {
+    return this._pendingClearNonces.has(namespace)
   }
 
   namespace() {
@@ -397,6 +478,34 @@ class ChatDrafts {
   _key() {
     const userId = document.body?.dataset?.currentUserId || 'guest'
     return `collavre_chat_drafts_${userId}`
+  }
+
+  _clearEventKey(namespace = this._key()) {
+    return `${CLEAR_EVENT_KEY}${KEY_SEPARATOR}${encodeURIComponent(namespace)}`
+  }
+
+  _compareClearSignals(left, right) {
+    const updatedAt = (signal) => {
+      const value = Number(signal?.updatedAt ?? String(signal?.nonce).split('-')[0])
+      return Number.isFinite(value) ? value : 0
+    }
+    return updatedAt(left) - updatedAt(right)
+  }
+
+  _readClearSignal(backend, key) {
+    let value
+    try {
+      value = backend.getItem(key)
+    } catch {
+      return { available: false, signal: null }
+    }
+    if (!value) return { available: true, signal: null }
+
+    try {
+      return { available: true, signal: JSON.parse(value) }
+    } catch {
+      return { available: true, signal: null }
+    }
   }
 
   _prefix() {

--- a/engines/collavre/app/javascript/lib/chat_drafts.js
+++ b/engines/collavre/app/javascript/lib/chat_drafts.js
@@ -146,20 +146,42 @@ class ChatDrafts {
         this.removeSubmissionBackup(key)
         return
       }
-      if (!this.clearSubmissionBackups(targetId)) return
+
+      const targetBackups = this._submissionBackups(targetId)
+      const restoreTargetBackups = () => {
+	const backend = this._backupBackend()
+	targetBackups.forEach((backup) => {
+	  try {
+	    backend.setItem(backup.key, JSON.stringify({
+	      text: backup.text,
+	      updatedAt: backup.updatedAt,
+	    }))
+	  } catch {
+	    // Keep any target backup that storage still allows.
+	  }
+	})
+      }
+      if (!this.clearSubmissionBackups(targetId)) {
+	restoreTargetBackups()
+	return
+      }
 
       const targetKey = `${targetPrefix}${key.slice(sourcePrefix.length)}`
       const value = JSON.stringify({ text, updatedAt })
       try {
         this._backupBackend().setItem(targetKey, value)
-        if (this._backupBackend().getItem(targetKey) !== value) return
+	if (this._backupBackend().getItem(targetKey) !== value) {
+	  restoreTargetBackups()
+	  return
+	}
         if (!this.removeSubmissionBackup(key)) {
           this.removeSubmissionBackup(targetKey)
+	  restoreTargetBackups()
           return
         }
         moved.set(key, targetKey)
       } catch {
-        // Keep the source backup when the destination cannot be persisted.
+	restoreTargetBackups()
       }
     })
     this._evictSubmissionBackups()

--- a/engines/collavre/app/javascript/lib/chat_drafts.js
+++ b/engines/collavre/app/javascript/lib/chat_drafts.js
@@ -13,8 +13,9 @@ const KEY_SEPARATOR = ':'
  * from restoring cleared text.
  */
 class ChatDrafts {
-  constructor(storage = null) {
+  constructor(storage = null, backupStorage = null) {
     this._storage = storage
+    this._backupStorage = backupStorage
     this._writerId = `${Date.now()}-${Math.random()}`
     this._sequence = 0
   }
@@ -50,6 +51,95 @@ class ChatDrafts {
           ? entry.version
           : null,
     }
+  }
+
+  saveSubmissionBackup(chatId, text) {
+    if (!chatId || !text || !text.trim()) return null
+
+    if (!this.clearSubmissionBackups(chatId)) return null
+
+    const updatedAt = Date.now()
+    this._sequence += 1
+    const version = `${updatedAt}-${this._writerId}-${this._sequence}`
+    const key = `${this._backupPrefix(String(chatId))}${encodeURIComponent(version)}`
+    try {
+      this._backupBackend().setItem(key, JSON.stringify({ text, updatedAt }))
+      this._evictSubmissionBackups()
+      return key
+    } catch {
+      return null
+    }
+  }
+
+  latestSubmissionBackup(chatId) {
+    if (!chatId) return null
+
+    return this._submissionBackups(String(chatId)).sort((left, right) => (
+      right.updatedAt - left.updatedAt || right.key.localeCompare(left.key)
+    ))[0] || null
+  }
+
+  removeSubmissionBackup(key, namespace = this._key()) {
+    if (!key || !key.startsWith(this._backupPrefix(null, namespace))) return false
+
+    try {
+      this._backupBackend().removeItem(key)
+      return this._backupBackend().getItem(key) === null
+    } catch {
+      return false
+    }
+  }
+
+  clearSubmissionBackups(chatId) {
+    if (!chatId) return false
+    return this._keys(
+      this._backupPrefix(String(chatId)),
+      this._backupBackend(),
+    ).every((key) => this.removeSubmissionBackup(key))
+  }
+
+  moveSubmissionBackups(sourceChatId, targetChatId) {
+    const moved = new Map()
+    if (!sourceChatId || !targetChatId) return moved
+
+    const sourceId = String(sourceChatId)
+    const targetId = String(targetChatId)
+    if (sourceId === targetId) return moved
+
+    const sourcePrefix = this._backupPrefix(sourceId)
+    const targetPrefix = this._backupPrefix(targetId)
+    this._submissionBackups(sourceId).forEach(({ key, text, updatedAt }) => {
+      const target = this.latestSubmissionBackup(targetId)
+      if (target && (
+        target.updatedAt > updatedAt ||
+        (
+          target.updatedAt === updatedAt &&
+          target.key.slice(targetPrefix.length).localeCompare(
+            key.slice(sourcePrefix.length),
+          ) >= 0
+        )
+      )) {
+        this.removeSubmissionBackup(key)
+        return
+      }
+      if (!this.clearSubmissionBackups(targetId)) return
+
+      const targetKey = `${targetPrefix}${key.slice(sourcePrefix.length)}`
+      const value = JSON.stringify({ text, updatedAt })
+      try {
+        this._backupBackend().setItem(targetKey, value)
+        if (this._backupBackend().getItem(targetKey) !== value) return
+        if (!this.removeSubmissionBackup(key)) {
+          this.removeSubmissionBackup(targetKey)
+          return
+        }
+        moved.set(key, targetKey)
+      } catch {
+        // Keep the source backup when the destination cannot be persisted.
+      }
+    })
+    this._evictSubmissionBackups()
+    return moved
   }
 
   set(chatId, text, { preserveBlank = false } = {}) {
@@ -124,6 +214,9 @@ class ChatDrafts {
         // Storage unavailable.
       }
     })
+    this._keys(this._backupPrefix(), this._backupBackend()).forEach((key) => {
+      this.removeSubmissionBackup(key)
+    })
     try {
       backend.removeItem(namespace)
     } catch {
@@ -159,6 +252,10 @@ class ChatDrafts {
     return this._storage || window.localStorage
   }
 
+  _backupBackend() {
+    return this._backupStorage || this._storage || window.sessionStorage
+  }
+
   _key() {
     const userId = document.body?.dataset?.currentUserId || 'guest'
     return `collavre_chat_drafts_${userId}`
@@ -172,12 +269,18 @@ class ChatDrafts {
     return `${this._prefix()}${encodeURIComponent(chatId)}${KEY_SEPARATOR}`
   }
 
+  _backupPrefix(chatId = null, namespace = this._key()) {
+    const prefix = `${namespace}_pending${KEY_SEPARATOR}`
+    return chatId === null
+      ? prefix
+      : `${prefix}${encodeURIComponent(chatId)}${KEY_SEPARATOR}`
+  }
+
   _operationKey(chatId, version) {
     return `${this._chatPrefix(chatId)}${encodeURIComponent(version)}`
   }
 
-  _keys(prefix = this._prefix()) {
-    const backend = this._backend()
+  _keys(prefix = this._prefix(), backend = this._backend()) {
     if (typeof backend.key !== 'function' || typeof backend.length !== 'number') return []
 
     const keys = []
@@ -236,6 +339,38 @@ class ChatDrafts {
       // Storage unavailable.
     }
     this._keys().forEach((key) => this._readOperation(key))
+    this._evictSubmissionBackups()
+  }
+
+  _submissionBackups(chatId = null) {
+    const prefix = this._backupPrefix(chatId)
+    const cutoff = Date.now() - DRAFT_TTL_MS
+
+    const backend = this._backupBackend()
+    return this._keys(prefix, backend).flatMap((key) => {
+      try {
+        const entry = JSON.parse(backend.getItem(key))
+        if (
+          !entry ||
+          typeof entry.text !== 'string' ||
+          !entry.text.trim() ||
+          !Number.isFinite(entry.updatedAt) ||
+          entry.updatedAt < cutoff
+        ) throw new Error('Invalid submission backup')
+
+        return [{ key, text: entry.text, updatedAt: entry.updatedAt }]
+      } catch {
+        this.removeSubmissionBackup(key)
+        return []
+      }
+    })
+  }
+
+  _evictSubmissionBackups() {
+    const backups = this._submissionBackups().sort((left, right) => (
+      right.updatedAt - left.updatedAt || right.key.localeCompare(left.key)
+    ))
+    backups.slice(MAX_DRAFTS).forEach(({ key }) => this.removeSubmissionBackup(key))
   }
 
   _valid(entry) {


### PR DESCRIPTION
## Summary

- persist unsent chat input in per-user localStorage, keyed by effective creative ID
- restore drafts across popup close/reopen, chat switches, and navigation
- clear drafts after successful sends and logout while retaining them after failures
- cap storage at 50 drafts with a seven-day TTL and preserve drafts during edit, slash-command, and in-flight chat-switch flows

## User impact

Users can leave a chat or reload the page without losing unsent text. Drafts remain isolated per chat and per user, and successful sends remove only the submitted chat's draft.

## Validation

- `npm test -- engines/collavre/app/javascript/lib/__tests__/chat_drafts.test.js engines/collavre/app/javascript/controllers/comments/__tests__/` — 26 suites, 277 tests passed
- chat draft store coverage — 100% statements, branches, functions, and lines
- `mise exec -- ./bin/rubocop -a` — 1,145 files, no offenses
- `PARALLEL_WORKERS=1 mise exec -- bin/rake test:system` — all engine system suites passed (67 tests, 2 skips)
- browser preview QA — close/reopen, cross-chat isolation, navigation restore, successful-send cleanup, and logout cleanup passed
- the full Rails unit command has 11 unrelated Active Record encryption configuration errors when run as one suite; the two affected test files pass together (11 tests, 74 assertions)
