### PR TITLE
fix: remove stalled Creative inbox alerts

### DIFF
--- a/engines/collavre/RELEASE_NOTES.md
+++ b/engines/collavre/RELEASE_NOTES.md
@@ -588,7 +588,6 @@
 - cea0b37b fix: remove duplicate GitHub integration modal render (#770)
 - 709153ae feat: add completion emoji reaction on review message update (#768)
 - 7e8df962 fix: disable stuck detection by default
-- b16a97db fix: strip HTML from creative title in stuck detector notifications (#767)
 - cfed92c9 feat: add review message (quote + reply) feature (#765)
 - f09c59c5 fix: share user search showing results briefly then disappearing (#766)
 
@@ -637,4 +636,3 @@
 ### Changes
 - 6664da75 feat: restrict sharing non-searchable AI agents to owners only (#739)
 - 9f78717f fix: exit fullscreen returns to mobile position on mobile devices (#738)
-

--- a/engines/collavre/app/jobs/collavre/stuck_detector_job.rb
+++ b/engines/collavre/app/jobs/collavre/stuck_detector_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Collavre
-  # StuckDetectorJob runs periodically to detect stuck tasks and creatives.
+  # StuckDetectorJob runs periodically to recover and escalate stuck tasks.
   #
   # This job should be scheduled to run every 5-10 minutes via cron or similar.
   #

--- a/engines/collavre/app/services/collavre/orchestration/policy_resolver.rb
+++ b/engines/collavre/app/services/collavre/orchestration/policy_resolver.rb
@@ -47,7 +47,6 @@ module Collavre
         "stuck_detection" => {
           "enabled" => true,
           "task_stuck_threshold_minutes" => 30,            # Task running for > N minutes
-          "creative_stall_threshold_minutes" => 120,       # Creative no progress for > N minutes
           "queued_orphan_threshold_minutes" => 5,          # Queued waiter with no live blocker for > N minutes
           "create_system_comment" => true                  # Create system comment on escalation
         },

--- a/engines/collavre/app/services/collavre/orchestration/stuck_detector.rb
+++ b/engines/collavre/app/services/collavre/orchestration/stuck_detector.rb
@@ -2,12 +2,11 @@
 
 module Collavre
   module Orchestration
-    # StuckDetector detects stuck tasks and creatives, then auto-escalates to admins.
+    # StuckDetector detects stuck tasks, auto-recovers them, and escalates to admins.
     #
     # Detection conditions:
     # 1. Running tasks that haven't progressed for N minutes
     # 2. Tasks with too many retries (escalated but not handled)
-    # 3. Creatives with no progress for extended periods
     #
     # Auto-escalation:
     # - Creates InboxItem for admin users
@@ -33,7 +32,6 @@ module Collavre
         stuck_items = []
         stuck_items.concat(detect_stuck_tasks(config))
         stuck_items.concat(detect_orphaned_queued_tasks(config))
-        stuck_items.concat(detect_stalled_creatives(config))
 
         auto_recover_stuck_tasks(stuck_items)
         escalated_count = escalate_stuck_items(stuck_items, config)
@@ -49,7 +47,6 @@ module Collavre
         stuck_items = []
         stuck_items.concat(detect_stuck_tasks(config))
         stuck_items.concat(detect_orphaned_queued_tasks(config))
-        stuck_items.concat(detect_stalled_creatives(config))
         stuck_items
       end
 
@@ -238,46 +235,6 @@ module Collavre
         end
       end
 
-      # Detect creatives that have stalled (no activity for extended period)
-      def detect_stalled_creatives(config)
-        threshold_minutes = config["creative_stall_threshold_minutes"] || 120
-        threshold_time = threshold_minutes.minutes.ago
-
-        # Find creatives with incomplete status but no recent activity
-        # Only check creatives that have at least one AI agent with access
-        stalled = []
-
-        Creative.where("progress < 1.0")
-                .where("updated_at < ?", threshold_time)
-                .includes(creative_shares: :user)
-                .find_each do |creative|
-          # Skip if no AI agents have access. Public shares carry no user, so
-          # drop them before asking whether the holder is an AI agent.
-          ai_agents = creative.creative_shares
-                              .reject { |s| s.permission == "no_access" }
-                              .filter_map(&:user)
-                              .select(&:ai_user?)
-
-          next if ai_agents.empty?
-
-          # Skip if already escalated recently
-          next if recently_escalated_creative?(creative)
-
-          escalation_targets = find_creative_escalation_targets(creative)
-          next if escalation_targets.empty?
-
-          stalled << StuckItem.new(
-            type: :creative,
-            item: creative,
-            reason: :stalled,
-            stuck_since: creative.updated_at,
-            escalation_targets: escalation_targets
-          )
-        end
-
-        stalled
-      end
-
       def find_escalation_targets(task)
         # Find admin users for the task's creative
         creative_id = task.trigger_event_payload&.dig("creative", "id")
@@ -308,18 +265,9 @@ module Collavre
         Rails.cache.exist?(cache_key)
       end
 
-      def recently_escalated_creative?(creative)
-        cache_key = "stuck_detector:creative:#{creative.id}"
-        Rails.cache.exist?(cache_key)
-      end
-
       def mark_escalated(item)
-        cache_key = case item.type
-        when :task then "stuck_detector:task:#{item.item.id}"
-        when :creative then "stuck_detector:creative:#{item.item.id}"
-        end
         # Don't re-escalate for 1 hour
-        Rails.cache.write(cache_key, true, expires_in: 1.hour)
+        Rails.cache.write("stuck_detector:task:#{item.item.id}", true, expires_in: 1.hour)
       end
 
       def escalate_stuck_items(stuck_items, config)
@@ -346,9 +294,7 @@ module Collavre
         end
 
         # Optionally create a system comment
-        if config["create_system_comment"] && stuck_item.type == :task
-          create_system_comment(stuck_item)
-        end
+        create_system_comment(stuck_item) if config["create_system_comment"]
 
         true
       rescue StandardError => e
@@ -359,13 +305,8 @@ module Collavre
       def create_inbox_notification(owner, stuck_item)
         message_key, message_params = build_message(stuck_item)
 
-        creative = case stuck_item.type
-        when :task
-                     creative_id = stuck_item.item.trigger_event_payload&.dig("creative", "id")
-                     Creative.find_by(id: creative_id)
-        when :creative
-                     stuck_item.item
-        end
+        creative_id = stuck_item.item.trigger_event_payload&.dig("creative", "id")
+        creative = Creative.find_by(id: creative_id)
 
         inbox_creative = Creative.inbox_for(owner)
         system_topic = inbox_creative.system_topic(fallback_user: owner)
@@ -384,36 +325,19 @@ module Collavre
       end
 
       def build_message(stuck_item)
-        case stuck_item.type
-        when :task
-          task = stuck_item.item
-          minutes_stuck = ((Time.current - stuck_item.stuck_since) / 60).round
-          [
-            "collavre.stuck_detection.task_stuck",
-            {
-              task_name: task.name,
-              agent_name: task.agent&.display_name || "Unknown",
-              minutes: minutes_stuck
-            }
-          ]
-        when :creative
-          creative = stuck_item.item
-          hours_stuck = ((Time.current - stuck_item.stuck_since) / 3600).round
-
-          [
-            "collavre.stuck_detection.creative_stalled",
-            {
-              creative_title: creative.creative_snippet,
-              hours: hours_stuck,
-              progress: ((creative.progress || 0) * 100).round
-            }
-          ]
-        end
+        task = stuck_item.item
+        minutes_stuck = ((Time.current - stuck_item.stuck_since) / 60).round
+        [
+          "collavre.stuck_detection.task_stuck",
+          {
+            task_name: task.name,
+            agent_name: task.agent&.display_name || "Unknown",
+            minutes: minutes_stuck
+          }
+        ]
       end
 
       def create_system_comment(stuck_item)
-        return unless stuck_item.type == :task
-
         task = stuck_item.item
         creative_id = task.trigger_event_payload&.dig("creative", "id")
         creative = Creative.find_by(id: creative_id)

--- a/engines/collavre/config/locales/ai_agent.en.yml
+++ b/engines/collavre/config/locales/ai_agent.en.yml
@@ -2,7 +2,6 @@ en:
   collavre:
     stuck_detection:
       task_stuck: "⚠️ Task '%{task_name}' assigned to %{agent_name} has been stuck for %{minutes} minutes."
-      creative_stalled: "⚠️ Creative '%{creative_title}' has stalled at %{progress}%% for %{hours} hours."
       system_comment: "[System] Task '%{task_name}' by %{agent_name} appears stuck. Admin attention required."
     ai_agent:
       approval:

--- a/engines/collavre/config/locales/ai_agent.ko.yml
+++ b/engines/collavre/config/locales/ai_agent.ko.yml
@@ -2,7 +2,6 @@ ko:
   collavre:
     stuck_detection:
       task_stuck: "⚠️ '%{task_name}' 작업이 %{agent_name}에게 할당된 후 %{minutes}분 동안 진행되지 않고 있습니다."
-      creative_stalled: "⚠️ '%{creative_title}' Creative가 %{progress}%%에서 %{hours}시간 동안 정체되어 있습니다."
       system_comment: "[시스템] %{agent_name}의 '%{task_name}' 작업이 막힌 것 같습니다. 관리자 확인이 필요합니다."
     ai_agent:
       approval:

--- a/engines/collavre/test/services/collavre/orchestration/stuck_detector_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/stuck_detector_test.rb
@@ -40,15 +40,13 @@ module Collavre
         )
       end
 
-      def create_policy_with_stuck_detection(enabled: true, task_threshold: 30, creative_threshold: 120,
-                                             queued_orphan_threshold: 5)
+      def create_policy_with_stuck_detection(enabled: true, task_threshold: 30, queued_orphan_threshold: 5)
         Collavre::OrchestratorPolicy.create!(
           policy_type: "stuck_detection",
           scope_type: nil,
           config: {
             "enabled" => enabled,
             "task_stuck_threshold_minutes" => task_threshold,
-            "creative_stall_threshold_minutes" => creative_threshold,
             "queued_orphan_threshold_minutes" => queued_orphan_threshold,
             "create_system_comment" => true
           }
@@ -125,70 +123,23 @@ module Collavre
         policy&.destroy
       end
 
-      test "detects stalled creative" do
-        policy = create_policy_with_stuck_detection(enabled: true, creative_threshold: 60)
-
-        # Give AI agent access to creative
+      test "does not alert for inactive creatives" do
+        policy = create_policy_with_stuck_detection(enabled: true)
         Collavre::CreativeShare.create!(
           creative: @creative,
           user: @ai_agent,
           permission: :write
         )
-
-        # Make creative stale
         @creative.update_columns(updated_at: 3.hours.ago)
 
-        detector = StuckDetector.new
-        stuck_items = detector.detect
+        inbox = Collavre::Creative.inbox_for(@human_user)
 
-        creative_stuck = stuck_items.find { |item| item.type == :creative }
-        assert_not_nil creative_stuck
-        assert_equal :stalled, creative_stuck.reason
-        assert_equal @creative.id, creative_stuck.item.id
-      ensure
-        policy&.destroy
-      end
+        assert_no_difference -> { inbox.comments.count } do
+          result = StuckDetector.new.detect_and_escalate
 
-      test "does not detect completed creative as stalled" do
-        policy = create_policy_with_stuck_detection(enabled: true, creative_threshold: 60)
-
-        # Complete the creative
-        @creative.update!(progress: 1.0)
-        @creative.update_columns(updated_at: 3.hours.ago)
-
-        detector = StuckDetector.new
-        stuck_items = detector.detect
-
-        creative_stuck = stuck_items.find { |item| item.type == :creative && item.item.id == @creative.id }
-        assert_nil creative_stuck
-      ensure
-        policy&.destroy
-      end
-
-      test "detects stalled creative that also has a public share" do
-        policy = create_policy_with_stuck_detection(enabled: true, creative_threshold: 60)
-
-        Collavre::CreativeShare.create!(
-          creative: @creative,
-          user: @ai_agent,
-          permission: :write
-        )
-
-        # A public share carries no user (see CreativeShare: user is optional)
-        Collavre::CreativeShare.create!(
-          creative: @creative,
-          user: nil,
-          permission: :read
-        )
-
-        @creative.update_columns(updated_at: 3.hours.ago)
-
-        detector = StuckDetector.new
-        stuck_items = detector.detect
-
-        creative_stuck = stuck_items.find { |item| item.type == :creative && item.item.id == @creative.id }
-        assert_not_nil creative_stuck
-        assert_equal :stalled, creative_stuck.reason
+          assert_empty result.stuck_items
+          assert_equal 0, result.escalated_count
+        end
       ensure
         policy&.destroy
       end


### PR DESCRIPTION
## Summary

- remove stalled Creative detection from `StuckDetector`
- remove the Creative-specific threshold, escalation cache path, message builder branch, and EN/KO translations
- remove stale release-note documentation and replace positive detection tests with a regression test that verifies inactive Creatives do not generate inbox alerts
- preserve stuck Task recovery/escalation and orphaned queued-task self-healing

## Why

Incomplete Creatives remained eligible for a new System-topic inbox alert every hour after the short-lived cache entry expired. These alerts accumulated indefinitely, had no actionable reply path, and could obscure replyable System-topic notifications.

## Impact

Inactive or incomplete Creatives no longer create stalled inbox notifications. Task-level stuck recovery, Task escalation notifications, and orphan queue recovery continue unchanged.

## Validation

- `mise exec -- ./bin/rubocop -a` (1,145 files, no offenses)
- `mise exec -- bundle exec rake test` (3,703 tests, 12,315 assertions)
- `mise exec -- bundle exec rake test:system` (67 tests, 388 assertions, 2 skips)
- `mise exec -- bin/rails test engines/collavre/test/services/collavre/orchestration/stuck_detector_test.rb` (28 tests, 59 assertions)
- independent code review: no actionable findings