### PR TITLE
fix: keep sent chat message out of the input on IME send

### DIFF
--- a/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_ime_send.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_ime_send.test.js
@@ -220,6 +220,92 @@ describe('FormController - IME composition send', () => {
     expect(chatDrafts.get(chatId)).toBeNull()
   })
 
+  test.each(['paste', 'drop'])('a compositionend that trails the commit input does not swallow a later %s', async (gesture) => {
+    dispatchTopicChange()
+    let finishFetch
+    global.fetch = jest.fn(() => new Promise((resolve) => { finishFetch = resolve }))
+
+    typeInto(controller.textareaTarget, 'send me twice')
+    controller.handleSend(new Event('submit', { cancelable: true }))
+
+    // Input-before-compositionend ordering: the commit input already identified
+    // itself, so the trailing compositionend has no input left to pair with.
+    controller.textareaTarget.dispatchEvent(
+      new InputEvent('input', { bubbles: true, isComposing: true }),
+    )
+    controller.textareaTarget.dispatchEvent(
+      new CompositionEvent('compositionend', { bubbles: true, data: 'send me twice' }),
+    )
+
+    // Select-all + paste (or drag-drop) of the identical string to send it again.
+    controller.textareaTarget.dispatchEvent(new Event(gesture, { bubbles: true }))
+    typeInto(controller.textareaTarget, 'send me twice')
+
+    finishFetch({ ok: true, status: 200, text: () => Promise.resolve('<div></div>') })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(controller.textareaTarget.value).toBe('send me twice')
+    expect(chatDrafts.get(chatId)).toBe('send me twice')
+  })
+
+  test('a compositionend that trails the commit input does not swallow later typing', async () => {
+    dispatchTopicChange()
+    let finishFetch
+    global.fetch = jest.fn(() => new Promise((resolve) => { finishFetch = resolve }))
+
+    typeInto(controller.textareaTarget, 'send me twice')
+    controller.handleSend(new Event('submit', { cancelable: true }))
+
+    controller.textareaTarget.dispatchEvent(
+      new InputEvent('input', { bubbles: true, isComposing: true }),
+    )
+    controller.textareaTarget.dispatchEvent(
+      new CompositionEvent('compositionend', { bubbles: true, data: 'send me twice' }),
+    )
+
+    // Retyping the same string by hand — an ordinary keystroke, not a commit.
+    controller.textareaTarget.dispatchEvent(new KeyboardEvent('keydown', {
+      key: 'e',
+      isComposing: false,
+      bubbles: true,
+      cancelable: true,
+    }))
+    typeInto(controller.textareaTarget, 'send me twice')
+
+    finishFetch({ ok: true, status: 200, text: () => Promise.resolve('<div></div>') })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(controller.textareaTarget.value).toBe('send me twice')
+    expect(chatDrafts.get(chatId)).toBe('send me twice')
+  })
+
+  test('a composing keydown between compositionend and the commit input keeps the latch', async () => {
+    dispatchTopicChange()
+    let finishFetch
+    global.fetch = jest.fn(() => new Promise((resolve) => { finishFetch = resolve }))
+
+    typeInto(controller.textareaTarget, '안녕하세요')
+    controller.handleSend(new Event('submit', { cancelable: true }))
+
+    controller.textareaTarget.dispatchEvent(
+      new CompositionEvent('compositionend', { bubbles: true, data: '안녕하세요' }),
+    )
+    // Soft keyboards can interleave the next composing keystroke before the
+    // commit input lands; that is not a fresh gesture, so it must not expire.
+    controller.textareaTarget.dispatchEvent(new KeyboardEvent('keydown', {
+      keyCode: 229,
+      bubbles: true,
+      cancelable: true,
+    }))
+    controller.textareaTarget.dispatchEvent(new Event('input', { bubbles: true }))
+
+    finishFetch({ ok: true, status: 200, text: () => Promise.resolve('<div></div>') })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(controller.textareaTarget.value).toBe('')
+    expect(chatDrafts.get(chatId)).toBeNull()
+  })
+
   test('text genuinely typed during the send is still preserved', async () => {
     dispatchTopicChange()
     let finishFetch

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_ime_send.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_ime_send.test.js
@@ -1,0 +1,189 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { jest } from '@jest/globals'
+import { Application } from '@hotwired/stimulus'
+import FormController from '../form_controller'
+import chatDrafts from '../../../lib/chat_drafts'
+
+describe('FormController - IME composition send', () => {
+  let application
+  let container
+  let controller
+  let popupEl
+
+  const FIXTURE = `
+    <div id="comments-popup"
+         data-controller="comments--form"
+         data-update-comment-text="Update">
+      <form data-comments--form-target="form">
+        <input type="hidden" name="comment[quoted_comment_id]" data-comments--form-target="quotedCommentId" value="" />
+        <input type="hidden" name="comment[quoted_text]" data-comments--form-target="quotedText" value="" />
+        <div data-comments--form-target="quoteIndicator" style="display:none;">
+          <span data-comments--form-target="quoteIndicatorText"></span>
+        </div>
+        <div class="review-quotes-container" data-comments--form-target="reviewQuotesContainer" style="display:none;"></div>
+        <textarea data-comments--form-target="textarea" rows="2"></textarea>
+        <input type="checkbox" data-comments--form-target="privateCheckbox" />
+        <button type="submit" data-comments--form-target="submit">Send</button>
+        <button data-comments--form-target="cancel" style="display:none;">Cancel</button>
+        <button data-comments--form-target="searchButton" style="display:none;">Search</button>
+        <button data-comments--form-target="voiceButton" style="display:none;">Voice</button>
+        <input type="file" data-comments--form-target="imageInput" style="display:none;" />
+        <button data-comments--form-target="imageButton" style="display:none;">Image</button>
+        <div data-comments--form-target="attachmentList"></div>
+      </form>
+    </div>`
+
+  // Stimulus disconnects a removed controller asynchronously, so a previous
+  // test's pending draft flush can land inside a later test's timer wait.
+  // Giving each test its own chat id keeps those flushes off our key.
+  let chatId
+  let nextChatId = 77
+
+  const dispatchTopicChange = (effectiveCreativeId = chatId, topicId = '10073') => {
+    popupEl.dataset.effectiveCreativeId = String(effectiveCreativeId)
+    popupEl.dispatchEvent(
+      new CustomEvent('comments--topics:change', { detail: { topicId } }),
+    )
+  }
+
+  const typeInto = (textarea, value) => {
+    textarea.value = value
+    textarea.dispatchEvent(new Event('input', { bubbles: true }))
+  }
+
+  beforeEach(async () => {
+    window.localStorage.clear()
+    window.sessionStorage.clear()
+    document.body.dataset.currentUserId = '9'
+
+    if (typeof global.requestAnimationFrame !== 'function') {
+      global.requestAnimationFrame = (cb) => setTimeout(cb, 0)
+    }
+    const meta = document.createElement('meta')
+    meta.name = 'csrf-token'
+    meta.content = 'test-token'
+    document.head.appendChild(meta)
+
+    container = document.createElement('div')
+    container.innerHTML = FIXTURE
+    document.body.appendChild(container)
+
+    application = Application.start()
+    application.register('comments--form', FormController)
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    popupEl = container.querySelector('#comments-popup')
+    controller = application.getControllerForElementAndIdentifier(popupEl, 'comments--form')
+    jest.spyOn(controller, 'setImageFiles').mockImplementation(() => {})
+    chatId = String(nextChatId)
+    nextChatId += 1
+    controller.creativeId = chatId
+  })
+
+  afterEach(() => {
+    application.stop()
+    document.body.removeChild(container)
+    document.head.querySelector('meta[name="csrf-token"]').remove()
+    delete document.body.dataset.currentUserId
+    jest.restoreAllMocks()
+  })
+
+  test('Enter pressed while an IME composition is active does not send', async () => {
+    dispatchTopicChange()
+    global.fetch = jest.fn(() => Promise.resolve({
+      ok: true,
+      status: 200,
+      text: () => Promise.resolve('<div></div>'),
+    }))
+    typeInto(controller.textareaTarget, '안녕하세')
+
+    controller.textareaTarget.dispatchEvent(new KeyboardEvent('keydown', {
+      key: 'Enter',
+      isComposing: true,
+      bubbles: true,
+      cancelable: true,
+    }))
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(global.fetch).not.toHaveBeenCalled()
+    expect(controller.textareaTarget.value).toBe('안녕하세')
+  })
+
+  test('an IME commit after send does not restore the sent text into the textarea', async () => {
+    dispatchTopicChange()
+    let finishFetch
+    global.fetch = jest.fn(() => new Promise((resolve) => { finishFetch = resolve }))
+
+    typeInto(controller.textareaTarget, '안녕하세요')
+    controller.handleSend(new Event('submit', { cancelable: true }))
+
+    // The IME commits the pending syllable right after keydown started the
+    // send. The textarea content is unchanged, but an input event still fires.
+    controller.textareaTarget.dispatchEvent(new Event('input', { bubbles: true }))
+
+    finishFetch({ ok: true, status: 200, text: () => Promise.resolve('<div></div>') })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(controller.textareaTarget.value).toBe('')
+    expect(chatDrafts.get(chatId)).toBeNull()
+  })
+
+  test('a slow send does not let the IME commit debounce the sent text into storage', async () => {
+    dispatchTopicChange()
+    let finishFetch
+    global.fetch = jest.fn(() => new Promise((resolve) => { finishFetch = resolve }))
+
+    typeInto(controller.textareaTarget, '안녕하세요')
+    controller.handleSend(new Event('submit', { cancelable: true }))
+    controller.textareaTarget.dispatchEvent(new Event('input', { bubbles: true }))
+
+    // The response outlives the 500ms draft debounce window.
+    await new Promise((resolve) => setTimeout(resolve, 600))
+    expect(chatDrafts.get(chatId)).toBeNull()
+
+    finishFetch({ ok: true, status: 200, text: () => Promise.resolve('<div></div>') })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(controller.textareaTarget.value).toBe('')
+    expect(chatDrafts.get(chatId)).toBeNull()
+  })
+
+  test('Enter after the composition ends still sends', async () => {
+    dispatchTopicChange()
+    global.fetch = jest.fn(() => Promise.resolve({
+      ok: true,
+      status: 200,
+      text: () => Promise.resolve('<div></div>'),
+    }))
+    typeInto(controller.textareaTarget, '안녕하세요')
+
+    controller.textareaTarget.dispatchEvent(new KeyboardEvent('keydown', {
+      key: 'Enter',
+      isComposing: false,
+      bubbles: true,
+      cancelable: true,
+    }))
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(global.fetch).toHaveBeenCalled()
+    expect(controller.textareaTarget.value).toBe('')
+  })
+
+  test('text genuinely typed during the send is still preserved', async () => {
+    dispatchTopicChange()
+    let finishFetch
+    global.fetch = jest.fn(() => new Promise((resolve) => { finishFetch = resolve }))
+
+    typeInto(controller.textareaTarget, 'first message')
+    controller.handleSend(new Event('submit', { cancelable: true }))
+    typeInto(controller.textareaTarget, 'typed while sending')
+
+    finishFetch({ ok: true, status: 200, text: () => Promise.resolve('<div></div>') })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(controller.textareaTarget.value).toBe('typed while sending')
+    expect(chatDrafts.get(chatId)).toBe('typed while sending')
+  })
+})

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_ime_send.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_ime_send.test.js
@@ -54,6 +54,14 @@ describe('FormController - IME composition send', () => {
     textarea.dispatchEvent(new Event('input', { bubbles: true }))
   }
 
+  // A real IME commit ends the composition and then fires `input` for the
+  // committed text. jsdom has no IME, so replay that exact pair.
+  const commitComposition = (textarea, value = textarea.value) => {
+    textarea.dispatchEvent(new CompositionEvent('compositionend', { bubbles: true, data: value }))
+    textarea.value = value
+    textarea.dispatchEvent(new Event('input', { bubbles: true }))
+  }
+
   beforeEach(async () => {
     window.localStorage.clear()
     window.sessionStorage.clear()
@@ -121,7 +129,7 @@ describe('FormController - IME composition send', () => {
 
     // The IME commits the pending syllable right after keydown started the
     // send. The textarea content is unchanged, but an input event still fires.
-    controller.textareaTarget.dispatchEvent(new Event('input', { bubbles: true }))
+    commitComposition(controller.textareaTarget)
 
     finishFetch({ ok: true, status: 200, text: () => Promise.resolve('<div></div>') })
     await new Promise((resolve) => setTimeout(resolve, 20))
@@ -137,7 +145,7 @@ describe('FormController - IME composition send', () => {
 
     typeInto(controller.textareaTarget, '안녕하세요')
     controller.handleSend(new Event('submit', { cancelable: true }))
-    controller.textareaTarget.dispatchEvent(new Event('input', { bubbles: true }))
+    commitComposition(controller.textareaTarget)
 
     // The response outlives the 500ms draft debounce window.
     await new Promise((resolve) => setTimeout(resolve, 600))
@@ -169,6 +177,47 @@ describe('FormController - IME composition send', () => {
 
     expect(global.fetch).toHaveBeenCalled()
     expect(controller.textareaTarget.value).toBe('')
+  })
+
+  test('re-entering the same text during the send is preserved, not treated as an IME commit', async () => {
+    dispatchTopicChange()
+    let finishFetch
+    global.fetch = jest.fn(() => new Promise((resolve) => { finishFetch = resolve }))
+
+    typeInto(controller.textareaTarget, 'send me twice')
+    controller.handleSend(new Event('submit', { cancelable: true }))
+
+    // Select-all + paste of the identical string to send it again. No
+    // composition is involved, so this is a genuine edit even though the
+    // value matches the in-flight submission.
+    typeInto(controller.textareaTarget, 'send me twice')
+
+    finishFetch({ ok: true, status: 200, text: () => Promise.resolve('<div></div>') })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(controller.textareaTarget.value).toBe('send me twice')
+    expect(chatDrafts.get(chatId)).toBe('send me twice')
+  })
+
+  test('an input event still carrying isComposing is treated as an IME commit', async () => {
+    dispatchTopicChange()
+    let finishFetch
+    global.fetch = jest.fn(() => new Promise((resolve) => { finishFetch = resolve }))
+
+    typeInto(controller.textareaTarget, '안녕하세요')
+    controller.handleSend(new Event('submit', { cancelable: true }))
+
+    // Some browsers fire the commit `input` before `compositionend`, with
+    // isComposing still set on the input event itself.
+    controller.textareaTarget.dispatchEvent(
+      new InputEvent('input', { bubbles: true, isComposing: true }),
+    )
+
+    finishFetch({ ok: true, status: 200, text: () => Promise.resolve('<div></div>') })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(controller.textareaTarget.value).toBe('')
+    expect(chatDrafts.get(chatId)).toBeNull()
   })
 
   test('text genuinely typed during the send is still preserved', async () => {

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -156,6 +156,16 @@ export default class extends Controller {
     this._handleCompositionEnd = () => {
       this._imeCommitPending = true
     }
+    // Chrome fires the commit `input` after `compositionend`, but Firefox has
+    // shipped the reverse order, where the commit input consumes the latch
+    // before it is even set. Nothing would clear the leftover latch, so the
+    // next ordinary edit would be misread as a commit. The commit input always
+    // arrives before the user can act again, so any fresh gesture expires it.
+    this._expireImeCommitLatch = (event) => {
+      if (event?.isComposing || event?.keyCode === 229) return
+
+      this._imeCommitPending = false
+    }
     this._handleDraftInput = (event) => {
       // Consume the composition flag before any early return, so it can never
       // outlive the `input` event that the commit itself fired. Firefox has
@@ -183,6 +193,9 @@ export default class extends Controller {
       this._draftSaveTimer = setTimeout(() => this._saveDraftNow(), 500)
     }
     this.textareaTarget.addEventListener('compositionend', this._handleCompositionEnd)
+    this.textareaTarget.addEventListener('keydown', this._expireImeCommitLatch)
+    this.textareaTarget.addEventListener('paste', this._expireImeCommitLatch)
+    this.textareaTarget.addEventListener('drop', this._expireImeCommitLatch)
     this.textareaTarget.addEventListener('input', this._handleDraftInput)
     window.addEventListener('pagehide', this._handlePageHide)
     window.addEventListener('storage', this._handleDraftStorage)
@@ -296,6 +309,9 @@ export default class extends Controller {
   disconnect() {
     this._flushDraftSave()
     this.textareaTarget.removeEventListener('compositionend', this._handleCompositionEnd)
+    this.textareaTarget.removeEventListener('keydown', this._expireImeCommitLatch)
+    this.textareaTarget.removeEventListener('paste', this._expireImeCommitLatch)
+    this.textareaTarget.removeEventListener('drop', this._expireImeCommitLatch)
     this.textareaTarget.removeEventListener('input', this._handleDraftInput)
     window.removeEventListener('pagehide', this._handlePageHide)
     window.removeEventListener('storage', this._handleDraftStorage)

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -153,7 +153,15 @@ export default class extends Controller {
       const clearedNamespace = chatDrafts.namespace()
       this._disableDraftNamespace(clearedNamespace)
     }
-    this._handleDraftInput = () => {
+    this._handleCompositionEnd = () => {
+      this._imeCommitPending = true
+    }
+    this._handleDraftInput = (event) => {
+      // Consume the composition flag before any early return, so it can never
+      // outlive the `input` event that the commit itself fired. Firefox has
+      // shipped both orderings, so accept isComposing on the input event too.
+      const isImeCommit = Boolean(event?.isComposing) || this._imeCommitPending === true
+      this._imeCommitPending = false
       if (
         this.editingId ||
 	this._draftPersistenceDisabled() ||
@@ -166,12 +174,15 @@ export default class extends Controller {
       // the textarea still holds exactly what went to the server. Counting it
       // as a revision would defeat _currentPendingSubmission and make the sent
       // message look like a draft typed mid-flight, restoring it on success.
-      if (this._currentTextIsPendingSubmission()) return
+      // Text equality alone is not enough to suppress: re-entering the same
+      // string mid-flight (select-all + paste to send it twice) is a real edit.
+      if (isImeCommit && this._currentTextIsPendingSubmission()) return
       const revisionKey = `${chatDrafts.namespace()}:${this._activeDraftKey}`
       this._draftRevisions.set(revisionKey, (this._draftRevisions.get(revisionKey) || 0) + 1)
       clearTimeout(this._draftSaveTimer)
       this._draftSaveTimer = setTimeout(() => this._saveDraftNow(), 500)
     }
+    this.textareaTarget.addEventListener('compositionend', this._handleCompositionEnd)
     this.textareaTarget.addEventListener('input', this._handleDraftInput)
     window.addEventListener('pagehide', this._handlePageHide)
     window.addEventListener('storage', this._handleDraftStorage)
@@ -284,6 +295,7 @@ export default class extends Controller {
 
   disconnect() {
     this._flushDraftSave()
+    this.textareaTarget.removeEventListener('compositionend', this._handleCompositionEnd)
     this.textareaTarget.removeEventListener('input', this._handleDraftInput)
     window.removeEventListener('pagehide', this._handlePageHide)
     window.removeEventListener('storage', this._handleDraftStorage)

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -162,6 +162,11 @@ export default class extends Controller {
         !this._reviewStore.isEmpty ||
         !this._activeDraftKey
       ) return
+      // An IME commit fires `input` after the keydown that started a send, so
+      // the textarea still holds exactly what went to the server. Counting it
+      // as a revision would defeat _currentPendingSubmission and make the sent
+      // message look like a draft typed mid-flight, restoring it on success.
+      if (this._currentTextIsPendingSubmission()) return
       const revisionKey = `${chatDrafts.namespace()}:${this._activeDraftKey}`
       this._draftRevisions.set(revisionKey, (this._draftRevisions.get(revisionKey) || 0) + 1)
       clearTimeout(this._draftSaveTimer)
@@ -176,6 +181,10 @@ export default class extends Controller {
         this.presenceController?.cancelAllAgentTasks()
         return
       }
+      // While an IME is composing (Korean, Japanese, Chinese), Enter confirms
+      // the pending syllable rather than submitting. keyCode 229 covers
+      // browsers that leave isComposing unset on the keydown itself.
+      if (event.isComposing || event.keyCode === 229) return
       if (event.key === 'Enter' && !event.shiftKey) {
         if (this.isMentionMenuVisible()) return
         this.handleSend(event)


### PR DESCRIPTION
## Problem

After sending a chat message, the message text stayed behind in the chat input field. Reported as a timing issue — it is.

## Root cause

Two defects compound, both introduced by the draft-persistence feature (#1496) meeting IME input:

1. **`keydown` had no `isComposing` guard.** With a Korean/Japanese/Chinese IME, pressing Enter to confirm a composing syllable fires `keydown` with `isComposing: true`. `form_controller.js` submitted from that keydown.

2. **The IME's commit `input` event was counted as a new draft revision.** Right after that keydown, the IME commits and fires an `input` event. The textarea still holds exactly the text that just went to the server, but `_handleDraftInput` bumped `_draftRevisions`. The revision bump defeats the existing `_currentPendingSubmission()` guard (it requires `keyRevision` to still match), so on success:

   - `hasNewerActiveDraft` became true, and `newerDraft` is read from the textarea *before* `resetForm()` — i.e. the already-sent text. It was then written back into the textarea and re-saved as a draft.
   - When the response outlived the 500ms debounce, `_saveDraftNow()` also persisted the sent text to `localStorage`, so `_restoreDraft()` brought it back on the next visit.

`engines/collavre/app/javascript/modules/creative_row_editor.js:668` already guards `event.isComposing`; the chat form was the outlier.

## Fix

- Skip the send when a composition is active (`event.isComposing || event.keyCode === 229`; the keyCode covers browsers that leave `isComposing` unset on the keydown itself). Escape handling stays ahead of the guard.
- Do not bump the draft revision for an `input` event whose text still matches a pending submission, reusing the existing `_currentTextIsPendingSubmission()` helper. This keeps "revision counts genuine user edits" true and closes both the sub-500ms and over-500ms windows.

## Tests

New `form_controller_ime_send.test.js`, 5 cases:

- Enter during composition does not send and leaves the text in place
- An IME commit after send does not restore the sent text into the textarea
- A slow send does not let the IME commit debounce the sent text into storage
- Enter after the composition ends still sends
- Text genuinely typed during the send is still preserved

Each fix was reverted independently to confirm the tests fail for the right reason: without the `isComposing` guard 1 test fails; without the revision guard the other 2 fail.

Full JS suite: 91 suites, 1173 tests, all passing. No Ruby, DB, or i18n changes.