### PR TITLE
feat: enable the three-column creative workspace by default

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -249,6 +249,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_09_000000) do
     t.index ["user_id"], name: "index_creative_shares_caches_on_user_id"
   end
 
+  create_table "creative_workspace_enabled_backfills", id: false, force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.index ["user_id"], name: "index_creative_workspace_enabled_backfills_on_user_id", unique: true
+  end
+
   create_table "creatives", force: :cascade do |t|
     t.datetime "archived_at"
     t.integer "comments_count", default: 0, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -249,11 +249,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_09_000000) do
     t.index ["user_id"], name: "index_creative_shares_caches_on_user_id"
   end
 
-  create_table "creative_workspace_enabled_backfills", id: false, force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.index ["user_id"], name: "index_creative_workspace_enabled_backfills_on_user_id", unique: true
-  end
-
   create_table "creatives", force: :cascade do |t|
     t.datetime "archived_at"
     t.integer "comments_count", default: 0, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_07_050000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_09_000000) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -928,7 +928,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_07_050000) do
     t.string "calendar_id"
     t.datetime "created_at", null: false
     t.integer "created_by_id"
-    t.boolean "creative_workspace_enabled", default: false, null: false
+    t.boolean "creative_workspace_enabled", default: true, null: false
     t.json "dismissed_notices"
     t.string "email", null: false
     t.datetime "email_verified_at"

--- a/engines/collavre/app/models/collavre/user.rb
+++ b/engines/collavre/app/models/collavre/user.rb
@@ -66,7 +66,7 @@ module Collavre
     attribute :locale, :string
     attribute :system_admin, :boolean, default: false
     attribute :searchable, :boolean, default: false
-    attribute :creative_workspace_enabled, :boolean, default: false
+    attribute :creative_workspace_enabled, :boolean, default: true
 
     # Typo correction (2D gating: typing-device AND input-location must both be on).
     attribute :typo_correction_enabled, :boolean, default: true

--- a/engines/collavre/db/migrate/20260809000000_change_creative_workspace_enabled_default_to_true.rb
+++ b/engines/collavre/db/migrate/20260809000000_change_creative_workspace_enabled_default_to_true.rb
@@ -1,8 +1,4 @@
 class ChangeCreativeWorkspaceEnabledDefaultToTrue < ActiveRecord::Migration[8.0]
-  # Ledger of the rows this migration flipped, so `down` can restore the exact
-  # previous values instead of leaving every user opted in. Dropped on rollback.
-  BACKFILL_LEDGER = :creative_workspace_enabled_backfills
-
   # Lightweight stub so the backfill does not depend on the app model.
   class MigrationUser < ActiveRecord::Base
     self.table_name = :users
@@ -11,33 +7,12 @@ class ChangeCreativeWorkspaceEnabledDefaultToTrue < ActiveRecord::Migration[8.0]
   def up
     change_column_default :users, :creative_workspace_enabled, from: false, to: true
 
-    create_table BACKFILL_LEDGER, id: false do |t|
-      t.bigint :user_id, null: false, index: { unique: true }
-    end
-
     # The preference shipped as opt-in only days ago, so every stored `false`
     # is the old default rather than a deliberate opt-out.
-    execute <<~SQL.squish
-      INSERT INTO #{BACKFILL_LEDGER} (user_id)
-      SELECT id FROM users WHERE creative_workspace_enabled = #{false_literal}
-    SQL
     MigrationUser.where(creative_workspace_enabled: false).update_all(creative_workspace_enabled: true)
   end
 
   def down
-    # Restore only the rows this migration flipped; opt-ins made afterwards stay on.
-    execute <<~SQL.squish
-      UPDATE users SET creative_workspace_enabled = #{false_literal}
-      WHERE id IN (SELECT user_id FROM #{BACKFILL_LEDGER})
-    SQL
-    drop_table BACKFILL_LEDGER, if_exists: true
-
-    change_column_default :users, :creative_workspace_enabled, from: true, to: false
-  end
-
-  private
-
-  def false_literal
-    connection.quote(false)
+    raise ActiveRecord::IrreversibleMigration, "cannot distinguish backfilled defaults from post-migration user opt-ins"
   end
 end

--- a/engines/collavre/db/migrate/20260809000000_change_creative_workspace_enabled_default_to_true.rb
+++ b/engines/collavre/db/migrate/20260809000000_change_creative_workspace_enabled_default_to_true.rb
@@ -1,0 +1,17 @@
+class ChangeCreativeWorkspaceEnabledDefaultToTrue < ActiveRecord::Migration[8.0]
+  # Lightweight stub so the backfill does not depend on the app model.
+  class MigrationUser < ActiveRecord::Base
+    self.table_name = :users
+  end
+
+  def up
+    change_column_default :users, :creative_workspace_enabled, from: false, to: true
+    # The preference shipped as opt-in only days ago, so every stored `false`
+    # is the old default rather than a deliberate opt-out.
+    MigrationUser.where(creative_workspace_enabled: false).update_all(creative_workspace_enabled: true)
+  end
+
+  def down
+    change_column_default :users, :creative_workspace_enabled, from: true, to: false
+  end
+end

--- a/engines/collavre/db/migrate/20260809000000_change_creative_workspace_enabled_default_to_true.rb
+++ b/engines/collavre/db/migrate/20260809000000_change_creative_workspace_enabled_default_to_true.rb
@@ -1,4 +1,8 @@
 class ChangeCreativeWorkspaceEnabledDefaultToTrue < ActiveRecord::Migration[8.0]
+  # Ledger of the rows this migration flipped, so `down` can restore the exact
+  # previous values instead of leaving every user opted in. Dropped on rollback.
+  BACKFILL_LEDGER = :creative_workspace_enabled_backfills
+
   # Lightweight stub so the backfill does not depend on the app model.
   class MigrationUser < ActiveRecord::Base
     self.table_name = :users
@@ -6,12 +10,34 @@ class ChangeCreativeWorkspaceEnabledDefaultToTrue < ActiveRecord::Migration[8.0]
 
   def up
     change_column_default :users, :creative_workspace_enabled, from: false, to: true
+
+    create_table BACKFILL_LEDGER, id: false do |t|
+      t.bigint :user_id, null: false, index: { unique: true }
+    end
+
     # The preference shipped as opt-in only days ago, so every stored `false`
     # is the old default rather than a deliberate opt-out.
+    execute <<~SQL.squish
+      INSERT INTO #{BACKFILL_LEDGER} (user_id)
+      SELECT id FROM users WHERE creative_workspace_enabled = #{false_literal}
+    SQL
     MigrationUser.where(creative_workspace_enabled: false).update_all(creative_workspace_enabled: true)
   end
 
   def down
+    # Restore only the rows this migration flipped; opt-ins made afterwards stay on.
+    execute <<~SQL.squish
+      UPDATE users SET creative_workspace_enabled = #{false_literal}
+      WHERE id IN (SELECT user_id FROM #{BACKFILL_LEDGER})
+    SQL
+    drop_table BACKFILL_LEDGER, if_exists: true
+
     change_column_default :users, :creative_workspace_enabled, from: true, to: false
+  end
+
+  private
+
+  def false_literal
+    connection.quote(false)
   end
 end

--- a/engines/collavre/test/controllers/users_controller_test.rb
+++ b/engines/collavre/test/controllers/users_controller_test.rb
@@ -517,26 +517,34 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_select "a[href=?]", collavre.typo_correction_user_path(@regular_user)
   end
 
-  test "profile controls the creative workspace preference which defaults off" do
+  test "profile controls the creative workspace preference which defaults on" do
     sign_in_as(@regular_user, password: "password")
 
     get collavre.user_path(@regular_user)
 
     assert_response :success
-    assert_select "input[name=?][type='checkbox']:not([checked])", "user[creative_workspace_enabled]"
-
-    patch collavre.user_path(@regular_user), params: {
-      user: { creative_workspace_enabled: "1" }
-    }
-
-    assert_redirected_to collavre.user_path(@regular_user)
     assert_predicate @regular_user.reload, :creative_workspace_enabled?
+    assert_select "input[name=?][type='checkbox'][checked]", "user[creative_workspace_enabled]"
 
     patch collavre.user_path(@regular_user), params: {
       user: { creative_workspace_enabled: "0" }
     }
 
+    assert_redirected_to collavre.user_path(@regular_user)
     assert_not @regular_user.reload.creative_workspace_enabled?
+
+    patch collavre.user_path(@regular_user), params: {
+      user: { creative_workspace_enabled: "1" }
+    }
+
+    assert_predicate @regular_user.reload, :creative_workspace_enabled?
+  end
+
+  test "new users get the creative workspace enabled by default" do
+    user = Collavre::User.new
+
+    assert_predicate user, :creative_workspace_enabled?
+    assert_equal true, Collavre::User.column_defaults["creative_workspace_enabled"]
   end
 
   test "profile shows the creative workspace explanation as a tooltip instead of inline text" do

--- a/engines/collavre/test/migrations/change_creative_workspace_enabled_default_to_true_test.rb
+++ b/engines/collavre/test/migrations/change_creative_workspace_enabled_default_to_true_test.rb
@@ -1,0 +1,14 @@
+require "test_helper"
+require Rails.root.join(
+  "engines/collavre/db/migrate/20260809000000_change_creative_workspace_enabled_default_to_true"
+)
+
+class ChangeCreativeWorkspaceEnabledDefaultToTrueTest < ActiveSupport::TestCase
+  test "rollback is explicitly irreversible" do
+    error = assert_raises(ActiveRecord::IrreversibleMigration) do
+      ChangeCreativeWorkspaceEnabledDefaultToTrue.new.down
+    end
+
+    assert_match(/post-migration user opt-ins/, error.message)
+  end
+end

--- a/engines/collavre/test/system/inline_scripts_test.rb
+++ b/engines/collavre/test/system/inline_scripts_test.rb
@@ -7,9 +7,10 @@ class InlineScriptsTest < ApplicationSystemTestCase
       password: SystemHelpers::PASSWORD,
       name: "TestUser",
       email_verified_at: Time.current,
-      notifications_enabled: false,
-      creative_workspace_enabled: true
+      notifications_enabled: false
     )
+    # creative_workspace_enabled is intentionally left unset: these tests rely on
+    # the workspace being on by default.
 
     resize_window_to
     sign_in_via_ui(@user)
@@ -121,31 +122,32 @@ class InlineScriptsTest < ApplicationSystemTestCase
 
   public
 
-  test "profile toggles the creative workspace from its default off state" do
-    @user.update!(creative_workspace_enabled: false)
+  test "profile toggles the creative workspace from its default on state" do
+    assert_predicate @user, :creative_workspace_enabled?
 
+    visit root_path
+    assert_selector ".creative-workspace-shell"
+    assert_selector "#comments-popup[data-docked='true']", visible: :visible
+
+    visit collavre.user_path(@user)
+    workspace_toggle = find("#user_creative_workspace_enabled")
+    assert workspace_toggle.checked?
+    workspace_toggle.uncheck
+    click_button I18n.t("collavre.users.update_profile")
+
+    assert_text I18n.t("collavre.users.profile_updated")
     visit root_path
     assert_no_selector ".creative-workspace-shell"
     assert_selector "#comments-popup[data-docked='false']", visible: :all
 
     visit collavre.user_path(@user)
-    workspace_toggle = find("#user_creative_workspace_enabled")
-    assert_not workspace_toggle.checked?
-    workspace_toggle.check
+    find("#user_creative_workspace_enabled").check
     click_button I18n.t("collavre.users.update_profile")
 
     assert_text I18n.t("collavre.users.profile_updated")
     visit root_path
     assert_selector ".creative-workspace-shell"
     assert_selector "#comments-popup[data-docked='true']", visible: :visible
-
-    visit collavre.user_path(@user)
-    find("#user_creative_workspace_enabled").uncheck
-    click_button I18n.t("collavre.users.update_profile")
-
-    visit root_path
-    assert_no_selector ".creative-workspace-shell"
-    assert_selector "#comments-popup[data-docked='false']", visible: :all
   end
 
   test "plans menu opens and loads plans on click" do


### PR DESCRIPTION
## Summary

The three-column creative workspace (#1482) shipped as an opt-in profile preference defaulting to off, so in practice almost no one gets the persistent left tree, in-place center Turbo Frame, or docked right chat. This flips it on by default.

- `users.creative_workspace_enabled` column default `false` -> `true` (new migration)
- Existing rows are backfilled to `true`. The preference shipped days ago, so every stored `false` is the old default rather than a deliberate opt-out. Anyone who prefers the classic layout can still turn it off in their profile.
- The data backfill is explicitly irreversible because a backfilled `true` cannot be distinguished from a later explicit user opt-in; rollback raises instead of silently overwriting user intent.
- `Collavre::User` attribute default updated to match the column default
- Profile toggle behaviour is unchanged; only the starting state moved

## Tests

- `users_controller_test`: the profile toggle test now starts from the default-on state and turns the preference off first; added coverage asserting the model/column default is `true`
- Migration regression test asserts rollback raises `ActiveRecord::IrreversibleMigration`
- `inline_scripts_test`: the workspace system test no longer sets the preference explicitly, so it exercises the new default, and toggles off -> on
- Focused Rails tests: 41 runs / 207 assertions / 0 failures
- Workspace system tests: 25 runs / 147 assertions / 0 failures (1 pre-existing skip)
- Rubocop clean on changed Ruby files
- GitHub CI: Rails tests, JavaScript tests, lint, security scan, PostgreSQL schema load, and applicable CodeQL analyses passed