### PR TITLE
fix: simplify actionable task empty-state label

### DIFF
--- a/engines/collavre/config/locales/creatives.en.yml
+++ b/engines/collavre/config/locales/creatives.en.yml
@@ -59,7 +59,7 @@ en:
         empty_state_heading_sub: No sub-creatives yet
         empty_state_concept_title: "💡 What's a creative?"
         empty_state_facet_doc: Tree-structured document piece
-        empty_state_facet_task: Actionable task (progress)
+        empty_state_facet_task: Actionable task
         empty_state_facet_chat: Discussion channel
         empty_state_block_label: One creative block
         empty_state_concept_caption: One block plays all three roles — document, task, and conversation. Stacked as a tree, it becomes a document-shaped project with automatic progress rollup.

--- a/engines/collavre/config/locales/creatives.ko.yml
+++ b/engines/collavre/config/locales/creatives.ko.yml
@@ -55,7 +55,7 @@ ko:
         empty_state_heading_sub: 아직 하위 크리에이티브가 없습니다
         empty_state_concept_title: "💡 크리에이티브란?"
         empty_state_facet_doc: 트리 구조 문서 조각
-        empty_state_facet_task: 실행 가능한 작업 (진행률)
+        empty_state_facet_task: 실행 가능한 작업
         empty_state_facet_chat: 관련 대화 채널
         empty_state_block_label: 크리에이티브 1블록
         empty_state_concept_caption: 하나의 블록이 문서·작업·대화 역할을 동시에 합니다. 트리로 쌓으면 진행률이 자동 집계되는 문서형 프로젝트가 됩니다.

--- a/engines/collavre/test/controllers/creatives_controller_empty_state_test.rb
+++ b/engines/collavre/test/controllers/creatives_controller_empty_state_test.rb
@@ -18,6 +18,15 @@ class CreativesControllerEmptyStateTest < ActionDispatch::IntegrationTest
     ERB::Util.html_escape(I18n.t(key))
   end
 
+  test "task facet omits the progress qualifier in both locales" do
+    { en: "Actionable task", ko: "실행 가능한 작업" }.each do |locale, expected|
+      label = I18n.t("collavre.creatives.index.empty_state_facet_task", locale: locale)
+
+      assert_equal expected, label
+      refute_match(/\(.+\)/, label)
+    end
+  end
+
   test "root empty state shows writable CTAs for an authenticated user" do
     sign_in_as(users(:one), password: "password")
 


### PR DESCRIPTION
## Summary

- remove the progress qualifier from the actionable-task empty-state label
- keep the English and Korean labels aligned
- add a bilingual regression test for the exact copy

## Why

The progress qualifier was redundant in the Creative concept description and made the label unnecessarily verbose.

## Validation

- `mise exec -- bin/rails test engines/collavre/test/controllers/creatives_controller_empty_state_test.rb`
- `mise exec -- ./bin/rubocop engines/collavre/test/controllers/creatives_controller_empty_state_test.rb`
- verified both localized labels in the development preview
