### PR TITLE
feat: persist AI agent model suggestions

### DIFF
--- a/app/javascript/controllers/__tests__/llm_model_controller.test.js
+++ b/app/javascript/controllers/__tests__/llm_model_controller.test.js
@@ -7,10 +7,11 @@ import { Application } from '@hotwired/stimulus'
 import LlmModelController from '../llm_model_controller'
 
 const flush = () => new Promise((resolve) => setTimeout(resolve, 0))
-const response = ({ ok, status = ok ? 200 : 500, headers = {} }) => ({
+const response = ({ ok, status = ok ? 204 : 500, headers = {}, redirected = false }) => ({
     ok,
     status,
-    headers: new Headers(headers)
+    headers: new Headers(headers),
+    redirected
 })
 
 describe('LlmModelController', () => {
@@ -158,6 +159,19 @@ describe('LlmModelController', () => {
         })
         expect(global.fetch.mock.calls[2][1].headers.get('X-CSRF-Token')).toBe('fresh-token')
         expect(controller.modelsValue.map((model) => model.id)).toEqual([1, 3])
+    })
+
+    test('keeps the suggestion when deletion follows an authentication redirect', async () => {
+        global.fetch.mockResolvedValue(response({ ok: true, status: 200, redirected: true }))
+        controller.show('gpt')
+
+        document.querySelector('.llm-model-delete').dispatchEvent(new MouseEvent('click', { bubbles: true }))
+        await flush()
+
+        expect(document.querySelector('.confirm-dialog-message').textContent).toBe('Delete failed')
+        document.querySelector('.modal-dialog-btn-primary').click()
+        await flush()
+        expect(controller.modelsValue.map((model) => model.id)).toEqual([1, 2, 3])
     })
 
     test('prevents delete pointer events from selecting the suggestion', () => {

--- a/app/javascript/controllers/__tests__/llm_model_controller.test.js
+++ b/app/javascript/controllers/__tests__/llm_model_controller.test.js
@@ -54,6 +54,7 @@ describe('LlmModelController', () => {
     })
 
     afterEach(() => {
+        jest.useRealTimers()
         application.stop()
         document.body.innerHTML = ''
         jest.clearAllMocks()
@@ -68,6 +69,34 @@ describe('LlmModelController', () => {
         controller.vendorTarget.value = 'google'
         controller.vendorChanged()
         expect(document.querySelector('.llm-model-name').textContent).toBe('gemini-3.1-flash-lite')
+    })
+
+    test('keeps the filtered popup open when a pending input blur follows a vendor change', () => {
+        jest.useFakeTimers()
+        controller.show('')
+        controller.blur()
+
+        controller.vendorTarget.value = 'google'
+        controller.vendorChanged()
+        jest.advanceTimersByTime(150)
+
+        expect(controller.menuElement.style.display).toBe('block')
+        expect(document.querySelector('.llm-model-name').textContent).toBe('gemini-3.1-flash-lite')
+    })
+
+    test('moves Tab focus from the model input to the active model delete button', () => {
+        jest.useFakeTimers()
+        controller.inputTarget.focus()
+        controller.show('gpt')
+        controller.blur()
+
+        const event = new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true })
+        controller.handleKeydown(event)
+        jest.advanceTimersByTime(150)
+
+        expect(event.defaultPrevented).toBe(true)
+        expect(document.activeElement).toBe(document.querySelector('.llm-model-delete'))
+        expect(controller.menuElement.style.display).toBe('block')
     })
 
     test('selects a model without including the delete control', () => {
@@ -98,6 +127,16 @@ describe('LlmModelController', () => {
         })
         expect(controller.inputTarget.value).toBe('gpt')
         expect(controller.modelsValue.map((model) => model.id)).toEqual([1, 3])
+    })
+
+    test('prevents delete pointer events from selecting the suggestion', () => {
+        controller.show('gpt')
+        const event = new MouseEvent('mousedown', { bubbles: true, cancelable: true })
+
+        document.querySelector('.llm-model-delete').dispatchEvent(event)
+
+        expect(event.defaultPrevented).toBe(true)
+        expect(controller.inputTarget.value).toBe('')
     })
 
     test('keeps the suggestion and shows a localized error when deletion fails', async () => {

--- a/app/javascript/controllers/__tests__/llm_model_controller.test.js
+++ b/app/javascript/controllers/__tests__/llm_model_controller.test.js
@@ -39,6 +39,7 @@ describe('LlmModelController', () => {
             <div id="llm-model-suggestions" style="display:none;">
               <ul class="common-popup-list"></ul>
             </div>
+            <input id="next-field">
           </div>
         `
         document.getElementById('llm-fields').dataset.llmModelModelsValue = JSON.stringify(models)
@@ -114,6 +115,44 @@ describe('LlmModelController', () => {
         expect(controller.menuElement.style.display).toBe('block')
     })
 
+    test('hides the popup when focus leaves the delete button and model controls', () => {
+        controller.inputTarget.focus()
+        controller.show('gpt')
+        controller.handleKeydown(new KeyboardEvent('keydown', {
+            key: 'Tab',
+            bubbles: true,
+            cancelable: true
+        }))
+
+        document.getElementById('next-field').focus()
+
+        expect(controller.menuElement.style.display).toBe('none')
+    })
+
+    test('keeps the popup open when focus returns from delete to the model input', () => {
+        controller.inputTarget.focus()
+        controller.show('gpt')
+        controller.handleKeydown(new KeyboardEvent('keydown', {
+            key: 'Tab',
+            bubbles: true,
+            cancelable: true
+        }))
+
+        controller.inputTarget.focus()
+
+        expect(controller.menuElement.style.display).toBe('block')
+    })
+
+    test('keeps the popup open when focus moves within its delete controls', () => {
+        controller.show('')
+        const buttons = document.querySelectorAll('.llm-model-delete')
+        buttons[0].focus()
+
+        buttons[1].focus()
+
+        expect(controller.menuElement.style.display).toBe('block')
+    })
+
     test('selects a model without including the delete control', () => {
         controller.show('gpt')
         document.querySelector('.llm-model-name').dispatchEvent(new MouseEvent('click', { bubbles: true }))
@@ -131,6 +170,7 @@ describe('LlmModelController', () => {
     test('deletes a suggestion without selecting it', async () => {
         global.fetch.mockResolvedValue(response({ ok: true }))
         controller.inputTarget.value = 'gpt'
+        controller.inputTarget.focus()
         controller.show('gpt')
 
         document.querySelector('.llm-model-delete').dispatchEvent(new MouseEvent('click', { bubbles: true }))
@@ -163,6 +203,43 @@ describe('LlmModelController', () => {
 
         expect(document.activeElement).toBe(controller.inputTarget)
         expect(controller.modelsValue.map((model) => model.id)).toEqual([1, 3])
+    })
+
+    test('keeps the popup hidden when focus leaves during deletion', async () => {
+        let resolveDelete
+        global.fetch.mockReturnValue(new Promise((resolve) => { resolveDelete = resolve }))
+        controller.inputTarget.focus()
+        controller.show('')
+        controller.handleKeydown(new KeyboardEvent('keydown', {
+            key: 'Tab',
+            bubbles: true,
+            cancelable: true
+        }))
+
+        document.activeElement.click()
+        document.getElementById('next-field').focus()
+        resolveDelete(response({ ok: true }))
+        await flush()
+
+        expect(controller.modelsValue.map((model) => model.id)).toEqual([1, 3])
+        expect(controller.menuElement.style.display).toBe('none')
+    })
+
+    test('restores input focus when deletion rebuilds another focused suggestion', async () => {
+        let resolveDelete
+        global.fetch.mockReturnValue(new Promise((resolve) => { resolveDelete = resolve }))
+        controller.show('')
+        const buttons = document.querySelectorAll('.llm-model-delete')
+        buttons[0].focus()
+        buttons[0].click()
+        buttons[1].focus()
+
+        resolveDelete(response({ ok: true }))
+        await flush()
+
+        expect(document.activeElement).toBe(controller.inputTarget)
+        expect(controller.modelsValue.map((model) => model.id)).toEqual([1, 3])
+        expect(controller.menuElement.style.display).toBe('block')
     })
 
     test('refreshes a stale CSRF token and retries deletion once', async () => {

--- a/app/javascript/controllers/__tests__/llm_model_controller.test.js
+++ b/app/javascript/controllers/__tests__/llm_model_controller.test.js
@@ -1,0 +1,115 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { jest } from '@jest/globals'
+import { Application } from '@hotwired/stimulus'
+import LlmModelController from '../llm_model_controller'
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0))
+
+describe('LlmModelController', () => {
+    let application
+    let controller
+
+    const models = [
+        { id: 1, vendor: 'google', name: 'gemini-3.1-flash-lite', delete_url: '/llm_models/1' },
+        { id: 2, vendor: 'openai', name: 'gpt-5.2', delete_url: '/llm_models/2' },
+        { id: 3, vendor: 'openai', name: '<img src=x onerror=alert(1)>', delete_url: '/llm_models/3' }
+    ]
+
+    const mount = async () => {
+        document.body.innerHTML = `
+          <meta name="csrf-token" content="test-token">
+          <div id="llm-fields" data-controller="llm-model"
+               data-llm-model-menu-id-value="llm-model-suggestions"
+               data-llm-model-delete-label-value="Remove"
+               data-llm-model-delete-failed-value="Delete failed">
+            <select data-llm-model-target="vendor">
+              <option value="google">Google</option>
+              <option value="openai" selected>OpenAI</option>
+            </select>
+            <input data-llm-model-target="input">
+            <div id="llm-model-suggestions" style="display:none;">
+              <ul class="common-popup-list"></ul>
+            </div>
+          </div>
+        `
+        document.getElementById('llm-fields').dataset.llmModelModelsValue = JSON.stringify(models)
+
+        application = Application.start()
+        application.register('llm-model', LlmModelController)
+        await flush()
+        controller = application.getControllerForElementAndIdentifier(
+            document.getElementById('llm-fields'),
+            'llm-model'
+        )
+    }
+
+    beforeEach(async () => {
+        global.requestAnimationFrame = (callback) => callback()
+        global.fetch = jest.fn()
+        window.HTMLElement.prototype.scrollIntoView = jest.fn()
+        await mount()
+    })
+
+    afterEach(() => {
+        application.stop()
+        document.body.innerHTML = ''
+        jest.clearAllMocks()
+    })
+
+    test('filters suggestions by the selected vendor and search term', () => {
+        controller.show('gpt')
+
+        const labels = Array.from(document.querySelectorAll('.llm-model-name'), (element) => element.textContent)
+        expect(labels).toEqual(['gpt-5.2'])
+
+        controller.vendorTarget.value = 'google'
+        controller.vendorChanged()
+        expect(document.querySelector('.llm-model-name').textContent).toBe('gemini-3.1-flash-lite')
+    })
+
+    test('selects a model without including the delete control', () => {
+        controller.show('gpt')
+        document.querySelector('.llm-model-name').dispatchEvent(new MouseEvent('click', { bubbles: true }))
+
+        expect(controller.inputTarget.value).toBe('gpt-5.2')
+    })
+
+    test('renders saved model names as text instead of executable markup', () => {
+        controller.show('img')
+
+        expect(document.querySelector('.llm-model-item img')).toBeNull()
+        expect(document.querySelector('.llm-model-name').textContent).toBe('<img src=x onerror=alert(1)>')
+    })
+
+    test('deletes a suggestion without selecting it', async () => {
+        global.fetch.mockResolvedValue({ ok: true })
+        controller.inputTarget.value = 'gpt'
+        controller.show('gpt')
+
+        document.querySelector('.llm-model-delete').dispatchEvent(new MouseEvent('click', { bubbles: true }))
+        await flush()
+
+        expect(global.fetch).toHaveBeenCalledWith('/llm_models/2', {
+            method: 'DELETE',
+            headers: { Accept: 'application/json', 'X-CSRF-Token': 'test-token' }
+        })
+        expect(controller.inputTarget.value).toBe('gpt')
+        expect(controller.modelsValue.map((model) => model.id)).toEqual([1, 3])
+    })
+
+    test('keeps the suggestion and shows a localized error when deletion fails', async () => {
+        global.fetch.mockResolvedValue({ ok: false, status: 500 })
+        controller.show('gpt')
+
+        document.querySelector('.llm-model-delete').dispatchEvent(new MouseEvent('click', { bubbles: true }))
+        await flush()
+
+        expect(document.querySelector('.confirm-dialog-message').textContent).toBe('Delete failed')
+        document.querySelector('.modal-dialog-btn-primary').click()
+        await flush()
+        expect(controller.modelsValue.map((model) => model.id)).toEqual([1, 2, 3])
+    })
+})

--- a/app/javascript/controllers/__tests__/llm_model_controller.test.js
+++ b/app/javascript/controllers/__tests__/llm_model_controller.test.js
@@ -77,6 +77,15 @@ describe('LlmModelController', () => {
         expect(document.querySelector('.llm-model-name').textContent).toBe('gemini-3.1-flash-lite')
     })
 
+    test('normalizes the selected vendor before filtering suggestions', () => {
+        controller.vendorTarget.insertAdjacentHTML('beforeend', '<option value="OpenAI">OpenAI extension</option>')
+        controller.vendorTarget.value = 'OpenAI'
+
+        controller.show('gpt')
+
+        expect(document.querySelector('.llm-model-name').textContent).toBe('gpt-5.2')
+    })
+
     test('keeps the filtered popup open when a pending input blur follows a vendor change', () => {
         jest.useFakeTimers()
         controller.show('')
@@ -136,6 +145,23 @@ describe('LlmModelController', () => {
         expect(requestHeaders.get('Accept')).toBe('application/json')
         expect(requestHeaders.get('X-CSRF-Token')).toBe('test-token')
         expect(controller.inputTarget.value).toBe('gpt')
+        expect(controller.modelsValue.map((model) => model.id)).toEqual([1, 3])
+    })
+
+    test('restores input focus after deleting with the keyboard', async () => {
+        global.fetch.mockResolvedValue(response({ ok: true }))
+        controller.inputTarget.focus()
+        controller.show('gpt')
+        controller.handleKeydown(new KeyboardEvent('keydown', {
+            key: 'Tab',
+            bubbles: true,
+            cancelable: true
+        }))
+
+        document.activeElement.click()
+        await flush()
+
+        expect(document.activeElement).toBe(controller.inputTarget)
         expect(controller.modelsValue.map((model) => model.id)).toEqual([1, 3])
     })
 

--- a/app/javascript/controllers/__tests__/llm_model_controller.test.js
+++ b/app/javascript/controllers/__tests__/llm_model_controller.test.js
@@ -7,6 +7,11 @@ import { Application } from '@hotwired/stimulus'
 import LlmModelController from '../llm_model_controller'
 
 const flush = () => new Promise((resolve) => setTimeout(resolve, 0))
+const response = ({ ok, status = ok ? 200 : 500, headers = {} }) => ({
+    ok,
+    status,
+    headers: new Headers(headers)
+})
 
 describe('LlmModelController', () => {
     let application
@@ -114,7 +119,7 @@ describe('LlmModelController', () => {
     })
 
     test('deletes a suggestion without selecting it', async () => {
-        global.fetch.mockResolvedValue({ ok: true })
+        global.fetch.mockResolvedValue(response({ ok: true }))
         controller.inputTarget.value = 'gpt'
         controller.show('gpt')
 
@@ -122,10 +127,36 @@ describe('LlmModelController', () => {
         await flush()
 
         expect(global.fetch).toHaveBeenCalledWith('/llm_models/2', {
+            credentials: 'same-origin',
             method: 'DELETE',
-            headers: { Accept: 'application/json', 'X-CSRF-Token': 'test-token' }
+            headers: expect.any(Headers)
         })
+        const requestHeaders = global.fetch.mock.calls[0][1].headers
+        expect(requestHeaders.get('Accept')).toBe('application/json')
+        expect(requestHeaders.get('X-CSRF-Token')).toBe('test-token')
         expect(controller.inputTarget.value).toBe('gpt')
+        expect(controller.modelsValue.map((model) => model.id)).toEqual([1, 3])
+    })
+
+    test('refreshes a stale CSRF token and retries deletion once', async () => {
+        global.fetch
+            .mockResolvedValueOnce(response({ ok: false, status: 422 }))
+            .mockResolvedValueOnce(response({
+                ok: true,
+                headers: { 'X-CSRF-Token': 'fresh-token' }
+            }))
+            .mockResolvedValueOnce(response({ ok: true }))
+        controller.show('gpt')
+
+        document.querySelector('.llm-model-delete').dispatchEvent(new MouseEvent('click', { bubbles: true }))
+        await flush()
+
+        expect(global.fetch).toHaveBeenCalledTimes(3)
+        expect(global.fetch.mock.calls[1][1]).toEqual({
+            method: 'HEAD',
+            credentials: 'same-origin'
+        })
+        expect(global.fetch.mock.calls[2][1].headers.get('X-CSRF-Token')).toBe('fresh-token')
         expect(controller.modelsValue.map((model) => model.id)).toEqual([1, 3])
     })
 
@@ -140,7 +171,7 @@ describe('LlmModelController', () => {
     })
 
     test('keeps the suggestion and shows a localized error when deletion fails', async () => {
-        global.fetch.mockResolvedValue({ ok: false, status: 500 })
+        global.fetch.mockResolvedValue(response({ ok: false, status: 500 }))
         controller.show('gpt')
 
         document.querySelector('.llm-model-delete').dispatchEvent(new MouseEvent('click', { bubbles: true }))

--- a/app/javascript/controllers/llm_model_controller.js
+++ b/app/javascript/controllers/llm_model_controller.js
@@ -73,6 +73,13 @@ export default class extends Controller {
         return true
     }
 
+    deleteButtonBlur(event) {
+        const nextTarget = event.relatedTarget
+        if (nextTarget === this.inputTarget || this.menuElement.contains(nextTarget)) return
+
+        this.hide()
+    }
+
     show(term) {
         if (!this.popup) return
 
@@ -133,9 +140,17 @@ export default class extends Controller {
                 throw new Error(`Unexpected DELETE response: ${response.status}`)
             }
 
+            const shouldRefreshPopup = this.popup?.isOpen() && (
+                document.activeElement === this.inputTarget ||
+                this.menuElement.contains(document.activeElement)
+            )
             this.modelsValue = this.modelsValue.filter((candidate) => candidate.id !== id)
-            if (document.activeElement === deleteButton) this.inputTarget.focus()
-            this.show(this.inputTarget.value.trim())
+            if (this.menuElement.contains(document.activeElement)) this.inputTarget.focus()
+            if (shouldRefreshPopup) {
+                this.show(this.inputTarget.value.trim())
+            } else {
+                this.hide()
+            }
         } catch (error) {
             await alertDialog(this.deleteFailedValue)
         }
@@ -158,6 +173,7 @@ export default class extends Controller {
             button.addEventListener('touchend', this.deleteModel.bind(this))
             button.addEventListener('click', this.deleteModel.bind(this))
             button.addEventListener('focus', () => clearTimeout(this.hideTimeout))
+            button.addEventListener('blur', this.deleteButtonBlur.bind(this))
         })
     }
 

--- a/app/javascript/controllers/llm_model_controller.js
+++ b/app/javascript/controllers/llm_model_controller.js
@@ -36,6 +36,7 @@ export default class extends Controller {
     }
 
     vendorChanged() {
+        clearTimeout(this.hideTimeout)
         this.show(this.inputTarget.value.trim())
     }
 
@@ -49,9 +50,26 @@ export default class extends Controller {
     }
 
     handleKeydown(event) {
+        if (event.key === 'Tab' && !event.shiftKey && this.focusActiveDeleteButton()) {
+            event.preventDefault()
+            return
+        }
+
         if (this.popup?.handleKey(event)) {
             event.preventDefault()
         }
+    }
+
+    focusActiveDeleteButton() {
+        if (!this.popup?.isOpen()) return false
+
+        const button = this.listElement
+            .querySelector('.common-popup-item.active .llm-model-delete')
+        if (!button) return false
+
+        clearTimeout(this.hideTimeout)
+        button.focus()
+        return true
     }
 
     show(term) {
@@ -131,6 +149,7 @@ export default class extends Controller {
             button.addEventListener('touchstart', this.prepareDelete.bind(this))
             button.addEventListener('touchend', this.deleteModel.bind(this))
             button.addEventListener('click', this.deleteModel.bind(this))
+            button.addEventListener('focus', () => clearTimeout(this.hideTimeout))
         })
     }
 

--- a/app/javascript/controllers/llm_model_controller.js
+++ b/app/javascript/controllers/llm_model_controller.js
@@ -128,7 +128,9 @@ export default class extends Controller {
                 await refreshCsrfToken()
                 response = await deleteRequest()
             }
-            if (!response.ok) throw new Error(`HTTP ${response.status}`)
+            if (!response.ok || response.redirected || response.status !== 204) {
+                throw new Error(`Unexpected DELETE response: ${response.status}`)
+            }
 
             this.modelsValue = this.modelsValue.filter((candidate) => candidate.id !== id)
             this.show(this.inputTarget.value.trim())

--- a/app/javascript/controllers/llm_model_controller.js
+++ b/app/javascript/controllers/llm_model_controller.js
@@ -77,7 +77,7 @@ export default class extends Controller {
         if (!this.popup) return
 
         const lowered = term.toLowerCase()
-        const vendor = this.vendorTarget.value
+        const vendor = this.vendorTarget.value.toLowerCase()
         const filtered = this.modelsValue.filter((model) => (
             model.vendor === vendor && model.name.toLowerCase().includes(lowered)
         ))
@@ -113,7 +113,8 @@ export default class extends Controller {
         event.preventDefault()
         event.stopPropagation()
 
-        const id = Number(event.currentTarget.dataset.modelId)
+        const deleteButton = event.currentTarget
+        const id = Number(deleteButton.dataset.modelId)
         const model = this.modelsValue.find((candidate) => candidate.id === id)
         if (!model) return
 
@@ -133,6 +134,7 @@ export default class extends Controller {
             }
 
             this.modelsValue = this.modelsValue.filter((candidate) => candidate.id !== id)
+            if (document.activeElement === deleteButton) this.inputTarget.focus()
             this.show(this.inputTarget.value.trim())
         } catch (error) {
             await alertDialog(this.deleteFailedValue)

--- a/app/javascript/controllers/llm_model_controller.js
+++ b/app/javascript/controllers/llm_model_controller.js
@@ -1,11 +1,14 @@
 import { Controller } from '@hotwired/stimulus'
 import CommonPopup from 'collavre/lib/common_popup.js'
+import { alertDialog } from 'collavre/lib/utils/dialog.js'
 
 export default class extends Controller {
-    static targets = ['input']
+    static targets = ['input', 'vendor']
     static values = {
         models: Array,
-        menuId: String
+        menuId: String,
+        deleteLabel: String,
+        deleteFailed: String
     }
 
     connect() {
@@ -13,11 +16,11 @@ export default class extends Controller {
         this.listElement = this.menuElement?.querySelector('.mention-results') ||
             this.menuElement?.querySelector('.common-popup-list')
 
-        if (!this.menuElement || !this.listElement || this.modelsValue.length === 0) return
+        if (!this.menuElement || !this.listElement) return
 
         this.popup = new CommonPopup(this.menuElement, {
             listElement: this.listElement,
-            renderItem: (model) => `<div class="mention-item">${model}</div>`,
+            renderItem: (model) => this.renderModel(model),
             onSelect: this.select.bind(this)
         })
     }
@@ -29,6 +32,10 @@ export default class extends Controller {
     }
 
     search() {
+        this.show(this.inputTarget.value.trim())
+    }
+
+    vendorChanged() {
         this.show(this.inputTarget.value.trim())
     }
 
@@ -51,7 +58,10 @@ export default class extends Controller {
         if (!this.popup) return
 
         const lowered = term.toLowerCase()
-        const filtered = this.modelsValue.filter((model) => model.toLowerCase().includes(lowered))
+        const vendor = this.vendorTarget.value
+        const filtered = this.modelsValue.filter((model) => (
+            model.vendor === vendor && model.name.toLowerCase().includes(lowered)
+        ))
 
         if (filtered.length === 0) {
             this.hide()
@@ -59,6 +69,7 @@ export default class extends Controller {
         }
 
         this.popup.setItems(filtered)
+        this.bindDeleteButtons()
         this.popup.showAt(this.inputTarget.getBoundingClientRect())
     }
 
@@ -67,10 +78,68 @@ export default class extends Controller {
     }
 
     select(model) {
-        this.inputTarget.value = model
+        this.inputTarget.value = model.name
         this.hide()
         this.inputTarget.focus()
         this.inputTarget.dispatchEvent(new Event('input', { bubbles: true }))
         this.inputTarget.dispatchEvent(new Event('change', { bubbles: true }))
+    }
+
+    prepareDelete(event) {
+        event.preventDefault()
+        event.stopPropagation()
+    }
+
+    async deleteModel(event) {
+        event.preventDefault()
+        event.stopPropagation()
+
+        const id = Number(event.currentTarget.dataset.modelId)
+        const model = this.modelsValue.find((candidate) => candidate.id === id)
+        if (!model) return
+
+        try {
+            const response = await fetch(model.delete_url, {
+                method: 'DELETE',
+                headers: {
+                    Accept: 'application/json',
+                    'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]')?.content || ''
+                }
+            })
+            if (!response.ok) throw new Error(`HTTP ${response.status}`)
+
+            this.modelsValue = this.modelsValue.filter((candidate) => candidate.id !== id)
+            this.show(this.inputTarget.value.trim())
+        } catch (error) {
+            await alertDialog(this.deleteFailedValue)
+        }
+    }
+
+    renderModel(model) {
+        const name = this.escapeHtml(model.name)
+        const label = this.escapeHtml(`${this.deleteLabelValue}: ${model.name}`)
+
+        return `<div class="mention-item llm-model-item">` +
+            `<span class="llm-model-name">${name}</span>` +
+            `<button type="button" class="llm-model-delete" data-model-id="${model.id}" aria-label="${label}" title="${label}">&times;</button>` +
+            `</div>`
+    }
+
+    bindDeleteButtons() {
+        this.listElement.querySelectorAll('.llm-model-delete').forEach((button) => {
+            button.addEventListener('mousedown', this.prepareDelete.bind(this))
+            button.addEventListener('touchstart', this.prepareDelete.bind(this))
+            button.addEventListener('touchend', this.deleteModel.bind(this))
+            button.addEventListener('click', this.deleteModel.bind(this))
+        })
+    }
+
+    escapeHtml(value) {
+        return String(value)
+            .replaceAll('&', '&amp;')
+            .replaceAll('<', '&lt;')
+            .replaceAll('>', '&gt;')
+            .replaceAll('"', '&quot;')
+            .replaceAll("'", '&#39;')
     }
 }

--- a/app/javascript/controllers/llm_model_controller.js
+++ b/app/javascript/controllers/llm_model_controller.js
@@ -1,5 +1,6 @@
 import { Controller } from '@hotwired/stimulus'
 import CommonPopup from 'collavre/lib/common_popup.js'
+import csrfFetch, { refreshCsrfToken } from 'collavre/lib/api/csrf_fetch.js'
 import { alertDialog } from 'collavre/lib/utils/dialog.js'
 
 export default class extends Controller {
@@ -117,13 +118,16 @@ export default class extends Controller {
         if (!model) return
 
         try {
-            const response = await fetch(model.delete_url, {
+            const deleteRequest = () => csrfFetch(model.delete_url, {
                 method: 'DELETE',
-                headers: {
-                    Accept: 'application/json',
-                    'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]')?.content || ''
-                }
+                headers: { Accept: 'application/json' }
             })
+
+            let response = await deleteRequest()
+            if (response.status === 422) {
+                await refreshCsrfToken()
+                response = await deleteRequest()
+            }
             if (!response.ok) throw new Error(`HTTP ${response.status}`)
 
             this.modelsValue = this.modelsValue.filter((candidate) => candidate.id !== id)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_07_050000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_09_000000) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -455,6 +455,16 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_07_050000) do
     t.index ["creative_id"], name: "index_linear_project_links_on_creative_id", unique: true
     t.index ["linear_project_id"], name: "index_linear_project_links_on_linear_project_id", unique: true
     t.index ["team_id"], name: "index_linear_project_links_on_team_id"
+  end
+
+  create_table "llm_models", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "created_by_id"
+    t.string "llm_vendor", null: false
+    t.string "name", null: false
+    t.datetime "updated_at", null: false
+    t.index ["created_by_id"], name: "index_llm_models_on_created_by_id"
+    t.index ["llm_vendor", "name"], name: "index_llm_models_on_llm_vendor_and_name", unique: true
   end
 
   create_table "mcp_tools", force: :cascade do |t|
@@ -1030,6 +1040,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_07_050000) do
   add_foreign_key "linear_issue_links", "linear_project_links", column: "project_link_id"
   add_foreign_key "linear_project_links", "creatives"
   add_foreign_key "linear_project_links", "linear_accounts", column: "account_id"
+  add_foreign_key "llm_models", "users", column: "created_by_id", on_delete: :nullify
   add_foreign_key "mcp_tools", "creatives"
   add_foreign_key "notion_accounts", "users"
   add_foreign_key "notion_block_links", "creatives"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -460,8 +460,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_09_000000) do
   create_table "llm_models", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.integer "created_by_id"
-    t.string "llm_vendor", null: false
-    t.string "name", null: false
+    t.string "llm_vendor", limit: 255, null: false
+    t.string "name", limit: 255, null: false
     t.datetime "updated_at", null: false
     t.index ["created_by_id"], name: "index_llm_models_on_created_by_id"
     t.index ["llm_vendor", "name"], name: "index_llm_models_on_llm_vendor_and_name", unique: true

--- a/engines/collavre/app/assets/stylesheets/collavre/mention_menu.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/mention_menu.css
@@ -34,6 +34,38 @@
   cursor: pointer;
 }
 
+.llm-model-item {
+  display: flex;
+  gap: 0.75em;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.llm-model-name {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.llm-model-delete {
+  flex: 0 0 auto;
+  width: 1.75em;
+  height: 1.75em;
+  padding: 0;
+  color: var(--text-muted);
+  font: inherit;
+  line-height: 1;
+  cursor: pointer;
+  background: transparent;
+  border: 0;
+  border-radius: var(--radius-round);
+}
+
+.llm-model-delete:hover,
+.llm-model-delete:focus-visible {
+  color: var(--text-primary);
+  background: var(--surface-hover);
+}
+
 .mention-item:hover,
 .mention-item.active,
 .common-popup-item:hover,

--- a/engines/collavre/app/controllers/collavre/llm_models_controller.rb
+++ b/engines/collavre/app/controllers/collavre/llm_models_controller.rb
@@ -1,7 +1,7 @@
 module Collavre
   class LlmModelsController < ApplicationController
     def destroy
-      LlmModel.find(params[:id]).destroy!
+      LlmModel.find_by(id: params[:id])&.destroy!
       head :no_content
     end
   end

--- a/engines/collavre/app/controllers/collavre/llm_models_controller.rb
+++ b/engines/collavre/app/controllers/collavre/llm_models_controller.rb
@@ -1,0 +1,8 @@
+module Collavre
+  class LlmModelsController < ApplicationController
+    def destroy
+      LlmModel.find(params[:id]).destroy!
+      head :no_content
+    end
+  end
+end

--- a/engines/collavre/app/controllers/concerns/collavre/users_controller/ai_user_management.rb
+++ b/engines/collavre/app/controllers/concerns/collavre/users_controller/ai_user_management.rb
@@ -10,7 +10,7 @@ module Collavre
 
     def new_ai
       @available_tools = load_available_tools
-      @llm_models = Collavre::LlmModel.ordered
+      @llm_models = Collavre::LlmModel.suggestions
 
       if params[:copy_from].present?
         source = Collavre::User.find_by(id: params[:copy_from])
@@ -51,14 +51,14 @@ module Collavre
       else
         flash.now[:alert] = @user.errors.full_messages.to_sentence
         @available_tools = load_available_tools
-        @llm_models = Collavre::LlmModel.ordered
+        @llm_models = Collavre::LlmModel.suggestions
         render :new_ai, status: :unprocessable_entity
       end
     end
 
     def edit_ai
       @available_tools = load_available_tools
-      @llm_models = Collavre::LlmModel.ordered
+      @llm_models = Collavre::LlmModel.suggestions
       @has_stored_llm_api_key = @user.llm_api_key.present?
     end
 
@@ -81,7 +81,7 @@ module Collavre
         redirect_to edit_ai_user_path(@user), notice: I18n.t("collavre.users.update_ai.success")
       else
         @available_tools = load_available_tools
-        @llm_models = Collavre::LlmModel.ordered
+        @llm_models = Collavre::LlmModel.suggestions
         flash.now[:alert] = @user.errors.full_messages.to_sentence
         render :edit_ai, status: :unprocessable_entity
       end

--- a/engines/collavre/app/controllers/concerns/collavre/users_controller/ai_user_management.rb
+++ b/engines/collavre/app/controllers/concerns/collavre/users_controller/ai_user_management.rb
@@ -10,6 +10,7 @@ module Collavre
 
     def new_ai
       @available_tools = load_available_tools
+      @llm_models = Collavre::LlmModel.ordered
 
       if params[:copy_from].present?
         source = Collavre::User.find_by(id: params[:copy_from])
@@ -43,18 +44,21 @@ module Collavre
       @user.agent_conf = params[:agent_conf] if @user.respond_to?(:agent_conf=) && params[:agent_conf].present?
 
       if @user.save
+        remember_llm_model(@user)
         Collavre::Contact.ensure(user: Current.user, contact_user: @user)
         share_ai_agent_to_creative(@user, params[:creative_id])
         redirect_to user_path(Current.user, tab: "contacts"), notice: I18n.t("collavre.users.create_ai.success")
       else
         flash.now[:alert] = @user.errors.full_messages.to_sentence
         @available_tools = load_available_tools
+        @llm_models = Collavre::LlmModel.ordered
         render :new_ai, status: :unprocessable_entity
       end
     end
 
     def edit_ai
       @available_tools = load_available_tools
+      @llm_models = Collavre::LlmModel.ordered
       @has_stored_llm_api_key = @user.llm_api_key.present?
     end
 
@@ -71,15 +75,27 @@ module Collavre
       end
 
       if @user.update(ai_params)
+        if @user.saved_change_to_llm_vendor? || @user.saved_change_to_llm_model?
+          remember_llm_model(@user)
+        end
         redirect_to edit_ai_user_path(@user), notice: I18n.t("collavre.users.update_ai.success")
       else
         @available_tools = load_available_tools
+        @llm_models = Collavre::LlmModel.ordered
         flash.now[:alert] = @user.errors.full_messages.to_sentence
         render :edit_ai, status: :unprocessable_entity
       end
     end
 
     private
+
+    def remember_llm_model(user)
+      Collavre::LlmModel.remember!(
+        vendor: user.llm_vendor,
+        name: user.llm_model,
+        creator: Current.user
+      )
+    end
 
     def load_available_tools
       Collavre::McpService.available_tools(Current.user).map do |tool|

--- a/engines/collavre/app/controllers/concerns/collavre/users_controller/ai_user_management.rb
+++ b/engines/collavre/app/controllers/concerns/collavre/users_controller/ai_user_management.rb
@@ -43,10 +43,16 @@ module Collavre
       )
       @user.agent_conf = params[:agent_conf] if @user.respond_to?(:agent_conf=) && params[:agent_conf].present?
 
-      if @user.save
+      saved = Collavre::User.transaction do
+        next false unless @user.save
+
         remember_llm_model(@user)
         Collavre::Contact.ensure(user: Current.user, contact_user: @user)
         share_ai_agent_to_creative(@user, params[:creative_id])
+        true
+      end
+
+      if saved
         redirect_to user_path(Current.user, tab: "contacts"), notice: I18n.t("collavre.users.create_ai.success")
       else
         flash.now[:alert] = @user.errors.full_messages.to_sentence
@@ -74,10 +80,16 @@ module Collavre
         ai_params.delete(:llm_api_key)
       end
 
-      if @user.update(ai_params)
+      updated = Collavre::User.transaction do
+        next false unless @user.update(ai_params)
+
         if @user.saved_change_to_llm_vendor? || @user.saved_change_to_llm_model?
           remember_llm_model(@user)
         end
+        true
+      end
+
+      if updated
         redirect_to edit_ai_user_path(@user), notice: I18n.t("collavre.users.update_ai.success")
       else
         @available_tools = load_available_tools

--- a/engines/collavre/app/models/collavre/llm_model.rb
+++ b/engines/collavre/app/models/collavre/llm_model.rb
@@ -1,6 +1,8 @@
 module Collavre
   class LlmModel < ApplicationRecord
     MAX_SUGGESTIONS = 100
+    MAX_VENDOR_LENGTH = 255
+    MAX_NAME_LENGTH = 255
 
     self.table_name = "llm_models"
 
@@ -13,8 +15,11 @@ module Collavre
     normalizes :llm_vendor, with: ->(vendor) { vendor.to_s.strip.downcase }
     normalizes :name, with: ->(name) { name.to_s.strip }
 
-    validates :llm_vendor, presence: true
-    validates :name, presence: true, uniqueness: { scope: :llm_vendor }
+    validates :llm_vendor, presence: true, length: { maximum: MAX_VENDOR_LENGTH }
+    validates :name,
+              presence: true,
+              length: { maximum: MAX_NAME_LENGTH },
+              uniqueness: { scope: :llm_vendor }
 
     scope :ordered, -> { order(:llm_vendor, :name) }
     scope :suggestions, -> {

--- a/engines/collavre/app/models/collavre/llm_model.rb
+++ b/engines/collavre/app/models/collavre/llm_model.rb
@@ -1,5 +1,7 @@
 module Collavre
   class LlmModel < ApplicationRecord
+    MAX_SUGGESTIONS = 100
+
     self.table_name = "llm_models"
 
     belongs_to :creator,
@@ -15,17 +17,33 @@ module Collavre
     validates :name, presence: true, uniqueness: { scope: :llm_vendor }
 
     scope :ordered, -> { order(:llm_vendor, :name) }
+    scope :suggestions, -> {
+      recent_ids = reorder(updated_at: :desc, id: :desc).limit(MAX_SUGGESTIONS).select(:id)
+      where(id: recent_ids).ordered
+    }
 
     def self.remember!(vendor:, name:, creator: nil)
       vendor = vendor.to_s.strip.downcase
       name = name.to_s.strip
       return if vendor.blank? || name.blank?
 
-      find_or_create_by!(llm_vendor: vendor, name: name) do |model|
-        model.creator = creator
+      model = find_or_create_by!(llm_vendor: vendor, name: name) do |record|
+        record.creator = creator
       end
+      model.touch unless model.previously_new_record?
+      prune_excess!
+      model
     rescue ActiveRecord::RecordNotUnique
-      find_by!(llm_vendor: vendor, name: name)
+      model = find_by!(llm_vendor: vendor, name: name)
+      model.touch
+      prune_excess!
+      model
     end
+
+    def self.prune_excess!
+      keep_ids = reorder(updated_at: :desc, id: :desc).limit(MAX_SUGGESTIONS).select(:id)
+      where.not(id: keep_ids).delete_all
+    end
+    private_class_method :prune_excess!
   end
 end

--- a/engines/collavre/app/models/collavre/llm_model.rb
+++ b/engines/collavre/app/models/collavre/llm_model.rb
@@ -1,0 +1,31 @@
+module Collavre
+  class LlmModel < ApplicationRecord
+    self.table_name = "llm_models"
+
+    belongs_to :creator,
+               class_name: "Collavre::User",
+               foreign_key: :created_by_id,
+               optional: true,
+               inverse_of: :created_llm_models
+
+    normalizes :llm_vendor, with: ->(vendor) { vendor.to_s.strip.downcase }
+    normalizes :name, with: ->(name) { name.to_s.strip }
+
+    validates :llm_vendor, presence: true
+    validates :name, presence: true, uniqueness: { scope: :llm_vendor }
+
+    scope :ordered, -> { order(:llm_vendor, :name) }
+
+    def self.remember!(vendor:, name:, creator: nil)
+      vendor = vendor.to_s.strip.downcase
+      name = name.to_s.strip
+      return if vendor.blank? || name.blank?
+
+      find_or_create_by!(llm_vendor: vendor, name: name) do |model|
+        model.creator = creator
+      end
+    rescue ActiveRecord::RecordNotUnique
+      find_by!(llm_vendor: vendor, name: name)
+    end
+  end
+end

--- a/engines/collavre/app/models/collavre/user.rb
+++ b/engines/collavre/app/models/collavre/user.rb
@@ -55,6 +55,11 @@ module Collavre
 
     belongs_to :creator, class_name: "Collavre::User", foreign_key: "created_by_id", optional: true
     has_many :created_ai_users, class_name: "Collavre::User", foreign_key: "created_by_id", dependent: :destroy
+    has_many :created_llm_models,
+             class_name: "Collavre::LlmModel",
+             foreign_key: :created_by_id,
+             dependent: :nullify,
+             inverse_of: :creator
 
     has_one_attached :avatar
 

--- a/engines/collavre/app/models/collavre/user.rb
+++ b/engines/collavre/app/models/collavre/user.rb
@@ -246,6 +246,12 @@ module Collavre
     validates :email, presence: true, uniqueness: true,
                       format: { with: URI::MailTo::EMAIL_REGEXP }
     validates :name, presence: true
+    validates :llm_vendor,
+              length: { maximum: Collavre::LlmModel::MAX_VENDOR_LENGTH },
+              if: :will_save_change_to_llm_vendor?
+    validates :llm_model,
+              length: { maximum: Collavre::LlmModel::MAX_NAME_LENGTH },
+              if: :will_save_change_to_llm_model?
     validate :theme_accessibility
     validate :password_meets_minimum_length
     validates :timezone,

--- a/engines/collavre/app/views/collavre/users/_llm_fields.html.erb
+++ b/engines/collavre/app/views/collavre/users/_llm_fields.html.erb
@@ -1,0 +1,43 @@
+<% models = @llm_models.map do |model|
+     {
+       id: model.id,
+       vendor: model.llm_vendor,
+       name: model.name,
+       delete_url: collavre.llm_model_path(model)
+     }
+   end %>
+
+<div data-controller="llm-model"
+     data-llm-model-menu-id-value="llm-model-suggestions"
+     data-llm-model-models-value="<%= models.to_json %>"
+     data-llm-model-delete-label-value="<%= t('collavre.users.new_ai.remove_model') %>"
+     data-llm-model-delete-failed-value="<%= t('collavre.users.new_ai.remove_model_failed') %>">
+  <div class="form-group">
+    <%= form.label :llm_vendor, t('collavre.users.new_ai.vendor_label') %>
+    <%= form.select :llm_vendor,
+                    options_for_select(Collavre::User::LLM_VENDOR_OPTIONS, selected_vendor),
+                    {},
+                    class: "stacked-form-control",
+                    data: {
+                      llm_model_target: "vendor",
+                      action: "change->llm-model#vendorChanged"
+                    } %>
+    <small class="form-text text-muted"><%= t('collavre.users.new_ai.vendor_help') %></small>
+  </div>
+
+  <div class="form-group">
+    <%= form.label :llm_model, t('collavre.users.new_ai.model_label') %>
+    <div style="position: relative;">
+      <%= form.text_field :llm_model,
+                          required: true,
+                          class: "stacked-form-control",
+                          autocomplete: "off",
+                          value: selected_model,
+                          data: {
+                            llm_model_target: "input",
+                            action: "input->llm-model#search focus->llm-model#focus blur->llm-model#blur keydown->llm-model#handleKeydown"
+                          } %>
+      <%= render Collavre::UserMentionMenuComponent.new(menu_id: 'llm-model-suggestions') %>
+    </div>
+  </div>
+</div>

--- a/engines/collavre/app/views/collavre/users/_llm_fields.html.erb
+++ b/engines/collavre/app/views/collavre/users/_llm_fields.html.erb
@@ -30,6 +30,7 @@
     <div style="position: relative;">
       <%= form.text_field :llm_model,
                           required: true,
+                          maxlength: Collavre::LlmModel::MAX_NAME_LENGTH,
                           class: "stacked-form-control",
                           autocomplete: "off",
                           value: selected_model,

--- a/engines/collavre/app/views/collavre/users/edit_ai.html.erb
+++ b/engines/collavre/app/views/collavre/users/edit_ai.html.erb
@@ -14,31 +14,10 @@
 
   <%= render "collavre/users/trigger_field", form: form, routing_expression: @user.routing_expression %>
 
-  <div class="form-group">
-    <%= form.label :llm_vendor, t('collavre.users.new_ai.vendor_label', default: 'LLM Provider') %>
-    <%= form.select :llm_vendor, options_for_select(
-      Collavre::User::LLM_VENDOR_OPTIONS, @user.llm_vendor || "google"
-    ), {}, class: "stacked-form-control" %>
-    <small class="form-text text-muted"><%= t('collavre.users.new_ai.vendor_help', default: 'Select the AI provider for this agent') %></small>
-  </div>
-
-  <div class="form-group">
-    <%= form.label :llm_model, t('collavre.users.new_ai.model_label') %>
-    <div style="position: relative;"
-         data-controller="llm-model"
-         data-llm-model-menu-id-value="llm-model-suggestions"
-         data-llm-model-models-value="<%= Collavre::User::SUPPORTED_LLM_MODELS.to_json %>">
-      <%= form.text_field :llm_model,
-                          required: true,
-                          class: "stacked-form-control",
-                          autocomplete: "off",
-                          data: {
-                            llm_model_target: "input",
-                            action: "input->llm-model#search focus->llm-model#focus blur->llm-model#blur keydown->llm-model#handleKeydown"
-                          } %>
-      <%= render Collavre::UserMentionMenuComponent.new(menu_id: 'llm-model-suggestions') %>
-    </div>
-  </div>
+  <%= render "collavre/users/llm_fields",
+             form: form,
+             selected_vendor: @user.llm_vendor || "google",
+             selected_model: @user.llm_model %>
 
   <div class="form-group">
     <%= form.label :llm_api_key, t('collavre.users.new_ai.api_key_label') %>

--- a/engines/collavre/app/views/collavre/users/new_ai.html.erb
+++ b/engines/collavre/app/views/collavre/users/new_ai.html.erb
@@ -28,32 +28,10 @@
 
   <%= render "collavre/users/trigger_field", form: form, routing_expression: @copy_source&.routing_expression %>
 
-  <div class="form-group">
-    <%= form.label :llm_vendor, t('collavre.users.new_ai.vendor_label', default: 'LLM Provider') %>
-    <%= form.select :llm_vendor, options_for_select(
-      Collavre::User::LLM_VENDOR_OPTIONS, @copy_source&.llm_vendor || "google"
-    ), {}, class: "stacked-form-control" %>
-    <small class="form-text text-muted"><%= t('collavre.users.new_ai.vendor_help', default: 'Select the AI provider for this agent') %></small>
-  </div>
-
-  <div class="form-group">
-    <%= form.label :llm_model, t('collavre.users.new_ai.model_label') %>
-    <div style="position: relative;"
-         data-controller="llm-model"
-         data-llm-model-menu-id-value="llm-model-suggestions"
-         data-llm-model-models-value="<%= Collavre::User::SUPPORTED_LLM_MODELS.to_json %>">
-      <%= form.text_field :llm_model,
-                          required: true,
-                          class: "stacked-form-control",
-                          autocomplete: "off",
-                          value: @copy_source&.llm_model,
-                          data: {
-                            llm_model_target: "input",
-                            action: "input->llm-model#search focus->llm-model#focus blur->llm-model#blur keydown->llm-model#handleKeydown"
-                          } %>
-      <%= render Collavre::UserMentionMenuComponent.new(menu_id: 'llm-model-suggestions') %>
-    </div>
-  </div>
+  <%= render "collavre/users/llm_fields",
+             form: form,
+             selected_vendor: @user&.llm_vendor || @copy_source&.llm_vendor || "google",
+             selected_model: @user&.llm_model || @copy_source&.llm_model %>
 
   <div class="form-group">
     <%= form.label :llm_api_key, t('collavre.users.new_ai.api_key_label') %>

--- a/engines/collavre/config/locales/users.en.yml
+++ b/engines/collavre/config/locales/users.en.yml
@@ -24,6 +24,8 @@ en:
         vendor_label: LLM Vendor
         vendor_help: Select the AI provider for this agent
         model_label: Model
+        remove_model: Remove from model list
+        remove_model_failed: Could not remove the model from the list.
         api_key_label: API Key
         api_key_help: If provided, this key will be used instead of the system default.
           Stored encrypted.

--- a/engines/collavre/config/locales/users.ko.yml
+++ b/engines/collavre/config/locales/users.ko.yml
@@ -23,6 +23,8 @@ ko:
         vendor_label: LLM 벤더
         vendor_help: 이 에이전트에 사용할 AI 제공업체를 선택하세요
         model_label: 모델
+        remove_model: 모델 목록에서 삭제
+        remove_model_failed: 모델을 목록에서 삭제하지 못했습니다.
         api_key_label: API Key
         api_key_help: 입력하면 시스템 기본값 대신 이 키가 사용됩니다. 암호화되어 저장됩니다.
         gateway_url_label: Gateway URL

--- a/engines/collavre/config/routes.rb
+++ b/engines/collavre/config/routes.rb
@@ -59,6 +59,8 @@ Collavre::Engine.routes.draw do
     end
   end
 
+  resources :llm_models, only: [ :destroy ]
+
   resources :typo_corrections, only: [ :create ]
 
   resources :creative_imports, only: [ :create ]

--- a/engines/collavre/db/migrate/20260809000000_create_llm_models.rb
+++ b/engines/collavre/db/migrate/20260809000000_create_llm_models.rb
@@ -1,5 +1,7 @@
 class CreateLlmModels < ActiveRecord::Migration[8.1]
   MAX_SUGGESTIONS = 100
+  MAX_VENDOR_LENGTH = 255
+  MAX_NAME_LENGTH = 255
 
   DEFAULT_MODELS = {
     "google" => [
@@ -11,8 +13,8 @@ class CreateLlmModels < ActiveRecord::Migration[8.1]
 
   def up
     create_table :llm_models do |t|
-      t.string :llm_vendor, null: false
-      t.string :name, null: false
+      t.string :llm_vendor, null: false, limit: MAX_VENDOR_LENGTH
+      t.string :name, null: false, limit: MAX_NAME_LENGTH
       t.references :created_by,
                    null: true,
                    foreign_key: { to_table: :users, on_delete: :nullify }
@@ -39,9 +41,14 @@ class CreateLlmModels < ActiveRecord::Migration[8.1]
     )
 
     models.each do |vendor, name|
+      vendor = vendor.to_s.strip.downcase
+      name = name.to_s.strip
+      next if vendor.blank? || name.blank?
+      next if vendor.length > MAX_VENDOR_LENGTH || name.length > MAX_NAME_LENGTH
+
       llm_model_class.find_or_create_by!(
-        llm_vendor: vendor.to_s.strip.downcase,
-        name: name.to_s.strip
+        llm_vendor: vendor,
+        name: name
       )
     end
 

--- a/engines/collavre/db/migrate/20260809000000_create_llm_models.rb
+++ b/engines/collavre/db/migrate/20260809000000_create_llm_models.rb
@@ -1,4 +1,6 @@
 class CreateLlmModels < ActiveRecord::Migration[8.1]
+  MAX_SUGGESTIONS = 100
+
   DEFAULT_MODELS = {
     "google" => [
       "gemini-3.1-flash-lite",
@@ -42,6 +44,11 @@ class CreateLlmModels < ActiveRecord::Migration[8.1]
         name: name.to_s.strip
       )
     end
+
+    keep_ids = llm_model_class.order(updated_at: :desc, id: :desc)
+                              .limit(MAX_SUGGESTIONS)
+                              .select(:id)
+    llm_model_class.where.not(id: keep_ids).delete_all
   end
 
   def down

--- a/engines/collavre/db/migrate/20260809000000_create_llm_models.rb
+++ b/engines/collavre/db/migrate/20260809000000_create_llm_models.rb
@@ -1,0 +1,50 @@
+class CreateLlmModels < ActiveRecord::Migration[8.1]
+  DEFAULT_MODELS = {
+    "google" => [
+      "gemini-3.1-flash-lite",
+      "gemini-1.5-flash",
+      "gemini-1.5-pro"
+    ]
+  }.freeze
+
+  def up
+    create_table :llm_models do |t|
+      t.string :llm_vendor, null: false
+      t.string :name, null: false
+      t.references :created_by,
+                   null: true,
+                   foreign_key: { to_table: :users, on_delete: :nullify }
+      t.timestamps
+    end
+
+    add_index :llm_models, [ :llm_vendor, :name ], unique: true
+
+    llm_model_class = Class.new(ActiveRecord::Base) do
+      self.table_name = "llm_models"
+    end
+    user_class = Class.new(ActiveRecord::Base) do
+      self.table_name = "users"
+    end
+
+    models = DEFAULT_MODELS.flat_map do |vendor, names|
+      names.map { |name| [ vendor, name ] }
+    end
+    models.concat(
+      user_class.where.not(llm_vendor: [ nil, "" ])
+                .where.not(llm_model: [ nil, "" ])
+                .distinct
+                .pluck(:llm_vendor, :llm_model)
+    )
+
+    models.each do |vendor, name|
+      llm_model_class.find_or_create_by!(
+        llm_vendor: vendor.to_s.strip.downcase,
+        name: name.to_s.strip
+      )
+    end
+  end
+
+  def down
+    drop_table :llm_models
+  end
+end

--- a/engines/collavre/test/controllers/llm_models_controller_test.rb
+++ b/engines/collavre/test/controllers/llm_models_controller_test.rb
@@ -34,4 +34,15 @@ class LlmModelsControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to collavre.new_session_path
   end
+
+  test "removing an already absent model succeeds" do
+    model = Collavre::LlmModel.create!(llm_vendor: "openai", name: "gpt-5")
+    model.destroy!
+
+    assert_no_difference("Collavre::LlmModel.count") do
+      delete collavre.llm_model_path(model)
+    end
+
+    assert_response :no_content
+  end
 end

--- a/engines/collavre/test/controllers/llm_models_controller_test.rb
+++ b/engines/collavre/test/controllers/llm_models_controller_test.rb
@@ -1,0 +1,37 @@
+require "test_helper"
+
+class LlmModelsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:two)
+    sign_in_as @user, password: "password"
+  end
+
+  test "signed-in user can remove a model from the shared list" do
+    model = Collavre::LlmModel.create!(llm_vendor: "openai", name: "gpt-5")
+    agent = User.create!(
+      email: "kept-model-agent@ai.local",
+      password: "password",
+      name: "Kept model agent",
+      llm_vendor: model.llm_vendor,
+      llm_model: model.name
+    )
+
+    assert_difference("Collavre::LlmModel.count", -1) do
+      delete collavre.llm_model_path(model)
+    end
+
+    assert_response :no_content
+    assert_equal "gpt-5", agent.reload.llm_model
+  end
+
+  test "signed-out user cannot remove a model" do
+    model = Collavre::LlmModel.create!(llm_vendor: "openai", name: "gpt-5")
+    sign_out
+
+    assert_no_difference("Collavre::LlmModel.count") do
+      delete collavre.llm_model_path(model)
+    end
+
+    assert_redirected_to collavre.new_session_path
+  end
+end

--- a/engines/collavre/test/controllers/users_controller_ai_test.rb
+++ b/engines/collavre/test/controllers/users_controller_ai_test.rb
@@ -8,11 +8,22 @@ class UsersControllerAiTest < ActionDispatch::IntegrationTest
   end
 
   test "should get new_ai page with tools list" do
+    model = Collavre::LlmModel.create!(llm_vendor: "openai", name: "gpt-5")
+
     get new_ai_users_url
     assert_response :success
     assert_select "h1", I18n.t("collavre.users.new_ai.title")
     assert_select "form[action=?]", create_ai_users_path
     assert_select "input[type='text'][name='llm_api_key'].masked-secret-field[autocomplete='off'][autocapitalize='none'][spellcheck='false']"
+    assert_select "[data-controller='llm-model']" do |nodes|
+      models = JSON.parse(nodes.first["data-llm-model-models-value"])
+      assert_includes models, {
+        "id" => model.id,
+        "vendor" => "openai",
+        "name" => "gpt-5",
+        "delete_url" => llm_model_path(model)
+      }
+    end
     # Verify tools section is rendered
     assert_select "label", I18n.t("collavre.users.edit_ai.tools_title")
   end
@@ -76,6 +87,57 @@ class UsersControllerAiTest < ActionDispatch::IntegrationTest
     assert_equal "New prompt", @ai_user.system_prompt
     assert_equal "gemini-1.5-pro", @ai_user.llm_model
     assert @ai_user.searchable
+  end
+
+  test "creating an ai user remembers its model" do
+    assert_difference("Collavre::LlmModel.count", 1) do
+      post create_ai_users_url, params: {
+        ai_id: "custom-model-bot",
+        name: "Custom Model Bot",
+        system_prompt: "Use the configured model.",
+        llm_vendor: "openai",
+        llm_model: "gpt-5.2"
+      }
+    end
+
+    model = Collavre::LlmModel.find_by!(llm_vendor: "openai", name: "gpt-5.2")
+    assert_equal @admin, model.creator
+  end
+
+  test "failed ai user creation does not remember its model" do
+    assert_no_difference("Collavre::LlmModel.count") do
+      post create_ai_users_url, params: {
+        ai_id: "invalid-model-bot",
+        name: "",
+        system_prompt: "Use the configured model.",
+        llm_vendor: "openai",
+        llm_model: "unsaved-model"
+      }
+    end
+
+    assert_response :unprocessable_entity
+    refute Collavre::LlmModel.exists?(llm_vendor: "openai", name: "unsaved-model")
+  end
+
+  test "changing an ai user's vendor or model remembers the new selection" do
+    assert_difference("Collavre::LlmModel.count", 1) do
+      patch update_ai_user_url(@ai_user), params: {
+        user: { llm_vendor: "anthropic", llm_model: "claude-sonnet-4" }
+      }
+    end
+
+    assert Collavre::LlmModel.exists?(llm_vendor: "anthropic", name: "claude-sonnet-4")
+  end
+
+  test "updating unrelated ai settings does not restore a deleted list entry" do
+    model = Collavre::LlmModel.find_or_create_by!(llm_vendor: @ai_user.llm_vendor, name: @ai_user.llm_model)
+    model.destroy!
+
+    assert_no_difference("Collavre::LlmModel.count") do
+      patch update_ai_user_url(@ai_user), params: { user: { name: "Renamed Agent" } }
+    end
+
+    refute Collavre::LlmModel.exists?(llm_vendor: @ai_user.llm_vendor, name: @ai_user.llm_model)
   end
 
   test "should preserve existing api key when submitted value is blank" do

--- a/engines/collavre/test/controllers/users_controller_ai_test.rb
+++ b/engines/collavre/test/controllers/users_controller_ai_test.rb
@@ -14,6 +14,7 @@ class UsersControllerAiTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select "h1", I18n.t("collavre.users.new_ai.title")
     assert_select "form[action=?]", create_ai_users_path
+    assert_select "input[name='llm_model'][maxlength=?]", Collavre::LlmModel::MAX_NAME_LENGTH.to_s
     assert_select "input[type='text'][name='llm_api_key'].masked-secret-field[autocomplete='off'][autocapitalize='none'][spellcheck='false']"
     assert_select "[data-controller='llm-model']" do |nodes|
       models = JSON.parse(nodes.first["data-llm-model-models-value"])
@@ -119,6 +120,36 @@ class UsersControllerAiTest < ActionDispatch::IntegrationTest
     refute Collavre::LlmModel.exists?(llm_vendor: "openai", name: "unsaved-model")
   end
 
+  test "oversized model does not partially create an ai user or suggestion" do
+    oversized_model = "m" * (Collavre::LlmModel::MAX_NAME_LENGTH + 1)
+
+    assert_no_difference([ "Collavre::User.count", "Collavre::LlmModel.count" ]) do
+      post create_ai_users_url, params: {
+        ai_id: "oversized-model-bot",
+        name: "Oversized Model Bot",
+        llm_vendor: "openai",
+        llm_model: oversized_model
+      }
+    end
+
+    assert_response :unprocessable_entity
+    assert_select "input[name='llm_model'][maxlength=?]", Collavre::LlmModel::MAX_NAME_LENGTH.to_s
+  end
+
+  test "oversized model does not partially update an ai user or suggestion" do
+    original_model = @ai_user.llm_model
+    oversized_model = "m" * (Collavre::LlmModel::MAX_NAME_LENGTH + 1)
+
+    assert_no_difference("Collavre::LlmModel.count") do
+      patch update_ai_user_url(@ai_user), params: {
+        user: { llm_vendor: "openai", llm_model: oversized_model }
+      }
+    end
+
+    assert_response :unprocessable_entity
+    assert_equal original_model, @ai_user.reload.llm_model
+  end
+
   test "changing an ai user's vendor or model remembers the new selection" do
     assert_difference("Collavre::LlmModel.count", 1) do
       patch update_ai_user_url(@ai_user), params: {
@@ -127,6 +158,40 @@ class UsersControllerAiTest < ActionDispatch::IntegrationTest
     end
 
     assert Collavre::LlmModel.exists?(llm_vendor: "anthropic", name: "claude-sonnet-4")
+  end
+
+  test "ai user creation rolls back when remembering the model fails" do
+    failure = ->(**) { raise "model suggestion failed" }
+
+    Collavre::LlmModel.stub(:remember!, failure) do
+      assert_no_difference([ "Collavre::User.count", "Collavre::Contact.count" ]) do
+        assert_raises(RuntimeError, "model suggestion failed") do
+          post create_ai_users_url, params: {
+            ai_id: "rollback-model-bot",
+            name: "Rollback Model Bot",
+            llm_vendor: "openai",
+            llm_model: "gpt-5.2"
+          }
+        end
+      end
+    end
+  end
+
+  test "ai user update rolls back when remembering the model fails" do
+    original_vendor = @ai_user.llm_vendor
+    original_model = @ai_user.llm_model
+    failure = ->(**) { raise "model suggestion failed" }
+
+    Collavre::LlmModel.stub(:remember!, failure) do
+      assert_raises(RuntimeError, "model suggestion failed") do
+        patch update_ai_user_url(@ai_user), params: {
+          user: { llm_vendor: "openai", llm_model: "gpt-5.2" }
+        }
+      end
+    end
+
+    assert_equal original_vendor, @ai_user.reload.llm_vendor
+    assert_equal original_model, @ai_user.llm_model
   end
 
   test "updating unrelated ai settings does not restore a deleted list entry" do

--- a/engines/collavre/test/models/llm_model_test.rb
+++ b/engines/collavre/test/models/llm_model_test.rb
@@ -23,6 +23,25 @@ class LlmModelTest < ActiveSupport::TestCase
     assert same_name_other_vendor.valid?
   end
 
+  test "bounds vendor and model name lengths" do
+    model = Collavre::LlmModel.new(
+      llm_vendor: "v" * Collavre::LlmModel::MAX_VENDOR_LENGTH,
+      name: "m" * Collavre::LlmModel::MAX_NAME_LENGTH
+    )
+
+    model.save!
+    assert_predicate model, :persisted?
+
+    model.llm_vendor = "v" * (Collavre::LlmModel::MAX_VENDOR_LENGTH + 1)
+    assert_not model.valid?
+    assert model.errors.of_kind?(:llm_vendor, :too_long)
+
+    model.llm_vendor = "vendor"
+    model.name = "m" * (Collavre::LlmModel::MAX_NAME_LENGTH + 1)
+    assert_not model.valid?
+    assert model.errors.of_kind?(:name, :too_long)
+  end
+
   test "remember creates one shared model and records its first creator" do
     creator = users(:one)
 
@@ -56,6 +75,17 @@ class LlmModelTest < ActiveSupport::TestCase
     assert_no_difference("Collavre::LlmModel.count") do
       assert_nil Collavre::LlmModel.remember!(vendor: "openai", name: "")
       assert_nil Collavre::LlmModel.remember!(vendor: "", name: "gpt-5")
+    end
+  end
+
+  test "remember rejects an oversized model name without saving it" do
+    oversized_name = "m" * (Collavre::LlmModel::MAX_NAME_LENGTH + 1)
+
+    assert_no_difference("Collavre::LlmModel.count") do
+      error = assert_raises(ActiveRecord::RecordInvalid) do
+        Collavre::LlmModel.remember!(vendor: "openai", name: oversized_name)
+      end
+      assert error.record.errors.of_kind?(:name, :too_long)
     end
   end
 

--- a/engines/collavre/test/models/llm_model_test.rb
+++ b/engines/collavre/test/models/llm_model_test.rb
@@ -40,6 +40,18 @@ class LlmModelTest < ActiveSupport::TestCase
     assert_equal creator, model.creator
   end
 
+  test "remember marks an existing model as recently used" do
+    model = Collavre::LlmModel.create!(
+      llm_vendor: "openai",
+      name: "gpt-5",
+      updated_at: 1.year.ago
+    )
+
+    assert_changes -> { model.reload.updated_at } do
+      Collavre::LlmModel.remember!(vendor: "openai", name: "gpt-5")
+    end
+  end
+
   test "remember ignores blank values" do
     assert_no_difference("Collavre::LlmModel.count") do
       assert_nil Collavre::LlmModel.remember!(vendor: "openai", name: "")
@@ -53,6 +65,50 @@ class LlmModelTest < ActiveSupport::TestCase
     Collavre::LlmModel.stub(:find_or_create_by!, ->(**) { raise ActiveRecord::RecordNotUnique }) do
       assert_equal existing, Collavre::LlmModel.remember!(vendor: "openai", name: "gpt-5")
     end
+  end
+
+  test "suggestions are bounded to the most recently used models" do
+    Collavre::LlmModel.delete_all
+    rows = (1..(Collavre::LlmModel::MAX_SUGGESTIONS + 1)).map do |index|
+      {
+        llm_vendor: "vendor-#{index}",
+        name: "model-#{index}",
+        created_at: index.minutes.ago,
+        updated_at: index.minutes.ago
+      }
+    end
+    Collavre::LlmModel.insert_all!(rows)
+
+    suggestions = Collavre::LlmModel.suggestions.to_a
+
+    assert_equal Collavre::LlmModel::MAX_SUGGESTIONS, suggestions.size
+    assert_not_includes suggestions.map(&:name), "model-101"
+    assert_equal suggestions.sort_by { |model| [ model.llm_vendor, model.name ] }, suggestions
+  end
+
+  test "remember prunes the oldest shared suggestion beyond the global cap" do
+    Collavre::LlmModel.delete_all
+    oldest = Collavre::LlmModel.create!(
+      llm_vendor: "old-vendor",
+      name: "old-model",
+      created_at: 1.year.ago,
+      updated_at: 1.year.ago
+    )
+    rows = (1...Collavre::LlmModel::MAX_SUGGESTIONS).map do |index|
+      {
+        llm_vendor: "vendor-#{index}",
+        name: "model-#{index}",
+        created_at: index.minutes.ago,
+        updated_at: index.minutes.ago
+      }
+    end
+    Collavre::LlmModel.insert_all!(rows)
+
+    remembered = Collavre::LlmModel.remember!(vendor: "openai", name: "new-model")
+
+    assert_equal "new-model", remembered.name
+    assert_equal Collavre::LlmModel::MAX_SUGGESTIONS, Collavre::LlmModel.count
+    refute Collavre::LlmModel.exists?(oldest.id)
   end
 
   test "deleting a creator keeps the shared model" do

--- a/engines/collavre/test/models/llm_model_test.rb
+++ b/engines/collavre/test/models/llm_model_test.rb
@@ -1,0 +1,58 @@
+require "test_helper"
+
+class LlmModelTest < ActiveSupport::TestCase
+  test "normalizes vendor and model name" do
+    model = Collavre::LlmModel.create!(
+      llm_vendor: " Anthropic ",
+      name: " claude-sonnet-4 ",
+      creator: users(:one)
+    )
+
+    assert_equal "anthropic", model.llm_vendor
+    assert_equal "claude-sonnet-4", model.name
+  end
+
+  test "requires a unique model name within each vendor" do
+    Collavre::LlmModel.create!(llm_vendor: "openai", name: "gpt-5")
+
+    duplicate = Collavre::LlmModel.new(llm_vendor: "openai", name: "gpt-5")
+    same_name_other_vendor = Collavre::LlmModel.new(llm_vendor: "openrouter", name: "gpt-5")
+
+    refute duplicate.valid?
+    assert duplicate.errors.of_kind?(:name, :taken)
+    assert same_name_other_vendor.valid?
+  end
+
+  test "remember creates one shared model and records its first creator" do
+    creator = users(:one)
+
+    assert_difference("Collavre::LlmModel.count", 1) do
+      2.times do
+        Collavre::LlmModel.remember!(
+          vendor: " OpenAI ",
+          name: " gpt-5.2 ",
+          creator: creator
+        )
+      end
+    end
+
+    model = Collavre::LlmModel.find_by!(llm_vendor: "openai", name: "gpt-5.2")
+    assert_equal creator, model.creator
+  end
+
+  test "remember ignores blank values" do
+    assert_no_difference("Collavre::LlmModel.count") do
+      assert_nil Collavre::LlmModel.remember!(vendor: "openai", name: "")
+      assert_nil Collavre::LlmModel.remember!(vendor: "", name: "gpt-5")
+    end
+  end
+
+  test "deleting a creator keeps the shared model" do
+    creator = User.create!(email: "model-owner@example.com", password: "password", name: "Owner")
+    model = Collavre::LlmModel.create!(llm_vendor: "openai", name: "gpt-5", creator: creator)
+
+    creator.destroy!
+
+    assert_nil model.reload.creator
+  end
+end

--- a/engines/collavre/test/models/llm_model_test.rb
+++ b/engines/collavre/test/models/llm_model_test.rb
@@ -47,6 +47,14 @@ class LlmModelTest < ActiveSupport::TestCase
     end
   end
 
+  test "remember returns the existing model when concurrent creation wins" do
+    existing = Collavre::LlmModel.create!(llm_vendor: "openai", name: "gpt-5")
+
+    Collavre::LlmModel.stub(:find_or_create_by!, ->(**) { raise ActiveRecord::RecordNotUnique }) do
+      assert_equal existing, Collavre::LlmModel.remember!(vendor: "openai", name: "gpt-5")
+    end
+  end
+
   test "deleting a creator keeps the shared model" do
     creator = User.create!(email: "model-owner@example.com", password: "password", name: "Owner")
     model = Collavre::LlmModel.create!(llm_vendor: "openai", name: "gpt-5", creator: creator)

--- a/engines/collavre/test/models/user_test.rb
+++ b/engines/collavre/test/models/user_test.rb
@@ -59,6 +59,46 @@ class UserTest < ActiveSupport::TestCase
       "72-char password should pass when min is capped at 72"
   end
 
+  test "bounds AI vendor and model lengths" do
+    user = User.new(
+      email: "bounded-agent@example.com",
+      password: "password123",
+      name: "Bounded Agent",
+      llm_vendor: "v" * Collavre::LlmModel::MAX_VENDOR_LENGTH,
+      llm_model: "m" * Collavre::LlmModel::MAX_NAME_LENGTH
+    )
+
+    user.save!
+    assert_predicate user, :persisted?
+
+    user.llm_vendor = "v" * (Collavre::LlmModel::MAX_VENDOR_LENGTH + 1)
+    assert_not user.valid?
+    assert user.errors.of_kind?(:llm_vendor, :too_long)
+
+    user.llm_vendor = "vendor"
+    user.llm_model = "m" * (Collavre::LlmModel::MAX_NAME_LENGTH + 1)
+    assert_not user.valid?
+    assert user.errors.of_kind?(:llm_model, :too_long)
+  end
+
+  test "allows unrelated updates for a legacy AI user with oversized fields" do
+    user = User.create!(
+      email: "legacy-agent@example.com",
+      password: "password123",
+      name: "Legacy Agent",
+      llm_vendor: "vendor",
+      llm_model: "model"
+    )
+    user.update_columns(
+      llm_vendor: "v" * (Collavre::LlmModel::MAX_VENDOR_LENGTH + 1),
+      llm_model: "m" * (Collavre::LlmModel::MAX_NAME_LENGTH + 1)
+    )
+
+    user.name = "Renamed Legacy Agent"
+
+    assert user.save
+  end
+
   test "nullifies shares created by user as sharer when destroyed" do
     sharer = users(:two)
     recipient = users(:three)


### PR DESCRIPTION
## Summary

- add a shared `llm_models` table and backfill existing AI agent model selections
- remember newly entered models after successful AI agent creation or vendor/model changes
- filter suggestions by vendor and allow signed-in users to remove entries without changing existing agent settings
- add localized delete controls and protect user-entered model names from popup HTML injection

## User impact

AI agent model fields remain free text. Once a model is saved, it appears in future suggestion lists for the matching vendor and can be removed directly from the popup.

## Validation

- `bundle exec rake test:all` (3,719 runs, 12,373 assertions)
- `bundle exec rake test:system` (66 runs, 379 assertions; 2 existing skips)
- `npm test -- --runInBand` (91 suites, 1,172 tests)
- `./bin/rubocop -a` (1,150 files)
- targeted Stylelint and asset build
- migration rollback and re-apply