### PR TITLE
fix(collavre): navigate list filters via turbo frame instead of full reload

### DIFF
--- a/engines/collavre/app/components/collavre/progress_filter_component.html.erb
+++ b/engines/collavre/app/components/collavre/progress_filter_component.html.erb
@@ -1,5 +1,5 @@
-<div class="progress-filter-group" data-controller="progress-filter">
+<div class="progress-filter-group" data-controller="progress-filter" data-progress-filter-index-path-value="<%= index_path %>" data-progress-filter-on-index-value="<%= on_index? %>">
   <% states.each do |state| %>
-    <button class="progress-filter-btn<%= ' active' if current_state.to_s == state[:value].to_s %>" data-action="click->progress-filter#apply" data-progress-filter-target="button" data-progress-filter-filter-param="<%= state[:value] %>"><%= state[:name] %></button>
+    <button class="progress-filter-btn<%= ' active' if current_state.to_s == state[:value].to_s %>" data-action="click->progress-filter#apply" data-progress-filter-target="button" data-filter-state="<%= filter_state_key(state[:value]) %>" data-progress-filter-filter-param="<%= state[:value] %>"><%= state[:name] %></button>
   <% end %>
 </div>

--- a/engines/collavre/app/components/collavre/progress_filter_component.rb
+++ b/engines/collavre/app/components/collavre/progress_filter_component.rb
@@ -1,10 +1,30 @@
 module Collavre
 class ProgressFilterComponent < ViewComponent::Base
+  # Progress/comment params are only consumed by Creatives::IndexQuery, so the
+  # buttons carry the creative index path and whether we are already on it.
+  # See app/javascript/lib/utils/filter_navigation.js.
+  PROGRESS_VALUES = %w[all complete incomplete].freeze
+
   def initialize(current_state:, states: [])
     @current_state = current_state&.to_sym
     @states = states
   end
 
   attr_reader :current_state, :states
+
+  def index_path
+    helpers.collavre.creatives_path
+  end
+
+  def on_index?
+    helpers.creative_index_page?
+  end
+
+  # Mirrors the keys syncFilterButtons() derives from the URL, so a frame-only
+  # navigation can re-apply the `active` class without a server round trip.
+  def filter_state_key(value)
+    value = value.to_s
+    PROGRESS_VALUES.include?(value) ? "progress:#{value}" : value
+  end
 end
 end

--- a/engines/collavre/app/helpers/collavre/application_helper.rb
+++ b/engines/collavre/app/helpers/collavre/application_helper.rb
@@ -70,10 +70,16 @@ module Collavre
       end
     end
 
+    # The creative index is reachable at both "/" (root route) and
+    # "/creatives", so the list filters cannot decide "am I already on the
+    # index?" from the pathname alone — they read this instead.
+    def creative_index_page?
+      controller_path == "collavre/creatives" && action_name == "index"
+    end
+
     def creative_workspace?
       Current.user&.creative_workspace_enabled? &&
-        controller_path == "collavre/creatives" &&
-        action_name == "index" &&
+        creative_index_page? &&
         !@auto_fullscreen
     end
 

--- a/engines/collavre/app/javascript/controllers/__tests__/progress_filter_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/progress_filter_controller.test.js
@@ -1,0 +1,134 @@
+/**
+ * @jest-environment jsdom
+ */
+import { jest } from '@jest/globals'
+import { Application } from '@hotwired/stimulus'
+
+const { default: ProgressFilterController } = await import('../progress_filter_controller')
+
+const WORKSPACE_FRAME_ID = 'creative-workspace-content'
+
+describe('ProgressFilterController', () => {
+  let application
+  let visit
+
+  // jsdom's window.location is unforgeable, so drive it through history.
+  function setLocation(href) {
+    window.history.replaceState({}, '', href)
+  }
+
+  async function mount({ onIndex = true, withFrame = true, indexPath = '/creatives' } = {}) {
+    document.body.innerHTML = `
+      ${withFrame ? `<turbo-frame id="${WORKSPACE_FRAME_ID}"></turbo-frame>` : ''}
+      <div class="progress-filter-group"
+           data-controller="progress-filter"
+           data-progress-filter-index-path-value="${indexPath}"
+           data-progress-filter-on-index-value="${onIndex}">
+        <button class="progress-filter-btn"
+                data-action="click->progress-filter#apply"
+                data-progress-filter-target="button"
+                data-filter-state="comment"
+                data-progress-filter-filter-param="comment">Chat</button>
+      </div>
+    `
+
+    application = Application.start()
+    application.register('progress-filter', ProgressFilterController)
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    return document.querySelector('.progress-filter-btn')
+  }
+
+  beforeEach(() => {
+    visit = jest.fn()
+    window.Turbo = { visit }
+    setLocation('http://localhost/creatives')
+  })
+
+  afterEach(() => {
+    application?.stop()
+    application = null
+    delete window.Turbo
+    document.body.innerHTML = ''
+    jest.restoreAllMocks()
+  })
+
+  test('replaces only the workspace frame instead of reloading the page', async () => {
+    const button = await mount()
+
+    button.click()
+
+    expect(visit).toHaveBeenCalledWith('/creatives?comment=true', {
+      action: 'advance',
+      frame: WORKSPACE_FRAME_ID
+    })
+    expect(window.location.href).toBe('http://localhost/creatives')
+  })
+
+  test('preserves the other list filters already in the URL', async () => {
+    setLocation('http://localhost/creatives?id=7&search=hi')
+    const button = await mount()
+
+    button.click()
+
+    const [target] = visit.mock.calls[0]
+    expect(target).toContain('id=7')
+    expect(target).toContain('search=hi')
+    expect(target).toContain('comment=true')
+  })
+
+  test('toggles the comment filter back off', async () => {
+    setLocation('http://localhost/creatives?comment=true')
+    const button = await mount()
+
+    button.click()
+
+    expect(visit).toHaveBeenCalledWith('/creatives', {
+      action: 'advance',
+      frame: WORKSPACE_FRAME_ID
+    })
+  })
+
+  test('updates the button state, which the untouched GNB would otherwise keep stale', async () => {
+    const button = await mount()
+
+    button.click()
+    expect(button.classList.contains('active')).toBe(true)
+  })
+
+  test('navigates to the creative index from a page that cannot use the filter', async () => {
+    setLocation('http://localhost/settings?tab=profile')
+    const button = await mount({ onIndex: false, withFrame: false })
+
+    button.click()
+
+    expect(visit).toHaveBeenCalledWith('/creatives?comment=true', { action: 'advance' })
+  })
+
+  test('leaves the button state to the server when the whole page is replaced', async () => {
+    const button = await mount({ withFrame: false })
+
+    button.click()
+
+    expect(visit).toHaveBeenCalledWith('/creatives?comment=true', { action: 'advance' })
+    expect(button.classList.contains('active')).toBe(false)
+  })
+
+  test('prevents the default click action', async () => {
+    const button = await mount()
+
+    const event = new MouseEvent('click', { bubbles: true, cancelable: true })
+    button.dispatchEvent(event)
+
+    expect(event.defaultPrevented).toBe(true)
+  })
+
+  test('does nothing when the button carries no filter', async () => {
+    const button = await mount()
+    button.removeAttribute('data-progress-filter-filter-param')
+
+    button.click()
+
+    expect(visit).not.toHaveBeenCalled()
+  })
+})

--- a/engines/collavre/app/javascript/controllers/__tests__/search_popup_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/search_popup_controller.test.js
@@ -266,6 +266,22 @@ describe('SearchPopupController filter navigation', () => {
     })
   })
 
+  test('clears whitespace-only searches', async () => {
+    setLocation('http://localhost/creatives?search=roadmap')
+    await mount()
+    const input = document.querySelector('[data-search-popup-target="input"]')
+
+    input.value = '   '
+    input.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true })
+    )
+
+    expect(visit).toHaveBeenLastCalledWith('/creatives', {
+      action: 'advance',
+      frame: WORKSPACE_FRAME_ID
+    })
+  })
+
   test('ignores keys other than Enter in the search input', async () => {
     await mount()
     const input = document.querySelector('[data-search-popup-target="input"]')

--- a/engines/collavre/app/javascript/controllers/__tests__/search_popup_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/search_popup_controller.test.js
@@ -300,6 +300,63 @@ describe('SearchPopupController filter navigation', () => {
     )
   })
 
+  test('resyncs persistent controls when workspace-tree navigation loads the frame', async () => {
+    setLocation('http://localhost/creatives?search=roadmap&show_archived=true')
+    await mount()
+    const input = document.querySelector('[data-search-popup-target="input"]')
+    const archiveButton = document.querySelector('[data-filter-state="archived"]')
+
+    expect(input.value).toBe('roadmap')
+    expect(archiveButton.classList).toContain('active')
+    expect(archiveButton.textContent).toBe('Hide archived')
+
+    setLocation('http://localhost/creatives?id=7')
+    document
+      .getElementById(WORKSPACE_FRAME_ID)
+      .dispatchEvent(new CustomEvent('turbo:frame-load', { bubbles: true }))
+
+    expect(input.value).toBe('')
+    expect(archiveButton.classList).not.toContain('active')
+    expect(archiveButton.textContent).toBe('Show archived')
+    expect(document.querySelector('[data-filter-state="any-filter"]').classList).not.toContain(
+      'active'
+    )
+  })
+
+  test('resyncs persistent controls during browser history traversal', async () => {
+    await mount()
+    const input = document.querySelector('[data-search-popup-target="input"]')
+
+    setLocation('http://localhost/creatives?search=restored')
+    window.dispatchEvent(new PopStateEvent('popstate'))
+
+    expect(input.value).toBe('restored')
+    expect(document.querySelector('[data-filter-state="any-filter"].active')).not.toBeNull()
+  })
+
+  test('ignores frame loads outside the creative workspace', async () => {
+    await mount()
+    const input = document.querySelector('[data-search-popup-target="input"]')
+
+    setLocation('http://localhost/creatives?search=ignored')
+    document.body.dispatchEvent(new CustomEvent('turbo:frame-load', { bubbles: true }))
+
+    expect(input.value).toBe('')
+    expect(document.querySelector('[data-filter-state="any-filter"].active')).toBeNull()
+  })
+
+  test('stops resyncing after the persistent controller disconnects', async () => {
+    await mount()
+    const input = document.querySelector('[data-search-popup-target="input"]')
+
+    input.closest('[data-controller="search-popup"]').remove()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    setLocation('http://localhost/creatives?search=ignored')
+    window.dispatchEvent(new PopStateEvent('popstate'))
+
+    expect(input.value).toBe('')
+  })
+
   test('sends filters to the creative index from a page that cannot use them', async () => {
     setLocation('http://localhost/settings?tab=profile')
     await mount({ onIndex: false, withFrame: false })

--- a/engines/collavre/app/javascript/controllers/__tests__/search_popup_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/search_popup_controller.test.js
@@ -102,3 +102,240 @@ describe('SearchPopupController Ctrl+K shortcut', () => {
     expect(event.defaultPrevented).toBe(false)
   })
 })
+
+const WORKSPACE_FRAME_ID = 'creative-workspace-content'
+
+describe('SearchPopupController filter navigation', () => {
+  let application
+  let visit
+  let popup
+
+  // jsdom's window.location is unforgeable, so drive it through history.
+  function setLocation(href) {
+    window.history.replaceState({}, '', href)
+  }
+
+  async function mount({ onIndex = true, withFrame = true } = {}) {
+    document.body.innerHTML = `
+      ${withFrame ? `<turbo-frame id="${WORKSPACE_FRAME_ID}"></turbo-frame>` : ''}
+      <div data-controller="search-popup"
+           data-search-popup-index-path-value="/creatives"
+           data-search-popup-on-index-value="${onIndex}">
+        <button data-filter-state="any-filter"></button>
+        <input type="text" data-search-popup-target="input"
+               data-action="keydown->search-popup#submitSearch" />
+        <div data-search-popup-target="popup" class="open"></div>
+        <button data-filter="all" data-filter-state="progress:all"
+                data-action="click->search-popup#applyProgressFilter"></button>
+        <button data-filter="incomplete" data-filter-state="progress:incomplete"
+                data-action="click->search-popup#applyProgressFilter"></button>
+        <button data-filter-state="comment"
+                data-action="click->search-popup#applyCommentFilter"></button>
+        <button data-filter-state="archived"
+                data-label-on="Hide archived" data-label-off="Show archived"
+                data-action="click->search-popup#toggleArchive">Show archived</button>
+        <button data-mode="tree" data-action="click->search-popup#applySearchMode"></button>
+        <button data-mode="flat" data-action="click->search-popup#applySearchMode"></button>
+      </div>
+    `
+
+    application = Application.start()
+    application.register('search-popup', SearchPopupController)
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    popup = document.querySelector('[data-search-popup-target="popup"]')
+  }
+
+  function click(selector) {
+    document.querySelector(selector).click()
+  }
+
+  beforeEach(() => {
+    visit = jest.fn()
+    window.Turbo = { visit }
+    setLocation('http://localhost/creatives')
+  })
+
+  afterEach(() => {
+    application?.stop()
+    application = null
+    delete window.Turbo
+    document.body.innerHTML = ''
+    jest.restoreAllMocks()
+  })
+
+  test('applies a progress filter through the workspace frame', async () => {
+    await mount()
+
+    click('[data-filter="incomplete"]')
+
+    expect(visit).toHaveBeenCalledWith('/creatives?min_progress=0&max_progress=0.99', {
+      action: 'advance',
+      frame: WORKSPACE_FRAME_ID
+    })
+  })
+
+  test('applies the comment filter through the workspace frame', async () => {
+    await mount()
+
+    click('[data-filter-state="comment"]')
+
+    expect(visit).toHaveBeenCalledWith('/creatives?comment=true', {
+      action: 'advance',
+      frame: WORKSPACE_FRAME_ID
+    })
+  })
+
+  test('toggles the archive filter and swaps its label', async () => {
+    await mount()
+
+    click('[data-filter-state="archived"]')
+
+    expect(visit).toHaveBeenCalledWith('/creatives?show_archived=true', {
+      action: 'advance',
+      frame: WORKSPACE_FRAME_ID
+    })
+    expect(document.querySelector('[data-filter-state="archived"]').textContent).toBe(
+      'Hide archived'
+    )
+  })
+
+  test('toggles the archive filter back off', async () => {
+    setLocation('http://localhost/creatives?show_archived=true')
+    await mount()
+
+    click('[data-filter-state="archived"]')
+
+    expect(visit).toHaveBeenCalledWith('/creatives', {
+      action: 'advance',
+      frame: WORKSPACE_FRAME_ID
+    })
+  })
+
+  test('applies the tree search mode', async () => {
+    await mount()
+
+    click('[data-mode="tree"]')
+
+    expect(visit).toHaveBeenCalledWith('/creatives?search_mode=tree', {
+      action: 'advance',
+      frame: WORKSPACE_FRAME_ID
+    })
+  })
+
+  test('drops the search mode param when returning to flat mode', async () => {
+    setLocation('http://localhost/creatives?search_mode=tree')
+    await mount()
+
+    click('[data-mode="flat"]')
+
+    expect(visit).toHaveBeenCalledWith('/creatives', {
+      action: 'advance',
+      frame: WORKSPACE_FRAME_ID
+    })
+  })
+
+  test('submits the search term on Enter', async () => {
+    await mount()
+    const input = document.querySelector('[data-search-popup-target="input"]')
+    input.value = 'roadmap'
+
+    input.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true })
+    )
+
+    expect(visit).toHaveBeenCalledWith('/creatives?search=roadmap', {
+      action: 'advance',
+      frame: WORKSPACE_FRAME_ID
+    })
+  })
+
+  test('clears the search term when submitted empty', async () => {
+    setLocation('http://localhost/creatives?search=roadmap')
+    await mount()
+    const input = document.querySelector('[data-search-popup-target="input"]')
+    input.value = ''
+
+    input.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true })
+    )
+
+    expect(visit).toHaveBeenCalledWith('/creatives', {
+      action: 'advance',
+      frame: WORKSPACE_FRAME_ID
+    })
+  })
+
+  test('ignores keys other than Enter in the search input', async () => {
+    await mount()
+    const input = document.querySelector('[data-search-popup-target="input"]')
+
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'a', bubbles: true }))
+
+    expect(visit).not.toHaveBeenCalled()
+  })
+
+  test('closes the popup, which a frame-only navigation would leave open', async () => {
+    await mount()
+
+    click('[data-filter-state="comment"]')
+
+    expect(popup.classList.contains('open')).toBe(false)
+  })
+
+  test('refreshes the stale GNB filter state after a frame-only navigation', async () => {
+    setLocation('http://localhost/creatives?min_progress=0&max_progress=0.99')
+    await mount()
+
+    click('[data-filter="all"]')
+
+    expect(document.querySelector('[data-filter-state="progress:all"]').classList).toContain(
+      'active'
+    )
+    expect(
+      document.querySelector('[data-filter-state="progress:incomplete"]').classList
+    ).not.toContain('active')
+    expect(document.querySelector('[data-filter-state="any-filter"]').classList).not.toContain(
+      'active'
+    )
+  })
+
+  test('sends filters to the creative index from a page that cannot use them', async () => {
+    setLocation('http://localhost/settings?tab=profile')
+    await mount({ onIndex: false, withFrame: false })
+
+    click('[data-filter-state="comment"]')
+
+    expect(visit).toHaveBeenCalledWith('/creatives?comment=true', { action: 'advance' })
+  })
+
+  test('leaves the filter state to the server when the whole page is replaced', async () => {
+    await mount({ withFrame: false })
+
+    click('[data-filter-state="comment"]')
+
+    expect(document.querySelector('[data-filter-state="comment"]').classList).not.toContain(
+      'active'
+    )
+  })
+
+  test('does nothing when a progress button carries no filter', async () => {
+    await mount()
+    const button = document.querySelector('[data-filter="all"]')
+    button.removeAttribute('data-filter')
+
+    button.click()
+
+    expect(visit).not.toHaveBeenCalled()
+  })
+
+  test('does nothing when a search mode button carries no mode', async () => {
+    await mount()
+    const button = document.querySelector('[data-mode="tree"]')
+    button.removeAttribute('data-mode')
+
+    button.click()
+
+    expect(visit).not.toHaveBeenCalled()
+  })
+})

--- a/engines/collavre/app/javascript/controllers/progress_filter_controller.js
+++ b/engines/collavre/app/javascript/controllers/progress_filter_controller.js
@@ -1,35 +1,25 @@
 import { Controller } from '@hotwired/stimulus'
+import {
+  applyFilterParam,
+  buildFilterUrl,
+  syncFilterButtons,
+  visitFilterUrl
+} from '../lib/utils/filter_navigation'
 
 export default class extends Controller {
   static targets = ['button']
+  static values = { indexPath: String, onIndex: Boolean }
 
   apply(event) {
     event.preventDefault()
     const filter = event.params.filter ?? event.currentTarget.dataset.filter
     if (!filter) return
 
-    const url = new URL(window.location.href)
+    const url = buildFilterUrl(
+      { indexPath: this.indexPathValue, onIndex: this.onIndexValue },
+      (params) => applyFilterParam(params, filter)
+    )
 
-    if (filter === 'comment') {
-      if (url.searchParams.get('comment') === 'true') {
-        url.searchParams.delete('comment')
-      } else {
-        url.searchParams.set('comment', 'true')
-      }
-    } else {
-      url.searchParams.delete('min_progress')
-      url.searchParams.delete('max_progress')
-
-      if (filter === 'complete') {
-        url.searchParams.set('min_progress', '1')
-        url.searchParams.set('max_progress', '1')
-      } else if (filter === 'incomplete') {
-        url.searchParams.set('min_progress', '0')
-        url.searchParams.set('max_progress', '0.99')
-      }
-    }
-
-    const query = url.searchParams.toString()
-    window.location.href = query ? `${url.pathname}?${query}` : url.pathname
+    if (visitFilterUrl(url)) syncFilterButtons(url)
   }
 }

--- a/engines/collavre/app/javascript/controllers/search_popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/search_popup_controller.js
@@ -143,8 +143,9 @@ export default class extends Controller {
     this._navigate((params) => {
       if (!('search' in overrides)) return
 
-      if (overrides.search) {
-        params.set('search', overrides.search)
+      const search = overrides.search
+      if (search.trim()) {
+        params.set('search', search)
       } else {
         params.delete('search')
       }

--- a/engines/collavre/app/javascript/controllers/search_popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/search_popup_controller.js
@@ -1,7 +1,14 @@
 import { Controller } from '@hotwired/stimulus'
+import {
+  applyFilterParam,
+  buildFilterUrl,
+  syncFilterButtons,
+  visitFilterUrl
+} from '../lib/utils/filter_navigation'
 
 export default class extends Controller {
   static targets = ['input', 'popup', 'overlay']
+  static values = { indexPath: String, onIndex: Boolean }
 
   connect() {
     this._escHandler = (e) => {
@@ -81,33 +88,13 @@ export default class extends Controller {
     const filter = event.currentTarget.dataset.filter
     if (!filter) return
 
-    const url = new URL(window.location.href)
-    url.searchParams.delete('min_progress')
-    url.searchParams.delete('max_progress')
-
-    if (filter === 'complete') {
-      url.searchParams.set('min_progress', '1')
-      url.searchParams.set('max_progress', '1')
-    } else if (filter === 'incomplete') {
-      url.searchParams.set('min_progress', '0')
-      url.searchParams.set('max_progress', '0.99')
-    }
-
-    const query = url.searchParams.toString()
-    window.location.href = query ? `${url.pathname}?${query}` : url.pathname
+    this._navigate((params) => applyFilterParam(params, filter))
   }
 
   // Apply comment filter
   applyCommentFilter(event) {
     event.preventDefault()
-    const url = new URL(window.location.href)
-    if (url.searchParams.get('comment') === 'true') {
-      url.searchParams.delete('comment')
-    } else {
-      url.searchParams.set('comment', 'true')
-    }
-    const query = url.searchParams.toString()
-    window.location.href = query ? `${url.pathname}?${query}` : url.pathname
+    this._navigate((params) => applyFilterParam(params, 'comment'))
   }
 
   // Toggle search mode (flat/tree)
@@ -116,39 +103,48 @@ export default class extends Controller {
     const mode = event.currentTarget.dataset.mode
     if (!mode) return
 
-    const url = new URL(window.location.href)
-    if (mode === 'tree') {
-      url.searchParams.set('search_mode', 'tree')
-    } else {
-      url.searchParams.delete('search_mode')
-    }
-    const query = url.searchParams.toString()
-    window.location.href = query ? `${url.pathname}?${query}` : url.pathname
+    this._navigate((params) => {
+      if (mode === 'tree') {
+        params.set('search_mode', 'tree')
+      } else {
+        params.delete('search_mode')
+      }
+    })
   }
 
   // Toggle archive visibility via URL parameter
   toggleArchive(event) {
     event.preventDefault()
-    const url = new URL(window.location.href)
-    if (url.searchParams.get('show_archived') === 'true') {
-      url.searchParams.delete('show_archived')
-    } else {
-      url.searchParams.set('show_archived', 'true')
-    }
-    const query = url.searchParams.toString()
-    window.location.href = query ? `${url.pathname}?${query}` : url.pathname
+    this._navigate((params) => {
+      if (params.get('show_archived') === 'true') {
+        params.delete('show_archived')
+      } else {
+        params.set('show_archived', 'true')
+      }
+    })
   }
 
   _applyFilters(overrides = {}) {
-    const url = new URL(window.location.href)
-    if ('search' in overrides) {
+    this._navigate((params) => {
+      if (!('search' in overrides)) return
+
       if (overrides.search) {
-        url.searchParams.set('search', overrides.search)
+        params.set('search', overrides.search)
       } else {
-        url.searchParams.delete('search')
+        params.delete('search')
       }
-    }
-    const query = url.searchParams.toString()
-    window.location.href = query ? `${url.pathname}?${query}` : url.pathname
+    })
+  }
+
+  // The popup lives in the GNB, outside the workspace frame, so a frame-only
+  // navigation leaves it open and showing the previous filter state.
+  _navigate(mutate) {
+    const url = buildFilterUrl(
+      { indexPath: this.indexPathValue, onIndex: this.onIndexValue },
+      mutate
+    )
+
+    this.close()
+    if (visitFilterUrl(url)) syncFilterButtons(url)
   }
 }

--- a/engines/collavre/app/javascript/controllers/search_popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/search_popup_controller.js
@@ -1,5 +1,6 @@
 import { Controller } from '@hotwired/stimulus'
 import {
+  WORKSPACE_FRAME_ID,
   applyFilterParam,
   buildFilterUrl,
   syncFilterButtons,
@@ -29,6 +30,18 @@ export default class extends Controller {
       }
     }
     document.addEventListener('keydown', this._shortcutHandler)
+
+    // The GNB survives workspace-frame visits. Tree navigation and frame
+    // history traversal bypass _navigate(), so keep its controls aligned with
+    // the browser URL whenever that frame loads or history changes.
+    this._frameLoadHandler = (event) => {
+      if (event.target.id !== WORKSPACE_FRAME_ID) return
+      this._syncFromLocation()
+    }
+    this._historyHandler = () => this._syncFromLocation()
+    document.addEventListener('turbo:frame-load', this._frameLoadHandler)
+    window.addEventListener('popstate', this._historyHandler)
+    this._syncFromLocation()
   }
 
   _isEditableTarget(target) {
@@ -45,6 +58,8 @@ export default class extends Controller {
   disconnect() {
     document.removeEventListener('keydown', this._escHandler)
     document.removeEventListener('keydown', this._shortcutHandler)
+    document.removeEventListener('turbo:frame-load', this._frameLoadHandler)
+    window.removeEventListener('popstate', this._historyHandler)
   }
 
   open() {
@@ -146,5 +161,11 @@ export default class extends Controller {
 
     this.close()
     if (visitFilterUrl(url)) syncFilterButtons(url)
+  }
+
+  _syncFromLocation() {
+    const url = new URL(window.location.href)
+    syncFilterButtons(url)
+    this.inputTarget.value = url.searchParams.get('search') || ''
   }
 }

--- a/engines/collavre/app/javascript/lib/utils/__tests__/filter_navigation.test.js
+++ b/engines/collavre/app/javascript/lib/utils/__tests__/filter_navigation.test.js
@@ -186,8 +186,8 @@ describe('syncFilterButtons', () => {
     expect(activeStates()).toContain('any-filter')
   })
 
-  test('ignores blank filter values, matching the server-side .present? check', () => {
-    syncFilterButtons(new URL('http://localhost/creatives?search=&min_progress='))
+  test('ignores blank and whitespace-only filter values, matching server-side .present?', () => {
+    syncFilterButtons(new URL('http://localhost/creatives?search=%20%20%20&min_progress='))
 
     expect(activeStates()).toEqual(['progress:all'])
   })

--- a/engines/collavre/app/javascript/lib/utils/__tests__/filter_navigation.test.js
+++ b/engines/collavre/app/javascript/lib/utils/__tests__/filter_navigation.test.js
@@ -1,0 +1,210 @@
+/**
+ * @jest-environment jsdom
+ */
+import { jest } from '@jest/globals'
+import {
+  WORKSPACE_FRAME_ID,
+  applyFilterParam,
+  buildFilterUrl,
+  syncFilterButtons,
+  visitFilterUrl
+} from '../filter_navigation'
+
+// jsdom's window.location is unforgeable, so drive it through history instead
+// of replacing the object.
+function setLocation(href) {
+  window.history.replaceState({}, '', href)
+}
+
+describe('buildFilterUrl', () => {
+  test('keeps the current URL and its params when already on the index', () => {
+    setLocation('http://localhost/creatives?id=7&search=hi')
+
+    const url = buildFilterUrl({ indexPath: '/creatives', onIndex: true }, (params) => {
+      params.set('comment', 'true')
+    })
+
+    expect(url.pathname).toBe('/creatives')
+    expect(url.searchParams.get('id')).toBe('7')
+    expect(url.searchParams.get('search')).toBe('hi')
+    expect(url.searchParams.get('comment')).toBe('true')
+  })
+
+  test('preserves the root route pathname when the index is served at "/"', () => {
+    setLocation('http://localhost/?tags=a')
+
+    const url = buildFilterUrl({ indexPath: '/creatives', onIndex: true }, (params) => {
+      params.set('comment', 'true')
+    })
+
+    expect(url.pathname).toBe('/')
+    expect(url.searchParams.get('tags')).toBe('a')
+  })
+
+  test('redirects to the index and drops foreign params when elsewhere', () => {
+    setLocation('http://localhost/settings?tab=profile')
+
+    const url = buildFilterUrl({ indexPath: '/creatives', onIndex: false }, (params) => {
+      params.set('comment', 'true')
+    })
+
+    expect(url.pathname).toBe('/creatives')
+    expect(url.searchParams.get('tab')).toBeNull()
+    expect(url.searchParams.get('comment')).toBe('true')
+  })
+
+  test('falls back to the root path when no index path was provided', () => {
+    setLocation('http://localhost/settings')
+
+    const url = buildFilterUrl({ indexPath: '', onIndex: false }, () => {})
+
+    expect(url.pathname).toBe('/')
+  })
+})
+
+describe('applyFilterParam', () => {
+  test('turns the comment filter on when absent', () => {
+    const params = new URLSearchParams()
+    applyFilterParam(params, 'comment')
+    expect(params.get('comment')).toBe('true')
+  })
+
+  test('turns the comment filter off when already on', () => {
+    const params = new URLSearchParams('comment=true')
+    applyFilterParam(params, 'comment')
+    expect(params.has('comment')).toBe(false)
+  })
+
+  test('sets the complete progress range', () => {
+    const params = new URLSearchParams()
+    applyFilterParam(params, 'complete')
+    expect(params.get('min_progress')).toBe('1')
+    expect(params.get('max_progress')).toBe('1')
+  })
+
+  test('sets the incomplete progress range', () => {
+    const params = new URLSearchParams()
+    applyFilterParam(params, 'incomplete')
+    expect(params.get('min_progress')).toBe('0')
+    expect(params.get('max_progress')).toBe('0.99')
+  })
+
+  test('clears the progress range for "all" without touching other filters', () => {
+    const params = new URLSearchParams('min_progress=1&max_progress=1&comment=true')
+    applyFilterParam(params, 'all')
+    expect(params.has('min_progress')).toBe(false)
+    expect(params.has('max_progress')).toBe(false)
+    expect(params.get('comment')).toBe('true')
+  })
+})
+
+describe('visitFilterUrl', () => {
+  let visit
+
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    setLocation('http://localhost/creatives')
+    visit = jest.fn()
+    window.Turbo = { visit }
+  })
+
+  afterEach(() => {
+    delete window.Turbo
+    document.body.innerHTML = ''
+  })
+
+  test('replaces only the workspace frame when it is present', () => {
+    document.body.innerHTML = `<turbo-frame id="${WORKSPACE_FRAME_ID}"></turbo-frame>`
+
+    const result = visitFilterUrl(new URL('http://localhost/creatives?comment=true'))
+
+    expect(visit).toHaveBeenCalledWith('/creatives?comment=true', {
+      action: 'advance',
+      frame: WORKSPACE_FRAME_ID
+    })
+    expect(result).toBe(true)
+  })
+
+  test('performs a full Turbo visit when there is no workspace frame', () => {
+    const result = visitFilterUrl(new URL('http://localhost/creatives?comment=true'))
+
+    expect(visit).toHaveBeenCalledWith('/creatives?comment=true', { action: 'advance' })
+    expect(result).toBe(false)
+  })
+
+  test('omits the query string entirely when no filters remain', () => {
+    visitFilterUrl(new URL('http://localhost/creatives'))
+
+    expect(visit).toHaveBeenCalledWith('/creatives', { action: 'advance' })
+  })
+})
+
+describe('syncFilterButtons', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <button data-filter-state="any-filter" class="active"></button>
+      <button data-filter-state="progress:all"></button>
+      <button data-filter-state="progress:incomplete" class="active"></button>
+      <button data-filter-state="progress:complete"></button>
+      <button data-filter-state="comment"></button>
+      <button data-filter-state="archived" data-label-on="Hide archived" data-label-off="Show archived">Show archived</button>
+    `
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  function activeStates() {
+    return Array.from(document.querySelectorAll('[data-filter-state].active')).map(
+      (el) => el.dataset.filterState
+    )
+  }
+
+  test('activates the comment button and resets a stale progress selection', () => {
+    syncFilterButtons(new URL('http://localhost/creatives?comment=true'))
+
+    expect(activeStates().sort()).toEqual(['comment', 'progress:all'])
+  })
+
+  test('does not treat the comment filter as a generic "any filter"', () => {
+    syncFilterButtons(new URL('http://localhost/creatives?comment=true'))
+
+    expect(document.querySelector('[data-filter-state="any-filter"]').classList).not.toContain(
+      'active'
+    )
+  })
+
+  test('marks the search trigger active for progress, archive and search filters', () => {
+    syncFilterButtons(new URL('http://localhost/creatives?min_progress=1&max_progress=1'))
+    expect(activeStates()).toContain('any-filter')
+
+    syncFilterButtons(new URL('http://localhost/creatives?show_archived=true'))
+    expect(activeStates()).toContain('any-filter')
+
+    syncFilterButtons(new URL('http://localhost/creatives?search=abc'))
+    expect(activeStates()).toContain('any-filter')
+  })
+
+  test('ignores blank filter values, matching the server-side .present? check', () => {
+    syncFilterButtons(new URL('http://localhost/creatives?search=&min_progress='))
+
+    expect(activeStates()).toEqual(['progress:all'])
+  })
+
+  test('recognizes the incomplete progress range', () => {
+    syncFilterButtons(new URL('http://localhost/creatives?min_progress=0&max_progress=0.99'))
+
+    expect(activeStates().sort()).toEqual(['any-filter', 'progress:incomplete'])
+  })
+
+  test('swaps the archive button label along with its active state', () => {
+    const button = document.querySelector('[data-filter-state="archived"]')
+
+    syncFilterButtons(new URL('http://localhost/creatives?show_archived=true'))
+    expect(button.textContent).toBe('Hide archived')
+
+    syncFilterButtons(new URL('http://localhost/creatives'))
+    expect(button.textContent).toBe('Show archived')
+  })
+})

--- a/engines/collavre/app/javascript/lib/utils/filter_navigation.js
+++ b/engines/collavre/app/javascript/lib/utils/filter_navigation.js
@@ -1,0 +1,99 @@
+// Shared navigation for the creative list filters (GNB chat button and the
+// search popup).
+//
+// Two things these filters have in common:
+//
+//   1. Their parameters (comment, min_progress, search, show_archived,
+//      search_mode) are only consumed by Creatives::IndexQuery, so a toggle
+//      pressed anywhere else has to land on the creative index rather than
+//      decorate the current path with a parameter nothing reads.
+//   2. In workspace mode the list is rendered inside the
+//      #creative-workspace-content turbo-frame, so only that frame needs to be
+//      replaced. Assigning window.location.href bypasses Turbo entirely and
+//      rebuilds the whole page — assets, workspace tree and docked chat
+//      included.
+
+export const WORKSPACE_FRAME_ID = 'creative-workspace-content'
+
+// The creative index is reachable at both "/" (root route) and "/creatives",
+// so `onIndex` has to come from the server; a pathname comparison would get
+// the root route wrong.
+export function buildFilterUrl({ indexPath, onIndex }, mutate) {
+  const url = onIndex
+    ? new URL(window.location.href)
+    : new URL(indexPath || '/', window.location.origin)
+
+  mutate(url.searchParams)
+  return url
+}
+
+// Shared by the GNB component and the search popup's progress/comment buttons.
+export function applyFilterParam(params, filter) {
+  if (filter === 'comment') {
+    if (params.get('comment') === 'true') {
+      params.delete('comment')
+    } else {
+      params.set('comment', 'true')
+    }
+    return
+  }
+
+  params.delete('min_progress')
+  params.delete('max_progress')
+
+  if (filter === 'complete') {
+    params.set('min_progress', '1')
+    params.set('max_progress', '1')
+  } else if (filter === 'incomplete') {
+    params.set('min_progress', '0')
+    params.set('max_progress', '0.99')
+  }
+}
+
+// Returns true when only the workspace frame was replaced, meaning the GNB
+// survived the navigation and its server-rendered state is now stale.
+//
+// Turbo is imported unconditionally by application.js, so it is assumed
+// present here the same way creative_tree_row.js assumes it.
+export function visitFilterUrl(url) {
+  const frame = document.getElementById(WORKSPACE_FRAME_ID)
+
+  window.Turbo.visit(
+    `${url.pathname}${url.search}`,
+    frame ? { action: 'advance', frame: WORKSPACE_FRAME_ID } : { action: 'advance' }
+  )
+  return Boolean(frame)
+}
+
+function progressState(params) {
+  const min = params.get('min_progress')
+  const max = params.get('max_progress')
+  if (min === '1' && max === '1') return 'complete'
+  if (min === '0' && max === '0.99') return 'incomplete'
+  return 'all'
+}
+
+// Re-derives the `active` classes the server would have rendered for the URL
+// we are navigating to. Mirrors _search_form.html.erb; only needed on the
+// frame path, where the GNB is not re-rendered.
+export function syncFilterButtons(url) {
+  const params = url.searchParams
+  const hasProgress = Boolean(params.get('min_progress') || params.get('max_progress'))
+  const hasArchived = params.get('show_archived') === 'true'
+  const active = {
+    [`progress:${progressState(params)}`]: true,
+    comment: params.get('comment') === 'true',
+    archived: hasArchived,
+    'any-filter': hasProgress || hasArchived || Boolean(params.get('search'))
+  }
+
+  document.querySelectorAll('[data-filter-state]').forEach((element) => {
+    const isActive = active[element.dataset.filterState] === true
+    element.classList.toggle('active', isActive)
+
+    // Buttons whose label depends on the filter state (archive show/hide)
+    // carry both translations so they can be swapped without a round trip.
+    const label = isActive ? element.dataset.labelOn : element.dataset.labelOff
+    if (label) element.textContent = label
+  })
+}

--- a/engines/collavre/app/javascript/lib/utils/filter_navigation.js
+++ b/engines/collavre/app/javascript/lib/utils/filter_navigation.js
@@ -80,11 +80,12 @@ export function syncFilterButtons(url) {
   const params = url.searchParams
   const hasProgress = Boolean(params.get('min_progress') || params.get('max_progress'))
   const hasArchived = params.get('show_archived') === 'true'
+  const hasSearch = Boolean(params.get('search')?.trim())
   const active = {
     [`progress:${progressState(params)}`]: true,
     comment: params.get('comment') === 'true',
     archived: hasArchived,
-    'any-filter': hasProgress || hasArchived || Boolean(params.get('search'))
+    'any-filter': hasProgress || hasArchived || hasSearch
   }
 
   document.querySelectorAll('[data-filter-state]').forEach((element) => {

--- a/engines/collavre/app/views/collavre/shared/navigation/_search_form.html.erb
+++ b/engines/collavre/app/views/collavre/shared/navigation/_search_form.html.erb
@@ -1,4 +1,7 @@
-<div class="search-popup-wrapper" data-controller="search-popup">
+<div class="search-popup-wrapper"
+     data-controller="search-popup"
+     data-search-popup-index-path-value="<%= collavre.creatives_path %>"
+     data-search-popup-on-index-value="<%= creative_index_page? %>">
   <%
     raw_url = begin; request.original_url; rescue; request.url; end
     url = URI.parse(raw_url)
@@ -19,7 +22,7 @@
                      end
   %>
 
-  <button type="button" class="search-popup-trigger<%= ' active' if has_any_filter %>" data-action="click->search-popup#toggle" aria-label="<%= t('app.search_placeholder') %>">
+  <button type="button" class="search-popup-trigger<%= ' active' if has_any_filter %>" data-filter-state="any-filter" data-action="click->search-popup#toggle" aria-label="<%= t('app.search_placeholder') %>">
     <span class="search-popup-trigger-icon" aria-hidden="true"><%= svg_tag 'search.svg', width: 16, height: 16 rescue '🔍' %></span>
     <span class="search-popup-trigger-label"><%= t('collavre.search_popup.search') %></span>
   </button>
@@ -54,14 +57,17 @@
           <button type="button"
                   class="search-popup-filter-btn<%= ' active' if progress_state == :all %>"
                   data-filter="all"
+                  data-filter-state="progress:all"
                   data-action="click->search-popup#applyProgressFilter"><%= t('app.filter_all') %></button>
           <button type="button"
                   class="search-popup-filter-btn<%= ' active' if progress_state == :incomplete %>"
                   data-filter="incomplete"
+                  data-filter-state="progress:incomplete"
                   data-action="click->search-popup#applyProgressFilter"><%= t('app.filter_incomplete') %></button>
           <button type="button"
                   class="search-popup-filter-btn<%= ' active' if progress_state == :complete %>"
                   data-filter="complete"
+                  data-filter-state="progress:complete"
                   data-action="click->search-popup#applyProgressFilter"><%= t('app.filter_complete') %></button>
         </div>
       </div>
@@ -71,10 +77,15 @@
         <div class="search-popup-filter-buttons">
           <button type="button"
                   class="search-popup-filter-btn<%= ' active' if has_comment %>"
+                  data-filter-state="comment"
                   data-action="click->search-popup#applyCommentFilter"><%= t('app.filter_comments') %></button>
           <% if authenticated? %>
+            <%# Both labels ship up front so a frame-only navigation can swap them without a round trip. %>
             <button type="button"
                     class="search-popup-filter-btn<%= ' active' if has_archived %>"
+                    data-filter-state="archived"
+                    data-label-on="<%= t('collavre.creatives.index.hide_archived') %>"
+                    data-label-off="<%= t('collavre.creatives.index.show_archived') %>"
                     data-action="click->search-popup#toggleArchive"><%= has_archived ? t('collavre.creatives.index.hide_archived') : t('collavre.creatives.index.show_archived') %></button>
           <% end %>
         </div>

--- a/engines/collavre/test/components/progress_filter_component_test.rb
+++ b/engines/collavre/test/components/progress_filter_component_test.rb
@@ -1,0 +1,70 @@
+require "test_helper"
+
+class ProgressFilterComponentTest < ViewComponent::TestCase
+  COMMENT_STATE = { name: "Chat", value: :comment }.freeze
+
+  test "renders a button per state with the Stimulus filter param" do
+    render_inline(Collavre::ProgressFilterComponent.new(current_state: nil, states: [ COMMENT_STATE ]))
+
+    assert_selector "button.progress-filter-btn[data-progress-filter-filter-param='comment']", text: "Chat"
+    assert_selector "button[data-action='click->progress-filter#apply']"
+  end
+
+  test "marks the button active when it matches the current state" do
+    render_inline(Collavre::ProgressFilterComponent.new(current_state: :comment, states: [ COMMENT_STATE ]))
+
+    assert_selector "button.progress-filter-btn.active"
+  end
+
+  test "leaves the button inactive when it does not match the current state" do
+    render_inline(Collavre::ProgressFilterComponent.new(current_state: nil, states: [ COMMENT_STATE ]))
+
+    assert_no_selector "button.progress-filter-btn.active"
+  end
+
+  test "exposes the creative index path so the filter can navigate off other pages" do
+    render_inline(Collavre::ProgressFilterComponent.new(current_state: nil, states: [ COMMENT_STATE ]))
+
+    assert_selector "[data-controller='progress-filter'][data-progress-filter-index-path-value='/creatives']"
+  end
+
+  test "reports whether the current page is the creative index" do
+    render_inline(Collavre::ProgressFilterComponent.new(current_state: nil, states: [ COMMENT_STATE ]))
+
+    # The component test controller is not creatives#index.
+    assert_selector "[data-progress-filter-on-index-value='false']"
+  end
+
+  test "renders nothing but the wrapper when no states are given" do
+    render_inline(Collavre::ProgressFilterComponent.new(current_state: nil))
+
+    assert_selector "div.progress-filter-group"
+    assert_no_selector "button"
+  end
+
+  test "filter_state_key namespaces progress values and passes others through" do
+    component = Collavre::ProgressFilterComponent.new(current_state: nil)
+
+    assert_equal "progress:all", component.filter_state_key(:all)
+    assert_equal "progress:complete", component.filter_state_key(:complete)
+    assert_equal "progress:incomplete", component.filter_state_key(:incomplete)
+    assert_equal "comment", component.filter_state_key(:comment)
+  end
+
+  test "renders the state key the client uses to re-apply the active class" do
+    render_inline(Collavre::ProgressFilterComponent.new(current_state: nil, states: [ COMMENT_STATE ]))
+
+    assert_selector "button[data-filter-state='comment']"
+  end
+
+  test "renders the progress state key for a progress state" do
+    render_inline(
+      Collavre::ProgressFilterComponent.new(
+        current_state: nil,
+        states: [ { name: "Done", value: :complete } ]
+      )
+    )
+
+    assert_selector "button[data-filter-state='progress:complete']"
+  end
+end

--- a/engines/collavre/test/helpers/navigation_helper_test.rb
+++ b/engines/collavre/test/helpers/navigation_helper_test.rb
@@ -6,12 +6,17 @@ class NavigationHelperTest < ActionView::TestCase
   include Collavre::NavigationHelper
   include ApplicationHelper
 
+  # The registry is a process-wide singleton seeded by the engine initializer,
+  # so resetting it without putting the engine's items back leaves every later
+  # test in the process with an empty GNB.
   setup do
+    @registry_snapshot = Navigation::Registry.instance.all
     Navigation::Registry.instance.reset!
   end
 
   teardown do
     Navigation::Registry.instance.reset!
+    @registry_snapshot.each { |item| Navigation::Registry.instance.register(item) }
   end
 
   # Stub authentication methods

--- a/engines/collavre/test/integration/creative_filter_navigation_test.rb
+++ b/engines/collavre/test/integration/creative_filter_navigation_test.rb
@@ -1,0 +1,81 @@
+require "test_helper"
+
+# The GNB chat button and the search popup filters only mean something on the
+# creative index (Creatives::IndexQuery is the sole consumer of their params),
+# so both ship the index path and an "am I already there?" flag to the client.
+class CreativeFilterNavigationTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = User.create!(email: "filter-nav@example.com", password: TEST_PASSWORD, name: "Filter Nav", system_admin: true)
+    Rails.cache.clear
+    SystemSetting.where(key: [ "home_page_path", "home_page_path_authenticated" ]).destroy_all
+    Rails.cache.clear
+    sign_in_as(@user)
+  end
+
+  teardown do
+    SystemSetting.where(key: [ "home_page_path", "home_page_path_authenticated" ]).destroy_all
+    Rails.cache.clear
+  end
+
+  test "creative index marks both filter controls as already on the index" do
+    get creatives_path
+
+    assert_response :success
+    assert_select "[data-controller='progress-filter'][data-progress-filter-on-index-value='true']"
+    assert_select "[data-controller='search-popup'][data-search-popup-on-index-value='true']"
+  end
+
+  # The reason on-index cannot be a JS pathname comparison: with the
+  # authenticated home page left at "/", the root route renders
+  # creatives#index while the browser URL stays "/" rather than "/creatives".
+  test "root route marks the filter controls as on the index despite the different path" do
+    SystemSetting.create!(key: "home_page_path_authenticated", value: "/")
+    Rails.cache.clear
+
+    get root_path
+
+    assert_response :success
+    assert_select "[data-progress-filter-on-index-value='true']"
+    assert_select "[data-search-popup-on-index-value='true']"
+    assert_select "[data-progress-filter-index-path-value='#{creatives_path}']"
+  end
+
+  test "a page outside the creative index marks the filter controls as off-index" do
+    get users_path
+
+    assert_response :success
+    assert_select "[data-progress-filter-on-index-value='false']"
+    assert_select "[data-search-popup-on-index-value='false']"
+  end
+
+  test "filter controls carry the creative index path so they can navigate back to it" do
+    get users_path
+
+    assert_response :success
+    assert_select "[data-progress-filter-index-path-value='#{creatives_path}']"
+    assert_select "[data-search-popup-index-path-value='#{creatives_path}']"
+  end
+
+  test "search popup filter buttons expose the state keys the client re-derives" do
+    get creatives_path
+
+    assert_response :success
+    assert_select "[data-filter-state='any-filter']"
+    assert_select "[data-filter-state='progress:all']"
+    assert_select "[data-filter-state='progress:incomplete']"
+    assert_select "[data-filter-state='progress:complete']"
+    assert_select "[data-filter-state='comment']"
+    assert_select "[data-filter-state='archived'][data-label-on][data-label-off]"
+  end
+
+  test "archive button ships both labels so the client can swap them without a round trip" do
+    get creatives_path
+
+    assert_response :success
+    assert_select "[data-filter-state='archived']" do |elements|
+      button = elements.first
+      assert_equal I18n.t("collavre.creatives.index.hide_archived"), button["data-label-on"]
+      assert_equal I18n.t("collavre.creatives.index.show_archived"), button["data-label-off"]
+    end
+  end
+end

--- a/engines/collavre/test/system/creative_filter_navigation_test.rb
+++ b/engines/collavre/test/system/creative_filter_navigation_test.rb
@@ -1,0 +1,90 @@
+require_relative "../application_system_test_case"
+
+# The GNB "chat" button used to assign window.location.href, which is a full
+# browser navigation: assets are re-downloaded and the workspace tree and
+# docked chat are rebuilt. It now drives the #creative-workspace-content
+# turbo-frame instead.
+class CreativeFilterNavigationTest < ApplicationSystemTestCase
+  COMMENT_BUTTON = ".progress-filter-btn[data-progress-filter-filter-param='comment']".freeze
+
+  setup do
+    @user = User.create!(
+      email: "filter-nav@example.com",
+      password: SystemHelpers::PASSWORD,
+      name: "Filter Nav",
+      email_verified_at: Time.current,
+      notifications_enabled: false,
+      creative_workspace_enabled: true,
+      system_admin: true
+    )
+    Creative.create!(description: "Root creative", user: @user)
+
+    resize_window_to
+    sign_in_via_ui(@user)
+  end
+
+  # Marks both the window and a node outside the workspace frame. A hard
+  # navigation loses both; a full Turbo Drive visit keeps the window but
+  # replaces the body, so only a frame-scoped visit keeps the DOM marker.
+  def mark_page
+    page.execute_script(<<~JS)
+      window.__filterNavMarker = 'kept'
+      document.querySelector('.creative-workspace-shell').dataset.filterNavMarker = 'kept'
+    JS
+  end
+
+  test "chat filter replaces only the workspace frame" do
+    visit collavre.creatives_path
+    assert_selector "turbo-frame#creative-workspace-content"
+    mark_page
+
+    find(COMMENT_BUTTON).click
+
+    assert_current_path(/comment=true/, url: false)
+    assert_selector ".creative-workspace-shell[data-filter-nav-marker='kept']"
+    assert_equal "kept", page.evaluate_script("window.__filterNavMarker")
+  end
+
+  test "chat filter keeps the workspace tree and docked chat mounted" do
+    visit collavre.creatives_path
+    assert_selector ".creative-workspace-shell"
+    tree_present = page.has_selector?("#creative-workspace-content")
+    assert tree_present
+
+    mark_page
+    find(COMMENT_BUTTON).click
+    assert_current_path(/comment=true/, url: false)
+
+    assert_selector ".creative-workspace-shell[data-filter-nav-marker='kept']"
+  end
+
+  test "chat filter button reflects the new state without a server round trip" do
+    visit collavre.creatives_path
+    assert_no_selector "#{COMMENT_BUTTON}.active"
+
+    find(COMMENT_BUTTON).click
+
+    assert_selector "#{COMMENT_BUTTON}.active"
+  end
+
+  test "chat filter toggles back off" do
+    visit collavre.creatives_path
+    find(COMMENT_BUTTON).click
+    assert_selector "#{COMMENT_BUTTON}.active"
+
+    find(COMMENT_BUTTON).click
+
+    assert_no_selector "#{COMMENT_BUTTON}.active"
+    assert_current_path(collavre.creatives_path)
+  end
+
+  test "chat filter pressed outside the creative index lands on the index" do
+    visit collavre.users_path
+    assert_no_selector "turbo-frame#creative-workspace-content"
+
+    find(COMMENT_BUTTON).click
+
+    assert_current_path(/\/creatives\?comment=true/, url: false)
+    assert_selector "turbo-frame#creative-workspace-content"
+  end
+end

--- a/engines/collavre/test/system/creative_filter_navigation_test.rb
+++ b/engines/collavre/test/system/creative_filter_navigation_test.rb
@@ -17,7 +17,8 @@ class CreativeFilterNavigationTest < ApplicationSystemTestCase
       creative_workspace_enabled: true,
       system_admin: true
     )
-    Creative.create!(description: "Root creative", user: @user)
+    @creative = Creative.create!(description: "Root creative", user: @user)
+    Creative.create!(description: "Root child", user: @user, parent: @creative)
 
     resize_window_to
     sign_in_via_ui(@user)
@@ -86,5 +87,23 @@ class CreativeFilterNavigationTest < ApplicationSystemTestCase
 
     assert_current_path(/\/creatives\?comment=true/, url: false)
     assert_selector "turbo-frame#creative-workspace-content"
+  end
+
+  test "tree navigation clears persistent search controls with the filter URL" do
+    visit collavre.creatives_path
+    find(".search-popup-trigger").click
+    fill_in "search", with: "Root"
+    find("#search").send_keys(:enter)
+
+    assert_current_path(/search=Root/, url: false)
+    assert_selector ".search-popup-trigger.active"
+
+    find(".creative-workspace-tree-toggle").click
+    assert_selector ".creative-workspace-tree-link[data-creative-id='#{@creative.id}']", wait: 10
+    find(".creative-workspace-tree-link", text: "Root creative").click
+
+    assert_current_path(collavre.creatives_path(id: @creative.id))
+    assert_no_selector ".search-popup-trigger.active"
+    assert_equal "", find("#search", visible: :all).value
   end
 end


### PR DESCRIPTION
## Problem

Pressing **chat** in the GNB assigned `window.location.href`. That is a full browser navigation: assets are re-downloaded, the page flashes, and the workspace tree and docked chat are rebuilt — even though only the creative list changes.

```js
// progress_filter_controller.js (before)
window.location.href = query ? `${url.pathname}?${query}` : url.pathname
```

The identical code was duplicated across all five navigation sites in `search_popup_controller.js` (progress, comment, archive, search mode, search term).

Those toggles also appended their params to whatever path happened to be current. `comment`, `min_progress`, `max_progress`, `search` and `show_archived` are only consumed by `Creatives::IndexQuery`, so pressing chat on, say, the settings page produced `/settings?comment=true` and did nothing.

## Change

**Frame-targeted navigation.** All six toggles now drive the `#creative-workspace-content` turbo frame, the same mechanism `creative_tree_row.js` already uses for tree clicks. Only the creative list is replaced; the workspace tree and docked chat stay mounted. Outside workspace mode there is no frame, so it falls back to a full Turbo Drive visit — still no asset reload.

**Filters land on the creative index.** When the current page cannot use the filter, navigation targets `creatives_path` rather than decorating the current path.

Whether we are already on the index comes from the server via a new `creative_index_page?` helper, not a client-side pathname comparison. The index is reachable at both `/` (root route) and `/creatives`, so comparing `window.location.pathname` to `creatives_path` would misjudge the root route. `creative_workspace?` now reuses the same helper.

**Active state after a frame-only navigation.** The GNB is outside the frame, so its server-rendered `active` classes would go stale. Filter buttons carry a `data-filter-state` key that the client re-derives from the target URL. The archive button ships both labels (`data-label-on` / `data-label-off`) so it can swap text without a round trip. On the full-navigation path nothing is synced client-side — the server render is authoritative.

**Deduplication.** The shared logic moved into `lib/utils/filter_navigation.js` (`buildFilterUrl`, `applyFilterParam`, `visitFilterUrl`, `syncFilterButtons`).

## Test pollution fix

`navigation_helper_test.rb` called `Navigation::Registry.instance.reset!` in setup and teardown without restoring it. The registry is a process-wide singleton seeded by an engine initializer, so every later test in the same process rendered an empty GNB. It now snapshots and restores. Without this the new integration test passes or fails depending on the seed.

## Tests

| Suite | |
|---|---|
| `lib/utils/__tests__/filter_navigation.test.js` | new — 18 cases |
| `controllers/__tests__/progress_filter_controller.test.js` | new — this controller had no tests |
| `controllers/__tests__/search_popup_controller.test.js` | + 15 cases for filter navigation |
| `test/components/progress_filter_component_test.rb` | new — 9 cases |
| `test/integration/creative_filter_navigation_test.rb` | new — covers `/creatives`, root route, and off-index |
| `test/system/creative_filter_navigation_test.rb` | new — real browser, asserts the workspace shell survives the click |

The system test marks both `window` and a DOM node outside the frame before clicking. A hard navigation loses both; a full Turbo Drive visit keeps the window but replaces the body — so only a frame-scoped visit keeps the DOM marker.

Results:
- jest full suite: 92 suites, 1209 tests, 0 failures
- coverage: 100% statements/branches on `filter_navigation.js` and `progress_filter_controller.js`; remaining gaps in `search_popup_controller.js` are pre-existing untouched lines (`disconnect`, overlay branches)
- system: 5 runs, 0 failures
- integration + components + helpers: 90 runs, 0 failures (stable across seeds, single process)
- creatives controller: 40 runs, 0 failures
- rubocop: clean