### PR TITLE
fix: show all creatives in the workspace tree

### DIFF
--- a/engines/collavre/app/javascript/controllers/workspace_tree_controller.js
+++ b/engines/collavre/app/javascript/controllers/workspace_tree_controller.js
@@ -612,8 +612,8 @@ export default class extends Controller {
   restoreCreativeIdFromFrameResponse(creativeId) {
     const id = String(creativeId)
     if (this.destroyedCreativeIds.has(id)) return
-    // Only a frame request started after the latest invalidation proves current access;
-    // leaf creatives never appear in the workspace tree payload, so this is their only restore path.
+    // Only a frame request started after the latest invalidation proves current access.
+    // This also covers creatives hidden under collapsed ancestors in the tree payload.
     if (this.frameRequestGeneration !== this.invalidationGeneration) return
 
     this.invalidatedCreativeIds.delete(id)

--- a/engines/collavre/app/services/collavre/creatives/workspace_tree_builder.rb
+++ b/engines/collavre/app/services/collavre/creatives/workspace_tree_builder.rb
@@ -9,8 +9,11 @@ module Collavre
         @permission_rank = {}
       end
 
+      # Roots stay visible even when they have nothing to expand, so the tree
+      # never silently drops a creative the user navigated to. Below the root
+      # level only branches render, which keeps leaf chatter out of the tree.
       def build(collection)
-        entries = Array(collection).map { |creative| { creative: creative, ancestor_ids: Set.new } }
+        entries = Array(collection).map { |creative| { creative: creative, ancestor_ids: Set.new, root: true } }
         build_entries(entries)
       end
 
@@ -23,26 +26,28 @@ module Collavre
 
         creatives = entries.map { |entry| entry.fetch(:creative) }.uniq(&:id)
         prepare_level(creatives)
-        branch_entries = entries.select { |entry| children_index.has_children?(entry.fetch(:creative)) }
-        branches = branch_entries.map { |entry| entry.fetch(:creative) }.uniq(&:id)
-        children_index.load(branches)
-        children_by_parent = branches.to_h { |creative| [ creative.id, children_index.children_for(creative) ] }
+        visible_entries = entries.select do |entry|
+          entry.fetch(:root) || children_index.has_children?(entry.fetch(:creative))
+        end
+        visible_creatives = visible_entries.map { |entry| entry.fetch(:creative) }.uniq(&:id)
+        children_index.load(visible_creatives)
+        children_by_parent = visible_creatives.to_h { |creative| [ creative.id, children_index.children_for(creative) ] }
         prepare_presence(children_by_parent.values.flatten)
         branch_children_by_parent = children_by_parent.transform_values do |children|
           children.select { |child| children_index.has_children?(child) }
         end
-        child_entries_by_parent = branch_entries.to_h do |entry|
+        child_entries_by_parent = visible_entries.to_h do |entry|
           creative = entry.fetch(:creative)
           children = expanded?(creative) ? acyclic_children(entry, branch_children_by_parent.fetch(creative.id)) : []
           child_entries = children.map do |child|
-            { creative: child, ancestor_ids: entry.fetch(:ancestor_ids).dup.add(creative.id) }
+            { creative: child, ancestor_ids: entry.fetch(:ancestor_ids).dup.add(creative.id), root: false }
           end
           [ entry.object_id, child_entries ]
         end
         child_nodes = build_entries(child_entries_by_parent.values.flatten)
         next_child_node = child_nodes.each
 
-        branch_entries.map do |entry|
+        visible_entries.map do |entry|
           creative = entry.fetch(:creative)
           visible_children = acyclic_children(entry, branch_children_by_parent.fetch(creative.id))
           children = child_entries_by_parent.fetch(entry.object_id).map { next_child_node.next }

--- a/engines/collavre/app/services/collavre/creatives/workspace_tree_builder.rb
+++ b/engines/collavre/app/services/collavre/creatives/workspace_tree_builder.rb
@@ -9,11 +9,8 @@ module Collavre
         @permission_rank = {}
       end
 
-      # Roots stay visible even when they have nothing to expand, so the tree
-      # never silently drops a creative the user navigated to. Below the root
-      # level only branches render, which keeps leaf chatter out of the tree.
       def build(collection)
-        entries = Array(collection).map { |creative| { creative: creative, ancestor_ids: Set.new, root: true } }
+        entries = Array(collection).map { |creative| { creative: creative, ancestor_ids: Set.new } }
         build_entries(entries)
       end
 
@@ -26,30 +23,23 @@ module Collavre
 
         creatives = entries.map { |entry| entry.fetch(:creative) }.uniq(&:id)
         prepare_level(creatives)
-        visible_entries = entries.select do |entry|
-          entry.fetch(:root) || children_index.has_children?(entry.fetch(:creative))
-        end
-        visible_creatives = visible_entries.map { |entry| entry.fetch(:creative) }.uniq(&:id)
-        children_index.load(visible_creatives)
-        children_by_parent = visible_creatives.to_h { |creative| [ creative.id, children_index.children_for(creative) ] }
+        children_index.load(creatives)
+        children_by_parent = creatives.to_h { |creative| [ creative.id, children_index.children_for(creative) ] }
         prepare_presence(children_by_parent.values.flatten)
-        branch_children_by_parent = children_by_parent.transform_values do |children|
-          children.select { |child| children_index.has_children?(child) }
-        end
-        child_entries_by_parent = visible_entries.to_h do |entry|
+        child_entries_by_parent = entries.to_h do |entry|
           creative = entry.fetch(:creative)
-          children = expanded?(creative) ? acyclic_children(entry, branch_children_by_parent.fetch(creative.id)) : []
+          children = expanded?(creative) ? acyclic_children(entry, children_by_parent.fetch(creative.id)) : []
           child_entries = children.map do |child|
-            { creative: child, ancestor_ids: entry.fetch(:ancestor_ids).dup.add(creative.id), root: false }
+            { creative: child, ancestor_ids: entry.fetch(:ancestor_ids).dup.add(creative.id) }
           end
           [ entry.object_id, child_entries ]
         end
         child_nodes = build_entries(child_entries_by_parent.values.flatten)
         next_child_node = child_nodes.each
 
-        visible_entries.map do |entry|
+        entries.map do |entry|
           creative = entry.fetch(:creative)
-          visible_children = acyclic_children(entry, branch_children_by_parent.fetch(creative.id))
+          visible_children = acyclic_children(entry, children_by_parent.fetch(creative.id))
           children = child_entries_by_parent.fetch(entry.object_id).map { next_child_node.next }
           {
             id: creative.id,

--- a/engines/collavre/test/controllers/creatives_controller_test.rb
+++ b/engines/collavre/test/controllers/creatives_controller_test.rb
@@ -342,7 +342,7 @@ class CreativesControllerTest < ActionDispatch::IntegrationTest
     assert_select "a.creative-breadcrumb-current[href='#{creative_path(child)}'][data-turbo-action='replace'][data-turbo-prefetch='false']"
   end
 
-  test "workspace tree JSON returns collapsed branches and childless roots" do
+  test "workspace tree JSON returns childless creatives at every expanded level" do
     branch = Creative.create!(user: users(:one), description: "Workspace branch")
     child = Creative.create!(user: users(:one), parent: branch, description: "Workspace child")
     nested_leaf = Creative.create!(user: users(:one), parent: child, description: "Workspace leaf")
@@ -373,6 +373,14 @@ class CreativesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     expanded_branch = JSON.parse(response.body).fetch("creatives").find { |node| node.fetch("id") == branch.id }
     assert_equal [ child.id ], expanded_branch.fetch("children").pluck("id")
+
+    get creatives_path(format: :json, workspace_tree: 1, expand: [ branch.id, child.id ])
+
+    assert_response :success
+    expanded_branch = JSON.parse(response.body).fetch("creatives").find { |node| node.fetch("id") == branch.id }
+    expanded_child = expanded_branch.fetch("children").find { |node| node.fetch("id") == child.id }
+    assert_equal [ nested_leaf.id ], expanded_child.fetch("children").pluck("id")
+    refute expanded_child.fetch("children").first.fetch("has_children")
   end
 
   test "workspace tree JSON ignores invalid and excessive expansion ids" do

--- a/engines/collavre/test/controllers/creatives_controller_test.rb
+++ b/engines/collavre/test/controllers/creatives_controller_test.rb
@@ -342,10 +342,10 @@ class CreativesControllerTest < ActionDispatch::IntegrationTest
     assert_select "a.creative-breadcrumb-current[href='#{creative_path(child)}'][data-turbo-action='replace'][data-turbo-prefetch='false']"
   end
 
-  test "workspace tree JSON returns collapsed branches without leaf roots" do
+  test "workspace tree JSON returns collapsed branches and childless roots" do
     branch = Creative.create!(user: users(:one), description: "Workspace branch")
     child = Creative.create!(user: users(:one), parent: branch, description: "Workspace child")
-    Creative.create!(user: users(:one), parent: child, description: "Workspace leaf")
+    nested_leaf = Creative.create!(user: users(:one), parent: child, description: "Workspace leaf")
     leaf = Creative.create!(user: users(:one), description: "Workspace leaf")
 
     get creatives_path(format: :json, workspace_tree: 1)
@@ -354,7 +354,12 @@ class CreativesControllerTest < ActionDispatch::IntegrationTest
     payload = JSON.parse(response.body)
     ids = payload.fetch("creatives").pluck("id")
     assert_includes ids, branch.id
-    refute_includes ids, leaf.id
+    assert_includes ids, leaf.id
+    refute_includes ids, nested_leaf.id
+    leaf_payload = payload.fetch("creatives").find { |node| node.fetch("id") == leaf.id }
+    assert_equal creatives_path(id: leaf.id), leaf_payload.fetch("url")
+    refute leaf_payload.fetch("has_children")
+    assert_empty leaf_payload.fetch("children")
     branch_payload = payload.fetch("creatives").find { |node| node.fetch("id") == branch.id }
     assert_equal creatives_path(id: branch.id), branch_payload.fetch("url")
     assert_equal branch.creative_snippet, branch_payload.fetch("snippet")

--- a/engines/collavre/test/services/creatives/workspace_tree_builder_test.rb
+++ b/engines/collavre/test/services/creatives/workspace_tree_builder_test.rb
@@ -21,7 +21,7 @@ module Creatives
       @view_context = FakeViewContext.new
     end
 
-    test "returns only readable branches without loading their children" do
+    test "returns every readable root without loading their children" do
       root = Creative.create!(user: @user, description: "<strong>Root</strong>")
       branch = Creative.create!(user: @user, parent: root, description: "Branch")
       Creative.create!(user: @user, parent: branch, description: "Leaf")
@@ -29,13 +29,48 @@ module Creatives
 
       nodes = build_tree([ root, root_leaf ])
 
-      assert_equal [ root.id ], nodes.pluck(:id)
+      assert_equal [ root.id, root_leaf.id ], nodes.pluck(:id)
       assert_equal "Root", nodes.first[:label]
       assert_equal root.creative_snippet, nodes.first[:snippet]
       assert nodes.first[:can_comment]
       assert_equal "/creatives?id=#{root.id}", nodes.first[:url]
       assert nodes.first[:has_children]
       assert_empty nodes.first[:children]
+    end
+
+    test "keeps a childless root visible with its own metadata" do
+      root_leaf = Creative.create!(user: @user, description: "<em>Root leaf</em>")
+
+      nodes = build_tree([ root_leaf ])
+
+      assert_equal [ root_leaf.id ], nodes.pluck(:id)
+      assert_equal "Root leaf", nodes.first[:label]
+      assert_equal root_leaf.creative_snippet, nodes.first[:snippet]
+      assert nodes.first[:can_comment]
+      assert_equal "/creatives?id=#{root_leaf.id}", nodes.first[:url]
+      refute nodes.first[:has_children]
+      assert_empty nodes.first[:children]
+    end
+
+    test "keeps a childless root visible when it is expanded" do
+      root_leaf = Creative.create!(user: @user, description: "Root leaf")
+
+      nodes = build_tree([ root_leaf ], expanded_ids: [ root_leaf.id ])
+
+      assert_equal [ root_leaf.id ], nodes.pluck(:id)
+      refute nodes.first[:has_children]
+      assert_empty nodes.first[:children]
+    end
+
+    test "hides childless creatives below the root level" do
+      root = Creative.create!(user: @user, description: "Root")
+      branch = Creative.create!(user: @user, parent: root, description: "Branch")
+      Creative.create!(user: @user, parent: branch, description: "Leaf")
+      Creative.create!(user: @user, parent: root, description: "Root child leaf")
+
+      nodes = build_tree([ root ], expanded_ids: [ root.id ])
+
+      assert_equal [ branch.id ], nodes.first[:children].pluck(:id)
     end
 
     test "loads only requested branches" do
@@ -50,11 +85,27 @@ module Creatives
       assert_empty nodes.first[:children].first[:children]
     end
 
-    test "hides a branch whose children are not readable" do
+    test "renders a root whose children are not readable as childless" do
       root = Creative.create!(user: @user, description: "Private child root")
       Creative.create!(user: users(:two), parent: root, description: "Foreign child")
 
-      assert_empty build_tree([ root ])
+      nodes = build_tree([ root ], expanded_ids: [ root.id ])
+
+      assert_equal [ root.id ], nodes.pluck(:id)
+      refute nodes.first[:has_children]
+      assert_empty nodes.first[:children]
+    end
+
+    test "hides a non-root branch whose children are not readable" do
+      root = Creative.create!(user: @user, description: "Root")
+      branch = Creative.create!(user: @user, parent: root, description: "Private child branch")
+      Creative.create!(user: users(:two), parent: branch, description: "Foreign child")
+
+      nodes = build_tree([ root ], expanded_ids: [ root.id ])
+
+      assert_equal [ root.id ], nodes.pluck(:id)
+      refute nodes.first[:has_children]
+      assert_empty nodes.first[:children]
     end
 
     test "expands requested paths beyond the former display level" do

--- a/engines/collavre/test/services/creatives/workspace_tree_builder_test.rb
+++ b/engines/collavre/test/services/creatives/workspace_tree_builder_test.rb
@@ -62,18 +62,20 @@ module Creatives
       assert_empty nodes.first[:children]
     end
 
-    test "hides childless creatives below the root level" do
+    test "includes childless creatives below the root level" do
       root = Creative.create!(user: @user, description: "Root")
       branch = Creative.create!(user: @user, parent: root, description: "Branch")
       Creative.create!(user: @user, parent: branch, description: "Leaf")
-      Creative.create!(user: @user, parent: root, description: "Root child leaf")
+      root_child_leaf = Creative.create!(user: @user, parent: root, description: "Root child leaf")
 
       nodes = build_tree([ root ], expanded_ids: [ root.id ])
 
-      assert_equal [ branch.id ], nodes.first[:children].pluck(:id)
+      assert_equal [ branch.id, root_child_leaf.id ], nodes.first[:children].pluck(:id)
+      refute nodes.first[:children].last[:has_children]
+      assert_empty nodes.first[:children].last[:children]
     end
 
-    test "loads only requested branches" do
+    test "loads children only for expanded creatives" do
       root = Creative.create!(user: @user, description: "Root")
       branch = Creative.create!(user: @user, parent: root, description: "Branch")
       Creative.create!(user: @user, parent: branch, description: "Leaf")
@@ -81,7 +83,7 @@ module Creatives
       nodes = build_tree([ root ], expanded_ids: [ root.id ])
 
       assert_equal [ branch.id ], nodes.first[:children].pluck(:id)
-      refute nodes.first[:children].first[:has_children]
+      assert nodes.first[:children].first[:has_children]
       assert_empty nodes.first[:children].first[:children]
     end
 
@@ -96,7 +98,7 @@ module Creatives
       assert_empty nodes.first[:children]
     end
 
-    test "hides a non-root branch whose children are not readable" do
+    test "renders a non-root creative whose children are not readable as childless" do
       root = Creative.create!(user: @user, description: "Root")
       branch = Creative.create!(user: @user, parent: root, description: "Private child branch")
       Creative.create!(user: users(:two), parent: branch, description: "Foreign child")
@@ -104,8 +106,10 @@ module Creatives
       nodes = build_tree([ root ], expanded_ids: [ root.id ])
 
       assert_equal [ root.id ], nodes.pluck(:id)
-      refute nodes.first[:has_children]
-      assert_empty nodes.first[:children]
+      assert nodes.first[:has_children]
+      assert_equal [ branch.id ], nodes.first[:children].pluck(:id)
+      refute nodes.first[:children].first[:has_children]
+      assert_empty nodes.first[:children].first[:children]
     end
 
     test "expands requested paths beyond the former display level" do
@@ -114,7 +118,7 @@ module Creatives
       6.times do |index|
         path << Creative.create!(user: @user, parent: path.last, description: "Level #{index + 2}")
       end
-      Creative.create!(user: @user, parent: path.last, description: "Leaf")
+      leaf = Creative.create!(user: @user, parent: path.last, description: "Leaf")
 
       nodes = build_tree([ root ], expanded_ids: path.map(&:id))
 
@@ -124,7 +128,7 @@ module Creatives
         rendered_ids << remaining.first.fetch(:id)
         remaining = remaining.first.fetch(:children)
       end
-      assert_equal path.map(&:id), rendered_ids
+      assert_equal [ *path.map(&:id), leaf.id ], rendered_ids
     end
 
     test "stops linked shell cycles without hiding the shell" do

--- a/engines/collavre/test/system/inline_scripts_test.rb
+++ b/engines/collavre/test/system/inline_scripts_test.rb
@@ -308,7 +308,7 @@ class InlineScriptsTest < ApplicationSystemTestCase
 
     assert_selector "#creative-workspace-content [data-workspace-navigation-state][data-creative-id='#{leaf.id}']",
                     visible: :all, wait: 10
-    assert_selector ".creative-workspace-tree-link[data-creative-id='#{branch.id}'].is-current"
+    assert_selector ".creative-workspace-tree-link[data-creative-id='#{leaf.id}'].is-current"
     assert_equal leaf.id.to_s, find("#comments-popup", visible: :visible)["data-creative-id"]
 
     visit collavre.creatives_path
@@ -384,24 +384,20 @@ class InlineScriptsTest < ApplicationSystemTestCase
     assert_text I18n.t("collavre.creatives.workspace.select_chat")
   end
 
-  test "workspace tree keeps a childless root visible and selectable" do
+  test "workspace tree keeps a childless nested creative visible and selectable" do
     resize_window_to(1440, 900)
-    branch = Creative.create!(user: @user, description: "Childless root sibling branch")
-    Creative.create!(user: @user, parent: branch, description: "Sibling child")
-    childless_root = Creative.create!(user: @user, description: "Childless workspace root")
+    root = Creative.create!(user: @user, description: "Workspace root")
+    childless_creative = Creative.create!(user: @user, parent: root, description: "Childless nested creative")
 
-    visit collavre.creatives_path(id: branch.id)
-    assert_selector ".creative-workspace-tree-link[data-creative-id='#{childless_root.id}']", wait: 10
+    visit collavre.creatives_path(id: childless_creative.id)
+    assert_selector ".creative-workspace-tree-link[data-creative-id='#{childless_creative.id}']", wait: 10
 
-    find(".creative-workspace-tree-link[data-creative-id='#{childless_root.id}']").click
+    find(".creative-workspace-tree-link[data-creative-id='#{childless_creative.id}']").click
 
-    assert_selector ".creative-workspace-tree-link[data-creative-id='#{childless_root.id}'].is-current", wait: 10
-    assert_selector "#comments-popup[data-creative-id='#{childless_root.id}']", visible: :visible, wait: 10
+    assert_selector ".creative-workspace-tree-link[data-creative-id='#{childless_creative.id}'].is-current", wait: 10
+    assert_selector "#comments-popup[data-creative-id='#{childless_creative.id}']", visible: :visible, wait: 10
   end
 
-  # Structural refresh is asserted one level below the root: roots always
-  # render, so only a nested branch flips in and out of the tree when its
-  # children appear and disappear.
   test "workspace tree refreshes first-child and last-child structural changes" do
     resize_window_to(1440, 900)
     root = Creative.create!(user: @user, description: "Structural workspace root")
@@ -411,17 +407,19 @@ class InlineScriptsTest < ApplicationSystemTestCase
 
     visit collavre.creatives_path(id: stable_branch.id)
     assert_selector ".creative-workspace-tree-link[data-creative-id='#{stable_branch.id}']", wait: 10
-    assert_no_selector ".creative-workspace-tree-link[data-creative-id='#{changing_creative.id}']"
+    assert_selector ".creative-workspace-tree-link[data-creative-id='#{changing_creative.id}']"
+    assert_no_selector ".creative-workspace-tree-item[data-creative-id='#{changing_creative.id}'] .creative-workspace-tree-branch-toggle"
 
     child = Creative.create!(user: @user, parent: changing_creative, description: "Temporary child")
     page.execute_script("document.dispatchEvent(new CustomEvent('workspace-tree:invalidate'))")
 
-    assert_selector ".creative-workspace-tree-link[data-creative-id='#{changing_creative.id}']", wait: 10
+    assert_selector ".creative-workspace-tree-item[data-creative-id='#{changing_creative.id}'] .creative-workspace-tree-branch-toggle", wait: 10
 
     child.destroy!
     page.execute_script("document.dispatchEvent(new CustomEvent('workspace-tree:invalidate'))")
 
-    assert_no_selector ".creative-workspace-tree-link[data-creative-id='#{changing_creative.id}']", wait: 10
+    assert_selector ".creative-workspace-tree-link[data-creative-id='#{changing_creative.id}']", wait: 10
+    assert_no_selector ".creative-workspace-tree-item[data-creative-id='#{changing_creative.id}'] .creative-workspace-tree-branch-toggle", wait: 10
   end
 
   test "workspace tree refresh does not reopen a destroyed creative chat" do
@@ -443,7 +441,9 @@ class InlineScriptsTest < ApplicationSystemTestCase
     JS
 
     assert_selector "#comments-popup[data-creative-id='']", visible: :visible, wait: 10
-    assert_no_selector ".creative-workspace-tree-link[data-creative-id='#{branch.id}']", wait: 10
+    assert_selector ".creative-workspace-tree-link[data-creative-id='#{branch.id}']", wait: 10
+    assert_no_selector ".creative-workspace-tree-link[data-creative-id='#{leaf.id}']", wait: 10
+    assert_no_selector ".creative-workspace-tree-item[data-creative-id='#{branch.id}'] .creative-workspace-tree-branch-toggle", wait: 10
     assert_text I18n.t("collavre.creatives.workspace.select_chat")
   end
 

--- a/engines/collavre/test/system/inline_scripts_test.rb
+++ b/engines/collavre/test/system/inline_scripts_test.rb
@@ -384,11 +384,30 @@ class InlineScriptsTest < ApplicationSystemTestCase
     assert_text I18n.t("collavre.creatives.workspace.select_chat")
   end
 
+  test "workspace tree keeps a childless root visible and selectable" do
+    resize_window_to(1440, 900)
+    branch = Creative.create!(user: @user, description: "Childless root sibling branch")
+    Creative.create!(user: @user, parent: branch, description: "Sibling child")
+    childless_root = Creative.create!(user: @user, description: "Childless workspace root")
+
+    visit collavre.creatives_path(id: branch.id)
+    assert_selector ".creative-workspace-tree-link[data-creative-id='#{childless_root.id}']", wait: 10
+
+    find(".creative-workspace-tree-link[data-creative-id='#{childless_root.id}']").click
+
+    assert_selector ".creative-workspace-tree-link[data-creative-id='#{childless_root.id}'].is-current", wait: 10
+    assert_selector "#comments-popup[data-creative-id='#{childless_root.id}']", visible: :visible, wait: 10
+  end
+
+  # Structural refresh is asserted one level below the root: roots always
+  # render, so only a nested branch flips in and out of the tree when its
+  # children appear and disappear.
   test "workspace tree refreshes first-child and last-child structural changes" do
     resize_window_to(1440, 900)
-    stable_branch = Creative.create!(user: @user, description: "Stable workspace branch")
+    root = Creative.create!(user: @user, description: "Structural workspace root")
+    stable_branch = Creative.create!(user: @user, parent: root, description: "Stable workspace branch")
     Creative.create!(user: @user, parent: stable_branch, description: "Stable child")
-    changing_creative = Creative.create!(user: @user, description: "Changing workspace creative")
+    changing_creative = Creative.create!(user: @user, parent: root, description: "Changing workspace creative")
 
     visit collavre.creatives_path(id: stable_branch.id)
     assert_selector ".creative-workspace-tree-link[data-creative-id='#{stable_branch.id}']", wait: 10
@@ -407,7 +426,8 @@ class InlineScriptsTest < ApplicationSystemTestCase
 
   test "workspace tree refresh does not reopen a destroyed creative chat" do
     resize_window_to(1440, 900)
-    branch = Creative.create!(user: @user, description: "Destroyed chat branch")
+    root = Creative.create!(user: @user, description: "Destroyed chat root")
+    branch = Creative.create!(user: @user, parent: root, description: "Destroyed chat branch")
     leaf = Creative.create!(user: @user, parent: branch, description: "Destroyed chat leaf")
 
     visit collavre.creatives_path(id: leaf.id)


### PR DESCRIPTION
## Problem

The persistent workspace tree filtered every nested level with `ChildrenIndex#has_children?`. Readable leaf creatives were omitted, so users could not see the complete hierarchy or navigate to leaf content from the tree.

## Change

- Include every readable, active creative returned at the root and under expanded ancestors, including leaves.
- Preserve the existing collapsed/lazy expansion behavior; the response does not recursively expand closed branches.
- Preserve permission checks, archived-item exclusion, linked-shell cycle protection, batched per-level reads, and expand-state persistence.
- Keep leaf rows visible when their first child is created or last child is removed; only the expand affordance changes.
- Synchronize history restoration to the leaf row now that leaf creatives are renderable.

## Tests

- Workspace tree builder covers root and nested leaves, unreadable children, deep expansion, linked cycles, and batched reads.
- Controller JSON tests cover leaf payloads at multiple expanded levels.
- System tests cover nested leaf selection, structural refresh, deletion, and leaf history restoration.
- Focused Rails: 39 runs / 231 assertions.
- Workspace system: 24 runs / 146 assertions.
- Full Rails unit/integration: 4,489 runs / 15,290 assertions.
- Full system: 99 runs / 629 assertions (2 existing skips).
- Jest: 1,574 tests.
- Rubocop: 1,271 files, 0 offenses.
- Asset build passed.
