### PR TITLE
feat: split agent workspace and credential identity axes

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_09_000004) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_10_000000) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -88,7 +88,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_09_000004) do
     t.datetime "created_at", null: false
     t.string "manifest_token", null: false
     t.string "manifest_token_digest", null: false
-    t.string "proxy_user_id", null: false
+    t.string "proxy_credential_id", null: false
+    t.string "proxy_workspace_id", null: false
     t.datetime "updated_at", null: false
     t.integer "user_id"
     t.index ["agent_gateway_id"], name: "index_agent_workspaces_on_agent_gateway_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -88,8 +88,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_10_000000) do
     t.datetime "created_at", null: false
     t.string "manifest_token", null: false
     t.string "manifest_token_digest", null: false
-    t.string "proxy_credential_id", null: false
-    t.string "proxy_workspace_id", null: false
+    t.string "proxy_credential_id"
+    t.string "proxy_user_id"
+    t.string "proxy_workspace_id"
     t.datetime "updated_at", null: false
     t.integer "user_id"
     t.index ["agent_gateway_id"], name: "index_agent_workspaces_on_agent_gateway_id"

--- a/engines/collavre/app/controllers/collavre/agent_connections_controller.rb
+++ b/engines/collavre/app/controllers/collavre/agent_connections_controller.rb
@@ -18,7 +18,11 @@ module Collavre
       render json: {
         engines: engine_rows,
         provision: client.provision_status,
-        workspace: { user_id: @workspace.proxy_user_id, mode: @agent.agent_gateway.workspace_mode }
+        workspace: {
+          credential_id: @workspace.proxy_credential_id,
+          workspace_id: @workspace.proxy_workspace_id,
+          mode: @agent.agent_gateway.workspace_mode
+        }
       }
     rescue Collavre::CliProxy::Client::Error => e
       render_proxy_error(e)

--- a/engines/collavre/app/models/collavre/agent_workspace.rb
+++ b/engines/collavre/app/models/collavre/agent_workspace.rb
@@ -80,6 +80,17 @@ module Collavre
         user ? "user-#{user.id}" : "agent-#{agent.id}"
       end
 
+      # Nothing here reads proxy_user_id; it is written so a process still
+      # running the pre-split code can resolve rows this release creates —
+      # the previous container during a Kamal rollout, or the whole app after
+      # a rollback. Drop this together with the column in the contract
+      # migration that follows this release.
+      def legacy_proxy_user_id_for(agent, user)
+        return "agent-#{agent.id}" unless user
+
+        "agent-#{agent.id}--user-#{user.id}"
+      end
+
       private
 
       def resolve_shared!(agent, gateway)
@@ -129,6 +140,7 @@ module Collavre
             agent_gateway: gateway,
             proxy_workspace_id: proxy_workspace_id_for(agent),
             proxy_credential_id: proxy_credential_id_for(agent, user),
+            proxy_user_id: legacy_proxy_user_id_for(agent, user),
             manifest_token: SecureRandom.urlsafe_base64(32),
             callback_token: callback_token
           )

--- a/engines/collavre/app/models/collavre/agent_workspace.rb
+++ b/engines/collavre/app/models/collavre/agent_workspace.rb
@@ -13,8 +13,17 @@ module Collavre
     encrypts :manifest_token, deterministic: false
     encrypts :callback_token, deterministic: false
 
-    validates :proxy_user_id, :manifest_token, :manifest_token_digest, :callback_token, presence: true
-    validates :proxy_user_id, format: { with: /\A[A-Za-z0-9][A-Za-z0-9._:@\/-]{0,199}\z/ }
+    # Mirrors the proxy's STABLE_ID_RE: the credential axis selects the OS worker.
+    CREDENTIAL_ID_FORMAT = /\A[A-Za-z0-9][A-Za-z0-9._:@\/-]{0,199}\z/
+    # Mirrors the proxy's WORKSPACE_ID_RE. Narrower than the credential format
+    # because this value becomes one path segment below the worker's HOME, so
+    # "/" and "." must stay out of it.
+    WORKSPACE_ID_FORMAT = /\A[A-Za-z0-9][A-Za-z0-9_:@-]{0,199}\z/
+
+    validates :proxy_credential_id, :proxy_workspace_id, :manifest_token,
+              :manifest_token_digest, :callback_token, presence: true
+    validates :proxy_credential_id, format: { with: CREDENTIAL_ID_FORMAT }
+    validates :proxy_workspace_id, format: { with: WORKSPACE_ID_FORMAT }
     validates :manifest_token_digest, uniqueness: true
 
     before_validation :derive_manifest_token_digest, if: :will_save_change_to_manifest_token?
@@ -57,11 +66,28 @@ module Collavre
         Digest::SHA256.hexdigest(token)
       end
 
+      # The workspace axis is always the agent: skills, workspace config, and the
+      # provisioning lockfile are per agent regardless of the gateway mode.
+      def proxy_workspace_id_for(agent)
+        "agent-#{agent.id}"
+      end
+
+      # The credential axis selects the proxy worker that holds the engine
+      # logins. A per-user gateway keys it by Collavre user so one login covers
+      # every agent that user reaches; a shared gateway keys it by agent so all
+      # of its users keep sharing the one login.
+      def proxy_credential_id_for(agent, user)
+        user ? "user-#{user.id}" : "agent-#{agent.id}"
+      end
+
       private
 
       def resolve_shared!(agent, gateway)
-        find_by(agent: agent, agent_gateway: gateway, user_id: nil) ||
-          create_workspace!(agent: agent, user: nil, gateway: gateway, proxy_user_id: "agent-#{agent.id}")
+        existing = find_by(agent: agent, agent_gateway: gateway, user_id: nil)
+        return existing if identity_current?(existing, agent, nil)
+
+        existing&.destroy!
+        create_workspace!(agent: agent, user: nil, gateway: gateway)
       rescue ActiveRecord::RecordNotUnique
         find_by!(agent: agent, agent_gateway: gateway, user_id: nil)
       end
@@ -69,9 +95,8 @@ module Collavre
       def resolve_per_user!(agent, user, gateway)
         raise ArgumentError, "A user is required for a per-user workspace" unless user
 
-        expected_proxy_user_id = "agent-#{agent.id}--user-#{user.id}"
         existing = find_by(agent: agent, user: user, agent_gateway: gateway)
-        return existing if existing&.proxy_user_id == expected_proxy_user_id
+        return existing if identity_current?(existing, agent, user)
 
         existing&.destroy!
 
@@ -79,17 +104,22 @@ module Collavre
           find_by(agent: agent, agent_gateway: gateway, user_id: nil)&.destroy!
         end
 
-        create_workspace!(
-          agent: agent,
-          user: user,
-          gateway: gateway,
-          proxy_user_id: expected_proxy_user_id
-        )
+        create_workspace!(agent: agent, user: user, gateway: gateway)
       rescue ActiveRecord::RecordNotUnique
         find_by!(agent: agent, user: user, agent_gateway: gateway)
       end
 
-      def create_workspace!(agent:, user:, gateway:, proxy_user_id:)
+      # A row minted under an older identity scheme addresses a proxy workspace
+      # that no longer matches its agent/user pair, so it is replaced rather than
+      # reused — its credentials would resolve to the wrong worker or directory.
+      def identity_current?(workspace, agent, user)
+        return false unless workspace
+
+        workspace.proxy_workspace_id == proxy_workspace_id_for(agent) &&
+          workspace.proxy_credential_id == proxy_credential_id_for(agent, user)
+      end
+
+      def create_workspace!(agent:, user:, gateway:)
         transaction do
           callback_token = issue_callback_token!(gateway: gateway, owner: user || agent)
 
@@ -97,7 +127,8 @@ module Collavre
             agent: agent,
             user: user,
             agent_gateway: gateway,
-            proxy_user_id: proxy_user_id,
+            proxy_workspace_id: proxy_workspace_id_for(agent),
+            proxy_credential_id: proxy_credential_id_for(agent, user),
             manifest_token: SecureRandom.urlsafe_base64(32),
             callback_token: callback_token
           )

--- a/engines/collavre/app/services/collavre/cli_proxy/identity.rb
+++ b/engines/collavre/app/services/collavre/cli_proxy/identity.rb
@@ -8,21 +8,36 @@ module Collavre
       HEADER_NAMES = {
         tenant: "X-CLI-Proxy-Tenant-ID",
         user: "X-CLI-Proxy-User-ID",
+        workspace: "X-CLI-Proxy-Workspace-ID",
         timestamp: "X-CLI-Proxy-Identity-Timestamp",
         signature: "X-CLI-Proxy-Identity-Signature"
       }.freeze
+
+      # The workspace header is part of the signed payload. Signing it outside
+      # the HMAC would let anyone holding a completion key retarget the request
+      # at another workspace of the same user.
+      PAYLOAD_VERSION = "v2"
 
       def self.headers(gateway:, workspace:, method:, path:, at: Time.current)
         secret = gateway.identity_secret.to_s
         return {} if secret.blank?
 
         timestamp = at.to_i.to_s
-        payload = [ "v1", method.to_s.upcase, path, timestamp, gateway.tenant_id, workspace.proxy_user_id ].join("\n")
+        payload = [
+          PAYLOAD_VERSION,
+          method.to_s.upcase,
+          path,
+          timestamp,
+          gateway.tenant_id,
+          workspace.proxy_credential_id,
+          workspace.proxy_workspace_id
+        ].join("\n")
         signature = OpenSSL::HMAC.hexdigest("SHA256", secret, payload)
 
         {
           HEADER_NAMES[:tenant] => gateway.tenant_id,
-          HEADER_NAMES[:user] => workspace.proxy_user_id,
+          HEADER_NAMES[:user] => workspace.proxy_credential_id,
+          HEADER_NAMES[:workspace] => workspace.proxy_workspace_id,
           HEADER_NAMES[:timestamp] => timestamp,
           HEADER_NAMES[:signature] => signature
         }

--- a/engines/collavre/app/views/collavre/agent_connections/show.html.erb
+++ b/engines/collavre/app/views/collavre/agent_connections/show.html.erb
@@ -3,7 +3,11 @@
 <div class="alert alert-info">
   <strong><%= @agent.agent_gateway.name %></strong>
   · <%= t("collavre.agent_gateways.workspace_mode.#{@agent.agent_gateway.workspace_mode}") %>
-  · <code><%= @workspace.proxy_user_id %></code>
+  · <%= t("collavre.agent_connections.credential_axis") %> <code><%= @workspace.proxy_credential_id %></code>
+  · <%= t("collavre.agent_connections.workspace_axis") %> <code><%= @workspace.proxy_workspace_id %></code>
+  <p class="text-muted" style="margin-bottom: 0;">
+    <%= t("collavre.agent_connections.axis_help.#{@agent.agent_gateway.workspace_mode}") %>
+  </p>
 </div>
 
 <div data-controller="agent-connection"

--- a/engines/collavre/config/locales/agent_gateway.en.yml
+++ b/engines/collavre/config/locales/agent_gateway.en.yml
@@ -81,6 +81,11 @@ en:
         shared: This agent uses one shared CLI Proxy workspace. Its owner manages the shared provider connection.
         per_user: This agent uses per-user CLI Proxy workspaces. Connect your own providers before using it.
       manage: Manage connection
+      credential_axis: 'Login:'
+      workspace_axis: 'Workspace:'
+      axis_help:
+        shared: Provider login and provisioning are both shared by every user of this agent. Logging in once here covers everyone.
+        per_user: Provider login is yours and is reused by every agent you connect to this gateway — log in once per provider, not once per agent. Skills and workspace config stay separate per agent.
       engines: Agent providers
       loading: Loading…
       refresh: Refresh

--- a/engines/collavre/config/locales/agent_gateway.ko.yml
+++ b/engines/collavre/config/locales/agent_gateway.ko.yml
@@ -81,6 +81,11 @@ ko:
         shared: 이 에이전트는 하나의 공유 CLI Proxy 워크스페이스를 사용합니다. 에이전트 소유자가 공유 provider 연결을 관리합니다.
         per_user: 이 에이전트는 사용자별 CLI Proxy 워크스페이스를 사용합니다. 사용 전에 내 provider를 연결하세요.
       manage: 내 연결 관리
+      credential_axis: '로그인:'
+      workspace_axis: '워크스페이스:'
+      axis_help:
+        shared: provider 로그인과 프로비저닝을 이 에이전트의 모든 사용자가 공유합니다. 여기서 한 번 로그인하면 전원에게 적용됩니다.
+        per_user: provider 로그인은 내 계정 단위이며, 이 게이트웨이에 연결한 모든 에이전트가 함께 사용합니다. 에이전트마다가 아니라 provider마다 한 번만 로그인하면 됩니다. 스킬과 워크스페이스 설정은 에이전트별로 분리됩니다.
       engines: Agent provider
       loading: 불러오는 중…
       refresh: 새로고침

--- a/engines/collavre/db/migrate/20260810000000_split_agent_workspace_identity_axes.rb
+++ b/engines/collavre/db/migrate/20260810000000_split_agent_workspace_identity_axes.rb
@@ -5,13 +5,21 @@
 # a path workspace below that worker's HOME. Split the single proxy_user_id into
 # those axes so engine login is per Collavre user while skills and workspace
 # config stay per agent.
+#
+# Expand only. bin/docker-entrypoint runs db:migrate while the previous release
+# is still serving requests against the same database, so proxy_user_id has to
+# stay readable and writable until every process runs the new code. The new
+# columns are therefore nullable here and the old one merely loses its NOT NULL,
+# which also keeps a Kamal rollback working. The contract half — dropping
+# proxy_user_id and adding NOT NULL to the two new columns — belongs to a later
+# release, once no process writes the legacy column anymore.
 class SplitAgentWorkspaceIdentityAxes < ActiveRecord::Migration[8.0]
   class MigrationWorkspace < ActiveRecord::Base
     self.table_name = "agent_workspaces"
   end
 
   def up
-    rename_column :agent_workspaces, :proxy_user_id, :proxy_credential_id
+    add_column :agent_workspaces, :proxy_credential_id, :string
     add_column :agent_workspaces, :proxy_workspace_id, :string
 
     MigrationWorkspace.reset_column_information
@@ -22,17 +30,18 @@ class SplitAgentWorkspaceIdentityAxes < ActiveRecord::Migration[8.0]
       )
     end
 
-    change_column_null :agent_workspaces, :proxy_workspace_id, false
+    change_column_null :agent_workspaces, :proxy_user_id, true
   end
 
   def down
     MigrationWorkspace.reset_column_information
-    MigrationWorkspace.find_each do |workspace|
-      workspace.update_columns(proxy_credential_id: legacy_proxy_user_id_for(workspace))
+    MigrationWorkspace.where(proxy_user_id: nil).find_each do |workspace|
+      workspace.update_columns(proxy_user_id: legacy_proxy_user_id_for(workspace))
     end
 
+    change_column_null :agent_workspaces, :proxy_user_id, false
     remove_column :agent_workspaces, :proxy_workspace_id
-    rename_column :agent_workspaces, :proxy_credential_id, :proxy_user_id
+    remove_column :agent_workspaces, :proxy_credential_id
   end
 
   private

--- a/engines/collavre/db/migrate/20260810000000_split_agent_workspace_identity_axes.rb
+++ b/engines/collavre/db/migrate/20260810000000_split_agent_workspace_identity_axes.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+# The CLI proxy now carries two identity axes: X-CLI-Proxy-User-ID selects the
+# OS worker holding the engine credentials, and X-CLI-Proxy-Workspace-ID selects
+# a path workspace below that worker's HOME. Split the single proxy_user_id into
+# those axes so engine login is per Collavre user while skills and workspace
+# config stay per agent.
+class SplitAgentWorkspaceIdentityAxes < ActiveRecord::Migration[8.0]
+  class MigrationWorkspace < ActiveRecord::Base
+    self.table_name = "agent_workspaces"
+  end
+
+  def up
+    rename_column :agent_workspaces, :proxy_user_id, :proxy_credential_id
+    add_column :agent_workspaces, :proxy_workspace_id, :string
+
+    MigrationWorkspace.reset_column_information
+    MigrationWorkspace.find_each do |workspace|
+      workspace.update_columns(
+        proxy_workspace_id: "agent-#{workspace.agent_id}",
+        proxy_credential_id: credential_id_for(workspace)
+      )
+    end
+
+    change_column_null :agent_workspaces, :proxy_workspace_id, false
+  end
+
+  def down
+    MigrationWorkspace.reset_column_information
+    MigrationWorkspace.find_each do |workspace|
+      workspace.update_columns(proxy_credential_id: legacy_proxy_user_id_for(workspace))
+    end
+
+    remove_column :agent_workspaces, :proxy_workspace_id
+    rename_column :agent_workspaces, :proxy_credential_id, :proxy_user_id
+  end
+
+  private
+
+  def credential_id_for(workspace)
+    workspace.user_id ? "user-#{workspace.user_id}" : "agent-#{workspace.agent_id}"
+  end
+
+  def legacy_proxy_user_id_for(workspace)
+    return "agent-#{workspace.agent_id}" unless workspace.user_id
+
+    "agent-#{workspace.agent_id}--user-#{workspace.user_id}"
+  end
+end

--- a/engines/collavre/test/controllers/agent_connections_controller_test.rb
+++ b/engines/collavre/test/controllers/agent_connections_controller_test.rb
@@ -32,8 +32,10 @@ class AgentConnectionsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     workspace = Collavre::AgentWorkspace.find_by!(agent: @agent, user: @other)
-    assert_includes response.body, workspace.proxy_user_id
-    assert_equal "agent-#{@agent.id}--user-#{@other.id}", workspace.proxy_user_id
+    assert_includes response.body, workspace.proxy_credential_id
+    assert_includes response.body, workspace.proxy_workspace_id
+    assert_equal "user-#{@other.id}", workspace.proxy_credential_id
+    assert_equal "agent-#{@agent.id}", workspace.proxy_workspace_id
   end
 
   test "shared mode only lets the agent owner manage login" do

--- a/engines/collavre/test/controllers/agent_gateways_controller_test.rb
+++ b/engines/collavre/test/controllers/agent_gateways_controller_test.rb
@@ -231,7 +231,8 @@ class AgentGatewaysControllerTest < ActionDispatch::IntegrationTest
       agent: agent,
       user: user,
       agent_gateway: @gateway,
-      proxy_user_id: "agent-#{agent.id}-#{suffix}",
+      proxy_credential_id: "agent-#{agent.id}-#{suffix}",
+      proxy_workspace_id: "agent-#{agent.id}-#{suffix}",
       manifest_token: SecureRandom.urlsafe_base64(32),
       callback_token: SecureRandom.hex(32)
     )

--- a/engines/collavre/test/models/agent_gateway_test.rb
+++ b/engines/collavre/test/models/agent_gateway_test.rb
@@ -120,7 +120,8 @@ class AgentGatewayTest < ActiveSupport::TestCase
     assert_not_equal original_shared_workspace, shared_workspace
     assert_not_equal owner_workspace, shared_workspace
     assert_nil shared_workspace.user_id
-    assert_equal "agent-#{agent.id}", shared_workspace.proxy_user_id
+    assert_equal "agent-#{agent.id}", shared_workspace.proxy_credential_id
+    assert_equal "agent-#{agent.id}", shared_workspace.proxy_workspace_id
     assert_not_equal owner_manifest_token, shared_workspace.manifest_token
     assert_not_equal other_manifest_token, shared_workspace.manifest_token
     assert_not_equal owner_callback_token, shared_workspace.callback_token
@@ -152,7 +153,8 @@ class AgentGatewayTest < ActiveSupport::TestCase
     owner_workspace = Collavre::AgentWorkspace.find_by!(agent: agent, user: @owner, agent_gateway: gateway)
     assert_not_equal shared_workspace.id, owner_workspace.id
     assert_equal @owner, owner_workspace.user
-    assert_equal "agent-#{agent.id}--user-#{@owner.id}", owner_workspace.proxy_user_id
+    assert_equal "user-#{@owner.id}", owner_workspace.proxy_credential_id
+    assert_equal "agent-#{agent.id}", owner_workspace.proxy_workspace_id
     assert_not_equal shared_manifest_token, owner_workspace.manifest_token
     assert_not_equal shared_callback_token, owner_workspace.callback_token
     assert_predicate shared_access_token.reload, :revoked?
@@ -200,7 +202,8 @@ class AgentGatewayTest < ActiveSupport::TestCase
 
     gateway.update!(active: true)
     owner_workspace = Collavre::AgentWorkspace.resolve!(agent: agent, user: @owner)
-    assert_equal "agent-#{agent.id}--user-#{@owner.id}", owner_workspace.proxy_user_id
+    assert_equal "user-#{@owner.id}", owner_workspace.proxy_credential_id
+    assert_equal "agent-#{agent.id}", owner_workspace.proxy_workspace_id
     assert_not_equal shared_manifest_token, owner_workspace.manifest_token
   end
 

--- a/engines/collavre/test/models/agent_workspace_test.rb
+++ b/engines/collavre/test/models/agent_workspace_test.rb
@@ -1,6 +1,7 @@
 require "test_helper"
 require Rails.root.join("engines/collavre/db/migrate/20260809000003_hash_agent_workspace_callback_tokens")
 require Rails.root.join("engines/collavre/db/migrate/20260809000004_encrypt_agent_workspace_manifest_tokens")
+require Rails.root.join("engines/collavre/db/migrate/20260810000000_split_agent_workspace_identity_axes")
 
 class AgentWorkspaceTest < ActiveSupport::TestCase
   setup do
@@ -33,7 +34,8 @@ class AgentWorkspaceTest < ActiveSupport::TestCase
 
     assert_equal first, second
     assert_nil first.user
-    assert_equal "agent-#{@agent.id}", first.proxy_user_id
+    assert_equal "agent-#{@agent.id}", first.proxy_credential_id
+    assert_equal "agent-#{@agent.id}", first.proxy_workspace_id
     assert Doorkeeper::AccessToken.by_token(first.callback_token).accessible?
   end
 
@@ -190,7 +192,8 @@ class AgentWorkspaceTest < ActiveSupport::TestCase
 
     assert_not_equal shared.id, owner_workspace.id
     assert_equal @owner, owner_workspace.user
-    assert_equal "agent-#{@agent.id}--user-#{@owner.id}", owner_workspace.proxy_user_id
+    assert_equal "user-#{@owner.id}", owner_workspace.proxy_credential_id
+    assert_equal "agent-#{@agent.id}", owner_workspace.proxy_workspace_id
     assert_not_equal shared_manifest_token, owner_workspace.manifest_token
     assert_not_equal shared_callback_token, owner_workspace.callback_token
     assert_predicate shared_access_token.reload, :revoked?
@@ -200,7 +203,8 @@ class AgentWorkspaceTest < ActiveSupport::TestCase
     owner_access_token = Doorkeeper::AccessToken.by_token(owner_workspace.callback_token)
     assert_equal @owner.id, owner_access_token.resource_owner_id
     assert_predicate owner_access_token, :accessible?
-    assert_equal "agent-#{@agent.id}--user-#{@other.id}", other_workspace.proxy_user_id
+    assert_equal "user-#{@other.id}", other_workspace.proxy_credential_id
+    assert_equal "agent-#{@agent.id}", other_workspace.proxy_workspace_id
     assert_not_equal owner_workspace.callback_token, other_workspace.callback_token
   end
 
@@ -214,7 +218,8 @@ class AgentWorkspaceTest < ActiveSupport::TestCase
 
     assert_not_equal shared.id, owner_workspace.id
     assert_equal @owner, owner_workspace.user
-    assert_equal "agent-#{@agent.id}--user-#{@owner.id}", owner_workspace.proxy_user_id
+    assert_equal "user-#{@owner.id}", owner_workspace.proxy_credential_id
+    assert_equal "agent-#{@agent.id}", owner_workspace.proxy_workspace_id
     assert_not_equal shared_manifest_token, owner_workspace.manifest_token
     assert_predicate shared_access_token.reload, :revoked?
     assert_raises(ActiveRecord::RecordNotFound) do
@@ -232,7 +237,8 @@ class AgentWorkspaceTest < ActiveSupport::TestCase
     owner_workspace = Collavre::AgentWorkspace.resolve!(agent: @agent, user: @owner)
 
     assert_not_equal legacy.id, owner_workspace.id
-    assert_equal "agent-#{@agent.id}--user-#{@owner.id}", owner_workspace.proxy_user_id
+    assert_equal "user-#{@owner.id}", owner_workspace.proxy_credential_id
+    assert_equal "agent-#{@agent.id}", owner_workspace.proxy_workspace_id
     assert_not_equal legacy_manifest_token, owner_workspace.manifest_token
     assert_predicate legacy_access_token.reload, :revoked?
     assert_raises(ActiveRecord::RecordNotFound) do
@@ -288,5 +294,67 @@ class AgentWorkspaceTest < ActiveSupport::TestCase
 
     assert_raises(ActiveRecord::RecordNotFound) { workspace.rotate_tokens! }
     assert_equal access_token_count, Doorkeeper::AccessToken.count
+  end
+
+  test "per-user credential axis is the Collavre user so one login covers every agent" do
+    @gateway.update!(workspace_mode: :per_user)
+    second_agent = Collavre::User.create!(
+      name: "Second Workspace Agent",
+      email: "workspace-agent-2@ai.local",
+      password: SecureRandom.hex(24),
+      system_prompt: "Help",
+      llm_vendor: "cli_proxy",
+      llm_model: "paperclip/codex_local",
+      created_by_id: @owner.id,
+      agent_gateway: @gateway
+    )
+
+    first = Collavre::AgentWorkspace.resolve!(agent: @agent, user: @owner)
+    second = Collavre::AgentWorkspace.resolve!(agent: second_agent, user: @owner)
+
+    # Same worker (one engine login) but separate path workspaces.
+    assert_equal first.proxy_credential_id, second.proxy_credential_id
+    assert_equal "user-#{@owner.id}", first.proxy_credential_id
+    assert_not_equal first.proxy_workspace_id, second.proxy_workspace_id
+    assert_not_equal first.callback_token, second.callback_token
+  end
+
+  test "workspace axis rejects identifiers that are not one safe path segment" do
+    workspace = Collavre::AgentWorkspace.resolve!(agent: @agent, user: nil)
+
+    [ "../escape", "agent/12", "agent.12", "/agent-12", "" ].each do |candidate|
+      workspace.proxy_workspace_id = candidate
+      assert_not workspace.valid?, "expected #{candidate.inspect} to be rejected"
+      assert_includes workspace.errors.attribute_names, :proxy_workspace_id
+    end
+  end
+
+  test "resolution replaces a workspace minted under the legacy single-axis identity" do
+    @gateway.update!(workspace_mode: :per_user)
+    legacy = Collavre::AgentWorkspace.resolve!(agent: @agent, user: @owner)
+    legacy.update_column(:proxy_credential_id, "agent-#{@agent.id}--user-#{@owner.id}")
+    legacy_manifest_token = legacy.manifest_token
+    legacy_access_token = Doorkeeper::AccessToken.by_token(legacy.callback_token)
+
+    replacement = Collavre::AgentWorkspace.resolve!(agent: @agent, user: @owner)
+
+    assert_not_equal legacy.id, replacement.id
+    assert_equal "user-#{@owner.id}", replacement.proxy_credential_id
+    assert_equal "agent-#{@agent.id}", replacement.proxy_workspace_id
+    assert_predicate legacy_access_token.reload, :revoked?
+    assert_raises(ActiveRecord::RecordNotFound) do
+      Collavre::AgentWorkspace.find_by_manifest_token!(agent_id: @agent.id, token: legacy_manifest_token)
+    end
+  end
+
+  test "migration maps each legacy identity onto both axes and back" do
+    migration = SplitAgentWorkspaceIdentityAxes.new
+    shared = Struct.new(:agent_id, :user_id).new(11, nil)
+    per_user = Struct.new(:agent_id, :user_id).new(11, 7)
+
+    assert_equal "agent-11", migration.send(:credential_id_for, shared)
+    assert_equal "user-7", migration.send(:credential_id_for, per_user)
+    assert_equal "agent-11", migration.send(:legacy_proxy_user_id_for, shared)
+    assert_equal "agent-11--user-7", migration.send(:legacy_proxy_user_id_for, per_user)
   end
 end

--- a/engines/collavre/test/models/agent_workspace_test.rb
+++ b/engines/collavre/test/models/agent_workspace_test.rb
@@ -347,6 +347,40 @@ class AgentWorkspaceTest < ActiveSupport::TestCase
     end
   end
 
+  test "the legacy identity column outlives the split so the previous release keeps resolving" do
+    column = Collavre::AgentWorkspace.columns_hash["proxy_user_id"]
+
+    assert_not_nil column, "proxy_user_id must survive this release; a later contract migration drops it"
+    assert column.null, "proxy_user_id must be nullable so dropping the write is not a breaking change"
+  end
+
+  test "creation still writes the legacy identity a pre-split release would read" do
+    shared = Collavre::AgentWorkspace.resolve!(agent: @agent, user: @owner)
+    assert_equal "agent-#{@agent.id}", shared.proxy_user_id
+
+    @gateway.update!(workspace_mode: :per_user)
+    per_user = Collavre::AgentWorkspace.resolve!(agent: @agent, user: @other)
+
+    assert_equal "agent-#{@agent.id}--user-#{@other.id}", per_user.proxy_user_id
+  end
+
+  test "resolution repairs a workspace the previous release created mid-rollout" do
+    workspace = Collavre::AgentWorkspace.resolve!(agent: @agent, user: @owner)
+    # What the pre-split code inserts once the expand migration has landed: the
+    # legacy column only, both new axes left NULL.
+    workspace.update_columns(
+      proxy_workspace_id: nil,
+      proxy_credential_id: nil,
+      proxy_user_id: "agent-#{@agent.id}"
+    )
+
+    replacement = Collavre::AgentWorkspace.resolve!(agent: @agent, user: @owner)
+
+    assert_not_equal workspace.id, replacement.id
+    assert_equal "agent-#{@agent.id}", replacement.proxy_workspace_id
+    assert_equal "agent-#{@agent.id}", replacement.proxy_credential_id
+  end
+
   test "migration maps each legacy identity onto both axes and back" do
     migration = SplitAgentWorkspaceIdentityAxes.new
     shared = Struct.new(:agent_id, :user_id).new(11, nil)

--- a/engines/collavre/test/services/ai_client_test.rb
+++ b/engines/collavre/test/services/ai_client_test.rb
@@ -532,8 +532,8 @@ class AiClientTest < ActiveSupport::TestCase
     assert_equal "completion-secret", context_config.openai_api_key
     assert_equal "https://proxy.example.com/v1", context_config.openai_api_base
     assert_equal Collavre::CliProxy::SafeNetHttpAdapter, context_config.faraday_adapter
-    assert_equal "agent-#{agent.id}--user-#{workspace_user.id}",
-                 fake_chat.headers_set.fetch("X-CLI-Proxy-User-ID")
+    assert_equal "user-#{workspace_user.id}", fake_chat.headers_set.fetch("X-CLI-Proxy-User-ID")
+    assert_equal "agent-#{agent.id}", fake_chat.headers_set.fetch("X-CLI-Proxy-Workspace-ID")
     assert fake_chat.headers_set.fetch("X-CLI-Proxy-Identity-Signature").present?
     assert_equal "creative_42_topic_7", fake_chat.headers_set.fetch("X-Session-Id")
 
@@ -639,9 +639,8 @@ class AiClientTest < ActiveSupport::TestCase
       client.send(:build_conversation)
     end
 
-    assert_equal "agent-#{agent.id}--user-#{owner.id}",
-                 fake_chat.headers_set.fetch("X-CLI-Proxy-User-ID")
-    refute_includes fake_chat.headers_set.fetch("X-CLI-Proxy-User-ID"), "user-#{upstream_agent.id}"
+    assert_equal "user-#{owner.id}", fake_chat.headers_set.fetch("X-CLI-Proxy-User-ID")
+    assert_not_equal "user-#{upstream_agent.id}", fake_chat.headers_set.fetch("X-CLI-Proxy-User-ID")
   end
 
   test "build_conversation rejects an explicitly unverified per-user workspace principal" do

--- a/engines/collavre/test/services/cli_proxy_client_test.rb
+++ b/engines/collavre/test/services/cli_proxy_client_test.rb
@@ -33,7 +33,7 @@ class CliProxyClientTest < ActiveSupport::TestCase
         "https://proxy.example.com#{path}"
       end
     end.new("admin-secret", "identity-secret" * 3, "collavre")
-    workspace = Struct.new(:proxy_user_id).new("agent-42--user-7")
+    workspace = Struct.new(:proxy_credential_id, :proxy_workspace_id).new("user-7", "agent-42")
     response = FakeResponse.new(code: 201, message: "Created", payload: { "status" => "pending" }, successful: true)
     http = FakeHttpClient.new(response)
 
@@ -48,7 +48,8 @@ class CliProxyClientTest < ActiveSupport::TestCase
     request = http.requests.fetch(0)
     assert_equal :post, request.fetch(:method)
     assert_equal "Bearer admin-secret", request.dig(:headers, "Authorization")
-    assert_equal "agent-42--user-7", request.dig(:headers, "X-CLI-Proxy-User-ID")
+    assert_equal "user-7", request.dig(:headers, "X-CLI-Proxy-User-ID")
+    assert_equal "agent-42", request.dig(:headers, "X-CLI-Proxy-Workspace-ID")
     assert_equal "device-code", JSON.parse(request.fetch(:body)).fetch("flow")
   end
 

--- a/engines/collavre/test/services/cli_proxy_identity_test.rb
+++ b/engines/collavre/test/services/cli_proxy_identity_test.rb
@@ -1,9 +1,11 @@
 require "test_helper"
 
 class CliProxyIdentityTest < ActiveSupport::TestCase
-  test "signs the exact proxy request identity contract" do
+  Workspace = Struct.new(:proxy_credential_id, :proxy_workspace_id)
+
+  test "signs the exact proxy v2 request identity contract" do
     gateway = Struct.new(:identity_secret, :tenant_id).new("secret" * 8, "collavre")
-    workspace = Struct.new(:proxy_user_id).new("agent-42--user-7")
+    workspace = Workspace.new("user-7", "agent-42")
     at = Time.at(1_786_224_000)
 
     headers = Collavre::CliProxy::Identity.headers(
@@ -14,11 +16,29 @@ class CliProxyIdentityTest < ActiveSupport::TestCase
       at: at
     )
 
-    payload = "v1\nPOST\n/v1/chat/completions\n#{at.to_i}\ncollavre\nagent-42--user-7"
+    payload = "v2\nPOST\n/v1/chat/completions\n#{at.to_i}\ncollavre\nuser-7\nagent-42"
     assert_equal OpenSSL::HMAC.hexdigest("SHA256", gateway.identity_secret, payload),
                  headers.fetch("X-CLI-Proxy-Identity-Signature")
     assert_equal "collavre", headers.fetch("X-CLI-Proxy-Tenant-ID")
-    assert_equal "agent-42--user-7", headers.fetch("X-CLI-Proxy-User-ID")
+    assert_equal "user-7", headers.fetch("X-CLI-Proxy-User-ID")
+    assert_equal "agent-42", headers.fetch("X-CLI-Proxy-Workspace-ID")
+  end
+
+  test "the workspace axis is covered by the signature" do
+    gateway = Struct.new(:identity_secret, :tenant_id).new("secret" * 8, "collavre")
+    at = Time.at(1_786_224_000)
+
+    signature = lambda do |workspace_id|
+      Collavre::CliProxy::Identity.headers(
+        gateway: gateway,
+        workspace: Workspace.new("user-7", workspace_id),
+        method: :get,
+        path: "/v1/provision",
+        at: at
+      ).fetch("X-CLI-Proxy-Identity-Signature")
+    end
+
+    refute_equal signature.call("agent-42"), signature.call("agent-43")
   end
 
   test "omits identity headers when shared fallback has no secret" do

--- a/skills/collavre/scripts/collavre
+++ b/skills/collavre/scripts/collavre
@@ -7,6 +7,7 @@ import path from "node:path";
 import https from "node:https";
 import http from "node:http";
 import os from "node:os";
+import { randomBytes } from "node:crypto";
 import { decodeHtmlEntities } from "./html_entities.js";
 
 const CONFIG_DIR = path.join(
@@ -26,8 +27,26 @@ function loadConfig() {
 }
 
 function saveConfig(config) {
-  fs.mkdirSync(CONFIG_DIR, { recursive: true });
-  fs.writeFileSync(CONFIG_FILE, JSON.stringify(config, null, 2));
+  fs.mkdirSync(CONFIG_DIR, { recursive: true, mode: 0o700 });
+  fs.chmodSync(CONFIG_DIR, 0o700);
+
+  const temporaryFile = path.join(
+    CONFIG_DIR,
+    `.config.json.${process.pid}.${randomBytes(8).toString("hex")}.tmp`
+  );
+  let descriptor;
+  try {
+    descriptor = fs.openSync(temporaryFile, "wx", 0o600);
+    fs.fchmodSync(descriptor, 0o600);
+    fs.writeFileSync(descriptor, JSON.stringify(config, null, 2), "utf8");
+    fs.fsyncSync(descriptor);
+    fs.closeSync(descriptor);
+    descriptor = undefined;
+    fs.renameSync(temporaryFile, CONFIG_FILE);
+  } finally {
+    if (descriptor !== undefined) fs.closeSync(descriptor);
+    if (fs.existsSync(temporaryFile)) fs.unlinkSync(temporaryFile);
+  }
 }
 
 // --- MCP SSE Client ---


### PR DESCRIPTION
## Summary

The CLI proxy now carries two identity axes (`cli-openai-proxy@4d2e086`): `X-CLI-Proxy-User-ID` selects the OS worker holding the engine logins, and `X-CLI-Proxy-Workspace-ID` selects a path workspace below that worker's `HOME`. This sends both, so provider login is per Collavre user while skills and workspace config stay per agent.

Engine logins drop from `agents x users x engines` to `users x engines`, and Linux accounts on the proxy from `agents x users` to `users`.

| Gateway mode | `proxy_workspace_id` | `proxy_credential_id` |
|---|---|---|
| `per_user` | `agent-{agent_id}` | `user-{user_id}` |
| `shared` | `agent-{agent_id}` | `agent-{agent_id}` |

## Changes

- **Identity** — sign the proxy's v2 payload (`v2\nMETHOD\nPATH\nTS\nTENANT\nUSER\nWORKSPACE`) and add the workspace header. The workspace axis is inside the HMAC, so a completion key alone cannot retarget a request at another workspace of the same user. The empty-secret degradation path is unchanged.
- **Schema** — add `proxy_credential_id` + `proxy_workspace_id` alongside `agent_workspaces.proxy_user_id`, backfilling both from the agent/user pair. Expand only: `db:migrate` runs while the previous release still serves, so the legacy column stays (it merely loses its `NOT NULL`) and creation keeps writing it. Dropping it, and adding `NOT NULL` to the two new columns, is a follow-up migration for a later release. The workspace axis validates against the proxy's narrower path-segment format (`[A-Za-z0-9][A-Za-z0-9_:@-]{0,199}`) because it becomes one directory name.
- **Resolution** — rows minted under the single-axis scheme are replaced rather than reused; their identity would address the wrong worker or directory.
- **UI** — the connection screen shows both axes and states that provider login is per user while provisioning is per agent, which the previous single identifier did not distinguish.
- **Drive-by** — `skills/collavre/scripts/collavre` had drifted from the engine copy (missing the hardened `0600` atomic config writer added in #1507), leaving `agent_provisioning_archive_test` red on `main`. Synced.

## Rollout

The proxy must be redeployed to a build containing the two-axis support **before** this merges — an older proxy computes the v1 payload and rejects these signatures. `collavre-dev1` is currently on `20260809T140747Z`, which predates it.

Existing workspaces keep their manifest and callback tokens but move to a different worker/directory, so each needs one re-login to re-register its manifest.

The schema change is rollout- and rollback-safe on its own: the previous release keeps reading and writing `proxy_user_id` throughout, and any row it inserts mid-rollout (both axes NULL) is replaced on the next resolve. **Follow-up:** once this release is everywhere, contract with a migration that drops `proxy_user_id` and adds `NOT NULL` to `proxy_credential_id` / `proxy_workspace_id`, and drop the legacy write in `AgentWorkspace.create_workspace!`.

## Verification

- 198 tests / 868 assertions across the gateway, workspace, provisioning, chat, and orchestration surface
- Signature cross-checked byte-for-byte against the proxy's own `signedIdentity()` construction
- RuboCop and Zeitwerk pass
