### PR TITLE
feat: re-register the workspace manifest from Sync now

### DIFF
--- a/engines/collavre/app/controllers/collavre/agent_connections_controller.rb
+++ b/engines/collavre/app/controllers/collavre/agent_connections_controller.rb
@@ -54,7 +54,7 @@ module Collavre
     end
 
     def provision_sync
-      render json: proxy_client.provision_sync
+      render json: sync_provisioning
     rescue Collavre::CliProxy::Client::Error => e
       render_proxy_error(e)
     end
@@ -96,6 +96,29 @@ module Collavre
 
     def proxy_client
       @proxy_client ||= Collavre::CliProxy::Client.new(gateway: @workspace.agent_gateway, workspace: @workspace)
+    end
+
+    # "Sync now" starts from registration rather than assuming one happened.
+    # A manifest URL otherwise only reaches the proxy as a side effect of a
+    # login, so a workspace whose registration never landed — an engine
+    # authenticated before provisioning existed, a first sync that failed, a
+    # proxy that lost its state — could only be repaired by logging in again.
+    #
+    # Registration is idempotent: re-registering the same URL is a plain
+    # re-sync. Two answers mean the proxy will not take a URL from us at all
+    # and a plain sync is the whole of what we can do — an operator who pinned
+    # the workspace with PROVISION_MANIFEST_URL (409 manifest_url_locked), and
+    # a proxy predating the endpoint, whose router answers 404 for it. The one
+    # 404 that is not that is provisioning_disabled, where the plain sync would
+    # only repeat the same answer and hide which of the two it was.
+    def sync_provisioning
+      proxy_client.provision_register_manifest(manifest_url)
+    rescue Collavre::CliProxy::Client::Error => error
+      registration_refused = error.code == "manifest_url_locked" ||
+        (error.status == 404 && error.code != "provisioning_disabled")
+      raise unless registration_refused
+
+      proxy_client.provision_sync
     end
 
     def manifest_url

--- a/engines/collavre/app/javascript/controllers/__tests__/agent_connection_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/agent_connection_controller.test.js
@@ -24,11 +24,14 @@ describe("AgentConnectionController", () => {
            data-agent-connection-approve-value="승인"
            data-agent-connection-revoke-value="승인 회수"
            data-agent-connection-error-value="CLI Proxy 오류"
+           data-agent-connection-manifest-unregistered-value="등록된 매니페스트가 없습니다"
+           data-agent-connection-last-error-value="최근 프로비저닝 오류"
            data-agent-connection-status-labels-value='{"unknown":"알 수 없음","authorized":"인증 완료","not_synced":"동기화되지 않음","pending_approval":"승인 대기","installed":"설치됨"}'
            data-agent-connection-item-type-labels-value='{"skill":"스킬","config":"설정"}'>
         <div data-agent-connection-target="error" hidden></div>
         <div data-agent-connection-target="engines"></div>
         <div data-agent-connection-target="session"></div>
+        <div data-agent-connection-target="manifest"></div>
         <table><tbody data-agent-connection-target="provision"></tbody></table>
       </div>
     `
@@ -83,6 +86,23 @@ describe("AgentConnectionController", () => {
 
     expect(controller.statusLabel("future_state")).toBe("future_state")
     expect(controller.itemTypeLabel("future_type")).toBe("future_type")
+  })
+
+  test("names why provisioning is stalled next to the sync button", async () => {
+    await mount()
+    const controller = application.getControllerForElementAndIdentifier(
+      document.querySelector('[data-controller="agent-connection"]'),
+      "agent-connection"
+    )
+    const manifest = document.querySelector('[data-agent-connection-target="manifest"]')
+
+    expect(manifest.textContent).toContain("등록된 매니페스트가 없습니다")
+
+    controller.renderProvision({ manifest_url: "https://collavre.example/provision.json", last_error: "manifest fetch failed" })
+    expect(manifest.textContent).toContain("최근 프로비저닝 오류: manifest fetch failed")
+
+    controller.renderProvision({ manifest_url: "https://collavre.example/provision.json", items: [] })
+    expect(manifest.textContent).toBe("")
   })
 
   test("submits provider credentials under a log-filtered parameter name", async () => {

--- a/engines/collavre/app/javascript/controllers/agent_connection_controller.js
+++ b/engines/collavre/app/javascript/controllers/agent_connection_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["engines", "provision", "session", "error"]
+  static targets = ["engines", "provision", "session", "error", "manifest"]
   static values = {
     statusUrl: String,
     sessionUrl: String,
@@ -17,6 +17,8 @@ export default class extends Controller {
     approve: String,
     revoke: String,
     error: String,
+    manifestUnregistered: String,
+    lastError: String,
     statusLabels: Object,
     itemTypeLabels: Object
   }
@@ -144,6 +146,7 @@ export default class extends Controller {
   }
 
   renderProvision(data) {
+    this.renderManifestState(data)
     const items = data.items || data.data || []
     const expected = [
       { type: "skill", name: "collavre" },
@@ -173,6 +176,26 @@ export default class extends Controller {
       row.append(actions)
       return row
     }))
+  }
+
+  // Why provisioning is not happening, which the per-item states cannot say:
+  // an unregistered manifest leaves every item at "not synced", and a manifest
+  // the proxy could not fetch or parse leaves them at their previous state.
+  // Both are repaired by "Sync now", so name the cause next to that button.
+  renderManifestState(data) {
+    if (!this.hasManifestTarget) return
+    const notice = document.createElement("div")
+    if (data.last_error) {
+      notice.className = "alert alert-danger"
+      notice.textContent = `${this.lastErrorValue}: ${data.last_error}`
+    } else if (!data.manifest_url) {
+      notice.className = "alert alert-warning"
+      notice.textContent = this.manifestUnregisteredValue
+    } else {
+      this.manifestTarget.replaceChildren()
+      return
+    }
+    this.manifestTarget.replaceChildren(notice)
   }
 
   provisionButton(label, action, item) {

--- a/engines/collavre/app/services/collavre/cli_proxy/client.rb
+++ b/engines/collavre/app/services/collavre/cli_proxy/client.rb
@@ -57,6 +57,14 @@ module Collavre
         request(:get, "/v1/provision")
       end
 
+      # Registers the workspace manifest URL and applies it, without a login.
+      # The login-carried provisioning_url does the same thing as a side effect
+      # of authenticating; this route is how an already-authenticated workspace
+      # gets (re)provisioned.
+      def provision_register_manifest(url)
+        request(:post, "/v1/provision/manifest", body: { url: url })
+      end
+
       def provision_sync
         request(:post, "/v1/provision/sync")
       end
@@ -97,7 +105,7 @@ module Collavre
             headers: headers
           )
         end
-        parsed = response.json
+        parsed = parse_body(response)
         return parsed || {} if response.success?
 
         error = parsed.is_a?(Hash) ? (parsed["error"] || parsed) : {}
@@ -107,12 +115,23 @@ module Collavre
           code: error["code"],
           details: parsed
         )
-      rescue JSON::ParserError => e
-        raise Error.new("Invalid JSON from CLI proxy", details: e.message)
       rescue Collavre::HttpClient::ConnectionError => e
         raise Error.new(e.message, code: "proxy_unreachable")
       rescue EndpointPolicy::UnsafeEndpoint
         raise Error.new(I18n.t("collavre.agent_gateways.unsafe_endpoint"), code: "unsafe_proxy_endpoint")
+      end
+
+      # A failure may answer with a non-JSON body: the proxy itself answers JSON
+      # throughout, but anything in front of it (a reverse proxy, a gateway
+      # error page) does not. Keep the HTTP status in that case so a caller can
+      # branch on it — a 404 is how an endpoint this proxy version lacks reports
+      # itself — instead of collapsing it into a status-less parse error.
+      def parse_body(response)
+        response.json
+      rescue JSON::ParserError => e
+        raise Error.new("Invalid JSON from CLI proxy", details: e.message) if response.success?
+
+        nil
       end
 
       def segment(value)

--- a/engines/collavre/app/views/collavre/agent_connections/show.html.erb
+++ b/engines/collavre/app/views/collavre/agent_connections/show.html.erb
@@ -21,6 +21,8 @@
      data-agent-connection-approve-value="<%= t('collavre.agent_connections.approve') %>"
      data-agent-connection-revoke-value="<%= t('collavre.agent_connections.revoke') %>"
      data-agent-connection-error-value="<%= t('collavre.agent_connections.error') %>"
+     data-agent-connection-manifest-unregistered-value="<%= t('collavre.agent_connections.manifest_unregistered') %>"
+     data-agent-connection-last-error-value="<%= t('collavre.agent_connections.last_error') %>"
      data-agent-connection-status-labels-value="<%= t('collavre.agent_connections.statuses').to_json %>"
      data-agent-connection-item-type-labels-value="<%= t('collavre.agent_connections.item_types').to_json %>">
   <section class="form-section">
@@ -41,6 +43,7 @@
       </div>
       <button type="button" class="btn btn-sm btn-primary" data-action="agent-connection#sync"><%= t("collavre.agent_connections.sync") %></button>
     </div>
+    <div data-agent-connection-target="manifest"></div>
     <table class="settings-table" style="width:100%">
       <thead><tr><th><%= t("collavre.agent_connections.item") %></th><th><%= t("collavre.agent_connections.kind") %></th><th><%= t("collavre.agent_connections.state") %></th><th><%= t("collavre.agent_connections.actions") %></th></tr></thead>
       <tbody data-agent-connection-target="provision">

--- a/engines/collavre/config/locales/agent_gateway.en.yml
+++ b/engines/collavre/config/locales/agent_gateway.en.yml
@@ -89,8 +89,10 @@ en:
       open_url: Open verification page
       error: CLI Proxy error
       provisioning: Provisioning
-      provisioning_help: Collavre always provisions one collavre-cli skill and one workspace-specific config containing the callback URL and token.
+      provisioning_help: Collavre always provisions one collavre-cli skill and one workspace-specific config containing the callback URL and token. "Sync now" re-registers this workspace's manifest first, so it also repairs provisioning that never ran or failed — no new login needed.
       sync: Sync now
+      manifest_unregistered: No manifest is registered with this workspace yet. Press "Sync now" to register it and provision.
+      last_error: Last provisioning error
       item: Item
       kind: Type
       state: Status

--- a/engines/collavre/config/locales/agent_gateway.ko.yml
+++ b/engines/collavre/config/locales/agent_gateway.ko.yml
@@ -89,8 +89,10 @@ ko:
       open_url: 인증 페이지 열기
       error: CLI Proxy 오류
       provisioning: 프로비저닝
-      provisioning_help: Collavre는 collavre-cli 스킬 하나와 callback URL·token이 든 워크스페이스 설정 하나를 항상 프로비저닝합니다.
+      provisioning_help: Collavre는 collavre-cli 스킬 하나와 callback URL·token이 든 워크스페이스 설정 하나를 항상 프로비저닝합니다. "지금 동기화"는 이 워크스페이스의 매니페스트를 먼저 다시 등록하므로, 프로비저닝이 안 됐거나 실패한 경우에도 다시 로그인하지 않고 복구합니다.
       sync: 지금 동기화
+      manifest_unregistered: 이 워크스페이스에 등록된 매니페스트가 아직 없습니다. "지금 동기화"를 누르면 등록하고 프로비저닝합니다.
+      last_error: 최근 프로비저닝 오류
       item: 항목
       kind: 유형
       state: 상태

--- a/engines/collavre/test/controllers/agent_connections_controller_test.rb
+++ b/engines/collavre/test/controllers/agent_connections_controller_test.rb
@@ -75,6 +75,70 @@ class AgentConnectionsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "설정", item_types.fetch("config")
   end
 
+  test "sync registers this workspace's manifest before applying it" do
+    registered = nil
+    fake_client = Object.new
+    fake_client.define_singleton_method(:provision_register_manifest) do |url|
+      registered = url
+      { "items" => [], "manifest_url" => url }
+    end
+    fake_client.define_singleton_method(:provision_sync) { flunk("must register before falling back to a plain sync") }
+    sign_in_as(@owner, password: "password")
+
+    Collavre::CliProxy::Client.stub(:new, fake_client) do
+      post collavre.agent_connection_provision_sync_path(user_id: @agent.id), as: :json
+    end
+
+    assert_response :success
+    workspace = Collavre::AgentWorkspace.find_by!(agent: @agent, user: @owner)
+    assert_equal(
+      "http://www.example.com/agents/#{@agent.id}/workspaces/#{workspace.manifest_token}/provision.json",
+      registered
+    )
+    assert_equal registered, response.parsed_body.fetch("manifest_url")
+  end
+
+  test "sync falls back to a plain sync when the proxy refuses to take a manifest url" do
+    [
+      Collavre::CliProxy::Client::Error.new("Manifest URL is pinned", status: 409, code: "manifest_url_locked"),
+      Collavre::CliProxy::Client::Error.new("Not found", status: 404, code: "not_found"),
+      Collavre::CliProxy::Client::Error.new("Not Found", status: 404)
+    ].each do |refusal|
+      fake_client = Object.new
+      fake_client.define_singleton_method(:provision_register_manifest) { |_url| raise refusal }
+      fake_client.define_singleton_method(:provision_sync) { { "items" => [], "synced" => true } }
+      sign_in_as(@owner, password: "password")
+
+      Collavre::CliProxy::Client.stub(:new, fake_client) do
+        post collavre.agent_connection_provision_sync_path(user_id: @agent.id), as: :json
+      end
+
+      assert_response :success
+      assert response.parsed_body.fetch("synced"), "expected #{refusal.code || refusal.status} to fall back"
+    end
+  end
+
+  test "sync surfaces a registration failure a plain sync cannot answer differently" do
+    [
+      [ Collavre::CliProxy::Client::Error.new("Manifest fetch failed", status: 502, code: "manifest_fetch_failed"),
+        :bad_gateway ],
+      [ Collavre::CliProxy::Client::Error.new("Provisioning is disabled", status: 404, code: "provisioning_disabled"),
+        :not_found ]
+    ].each do |failure, expected_status|
+      fake_client = Object.new
+      fake_client.define_singleton_method(:provision_register_manifest) { |_url| raise failure }
+      fake_client.define_singleton_method(:provision_sync) { flunk("#{failure.code} must not be retried as a plain sync") }
+      sign_in_as(@owner, password: "password")
+
+      Collavre::CliProxy::Client.stub(:new, fake_client) do
+        post collavre.agent_connection_provision_sync_path(user_id: @agent.id), as: :json
+      end
+
+      assert_response expected_status
+      assert_equal failure.code, response.parsed_body.dig("error", "code")
+    end
+  end
+
   test "authentication submission uses a filtered secret parameter" do
     credential = "provider-secret-that-must-not-be-logged"
     received = nil

--- a/engines/collavre/test/services/cli_proxy_client_test.rb
+++ b/engines/collavre/test/services/cli_proxy_client_test.rb
@@ -89,6 +89,62 @@ class CliProxyClientTest < ActiveSupport::TestCase
     assert_nil request.dig(:headers, "X-CLI-Proxy-User-ID")
   end
 
+  test "registers a manifest url so provisioning can be repaired without a login" do
+    gateway = Struct.new(:admin_key) do
+      def proxy_path(path)
+        "https://proxy.example.com#{path}"
+      end
+    end.new("admin-secret")
+    response = FakeResponse.new(code: 200, message: "OK", payload: { "items" => [] }, successful: true)
+    http = FakeHttpClient.new(response)
+
+    Collavre::CliProxy::Client.new(gateway: gateway, http_client: http)
+                              .provision_register_manifest("https://collavre.example/provision.json")
+
+    request = http.requests.fetch(0)
+    assert_equal :post, request.fetch(:method)
+    assert_equal "https://proxy.example.com/v1/provision/manifest", request.fetch(:url)
+    assert_equal(
+      { "url" => "https://collavre.example/provision.json" },
+      JSON.parse(request.fetch(:body))
+    )
+  end
+
+  test "keeps the status of a failure whose body is not json" do
+    gateway = Struct.new(:admin_key) do
+      def proxy_path(path)
+        "https://proxy.example.com#{path}"
+      end
+    end.new("admin-secret")
+    response = FakeResponse.new(code: 404, message: "Not Found", payload: nil, successful: false)
+    response.define_singleton_method(:json) { raise JSON::ParserError, "unexpected token at '<html>'" }
+
+    error = assert_raises(Collavre::CliProxy::Client::Error) do
+      Collavre::CliProxy::Client.new(gateway: gateway, http_client: FakeHttpClient.new(response))
+                                .provision_register_manifest("https://collavre.example/provision.json")
+    end
+
+    assert_equal 404, error.status
+    assert_nil error.code
+    assert_equal "Not Found", error.message
+  end
+
+  test "still reports an unparsable success body as an error" do
+    gateway = Struct.new(:admin_key) do
+      def proxy_path(path)
+        "https://proxy.example.com#{path}"
+      end
+    end.new("admin-secret")
+    response = FakeResponse.new(code: 200, message: "OK", payload: nil, successful: true)
+    response.define_singleton_method(:json) { raise JSON::ParserError, "unexpected token at '<html>'" }
+
+    error = assert_raises(Collavre::CliProxy::Client::Error) do
+      Collavre::CliProxy::Client.new(gateway: gateway, http_client: FakeHttpClient.new(response)).provision_status
+    end
+
+    assert_equal "Invalid JSON from CLI proxy", error.message
+  end
+
   test "maps blocked regular-user endpoints without making a request" do
     owner = users(:two)
     gateway = Collavre::AgentGateway.create!(


### PR DESCRIPTION
## Problem

A manifest URL only reached the proxy as a side effect of a provider login — it travelled on the auth session as `provisioning_url`. So when provisioning had never run, or had failed, the agent connection screen offered no way forward: **Sync now** answered with an empty item list (every row "not synced") and the only actual repair was logging the engine in again, purely to carry a URL.

## Change

**Sync now** now calls `POST /v1/provision/manifest` (cli-openai-proxy #42), registering the server-derived manifest URL for this workspace and applying it in the same call. Manual provisioning can therefore be redone from scratch at any time, without touching authentication.

- `CliProxy::Client#provision_register_manifest` — the new endpoint.
- `AgentConnectionsController#provision_sync` — register, then fall back to a plain `POST /v1/provision/sync` for the two answers that mean the proxy will not take a URL from us at all: a workspace pinned with `PROVISION_MANIFEST_URL` (`409 manifest_url_locked`) and a proxy predating the endpoint (`404`). `404 provisioning_disabled` is surfaced instead, since a plain sync would only repeat it.
- The client keeps the HTTP status of a failure whose body is not JSON, so that `404` is distinguishable rather than collapsing into a parse error.
- The provisioning card names why it is stalled — an unregistered manifest, or the proxy's `last_error` — next to the button that fixes it.

Registration is idempotent (re-registering the same URL is a plain re-sync), so the button keeps its previous meaning for a healthy workspace. The admin key stays server-side and the manifest URL is always derived server-side; a client cannot choose it.

## Verification

- `agent_connections_controller_test.rb`, `cli_proxy_client_test.rb`, `agent_provisioning_controller_test.rb` — 21 runs, 115 assertions, 0 failures. Jest `agent_connection_controller.test.js` — 4 passed. RuboCop clean over `engines/collavre`.
- Against a real proxy built from cli-openai-proxy `main` (isolated `HOME`, `PROVISION_SYNC=1`), with a never-authenticated agent:
  - register + sync from an unregistered state → `skill:collavre` and `config:collavre` both `pending_approval`, then `installed` after approval, with the files actually on disk (`~/.claude/skills/collavre/`, `~/.config/collavre/config.json` at `0600`).
  - re-registering the same URL → plain re-sync, no reinstall.
  - callback-token rotation → config `sha256` changes and reinstalls without another approval.
  - a proxy started with `PROVISION_MANIFEST_URL` → `manifest_url_locked`, i.e. the fallback branch is reached by the real refusal.