### PR TITLE
fix: compare the skill archive against the skill it packages

### DIFF
--- a/engines/collavre/test/services/agent_provisioning_archive_test.rb
+++ b/engines/collavre/test/services/agent_provisioning_archive_test.rb
@@ -7,7 +7,7 @@ class AgentProvisioningArchiveTest < ActiveSupport::TestCase
     first = Collavre::AgentProvisioning::Archive.collavre_skill
     second = Collavre::AgentProvisioning::Archive.send(
       :build_from_directory,
-      Rails.root.join("skills/collavre")
+      Collavre::Engine.root.join("skills/collavre")
     )
 
     assert_equal first, second
@@ -15,6 +15,18 @@ class AgentProvisioningArchiveTest < ActiveSupport::TestCase
     assert_includes entries.keys, "SKILL.md"
     assert_includes entries.keys, "scripts/collavre"
     assert_includes entries.fetch("SKILL.md"), "Manage Collavre Creatives"
+  end
+
+  test "the repository skill copy matches the packaged skill" do
+    packaged = Collavre::Engine.root.join("skills/collavre")
+    repository = Rails.root.join("skills/collavre")
+
+    assert_equal(
+      skill_tree(packaged),
+      skill_tree(repository),
+      "skills/collavre and engines/collavre/skills/collavre have drifted. " \
+      "The engine copy is the one provisioned to agents — copy it over the repository copy."
+    )
   end
 
   test "engine gem packages the provisioning skill" do
@@ -69,6 +81,12 @@ class AgentProvisioningArchiveTest < ActiveSupport::TestCase
   end
 
   private
+
+  def skill_tree(root)
+    Pathname.glob(root.join("**/*")).select(&:file?).to_h do |path|
+      [ path.relative_path_from(root).to_s, path.read ]
+    end
+  end
 
   def archive_entries(bytes)
     gzip = Zlib::GzipReader.new(StringIO.new(bytes))

--- a/skills/collavre/scripts/collavre
+++ b/skills/collavre/scripts/collavre
@@ -7,6 +7,7 @@ import path from "node:path";
 import https from "node:https";
 import http from "node:http";
 import os from "node:os";
+import { randomBytes } from "node:crypto";
 import { decodeHtmlEntities } from "./html_entities.js";
 
 const CONFIG_DIR = path.join(
@@ -26,8 +27,26 @@ function loadConfig() {
 }
 
 function saveConfig(config) {
-  fs.mkdirSync(CONFIG_DIR, { recursive: true });
-  fs.writeFileSync(CONFIG_FILE, JSON.stringify(config, null, 2));
+  fs.mkdirSync(CONFIG_DIR, { recursive: true, mode: 0o700 });
+  fs.chmodSync(CONFIG_DIR, 0o700);
+
+  const temporaryFile = path.join(
+    CONFIG_DIR,
+    `.config.json.${process.pid}.${randomBytes(8).toString("hex")}.tmp`
+  );
+  let descriptor;
+  try {
+    descriptor = fs.openSync(temporaryFile, "wx", 0o600);
+    fs.fchmodSync(descriptor, 0o600);
+    fs.writeFileSync(descriptor, JSON.stringify(config, null, 2), "utf8");
+    fs.fsyncSync(descriptor);
+    fs.closeSync(descriptor);
+    descriptor = undefined;
+    fs.renameSync(temporaryFile, CONFIG_FILE);
+  } finally {
+    if (descriptor !== undefined) fs.closeSync(descriptor);
+    if (fs.existsSync(temporaryFile)) fs.unlinkSync(temporaryFile);
+  }
 }
 
 // --- MCP SSE Client ---


### PR DESCRIPTION
`main` has been red since #1507: `AgentProvisioningArchiveTest#test_skill_archive_is_deterministic_and_contains_the_Collavre_skill` fails on every branch, including open PRs that never touch provisioning (#1513).

## What was wrong

The test builds the archive twice and asserts the bytes match. But `Archive.collavre_skill` builds from `Collavre::Engine.root.join("skills/collavre")` — the copy the gemspec packages and the proxy installs — while the test's second build read `Rails.root.join("skills/collavre")`, the older repository copy. So it never tested reproducibility; it tested that two directories happen to hold identical bytes.

#1507 hardened `saveConfig` in the packaged copy (atomic write, `0600` file, `0700` directory) and left the repository copy on the old `writeFileSync`. The assertion had nothing left to stand on.

## What this changes

- The second build reads the packaged directory, so the test asserts the determinism it names.
- That accidental cross-copy check was catching something real — nothing syncs the two trees — so a dedicated test compares them and names the packaged copy as the one that wins.
- The repository copy takes the atomic `0600` config write. It was writing agent credentials at the process umask.

## Verification

- `bin/rails test engines/collavre/test/services/agent_provisioning_archive_test.rb engines/collavre/test/skills/collavre_cli_test.rb` — 7 runs, 41 assertions, 0 failures (fails on `main` before the change).
- Appended a line to the repository copy and confirmed the new test fails with the message naming which copy to copy from.
- RuboCop clean.