### PR TITLE
fix: isolate navigation registry tests

### DIFF
--- a/engines/collavre/test/lib/navigation/registry_test.rb
+++ b/engines/collavre/test/lib/navigation/registry_test.rb
@@ -143,6 +143,13 @@ class Navigation::RegistryTest < ActiveSupport::TestCase
     assert_empty @registry.all
   end
 
+  test "suite guard restores initializer items before reporting a leak" do
+    error = assert_raises(RuntimeError) { NavigationRegistryTestGuard.verify! }
+
+    assert_match(/was left empty/, error.message)
+    assert_not_empty @registry.all
+  end
+
   test "find returns item by key" do
     @registry.register(key: :test_item, label: "Test")
 

--- a/engines/collavre/test/lib/navigation/registry_test.rb
+++ b/engines/collavre/test/lib/navigation/registry_test.rb
@@ -3,13 +3,18 @@
 require "test_helper"
 
 class Navigation::RegistryTest < ActiveSupport::TestCase
+  # The registry is a process-wide singleton seeded by the engine initializer,
+  # so resetting it without putting the engine's items back leaves every later
+  # test in the process with an empty GNB.
   setup do
     @registry = Navigation::Registry.instance
+    @registry_snapshot = @registry.all
     @registry.reset!
   end
 
   teardown do
     @registry.reset!
+    @registry_snapshot.each { |item| @registry.register(item) }
   end
 
   test "register adds a navigation item" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -43,6 +43,21 @@ module ActiveSupport
       # Rebuild the closure tree for Creatives fixture
       Creative.rebuild! if defined?(Creative)
     end
+
+    # The navigation registry is a process-wide singleton seeded once by the
+    # engine initializer. A test that resets it without restoring leaves every
+    # later test in the same process rendering an empty GNB, which surfaces as
+    # unrelated view assertions failing under some seeds. Fail on the test that
+    # emptied it instead of on its victims.
+    # Raises rather than asserts so the guard does not add an assertion to every
+    # test in the suite, which would hide the "missing assertions" reporter.
+    teardown do
+      next unless defined?(Navigation::Registry)
+      next if Navigation::Registry.instance.all.any?
+
+      raise("Navigation::Registry was left empty by this test. " \
+      "Snapshot it with `.all` in setup and re-register the items in teardown.")
+    end
   end
 end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,6 +11,19 @@ require "minitest/mock"
 # Engine route set only; app route host stays unset (OpenRedirect guard).
 Collavre::Engine.routes.default_url_options[:host] ||= "www.example.com"
 
+module NavigationRegistryTestGuard
+  INITIAL_ITEMS = Navigation::Registry.instance.all.map(&:deep_dup).freeze
+
+  def self.verify!
+    registry = Navigation::Registry.instance
+    return if registry.all.any?
+
+    INITIAL_ITEMS.each { |item| registry.register(item.deep_dup) }
+    raise("Navigation::Registry was left empty by this test. " \
+    "Snapshot it with `.all` in setup and re-register the items in teardown.")
+  end
+end
+
 # Add engines test directories to the test runner
 # Note: We do not auto-load engine tests here to avoid running them during targeted app tests.
 # Use `rails test engines/` or `rake test:engines` to run engine tests.
@@ -52,11 +65,7 @@ module ActiveSupport
     # Raises rather than asserts so the guard does not add an assertion to every
     # test in the suite, which would hide the "missing assertions" reporter.
     teardown do
-      next unless defined?(Navigation::Registry)
-      next if Navigation::Registry.instance.all.any?
-
-      raise("Navigation::Registry was left empty by this test. " \
-      "Snapshot it with `.all` in setup and re-register the items in teardown.")
+      NavigationRegistryTestGuard.verify!
     end
   end
 end


### PR DESCRIPTION
## Summary

- restore the process-wide navigation registry after each registry unit test
- restore the initializer snapshot and fail immediately when any test leaves the navigation registry empty

## Root cause

`Navigation::RegistryTest` reset the engine-seeded singleton in teardown without restoring its original items. Depending on the randomized suite order, later integration tests rendered an empty GNB and reported unrelated missing filter-control elements.

## Impact

The Ruby test suite no longer depends on whether the navigation registry tests run before view and integration tests. Future registry leaks will be repaired and reported at their source so they do not cascade into unrelated failures.

## Validation

- `mise exec -- bin/rails test engines/collavre/test/lib/navigation/registry_test.rb engines/collavre/test/integration/creative_filter_navigation_test.rb --seed 5984` (28 runs, 96 assertions, 0 failures)
- `mise exec -- bundle exec rubocop engines/collavre/test/lib/navigation/registry_test.rb test/test_helper.rb`
- `mise exec -- bundle exec rake test` (3865 runs, 13108 assertions, 0 failures)
