### PR TITLE
feat: show the workspace tree as a drawer at one-panel widths

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/workspace.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/workspace.css
@@ -197,7 +197,13 @@ body.creative-workspace .creative-content {
     .creative-workspace-shell:has(#comments-popup.docked-collapsed) {
         grid-template-columns: minmax(0, 1fr) 3rem;
     }
+}
 
+/* Below the three-column breakpoint the tree gives up its own column and
+   becomes an off-canvas drawer with a toggle handle. Shared by the two-panel
+   band and the one-panel (mobile) band so both collapse the same way — and so
+   the tree stays mounted in both, preserving its expansion state. */
+@media (max-width: 1279px) {
     .creative-workspace-tree-region {
         position: fixed;
         top: 0;
@@ -261,8 +267,12 @@ body.creative-workspace .creative-content {
         max-width: var(--max-width);
     }
 
-    .creative-workspace-tree-region {
-        display: none;
+    /* In the two-panel band the handle's default offset lands in the left
+       gutter main leaves itself. One-panel main runs flush to the edge, so the
+       same offset would sit on top of the breadcrumb row — park the handle in
+       the nav's empty left corner instead, where it reads as the menu button
+       it effectively is. */
+    .creative-workspace-tree-toggle {
+        top: var(--space-3);
     }
-
 }

--- a/engines/collavre/test/system/workspace_tree_drawer_test.rb
+++ b/engines/collavre/test/system/workspace_tree_drawer_test.rb
@@ -1,0 +1,136 @@
+require_relative "../application_system_test_case"
+
+# Below 1280px the workspace tree gives up its own grid column and becomes an
+# off-canvas drawer behind a toggle handle. That used to apply only to the
+# two-panel band (768-1279px); at one-panel widths the tree was `display: none`,
+# so mobile users had no way to reach it at all. Both bands now share the same
+# drawer rules — these lock that in at a mobile width and at the two-panel width
+# that already worked.
+class WorkspaceTreeDrawerTest < ApplicationSystemTestCase
+  MOBILE_WIDTH = 430
+  TWO_PANEL_WIDTH = 1000
+  THREE_PANEL_WIDTH = 1400
+
+  setup do
+    @user = User.create!(
+      email: "tree-drawer@example.com",
+      password: SystemHelpers::PASSWORD,
+      name: "Tree Drawer",
+      email_verified_at: Time.current,
+      notifications_enabled: false,
+      creative_workspace_enabled: true
+    )
+    # The tree only renders branch nodes, so "Root child" needs its own child to
+    # show up under "Root creative" when the branch is expanded.
+    @creative = Creative.create!(description: "Root creative", user: @user)
+    @child = Creative.create!(description: "Root child", user: @user, parent: @creative)
+    Creative.create!(description: "Leaf", user: @user, parent: @child)
+
+    resize_window_to
+    sign_in_via_ui(@user)
+  end
+
+  [ MOBILE_WIDTH, TWO_PANEL_WIDTH ].each do |width|
+    test "the tree collapses to a reachable drawer at #{width}px" do
+      visit_workspace(width)
+
+      # Closed: slid off-canvas and hidden from the tab order, but still mounted.
+      assert_selector ".creative-workspace-tree-region", visible: :all
+      assert_no_selector ".creative-workspace-tree-link", text: "Root creative"
+      assert_equal "fixed", computed_style(".creative-workspace-tree-region", "position")
+
+      toggle = find(".creative-workspace-tree-toggle")
+      assert toggle.visible?, "the drawer toggle is not reachable at #{width}px"
+      assert_toggle_within_viewport
+
+      toggle.click
+
+      assert_selector ".creative-workspace-tree-region.is-open"
+      assert_selector ".creative-workspace-tree-link", text: "Root creative", wait: 10
+      assert_toggle_within_viewport "the toggle must stay on screen while open so the drawer can be closed"
+    end
+
+    test "the drawer keeps its expansion state across close and reopen at #{width}px" do
+      visit_workspace(width)
+      find(".creative-workspace-tree-toggle").click
+      assert_selector ".creative-workspace-tree-link", text: "Root creative", wait: 10
+
+      find(".creative-workspace-tree-branch-toggle").click
+      assert_selector ".creative-workspace-tree-link", text: "Root child", wait: 10
+
+      find(".creative-workspace-tree-toggle").click
+      assert_no_selector ".creative-workspace-tree-region.is-open"
+      find(".creative-workspace-tree-toggle").click
+
+      assert_selector ".creative-workspace-tree-region.is-open"
+      assert_selector ".creative-workspace-tree-link", text: "Root child", wait: 10
+    end
+  end
+
+  # The handle is a fixed overlay. In the two-panel band it lands in the gutter
+  # main leaves itself, but one-panel main runs flush to the left edge, so the
+  # same offset would sit on top of the breadcrumb row and eat taps meant for it.
+  [ MOBILE_WIDTH, TWO_PANEL_WIDTH ].each do |width|
+    test "the closed drawer handle covers no control in the content column at #{width}px" do
+      visit_workspace(width)
+      assert_selector ".creative-workspace-tree-toggle"
+
+      covered = page.evaluate_script(<<~JS)
+        (function () {
+          var handle = document.querySelector('.creative-workspace-tree-toggle').getBoundingClientRect();
+          var controls = document.querySelectorAll('main a, main button, main input, main [role="button"]');
+          return Array.prototype.filter.call(controls, function (control) {
+            var rect = control.getBoundingClientRect();
+            if (rect.width === 0 || rect.height === 0) return false;
+            return rect.left < handle.right && rect.right > handle.left &&
+                   rect.top < handle.bottom && rect.bottom > handle.top;
+          }).map(function (control) {
+            return (control.textContent || control.getAttribute('aria-label') || control.tagName).trim();
+          });
+        })();
+      JS
+
+      assert_empty covered, "the drawer handle overlaps content controls: #{covered.inspect}"
+    end
+  end
+
+  test "the tree keeps its own column and hides the toggle at three-panel width" do
+    visit_workspace(THREE_PANEL_WIDTH)
+
+    assert_selector ".creative-workspace-tree-link", text: "Root creative", wait: 10
+    assert_equal "static", computed_style(".creative-workspace-tree-region", "position")
+    assert_equal "none", computed_style(".creative-workspace-tree-toggle", "display")
+  end
+
+  private
+
+  def visit_workspace(width)
+    resize_window_to(width, 800)
+    visit collavre.creatives_path
+    assert_selector ".creative-workspace-shell"
+  end
+
+  def computed_style(selector, property)
+    page.evaluate_script(<<~JS)
+      getComputedStyle(document.querySelector(#{selector.to_json})).getPropertyValue(#{property.to_json});
+    JS
+  end
+
+  # `visible?` only proves the element is painted, not that a tap would land on
+  # it — a drawer handle parked past the edge of a narrow viewport is dead. Hit
+  # testing its centre point is the assertion that actually means "tappable".
+  def assert_toggle_within_viewport(message = nil)
+    hit = page.evaluate_script(<<~JS)
+      (function () {
+        var toggle = document.querySelector('.creative-workspace-tree-toggle');
+        var rect = toggle.getBoundingClientRect();
+        var x = rect.left + rect.width / 2;
+        var y = rect.top + rect.height / 2;
+        if (x < 0 || y < 0 || x > window.innerWidth || y > window.innerHeight) return false;
+        return toggle.contains(document.elementFromPoint(x, y));
+      })();
+    JS
+
+    assert hit, message || "the drawer toggle is not tappable — its centre is off screen or covered"
+  end
+end


### PR DESCRIPTION
## Problem

Below 1280px the workspace tree gives up its own grid column, but only the
two-panel band (768-1279px) turned it into an off-canvas drawer with a toggle
handle. At one-panel widths `.creative-workspace-tree-region` was
`display: none`, so the tree was unreachable — even though the Stimulus
controller still mounted and still fetched the tree JSON on every page load.

## Change

Lift the drawer rules out of the `768px-1279px` media query into a shared
`max-width: 1279px` block. The two-panel query keeps only what is genuinely
two-panel-specific (the grid template and column assignments).

Both bands now collapse the tree the same way and keep it mounted, so the
expansion set, scroll position and turbo-stream subscription survive being
hidden — the state preservation that already worked at two-panel widths now
works at one-panel widths for free.

One offset has to differ. The handle's default `top: 5rem` lands in the left
gutter that two-panel `main` leaves itself, but one-panel `main` runs flush to
the left edge, so the same offset sat on top of the "Top" breadcrumb link and
ate taps meant for it. At one-panel widths the handle moves into the nav's
empty left corner, where it reads as the menu button it effectively is.

Net diff: one `display: none` rule removed, one media query split, one
offset override added.

## Tests

New `engines/collavre/test/system/workspace_tree_drawer_test.rb`, parameterised
over a mobile width (430px) and a two-panel width (1000px):

- the tree collapses to a reachable drawer, and the handle is hit-tested
  (`elementFromPoint`) as tappable both closed and open — `visible?` alone
  would pass on a handle parked off the viewport edge
- expansion state survives close and reopen
- the closed handle overlaps no control inside `main`
- at three-panel width the tree keeps its own column and the handle stays hidden

Verified red-then-green: on the pre-change CSS the 430px cases fail
(`position` is `static`, no handle) while the 1000px cases pass; the overlap
assertion independently fails at 430px with `["Top"]` if the handle keeps its
two-panel offset.

```
7 runs, 49 assertions, 0 failures, 0 errors, 0 skips
```

Also green: `creative_filter_navigation_test`,
`creative_empty_state_typography_test` (10 runs), the
`workspace_tree_controller` jest suite (34 tests), and rubocop.