### PR TITLE
Fix mobile workspace tree drawer layering and icons

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/workspace.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/workspace.css
@@ -258,6 +258,13 @@ body.creative-workspace .creative-content {
         overflow: visible;
     }
 
+    /* The floating chat is rendered after the tree in the workspace shell and
+       uses the modal layer. Keep the opened tree above it so its rows remain
+       visible and tappable on one-panel screens. */
+    .creative-workspace-tree-region {
+	z-index: calc(var(--layer-modal) + 1);
+    }
+
     .creative-workspace-shell {
         display: block;
     }

--- a/engines/collavre/app/javascript/components/__tests__/creative_tree_row_parent_id.test.js
+++ b/engines/collavre/app/javascript/components/__tests__/creative_tree_row_parent_id.test.js
@@ -41,6 +41,17 @@ afterEach(() => {
 });
 
 describe("creative-tree-row parentId convention", () => {
+  test("uses the shared chevrons for collapsed and expanded branches", async () => {
+    const el = await mountRow({ creativeId: "8", hasChildren: true, expanded: true });
+
+    expect(el.querySelector(".creative-toggle-btn path").getAttribute("d")).toBe("M6 9L12 15L18 9");
+
+    el.expanded = false;
+    await el.updateComplete;
+
+    expect(el.querySelector(".creative-toggle-btn path").getAttribute("d")).toBe("M9 6L15 12L9 18");
+  });
+
   test("non-title row under a page-title parent keeps the parent id", async () => {
     const el = await mountRow({ creativeId: "8", parentId: "5", level: 2 });
     const tree = treeOf(el);

--- a/engines/collavre/app/javascript/components/creative_tree_row.js
+++ b/engines/collavre/app/javascript/components/creative_tree_row.js
@@ -1,5 +1,6 @@
-import { LitElement, html, svg, nothing } from "lit";
+import { LitElement, html, nothing } from "lit";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
+import { CHEVRON_COLLAPSED, CHEVRON_EXPANDED } from "../utils/chevron_icons";
 import { parseEmojis } from "../utils/emoji_parser";
 import { highlightCodeBlocks } from "../lib/utils/markdown";
 import { addCreativeTableDownloadButtons } from "../lib/utils/table_download";
@@ -485,14 +486,7 @@ class CreativeTreeRow extends LitElement {
   }
 
   _toggleIcon() {
-    if (this.expanded) {
-      return svg`<svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-        <path d="M6 9L12 15L18 9"/>
-      </svg>`;
-    }
-    return svg`<svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-      <path d="M9 6L15 12L9 18"/>
-    </svg>`;
+    return unsafeHTML(this.expanded ? CHEVRON_EXPANDED : CHEVRON_COLLAPSED);
   }
 
   _handleToggleClick(event) {

--- a/engines/collavre/app/javascript/controllers/__tests__/workspace_tree_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/workspace_tree_controller.test.js
@@ -86,6 +86,7 @@ describe('WorkspaceTreeController', () => {
     expect(document.querySelector('[data-creative-id="2"] a').dataset.turboFrame).toBe('creative-workspace-content')
     expect(document.querySelector('[data-creative-id="2"] a').dataset.turboAction).toBe('advance')
     expect(document.querySelector('.creative-workspace-tree-branch-toggle').getAttribute('aria-label')).toBe('Root')
+    expect(document.querySelector('.creative-workspace-tree-branch-toggle svg path').getAttribute('d')).toBe('M6 9L12 15L18 9')
   })
 
   test('lazily reloads toggled branches and restores focus and scroll', async () => {
@@ -97,6 +98,7 @@ describe('WorkspaceTreeController', () => {
     expect(document.querySelector('[data-creative-id="1"] > ul')).toBeNull()
     branchToggle = document.querySelector('.creative-workspace-tree-branch-toggle')
     expect(branchToggle.getAttribute('aria-expanded')).toBe('false')
+    expect(branchToggle.querySelector('svg path').getAttribute('d')).toBe('M9 6L15 12L9 18')
     expect(document.activeElement).toBe(branchToggle)
     expect(controller.treeTarget.scrollTop).toBe(24)
     let requestUrl = fetchMock.mock.calls[1][0]
@@ -107,6 +109,7 @@ describe('WorkspaceTreeController', () => {
     branchToggle = document.querySelector('.creative-workspace-tree-branch-toggle')
     expect(document.querySelector('[data-creative-id="1"] > ul')).not.toBeNull()
     expect(branchToggle.getAttribute('aria-expanded')).toBe('true')
+    expect(branchToggle.querySelector('svg path').getAttribute('d')).toBe('M6 9L12 15L18 9')
     expect(document.activeElement).toBe(branchToggle)
     requestUrl = fetchMock.mock.calls[2][0]
     expect(new URL(requestUrl, window.location.origin).searchParams.getAll('expand[]')).toEqual(['2', '3', '1'])

--- a/engines/collavre/app/javascript/controllers/link_creative_controller.js
+++ b/engines/collavre/app/javascript/controllers/link_creative_controller.js
@@ -1,16 +1,10 @@
 import CommonPopupController from './common_popup_controller'
 import creativesApi from '../lib/api/creatives'
+import { CHEVRON_COLLAPSED, CHEVRON_EXPANDED } from '../utils/chevron_icons'
 
 // Minimum characters before a text search fires. Below this the popup shows the
 // browsable mini-tree instead (empty input => tree, >= MIN_QUERY chars => search).
 const MIN_QUERY = 2
-
-// Chevron icons matched to the main creative tree (creative_tree_row.js#_toggleIcon)
-// so the mini-tree expand/collapse affordance is visually identical.
-const CHEVRON_COLLAPSED =
-    '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 6L15 12L9 18"/></svg>'
-const CHEVRON_EXPANDED =
-    '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 9L12 15L18 9"/></svg>'
 
 export default class extends CommonPopupController {
     static targets = ['input', 'list', 'close']

--- a/engines/collavre/app/javascript/controllers/workspace_tree_controller.js
+++ b/engines/collavre/app/javascript/controllers/workspace_tree_controller.js
@@ -7,6 +7,13 @@ import { Controller } from '@hotwired/stimulus'
 let lastVisitAction = null
 const MAX_EXPANDED_BRANCHES = 100
 
+// Keep the workspace tree's branch affordance visually aligned with the
+// central creative tree (components/creative_tree_row.js#_toggleIcon).
+const CHEVRON_COLLAPSED =
+  '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9 6L15 12L9 18"/></svg>'
+const CHEVRON_EXPANDED =
+  '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M6 9L12 15L18 9"/></svg>'
+
 export default class extends Controller {
   static targets = ['tree', 'panelToggle']
 
@@ -153,7 +160,7 @@ export default class extends Controller {
       toggle.className = 'creative-workspace-tree-branch-toggle'
       toggle.setAttribute('aria-expanded', String(expanded))
       toggle.setAttribute('aria-label', node.label)
-      toggle.textContent = expanded ? '▾' : '▸'
+      toggle.innerHTML = expanded ? CHEVRON_EXPANDED : CHEVRON_COLLAPSED
       toggle.addEventListener('click', () => this.toggleBranch(item, toggle))
       row.appendChild(toggle)
     } else {

--- a/engines/collavre/app/javascript/controllers/workspace_tree_controller.js
+++ b/engines/collavre/app/javascript/controllers/workspace_tree_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from '@hotwired/stimulus'
+import { CHEVRON_COLLAPSED, CHEVRON_EXPANDED } from '../utils/chevron_icons'
 
 // Module-scoped: a history restore replaces the whole body, swapping this
 // controller's instance mid-visit. The instance that observes turbo:visit is
@@ -6,13 +7,6 @@ import { Controller } from '@hotwired/stimulus'
 // visit action must outlive any single instance.
 let lastVisitAction = null
 const MAX_EXPANDED_BRANCHES = 100
-
-// Keep the workspace tree's branch affordance visually aligned with the
-// central creative tree (components/creative_tree_row.js#_toggleIcon).
-const CHEVRON_COLLAPSED =
-  '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9 6L15 12L9 18"/></svg>'
-const CHEVRON_EXPANDED =
-  '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M6 9L12 15L18 9"/></svg>'
 
 export default class extends Controller {
   static targets = ['tree', 'panelToggle']

--- a/engines/collavre/app/javascript/utils/__tests__/chevron_icons.test.js
+++ b/engines/collavre/app/javascript/utils/__tests__/chevron_icons.test.js
@@ -1,0 +1,15 @@
+import { CHEVRON_COLLAPSED, CHEVRON_EXPANDED } from '../chevron_icons'
+
+describe('tree chevron icons', () => {
+  test('shares consistent SVG attributes and the expected toggle directions', () => {
+    const collapsed = document.createElement('template')
+    collapsed.innerHTML = CHEVRON_COLLAPSED
+    const expanded = document.createElement('template')
+    expanded.innerHTML = CHEVRON_EXPANDED
+
+    expect(collapsed.content.querySelector('svg').getAttribute('aria-hidden')).toBe('true')
+    expect(collapsed.content.querySelector('path').getAttribute('d')).toBe('M9 6L15 12L9 18')
+    expect(expanded.content.querySelector('svg').getAttribute('aria-hidden')).toBe('true')
+    expect(expanded.content.querySelector('path').getAttribute('d')).toBe('M6 9L12 15L18 9')
+  })
+})

--- a/engines/collavre/app/javascript/utils/chevron_icons.js
+++ b/engines/collavre/app/javascript/utils/chevron_icons.js
@@ -1,0 +1,7 @@
+const CHEVRON_ATTRIBUTES =
+  'width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"'
+
+export const CHEVRON_COLLAPSED =
+  `<svg ${CHEVRON_ATTRIBUTES}><path d="M9 6L15 12L9 18"/></svg>`
+export const CHEVRON_EXPANDED =
+  `<svg ${CHEVRON_ATTRIBUTES}><path d="M6 9L12 15L18 9"/></svg>`

--- a/engines/collavre/test/system/workspace_tree_drawer_test.rb
+++ b/engines/collavre/test/system/workspace_tree_drawer_test.rb
@@ -67,6 +67,22 @@ class WorkspaceTreeDrawerTest < ApplicationSystemTestCase
     end
   end
 
+  test "the opened tree stays above the floating chat at mobile width" do
+    visit_workspace(MOBILE_WIDTH)
+    find(".creative-workspace-tree-toggle").click
+    assert_selector ".creative-workspace-tree-region.is-open"
+
+    # The docked chat is normally closed below 768px. Show it at its mobile
+    # position to exercise the exact overlap that previously hid the drawer.
+    page.execute_script(<<~JS)
+      var popup = document.querySelector('#comments-popup');
+      popup.style.display = 'flex';
+      popup.classList.add('open');
+    JS
+
+    assert_tree_covers_floating_chat
+  end
+
   # The handle is a fixed overlay. In the two-panel band it lands in the gutter
   # main leaves itself, but one-panel main runs flush to the left edge, so the
   # same offset would sit on top of the breadcrumb row and eat taps meant for it.
@@ -132,5 +148,26 @@ class WorkspaceTreeDrawerTest < ApplicationSystemTestCase
     JS
 
     assert hit, message || "the drawer toggle is not tappable — its centre is off screen or covered"
+  end
+
+  def assert_tree_covers_floating_chat
+    covered_by_tree = page.evaluate_script(<<~JS)
+      (function () {
+	var tree = document.querySelector('.creative-workspace-tree-region');
+	var popup = document.querySelector('#comments-popup');
+	var treeRect = tree.getBoundingClientRect();
+	var popupRect = popup.getBoundingClientRect();
+	var left = Math.max(treeRect.left, popupRect.left);
+	var right = Math.min(treeRect.right, popupRect.right);
+	var top = Math.max(treeRect.top, popupRect.top);
+	var bottom = Math.min(treeRect.bottom, popupRect.bottom);
+	if (right <= left || bottom <= top) return false;
+
+	var target = document.elementFromPoint((left + right) / 2, (top + bottom) / 2);
+	return tree.contains(target);
+      })();
+    JS
+
+    assert covered_by_tree, "the floating chat covers the opened workspace tree"
   end
 end


### PR DESCRIPTION
## Summary
- unify workspace tree toggle icons with the central creative tree
- keep the opened mobile workspace tree above the floating chat
- add a system regression test for the mobile overlap

## Validation
- `npm test -- --runInBand engines/collavre/app/javascript/controllers/__tests__/workspace_tree_controller.test.js`
- `npm run build`
- `rbenv exec bundle exec rails test engines/collavre/test/system/workspace_tree_drawer_test.rb`
- `rbenv exec bundle exec rubocop engines/collavre/test/system/workspace_tree_drawer_test.rb`