### PR TITLE
Fix mobile workspace tree swipe close

### DIFF
--- a/engines/collavre/app/javascript/controllers/__tests__/workspace_tree_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/workspace_tree_controller.test.js
@@ -123,6 +123,51 @@ describe('WorkspaceTreeController', () => {
     expect(panelToggle.closest('section').classList.contains('is-open')).toBe(false)
   })
 
+  test.each([100, 260])('closes an open mobile drawer after a horizontal swipe in either direction (%i)', (endX) => {
+    const panelToggle = document.querySelector('[data-workspace-tree-target="panelToggle"]')
+    const treeRegion = panelToggle.closest('section')
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 430 })
+    panelToggle.click()
+    treeRegion.dispatchEvent(new TouchEvent('touchstart', {
+      bubbles: true,
+      touches: [{ clientX: 180, clientY: 100 }],
+    }))
+    treeRegion.dispatchEvent(new TouchEvent('touchend', {
+      bubbles: true,
+      changedTouches: [{ clientX: endX, clientY: 110 }],
+    }))
+
+    expect(treeRegion.classList.contains('is-open')).toBe(false)
+    expect(panelToggle.getAttribute('aria-expanded')).toBe('false')
+  })
+
+  test('keeps the drawer open for vertical swipes and desktop gestures', () => {
+    const panelToggle = document.querySelector('[data-workspace-tree-target="panelToggle"]')
+    const treeRegion = panelToggle.closest('section')
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 430 })
+    panelToggle.click()
+    treeRegion.dispatchEvent(new TouchEvent('touchstart', {
+      bubbles: true,
+      touches: [{ clientX: 180, clientY: 100 }],
+    }))
+    treeRegion.dispatchEvent(new TouchEvent('touchend', {
+      bubbles: true,
+      changedTouches: [{ clientX: 170, clientY: 220 }],
+    }))
+    expect(treeRegion.classList.contains('is-open')).toBe(true)
+
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1280 })
+    treeRegion.dispatchEvent(new TouchEvent('touchstart', {
+      bubbles: true,
+      touches: [{ clientX: 180, clientY: 100 }],
+    }))
+    treeRegion.dispatchEvent(new TouchEvent('touchend', {
+      bubbles: true,
+      changedTouches: [{ clientX: 100, clientY: 110 }],
+    }))
+    expect(treeRegion.classList.contains('is-open')).toBe(true)
+  })
+
   test('preserves link focus across background tree refreshes', async () => {
     let rootLink = document.querySelector('[data-creative-id="1"] > div > a')
     rootLink.focus()

--- a/engines/collavre/app/javascript/controllers/__tests__/workspace_tree_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/workspace_tree_controller.test.js
@@ -86,6 +86,7 @@ describe('WorkspaceTreeController', () => {
     expect(document.querySelector('[data-creative-id="2"] a').dataset.turboFrame).toBe('creative-workspace-content')
     expect(document.querySelector('[data-creative-id="2"] a').dataset.turboAction).toBe('advance')
     expect(document.querySelector('.creative-workspace-tree-branch-toggle').getAttribute('aria-label')).toBe('Root')
+    expect(document.querySelector('.creative-workspace-tree-branch-toggle svg path').getAttribute('d')).toBe('M6 9L12 15L18 9')
   })
 
   test('lazily reloads toggled branches and restores focus and scroll', async () => {
@@ -97,6 +98,7 @@ describe('WorkspaceTreeController', () => {
     expect(document.querySelector('[data-creative-id="1"] > ul')).toBeNull()
     branchToggle = document.querySelector('.creative-workspace-tree-branch-toggle')
     expect(branchToggle.getAttribute('aria-expanded')).toBe('false')
+    expect(branchToggle.querySelector('svg path').getAttribute('d')).toBe('M9 6L15 12L9 18')
     expect(document.activeElement).toBe(branchToggle)
     expect(controller.treeTarget.scrollTop).toBe(24)
     let requestUrl = fetchMock.mock.calls[1][0]
@@ -107,6 +109,7 @@ describe('WorkspaceTreeController', () => {
     branchToggle = document.querySelector('.creative-workspace-tree-branch-toggle')
     expect(document.querySelector('[data-creative-id="1"] > ul')).not.toBeNull()
     expect(branchToggle.getAttribute('aria-expanded')).toBe('true')
+    expect(branchToggle.querySelector('svg path').getAttribute('d')).toBe('M6 9L12 15L18 9')
     expect(document.activeElement).toBe(branchToggle)
     requestUrl = fetchMock.mock.calls[2][0]
     expect(new URL(requestUrl, window.location.origin).searchParams.getAll('expand[]')).toEqual(['2', '3', '1'])

--- a/engines/collavre/app/javascript/controllers/workspace_tree_controller.js
+++ b/engines/collavre/app/javascript/controllers/workspace_tree_controller.js
@@ -7,6 +7,13 @@ import { Controller } from '@hotwired/stimulus'
 let lastVisitAction = null
 const MAX_EXPANDED_BRANCHES = 100
 
+// Keep the workspace tree's branch affordance visually aligned with the
+// central creative tree (components/creative_tree_row.js#_toggleIcon).
+const CHEVRON_COLLAPSED =
+  '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9 6L15 12L9 18"/></svg>'
+const CHEVRON_EXPANDED =
+  '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M6 9L12 15L18 9"/></svg>'
+
 export default class extends Controller {
   static targets = ['tree', 'panelToggle']
 
@@ -153,7 +160,7 @@ export default class extends Controller {
       toggle.className = 'creative-workspace-tree-branch-toggle'
       toggle.setAttribute('aria-expanded', String(expanded))
       toggle.setAttribute('aria-label', node.label)
-      toggle.textContent = expanded ? '▾' : '▸'
+      toggle.innerHTML = expanded ? CHEVRON_EXPANDED : CHEVRON_COLLAPSED
       toggle.addEventListener('click', () => this.toggleBranch(item, toggle))
       row.appendChild(toggle)
     } else {

--- a/engines/collavre/app/javascript/controllers/workspace_tree_controller.js
+++ b/engines/collavre/app/javascript/controllers/workspace_tree_controller.js
@@ -6,6 +6,7 @@ import { Controller } from '@hotwired/stimulus'
 // visit action must outlive any single instance.
 let lastVisitAction = null
 const MAX_EXPANDED_BRANCHES = 100
+const PANEL_SWIPE_CLOSE_DISTANCE = 50
 
 // Keep the workspace tree's branch affordance visually aligned with the
 // central creative tree (components/creative_tree_row.js#_toggleIcon).
@@ -37,8 +38,12 @@ export default class extends Controller {
     this.handleTurboRender = this.handleTurboRender.bind(this)
     this.handleVisitStart = this.handleVisitStart.bind(this)
     this.handlePopState = this.handlePopState.bind(this)
+    this.handlePanelTouchStart = this.handlePanelTouchStart.bind(this)
+    this.handlePanelTouchEnd = this.handlePanelTouchEnd.bind(this)
     this.queueRefresh = this.queueRefresh.bind(this)
     window.addEventListener('popstate', this.handlePopState)
+    this.element.addEventListener('touchstart', this.handlePanelTouchStart, { passive: true })
+    this.element.addEventListener('touchend', this.handlePanelTouchEnd, { passive: true })
     document.addEventListener('turbo:visit', this.handleVisitStart)
     document.addEventListener('turbo:before-fetch-request', this.handleFrameRequest)
     document.addEventListener('turbo:frame-load', this.handleFrameLoad)
@@ -66,6 +71,8 @@ export default class extends Controller {
     if (this.refreshTimeout) window.clearTimeout(this.refreshTimeout)
     if (this.popStateSyncTimer) window.clearTimeout(this.popStateSyncTimer)
     window.removeEventListener('popstate', this.handlePopState)
+    this.element.removeEventListener('touchstart', this.handlePanelTouchStart)
+    this.element.removeEventListener('touchend', this.handlePanelTouchEnd)
     document.removeEventListener('turbo:visit', this.handleVisitStart)
     document.removeEventListener('turbo:before-fetch-request', this.handleFrameRequest)
     document.removeEventListener('turbo:frame-load', this.handleFrameLoad)
@@ -223,6 +230,31 @@ export default class extends Controller {
   closePanel() {
     this.element.classList.remove('is-open')
     this.panelToggleTarget.setAttribute('aria-expanded', 'false')
+  }
+
+  handlePanelTouchStart(event) {
+    if (!this.element.classList.contains('is-open') || event.touches.length !== 1) {
+      this.panelTouchStart = null
+      return
+    }
+
+    const touch = event.touches[0]
+    this.panelTouchStart = { x: touch.clientX, y: touch.clientY }
+  }
+
+  handlePanelTouchEnd(event) {
+    const touchStart = this.panelTouchStart
+    this.panelTouchStart = null
+    if (!touchStart || event.changedTouches.length !== 1 || !this.isDrawerViewport()) return
+
+    const touch = event.changedTouches[0]
+    const horizontalDistance = Math.abs(touch.clientX - touchStart.x)
+    const verticalDistance = Math.abs(touch.clientY - touchStart.y)
+    if (horizontalDistance >= PANEL_SWIPE_CLOSE_DISTANCE && horizontalDistance > verticalDistance) this.closePanel()
+  }
+
+  isDrawerViewport() {
+    return window.innerWidth < 1280
   }
 
   selectNode(event) {


### PR DESCRIPTION
## Summary
- close the open mobile workspace-tree drawer after a deliberate horizontal swipe in either direction
- preserve vertical scrolling and leave desktop layouts unchanged
- cover both horizontal directions and ignored gestures with controller tests

## Validation
- `npm test -- engines/collavre/app/javascript/controllers/__tests__/workspace_tree_controller.test.js --runInBand`
- `bin/rails test engines/collavre/test/system/workspace_tree_drawer_test.rb`
- `./bin/rubocop -a`

`bin/rails test` is currently blocked by 11 unrelated GitHub webhook tests that raise `ActiveRecord::Encryption::Errors::Configuration` before test setup. `bin/rails test:system` is also not runnable because the host app has no `test/system` directory; the relevant engine system test above passes.