### PR TITLE
Fix mobile workspace tree scroll containment

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/workspace.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/workspace.css
@@ -65,6 +65,7 @@ body.creative-workspace .creative-content {
     min-height: 0;
     padding: var(--space-2);
     overflow: auto;
+    overscroll-behavior-y: contain;
     background: transparent;
     border: 0;
 }

--- a/engines/collavre/test/system/workspace_tree_drawer_test.rb
+++ b/engines/collavre/test/system/workspace_tree_drawer_test.rb
@@ -102,6 +102,14 @@ class WorkspaceTreeDrawerTest < ApplicationSystemTestCase
     assert_equal "none", computed_style(".creative-workspace-tree-toggle", "display")
   end
 
+  test "the mobile drawer tree contains vertical overscroll" do
+    visit_workspace(MOBILE_WIDTH)
+
+    find(".creative-workspace-tree-toggle").click
+
+    assert_equal "contain", computed_style(".creative-workspace-tree-nav", "overscroll-behavior-y")
+  end
+
   private
 
   def visit_workspace(width)


### PR DESCRIPTION
## Summary
- contain vertical overscroll within the mobile workspace tree drawer
- add a system-test regression assertion for the drawer's scroll behavior

## Why
When the tree reached its scroll boundary, touch scrolling could chain into the creative page behind the open drawer.

## Validation
- `RUBYOPT=-Iengines/collavre/test mise exec ruby@3.4.4 -- bundle exec rails test engines/collavre/test/system/workspace_tree_drawer_test.rb`