### PR TITLE
Fix workspace tree drawer outside-click closing

### DIFF
--- a/engines/collavre/app/javascript/controllers/__tests__/workspace_tree_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/workspace_tree_controller.test.js
@@ -168,6 +168,31 @@ describe('WorkspaceTreeController', () => {
     expect(treeRegion.classList.contains('is-open')).toBe(true)
   })
 
+  test('closes an open drawer when the user clicks outside it', () => {
+    const panelToggle = document.querySelector('[data-workspace-tree-target="panelToggle"]')
+    const treeRegion = panelToggle.closest('section')
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1000 })
+    panelToggle.click()
+
+    document.getElementById('creative-workspace-content').dispatchEvent(new MouseEvent('click', { bubbles: true }))
+
+    expect(treeRegion.classList.contains('is-open')).toBe(false)
+    expect(panelToggle.getAttribute('aria-expanded')).toBe('false')
+  })
+
+  test('keeps the tree open after an outside click at three-panel width', () => {
+    const panelToggle = document.querySelector('[data-workspace-tree-target="panelToggle"]')
+    const treeRegion = panelToggle.closest('section')
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1280 })
+    treeRegion.classList.add('is-open')
+    panelToggle.setAttribute('aria-expanded', 'true')
+
+    document.getElementById('creative-workspace-content').dispatchEvent(new MouseEvent('click', { bubbles: true }))
+
+    expect(treeRegion.classList.contains('is-open')).toBe(true)
+    expect(panelToggle.getAttribute('aria-expanded')).toBe('true')
+  })
+
   test('preserves link focus across background tree refreshes', async () => {
     let rootLink = document.querySelector('[data-creative-id="1"] > div > a')
     rootLink.focus()

--- a/engines/collavre/app/javascript/controllers/workspace_tree_controller.js
+++ b/engines/collavre/app/javascript/controllers/workspace_tree_controller.js
@@ -9,13 +9,6 @@ let lastVisitAction = null
 const MAX_EXPANDED_BRANCHES = 100
 const PANEL_SWIPE_CLOSE_DISTANCE = 50
 
-// Keep the workspace tree's branch affordance visually aligned with the
-// central creative tree (components/creative_tree_row.js#_toggleIcon).
-const CHEVRON_COLLAPSED =
-  '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9 6L15 12L9 18"/></svg>'
-const CHEVRON_EXPANDED =
-  '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M6 9L12 15L18 9"/></svg>'
-
 export default class extends Controller {
   static targets = ['tree', 'panelToggle']
 
@@ -41,6 +34,7 @@ export default class extends Controller {
     this.handlePopState = this.handlePopState.bind(this)
     this.handlePanelTouchStart = this.handlePanelTouchStart.bind(this)
     this.handlePanelTouchEnd = this.handlePanelTouchEnd.bind(this)
+    this.handleOutsidePanelClick = this.handleOutsidePanelClick.bind(this)
     this.queueRefresh = this.queueRefresh.bind(this)
     window.addEventListener('popstate', this.handlePopState)
     this.element.addEventListener('touchstart', this.handlePanelTouchStart, { passive: true })
@@ -50,6 +44,7 @@ export default class extends Controller {
     document.addEventListener('turbo:frame-load', this.handleFrameLoad)
     document.addEventListener('turbo:frame-render', this.handleFrameLoad)
     document.addEventListener('turbo:render', this.handleTurboRender)
+    document.addEventListener('click', this.handleOutsidePanelClick)
     document.addEventListener('workspace-tree:invalidate', this.queueRefresh)
     document.addEventListener('creative-destroyed', this.queueRefresh)
     window.addEventListener('collavre:creative-drop-complete', this.queueRefresh)
@@ -79,6 +74,7 @@ export default class extends Controller {
     document.removeEventListener('turbo:frame-load', this.handleFrameLoad)
     document.removeEventListener('turbo:frame-render', this.handleFrameLoad)
     document.removeEventListener('turbo:render', this.handleTurboRender)
+    document.removeEventListener('click', this.handleOutsidePanelClick)
     document.removeEventListener('workspace-tree:invalidate', this.queueRefresh)
     document.removeEventListener('creative-destroyed', this.queueRefresh)
     window.removeEventListener('collavre:creative-drop-complete', this.queueRefresh)
@@ -231,6 +227,11 @@ export default class extends Controller {
   closePanel() {
     this.element.classList.remove('is-open')
     this.panelToggleTarget.setAttribute('aria-expanded', 'false')
+  }
+
+  handleOutsidePanelClick(event) {
+    if (!this.element.classList.contains('is-open') || !this.isDrawerViewport()) return
+    if (!this.element.contains(event.target)) this.closePanel()
   }
 
   handlePanelTouchStart(event) {


### PR DESCRIPTION
## Summary

- close the workspace tree drawer when the user clicks outside it below the three-panel breakpoint
- preserve the persistent three-panel tree behavior at desktop widths
- remove duplicate chevron declarations that prevented the JavaScript bundle from building

## Validation

- `npm test -- --runInBand engines/collavre/app/javascript/controllers/__tests__/workspace_tree_controller.test.js`
- `npm run build`
- `./bin/rubocop -a`
- `bin/rails test engines/collavre/test/system/workspace_tree_drawer_test.rb`

The full `bin/rails test` suite still has 11 pre-existing errors because the test environment is missing the Active Record encryption primary key.