### PR TITLE
Fix duplicate workspace tree icon declarations

### DIFF
--- a/engines/collavre/app/javascript/controllers/workspace_tree_controller.js
+++ b/engines/collavre/app/javascript/controllers/workspace_tree_controller.js
@@ -1,4 +1,6 @@
 import { Controller } from '@hotwired/stimulus'
+// Keep the workspace tree's branch affordance visually aligned with the
+// central creative tree (components/creative_tree_row.js#_toggleIcon).
 import { CHEVRON_COLLAPSED, CHEVRON_EXPANDED } from '../utils/chevron_icons'
 
 // Module-scoped: a history restore replaces the whole body, swapping this
@@ -8,13 +10,6 @@ import { CHEVRON_COLLAPSED, CHEVRON_EXPANDED } from '../utils/chevron_icons'
 let lastVisitAction = null
 const MAX_EXPANDED_BRANCHES = 100
 const PANEL_SWIPE_CLOSE_DISTANCE = 50
-
-// Keep the workspace tree's branch affordance visually aligned with the
-// central creative tree (components/creative_tree_row.js#_toggleIcon).
-const CHEVRON_COLLAPSED =
-  '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9 6L15 12L9 18"/></svg>'
-const CHEVRON_EXPANDED =
-  '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M6 9L12 15L18 9"/></svg>'
 
 export default class extends Controller {
   static targets = ['tree', 'panelToggle']


### PR DESCRIPTION
## Summary
- remove local chevron constants that redeclared imported shared icons
- restore successful JavaScript bundling

## Tests
- npm run build
- npm test -- --runInBand engines/collavre/app/javascript/utils/__tests__/chevron_icons.test.js engines/collavre/app/javascript/controllers/__tests__/workspace_tree_controller.test.js