### PR TITLE
feat: restore the last visited Creative on launch

### DIFF
--- a/app/javascript/controllers/__tests__/llm_model_controller.test.js
+++ b/app/javascript/controllers/__tests__/llm_model_controller.test.js
@@ -258,7 +258,9 @@ describe('LlmModelController', () => {
         expect(global.fetch).toHaveBeenCalledTimes(3)
         expect(global.fetch.mock.calls[1][1]).toEqual({
             method: 'HEAD',
-            credentials: 'same-origin'
+            credentials: 'same-origin',
+            headers: { 'X-Sec-Purpose': 'prefetch' },
+            signal: undefined
         })
         expect(global.fetch.mock.calls[2][1].headers.get('X-CSRF-Token')).toBe('fresh-token')
         expect(controller.modelsValue.map((model) => model.id)).toEqual([1, 3])

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_10_020000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_10_030000) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -986,7 +986,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_10_020000) do
     t.datetime "google_token_expires_at"
     t.string "google_uid"
     t.datetime "last_visited_creative_at"
+    t.string "last_visited_creative_client_id"
     t.integer "last_visited_creative_id"
+    t.bigint "last_visited_creative_visit_sequence"
     t.string "llm_api_key"
     t.string "llm_model"
     t.string "llm_vendor"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_10_010000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_10_020000) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -985,6 +985,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_10_010000) do
     t.string "google_refresh_token"
     t.datetime "google_token_expires_at"
     t.string "google_uid"
+    t.datetime "last_visited_creative_at"
     t.integer "last_visited_creative_id"
     t.string "llm_api_key"
     t.string "llm_model"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_10_030000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_10_060000) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -988,6 +988,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_10_030000) do
     t.datetime "last_visited_creative_at"
     t.string "last_visited_creative_client_id"
     t.integer "last_visited_creative_id"
+    t.bigint "last_visited_creative_issued_sequence"
     t.bigint "last_visited_creative_visit_sequence"
     t.string "llm_api_key"
     t.string "llm_model"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_10_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_10_010000) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -985,6 +985,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_10_000000) do
     t.string "google_refresh_token"
     t.datetime "google_token_expires_at"
     t.string "google_uid"
+    t.integer "last_visited_creative_id"
     t.string "llm_api_key"
     t.string "llm_model"
     t.string "llm_vendor"
@@ -1012,6 +1013,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_10_000000) do
     t.string "webauthn_id"
     t.index ["agent_gateway_id"], name: "index_users_on_agent_gateway_id"
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["last_visited_creative_id"], name: "index_users_on_last_visited_creative_id"
     t.index ["searchable"], name: "index_users_on_searchable"
     t.index ["system_admin"], name: "index_users_on_system_admin"
   end
@@ -1126,5 +1128,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_10_000000) do
   add_foreign_key "user_creative_preferences", "users"
   add_foreign_key "user_themes", "users"
   add_foreign_key "users", "agent_gateways"
+  add_foreign_key "users", "creatives", column: "last_visited_creative_id", on_delete: :nullify
   add_foreign_key "webauthn_credentials", "users"
 end

--- a/engines/collavre/app/controllers/collavre/application_controller.rb
+++ b/engines/collavre/app/controllers/collavre/application_controller.rb
@@ -45,7 +45,7 @@ module Collavre
       creative = Current.user.last_visited_creative
       return unless creative&.has_permission?(Current.user, :read)
 
-      collavre_engine.creatives_path(id: creative.id)
+      collavre_engine.creatives_path(id: creative.id, script_name: request.script_name)
     end
 
     def set_csrf_token_header

--- a/engines/collavre/app/controllers/collavre/application_controller.rb
+++ b/engines/collavre/app/controllers/collavre/application_controller.rb
@@ -41,6 +41,10 @@ module Collavre
 
     def last_visited_creative_path
       home_path = SystemSetting.home_page_path_authenticated.chomp("/")
+      mount_path = request.script_name.chomp("/")
+      if mount_path.present? && (home_path == mount_path || home_path.start_with?("#{mount_path}/"))
+        home_path = home_path.delete_prefix(mount_path)
+      end
       return unless home_path == "/creatives" || home_path == "/creatives.html"
 
       creative = Current.user.last_visited_creative

--- a/engines/collavre/app/controllers/collavre/application_controller.rb
+++ b/engines/collavre/app/controllers/collavre/application_controller.rb
@@ -14,7 +14,8 @@ module Collavre
     private
 
     # If the original request was for "/" and the user is signed in,
-    # honor SystemSetting.home_page_path_authenticated by redirecting.
+    # return them to their last readable Creative when the authenticated home
+    # page is the Creative index; otherwise honor the configured home page.
     # The middleware preserves "/" as a stable URL for unauthenticated
     # visitors; authenticated users get a real URL change so the address
     # bar reflects state.
@@ -31,11 +32,20 @@ module Collavre
       return unless request.env["collavre.root_request"]
       return unless authenticated?
 
-      target = SystemSetting.home_page_path_authenticated
+      target = last_visited_creative_path || SystemSetting.home_page_path_authenticated
       return if target.blank?
       return if target == "/"
 
       redirect_to target
+    end
+
+    def last_visited_creative_path
+      return unless SystemSetting.home_page_path_authenticated == "/creatives"
+
+      creative = Current.user.last_visited_creative
+      return unless creative&.has_permission?(Current.user, :read)
+
+      collavre_engine.creatives_path(id: creative.id)
     end
 
     def set_csrf_token_header

--- a/engines/collavre/app/controllers/collavre/application_controller.rb
+++ b/engines/collavre/app/controllers/collavre/application_controller.rb
@@ -40,7 +40,7 @@ module Collavre
     end
 
     def last_visited_creative_path
-      return unless SystemSetting.home_page_path_authenticated == "/creatives"
+      return unless SystemSetting.home_page_path_authenticated.chomp("/") == "/creatives"
 
       creative = Current.user.last_visited_creative
       return unless creative&.has_permission?(Current.user, :read)

--- a/engines/collavre/app/controllers/collavre/application_controller.rb
+++ b/engines/collavre/app/controllers/collavre/application_controller.rb
@@ -40,7 +40,8 @@ module Collavre
     end
 
     def last_visited_creative_path
-      return unless SystemSetting.home_page_path_authenticated.chomp("/") == "/creatives"
+      home_path = SystemSetting.home_page_path_authenticated.chomp("/")
+      return unless home_path == "/creatives" || home_path == "/creatives.html"
 
       creative = Current.user.last_visited_creative
       return unless creative&.has_permission?(Current.user, :read)

--- a/engines/collavre/app/controllers/collavre/creatives_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creatives_controller.rb
@@ -633,9 +633,9 @@ module Collavre
         visit = Rails.application.message_verifier(:last_visited_creative).verified(params[:visit_token])
         sequence = request.headers["X-Collavre-Last-Visited-Creative-Sequence"].to_i
         return unless visit.is_a?(Hash) && visit["creative_id"] == @creative.id &&
-          visit["client_id"] == last_visited_creative_client_id && sequence.positive?
+          visit["client_id"] == last_visited_creative_client_id
 
-        { client_id: visit.fetch("client_id"), sequence: sequence }
+        { client_id: visit.fetch("client_id"), sequence: sequence.positive? ? sequence : nil }
       rescue ActiveSupport::MessageVerifier::InvalidSignature, KeyError, ArgumentError
         nil
       end

--- a/engines/collavre/app/controllers/collavre/creatives_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creatives_controller.rb
@@ -30,9 +30,16 @@ module Collavre
           if params[:id].present?
             creative = Creative.find_by(id: params[:id])
             @parent_creative = creative if creative&.has_permission?(Current.user, :read)
-            unless turbo_prefetch_request?
-              @last_visited_creative_at = last_visited_creative_at
-              remember_last_visited_creative(@parent_creative, visited_at: @last_visited_creative_at)
+            if Current.user
+              @last_visited_creative_client_id = last_visited_creative_client_id
+              @last_visited_creative_visit_sequence = last_visited_creative_visit_sequence
+              unless turbo_prefetch_request?
+                remember_last_visited_creative(
+                  @parent_creative,
+                  client_id: @last_visited_creative_client_id,
+                  sequence: @last_visited_creative_visit_sequence
+                )
+              end
               @last_visited_creative_token = last_visited_creative_token
             end
           end
@@ -557,10 +564,10 @@ module Collavre
     def remember_last_visited
       return head :forbidden unless @creative.has_permission?(Current.user, :read)
 
-      visited_at = restored_visit_at
-      return head :unprocessable_entity unless visited_at
+      visit = restored_visit
+      return head :unprocessable_entity unless visit
 
-      remember_last_visited_creative(@creative, visited_at: visited_at)
+      remember_last_visited_creative(@creative, **visit)
       head :no_content
     end
 
@@ -577,41 +584,63 @@ module Collavre
     end
 
     private
-      def remember_last_visited_creative(creative, visited_at: Time.current)
+      def remember_last_visited_creative(creative, client_id:, sequence:)
         return unless Current.user && creative
 
         Current.user.with_lock do
-          return if Current.user.last_visited_creative_at && Current.user.last_visited_creative_at >= visited_at
+          same_client = Current.user.last_visited_creative_client_id == client_id
+          return if same_client && Current.user.last_visited_creative_visit_sequence.to_i >= sequence
 
           Current.user.update_columns(
             last_visited_creative_id: creative.id,
-            last_visited_creative_at: visited_at
+            last_visited_creative_at: Time.current,
+            last_visited_creative_client_id: client_id,
+            last_visited_creative_visit_sequence: sequence
           )
         end
       end
 
-      def last_visited_creative_at
-        # This server-issued timestamp is signed into the rendered page. A
-        # cached restore later submits the original value, preserving the
-        # navigation order even if its PATCH arrives after a newer visit.
-        Time.current
+      def last_visited_creative_client_id
+        session[:last_visited_creative_client_id] ||= SecureRandom.uuid
+      end
+
+      def last_visited_creative_visit_sequence
+        supplied_sequence = request.headers["X-Collavre-Last-Visited-Creative-Sequence"].to_i
+        return supplied_sequence if supplied_sequence.positive? && visit_token_client_id == last_visited_creative_client_id
+
+        if Current.user.last_visited_creative_client_id == last_visited_creative_client_id
+          Current.user.last_visited_creative_visit_sequence.to_i + 1
+        else
+          1
+        end
       end
 
       def last_visited_creative_token
-        return unless @parent_creative && @last_visited_creative_at
+        return unless @parent_creative && @last_visited_creative_client_id && @last_visited_creative_visit_sequence
 
         Rails.application.message_verifier(:last_visited_creative).generate({
           "creative_id" => @parent_creative.id,
-          "visited_at" => @last_visited_creative_at.iso8601(6)
+          "client_id" => @last_visited_creative_client_id,
+          "sequence" => @last_visited_creative_visit_sequence
         })
       end
 
-      def restored_visit_at
+      def restored_visit
         visit = Rails.application.message_verifier(:last_visited_creative).verified(params[:visit_token])
-        return unless visit.is_a?(Hash) && visit["creative_id"] == @creative.id
+        sequence = request.headers["X-Collavre-Last-Visited-Creative-Sequence"].to_i
+        return unless visit.is_a?(Hash) && visit["creative_id"] == @creative.id &&
+          visit["client_id"] == last_visited_creative_client_id && sequence.positive?
 
-        Time.iso8601(visit.fetch("visited_at"))
+        { client_id: visit.fetch("client_id"), sequence: sequence }
       rescue ActiveSupport::MessageVerifier::InvalidSignature, KeyError, ArgumentError
+        nil
+      end
+
+      def visit_token_client_id
+        token = request.headers["X-Collavre-Last-Visited-Creative-Token"]
+        visit = Rails.application.message_verifier(:last_visited_creative).verified(token)
+        visit["client_id"] if visit.is_a?(Hash)
+      rescue ActiveSupport::MessageVerifier::InvalidSignature
         nil
       end
 

--- a/engines/collavre/app/controllers/collavre/creatives_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creatives_controller.rb
@@ -584,10 +584,11 @@ module Collavre
       end
 
       def last_visited_creative_at
-        milliseconds = request.headers["X-Collavre-Last-Visited-Creative-At"].to_i
-        return Time.current unless milliseconds.positive?
-
-        Time.at(milliseconds / 1000.0)
+        # Capture this before acquiring the user-row lock. A request that
+        # arrived first but waits for a later visit to commit must not overwrite
+        # that later visit when it obtains the lock. Server time avoids relying
+        # on untrusted, device-specific browser clocks for this ordering.
+        Time.current
       end
 
       def turbo_prefetch_request?

--- a/engines/collavre/app/controllers/collavre/creatives_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creatives_controller.rb
@@ -574,6 +574,15 @@ module Collavre
       head :no_content
     end
 
+    # Reserve an ordering value before Turbo starts a Creative navigation.
+    # Reserving does not change the remembered Creative, so a cancelled request
+    # leaves only a harmless gap in the sequence.
+    def next_last_visited_sequence
+      return head :forbidden unless Current.user
+
+      render json: { sequence: issue_last_visited_creative_sequence }
+    end
+
     def destroy
       parent = @creative.parent
       unless @creative.has_permission?(Current.user, :admin)
@@ -592,7 +601,7 @@ module Collavre
 
         Current.user.with_lock do
           same_client = Current.user.last_visited_creative_client_id == client_id
-          sequence ||= same_client ? Current.user.last_visited_creative_visit_sequence.to_i + 1 : 1
+          sequence ||= issue_last_visited_creative_sequence_locked
           return sequence if same_client && Current.user.last_visited_creative_visit_sequence.to_i >= sequence
           return sequence if !same_client && Current.user.last_visited_creative_at &&
             Current.user.last_visited_creative_at >= received_at
@@ -608,6 +617,19 @@ module Collavre
           )
           sequence
         end
+      end
+
+      def issue_last_visited_creative_sequence
+        Current.user.with_lock { issue_last_visited_creative_sequence_locked }
+      end
+
+      def issue_last_visited_creative_sequence_locked
+        sequence = [
+          Current.user.last_visited_creative_issued_sequence.to_i,
+          Current.user.last_visited_creative_visit_sequence.to_i
+        ].max + 1
+        Current.user.update_column(:last_visited_creative_issued_sequence, sequence)
+        sequence
       end
 
       def last_visited_creative_client_id

--- a/engines/collavre/app/controllers/collavre/creatives_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creatives_controller.rb
@@ -30,7 +30,7 @@ module Collavre
           if params[:id].present?
             creative = Creative.find_by(id: params[:id])
             @parent_creative = creative if creative&.has_permission?(Current.user, :read)
-            remember_last_visited_creative(@parent_creative) unless turbo_prefetch_request?
+            remember_last_visited_creative(@parent_creative, visited_at: last_visited_creative_at) unless turbo_prefetch_request?
           end
           @creatives = []  # CSR will fetch via JSON
           @shared_list = @parent_creative ? @parent_creative.all_shared_users : []
@@ -553,7 +553,7 @@ module Collavre
     def remember_last_visited
       return head :forbidden unless @creative.has_permission?(Current.user, :read)
 
-      remember_last_visited_creative(@creative)
+      remember_last_visited_creative(@creative, visited_at: last_visited_creative_at)
       head :no_content
     end
 
@@ -570,11 +570,24 @@ module Collavre
     end
 
     private
-      def remember_last_visited_creative(creative)
+      def remember_last_visited_creative(creative, visited_at: Time.current)
         return unless Current.user && creative
-        return if Current.user.last_visited_creative_id == creative.id
 
-        Current.user.update_column(:last_visited_creative_id, creative.id)
+        Current.user.with_lock do
+          return if Current.user.last_visited_creative_at && Current.user.last_visited_creative_at >= visited_at
+
+          Current.user.update_columns(
+            last_visited_creative_id: creative.id,
+            last_visited_creative_at: visited_at
+          )
+        end
+      end
+
+      def last_visited_creative_at
+        milliseconds = request.headers["X-Collavre-Last-Visited-Creative-At"].to_i
+        return Time.current unless milliseconds.positive?
+
+        Time.at(milliseconds / 1000.0)
       end
 
       def turbo_prefetch_request?

--- a/engines/collavre/app/controllers/collavre/creatives_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creatives_controller.rb
@@ -34,7 +34,7 @@ module Collavre
             if Current.user
               @last_visited_creative_client_id = last_visited_creative_client_id
               @last_visited_creative_visit_sequence = last_visited_creative_visit_sequence
-              unless turbo_prefetch_request?
+              unless request.head? || turbo_prefetch_request?
                 @last_visited_creative_visit_sequence = remember_last_visited_creative(
                   @parent_creative,
                   client_id: @last_visited_creative_client_id,

--- a/engines/collavre/app/controllers/collavre/creatives_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creatives_controller.rb
@@ -578,8 +578,6 @@ module Collavre
     # Reserving does not change the remembered Creative, so a cancelled request
     # leaves only a harmless gap in the sequence.
     def next_last_visited_sequence
-      return head :forbidden unless Current.user
-
       render json: { sequence: issue_last_visited_creative_sequence }
     end
 

--- a/engines/collavre/app/controllers/collavre/creatives_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creatives_controller.rb
@@ -30,7 +30,11 @@ module Collavre
           if params[:id].present?
             creative = Creative.find_by(id: params[:id])
             @parent_creative = creative if creative&.has_permission?(Current.user, :read)
-            remember_last_visited_creative(@parent_creative, visited_at: last_visited_creative_at) unless turbo_prefetch_request?
+            unless turbo_prefetch_request?
+              @last_visited_creative_at = last_visited_creative_at
+              remember_last_visited_creative(@parent_creative, visited_at: @last_visited_creative_at)
+              @last_visited_creative_token = last_visited_creative_token
+            end
           end
           @creatives = []  # CSR will fetch via JSON
           @shared_list = @parent_creative ? @parent_creative.all_shared_users : []
@@ -553,7 +557,10 @@ module Collavre
     def remember_last_visited
       return head :forbidden unless @creative.has_permission?(Current.user, :read)
 
-      remember_last_visited_creative(@creative, visited_at: last_visited_creative_at)
+      visited_at = restored_visit_at
+      return head :unprocessable_entity unless visited_at
+
+      remember_last_visited_creative(@creative, visited_at: visited_at)
       head :no_content
     end
 
@@ -584,11 +591,28 @@ module Collavre
       end
 
       def last_visited_creative_at
-        # Capture this before acquiring the user-row lock. A request that
-        # arrived first but waits for a later visit to commit must not overwrite
-        # that later visit when it obtains the lock. Server time avoids relying
-        # on untrusted, device-specific browser clocks for this ordering.
+        # This server-issued timestamp is signed into the rendered page. A
+        # cached restore later submits the original value, preserving the
+        # navigation order even if its PATCH arrives after a newer visit.
         Time.current
+      end
+
+      def last_visited_creative_token
+        return unless @parent_creative && @last_visited_creative_at
+
+        Rails.application.message_verifier(:last_visited_creative).generate({
+          "creative_id" => @parent_creative.id,
+          "visited_at" => @last_visited_creative_at.iso8601(6)
+        })
+      end
+
+      def restored_visit_at
+        visit = Rails.application.message_verifier(:last_visited_creative).verified(params[:visit_token])
+        return unless visit.is_a?(Hash) && visit["creative_id"] == @creative.id
+
+        Time.iso8601(visit.fetch("visited_at"))
+      rescue ActiveSupport::MessageVerifier::InvalidSignature, KeyError, ArgumentError
+        nil
       end
 
       def turbo_prefetch_request?

--- a/engines/collavre/app/controllers/collavre/creatives_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creatives_controller.rb
@@ -30,7 +30,7 @@ module Collavre
           if params[:id].present?
             creative = Creative.find_by(id: params[:id])
             @parent_creative = creative if creative&.has_permission?(Current.user, :read)
-            remember_last_visited_creative(@parent_creative)
+            remember_last_visited_creative(@parent_creative) unless turbo_prefetch_request?
           end
           @creatives = []  # CSR will fetch via JSON
           @shared_list = @parent_creative ? @parent_creative.all_shared_users : []
@@ -575,6 +575,10 @@ module Collavre
         return if Current.user.last_visited_creative_id == creative.id
 
         Current.user.update_column(:last_visited_creative_id, creative.id)
+      end
+
+      def turbo_prefetch_request?
+        request.headers["X-Sec-Purpose"] == "prefetch"
       end
 
       def build_tree(collection, params:, expanded_state_map:, level:, select_mode: false, allowed_creative_ids: nil, progress_map: nil)

--- a/engines/collavre/app/controllers/collavre/creatives_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creatives_controller.rb
@@ -25,6 +25,7 @@ module Collavre
     def index
       respond_to do |format|
         format.html do
+          visit_received_at = Time.current
           # HTML only needs parent_creative for nav/title - skip expensive filtered queries
           # Must check permission to avoid leaking metadata (og:title, etc.) to unauthorized users
           if params[:id].present?
@@ -37,7 +38,8 @@ module Collavre
                 @last_visited_creative_visit_sequence = remember_last_visited_creative(
                   @parent_creative,
                   client_id: @last_visited_creative_client_id,
-                  sequence: @last_visited_creative_visit_sequence
+                  sequence: @last_visited_creative_visit_sequence,
+                  received_at: visit_received_at
                 )
               end
               @last_visited_creative_token = last_visited_creative_token
@@ -562,12 +564,13 @@ module Collavre
     # issuing the HTML request that normally records this value. The client
     # calls this endpoint after confirming the restored frame matches the URL.
     def remember_last_visited
+      visit_received_at = Time.current
       return head :forbidden unless @creative.has_permission?(Current.user, :read)
 
       visit = restored_visit
       return head :unprocessable_entity unless visit
 
-      remember_last_visited_creative(@creative, **visit)
+      remember_last_visited_creative(@creative, **visit, received_at: visit_received_at)
       head :no_content
     end
 
@@ -584,17 +587,22 @@ module Collavre
     end
 
     private
-      def remember_last_visited_creative(creative, client_id:, sequence:)
+      def remember_last_visited_creative(creative, client_id:, sequence:, received_at:)
         return unless Current.user && creative
 
         Current.user.with_lock do
           same_client = Current.user.last_visited_creative_client_id == client_id
           sequence ||= same_client ? Current.user.last_visited_creative_visit_sequence.to_i + 1 : 1
           return sequence if same_client && Current.user.last_visited_creative_visit_sequence.to_i >= sequence
+          return sequence if !same_client && Current.user.last_visited_creative_at &&
+            Current.user.last_visited_creative_at >= received_at
 
           Current.user.update_columns(
             last_visited_creative_id: creative.id,
-            last_visited_creative_at: Time.current,
+            # A request can wait on this lock after it reaches Rails. Retain
+            # its arrival time so an older request from another browser session
+            # cannot overwrite a Creative recorded by a later-arriving visit.
+            last_visited_creative_at: received_at,
             last_visited_creative_client_id: client_id,
             last_visited_creative_visit_sequence: sequence
           )

--- a/engines/collavre/app/controllers/collavre/creatives_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creatives_controller.rb
@@ -34,7 +34,7 @@ module Collavre
               @last_visited_creative_client_id = last_visited_creative_client_id
               @last_visited_creative_visit_sequence = last_visited_creative_visit_sequence
               unless turbo_prefetch_request?
-                remember_last_visited_creative(
+                @last_visited_creative_visit_sequence = remember_last_visited_creative(
                   @parent_creative,
                   client_id: @last_visited_creative_client_id,
                   sequence: @last_visited_creative_visit_sequence
@@ -589,7 +589,8 @@ module Collavre
 
         Current.user.with_lock do
           same_client = Current.user.last_visited_creative_client_id == client_id
-          return if same_client && Current.user.last_visited_creative_visit_sequence.to_i >= sequence
+          sequence ||= same_client ? Current.user.last_visited_creative_visit_sequence.to_i + 1 : 1
+          return sequence if same_client && Current.user.last_visited_creative_visit_sequence.to_i >= sequence
 
           Current.user.update_columns(
             last_visited_creative_id: creative.id,
@@ -597,6 +598,7 @@ module Collavre
             last_visited_creative_client_id: client_id,
             last_visited_creative_visit_sequence: sequence
           )
+          sequence
         end
       end
 
@@ -606,13 +608,7 @@ module Collavre
 
       def last_visited_creative_visit_sequence
         supplied_sequence = request.headers["X-Collavre-Last-Visited-Creative-Sequence"].to_i
-        return supplied_sequence if supplied_sequence.positive? && visit_token_client_id == last_visited_creative_client_id
-
-        if Current.user.last_visited_creative_client_id == last_visited_creative_client_id
-          Current.user.last_visited_creative_visit_sequence.to_i + 1
-        else
-          1
-        end
+        supplied_sequence if supplied_sequence.positive? && visit_token_client_id == last_visited_creative_client_id
       end
 
       def last_visited_creative_token

--- a/engines/collavre/app/controllers/collavre/creatives_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creatives_controller.rb
@@ -30,6 +30,7 @@ module Collavre
           if params[:id].present?
             creative = Creative.find_by(id: params[:id])
             @parent_creative = creative if creative&.has_permission?(Current.user, :read)
+            remember_last_visited_creative(@parent_creative)
           end
           @creatives = []  # CSR will fetch via JSON
           @shared_list = @parent_creative ? @parent_creative.all_shared_users : []
@@ -559,6 +560,13 @@ module Collavre
     end
 
     private
+      def remember_last_visited_creative(creative)
+        return unless Current.user && creative
+        return if Current.user.last_visited_creative_id == creative.id
+
+        Current.user.update_column(:last_visited_creative_id, creative.id)
+      end
+
       def build_tree(collection, params:, expanded_state_map:, level:, select_mode: false, allowed_creative_ids: nil, progress_map: nil)
         ::Creatives::TreeBuilder.new(
           user: Current.user,

--- a/engines/collavre/app/controllers/collavre/creatives_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creatives_controller.rb
@@ -19,7 +19,7 @@ module Collavre
     # tracked separately and intentionally deferred.
     allow_unauthenticated_access only: %i[ index children export_markdown show slide_view ]
     before_action :enforce_creatives_login_policy, only: %i[ index children export_markdown show slide_view ]
-    before_action :set_creative, only: %i[ show edit update destroy parent_suggestions slide_view request_permission unconvert contexts update_contexts update_metadata archive unarchive trigger_action ]
+    before_action :set_creative, only: %i[ show edit update destroy parent_suggestions slide_view request_permission unconvert contexts update_contexts update_metadata archive unarchive trigger_action remember_last_visited ]
     before_action :require_creative_write!, only: %i[archive unarchive]
 
     def index
@@ -545,6 +545,16 @@ module Collavre
     def unarchive
       @creative.unarchive!
       head :ok
+    end
+
+    # Turbo may restore a cached workspace frame from browser history without
+    # issuing the HTML request that normally records this value. The client
+    # calls this endpoint after confirming the restored frame matches the URL.
+    def remember_last_visited
+      return head :forbidden unless @creative.has_permission?(Current.user, :read)
+
+      remember_last_visited_creative(@creative)
+      head :no_content
     end
 
     def destroy

--- a/engines/collavre/app/javascript/collavre.js
+++ b/engines/collavre/app/javascript/collavre.js
@@ -18,6 +18,7 @@ import "./components/creative_tree_row"
 
 // Import and re-export lib utilities
 import "./lib/apply_lexical_styles"
+import "./lib/creative_link_prefetch"
 import "./lib/turbo_stream_actions"
 import "./lib/turbo_confirm"
 

--- a/engines/collavre/app/javascript/controllers/__tests__/index.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/index.test.js
@@ -1,0 +1,42 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { jest } from '@jest/globals'
+import LastVisitedCreativeController from '../last_visited_creative_controller'
+
+describe('registerControllers', () => {
+  test('registers the last-visited Creative controller', async () => {
+    jest.unstable_mockModule('@hotwired/turbo-rails', () => ({ Turbo: {} }))
+    for (const controller of [
+      '../comment_controller',
+      '../comment_version_controller',
+      '../link_creative_controller',
+      '../topic_search_controller',
+      '../topic_list_controller',
+      '../share_modal_controller',
+      '../share_user_search_controller',
+      '../inbox_badge_controller',
+      '../creatives/drag_drop_controller',
+      '../creatives/row_editor_controller',
+      '../creatives/tree_controller',
+      '../creatives/sync_controller',
+      '../comments/list_controller',
+      '../comments/form_controller',
+      '../comments/presence_controller',
+      '../comments/topics_controller',
+      '../comments/popup_controller',
+    ]) {
+      jest.unstable_mockModule(controller, () => ({ default: class {} }))
+    }
+    const { registerControllers } = await import('../index')
+    const application = { register: jest.fn() }
+
+    registerControllers(application)
+
+    expect(application.register).toHaveBeenCalledWith(
+      'last-visited-creative',
+      LastVisitedCreativeController,
+    )
+  })
+})

--- a/engines/collavre/app/javascript/controllers/__tests__/last_visited_creative_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/last_visited_creative_controller.test.js
@@ -1,0 +1,63 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { Application } from '@hotwired/stimulus'
+import { jest } from '@jest/globals'
+import LastVisitedCreativeController from '../last_visited_creative_controller'
+
+describe('LastVisitedCreativeController', () => {
+  let application
+  let fetchMock
+
+  beforeEach(async () => {
+    fetchMock = jest.fn().mockResolvedValue({ ok: true, headers: new Headers() })
+    global.fetch = fetchMock
+    document.head.innerHTML = '<meta name="csrf-token" content="token">'
+    document.body.innerHTML = `
+      <div data-controller="last-visited-creative"
+           data-last-visited-creative-url-value="/creatives"
+           data-last-visited-creative-creative-id-value="2"></div>
+    `
+    application = Application.start()
+    application.register('last-visited-creative', LastVisitedCreativeController)
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  })
+
+  afterEach(() => {
+    application?.stop()
+    document.head.innerHTML = ''
+    document.body.innerHTML = ''
+    delete global.fetch
+  })
+
+  test('records a cached history restore', async () => {
+    document.dispatchEvent(new CustomEvent('turbo:visit', { detail: { action: 'restore' } }))
+    document.dispatchEvent(new Event('turbo:render'))
+
+    await new Promise((resolve) => requestAnimationFrame(resolve))
+
+    expect(fetchMock).toHaveBeenCalledWith('/creatives/2/remember_last_visited', expect.objectContaining({
+      method: 'PATCH',
+      credentials: 'same-origin',
+    }))
+  })
+
+  test('records a cached history restore after Turbo reconnects the page', async () => {
+    document.dispatchEvent(new CustomEvent('turbo:visit', { detail: { action: 'restore' } }))
+    document.body.innerHTML = `
+      <div data-controller="last-visited-creative"
+           data-last-visited-creative-url-value="/creatives"
+           data-last-visited-creative-creative-id-value="1"></div>
+    `
+    document.dispatchEvent(new Event('turbo:render'))
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    await new Promise((resolve) => requestAnimationFrame(resolve))
+
+    expect(fetchMock).toHaveBeenCalledWith('/creatives/1/remember_last_visited', expect.objectContaining({
+      method: 'PATCH',
+      credentials: 'same-origin',
+    }))
+  })
+})

--- a/engines/collavre/app/javascript/controllers/__tests__/last_visited_creative_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/last_visited_creative_controller.test.js
@@ -41,6 +41,7 @@ describe('LastVisitedCreativeController', () => {
       method: 'PATCH',
       credentials: 'same-origin',
     }))
+    expect(fetchMock.mock.calls[0][1].headers.get('X-Collavre-Last-Visited-Creative-At')).toEqual(expect.any(String))
   })
 
   test('records a cached history restore after Turbo reconnects the page', async () => {

--- a/engines/collavre/app/javascript/controllers/__tests__/last_visited_creative_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/last_visited_creative_controller.test.js
@@ -12,7 +12,11 @@ describe('LastVisitedCreativeController', () => {
 
   beforeEach(async () => {
     window.localStorage.clear()
-    fetchMock = jest.fn().mockResolvedValue({ ok: true, headers: new Headers() })
+    fetchMock = jest.fn().mockImplementation((url) => Promise.resolve(
+      url === '/creatives/next_last_visited_sequence'
+        ? { ok: true, headers: new Headers(), json: async () => ({ sequence: 2 }) }
+        : { ok: true, headers: new Headers() }
+    ))
     global.fetch = fetchMock
     document.head.innerHTML = '<meta name="csrf-token" content="token">'
     document.body.innerHTML = `
@@ -24,6 +28,7 @@ describe('LastVisitedCreativeController', () => {
     `
     application = Application.start()
     application.register('last-visited-creative', LastVisitedCreativeController)
+    await new Promise((resolve) => requestAnimationFrame(resolve))
     await new Promise((resolve) => setTimeout(resolve, 0))
   })
 
@@ -40,12 +45,13 @@ describe('LastVisitedCreativeController', () => {
     document.dispatchEvent(new Event('turbo:render'))
 
     await new Promise((resolve) => requestAnimationFrame(resolve))
+    await new Promise((resolve) => setTimeout(resolve, 0))
 
     expect(fetchMock).toHaveBeenCalledWith('/creatives/2/remember_last_visited?visit_token=server-token', expect.objectContaining({
       method: 'PATCH',
       credentials: 'same-origin',
     }))
-    expect(fetchMock.mock.calls[0][1].headers.get('X-Collavre-Last-Visited-Creative-Sequence')).toBe('2')
+    expect(fetchMock.mock.calls[1][1].headers.get('X-Collavre-Last-Visited-Creative-Sequence')).toBe('2')
   })
 
   test('records a cached history restore after Turbo reconnects the page', async () => {
@@ -59,8 +65,9 @@ describe('LastVisitedCreativeController', () => {
     `
     document.dispatchEvent(new Event('turbo:render'))
 
-    await new Promise((resolve) => setTimeout(resolve, 0))
     await new Promise((resolve) => requestAnimationFrame(resolve))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    await new Promise((resolve) => setTimeout(resolve, 0))
 
     expect(fetchMock).toHaveBeenCalledWith('/creatives/1/remember_last_visited?visit_token=server-token', expect.objectContaining({
       method: 'PATCH',
@@ -68,24 +75,29 @@ describe('LastVisitedCreativeController', () => {
     }))
   })
 
-  test('adds an ordered visit token to a Turbo navigation request', () => {
+  test('obtains an ordered visit token from Rails before a Turbo navigation request', async () => {
     const fetchOptions = { method: 'GET', headers: new Headers() }
-    document.dispatchEvent(new CustomEvent('turbo:before-fetch-request', { detail: { fetchOptions } }))
+    const resume = jest.fn()
+    const event = new CustomEvent('turbo:before-fetch-request', {
+      cancelable: true,
+      detail: { fetchOptions, resume },
+    })
+    document.dispatchEvent(event)
+    await new Promise((resolve) => setTimeout(resolve, 0))
 
+    expect(event.defaultPrevented).toBe(true)
+    expect(resume).toHaveBeenCalled()
     expect(fetchOptions.headers.get('X-Collavre-Last-Visited-Creative-Token')).toBe('server-token')
-    expect(Number(fetchOptions.headers.get('X-Collavre-Last-Visited-Creative-Sequence'))).toBeGreaterThan(1)
+    expect(fetchOptions.headers.get('X-Collavre-Last-Visited-Creative-Sequence')).toBe('2')
   })
 
-  test('lets Rails allocate a restored visit sequence when local storage is unavailable', async () => {
-    const storageGetter = jest.spyOn(window, 'localStorage', 'get').mockImplementation(() => {
-      throw new Error('denied')
-    })
-
+  test('uses Rails to allocate a restored visit sequence without browser storage', async () => {
     document.dispatchEvent(new CustomEvent('turbo:visit', { detail: { action: 'restore' } }))
     document.dispatchEvent(new Event('turbo:render'))
     await new Promise((resolve) => requestAnimationFrame(resolve))
+    await new Promise((resolve) => setTimeout(resolve, 0))
 
-    expect(fetchMock.mock.calls[0][1].headers.get('X-Collavre-Last-Visited-Creative-Sequence')).toBeNull()
-    storageGetter.mockRestore()
+    expect(fetchMock).toHaveBeenCalledWith('/creatives/next_last_visited_sequence', expect.objectContaining({ method: 'PATCH' }))
+    expect(fetchMock.mock.calls.at(-1)[1].headers.get('X-Collavre-Last-Visited-Creative-Sequence')).toBe('2')
   })
 })

--- a/engines/collavre/app/javascript/controllers/__tests__/last_visited_creative_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/last_visited_creative_controller.test.js
@@ -75,4 +75,17 @@ describe('LastVisitedCreativeController', () => {
     expect(fetchOptions.headers.get('X-Collavre-Last-Visited-Creative-Token')).toBe('server-token')
     expect(Number(fetchOptions.headers.get('X-Collavre-Last-Visited-Creative-Sequence'))).toBeGreaterThan(1)
   })
+
+  test('lets Rails allocate a restored visit sequence when local storage is unavailable', async () => {
+    const storageGetter = jest.spyOn(window, 'localStorage', 'get').mockImplementation(() => {
+      throw new Error('denied')
+    })
+
+    document.dispatchEvent(new CustomEvent('turbo:visit', { detail: { action: 'restore' } }))
+    document.dispatchEvent(new Event('turbo:render'))
+    await new Promise((resolve) => requestAnimationFrame(resolve))
+
+    expect(fetchMock.mock.calls[0][1].headers.get('X-Collavre-Last-Visited-Creative-Sequence')).toBeNull()
+    storageGetter.mockRestore()
+  })
 })

--- a/engines/collavre/app/javascript/controllers/__tests__/last_visited_creative_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/last_visited_creative_controller.test.js
@@ -41,7 +41,6 @@ describe('LastVisitedCreativeController', () => {
       method: 'PATCH',
       credentials: 'same-origin',
     }))
-    expect(fetchMock.mock.calls[0][1].headers.get('X-Collavre-Last-Visited-Creative-At')).toEqual(expect.any(String))
   })
 
   test('records a cached history restore after Turbo reconnects the page', async () => {

--- a/engines/collavre/app/javascript/controllers/__tests__/last_visited_creative_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/last_visited_creative_controller.test.js
@@ -17,7 +17,8 @@ describe('LastVisitedCreativeController', () => {
     document.body.innerHTML = `
       <div data-controller="last-visited-creative"
            data-last-visited-creative-url-value="/creatives"
-           data-last-visited-creative-creative-id-value="2"></div>
+           data-last-visited-creative-creative-id-value="2"
+           data-last-visited-creative-visit-token-value="server-token"></div>
     `
     application = Application.start()
     application.register('last-visited-creative', LastVisitedCreativeController)
@@ -37,7 +38,7 @@ describe('LastVisitedCreativeController', () => {
 
     await new Promise((resolve) => requestAnimationFrame(resolve))
 
-    expect(fetchMock).toHaveBeenCalledWith('/creatives/2/remember_last_visited', expect.objectContaining({
+    expect(fetchMock).toHaveBeenCalledWith('/creatives/2/remember_last_visited?visit_token=server-token', expect.objectContaining({
       method: 'PATCH',
       credentials: 'same-origin',
     }))
@@ -48,14 +49,15 @@ describe('LastVisitedCreativeController', () => {
     document.body.innerHTML = `
       <div data-controller="last-visited-creative"
            data-last-visited-creative-url-value="/creatives"
-           data-last-visited-creative-creative-id-value="1"></div>
+           data-last-visited-creative-creative-id-value="1"
+           data-last-visited-creative-visit-token-value="server-token"></div>
     `
     document.dispatchEvent(new Event('turbo:render'))
 
     await new Promise((resolve) => setTimeout(resolve, 0))
     await new Promise((resolve) => requestAnimationFrame(resolve))
 
-    expect(fetchMock).toHaveBeenCalledWith('/creatives/1/remember_last_visited', expect.objectContaining({
+    expect(fetchMock).toHaveBeenCalledWith('/creatives/1/remember_last_visited?visit_token=server-token', expect.objectContaining({
       method: 'PATCH',
       credentials: 'same-origin',
     }))

--- a/engines/collavre/app/javascript/controllers/__tests__/last_visited_creative_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/last_visited_creative_controller.test.js
@@ -11,6 +11,7 @@ describe('LastVisitedCreativeController', () => {
   let fetchMock
 
   beforeEach(async () => {
+    window.localStorage.clear()
     fetchMock = jest.fn().mockResolvedValue({ ok: true, headers: new Headers() })
     global.fetch = fetchMock
     document.head.innerHTML = '<meta name="csrf-token" content="token">'
@@ -18,7 +19,8 @@ describe('LastVisitedCreativeController', () => {
       <div data-controller="last-visited-creative"
            data-last-visited-creative-url-value="/creatives"
            data-last-visited-creative-creative-id-value="2"
-           data-last-visited-creative-visit-token-value="server-token"></div>
+           data-last-visited-creative-visit-token-value="server-token"
+           data-last-visited-creative-visit-sequence-value="1"></div>
     `
     application = Application.start()
     application.register('last-visited-creative', LastVisitedCreativeController)
@@ -29,6 +31,7 @@ describe('LastVisitedCreativeController', () => {
     application?.stop()
     document.head.innerHTML = ''
     document.body.innerHTML = ''
+    window.localStorage.clear()
     delete global.fetch
   })
 
@@ -42,6 +45,7 @@ describe('LastVisitedCreativeController', () => {
       method: 'PATCH',
       credentials: 'same-origin',
     }))
+    expect(fetchMock.mock.calls[0][1].headers.get('X-Collavre-Last-Visited-Creative-Sequence')).toBe('2')
   })
 
   test('records a cached history restore after Turbo reconnects the page', async () => {
@@ -50,7 +54,8 @@ describe('LastVisitedCreativeController', () => {
       <div data-controller="last-visited-creative"
            data-last-visited-creative-url-value="/creatives"
            data-last-visited-creative-creative-id-value="1"
-           data-last-visited-creative-visit-token-value="server-token"></div>
+           data-last-visited-creative-visit-token-value="server-token"
+           data-last-visited-creative-visit-sequence-value="1"></div>
     `
     document.dispatchEvent(new Event('turbo:render'))
 
@@ -61,5 +66,13 @@ describe('LastVisitedCreativeController', () => {
       method: 'PATCH',
       credentials: 'same-origin',
     }))
+  })
+
+  test('adds an ordered visit token to a Turbo navigation request', () => {
+    const fetchOptions = { method: 'GET', headers: new Headers() }
+    document.dispatchEvent(new CustomEvent('turbo:before-fetch-request', { detail: { fetchOptions } }))
+
+    expect(fetchOptions.headers.get('X-Collavre-Last-Visited-Creative-Token')).toBe('server-token')
+    expect(Number(fetchOptions.headers.get('X-Collavre-Last-Visited-Creative-Sequence'))).toBeGreaterThan(1)
   })
 })

--- a/engines/collavre/app/javascript/controllers/__tests__/last_visited_creative_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/last_visited_creative_controller.test.js
@@ -80,7 +80,7 @@ describe('LastVisitedCreativeController', () => {
     const resume = jest.fn()
     const event = new CustomEvent('turbo:before-fetch-request', {
       cancelable: true,
-      detail: { fetchOptions, resume },
+      detail: { fetchOptions, resume, url: '/creatives?id=2' },
     })
     document.dispatchEvent(event)
     await new Promise((resolve) => setTimeout(resolve, 0))

--- a/engines/collavre/app/javascript/controllers/__tests__/workspace_tree_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/workspace_tree_controller.test.js
@@ -104,6 +104,45 @@ describe('WorkspaceTreeController', () => {
     })
   })
 
+  test('records a cached history restore after Turbo reconnects the workspace controller', async () => {
+    document.head.innerHTML = '<meta name="csrf-token" content="token">'
+    document.dispatchEvent(new CustomEvent('turbo:visit', { detail: { action: 'restore' } }))
+    document.body.innerHTML = `
+      <section data-controller="workspace-tree"
+               data-workspace-tree-url-value="/creatives.json?workspace_tree=1"
+               data-workspace-tree-last-visited-creative-url-value="/creatives"
+               data-workspace-tree-current-path-value="[1,2,3]"
+               data-workspace-tree-loading-text-value="Loading"
+               data-workspace-tree-empty-text-value="Empty"
+               data-workspace-tree-error-text-value="Error">
+        <button data-workspace-tree-target="panelToggle" data-action="workspace-tree#togglePanel" aria-expanded="false"></button>
+        <nav data-workspace-tree-target="tree"></nav>
+      </section>
+      <turbo-frame id="creative-workspace-content">
+        <div data-workspace-navigation-state
+             data-creative-id="2"
+             data-creative-snippet="Branch chat"
+             data-can-comment="false"
+             data-creative-path="[1,2,3]"></div>
+      </turbo-frame>
+    `
+    document.dispatchEvent(new Event('turbo:render'))
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    await new Promise((resolve) => requestAnimationFrame(resolve))
+
+    controller = application.getControllerForElementAndIdentifier(
+      document.querySelector('[data-controller="workspace-tree"]'),
+      'workspace-tree'
+    )
+
+    expect(fetchMock).toHaveBeenLastCalledWith('/creatives/2/remember_last_visited', {
+      method: 'PATCH',
+      credentials: 'same-origin',
+      headers: { Accept: 'application/json', 'X-CSRF-Token': 'token' },
+    })
+  })
+
   test('lazily reloads toggled branches and restores focus and scroll', async () => {
     let branchToggle = document.querySelector('.creative-workspace-tree-branch-toggle')
     controller.treeTarget.scrollTop = 24

--- a/engines/collavre/app/javascript/controllers/__tests__/workspace_tree_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/workspace_tree_controller.test.js
@@ -13,6 +13,7 @@ describe('WorkspaceTreeController', () => {
   let preventNavigation
 
   beforeEach(async () => {
+    window.localStorage.clear()
     fetchMock = jest.fn().mockResolvedValue({
       ok: true,
       json: async () => ({
@@ -46,6 +47,7 @@ describe('WorkspaceTreeController', () => {
                data-workspace-tree-url-value="/creatives.json?workspace_tree=1"
                data-workspace-tree-last-visited-creative-url-value="/creatives"
                data-workspace-tree-last-visited-creative-visit-token-value="server-token"
+               data-workspace-tree-last-visited-creative-visit-sequence-value="1"
                data-workspace-tree-current-path-value="[1,2,3]"
                data-workspace-tree-loading-text-value="Loading"
                data-workspace-tree-empty-text-value="Empty"
@@ -58,7 +60,9 @@ describe('WorkspaceTreeController', () => {
              data-creative-id="2"
              data-creative-snippet="Branch chat"
              data-can-comment="false"
-             data-creative-path="[1,2,3]"></div>
+             data-creative-path="[1,2,3]"
+             data-last-visited-creative-visit-token="server-token"
+             data-last-visited-creative-visit-sequence="1"></div>
       </turbo-frame>
     `
 
@@ -75,6 +79,7 @@ describe('WorkspaceTreeController', () => {
     application.stop()
     document.removeEventListener('click', preventNavigation)
     document.body.innerHTML = ''
+    window.localStorage.clear()
     delete global.fetch
   })
 
@@ -104,6 +109,7 @@ describe('WorkspaceTreeController', () => {
     expect(options).toEqual(expect.objectContaining({ method: 'PATCH', credentials: 'same-origin' }))
     expect(options.headers.get('Accept')).toBe('application/json')
     expect(options.headers.get('X-CSRF-Token')).toBe('token')
+    expect(options.headers.get('X-Collavre-Last-Visited-Creative-Sequence')).toBe('2')
   })
 
   test('records a cached history restore after Turbo reconnects the workspace controller', async () => {
@@ -114,6 +120,7 @@ describe('WorkspaceTreeController', () => {
                data-workspace-tree-url-value="/creatives.json?workspace_tree=1"
                data-workspace-tree-last-visited-creative-url-value="/creatives"
                data-workspace-tree-last-visited-creative-visit-token-value="server-token"
+               data-workspace-tree-last-visited-creative-visit-sequence-value="1"
                data-workspace-tree-current-path-value="[1,2,3]"
                data-workspace-tree-loading-text-value="Loading"
                data-workspace-tree-empty-text-value="Empty"
@@ -126,7 +133,9 @@ describe('WorkspaceTreeController', () => {
              data-creative-id="2"
              data-creative-snippet="Branch chat"
              data-can-comment="false"
-             data-creative-path="[1,2,3]"></div>
+             data-creative-path="[1,2,3]"
+             data-last-visited-creative-visit-token="server-token"
+             data-last-visited-creative-visit-sequence="1"></div>
       </turbo-frame>
     `
     document.dispatchEvent(new Event('turbo:render'))
@@ -189,6 +198,30 @@ describe('WorkspaceTreeController', () => {
     await new Promise((resolve) => setTimeout(resolve, 0))
 
     expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  test('uses the frame response token after workspace navigation', async () => {
+    const frame = document.getElementById('creative-workspace-content')
+    frame.innerHTML = `
+      <div data-workspace-navigation-state
+           data-creative-id="1"
+           data-creative-snippet="Root chat"
+           data-can-comment="true"
+           data-creative-path="[1]"
+           data-last-visited-creative-visit-token="new-server-token"
+           data-last-visited-creative-visit-sequence="2"></div>
+    `
+    frame.dispatchEvent(new Event('turbo:frame-load', { bubbles: true }))
+    window.history.replaceState({}, '', '/creatives?id=1')
+
+    document.head.innerHTML = '<meta name="csrf-token" content="token">'
+    document.dispatchEvent(new CustomEvent('turbo:visit', { detail: { action: 'restore' } }))
+    document.dispatchEvent(new Event('turbo:render'))
+    await new Promise((resolve) => requestAnimationFrame(resolve))
+
+    const [url, options] = fetchMock.mock.calls.at(-1)
+    expect(url).toBe('/creatives/1/remember_last_visited?visit_token=new-server-token')
+    expect(options.headers.get('X-Collavre-Last-Visited-Creative-Sequence')).toBe('3')
   })
 
   test('lazily reloads toggled branches and restores focus and scroll', async () => {

--- a/engines/collavre/app/javascript/controllers/__tests__/workspace_tree_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/workspace_tree_controller.test.js
@@ -167,6 +167,28 @@ describe('WorkspaceTreeController', () => {
     expect(fetchMock.mock.calls[2][1].headers.get('X-CSRF-Token')).toBe('fresh-token')
   })
 
+  test('does not retry a restored visit after a newer navigation starts', async () => {
+    document.head.innerHTML = '<meta name="csrf-token" content="stale-token">'
+    let resolveRefresh
+    fetchMock.mockReset()
+    fetchMock
+      .mockResolvedValueOnce({ ok: false, status: 422, headers: { get: () => null } })
+      .mockImplementationOnce(() => new Promise((resolve) => { resolveRefresh = resolve }))
+
+    document.dispatchEvent(new CustomEvent('turbo:visit', { detail: { action: 'restore' } }))
+    document.dispatchEvent(new Event('turbo:render'))
+
+    await new Promise((resolve) => requestAnimationFrame(resolve))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    document.dispatchEvent(new CustomEvent('turbo:visit', { detail: { action: 'advance' } }))
+    resolveRefresh({ headers: { get: () => 'fresh-token' } })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
   test('lazily reloads toggled branches and restores focus and scroll', async () => {
     let branchToggle = document.querySelector('.creative-workspace-tree-branch-toggle')
     controller.treeTarget.scrollTop = 24

--- a/engines/collavre/app/javascript/controllers/__tests__/workspace_tree_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/workspace_tree_controller.test.js
@@ -97,11 +97,11 @@ describe('WorkspaceTreeController', () => {
 
     await new Promise((resolve) => requestAnimationFrame(resolve))
 
-    expect(fetchMock).toHaveBeenLastCalledWith('/creatives/2/remember_last_visited', {
-      method: 'PATCH',
-      credentials: 'same-origin',
-      headers: { Accept: 'application/json', 'X-CSRF-Token': 'token' },
-    })
+    const [url, options] = fetchMock.mock.calls.at(-1)
+    expect(url).toBe('/creatives/2/remember_last_visited')
+    expect(options).toEqual(expect.objectContaining({ method: 'PATCH', credentials: 'same-origin' }))
+    expect(options.headers.get('Accept')).toBe('application/json')
+    expect(options.headers.get('X-CSRF-Token')).toBe('token')
   })
 
   test('records a cached history restore after Turbo reconnects the workspace controller', async () => {
@@ -136,11 +136,34 @@ describe('WorkspaceTreeController', () => {
       'workspace-tree'
     )
 
-    expect(fetchMock).toHaveBeenLastCalledWith('/creatives/2/remember_last_visited', {
-      method: 'PATCH',
+    const [url, options] = fetchMock.mock.calls.at(-1)
+    expect(url).toBe('/creatives/2/remember_last_visited')
+    expect(options).toEqual(expect.objectContaining({ method: 'PATCH', credentials: 'same-origin' }))
+    expect(options.headers.get('Accept')).toBe('application/json')
+    expect(options.headers.get('X-CSRF-Token')).toBe('token')
+  })
+
+  test('retries a cached history restore after refreshing a stale CSRF token', async () => {
+    document.head.innerHTML = '<meta name="csrf-token" content="stale-token">'
+    fetchMock.mockReset()
+    fetchMock
+      .mockResolvedValueOnce({ ok: false, status: 422, headers: { get: () => null } })
+      .mockResolvedValueOnce({ headers: { get: () => 'fresh-token' } })
+      .mockResolvedValueOnce({ ok: true, status: 204, headers: { get: () => null } })
+
+    document.dispatchEvent(new CustomEvent('turbo:visit', { detail: { action: 'restore' } }))
+    document.dispatchEvent(new Event('turbo:render'))
+
+    await new Promise((resolve) => requestAnimationFrame(resolve))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(fetchMock).toHaveBeenNthCalledWith(1, '/creatives/2/remember_last_visited', expect.objectContaining({ method: 'PATCH' }))
+    expect(fetchMock).toHaveBeenNthCalledWith(2, 'http://localhost/creatives?id=2', {
+      method: 'HEAD',
       credentials: 'same-origin',
-      headers: { Accept: 'application/json', 'X-CSRF-Token': 'token' },
     })
+    expect(fetchMock).toHaveBeenNthCalledWith(3, '/creatives/2/remember_last_visited', expect.objectContaining({ method: 'PATCH' }))
+    expect(fetchMock.mock.calls[2][1].headers.get('X-CSRF-Token')).toBe('fresh-token')
   })
 
   test('lazily reloads toggled branches and restores focus and scroll', async () => {

--- a/engines/collavre/app/javascript/controllers/__tests__/workspace_tree_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/workspace_tree_controller.test.js
@@ -170,10 +170,12 @@ describe('WorkspaceTreeController', () => {
     await new Promise((resolve) => setTimeout(resolve, 0))
 
     expect(fetchMock).toHaveBeenNthCalledWith(1, '/creatives/2/remember_last_visited?visit_token=server-token', expect.objectContaining({ method: 'PATCH' }))
-    expect(fetchMock).toHaveBeenNthCalledWith(2, 'http://localhost/creatives?id=2', {
+    expect(fetchMock).toHaveBeenNthCalledWith(2, 'http://localhost/creatives?id=2', expect.objectContaining({
       method: 'HEAD',
       credentials: 'same-origin',
-    })
+      headers: { 'X-Sec-Purpose': 'prefetch' },
+      signal: expect.any(AbortSignal),
+    }))
     expect(fetchMock).toHaveBeenNthCalledWith(3, '/creatives/2/remember_last_visited?visit_token=server-token', expect.objectContaining({ method: 'PATCH' }))
     expect(fetchMock.mock.calls[2][1].headers.get('X-CSRF-Token')).toBe('fresh-token')
   })

--- a/engines/collavre/app/javascript/controllers/__tests__/workspace_tree_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/workspace_tree_controller.test.js
@@ -14,9 +14,13 @@ describe('WorkspaceTreeController', () => {
 
   beforeEach(async () => {
     window.localStorage.clear()
-    fetchMock = jest.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({
+    fetchMock = jest.fn().mockImplementation((url) => Promise.resolve(
+      url === '/creatives/next_last_visited_sequence'
+        ? { ok: true, headers: new Headers(), json: async () => ({ sequence: 2 }) }
+        : {
+          ok: true,
+          headers: new Headers(),
+          json: async () => ({
         creatives: [
           {
             id: 1,
@@ -36,8 +40,9 @@ describe('WorkspaceTreeController', () => {
             ],
           },
         ],
-      }),
-    })
+          }),
+        }
+    ))
     global.fetch = fetchMock
     window.history.replaceState({}, '', '/creatives?id=2')
     preventNavigation = (event) => event.preventDefault()
@@ -103,6 +108,7 @@ describe('WorkspaceTreeController', () => {
     document.dispatchEvent(new Event('turbo:render'))
 
     await new Promise((resolve) => requestAnimationFrame(resolve))
+    await new Promise((resolve) => setTimeout(resolve, 0))
 
     const [url, options] = fetchMock.mock.calls.at(-1)
     expect(url).toBe('/creatives/2/remember_last_visited?visit_token=server-token')
@@ -142,6 +148,7 @@ describe('WorkspaceTreeController', () => {
 
     await new Promise((resolve) => setTimeout(resolve, 0))
     await new Promise((resolve) => requestAnimationFrame(resolve))
+    await new Promise((resolve) => setTimeout(resolve, 0))
 
     controller = application.getControllerForElementAndIdentifier(
       document.querySelector('[data-controller="workspace-tree"]'),
@@ -159,8 +166,10 @@ describe('WorkspaceTreeController', () => {
     document.head.innerHTML = '<meta name="csrf-token" content="stale-token">'
     fetchMock.mockReset()
     fetchMock
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ sequence: 2 }), headers: { get: () => null } })
       .mockResolvedValueOnce({ ok: false, status: 422, headers: { get: () => null } })
       .mockResolvedValueOnce({ headers: { get: () => 'fresh-token' } })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ sequence: 3 }), headers: { get: () => null } })
       .mockResolvedValueOnce({ ok: true, status: 204, headers: { get: () => null } })
 
     document.dispatchEvent(new CustomEvent('turbo:visit', { detail: { action: 'restore' } }))
@@ -169,15 +178,16 @@ describe('WorkspaceTreeController', () => {
     await new Promise((resolve) => requestAnimationFrame(resolve))
     await new Promise((resolve) => setTimeout(resolve, 0))
 
-    expect(fetchMock).toHaveBeenNthCalledWith(1, '/creatives/2/remember_last_visited?visit_token=server-token', expect.objectContaining({ method: 'PATCH' }))
-    expect(fetchMock).toHaveBeenNthCalledWith(2, 'http://localhost/creatives?id=2', expect.objectContaining({
+    expect(fetchMock).toHaveBeenNthCalledWith(1, '/creatives/next_last_visited_sequence', expect.objectContaining({ method: 'PATCH' }))
+    expect(fetchMock).toHaveBeenNthCalledWith(2, '/creatives/2/remember_last_visited?visit_token=server-token', expect.objectContaining({ method: 'PATCH' }))
+    expect(fetchMock).toHaveBeenNthCalledWith(3, 'http://localhost/creatives?id=2', expect.objectContaining({
       method: 'HEAD',
       credentials: 'same-origin',
       headers: { 'X-Sec-Purpose': 'prefetch' },
       signal: expect.any(AbortSignal),
     }))
-    expect(fetchMock).toHaveBeenNthCalledWith(3, '/creatives/2/remember_last_visited?visit_token=server-token', expect.objectContaining({ method: 'PATCH' }))
-    expect(fetchMock.mock.calls[2][1].headers.get('X-CSRF-Token')).toBe('fresh-token')
+    expect(fetchMock).toHaveBeenNthCalledWith(5, '/creatives/2/remember_last_visited?visit_token=server-token', expect.objectContaining({ method: 'PATCH' }))
+    expect(fetchMock.mock.calls[4][1].headers.get('X-CSRF-Token')).toBe('fresh-token')
   })
 
   test('does not retry a restored visit after a newer navigation starts', async () => {
@@ -185,6 +195,7 @@ describe('WorkspaceTreeController', () => {
     let resolveRefresh
     fetchMock.mockReset()
     fetchMock
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ sequence: 2 }), headers: { get: () => null } })
       .mockResolvedValueOnce({ ok: false, status: 422, headers: { get: () => null } })
       .mockImplementationOnce(() => new Promise((resolve) => { resolveRefresh = resolve }))
 
@@ -194,12 +205,12 @@ describe('WorkspaceTreeController', () => {
     await new Promise((resolve) => requestAnimationFrame(resolve))
     await new Promise((resolve) => setTimeout(resolve, 0))
 
-    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(fetchMock).toHaveBeenCalledTimes(3)
     document.dispatchEvent(new CustomEvent('turbo:visit', { detail: { action: 'advance' } }))
     resolveRefresh({ headers: { get: () => 'fresh-token' } })
     await new Promise((resolve) => setTimeout(resolve, 0))
 
-    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(fetchMock).toHaveBeenCalledTimes(3)
   })
 
   test('uses the frame response token after workspace navigation', async () => {
@@ -220,10 +231,11 @@ describe('WorkspaceTreeController', () => {
     document.dispatchEvent(new CustomEvent('turbo:visit', { detail: { action: 'restore' } }))
     document.dispatchEvent(new Event('turbo:render'))
     await new Promise((resolve) => requestAnimationFrame(resolve))
+    await new Promise((resolve) => setTimeout(resolve, 0))
 
     const [url, options] = fetchMock.mock.calls.at(-1)
     expect(url).toBe('/creatives/1/remember_last_visited?visit_token=new-server-token')
-    expect(options.headers.get('X-Collavre-Last-Visited-Creative-Sequence')).toBe('3')
+    expect(options.headers.get('X-Collavre-Last-Visited-Creative-Sequence')).toBe('2')
   })
 
   test('lazily reloads toggled branches and restores focus and scroll', async () => {

--- a/engines/collavre/app/javascript/controllers/__tests__/workspace_tree_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/workspace_tree_controller.test.js
@@ -86,6 +86,7 @@ describe('WorkspaceTreeController', () => {
     expect(document.querySelector('[data-creative-id="2"] a').getAttribute('aria-current')).toBe('page')
     expect(document.querySelector('[data-creative-id="2"] a').dataset.turboFrame).toBe('creative-workspace-content')
     expect(document.querySelector('[data-creative-id="2"] a').dataset.turboAction).toBe('advance')
+    expect(document.querySelector('[data-creative-id="2"] a').dataset.turboPrefetch).toBe('false')
     expect(document.querySelector('.creative-workspace-tree-branch-toggle').getAttribute('aria-label')).toBe('Root')
     expect(document.querySelector('.creative-workspace-tree-branch-toggle svg path').getAttribute('d')).toBe('M6 9L12 15L18 9')
   })

--- a/engines/collavre/app/javascript/controllers/__tests__/workspace_tree_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/workspace_tree_controller.test.js
@@ -45,6 +45,7 @@ describe('WorkspaceTreeController', () => {
       <section data-controller="workspace-tree"
                data-workspace-tree-url-value="/creatives.json?workspace_tree=1"
                data-workspace-tree-last-visited-creative-url-value="/creatives"
+               data-workspace-tree-last-visited-creative-visit-token-value="server-token"
                data-workspace-tree-current-path-value="[1,2,3]"
                data-workspace-tree-loading-text-value="Loading"
                data-workspace-tree-empty-text-value="Empty"
@@ -99,7 +100,7 @@ describe('WorkspaceTreeController', () => {
     await new Promise((resolve) => requestAnimationFrame(resolve))
 
     const [url, options] = fetchMock.mock.calls.at(-1)
-    expect(url).toBe('/creatives/2/remember_last_visited')
+    expect(url).toBe('/creatives/2/remember_last_visited?visit_token=server-token')
     expect(options).toEqual(expect.objectContaining({ method: 'PATCH', credentials: 'same-origin' }))
     expect(options.headers.get('Accept')).toBe('application/json')
     expect(options.headers.get('X-CSRF-Token')).toBe('token')
@@ -112,6 +113,7 @@ describe('WorkspaceTreeController', () => {
       <section data-controller="workspace-tree"
                data-workspace-tree-url-value="/creatives.json?workspace_tree=1"
                data-workspace-tree-last-visited-creative-url-value="/creatives"
+               data-workspace-tree-last-visited-creative-visit-token-value="server-token"
                data-workspace-tree-current-path-value="[1,2,3]"
                data-workspace-tree-loading-text-value="Loading"
                data-workspace-tree-empty-text-value="Empty"
@@ -138,7 +140,7 @@ describe('WorkspaceTreeController', () => {
     )
 
     const [url, options] = fetchMock.mock.calls.at(-1)
-    expect(url).toBe('/creatives/2/remember_last_visited')
+    expect(url).toBe('/creatives/2/remember_last_visited?visit_token=server-token')
     expect(options).toEqual(expect.objectContaining({ method: 'PATCH', credentials: 'same-origin' }))
     expect(options.headers.get('Accept')).toBe('application/json')
     expect(options.headers.get('X-CSRF-Token')).toBe('token')
@@ -158,12 +160,12 @@ describe('WorkspaceTreeController', () => {
     await new Promise((resolve) => requestAnimationFrame(resolve))
     await new Promise((resolve) => setTimeout(resolve, 0))
 
-    expect(fetchMock).toHaveBeenNthCalledWith(1, '/creatives/2/remember_last_visited', expect.objectContaining({ method: 'PATCH' }))
+    expect(fetchMock).toHaveBeenNthCalledWith(1, '/creatives/2/remember_last_visited?visit_token=server-token', expect.objectContaining({ method: 'PATCH' }))
     expect(fetchMock).toHaveBeenNthCalledWith(2, 'http://localhost/creatives?id=2', {
       method: 'HEAD',
       credentials: 'same-origin',
     })
-    expect(fetchMock).toHaveBeenNthCalledWith(3, '/creatives/2/remember_last_visited', expect.objectContaining({ method: 'PATCH' }))
+    expect(fetchMock).toHaveBeenNthCalledWith(3, '/creatives/2/remember_last_visited?visit_token=server-token', expect.objectContaining({ method: 'PATCH' }))
     expect(fetchMock.mock.calls[2][1].headers.get('X-CSRF-Token')).toBe('fresh-token')
   })
 

--- a/engines/collavre/app/javascript/controllers/__tests__/workspace_tree_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/workspace_tree_controller.test.js
@@ -44,6 +44,7 @@ describe('WorkspaceTreeController', () => {
     document.body.innerHTML = `
       <section data-controller="workspace-tree"
                data-workspace-tree-url-value="/creatives.json?workspace_tree=1"
+               data-workspace-tree-last-visited-creative-url-value="/creatives"
                data-workspace-tree-current-path-value="[1,2,3]"
                data-workspace-tree-loading-text-value="Loading"
                data-workspace-tree-empty-text-value="Empty"
@@ -87,6 +88,20 @@ describe('WorkspaceTreeController', () => {
     expect(document.querySelector('[data-creative-id="2"] a').dataset.turboAction).toBe('advance')
     expect(document.querySelector('.creative-workspace-tree-branch-toggle').getAttribute('aria-label')).toBe('Root')
     expect(document.querySelector('.creative-workspace-tree-branch-toggle svg path').getAttribute('d')).toBe('M6 9L12 15L18 9')
+  })
+
+  test('records the visible creative after a cached Turbo history restore', async () => {
+    document.head.innerHTML = '<meta name="csrf-token" content="token">'
+    document.dispatchEvent(new CustomEvent('turbo:visit', { detail: { action: 'restore' } }))
+    document.dispatchEvent(new Event('turbo:render'))
+
+    await new Promise((resolve) => requestAnimationFrame(resolve))
+
+    expect(fetchMock).toHaveBeenLastCalledWith('/creatives/2/remember_last_visited', {
+      method: 'PATCH',
+      credentials: 'same-origin',
+      headers: { Accept: 'application/json', 'X-CSRF-Token': 'token' },
+    })
   })
 
   test('lazily reloads toggled branches and restores focus and scroll', async () => {

--- a/engines/collavre/app/javascript/controllers/index.js
+++ b/engines/collavre/app/javascript/controllers/index.js
@@ -39,6 +39,7 @@ import ImageLightboxController from "./image_lightbox_controller"
 import SearchPopupController from "./search_popup_controller"
 import LandingVideoController from "./landing_video_controller"
 import InboxBadgeController from "./inbox_badge_controller"
+import LastVisitedCreativeController from "./last_visited_creative_controller"
 import WorkspaceTreeController from "./workspace_tree_controller"
 import GatewayCheckController from "./gateway_check_controller"
 import AgentConnectionController from "./agent_connection_controller"
@@ -81,6 +82,7 @@ export {
   CommentBadgeController,
   LandingVideoController,
   InboxBadgeController,
+  LastVisitedCreativeController,
   WorkspaceTreeController,
   GatewayCheckController,
   AgentConnectionController,
@@ -128,6 +130,7 @@ export function registerControllers(application) {
   application.register("comment-badge", CommentBadgeController)
   application.register("landing-video", LandingVideoController)
   application.register("inbox-badge", InboxBadgeController)
+  application.register("last-visited-creative", LastVisitedCreativeController)
   application.register("workspace-tree", WorkspaceTreeController)
   application.register("gateway-check", GatewayCheckController)
   application.register("agent-connection", AgentConnectionController)

--- a/engines/collavre/app/javascript/controllers/last_visited_creative_controller.js
+++ b/engines/collavre/app/javascript/controllers/last_visited_creative_controller.js
@@ -46,13 +46,13 @@ export default class extends Controller {
   }
 
   handleFetchRequest(event) {
-    prepareLastVisitedCreativeNavigation(event, this.visitTokenValue, this.visitSequenceValue)
+    prepareLastVisitedCreativeNavigation(event, this.urlValue, this.visitTokenValue)
   }
 
   rememberRestoredCreative() {
     if (lastVisitAction !== 'restore' || !this.element.isConnected) return
 
-    rememberLastVisitedCreative(this.urlValue, this.creativeIdValue, this.visitTokenValue, this.visitSequenceValue)
+    rememberLastVisitedCreative(this.urlValue, this.creativeIdValue, this.visitTokenValue)
     lastVisitAction = null
   }
 }

--- a/engines/collavre/app/javascript/controllers/last_visited_creative_controller.js
+++ b/engines/collavre/app/javascript/controllers/last_visited_creative_controller.js
@@ -1,5 +1,5 @@
 import { Controller } from '@hotwired/stimulus'
-import { rememberLastVisitedCreative } from '../lib/last_visited_creative'
+import { cancelPendingLastVisitedCreative, rememberLastVisitedCreative } from '../lib/last_visited_creative'
 
 // A Turbo restore can replace the entire body, so preserve the visit action
 // outside an individual controller instance until the restored page reconnects.
@@ -28,6 +28,7 @@ export default class extends Controller {
   }
 
   handleVisit(event) {
+    cancelPendingLastVisitedCreative()
     lastVisitAction = event.detail?.action
   }
 

--- a/engines/collavre/app/javascript/controllers/last_visited_creative_controller.js
+++ b/engines/collavre/app/javascript/controllers/last_visited_creative_controller.js
@@ -9,6 +9,7 @@ export default class extends Controller {
   static values = {
     url: String,
     creativeId: String,
+    visitToken: String,
   }
 
   connect() {
@@ -39,7 +40,7 @@ export default class extends Controller {
   rememberRestoredCreative() {
     if (lastVisitAction !== 'restore' || !this.element.isConnected) return
 
-    rememberLastVisitedCreative(this.urlValue, this.creativeIdValue)
+    rememberLastVisitedCreative(this.urlValue, this.creativeIdValue, this.visitTokenValue)
     lastVisitAction = null
   }
 }

--- a/engines/collavre/app/javascript/controllers/last_visited_creative_controller.js
+++ b/engines/collavre/app/javascript/controllers/last_visited_creative_controller.js
@@ -1,5 +1,9 @@
 import { Controller } from '@hotwired/stimulus'
-import { cancelPendingLastVisitedCreative, rememberLastVisitedCreative } from '../lib/last_visited_creative'
+import {
+  cancelPendingLastVisitedCreative,
+  prepareLastVisitedCreativeNavigation,
+  rememberLastVisitedCreative,
+} from '../lib/last_visited_creative'
 
 // A Turbo restore can replace the entire body, so preserve the visit action
 // outside an individual controller instance until the restored page reconnects.
@@ -10,13 +14,16 @@ export default class extends Controller {
     url: String,
     creativeId: String,
     visitToken: String,
+    visitSequence: Number,
   }
 
   connect() {
     this.handleVisit = this.handleVisit.bind(this)
     this.handleRender = this.handleRender.bind(this)
+    this.handleFetchRequest = this.handleFetchRequest.bind(this)
     document.addEventListener('turbo:visit', this.handleVisit)
     document.addEventListener('turbo:render', this.handleRender)
+    document.addEventListener('turbo:before-fetch-request', this.handleFetchRequest)
 
     if (lastVisitAction === 'restore') {
       requestAnimationFrame(() => this.rememberRestoredCreative())
@@ -26,6 +33,7 @@ export default class extends Controller {
   disconnect() {
     document.removeEventListener('turbo:visit', this.handleVisit)
     document.removeEventListener('turbo:render', this.handleRender)
+    document.removeEventListener('turbo:before-fetch-request', this.handleFetchRequest)
   }
 
   handleVisit(event) {
@@ -37,10 +45,14 @@ export default class extends Controller {
     requestAnimationFrame(() => this.rememberRestoredCreative())
   }
 
+  handleFetchRequest(event) {
+    prepareLastVisitedCreativeNavigation(event, this.visitTokenValue, this.visitSequenceValue)
+  }
+
   rememberRestoredCreative() {
     if (lastVisitAction !== 'restore' || !this.element.isConnected) return
 
-    rememberLastVisitedCreative(this.urlValue, this.creativeIdValue, this.visitTokenValue)
+    rememberLastVisitedCreative(this.urlValue, this.creativeIdValue, this.visitTokenValue, this.visitSequenceValue)
     lastVisitAction = null
   }
 }

--- a/engines/collavre/app/javascript/controllers/last_visited_creative_controller.js
+++ b/engines/collavre/app/javascript/controllers/last_visited_creative_controller.js
@@ -1,0 +1,44 @@
+import { Controller } from '@hotwired/stimulus'
+import { rememberLastVisitedCreative } from '../lib/last_visited_creative'
+
+// A Turbo restore can replace the entire body, so preserve the visit action
+// outside an individual controller instance until the restored page reconnects.
+let lastVisitAction = null
+
+export default class extends Controller {
+  static values = {
+    url: String,
+    creativeId: String,
+  }
+
+  connect() {
+    this.handleVisit = this.handleVisit.bind(this)
+    this.handleRender = this.handleRender.bind(this)
+    document.addEventListener('turbo:visit', this.handleVisit)
+    document.addEventListener('turbo:render', this.handleRender)
+
+    if (lastVisitAction === 'restore') {
+      requestAnimationFrame(() => this.rememberRestoredCreative())
+    }
+  }
+
+  disconnect() {
+    document.removeEventListener('turbo:visit', this.handleVisit)
+    document.removeEventListener('turbo:render', this.handleRender)
+  }
+
+  handleVisit(event) {
+    lastVisitAction = event.detail?.action
+  }
+
+  handleRender() {
+    requestAnimationFrame(() => this.rememberRestoredCreative())
+  }
+
+  rememberRestoredCreative() {
+    if (lastVisitAction !== 'restore' || !this.element.isConnected) return
+
+    rememberLastVisitedCreative(this.urlValue, this.creativeIdValue)
+    lastVisitAction = null
+  }
+}

--- a/engines/collavre/app/javascript/controllers/workspace_tree_controller.js
+++ b/engines/collavre/app/javascript/controllers/workspace_tree_controller.js
@@ -1,5 +1,5 @@
 import { Controller } from '@hotwired/stimulus'
-import { rememberLastVisitedCreative } from '../lib/last_visited_creative'
+import { cancelPendingLastVisitedCreative, rememberLastVisitedCreative } from '../lib/last_visited_creative'
 // Keep the workspace tree's branch affordance visually aligned with the
 // central creative tree (components/creative_tree_row.js#_toggleIcon).
 import { CHEVRON_COLLAPSED, CHEVRON_EXPANDED } from '../utils/chevron_icons'
@@ -294,6 +294,7 @@ export default class extends Controller {
   }
 
   handleVisitStart(event) {
+    cancelPendingLastVisitedCreative()
     lastVisitAction = event.detail?.action
   }
 

--- a/engines/collavre/app/javascript/controllers/workspace_tree_controller.js
+++ b/engines/collavre/app/javascript/controllers/workspace_tree_controller.js
@@ -1,5 +1,5 @@
 import { Controller } from '@hotwired/stimulus'
-import csrfFetch, { refreshCsrfToken } from '../lib/api/csrf_fetch'
+import { rememberLastVisitedCreative } from '../lib/last_visited_creative'
 // Keep the workspace tree's branch affordance visually aligned with the
 // central creative tree (components/creative_tree_row.js#_toggleIcon).
 import { CHEVRON_COLLAPSED, CHEVRON_EXPANDED } from '../utils/chevron_icons'
@@ -418,22 +418,7 @@ export default class extends Controller {
   rememberLastVisitedCreative(creativeId) {
     if (!creativeId || !this.hasLastVisitedCreativeUrlValue) return
 
-    const url = new URL(this.lastVisitedCreativeUrlValue, window.location.origin)
-    url.pathname = `${url.pathname.replace(/\/$/, '')}/${encodeURIComponent(creativeId)}/remember_last_visited`
-    const request = () => csrfFetch(`${url.pathname}${url.search}`, {
-      method: 'PATCH',
-      headers: { Accept: 'application/json' },
-    })
-
-    request()
-      .then(async (response) => {
-        if (response.ok) return
-        if (response.status !== 422) return
-
-        await refreshCsrfToken()
-        await request()
-      })
-      .catch(() => {})
+    rememberLastVisitedCreative(this.lastVisitedCreativeUrlValue, creativeId)
   }
 
   setActiveId(id) {

--- a/engines/collavre/app/javascript/controllers/workspace_tree_controller.js
+++ b/engines/collavre/app/javascript/controllers/workspace_tree_controller.js
@@ -16,6 +16,7 @@ export default class extends Controller {
 
   static values = {
     url: String,
+    lastVisitedCreativeUrl: String,
     currentPath: Array,
     loadingText: String,
     emptyText: String,
@@ -308,8 +309,9 @@ export default class extends Controller {
     requestAnimationFrame(() => {
       // The restore check must run even from an instance the render just
       // disconnected — it only reads the current document and URL.
-      if (lastVisitAction === 'restore') this.ensureFrameMatchesLocation()
-      if (this.element.isConnected) this.syncFromWorkspaceFrame()
+      const restoringHistory = lastVisitAction === 'restore'
+      if (restoringHistory) this.ensureFrameMatchesLocation()
+      if (this.element.isConnected) this.syncFromWorkspaceFrame(undefined, { rememberLastVisited: restoringHistory })
     })
   }
 
@@ -357,7 +359,7 @@ export default class extends Controller {
 
   syncFromWorkspaceFrame(
     frame = document.getElementById('creative-workspace-content'),
-    { authoritative = false, syncChat = true } = {}
+    { authoritative = false, syncChat = true, rememberLastVisited = false } = {}
   ) {
     if (!frame) return
 
@@ -400,6 +402,24 @@ export default class extends Controller {
         highlightId: authoritative ? this.commentIdFromLocation() : undefined,
       })
     }
+
+    if (rememberLastVisited) this.rememberLastVisitedCreative(stateCreativeId)
+  }
+
+  rememberLastVisitedCreative(creativeId) {
+    if (!creativeId || !this.hasLastVisitedCreativeUrlValue) return
+
+    const url = new URL(this.lastVisitedCreativeUrlValue, window.location.origin)
+    url.pathname = `${url.pathname.replace(/\/$/, '')}/${encodeURIComponent(creativeId)}/remember_last_visited`
+    const headers = {
+      Accept: 'application/json',
+      'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]')?.content || '',
+    }
+    fetch(`${url.pathname}${url.search}`, {
+      method: 'PATCH',
+      credentials: 'same-origin',
+      headers,
+    }).catch(() => {})
   }
 
   setActiveId(id) {

--- a/engines/collavre/app/javascript/controllers/workspace_tree_controller.js
+++ b/engines/collavre/app/javascript/controllers/workspace_tree_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from '@hotwired/stimulus'
+import csrfFetch, { refreshCsrfToken } from '../lib/api/csrf_fetch'
 // Keep the workspace tree's branch affordance visually aligned with the
 // central creative tree (components/creative_tree_row.js#_toggleIcon).
 import { CHEVRON_COLLAPSED, CHEVRON_EXPANDED } from '../utils/chevron_icons'
@@ -418,15 +419,20 @@ export default class extends Controller {
 
     const url = new URL(this.lastVisitedCreativeUrlValue, window.location.origin)
     url.pathname = `${url.pathname.replace(/\/$/, '')}/${encodeURIComponent(creativeId)}/remember_last_visited`
-    const headers = {
-      Accept: 'application/json',
-      'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]')?.content || '',
-    }
-    fetch(`${url.pathname}${url.search}`, {
+    const request = () => csrfFetch(`${url.pathname}${url.search}`, {
       method: 'PATCH',
-      credentials: 'same-origin',
-      headers,
-    }).catch(() => {})
+      headers: { Accept: 'application/json' },
+    })
+
+    request()
+      .then(async (response) => {
+        if (response.ok) return
+        if (response.status !== 422) return
+
+        await refreshCsrfToken()
+        await request()
+      })
+      .catch(() => {})
   }
 
   setActiveId(id) {

--- a/engines/collavre/app/javascript/controllers/workspace_tree_controller.js
+++ b/engines/collavre/app/javascript/controllers/workspace_tree_controller.js
@@ -18,6 +18,7 @@ export default class extends Controller {
   static values = {
     url: String,
     lastVisitedCreativeUrl: String,
+    lastVisitedCreativeVisitToken: String,
     currentPath: Array,
     loadingText: String,
     emptyText: String,
@@ -417,9 +418,9 @@ export default class extends Controller {
   }
 
   rememberLastVisitedCreative(creativeId) {
-    if (!creativeId || !this.hasLastVisitedCreativeUrlValue) return
+    if (!creativeId || !this.hasLastVisitedCreativeUrlValue || !this.hasLastVisitedCreativeVisitTokenValue) return
 
-    rememberLastVisitedCreative(this.lastVisitedCreativeUrlValue, creativeId)
+    rememberLastVisitedCreative(this.lastVisitedCreativeUrlValue, creativeId, this.lastVisitedCreativeVisitTokenValue)
   }
 
   setActiveId(id) {

--- a/engines/collavre/app/javascript/controllers/workspace_tree_controller.js
+++ b/engines/collavre/app/javascript/controllers/workspace_tree_controller.js
@@ -305,8 +305,8 @@ export default class extends Controller {
   handleFetchRequest(event) {
     prepareLastVisitedCreativeNavigation(
       event,
+      this.lastVisitedCreativeUrlValue,
       this.lastVisitedCreativeVisitTokenValue,
-      this.lastVisitedCreativeVisitSequenceValue
     )
   }
 
@@ -440,8 +440,7 @@ export default class extends Controller {
     rememberLastVisitedCreative(
       this.lastVisitedCreativeUrlValue,
       creativeId,
-      this.lastVisitedCreativeVisitTokenValue,
-      this.lastVisitedCreativeVisitSequenceValue
+      this.lastVisitedCreativeVisitTokenValue
     )
   }
 

--- a/engines/collavre/app/javascript/controllers/workspace_tree_controller.js
+++ b/engines/collavre/app/javascript/controllers/workspace_tree_controller.js
@@ -58,7 +58,11 @@ export default class extends Controller {
     // have started in between and supersedes the restore.
     if (lastVisitAction === 'restore') {
       requestAnimationFrame(() => {
-        if (lastVisitAction === 'restore') this.ensureFrameMatchesLocation()
+        if (lastVisitAction !== 'restore' || !this.element.isConnected) return
+
+        this.ensureFrameMatchesLocation()
+        this.syncFromWorkspaceFrame(undefined, { rememberLastVisited: true })
+        lastVisitAction = null
       })
     }
     this.load({ syncChat: false })
@@ -311,7 +315,10 @@ export default class extends Controller {
       // disconnected — it only reads the current document and URL.
       const restoringHistory = lastVisitAction === 'restore'
       if (restoringHistory) this.ensureFrameMatchesLocation()
-      if (this.element.isConnected) this.syncFromWorkspaceFrame(undefined, { rememberLastVisited: restoringHistory })
+      if (this.element.isConnected) {
+        this.syncFromWorkspaceFrame(undefined, { rememberLastVisited: restoringHistory })
+        if (restoringHistory) lastVisitAction = null
+      }
     })
   }
 

--- a/engines/collavre/app/javascript/controllers/workspace_tree_controller.js
+++ b/engines/collavre/app/javascript/controllers/workspace_tree_controller.js
@@ -1,5 +1,9 @@
 import { Controller } from '@hotwired/stimulus'
-import { cancelPendingLastVisitedCreative, rememberLastVisitedCreative } from '../lib/last_visited_creative'
+import {
+  cancelPendingLastVisitedCreative,
+  prepareLastVisitedCreativeNavigation,
+  rememberLastVisitedCreative,
+} from '../lib/last_visited_creative'
 // Keep the workspace tree's branch affordance visually aligned with the
 // central creative tree (components/creative_tree_row.js#_toggleIcon).
 import { CHEVRON_COLLAPSED, CHEVRON_EXPANDED } from '../utils/chevron_icons'
@@ -19,6 +23,7 @@ export default class extends Controller {
     url: String,
     lastVisitedCreativeUrl: String,
     lastVisitedCreativeVisitToken: String,
+    lastVisitedCreativeVisitSequence: Number,
     currentPath: Array,
     loadingText: String,
     emptyText: String,
@@ -34,6 +39,7 @@ export default class extends Controller {
     this.invalidationGeneration = 0
     this.handleFrameLoad = this.handleFrameLoad.bind(this)
     this.handleFrameRequest = this.handleFrameRequest.bind(this)
+    this.handleFetchRequest = this.handleFetchRequest.bind(this)
     this.handleTurboRender = this.handleTurboRender.bind(this)
     this.handleVisitStart = this.handleVisitStart.bind(this)
     this.handlePopState = this.handlePopState.bind(this)
@@ -46,6 +52,7 @@ export default class extends Controller {
     this.element.addEventListener('touchend', this.handlePanelTouchEnd, { passive: true })
     document.addEventListener('turbo:visit', this.handleVisitStart)
     document.addEventListener('turbo:before-fetch-request', this.handleFrameRequest)
+    document.addEventListener('turbo:before-fetch-request', this.handleFetchRequest)
     document.addEventListener('turbo:frame-load', this.handleFrameLoad)
     document.addEventListener('turbo:frame-render', this.handleFrameLoad)
     document.addEventListener('turbo:render', this.handleTurboRender)
@@ -80,6 +87,7 @@ export default class extends Controller {
     this.element.removeEventListener('touchend', this.handlePanelTouchEnd)
     document.removeEventListener('turbo:visit', this.handleVisitStart)
     document.removeEventListener('turbo:before-fetch-request', this.handleFrameRequest)
+    document.removeEventListener('turbo:before-fetch-request', this.handleFetchRequest)
     document.removeEventListener('turbo:frame-load', this.handleFrameLoad)
     document.removeEventListener('turbo:frame-render', this.handleFrameLoad)
     document.removeEventListener('turbo:render', this.handleTurboRender)
@@ -294,6 +302,14 @@ export default class extends Controller {
     this.frameRequestGeneration = this.invalidationGeneration
   }
 
+  handleFetchRequest(event) {
+    prepareLastVisitedCreativeNavigation(
+      event,
+      this.lastVisitedCreativeVisitTokenValue,
+      this.lastVisitedCreativeVisitSequenceValue
+    )
+  }
+
   handleVisitStart(event) {
     cancelPendingLastVisitedCreative()
     lastVisitAction = event.detail?.action
@@ -378,6 +394,7 @@ export default class extends Controller {
     if (!state) return
 
     const stateCreativeId = state.dataset.creativeId
+    this.updateLastVisitedCreativeNavigation(state)
     const locationCreativeId = this.creativeIdFromLocation()
     if (!stateCreativeId && (authoritative || !locationCreativeId)) {
       this.currentPathValue = []
@@ -420,7 +437,21 @@ export default class extends Controller {
   rememberLastVisitedCreative(creativeId) {
     if (!creativeId || !this.hasLastVisitedCreativeUrlValue || !this.hasLastVisitedCreativeVisitTokenValue) return
 
-    rememberLastVisitedCreative(this.lastVisitedCreativeUrlValue, creativeId, this.lastVisitedCreativeVisitTokenValue)
+    rememberLastVisitedCreative(
+      this.lastVisitedCreativeUrlValue,
+      creativeId,
+      this.lastVisitedCreativeVisitTokenValue,
+      this.lastVisitedCreativeVisitSequenceValue
+    )
+  }
+
+  updateLastVisitedCreativeNavigation(state) {
+    const token = state.dataset.lastVisitedCreativeVisitToken
+    const sequence = Number(state.dataset.lastVisitedCreativeVisitSequence)
+    if (!token || !Number.isFinite(sequence)) return
+
+    this.lastVisitedCreativeVisitTokenValue = token
+    this.lastVisitedCreativeVisitSequenceValue = sequence
   }
 
   setActiveId(id) {

--- a/engines/collavre/app/javascript/controllers/workspace_tree_controller.js
+++ b/engines/collavre/app/javascript/controllers/workspace_tree_controller.js
@@ -188,6 +188,7 @@ export default class extends Controller {
     link.className = 'creative-workspace-tree-link'
     link.dataset.turboFrame = 'creative-workspace-content'
     link.dataset.turboAction = 'advance'
+    link.dataset.turboPrefetch = 'false'
     link.dataset.creativeId = String(node.id)
     link.dataset.creativeSnippet = node.snippet || node.label
     link.dataset.canComment = String(node.can_comment === true)

--- a/engines/collavre/app/javascript/lib/__tests__/creative_link_prefetch.test.js
+++ b/engines/collavre/app/javascript/lib/__tests__/creative_link_prefetch.test.js
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import "../creative_link_prefetch"
+import { isCreativeVisitNavigation } from "../creative_link_prefetch"
 
 function prefetch(link) {
   const event = new Event("turbo:before-prefetch", { bubbles: true, cancelable: true })
@@ -33,4 +33,14 @@ test("does not prevent prefetching unrelated or external links", () => {
 
   expect(prefetch(unrelated).defaultPrevented).toBe(false)
   expect(prefetch(external).defaultPrevented).toBe(false)
+})
+
+test("identifies only Creative index and show routes as visit navigations", () => {
+  [ "/creatives", "/creatives.html", "/collavre/creatives/2" ].forEach((url) => {
+    expect(isCreativeVisitNavigation(url)).toBe(true)
+  })
+
+  ;[ "/creatives/2/comments/3/activity_log", "/creatives/next_last_visited_sequence" ].forEach((url) => {
+    expect(isCreativeVisitNavigation(url)).toBe(false)
+  })
 })

--- a/engines/collavre/app/javascript/lib/__tests__/creative_link_prefetch.test.js
+++ b/engines/collavre/app/javascript/lib/__tests__/creative_link_prefetch.test.js
@@ -9,6 +9,14 @@ function prefetch(link) {
   return event
 }
 
+function fetchRequest(url, headers = {}) {
+  const event = new CustomEvent("turbo:before-fetch-request", {
+    detail: { url: new URL(url, window.location.origin), fetchOptions: { headers } },
+  })
+  document.dispatchEvent(event)
+  return headers
+}
+
 afterEach(() => {
   document.body.innerHTML = ""
 })
@@ -33,4 +41,16 @@ test("does not prevent prefetching unrelated or external links", () => {
 
   expect(prefetch(unrelated).defaultPrevented).toBe(false)
   expect(prefetch(external).defaultPrevented).toBe(false)
+})
+
+test("orders same-origin Creative navigation requests", () => {
+  const headers = fetchRequest("/collavre/creatives?id=3")
+
+  expect(headers["X-Collavre-Last-Visited-Creative-At"]).toEqual(expect.any(String))
+})
+
+test("does not add ordering headers to unrelated requests", () => {
+  const headers = fetchRequest("/users/1")
+
+  expect(headers).not.toHaveProperty("X-Collavre-Last-Visited-Creative-At")
 })

--- a/engines/collavre/app/javascript/lib/__tests__/creative_link_prefetch.test.js
+++ b/engines/collavre/app/javascript/lib/__tests__/creative_link_prefetch.test.js
@@ -1,0 +1,36 @@
+/**
+ * @jest-environment jsdom
+ */
+import "../creative_link_prefetch"
+
+function prefetch(link) {
+  const event = new Event("turbo:before-prefetch", { bubbles: true, cancelable: true })
+  link.dispatchEvent(event)
+  return event
+}
+
+afterEach(() => {
+  document.body.innerHTML = ""
+})
+
+test("prevents prefetching any same-origin Creative navigation link", () => {
+  const links = [ "/creatives/1", "/collavre/creatives/2", "/workspace/creatives?id=3" ].map((href) => {
+    const link = document.createElement("a")
+    link.href = href
+    document.body.appendChild(link)
+    return link
+  })
+
+  links.forEach((link) => expect(prefetch(link).defaultPrevented).toBe(true))
+})
+
+test("does not prevent prefetching unrelated or external links", () => {
+  const unrelated = document.createElement("a")
+  unrelated.href = "/users/1"
+  const external = document.createElement("a")
+  external.href = "https://example.com/creatives/1"
+  document.body.append(unrelated, external)
+
+  expect(prefetch(unrelated).defaultPrevented).toBe(false)
+  expect(prefetch(external).defaultPrevented).toBe(false)
+})

--- a/engines/collavre/app/javascript/lib/__tests__/creative_link_prefetch.test.js
+++ b/engines/collavre/app/javascript/lib/__tests__/creative_link_prefetch.test.js
@@ -9,14 +9,6 @@ function prefetch(link) {
   return event
 }
 
-function fetchRequest(url, headers = {}) {
-  const event = new CustomEvent("turbo:before-fetch-request", {
-    detail: { url: new URL(url, window.location.origin), fetchOptions: { headers } },
-  })
-  document.dispatchEvent(event)
-  return headers
-}
-
 afterEach(() => {
   document.body.innerHTML = ""
 })
@@ -41,16 +33,4 @@ test("does not prevent prefetching unrelated or external links", () => {
 
   expect(prefetch(unrelated).defaultPrevented).toBe(false)
   expect(prefetch(external).defaultPrevented).toBe(false)
-})
-
-test("orders same-origin Creative navigation requests", () => {
-  const headers = fetchRequest("/collavre/creatives?id=3")
-
-  expect(headers["X-Collavre-Last-Visited-Creative-At"]).toEqual(expect.any(String))
-})
-
-test("does not add ordering headers to unrelated requests", () => {
-  const headers = fetchRequest("/users/1")
-
-  expect(headers).not.toHaveProperty("X-Collavre-Last-Visited-Creative-At")
 })

--- a/engines/collavre/app/javascript/lib/__tests__/last_visited_creative.test.js
+++ b/engines/collavre/app/javascript/lib/__tests__/last_visited_creative.test.js
@@ -40,6 +40,21 @@ describe('rememberLastVisitedCreative', () => {
     expect(csrfFetch).toHaveBeenCalledWith('/creatives/next_last_visited_sequence', expect.objectContaining({ method: 'PATCH' }))
   })
 
+  test('refreshes CSRF and retries sequence reservation before remembering a restored Creative', async () => {
+    csrfFetch
+      .mockResolvedValueOnce({ ok: false, status: 422 })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ sequence: 2 }) })
+      .mockResolvedValueOnce({ ok: true })
+
+    rememberLastVisitedCreative('/creatives', 1, 'restored-token')
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(refreshCsrfToken).toHaveBeenCalledWith(expect.objectContaining({ signal: expect.any(AbortSignal) }))
+    expect(csrfFetch).toHaveBeenNthCalledWith(1, '/creatives/next_last_visited_sequence', expect.objectContaining({ method: 'PATCH' }))
+    expect(csrfFetch).toHaveBeenNthCalledWith(2, '/creatives/next_last_visited_sequence', expect.objectContaining({ method: 'PATCH' }))
+    expect(csrfFetch).toHaveBeenNthCalledWith(3, '/creatives/1/remember_last_visited?visit_token=restored-token', expect.objectContaining({ method: 'PATCH' }))
+  })
+
   test('does not reserve a sequence for an unrelated Turbo navigation', async () => {
     const fetchOptions = { method: 'GET', headers: new Headers() }
     const resume = jest.fn()

--- a/engines/collavre/app/javascript/lib/__tests__/last_visited_creative.test.js
+++ b/engines/collavre/app/javascript/lib/__tests__/last_visited_creative.test.js
@@ -13,6 +13,7 @@ jest.unstable_mockModule('../api/csrf_fetch', () => ({
 }))
 
 const {
+  prepareLastVisitedCreativeNavigation,
   rememberLastVisitedCreative,
 } = await import('../last_visited_creative')
 
@@ -37,5 +38,20 @@ describe('rememberLastVisitedCreative', () => {
 
     expect(refreshCsrfToken).toHaveBeenCalledWith(expect.objectContaining({ signal: expect.any(AbortSignal) }))
     expect(csrfFetch).toHaveBeenCalledWith('/creatives/next_last_visited_sequence', expect.objectContaining({ method: 'PATCH' }))
+  })
+
+  test('does not reserve a sequence for an unrelated Turbo navigation', async () => {
+    const fetchOptions = { method: 'GET', headers: new Headers() }
+    const resume = jest.fn()
+    const event = new CustomEvent('turbo:before-fetch-request', {
+      cancelable: true,
+      detail: { fetchOptions, resume, url: '/users' },
+    })
+
+    await prepareLastVisitedCreativeNavigation(event, '/creatives', 'server-token')
+
+    expect(event.defaultPrevented).toBe(false)
+    expect(resume).not.toHaveBeenCalled()
+    expect(csrfFetch).not.toHaveBeenCalled()
   })
 })

--- a/engines/collavre/app/javascript/lib/__tests__/last_visited_creative.test.js
+++ b/engines/collavre/app/javascript/lib/__tests__/last_visited_creative.test.js
@@ -3,7 +3,19 @@
  */
 
 import { jest } from '@jest/globals'
-import { nextLastVisitedCreativeSequence } from '../last_visited_creative'
+
+const csrfFetch = jest.fn()
+const refreshCsrfToken = jest.fn()
+
+jest.unstable_mockModule('../api/csrf_fetch', () => ({
+  default: csrfFetch,
+  refreshCsrfToken,
+}))
+
+const {
+  nextLastVisitedCreativeSequence,
+  rememberLastVisitedCreative,
+} = await import('../last_visited_creative')
 
 describe('nextLastVisitedCreativeSequence', () => {
   test('defers sequence allocation to Rails when localStorage is unavailable', () => {
@@ -15,5 +27,27 @@ describe('nextLastVisitedCreativeSequence', () => {
     expect(nextLastVisitedCreativeSequence(1)).toBeNull()
 
     localStorageGetter.mockRestore()
+  })
+})
+
+describe('rememberLastVisitedCreative', () => {
+  beforeEach(() => {
+    csrfFetch.mockReset()
+    refreshCsrfToken.mockReset()
+    window.localStorage.clear()
+  })
+
+  test('cancels the CSRF refresh when a newer visit supersedes a restored visit', async () => {
+    csrfFetch.mockResolvedValue({ ok: true }).mockResolvedValueOnce({ ok: false, status: 422 })
+    refreshCsrfToken.mockImplementationOnce(({ signal }) => new Promise((resolve) => {
+      signal.addEventListener('abort', resolve, { once: true })
+    }))
+
+    rememberLastVisitedCreative('/creatives', 1, 'restored-token', 1)
+    await Promise.resolve()
+    rememberLastVisitedCreative('/creatives', 2, 'newer-token', 2)
+
+    expect(refreshCsrfToken).toHaveBeenCalledWith(expect.objectContaining({ signal: expect.any(AbortSignal) }))
+    expect(csrfFetch).toHaveBeenCalledTimes(2)
   })
 })

--- a/engines/collavre/app/javascript/lib/__tests__/last_visited_creative.test.js
+++ b/engines/collavre/app/javascript/lib/__tests__/last_visited_creative.test.js
@@ -69,4 +69,19 @@ describe('rememberLastVisitedCreative', () => {
     expect(resume).not.toHaveBeenCalled()
     expect(csrfFetch).not.toHaveBeenCalled()
   })
+
+  test('does not reserve a sequence for a nested Creative Turbo frame request', async () => {
+    const fetchOptions = { method: 'GET', headers: new Headers() }
+    const resume = jest.fn()
+    const event = new CustomEvent('turbo:before-fetch-request', {
+      cancelable: true,
+      detail: { fetchOptions, resume, url: '/creatives/1/comments/2/activity_log' },
+    })
+
+    await prepareLastVisitedCreativeNavigation(event, '/creatives', 'server-token')
+
+    expect(event.defaultPrevented).toBe(false)
+    expect(resume).not.toHaveBeenCalled()
+    expect(csrfFetch).not.toHaveBeenCalled()
+  })
 })

--- a/engines/collavre/app/javascript/lib/__tests__/last_visited_creative.test.js
+++ b/engines/collavre/app/javascript/lib/__tests__/last_visited_creative.test.js
@@ -1,0 +1,20 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { jest } from '@jest/globals'
+import { nextLastVisitedCreativeSequence } from '../last_visited_creative'
+
+describe('nextLastVisitedCreativeSequence', () => {
+  test('remains monotonic when localStorage is unavailable', () => {
+    const localStorageGetter = jest.spyOn(window, 'localStorage', 'get').mockImplementation(() => {
+      throw new DOMException('Access denied', 'SecurityError')
+    })
+
+    const firstSequence = nextLastVisitedCreativeSequence('token', 1)
+
+    expect(nextLastVisitedCreativeSequence('token', 1)).toBe(firstSequence + 1)
+
+    localStorageGetter.mockRestore()
+  })
+})

--- a/engines/collavre/app/javascript/lib/__tests__/last_visited_creative.test.js
+++ b/engines/collavre/app/javascript/lib/__tests__/last_visited_creative.test.js
@@ -6,14 +6,13 @@ import { jest } from '@jest/globals'
 import { nextLastVisitedCreativeSequence } from '../last_visited_creative'
 
 describe('nextLastVisitedCreativeSequence', () => {
-  test('remains monotonic when localStorage is unavailable', () => {
+  test('defers sequence allocation to Rails when localStorage is unavailable', () => {
     const localStorageGetter = jest.spyOn(window, 'localStorage', 'get').mockImplementation(() => {
       throw new DOMException('Access denied', 'SecurityError')
     })
 
-    const firstSequence = nextLastVisitedCreativeSequence('token', 1)
-
-    expect(nextLastVisitedCreativeSequence('token', 1)).toBe(firstSequence + 1)
+    expect(nextLastVisitedCreativeSequence(1)).toBeNull()
+    expect(nextLastVisitedCreativeSequence(1)).toBeNull()
 
     localStorageGetter.mockRestore()
   })

--- a/engines/collavre/app/javascript/lib/__tests__/last_visited_creative.test.js
+++ b/engines/collavre/app/javascript/lib/__tests__/last_visited_creative.test.js
@@ -13,41 +13,29 @@ jest.unstable_mockModule('../api/csrf_fetch', () => ({
 }))
 
 const {
-  nextLastVisitedCreativeSequence,
   rememberLastVisitedCreative,
 } = await import('../last_visited_creative')
-
-describe('nextLastVisitedCreativeSequence', () => {
-  test('defers sequence allocation to Rails when localStorage is unavailable', () => {
-    const localStorageGetter = jest.spyOn(window, 'localStorage', 'get').mockImplementation(() => {
-      throw new DOMException('Access denied', 'SecurityError')
-    })
-
-    expect(nextLastVisitedCreativeSequence(1)).toBeNull()
-    expect(nextLastVisitedCreativeSequence(1)).toBeNull()
-
-    localStorageGetter.mockRestore()
-  })
-})
 
 describe('rememberLastVisitedCreative', () => {
   beforeEach(() => {
     csrfFetch.mockReset()
     refreshCsrfToken.mockReset()
-    window.localStorage.clear()
   })
 
   test('cancels the CSRF refresh when a newer visit supersedes a restored visit', async () => {
-    csrfFetch.mockResolvedValue({ ok: true }).mockResolvedValueOnce({ ok: false, status: 422 })
+    csrfFetch
+      .mockResolvedValue({ ok: true, json: async () => ({ sequence: 3 }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ sequence: 2 }) })
+      .mockResolvedValueOnce({ ok: false, status: 422 })
     refreshCsrfToken.mockImplementationOnce(({ signal }) => new Promise((resolve) => {
       signal.addEventListener('abort', resolve, { once: true })
     }))
 
-    rememberLastVisitedCreative('/creatives', 1, 'restored-token', 1)
-    await Promise.resolve()
-    rememberLastVisitedCreative('/creatives', 2, 'newer-token', 2)
+    rememberLastVisitedCreative('/creatives', 1, 'restored-token')
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    rememberLastVisitedCreative('/creatives', 2, 'newer-token')
 
     expect(refreshCsrfToken).toHaveBeenCalledWith(expect.objectContaining({ signal: expect.any(AbortSignal) }))
-    expect(csrfFetch).toHaveBeenCalledTimes(2)
+    expect(csrfFetch).toHaveBeenCalledWith('/creatives/next_last_visited_sequence', expect.objectContaining({ method: 'PATCH' }))
   })
 })

--- a/engines/collavre/app/javascript/lib/api/__tests__/csrf_fetch.test.js
+++ b/engines/collavre/app/javascript/lib/api/__tests__/csrf_fetch.test.js
@@ -1,0 +1,27 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { jest } from '@jest/globals'
+import { refreshCsrfToken } from '../csrf_fetch'
+
+describe('refreshCsrfToken', () => {
+  afterEach(() => {
+    delete global.fetch
+  })
+
+  test('marks the refresh as a prefetch and passes through cancellation', async () => {
+    const signal = new AbortController().signal
+    const fetchMock = jest.fn().mockResolvedValue({ headers: new Headers() })
+    global.fetch = fetchMock
+
+    await refreshCsrfToken({ signal })
+
+    expect(fetchMock).toHaveBeenCalledWith(window.location.href, {
+      method: 'HEAD',
+      credentials: 'same-origin',
+      headers: { 'X-Sec-Purpose': 'prefetch' },
+      signal,
+    })
+  })
+})

--- a/engines/collavre/app/javascript/lib/api/csrf_fetch.js
+++ b/engines/collavre/app/javascript/lib/api/csrf_fetch.js
@@ -20,15 +20,17 @@ export function updateCsrfTokenFromResponse(response) {
 }
 
 /**
- * Fetch a fresh CSRF token from the server.  Uses a lightweight HEAD
- * request to the current page — the response body is discarded but the
- * X-CSRF-Token header gives us a valid token.
+ * Fetch a fresh CSRF token from the server. Uses a lightweight HEAD request
+ * marked as a prefetch so endpoints that record ordinary visits do not treat
+ * the refresh as navigation.
  */
-export async function refreshCsrfToken() {
+export async function refreshCsrfToken({ signal } = {}) {
   try {
     const response = await fetch(window.location.href, {
       method: 'HEAD',
       credentials: 'same-origin',
+      headers: { 'X-Sec-Purpose': 'prefetch' },
+      signal,
     })
     updateCsrfTokenFromResponse(response)
     return readCsrfToken()

--- a/engines/collavre/app/javascript/lib/creative_link_prefetch.js
+++ b/engines/collavre/app/javascript/lib/creative_link_prefetch.js
@@ -1,12 +1,3 @@
-export const LAST_VISITED_CREATIVE_AT_HEADER = "X-Collavre-Last-Visited-Creative-At"
-
-let lastVisitTimestamp = 0
-
-export function nextLastVisitedCreativeTimestamp() {
-  lastVisitTimestamp = Math.max(Date.now(), lastVisitTimestamp + 1)
-  return lastVisitTimestamp
-}
-
 export function isCreativeNavigation(url) {
   url = new URL(url, window.location.origin)
 
@@ -20,21 +11,7 @@ export function preventCreativeLinkPrefetch(event) {
   event.preventDefault()
 }
 
-export function orderCreativeNavigationRequest(event) {
-  const { url, fetchOptions } = event.detail || {}
-  if (!url || !fetchOptions || !isCreativeNavigation(url)) return
-
-  const timestamp = String(nextLastVisitedCreativeTimestamp())
-  const headers = fetchOptions.headers || (fetchOptions.headers = {})
-  if (headers instanceof Headers) {
-    headers.set(LAST_VISITED_CREATIVE_AT_HEADER, timestamp)
-  } else {
-    headers[LAST_VISITED_CREATIVE_AT_HEADER] = timestamp
-  }
-}
-
 // A prefetched Creative response can be promoted by Turbo without issuing a
 // second request. Prevent it globally so confirmed navigation remains the only
 // way to update the user's last visited Creative, regardless of link source.
 document.addEventListener("turbo:before-prefetch", preventCreativeLinkPrefetch)
-document.addEventListener("turbo:before-fetch-request", orderCreativeNavigationRequest)

--- a/engines/collavre/app/javascript/lib/creative_link_prefetch.js
+++ b/engines/collavre/app/javascript/lib/creative_link_prefetch.js
@@ -1,17 +1,40 @@
-function isCreativeNavigation(link) {
-  const url = new URL(link.href, window.location.origin)
+export const LAST_VISITED_CREATIVE_AT_HEADER = "X-Collavre-Last-Visited-Creative-At"
+
+let lastVisitTimestamp = 0
+
+export function nextLastVisitedCreativeTimestamp() {
+  lastVisitTimestamp = Math.max(Date.now(), lastVisitTimestamp + 1)
+  return lastVisitTimestamp
+}
+
+export function isCreativeNavigation(url) {
+  url = new URL(url, window.location.origin)
 
   return url.origin === window.location.origin && /\/creatives(?:\/|$)/.test(url.pathname)
 }
 
 export function preventCreativeLinkPrefetch(event) {
   const link = event.target
-  if (!(link instanceof HTMLAnchorElement) || !isCreativeNavigation(link)) return
+  if (!(link instanceof HTMLAnchorElement) || !isCreativeNavigation(link.href)) return
 
   event.preventDefault()
+}
+
+export function orderCreativeNavigationRequest(event) {
+  const { url, fetchOptions } = event.detail || {}
+  if (!url || !fetchOptions || !isCreativeNavigation(url)) return
+
+  const timestamp = String(nextLastVisitedCreativeTimestamp())
+  const headers = fetchOptions.headers || (fetchOptions.headers = {})
+  if (headers instanceof Headers) {
+    headers.set(LAST_VISITED_CREATIVE_AT_HEADER, timestamp)
+  } else {
+    headers[LAST_VISITED_CREATIVE_AT_HEADER] = timestamp
+  }
 }
 
 // A prefetched Creative response can be promoted by Turbo without issuing a
 // second request. Prevent it globally so confirmed navigation remains the only
 // way to update the user's last visited Creative, regardless of link source.
 document.addEventListener("turbo:before-prefetch", preventCreativeLinkPrefetch)
+document.addEventListener("turbo:before-fetch-request", orderCreativeNavigationRequest)

--- a/engines/collavre/app/javascript/lib/creative_link_prefetch.js
+++ b/engines/collavre/app/javascript/lib/creative_link_prefetch.js
@@ -1,0 +1,17 @@
+function isCreativeNavigation(link) {
+  const url = new URL(link.href, window.location.origin)
+
+  return url.origin === window.location.origin && /\/creatives(?:\/|$)/.test(url.pathname)
+}
+
+export function preventCreativeLinkPrefetch(event) {
+  const link = event.target
+  if (!(link instanceof HTMLAnchorElement) || !isCreativeNavigation(link)) return
+
+  event.preventDefault()
+}
+
+// A prefetched Creative response can be promoted by Turbo without issuing a
+// second request. Prevent it globally so confirmed navigation remains the only
+// way to update the user's last visited Creative, regardless of link source.
+document.addEventListener("turbo:before-prefetch", preventCreativeLinkPrefetch)

--- a/engines/collavre/app/javascript/lib/creative_link_prefetch.js
+++ b/engines/collavre/app/javascript/lib/creative_link_prefetch.js
@@ -4,6 +4,16 @@ export function isCreativeNavigation(url) {
   return url.origin === window.location.origin && /\/creatives(?:\/|$)/.test(url.pathname)
 }
 
+// Only these HTML routes reach CreativesController#index visit persistence:
+// the Creative index and a single Creative show route (which redirects there).
+// Nested Creative routes load supporting UI and must not reserve a visit
+// sequence merely because a last-visited controller is connected.
+export function isCreativeVisitNavigation(url) {
+  url = new URL(url, window.location.origin)
+
+  return url.origin === window.location.origin && /\/creatives(?:\.html|\/\d+)?\/?$/.test(url.pathname)
+}
+
 export function preventCreativeLinkPrefetch(event) {
   const link = event.target
   if (!(link instanceof HTMLAnchorElement) || !isCreativeNavigation(link.href)) return

--- a/engines/collavre/app/javascript/lib/last_visited_creative.js
+++ b/engines/collavre/app/javascript/lib/last_visited_creative.js
@@ -1,21 +1,36 @@
 import csrfFetch, { refreshCsrfToken } from './api/csrf_fetch'
 
+let pendingRequestController = null
+
+export function cancelPendingLastVisitedCreative() {
+  pendingRequestController?.abort()
+  pendingRequestController = null
+}
+
 export function rememberLastVisitedCreative(baseUrl, creativeId) {
   if (!baseUrl || !creativeId) return
 
+  cancelPendingLastVisitedCreative()
+  const requestController = new AbortController()
+  pendingRequestController = requestController
   const url = new URL(baseUrl, window.location.origin)
   url.pathname = `${url.pathname.replace(/\/$/, '')}/${encodeURIComponent(creativeId)}/remember_last_visited`
   const request = () => csrfFetch(`${url.pathname}${url.search}`, {
     method: 'PATCH',
     headers: { Accept: 'application/json' },
+    signal: requestController.signal,
   })
 
   request()
     .then(async (response) => {
-      if (response.ok || response.status !== 422) return
+      if (requestController.signal.aborted || response.ok || response.status !== 422) return
 
       await refreshCsrfToken()
+      if (requestController.signal.aborted) return
       await request()
     })
     .catch(() => {})
+    .finally(() => {
+      if (pendingRequestController === requestController) pendingRequestController = null
+    })
 }

--- a/engines/collavre/app/javascript/lib/last_visited_creative.js
+++ b/engines/collavre/app/javascript/lib/last_visited_creative.js
@@ -1,4 +1,5 @@
 import csrfFetch, { refreshCsrfToken } from './api/csrf_fetch'
+import { isCreativeNavigation } from './creative_link_prefetch'
 
 let pendingRequestController = null
 const SEQUENCE_HEADER = 'X-Collavre-Last-Visited-Creative-Sequence'
@@ -24,7 +25,13 @@ async function nextLastVisitedCreativeSequence(baseUrl, signal) {
 
 export async function prepareLastVisitedCreativeNavigation(event, baseUrl, visitToken) {
   const fetchOptions = event.detail?.fetchOptions
-  if (!baseUrl || !visitToken || !fetchOptions || String(fetchOptions.method || 'GET').toUpperCase() !== 'GET') return
+  if (
+    !baseUrl ||
+    !visitToken ||
+    !fetchOptions ||
+    !isCreativeNavigation(event.detail?.url) ||
+    String(fetchOptions.method || 'GET').toUpperCase() !== 'GET'
+  ) return
 
   event.preventDefault()
   try {

--- a/engines/collavre/app/javascript/lib/last_visited_creative.js
+++ b/engines/collavre/app/javascript/lib/last_visited_creative.js
@@ -1,7 +1,6 @@
 import csrfFetch, { refreshCsrfToken } from './api/csrf_fetch'
 
 let pendingRequestController = null
-let inMemorySequence = 0
 const SEQUENCE_HEADER = 'X-Collavre-Last-Visited-Creative-Sequence'
 const TOKEN_HEADER = 'X-Collavre-Last-Visited-Creative-Token'
 
@@ -9,29 +8,19 @@ function sequenceStorageKey() {
   return 'collavre:last-visited-creative-sequence'
 }
 
-function storedSequence() {
+export function nextLastVisitedCreativeSequence(currentSequence = 0) {
   try {
-    return Number.parseInt(window.localStorage.getItem(sequenceStorageKey()), 10) || 0
+    const stored = Number.parseInt(window.localStorage.getItem(sequenceStorageKey()), 10) || 0
+    const sequence = Math.max(stored, Number(currentSequence) || 0) + 1
+    window.localStorage.setItem(sequenceStorageKey(), String(sequence))
+
+    // A storage implementation can silently ignore writes. Only submit a
+    // client sequence after confirming tabs can share it; otherwise Rails
+    // allocates the sequence atomically while holding the user lock.
+    return Number.parseInt(window.localStorage.getItem(sequenceStorageKey()), 10) === sequence ? sequence : null
   } catch (_) {
     return null
   }
-}
-
-function storeSequence(sequence) {
-  try {
-    window.localStorage.setItem(sequenceStorageKey(), String(sequence))
-  } catch (_) {
-    // Private browsing can deny storage. The signed server sequence still
-    // provides a safe baseline for this page.
-  }
-}
-
-export function nextLastVisitedCreativeSequence(visitToken, currentSequence = 0) {
-  const stored = storedSequence()
-  const sequence = Math.max(stored === null ? inMemorySequence : stored, Number(currentSequence) || 0) + 1
-  inMemorySequence = sequence
-  storeSequence(sequence)
-  return sequence
 }
 
 export function prepareLastVisitedCreativeNavigation(event, visitToken, currentSequence) {
@@ -40,7 +29,8 @@ export function prepareLastVisitedCreativeNavigation(event, visitToken, currentS
 
   const headers = new Headers(fetchOptions.headers)
   headers.set(TOKEN_HEADER, visitToken)
-  headers.set(SEQUENCE_HEADER, String(nextLastVisitedCreativeSequence(visitToken, currentSequence)))
+  const sequence = nextLastVisitedCreativeSequence(currentSequence)
+  if (sequence) headers.set(SEQUENCE_HEADER, String(sequence))
   fetchOptions.headers = headers
 }
 
@@ -55,7 +45,7 @@ export function rememberLastVisitedCreative(baseUrl, creativeId, visitToken, cur
   cancelPendingLastVisitedCreative()
   const requestController = new AbortController()
   pendingRequestController = requestController
-  const sequence = nextLastVisitedCreativeSequence(visitToken, currentSequence)
+  const sequence = nextLastVisitedCreativeSequence(currentSequence)
   const url = new URL(baseUrl, window.location.origin)
   url.pathname = `${url.pathname.replace(/\/$/, '')}/${encodeURIComponent(creativeId)}/remember_last_visited`
   url.searchParams.set('visit_token', visitToken)
@@ -63,7 +53,7 @@ export function rememberLastVisitedCreative(baseUrl, creativeId, visitToken, cur
     method: 'PATCH',
     headers: {
       Accept: 'application/json',
-      [SEQUENCE_HEADER]: String(sequence),
+      ...(sequence && { [SEQUENCE_HEADER]: String(sequence) }),
     },
     signal: requestController.signal,
   })

--- a/engines/collavre/app/javascript/lib/last_visited_creative.js
+++ b/engines/collavre/app/javascript/lib/last_visited_creative.js
@@ -1,6 +1,7 @@
 import csrfFetch, { refreshCsrfToken } from './api/csrf_fetch'
 
 let pendingRequestController = null
+let inMemorySequence = 0
 const SEQUENCE_HEADER = 'X-Collavre-Last-Visited-Creative-Sequence'
 const TOKEN_HEADER = 'X-Collavre-Last-Visited-Creative-Token'
 
@@ -12,7 +13,7 @@ function storedSequence() {
   try {
     return Number.parseInt(window.localStorage.getItem(sequenceStorageKey()), 10) || 0
   } catch (_) {
-    return 0
+    return null
   }
 }
 
@@ -26,7 +27,9 @@ function storeSequence(sequence) {
 }
 
 export function nextLastVisitedCreativeSequence(visitToken, currentSequence = 0) {
-  const sequence = Math.max(storedSequence(), Number(currentSequence) || 0) + 1
+  const stored = storedSequence()
+  const sequence = Math.max(stored === null ? inMemorySequence : stored, Number(currentSequence) || 0) + 1
+  inMemorySequence = sequence
   storeSequence(sequence)
   return sequence
 }

--- a/engines/collavre/app/javascript/lib/last_visited_creative.js
+++ b/engines/collavre/app/javascript/lib/last_visited_creative.js
@@ -11,12 +11,17 @@ function sequenceUrl(baseUrl) {
   return `${url.pathname}${url.search}`
 }
 
-async function nextLastVisitedCreativeSequence(baseUrl, signal) {
+async function nextLastVisitedCreativeSequence(baseUrl, signal, retryCsrf = true) {
   const response = await csrfFetch(sequenceUrl(baseUrl), {
     method: 'PATCH',
     headers: { Accept: 'application/json' },
     signal,
   })
+  if (response.status === 422 && retryCsrf && !signal?.aborted) {
+    await refreshCsrfToken({ signal })
+    if (signal?.aborted) return null
+    return nextLastVisitedCreativeSequence(baseUrl, signal, false)
+  }
   if (!response.ok) return null
 
   const sequence = Number((await response.json()).sequence)

--- a/engines/collavre/app/javascript/lib/last_visited_creative.js
+++ b/engines/collavre/app/javascript/lib/last_visited_creative.js
@@ -1,5 +1,5 @@
 import csrfFetch, { refreshCsrfToken } from './api/csrf_fetch'
-import { isCreativeNavigation } from './creative_link_prefetch'
+import { isCreativeVisitNavigation } from './creative_link_prefetch'
 
 let pendingRequestController = null
 const SEQUENCE_HEADER = 'X-Collavre-Last-Visited-Creative-Sequence'
@@ -34,7 +34,7 @@ export async function prepareLastVisitedCreativeNavigation(event, baseUrl, visit
     !baseUrl ||
     !visitToken ||
     !fetchOptions ||
-    !isCreativeNavigation(event.detail?.url) ||
+    !isCreativeVisitNavigation(event.detail?.url) ||
     String(fetchOptions.method || 'GET').toUpperCase() !== 'GET'
   ) return
 

--- a/engines/collavre/app/javascript/lib/last_visited_creative.js
+++ b/engines/collavre/app/javascript/lib/last_visited_creative.js
@@ -1,0 +1,21 @@
+import csrfFetch, { refreshCsrfToken } from './api/csrf_fetch'
+
+export function rememberLastVisitedCreative(baseUrl, creativeId) {
+  if (!baseUrl || !creativeId) return
+
+  const url = new URL(baseUrl, window.location.origin)
+  url.pathname = `${url.pathname.replace(/\/$/, '')}/${encodeURIComponent(creativeId)}/remember_last_visited`
+  const request = () => csrfFetch(`${url.pathname}${url.search}`, {
+    method: 'PATCH',
+    headers: { Accept: 'application/json' },
+  })
+
+  request()
+    .then(async (response) => {
+      if (response.ok || response.status !== 422) return
+
+      await refreshCsrfToken()
+      await request()
+    })
+    .catch(() => {})
+}

--- a/engines/collavre/app/javascript/lib/last_visited_creative.js
+++ b/engines/collavre/app/javascript/lib/last_visited_creative.js
@@ -1,5 +1,4 @@
 import csrfFetch, { refreshCsrfToken } from './api/csrf_fetch'
-import { LAST_VISITED_CREATIVE_AT_HEADER, nextLastVisitedCreativeTimestamp } from './creative_link_prefetch'
 
 let pendingRequestController = null
 
@@ -14,14 +13,12 @@ export function rememberLastVisitedCreative(baseUrl, creativeId) {
   cancelPendingLastVisitedCreative()
   const requestController = new AbortController()
   pendingRequestController = requestController
-  const visitTimestamp = String(nextLastVisitedCreativeTimestamp())
   const url = new URL(baseUrl, window.location.origin)
   url.pathname = `${url.pathname.replace(/\/$/, '')}/${encodeURIComponent(creativeId)}/remember_last_visited`
   const request = () => csrfFetch(`${url.pathname}${url.search}`, {
     method: 'PATCH',
     headers: {
       Accept: 'application/json',
-      [LAST_VISITED_CREATIVE_AT_HEADER]: visitTimestamp,
     },
     signal: requestController.signal,
   })

--- a/engines/collavre/app/javascript/lib/last_visited_creative.js
+++ b/engines/collavre/app/javascript/lib/last_visited_creative.js
@@ -62,7 +62,7 @@ export function rememberLastVisitedCreative(baseUrl, creativeId, visitToken, cur
     .then(async (response) => {
       if (requestController.signal.aborted || response.ok || response.status !== 422) return
 
-      await refreshCsrfToken()
+      await refreshCsrfToken({ signal: requestController.signal })
       if (requestController.signal.aborted) return
       await request()
     })

--- a/engines/collavre/app/javascript/lib/last_visited_creative.js
+++ b/engines/collavre/app/javascript/lib/last_visited_creative.js
@@ -7,14 +7,15 @@ export function cancelPendingLastVisitedCreative() {
   pendingRequestController = null
 }
 
-export function rememberLastVisitedCreative(baseUrl, creativeId) {
-  if (!baseUrl || !creativeId) return
+export function rememberLastVisitedCreative(baseUrl, creativeId, visitToken) {
+  if (!baseUrl || !creativeId || !visitToken) return
 
   cancelPendingLastVisitedCreative()
   const requestController = new AbortController()
   pendingRequestController = requestController
   const url = new URL(baseUrl, window.location.origin)
   url.pathname = `${url.pathname.replace(/\/$/, '')}/${encodeURIComponent(creativeId)}/remember_last_visited`
+  url.searchParams.set('visit_token', visitToken)
   const request = () => csrfFetch(`${url.pathname}${url.search}`, {
     method: 'PATCH',
     headers: {

--- a/engines/collavre/app/javascript/lib/last_visited_creative.js
+++ b/engines/collavre/app/javascript/lib/last_visited_creative.js
@@ -1,4 +1,5 @@
 import csrfFetch, { refreshCsrfToken } from './api/csrf_fetch'
+import { LAST_VISITED_CREATIVE_AT_HEADER, nextLastVisitedCreativeTimestamp } from './creative_link_prefetch'
 
 let pendingRequestController = null
 
@@ -13,11 +14,15 @@ export function rememberLastVisitedCreative(baseUrl, creativeId) {
   cancelPendingLastVisitedCreative()
   const requestController = new AbortController()
   pendingRequestController = requestController
+  const visitTimestamp = String(nextLastVisitedCreativeTimestamp())
   const url = new URL(baseUrl, window.location.origin)
   url.pathname = `${url.pathname.replace(/\/$/, '')}/${encodeURIComponent(creativeId)}/remember_last_visited`
   const request = () => csrfFetch(`${url.pathname}${url.search}`, {
     method: 'PATCH',
-    headers: { Accept: 'application/json' },
+    headers: {
+      Accept: 'application/json',
+      [LAST_VISITED_CREATIVE_AT_HEADER]: visitTimestamp,
+    },
     signal: requestController.signal,
   })
 

--- a/engines/collavre/app/javascript/lib/last_visited_creative.js
+++ b/engines/collavre/app/javascript/lib/last_visited_creative.js
@@ -1,18 +1,58 @@
 import csrfFetch, { refreshCsrfToken } from './api/csrf_fetch'
 
 let pendingRequestController = null
+const SEQUENCE_HEADER = 'X-Collavre-Last-Visited-Creative-Sequence'
+const TOKEN_HEADER = 'X-Collavre-Last-Visited-Creative-Token'
+
+function sequenceStorageKey() {
+  return 'collavre:last-visited-creative-sequence'
+}
+
+function storedSequence() {
+  try {
+    return Number.parseInt(window.localStorage.getItem(sequenceStorageKey()), 10) || 0
+  } catch (_) {
+    return 0
+  }
+}
+
+function storeSequence(sequence) {
+  try {
+    window.localStorage.setItem(sequenceStorageKey(), String(sequence))
+  } catch (_) {
+    // Private browsing can deny storage. The signed server sequence still
+    // provides a safe baseline for this page.
+  }
+}
+
+export function nextLastVisitedCreativeSequence(visitToken, currentSequence = 0) {
+  const sequence = Math.max(storedSequence(), Number(currentSequence) || 0) + 1
+  storeSequence(sequence)
+  return sequence
+}
+
+export function prepareLastVisitedCreativeNavigation(event, visitToken, currentSequence) {
+  const fetchOptions = event.detail?.fetchOptions
+  if (!visitToken || !fetchOptions || String(fetchOptions.method || 'GET').toUpperCase() !== 'GET') return
+
+  const headers = new Headers(fetchOptions.headers)
+  headers.set(TOKEN_HEADER, visitToken)
+  headers.set(SEQUENCE_HEADER, String(nextLastVisitedCreativeSequence(visitToken, currentSequence)))
+  fetchOptions.headers = headers
+}
 
 export function cancelPendingLastVisitedCreative() {
   pendingRequestController?.abort()
   pendingRequestController = null
 }
 
-export function rememberLastVisitedCreative(baseUrl, creativeId, visitToken) {
+export function rememberLastVisitedCreative(baseUrl, creativeId, visitToken, currentSequence) {
   if (!baseUrl || !creativeId || !visitToken) return
 
   cancelPendingLastVisitedCreative()
   const requestController = new AbortController()
   pendingRequestController = requestController
+  const sequence = nextLastVisitedCreativeSequence(visitToken, currentSequence)
   const url = new URL(baseUrl, window.location.origin)
   url.pathname = `${url.pathname.replace(/\/$/, '')}/${encodeURIComponent(creativeId)}/remember_last_visited`
   url.searchParams.set('visit_token', visitToken)
@@ -20,6 +60,7 @@ export function rememberLastVisitedCreative(baseUrl, creativeId, visitToken) {
     method: 'PATCH',
     headers: {
       Accept: 'application/json',
+      [SEQUENCE_HEADER]: String(sequence),
     },
     signal: requestController.signal,
   })

--- a/engines/collavre/app/javascript/lib/last_visited_creative.js
+++ b/engines/collavre/app/javascript/lib/last_visited_creative.js
@@ -4,34 +4,40 @@ let pendingRequestController = null
 const SEQUENCE_HEADER = 'X-Collavre-Last-Visited-Creative-Sequence'
 const TOKEN_HEADER = 'X-Collavre-Last-Visited-Creative-Token'
 
-function sequenceStorageKey() {
-  return 'collavre:last-visited-creative-sequence'
+function sequenceUrl(baseUrl) {
+  const url = new URL(baseUrl, window.location.origin)
+  url.pathname = `${url.pathname.replace(/\/$/, '')}/next_last_visited_sequence`
+  return `${url.pathname}${url.search}`
 }
 
-export function nextLastVisitedCreativeSequence(currentSequence = 0) {
-  try {
-    const stored = Number.parseInt(window.localStorage.getItem(sequenceStorageKey()), 10) || 0
-    const sequence = Math.max(stored, Number(currentSequence) || 0) + 1
-    window.localStorage.setItem(sequenceStorageKey(), String(sequence))
+async function nextLastVisitedCreativeSequence(baseUrl, signal) {
+  const response = await csrfFetch(sequenceUrl(baseUrl), {
+    method: 'PATCH',
+    headers: { Accept: 'application/json' },
+    signal,
+  })
+  if (!response.ok) return null
 
-    // A storage implementation can silently ignore writes. Only submit a
-    // client sequence after confirming tabs can share it; otherwise Rails
-    // allocates the sequence atomically while holding the user lock.
-    return Number.parseInt(window.localStorage.getItem(sequenceStorageKey()), 10) === sequence ? sequence : null
-  } catch (_) {
-    return null
-  }
+  const sequence = Number((await response.json()).sequence)
+  return Number.isSafeInteger(sequence) && sequence > 0 ? sequence : null
 }
 
-export function prepareLastVisitedCreativeNavigation(event, visitToken, currentSequence) {
+export async function prepareLastVisitedCreativeNavigation(event, baseUrl, visitToken) {
   const fetchOptions = event.detail?.fetchOptions
-  if (!visitToken || !fetchOptions || String(fetchOptions.method || 'GET').toUpperCase() !== 'GET') return
+  if (!baseUrl || !visitToken || !fetchOptions || String(fetchOptions.method || 'GET').toUpperCase() !== 'GET') return
 
-  const headers = new Headers(fetchOptions.headers)
-  headers.set(TOKEN_HEADER, visitToken)
-  const sequence = nextLastVisitedCreativeSequence(currentSequence)
-  if (sequence) headers.set(SEQUENCE_HEADER, String(sequence))
-  fetchOptions.headers = headers
+  event.preventDefault()
+  try {
+    const sequence = await nextLastVisitedCreativeSequence(baseUrl)
+    if (!sequence) return
+
+    const headers = new Headers(fetchOptions.headers)
+    headers.set(TOKEN_HEADER, visitToken)
+    headers.set(SEQUENCE_HEADER, String(sequence))
+    fetchOptions.headers = headers
+  } finally {
+    event.detail.resume?.()
+  }
 }
 
 export function cancelPendingLastVisitedCreative() {
@@ -39,32 +45,38 @@ export function cancelPendingLastVisitedCreative() {
   pendingRequestController = null
 }
 
-export function rememberLastVisitedCreative(baseUrl, creativeId, visitToken, currentSequence) {
+export function rememberLastVisitedCreative(baseUrl, creativeId, visitToken) {
   if (!baseUrl || !creativeId || !visitToken) return
 
   cancelPendingLastVisitedCreative()
   const requestController = new AbortController()
   pendingRequestController = requestController
-  const sequence = nextLastVisitedCreativeSequence(currentSequence)
   const url = new URL(baseUrl, window.location.origin)
   url.pathname = `${url.pathname.replace(/\/$/, '')}/${encodeURIComponent(creativeId)}/remember_last_visited`
   url.searchParams.set('visit_token', visitToken)
-  const request = () => csrfFetch(`${url.pathname}${url.search}`, {
+  const request = (sequence) => csrfFetch(`${url.pathname}${url.search}`, {
     method: 'PATCH',
     headers: {
       Accept: 'application/json',
-      ...(sequence && { [SEQUENCE_HEADER]: String(sequence) }),
+      [SEQUENCE_HEADER]: String(sequence),
     },
     signal: requestController.signal,
   })
 
-  request()
+  nextLastVisitedCreativeSequence(baseUrl, requestController.signal)
+    .then(async (sequence) => {
+      if (!sequence || requestController.signal.aborted) return null
+      return request(sequence)
+    })
     .then(async (response) => {
+      if (!response) return
       if (requestController.signal.aborted || response.ok || response.status !== 422) return
 
       await refreshCsrfToken({ signal: requestController.signal })
       if (requestController.signal.aborted) return
-      await request()
+      const sequence = await nextLastVisitedCreativeSequence(baseUrl, requestController.signal)
+      if (!sequence || requestController.signal.aborted) return
+      await request(sequence)
     })
     .catch(() => {})
     .finally(() => {

--- a/engines/collavre/app/models/collavre/user.rb
+++ b/engines/collavre/app/models/collavre/user.rb
@@ -42,6 +42,7 @@ module Collavre
 
     # Leaf-first destroy to avoid closure_tree find(parent_id) errors
     has_many :creatives, class_name: "Collavre::Creative", dependent: nil
+    belongs_to :last_visited_creative, class_name: "Collavre::Creative", optional: true
     before_destroy :destroy_creatives_leaf_first
 
     # /compress and /merge summaries are durable recovery artifacts: they replace

--- a/engines/collavre/app/views/collavre/creatives/_workspace_tree.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/_workspace_tree.html.erb
@@ -2,6 +2,7 @@
          data-controller="workspace-tree"
          data-workspace-tree-url-value="<%= creatives_path(format: :json, workspace_tree: 1) %>"
          data-workspace-tree-last-visited-creative-url-value="<%= creatives_path %>"
+         data-workspace-tree-last-visited-creative-visit-token-value="<%= @last_visited_creative_token %>"
          data-workspace-tree-current-path-value="<%= @workspace_path_ids.to_json %>"
          data-workspace-tree-loading-text-value="<%= t('app.loading') %>"
          data-workspace-tree-empty-text-value="<%= t('collavre.creatives.workspace.empty') %>"

--- a/engines/collavre/app/views/collavre/creatives/_workspace_tree.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/_workspace_tree.html.erb
@@ -3,6 +3,7 @@
          data-workspace-tree-url-value="<%= creatives_path(format: :json, workspace_tree: 1) %>"
          data-workspace-tree-last-visited-creative-url-value="<%= creatives_path %>"
          data-workspace-tree-last-visited-creative-visit-token-value="<%= @last_visited_creative_token %>"
+         data-workspace-tree-last-visited-creative-visit-sequence-value="<%= @last_visited_creative_visit_sequence %>"
          data-workspace-tree-current-path-value="<%= @workspace_path_ids.to_json %>"
          data-workspace-tree-loading-text-value="<%= t('app.loading') %>"
          data-workspace-tree-empty-text-value="<%= t('collavre.creatives.workspace.empty') %>"

--- a/engines/collavre/app/views/collavre/creatives/_workspace_tree.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/_workspace_tree.html.erb
@@ -1,6 +1,7 @@
 <section class="creative-workspace-tree-region"
          data-controller="workspace-tree"
          data-workspace-tree-url-value="<%= creatives_path(format: :json, workspace_tree: 1) %>"
+         data-workspace-tree-last-visited-creative-url-value="<%= creatives_path %>"
          data-workspace-tree-current-path-value="<%= @workspace_path_ids.to_json %>"
          data-workspace-tree-loading-text-value="<%= t('app.loading') %>"
          data-workspace-tree-empty-text-value="<%= t('collavre.creatives.workspace.empty') %>"

--- a/engines/collavre/app/views/collavre/creatives/index.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/index.html.erb
@@ -7,7 +7,9 @@
                 creative_id: @parent_creative&.id,
                 creative_path: @workspace_path_ids,
                 creative_snippet: @parent_creative&.creative_snippet,
-                can_comment: @parent_creative&.has_permission?(Current.user, :feedback)
+                can_comment: @parent_creative&.has_permission?(Current.user, :feedback),
+                last_visited_creative_visit_token: @last_visited_creative_token,
+                last_visited_creative_visit_sequence: @last_visited_creative_visit_sequence
               } %>
 <% end %>
 <%= tag.div(flash[:alert], class: "flash-alert") if flash[:alert] %>
@@ -27,7 +29,8 @@
           controller: "last-visited-creative",
           last_visited_creative_url_value: creatives_path,
           last_visited_creative_creative_id_value: @parent_creative.id,
-          last_visited_creative_visit_token_value: @last_visited_creative_token
+          last_visited_creative_visit_token_value: @last_visited_creative_token,
+          last_visited_creative_visit_sequence_value: @last_visited_creative_visit_sequence
         }
       ) %>
 <% end %>

--- a/engines/collavre/app/views/collavre/creatives/index.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/index.html.erb
@@ -26,7 +26,8 @@
         data: {
           controller: "last-visited-creative",
           last_visited_creative_url_value: creatives_path,
-          last_visited_creative_creative_id_value: @parent_creative.id
+          last_visited_creative_creative_id_value: @parent_creative.id,
+          last_visited_creative_visit_token_value: @last_visited_creative_token
         }
       ) %>
 <% end %>

--- a/engines/collavre/app/views/collavre/creatives/index.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/index.html.erb
@@ -19,6 +19,17 @@
 <% if @auto_fullscreen %>
   <% content_for :comments_popup_auto_fullscreen, "true" %>
 <% end %>
+<% if authenticated? && !creative_workspace? && @parent_creative %>
+  <%= tag.div(
+        nil,
+        hidden: true,
+        data: {
+          controller: "last-visited-creative",
+          last_visited_creative_url_value: creatives_path,
+          last_visited_creative_creative_id_value: @parent_creative.id
+        }
+      ) %>
+<% end %>
 
 <div data-controller="creatives--import creatives--select-mode creatives--drag-drop creatives--expansion creatives--row-editor share-modal"
      data-creatives--import-parent-id-value="<%= @parent_creative&.id %>"

--- a/engines/collavre/app/views/collavre/creatives/index.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/index.html.erb
@@ -44,10 +44,10 @@
       <% if @parent_creative %>
         <% @parent_creative.ancestors.reverse.each do |ancestor| %>
           <span class="creative-breadcrumb-sep" aria-hidden="true">/</span>
-          <a href="<%= creative_path(ancestor) %>" class="creative-breadcrumb-link" data-turbo-action="advance" title="<%= Collavre::HtmlText.label(ancestor.effective_description) %>"><%= Collavre::HtmlText.truncated_label(ancestor.effective_description, 20) %></a>
+          <a href="<%= creative_path(ancestor) %>" class="creative-breadcrumb-link" data-turbo-action="advance" data-turbo-prefetch="false" title="<%= Collavre::HtmlText.label(ancestor.effective_description) %>"><%= Collavre::HtmlText.truncated_label(ancestor.effective_description, 20) %></a>
         <% end %>
         <span class="creative-breadcrumb-sep" aria-hidden="true">/</span>
-        <a href="<%= creative_path(@parent_creative) %>" class="creative-breadcrumb-link creative-breadcrumb-current" data-turbo-action="replace"><%= Collavre::HtmlText.truncated_label(@parent_creative.effective_description, 30) %></a>
+        <a href="<%= creative_path(@parent_creative) %>" class="creative-breadcrumb-link creative-breadcrumb-current" data-turbo-action="replace" data-turbo-prefetch="false"><%= Collavre::HtmlText.truncated_label(@parent_creative.effective_description, 30) %></a>
       <% end %>
     </div>
 

--- a/engines/collavre/config/routes.rb
+++ b/engines/collavre/config/routes.rb
@@ -154,6 +154,7 @@ Collavre::Engine.routes.draw do
       get :export_markdown
     end
     member do
+      patch :remember_last_visited
       get :children
       post :request_permission, to: "creatives#request_permission"
       post :unconvert

--- a/engines/collavre/config/routes.rb
+++ b/engines/collavre/config/routes.rb
@@ -149,6 +149,7 @@ Collavre::Engine.routes.draw do
     collection do
       post :reorder
       post :link_drop
+      patch :next_last_visited_sequence
       get :append_as_parent, to: "creatives#append_as_parent", as: :append_as_parent_creative
       get :append_below, to: "creatives#append_below", as: :append_below_creative
       get :export_markdown

--- a/engines/collavre/db/migrate/20260810010000_add_last_visited_creative_to_users.rb
+++ b/engines/collavre/db/migrate/20260810010000_add_last_visited_creative_to_users.rb
@@ -1,0 +1,8 @@
+class AddLastVisitedCreativeToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_reference :users, :last_visited_creative, foreign_key: {
+      to_table: :creatives,
+      on_delete: :nullify
+    }
+  end
+end

--- a/engines/collavre/db/migrate/20260810020000_add_last_visited_creative_at_to_users.rb
+++ b/engines/collavre/db/migrate/20260810020000_add_last_visited_creative_at_to_users.rb
@@ -1,0 +1,5 @@
+class AddLastVisitedCreativeAtToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :last_visited_creative_at, :datetime
+  end
+end

--- a/engines/collavre/db/migrate/20260810030000_add_last_visited_creative_navigation_order_to_users.rb
+++ b/engines/collavre/db/migrate/20260810030000_add_last_visited_creative_navigation_order_to_users.rb
@@ -1,0 +1,6 @@
+class AddLastVisitedCreativeNavigationOrderToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :last_visited_creative_client_id, :string
+    add_column :users, :last_visited_creative_visit_sequence, :bigint
+  end
+end

--- a/engines/collavre/db/migrate/20260810060000_add_last_visited_creative_issued_sequence_to_users.rb
+++ b/engines/collavre/db/migrate/20260810060000_add_last_visited_creative_issued_sequence_to_users.rb
@@ -1,0 +1,5 @@
+class AddLastVisitedCreativeIssuedSequenceToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :last_visited_creative_issued_sequence, :bigint
+  end
+end

--- a/engines/collavre/test/controllers/creatives_controller_test.rb
+++ b/engines/collavre/test/controllers/creatives_controller_test.rb
@@ -57,6 +57,41 @@ class CreativesControllerTest < ActionDispatch::IntegrationTest
     assert_equal 2, user.last_visited_creative_visit_sequence
   end
 
+  test "server-issued sequences preserve navigation order when requests arrive out of order" do
+    user = users(:one)
+    earlier_creative = creatives(:root_parent)
+    later_creative = creatives(:unconvert_target)
+
+    get creatives_path(id: earlier_creative.id)
+    visit_token = last_visited_creative_token
+
+    patch next_last_visited_sequence_creatives_path, as: :json
+    earlier_sequence = response.parsed_body.fetch("sequence")
+    patch next_last_visited_sequence_creatives_path, as: :json
+    later_sequence = response.parsed_body.fetch("sequence")
+
+    get creatives_path(id: later_creative.id), headers: {
+      "X-Collavre-Last-Visited-Creative-Token" => visit_token,
+      "X-Collavre-Last-Visited-Creative-Sequence" => later_sequence.to_s
+    }
+    patch remember_last_visited_creative_path(earlier_creative),
+      params: { visit_token: visit_token },
+      headers: { "X-Collavre-Last-Visited-Creative-Sequence" => earlier_sequence.to_s },
+      as: :json
+
+    assert_response :no_content
+    assert_equal later_creative, user.reload.last_visited_creative
+    assert_equal later_sequence, user.last_visited_creative_visit_sequence
+  end
+
+  test "issuing a visit sequence requires an authenticated user" do
+    delete session_path
+
+    patch next_last_visited_sequence_creatives_path, as: :json
+
+    assert_response :forbidden
+  end
+
   test "an earlier request from another browser session cannot overwrite a later visit" do
     user = users(:one)
     earlier_creative = creatives(:root_parent)

--- a/engines/collavre/test/controllers/creatives_controller_test.rb
+++ b/engines/collavre/test/controllers/creatives_controller_test.rb
@@ -40,6 +40,31 @@ class CreativesControllerTest < ActionDispatch::IntegrationTest
     assert_equal 2, user.last_visited_creative_visit_sequence
   end
 
+  test "an earlier request from another browser session cannot overwrite a later visit" do
+    user = users(:one)
+    earlier_creative = creatives(:root_parent)
+    later_creative = creatives(:unconvert_target)
+    earlier_received_at = 2.minutes.ago
+
+    user.update!(
+      last_visited_creative: later_creative,
+      last_visited_creative_at: 1.minute.ago,
+      last_visited_creative_client_id: "second-browser",
+      last_visited_creative_visit_sequence: 1
+    )
+
+    Collavre::CreativesController.new.send(
+      :remember_last_visited_creative,
+      earlier_creative,
+      client_id: "first-browser",
+      sequence: 1,
+      received_at: earlier_received_at
+    )
+
+    assert_equal later_creative, user.reload.last_visited_creative
+    assert_equal "second-browser", user.last_visited_creative_client_id
+  end
+
   test "prefetching a readable creative does not remember it as the user's last visited creative" do
     user = users(:one)
     creative = creatives(:root_parent)

--- a/engines/collavre/test/controllers/creatives_controller_test.rb
+++ b/engines/collavre/test/controllers/creatives_controller_test.rb
@@ -24,6 +24,20 @@ class CreativesControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_equal creative, user.reload.last_visited_creative
+    assert_equal 1, user.last_visited_creative_visit_sequence
+  end
+
+  test "a headerless Creative navigation allocates its sequence while holding the user lock" do
+    user = users(:one)
+    first_creative = creatives(:root_parent)
+    second_creative = creatives(:unconvert_target)
+
+    get creatives_path(id: first_creative.id)
+    get creatives_path(id: second_creative.id)
+
+    assert_response :success
+    assert_equal second_creative, user.reload.last_visited_creative
+    assert_equal 2, user.last_visited_creative_visit_sequence
   end
 
   test "prefetching a readable creative does not remember it as the user's last visited creative" do

--- a/engines/collavre/test/controllers/creatives_controller_test.rb
+++ b/engines/collavre/test/controllers/creatives_controller_test.rb
@@ -60,7 +60,10 @@ class CreativesControllerTest < ActionDispatch::IntegrationTest
     visit_token = last_visited_creative_token
     user.update!(last_visited_creative_id: nil)
 
-    patch remember_last_visited_creative_path(creative), params: { visit_token: visit_token }, as: :json
+    patch remember_last_visited_creative_path(creative),
+      params: { visit_token: visit_token },
+      headers: { "X-Collavre-Last-Visited-Creative-Sequence" => "2" },
+      as: :json
 
     assert_response :no_content
     assert_equal creative, user.reload.last_visited_creative
@@ -71,23 +74,45 @@ class CreativesControllerTest < ActionDispatch::IntegrationTest
     newer_creative = creatives(:root_parent)
     restored_creative = creatives(:unconvert_target)
 
-    travel_to 2.minutes.ago.change(usec: 0) do
-      get creatives_path(id: restored_creative.id)
-      @restored_visit_token = last_visited_creative_token
-    end
+    get creatives_path(id: restored_creative.id)
+    restored_visit_token = last_visited_creative_token
 
-    newer_visit_at = 1.minute.ago.change(usec: 0)
-    travel_to newer_visit_at do
-      get creatives_path(id: newer_creative.id)
-    end
+    get creatives_path(id: newer_creative.id), headers: {
+      "X-Collavre-Last-Visited-Creative-Token" => restored_visit_token,
+      "X-Collavre-Last-Visited-Creative-Sequence" => "2"
+    }
 
-    travel_to Time.current.change(usec: 0) do
-      patch remember_last_visited_creative_path(restored_creative), params: { visit_token: @restored_visit_token }, as: :json
-    end
+    patch remember_last_visited_creative_path(restored_creative),
+      params: { visit_token: restored_visit_token },
+      headers: { "X-Collavre-Last-Visited-Creative-Sequence" => "1" },
+      as: :json
 
     assert_response :no_content
     assert_equal newer_creative, user.reload.last_visited_creative
-    assert_equal newer_visit_at, user.last_visited_creative_at
+    assert_equal 2, user.last_visited_creative_visit_sequence
+  end
+
+  test "a browser history restore supersedes the Creative visited before it" do
+    user = users(:one)
+    restored_creative = creatives(:root_parent)
+    newer_creative = creatives(:unconvert_target)
+
+    get creatives_path(id: restored_creative.id)
+    restored_visit_token = last_visited_creative_token
+
+    get creatives_path(id: newer_creative.id), headers: {
+      "X-Collavre-Last-Visited-Creative-Token" => restored_visit_token,
+      "X-Collavre-Last-Visited-Creative-Sequence" => "2"
+    }
+
+    patch remember_last_visited_creative_path(restored_creative),
+      params: { visit_token: restored_visit_token },
+      headers: { "X-Collavre-Last-Visited-Creative-Sequence" => "3" },
+      as: :json
+
+    assert_response :no_content
+    assert_equal restored_creative, user.reload.last_visited_creative
+    assert_equal 3, user.last_visited_creative_visit_sequence
   end
 
   test "rejects unsigned restored visit tokens" do
@@ -109,7 +134,10 @@ class CreativesControllerTest < ActionDispatch::IntegrationTest
     get creatives_path(id: token_creative.id)
     visit_token = last_visited_creative_token
 
-    patch remember_last_visited_creative_path(visited_creative), params: { visit_token: visit_token }, as: :json
+    patch remember_last_visited_creative_path(visited_creative),
+      params: { visit_token: visit_token },
+      headers: { "X-Collavre-Last-Visited-Creative-Sequence" => "2" },
+      as: :json
 
     assert_response :unprocessable_entity
     assert_equal token_creative, users(:one).reload.last_visited_creative
@@ -154,8 +182,10 @@ class CreativesControllerTest < ActionDispatch::IntegrationTest
     assert_select ".creative-workspace-shell"
     assert_select "#creative-workspace-tree"
     assert_select "[data-controller='workspace-tree'][data-workspace-tree-last-visited-creative-visit-token-value]"
+    assert_select "[data-controller='workspace-tree'][data-workspace-tree-last-visited-creative-visit-sequence-value]"
     assert_select "[data-controller='last-visited-creative']", count: 0
     assert_select "turbo-frame#creative-workspace-content:not([target]) [data-workspace-navigation-state][data-creative-id='#{creative.id}']"
+    assert_select "turbo-frame#creative-workspace-content [data-workspace-navigation-state][data-last-visited-creative-visit-token][data-last-visited-creative-visit-sequence]"
     assert_select "form[data-turbo-frame='_top'][action='#{slide_view_creative_path(creative)}']"
     assert_select "#comments-popup[data-docked='true'][data-creative-id='#{creative.id}']"
     assert_select ".creative-workspace-shell #{creative_tree_stream_selector}", count: 1

--- a/engines/collavre/test/controllers/creatives_controller_test.rb
+++ b/engines/collavre/test/controllers/creatives_controller_test.rb
@@ -131,12 +131,12 @@ class CreativesControllerTest < ActionDispatch::IntegrationTest
     assert_nil user.reload.last_visited_creative
   end
 
-  test "a prefetch HEAD request for a creative does not remember it as the user's last visited creative" do
+  test "a HEAD request for a creative does not remember it as the user's last visited creative" do
     user = users(:one)
     creative = creatives(:root_parent)
     user.update!(last_visited_creative_id: nil)
 
-    head creatives_path(id: creative.id), headers: { "X-Sec-Purpose" => "prefetch" }
+    head creatives_path(id: creative.id)
 
     assert_response :success
     assert_nil user.reload.last_visited_creative

--- a/engines/collavre/test/controllers/creatives_controller_test.rb
+++ b/engines/collavre/test/controllers/creatives_controller_test.rb
@@ -40,6 +40,23 @@ class CreativesControllerTest < ActionDispatch::IntegrationTest
     assert_equal 2, user.last_visited_creative_visit_sequence
   end
 
+  test "storage-disabled tabs receive distinct server-allocated visit sequences" do
+    user = users(:one)
+    first_creative = creatives(:root_parent)
+    second_creative = creatives(:unconvert_target)
+
+    get creatives_path(id: first_creative.id)
+    visit_token = last_visited_creative_token
+
+    get creatives_path(id: second_creative.id), headers: {
+      "X-Collavre-Last-Visited-Creative-Token" => visit_token
+    }
+
+    assert_response :success
+    assert_equal second_creative, user.reload.last_visited_creative
+    assert_equal 2, user.last_visited_creative_visit_sequence
+  end
+
   test "an earlier request from another browser session cannot overwrite a later visit" do
     user = users(:one)
     earlier_creative = creatives(:root_parent)
@@ -106,6 +123,23 @@ class CreativesControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :no_content
     assert_equal creative, user.reload.last_visited_creative
+  end
+
+  test "a storage-disabled browser history restore receives a server-allocated sequence" do
+    user = users(:one)
+    creative = creatives(:root_parent)
+
+    get creatives_path(id: creative.id)
+    visit_token = last_visited_creative_token
+    user.update!(last_visited_creative_id: nil)
+
+    patch remember_last_visited_creative_path(creative),
+      params: { visit_token: visit_token },
+      as: :json
+
+    assert_response :no_content
+    assert_equal creative, user.reload.last_visited_creative
+    assert_equal 2, user.last_visited_creative_visit_sequence
   end
 
   test "a delayed restored visit cannot overwrite a later Creative navigation" do

--- a/engines/collavre/test/controllers/creatives_controller_test.rb
+++ b/engines/collavre/test/controllers/creatives_controller_test.rb
@@ -59,6 +59,25 @@ class CreativesControllerTest < ActionDispatch::IntegrationTest
     assert_equal creative, user.reload.last_visited_creative
   end
 
+  test "an older restored visit does not overwrite a newer Creative navigation" do
+    user = users(:one)
+    newer_creative = creatives(:root_parent)
+    restored_creative = creatives(:unconvert_target)
+    newer_visit_at = 1.minute.ago.change(usec: 0)
+    user.update_columns(
+      last_visited_creative_id: newer_creative.id,
+      last_visited_creative_at: newer_visit_at
+    )
+
+    patch remember_last_visited_creative_path(restored_creative), as: :json, headers: {
+      "X-Collavre-Last-Visited-Creative-At" => ((newer_visit_at - 1.second).to_f * 1000).to_i.to_s
+    }
+
+    assert_response :no_content
+    assert_equal newer_creative, user.reload.last_visited_creative
+    assert_equal newer_visit_at, user.last_visited_creative_at
+  end
+
   test "remembering an inaccessible browser history creative preserves the current last visit" do
     user = users(:one)
     remembered_creative = creatives(:root_parent)

--- a/engines/collavre/test/controllers/creatives_controller_test.rb
+++ b/engines/collavre/test/controllers/creatives_controller_test.rb
@@ -96,6 +96,17 @@ class CreativesControllerTest < ActionDispatch::IntegrationTest
     assert_nil user.reload.last_visited_creative
   end
 
+  test "a prefetch HEAD request for a creative does not remember it as the user's last visited creative" do
+    user = users(:one)
+    creative = creatives(:root_parent)
+    user.update!(last_visited_creative_id: nil)
+
+    head creatives_path(id: creative.id), headers: { "X-Sec-Purpose" => "prefetch" }
+
+    assert_response :success
+    assert_nil user.reload.last_visited_creative
+  end
+
   test "opening an inaccessible creative does not replace the last visited creative" do
     user = users(:one)
     remembered_creative = creatives(:root_parent)

--- a/engines/collavre/test/controllers/creatives_controller_test.rb
+++ b/engines/collavre/test/controllers/creatives_controller_test.rb
@@ -11,6 +11,29 @@ class CreativesControllerTest < ActionDispatch::IntegrationTest
     "turbo-cable-stream-source[signed-stream-name='#{signed_name}']"
   end
 
+  test "opening a readable creative remembers it as the user's last visited creative" do
+    user = users(:one)
+    creative = creatives(:root_parent)
+    user.update!(last_visited_creative_id: nil)
+
+    get creatives_path(id: creative.id), headers: { "Turbo-Frame" => "creative-workspace-content" }
+
+    assert_response :success
+    assert_equal creative, user.reload.last_visited_creative
+  end
+
+  test "opening an inaccessible creative does not replace the last visited creative" do
+    user = users(:one)
+    remembered_creative = creatives(:root_parent)
+    inaccessible_creative = Creative.create!(user: users(:two), description: "Private workspace creative")
+    user.update!(last_visited_creative: remembered_creative)
+
+    get creatives_path(id: inaccessible_creative.id), headers: { "Turbo-Frame" => "creative-workspace-content" }
+
+    assert_response :success
+    assert_equal remembered_creative, user.reload.last_visited_creative
+  end
+
   test "creative workspace is disabled by default" do
     users(:one).update!(creative_workspace_enabled: false)
     creative = creatives(:root_parent)

--- a/engines/collavre/test/controllers/creatives_controller_test.rb
+++ b/engines/collavre/test/controllers/creatives_controller_test.rb
@@ -34,6 +34,29 @@ class CreativesControllerTest < ActionDispatch::IntegrationTest
     assert_equal remembered_creative, user.reload.last_visited_creative
   end
 
+  test "remembering a creative restored from browser history updates the last visited creative" do
+    user = users(:one)
+    creative = creatives(:root_parent)
+    user.update!(last_visited_creative_id: nil)
+
+    patch remember_last_visited_creative_path(creative), as: :json
+
+    assert_response :no_content
+    assert_equal creative, user.reload.last_visited_creative
+  end
+
+  test "remembering an inaccessible browser history creative preserves the current last visit" do
+    user = users(:one)
+    remembered_creative = creatives(:root_parent)
+    inaccessible_creative = Creative.create!(user: users(:two), description: "Private workspace creative")
+    user.update!(last_visited_creative: remembered_creative)
+
+    patch remember_last_visited_creative_path(inaccessible_creative), as: :json
+
+    assert_response :forbidden
+    assert_equal remembered_creative, user.reload.last_visited_creative
+  end
+
   test "creative workspace is disabled by default" do
     users(:one).update!(creative_workspace_enabled: false)
     creative = creatives(:root_parent)

--- a/engines/collavre/test/controllers/creatives_controller_test.rb
+++ b/engines/collavre/test/controllers/creatives_controller_test.rb
@@ -11,6 +11,10 @@ class CreativesControllerTest < ActionDispatch::IntegrationTest
     "turbo-cable-stream-source[signed-stream-name='#{signed_name}']"
   end
 
+  def last_visited_creative_token
+    response.body.match(/data-(?:workspace-tree|last-visited-creative)-last-visited-creative-visit-token-value="([^"]+)"/)[1]
+  end
+
   test "opening a readable creative remembers it as the user's last visited creative" do
     user = users(:one)
     creative = creatives(:root_parent)
@@ -51,27 +55,34 @@ class CreativesControllerTest < ActionDispatch::IntegrationTest
   test "remembering a creative restored from browser history updates the last visited creative" do
     user = users(:one)
     creative = creatives(:root_parent)
+
+    get creatives_path(id: creative.id)
+    visit_token = last_visited_creative_token
     user.update!(last_visited_creative_id: nil)
 
-    patch remember_last_visited_creative_path(creative), as: :json
+    patch remember_last_visited_creative_path(creative), params: { visit_token: visit_token }, as: :json
 
     assert_response :no_content
     assert_equal creative, user.reload.last_visited_creative
   end
 
-  test "an earlier server-timed restored visit does not overwrite a later Creative navigation" do
+  test "a delayed restored visit cannot overwrite a later Creative navigation" do
     user = users(:one)
     newer_creative = creatives(:root_parent)
     restored_creative = creatives(:unconvert_target)
-    restored_visit_at = 2.minutes.ago.change(usec: 0)
-    newer_visit_at = restored_visit_at + 1.minute
-    user.update_columns(
-      last_visited_creative_id: newer_creative.id,
-      last_visited_creative_at: newer_visit_at
-    )
 
-    travel_to restored_visit_at do
-      patch remember_last_visited_creative_path(restored_creative), as: :json
+    travel_to 2.minutes.ago.change(usec: 0) do
+      get creatives_path(id: restored_creative.id)
+      @restored_visit_token = last_visited_creative_token
+    end
+
+    newer_visit_at = 1.minute.ago.change(usec: 0)
+    travel_to newer_visit_at do
+      get creatives_path(id: newer_creative.id)
+    end
+
+    travel_to Time.current.change(usec: 0) do
+      patch remember_last_visited_creative_path(restored_creative), params: { visit_token: @restored_visit_token }, as: :json
     end
 
     assert_response :no_content
@@ -79,26 +90,29 @@ class CreativesControllerTest < ActionDispatch::IntegrationTest
     assert_equal newer_visit_at, user.last_visited_creative_at
   end
 
-  test "uses server time instead of an untrusted browser clock" do
+  test "rejects unsigned restored visit tokens" do
     user = users(:one)
     previous_creative = creatives(:root_parent)
     visited_creative = creatives(:unconvert_target)
-    previous_visit_at = 2.minutes.ago.change(usec: 0)
-    server_visit_at = previous_visit_at + 1.minute
-    user.update_columns(
-      last_visited_creative_id: previous_creative.id,
-      last_visited_creative_at: previous_visit_at
-    )
+    user.update!(last_visited_creative: previous_creative)
 
-    travel_to server_visit_at do
-      patch remember_last_visited_creative_path(visited_creative), as: :json, headers: {
-        "X-Collavre-Last-Visited-Creative-At" => 1.year.from_now.to_i.to_s
-      }
-    end
+    patch remember_last_visited_creative_path(visited_creative), params: { visit_token: "forged" }, as: :json
 
-    assert_response :no_content
-    assert_equal visited_creative, user.reload.last_visited_creative
-    assert_equal server_visit_at, user.last_visited_creative_at
+    assert_response :unprocessable_entity
+    assert_equal previous_creative, user.reload.last_visited_creative
+  end
+
+  test "rejects a restored visit token for another Creative" do
+    token_creative = creatives(:root_parent)
+    visited_creative = creatives(:unconvert_target)
+
+    get creatives_path(id: token_creative.id)
+    visit_token = last_visited_creative_token
+
+    patch remember_last_visited_creative_path(visited_creative), params: { visit_token: visit_token }, as: :json
+
+    assert_response :unprocessable_entity
+    assert_equal token_creative, users(:one).reload.last_visited_creative
   end
 
   test "remembering an inaccessible browser history creative preserves the current last visit" do
@@ -125,7 +139,7 @@ class CreativesControllerTest < ActionDispatch::IntegrationTest
     assert_select "#creative-workspace-tree", count: 0
     assert_select "turbo-frame#creative-workspace-content", count: 0
     assert_select "[data-workspace-navigation-state]", count: 0
-    assert_select "[data-controller='last-visited-creative'][data-last-visited-creative-creative-id-value='#{creative.id}']"
+    assert_select "[data-controller='last-visited-creative'][data-last-visited-creative-creative-id-value='#{creative.id}'][data-last-visited-creative-visit-token-value]"
     assert_select "#comments-popup[data-docked='false']", count: 1
     assert_select creative_tree_stream_selector, count: 1
   end
@@ -139,6 +153,7 @@ class CreativesControllerTest < ActionDispatch::IntegrationTest
     assert_select "body.creative-workspace"
     assert_select ".creative-workspace-shell"
     assert_select "#creative-workspace-tree"
+    assert_select "[data-controller='workspace-tree'][data-workspace-tree-last-visited-creative-visit-token-value]"
     assert_select "[data-controller='last-visited-creative']", count: 0
     assert_select "turbo-frame#creative-workspace-content:not([target]) [data-workspace-navigation-state][data-creative-id='#{creative.id}']"
     assert_select "form[data-turbo-frame='_top'][action='#{slide_view_creative_path(creative)}']"

--- a/engines/collavre/test/controllers/creatives_controller_test.rb
+++ b/engines/collavre/test/controllers/creatives_controller_test.rb
@@ -22,6 +22,20 @@ class CreativesControllerTest < ActionDispatch::IntegrationTest
     assert_equal creative, user.reload.last_visited_creative
   end
 
+  test "prefetching a readable creative does not remember it as the user's last visited creative" do
+    user = users(:one)
+    creative = creatives(:root_parent)
+    user.update!(last_visited_creative_id: nil)
+
+    get creatives_path(id: creative.id), headers: {
+      "Turbo-Frame" => "creative-workspace-content",
+      "X-Sec-Purpose" => "prefetch"
+    }
+
+    assert_response :success
+    assert_nil user.reload.last_visited_creative
+  end
+
   test "opening an inaccessible creative does not replace the last visited creative" do
     user = users(:one)
     remembered_creative = creatives(:root_parent)

--- a/engines/collavre/test/controllers/creatives_controller_test.rb
+++ b/engines/collavre/test/controllers/creatives_controller_test.rb
@@ -84,12 +84,12 @@ class CreativesControllerTest < ActionDispatch::IntegrationTest
     assert_equal later_sequence, user.last_visited_creative_visit_sequence
   end
 
-  test "issuing a visit sequence requires an authenticated user" do
+  test "issuing a visit sequence redirects an unauthenticated user to sign in" do
     delete session_path
 
     patch next_last_visited_sequence_creatives_path, as: :json
 
-    assert_response :forbidden
+    assert_redirected_to new_session_path
   end
 
   test "an earlier request from another browser session cannot overwrite a later visit" do

--- a/engines/collavre/test/controllers/creatives_controller_test.rb
+++ b/engines/collavre/test/controllers/creatives_controller_test.rb
@@ -116,7 +116,8 @@ class CreativesControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_select "a.creative-breadcrumb-link[href='#{creatives_path}'][data-turbo-action='advance']"
-    assert_select "a.creative-breadcrumb-link[href='#{creative_path(ancestor)}'][data-turbo-action='advance']"
+    assert_select "a.creative-breadcrumb-link[href='#{creative_path(ancestor)}'][data-turbo-action='advance'][data-turbo-prefetch='false']"
+    assert_select "a.creative-breadcrumb-current[href='#{creative_path(child)}'][data-turbo-action='replace'][data-turbo-prefetch='false']"
   end
 
   test "workspace tree JSON returns collapsed branches without leaf roots" do

--- a/engines/collavre/test/controllers/creatives_controller_test.rb
+++ b/engines/collavre/test/controllers/creatives_controller_test.rb
@@ -83,6 +83,7 @@ class CreativesControllerTest < ActionDispatch::IntegrationTest
     assert_select "#creative-workspace-tree", count: 0
     assert_select "turbo-frame#creative-workspace-content", count: 0
     assert_select "[data-workspace-navigation-state]", count: 0
+    assert_select "[data-controller='last-visited-creative'][data-last-visited-creative-creative-id-value='#{creative.id}']"
     assert_select "#comments-popup[data-docked='false']", count: 1
     assert_select creative_tree_stream_selector, count: 1
   end
@@ -96,6 +97,7 @@ class CreativesControllerTest < ActionDispatch::IntegrationTest
     assert_select "body.creative-workspace"
     assert_select ".creative-workspace-shell"
     assert_select "#creative-workspace-tree"
+    assert_select "[data-controller='last-visited-creative']", count: 0
     assert_select "turbo-frame#creative-workspace-content:not([target]) [data-workspace-navigation-state][data-creative-id='#{creative.id}']"
     assert_select "form[data-turbo-frame='_top'][action='#{slide_view_creative_path(creative)}']"
     assert_select "#comments-popup[data-docked='true'][data-creative-id='#{creative.id}']"

--- a/engines/collavre/test/controllers/creatives_controller_test.rb
+++ b/engines/collavre/test/controllers/creatives_controller_test.rb
@@ -59,23 +59,46 @@ class CreativesControllerTest < ActionDispatch::IntegrationTest
     assert_equal creative, user.reload.last_visited_creative
   end
 
-  test "an older restored visit does not overwrite a newer Creative navigation" do
+  test "an earlier server-timed restored visit does not overwrite a later Creative navigation" do
     user = users(:one)
     newer_creative = creatives(:root_parent)
     restored_creative = creatives(:unconvert_target)
-    newer_visit_at = 1.minute.ago.change(usec: 0)
+    restored_visit_at = 2.minutes.ago.change(usec: 0)
+    newer_visit_at = restored_visit_at + 1.minute
     user.update_columns(
       last_visited_creative_id: newer_creative.id,
       last_visited_creative_at: newer_visit_at
     )
 
-    patch remember_last_visited_creative_path(restored_creative), as: :json, headers: {
-      "X-Collavre-Last-Visited-Creative-At" => ((newer_visit_at - 1.second).to_f * 1000).to_i.to_s
-    }
+    travel_to restored_visit_at do
+      patch remember_last_visited_creative_path(restored_creative), as: :json
+    end
 
     assert_response :no_content
     assert_equal newer_creative, user.reload.last_visited_creative
     assert_equal newer_visit_at, user.last_visited_creative_at
+  end
+
+  test "uses server time instead of an untrusted browser clock" do
+    user = users(:one)
+    previous_creative = creatives(:root_parent)
+    visited_creative = creatives(:unconvert_target)
+    previous_visit_at = 2.minutes.ago.change(usec: 0)
+    server_visit_at = previous_visit_at + 1.minute
+    user.update_columns(
+      last_visited_creative_id: previous_creative.id,
+      last_visited_creative_at: previous_visit_at
+    )
+
+    travel_to server_visit_at do
+      patch remember_last_visited_creative_path(visited_creative), as: :json, headers: {
+        "X-Collavre-Last-Visited-Creative-At" => 1.year.from_now.to_i.to_s
+      }
+    end
+
+    assert_response :no_content
+    assert_equal visited_creative, user.reload.last_visited_creative
+    assert_equal server_visit_at, user.last_visited_creative_at
   end
 
   test "remembering an inaccessible browser history creative preserves the current last visit" do

--- a/engines/collavre/test/integration/root_home_path_test.rb
+++ b/engines/collavre/test/integration/root_home_path_test.rb
@@ -90,6 +90,19 @@ class RootHomePathTest < ActionDispatch::IntegrationTest
     assert_equal creative.id.to_s, Rack::Utils.parse_nested_query(location.query)["id"]
   end
 
+  test "authenticated user redirect preserves the engine mount prefix" do
+    creative = creatives(:tshirt)
+    @user.update!(last_visited_creative: creative)
+
+    sign_in_as(@user, password: "password")
+    get "/", env: { "SCRIPT_NAME" => "/collavre" }
+
+    assert_response :redirect
+    location = URI.parse(response.location)
+    assert_equal "/collavre/creatives", location.path
+    assert_equal creative.id.to_s, Rack::Utils.parse_nested_query(location.query)["id"]
+  end
+
   test "authenticated user cannot be redirected to a creative they no longer can read" do
     private_creative = Collavre::Creative.create!(user: users(:two), description: "Private")
     @user.update!(last_visited_creative: private_creative)

--- a/engines/collavre/test/integration/root_home_path_test.rb
+++ b/engines/collavre/test/integration/root_home_path_test.rb
@@ -133,6 +133,21 @@ class RootHomePathTest < ActionDispatch::IntegrationTest
     assert_equal creative.id.to_s, Rack::Utils.parse_nested_query(location.query)["id"]
   end
 
+  test "authenticated user returns to their last visited creative with a mounted Creative home path" do
+    creative = creatives(:tshirt)
+    @user.update!(last_visited_creative: creative)
+    SystemSetting.create!(key: "home_page_path_authenticated", value: "/collavre/creatives")
+    Rails.cache.clear
+
+    sign_in_as(@user, password: "password")
+    get "/", env: { "SCRIPT_NAME" => "/collavre" }
+
+    assert_response :redirect
+    location = URI.parse(response.location)
+    assert_equal "/collavre/creatives", location.path
+    assert_equal creative.id.to_s, Rack::Utils.parse_nested_query(location.query)["id"]
+  end
+
   test "authenticated user cannot be redirected to a creative they no longer can read" do
     private_creative = Collavre::Creative.create!(user: users(:two), description: "Private")
     @user.update!(last_visited_creative: private_creative)

--- a/engines/collavre/test/integration/root_home_path_test.rb
+++ b/engines/collavre/test/integration/root_home_path_test.rb
@@ -90,6 +90,21 @@ class RootHomePathTest < ActionDispatch::IntegrationTest
     assert_equal creative.id.to_s, Rack::Utils.parse_nested_query(location.query)["id"]
   end
 
+  test "authenticated user returns to their last visited creative when the home path has a trailing slash" do
+    creative = creatives(:tshirt)
+    @user.update!(last_visited_creative: creative)
+    SystemSetting.create!(key: "home_page_path_authenticated", value: "/creatives/")
+    Rails.cache.clear
+
+    sign_in_as(@user, password: "password")
+    get "/"
+
+    assert_response :redirect
+    location = URI.parse(response.location)
+    assert_equal "/creatives", location.path
+    assert_equal creative.id.to_s, Rack::Utils.parse_nested_query(location.query)["id"]
+  end
+
   test "authenticated user redirect preserves the engine mount prefix" do
     creative = creatives(:tshirt)
     @user.update!(last_visited_creative: creative)

--- a/engines/collavre/test/integration/root_home_path_test.rb
+++ b/engines/collavre/test/integration/root_home_path_test.rb
@@ -3,6 +3,7 @@ require "test_helper"
 class RootHomePathTest < ActionDispatch::IntegrationTest
   setup do
     @user = users(:one)
+    @user.update!(last_visited_creative_id: nil)
     Rails.cache.clear
     SystemSetting.where(key: [ "home_page_path", "home_page_path_authenticated", "creatives_login_required" ]).destroy_all
     Rails.cache.clear
@@ -68,6 +69,30 @@ class RootHomePathTest < ActionDispatch::IntegrationTest
 
   test "authenticated user hitting / without setting is redirected to default /creatives" do
     Rails.cache.clear
+
+    sign_in_as(@user, password: "password")
+    get "/"
+
+    assert_response :redirect
+    assert_equal "/creatives", URI.parse(response.location).path
+  end
+
+  test "authenticated user hitting / returns to their last visited creative" do
+    creative = creatives(:tshirt)
+    @user.update!(last_visited_creative: creative)
+
+    sign_in_as(@user, password: "password")
+    get "/"
+
+    assert_response :redirect
+    location = URI.parse(response.location)
+    assert_equal "/creatives", location.path
+    assert_equal creative.id.to_s, Rack::Utils.parse_nested_query(location.query)["id"]
+  end
+
+  test "authenticated user cannot be redirected to a creative they no longer can read" do
+    private_creative = Collavre::Creative.create!(user: users(:two), description: "Private")
+    @user.update!(last_visited_creative: private_creative)
 
     sign_in_as(@user, password: "password")
     get "/"

--- a/engines/collavre/test/integration/root_home_path_test.rb
+++ b/engines/collavre/test/integration/root_home_path_test.rb
@@ -105,6 +105,21 @@ class RootHomePathTest < ActionDispatch::IntegrationTest
     assert_equal creative.id.to_s, Rack::Utils.parse_nested_query(location.query)["id"]
   end
 
+  test "authenticated user returns to their last visited creative when the home path uses the HTML format" do
+    creative = creatives(:tshirt)
+    @user.update!(last_visited_creative: creative)
+    SystemSetting.create!(key: "home_page_path_authenticated", value: "/creatives.html")
+    Rails.cache.clear
+
+    sign_in_as(@user, password: "password")
+    get "/"
+
+    assert_response :redirect
+    location = URI.parse(response.location)
+    assert_equal "/creatives", location.path
+    assert_equal creative.id.to_s, Rack::Utils.parse_nested_query(location.query)["id"]
+  end
+
   test "authenticated user redirect preserves the engine mount prefix" do
     creative = creatives(:tshirt)
     @user.update!(last_visited_creative: creative)


### PR DESCRIPTION
## Summary
- persist each user's last readable Creative
- restore that Creative when an authenticated user enters the configured Creative home
- fall back to the Creative index when access was removed or no Creative is remembered

## Why
Reopening the web app or installed PWA should return users to the Creative they were last working in.

## Validation
- `npm run build`
- `bin/rails test engines/collavre/test/controllers/creatives_controller_test.rb engines/collavre/test/integration/root_home_path_test.rb` (41 runs, 207 assertions)
- `./bin/rubocop -a` (1,184 files, no offenses)

## Known validation limitation
- `bin/rails test:system` cannot run because this checkout has no `test/system` directory.