### PR TITLE
feat: complete desktop CLI proxy setup

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -197,10 +197,11 @@ GEM
       activerecord (>= 7.2.0)
       with_advisory_lock (>= 7.5.0)
       zeitwerk (~> 2.7)
+    commonmarker (2.9.0)
+      rb_sys (~> 0.9)
     commonmarker (2.9.0-aarch64-linux)
     commonmarker (2.9.0-aarch64-linux-musl)
     commonmarker (2.9.0-arm-linux)
-    commonmarker (2.9.0-arm64-darwin)
     commonmarker (2.9.0-x86_64-linux)
     commonmarker (2.9.0-x86_64-linux-musl)
     concurrent-ruby (1.3.8)
@@ -286,11 +287,11 @@ GEM
     fcm (2.0.2)
       faraday (>= 1.0.0, < 3.0)
       googleauth (~> 1)
+    ffi (1.17.4)
     ffi (1.17.4-aarch64-linux-gnu)
     ffi (1.17.4-aarch64-linux-musl)
     ffi (1.17.4-arm-linux-gnu)
     ffi (1.17.4-arm-linux-musl)
-    ffi (1.17.4-arm64-darwin)
     ffi (1.17.4-x86_64-linux-gnu)
     ffi (1.17.4-x86_64-linux-musl)
     fugit (1.13.0)
@@ -382,6 +383,7 @@ GEM
       mime-types-data (~> 3.2025, >= 3.2025.0507)
     mime-types-data (3.2026.0317)
     mini_mime (1.1.5)
+    mini_portile2 (2.8.9)
     minitest (6.0.6)
       drb (~> 2.0)
       prism (~> 1.5)
@@ -408,6 +410,9 @@ GEM
       net-protocol
     net-ssh (7.3.3)
     nio4r (2.7.5)
+    nokogiri (1.19.4)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
     nokogiri (1.19.4-aarch64-linux-gnu)
       racc (~> 1.4)
     nokogiri (1.19.4-aarch64-linux-musl)
@@ -415,8 +420,6 @@ GEM
     nokogiri (1.19.4-arm-linux-gnu)
       racc (~> 1.4)
     nokogiri (1.19.4-arm-linux-musl)
-      racc (~> 1.4)
-    nokogiri (1.19.4-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.19.4-x86_64-linux-gnu)
       racc (~> 1.4)
@@ -465,7 +468,6 @@ GEM
     pg (1.6.3)
     pg (1.6.3-aarch64-linux)
     pg (1.6.3-aarch64-linux-musl)
-    pg (1.6.3-arm64-darwin)
     pg (1.6.3-x86_64-linux)
     pg (1.6.3-x86_64-linux-musl)
     pp (0.6.4)
@@ -531,6 +533,9 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.4.2)
+    rake-compiler-dock (1.12.0)
+    rb_sys (0.9.128)
+      rake-compiler-dock (= 1.12.0)
     rbs (4.0.3)
       logger
       prism (>= 1.6.0)
@@ -631,11 +636,12 @@ GEM
       railties (>= 7.1)
       thor (>= 1.3.1)
     sorbet-runtime (0.6.13055)
+    sqlite3 (2.9.5)
+      mini_portile2 (~> 2.8.0)
     sqlite3 (2.9.5-aarch64-linux-gnu)
     sqlite3 (2.9.5-aarch64-linux-musl)
     sqlite3 (2.9.5-arm-linux-gnu)
     sqlite3 (2.9.5-arm-linux-musl)
-    sqlite3 (2.9.5-arm64-darwin)
     sqlite3 (2.9.5-x86_64-linux-gnu)
     sqlite3 (2.9.5-x86_64-linux-musl)
     sshkit (1.25.0)
@@ -651,7 +657,6 @@ GEM
     thor (1.5.0)
     thruster (0.1.23)
     thruster (0.1.23-aarch64-linux)
-    thruster (0.1.23-arm64-darwin)
     thruster (0.1.23-x86_64-linux)
     timeout (0.6.1)
     tpm-key_attestation (0.14.1)
@@ -710,8 +715,7 @@ PLATFORMS
   aarch64-linux-musl
   arm-linux-gnu
   arm-linux-musl
-  arm64-darwin-24
-  arm64-darwin-25
+  ruby
   x86_64-linux
   x86_64-linux-gnu
   x86_64-linux-musl

--- a/bin/desktop-server
+++ b/bin/desktop-server
@@ -58,19 +58,10 @@ if [ -x "$VENDORED_RUBY" ]; then
   export BUNDLE_WITHOUT="development:test:production"
   export BUNDLE_WITH="desktop"
 
-  # ruby-build embeds its installation prefix in Ruby's default load path. The
-  # portable runtime is copied from that prefix into the .app, so a different
-  # Mac cannot use those baked-in paths to find standard-library files such as
-  # securerandom. Prepend the runtime's actual stdlib directories and discard
-  # any caller-supplied RUBYLIB: a packaged app must not load code from outside
-  # its signed bundle.
-  RUBY_STDLIB_DIR="$(find "$VENDOR_DIR/ruby/lib/ruby" -mindepth 1 -maxdepth 1 -type d -name '[0-9]*.[0-9]*.[0-9]*' -print -quit)"
-  [ -n "$RUBY_STDLIB_DIR" ] || {
-    echo "[desktop-server] bundled Ruby standard library is missing" >&2
-    exit 1
-  }
-  RUBY_ARCH_DIR="$(find "$RUBY_STDLIB_DIR" -mindepth 1 -maxdepth 1 -type d -name '*-darwin*' -print -quit)"
-  export RUBYLIB="$RUBY_STDLIB_DIR${RUBY_ARCH_DIR:+:$RUBY_ARCH_DIR}"
+  # The packaged runtime is self-relocating, so prevent caller-supplied paths
+  # from loading standard-library or gem code outside the signed app bundle.
+  unset RUBYLIB
+  unset RUBYOPT
 elif [ "$PACKAGED_APP" = true ]; then
   echo "[desktop-server] bundled Ruby is missing or not executable: $VENDORED_RUBY" >&2
   exit 1

--- a/bin/desktop-server
+++ b/bin/desktop-server
@@ -35,13 +35,19 @@ cd "$APP_ROOT"
 DATA_DIR="${COLLAVRE_DATA_DIR:-$HOME/Library/Application Support/Collavre}"
 mkdir -p "$DATA_DIR"
 
-# Pick the Ruby runtime: an explicit override, then a vendored portable Ruby
-# (present in packaged builds), then whatever `ruby` is on PATH (dev checkout).
+# Packaged apps must always use their vendored portable Ruby. Falling back to a
+# user's system Ruby makes the bundled Gemfile and gems incompatible with the
+# target Mac (and can silently select macOS's legacy Ruby 2.6). Development
+# checkouts have no vendor directory, so they may still use an explicit override
+# or `ruby` on PATH.
 VENDOR_DIR="$APP_ROOT/tools/desktop-app/vendor"
 VENDORED_RUBY="$VENDOR_DIR/ruby/bin/ruby"
-if [ -n "${COLLAVRE_RUBY:-}" ]; then
-  RUBY_BIN="$COLLAVRE_RUBY"
-elif [ -x "$VENDORED_RUBY" ]; then
+PACKAGED_APP=false
+case "$APP_ROOT" in
+  */Contents/Resources/app) PACKAGED_APP=true ;;
+esac
+
+if [ -x "$VENDORED_RUBY" ]; then
   RUBY_BIN="$VENDORED_RUBY"
   # Point Bundler at the vendored gems by absolute path resolved at runtime, so
   # the bundle works regardless of where the .app was installed (no reliance on
@@ -51,6 +57,11 @@ elif [ -x "$VENDORED_RUBY" ]; then
   export BUNDLE_PATH="$VENDOR_DIR/bundle"
   export BUNDLE_WITHOUT="development:test:production"
   export BUNDLE_WITH="desktop"
+elif [ "$PACKAGED_APP" = true ]; then
+  echo "[desktop-server] bundled Ruby is missing or not executable: $VENDORED_RUBY" >&2
+  exit 1
+elif [ -n "${COLLAVRE_RUBY:-}" ]; then
+  RUBY_BIN="$COLLAVRE_RUBY"
 else
   RUBY_BIN="ruby"
 fi

--- a/bin/desktop-server
+++ b/bin/desktop-server
@@ -57,6 +57,20 @@ if [ -x "$VENDORED_RUBY" ]; then
   export BUNDLE_PATH="$VENDOR_DIR/bundle"
   export BUNDLE_WITHOUT="development:test:production"
   export BUNDLE_WITH="desktop"
+
+  # ruby-build embeds its installation prefix in Ruby's default load path. The
+  # portable runtime is copied from that prefix into the .app, so a different
+  # Mac cannot use those baked-in paths to find standard-library files such as
+  # securerandom. Prepend the runtime's actual stdlib directories and discard
+  # any caller-supplied RUBYLIB: a packaged app must not load code from outside
+  # its signed bundle.
+  RUBY_STDLIB_DIR="$(find "$VENDOR_DIR/ruby/lib/ruby" -mindepth 1 -maxdepth 1 -type d -name '[0-9]*.[0-9]*.[0-9]*' -print -quit)"
+  [ -n "$RUBY_STDLIB_DIR" ] || {
+    echo "[desktop-server] bundled Ruby standard library is missing" >&2
+    exit 1
+  }
+  RUBY_ARCH_DIR="$(find "$RUBY_STDLIB_DIR" -mindepth 1 -maxdepth 1 -type d -name '*-darwin*' -print -quit)"
+  export RUBYLIB="$RUBY_STDLIB_DIR${RUBY_ARCH_DIR:+:$RUBY_ARCH_DIR}"
 elif [ "$PACKAGED_APP" = true ]; then
   echo "[desktop-server] bundled Ruby is missing or not executable: $VENDORED_RUBY" >&2
   exit 1

--- a/bin/desktop-server
+++ b/bin/desktop-server
@@ -72,6 +72,7 @@ export BOOTSNAP_CACHE_DIR="$DATA_DIR/tmp/cache"
 export SOLID_QUEUE_IN_PUMA=true
 export PORT="${PORT:-3000}"
 BIND_HOST="${COLLAVRE_BIND_HOST:-127.0.0.1}"
+export PIDFILE="$DATA_DIR/tmp/pids/desktop-server.pid"
 
 # In open mode the app is reached over LAN/Tailscale, so generated mail links
 # (share invites, password resets) must point at the externally reachable host —
@@ -86,7 +87,7 @@ if [ -z "${DEFAULT_URL_HOST:-}" ] && [ "$BIND_HOST" = "0.0.0.0" ] && [ -n "${COL
   [ -n "$DEFAULT_URL_HOST" ] && export DEFAULT_URL_HOST
 fi
 
-mkdir -p "$ACTIVE_STORAGE_DISK_ROOT" "$FLOCK_DIR" "$BOOTSNAP_CACHE_DIR"
+mkdir -p "$ACTIVE_STORAGE_DISK_ROOT" "$FLOCK_DIR" "$BOOTSNAP_CACHE_DIR" "$(dirname "$PIDFILE")"
 
 echo "[desktop-server] root=$APP_ROOT data=$DATA_DIR ruby=$RUBY_BIN bind=$BIND_HOST:$PORT" >&2
 
@@ -123,5 +124,7 @@ if [ -z "$SEED_FINGERPRINT" ] || [ "$(cat "$SEED_MARKER" 2>/dev/null || true)" !
   printf '%s\n' "$SEED_FINGERPRINT" > "$SEED_MARKER"
 fi
 
-# Hand off to Puma (Solid Queue runs in-process via SOLID_QUEUE_IN_PUMA).
-exec "$RUBY_BIN" "$APP_ROOT/bin/rails" server -b "$BIND_HOST" -p "$PORT"
+# `rails server` unconditionally creates Rails.root/tmp, which is inside the
+# read-only .app bundle. Running Puma directly avoids that Rails CLI setup; the
+# configured PID file and all desktop runtime state live under DATA_DIR.
+exec "$RUBY_BIN" -S bundle exec puma -C "$APP_ROOT/config/puma.rb" -b "tcp://$BIND_HOST:$PORT"

--- a/config/environments/desktop.rb
+++ b/config/environments/desktop.rb
@@ -62,6 +62,9 @@ Rails.application.configure do
   # user is granted system_admin (the default build is loopback-only, so that
   # first signup is the local owner; open mode is opt-in and set up afterwards).
   config.x.bootstrap_first_admin = true
+  # Desktop-only native setup endpoints must never bootstrap an administrator
+  # in a web deployment that happens to be reached through a loopback proxy.
+  config.x.desktop_proxy_setup = true
 
   # Boot must not depend on a checked-in master key. The desktop launcher
   # provisions and persists SECRET_KEY_BASE on first run (see

--- a/config/initializers/ruby_llm.rb
+++ b/config/initializers/ruby_llm.rb
@@ -15,7 +15,11 @@ RubyLLM.configure do |config|
   rescue StandardError
     1800
   end
-  config.log_file = Rails.root.join("log", "ruby_llm.log").to_s
+  # A packaged desktop app keeps its Rails source tree inside the read-only
+  # application bundle. Put the LLM log alongside the other writable desktop
+  # logs instead of trying to create `Contents/Resources/app/log` at boot.
+  log_root = ENV["COLLAVRE_DATA_DIR"].presence || Rails.root
+  config.log_file = File.join(log_root, "log", "ruby_llm.log")
   # Mirror the app's log level instead of hardcoding DEBUG. At DEBUG the Faraday
   # :logger middleware writes full request/response bodies to ruby_llm.log
   # (connection.rb: `bodies: RubyLLM.logger.debug?`). Provider error bodies arrive

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_10_060000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_10_100000) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -58,12 +58,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_10_060000) do
     t.string "base_url", null: false
     t.text "completion_key", null: false
     t.datetime "created_at", null: false
+    t.boolean "desktop_managed", default: false, null: false
     t.text "identity_secret"
     t.string "name", null: false
     t.integer "owner_id", null: false
     t.string "tenant_id", default: "collavre", null: false
     t.datetime "updated_at", null: false
     t.integer "workspace_mode", default: 0, null: false
+    t.index ["desktop_managed"], name: "index_agent_gateways_on_desktop_managed", unique: true, where: "desktop_managed"
     t.index ["owner_id", "name"], name: "index_agent_gateways_on_owner_id_and_name", unique: true
     t.index ["owner_id"], name: "index_agent_gateways_on_owner_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_10_100000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_10_100001) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -978,6 +978,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_10_100000) do
     t.datetime "created_at", null: false
     t.integer "created_by_id"
     t.boolean "creative_workspace_enabled", default: true, null: false
+    t.string "desktop_preset_adapter"
     t.json "dismissed_notices"
     t.string "email", null: false
     t.datetime "email_verified_at"
@@ -1018,6 +1019,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_10_100000) do
     t.datetime "updated_at", null: false
     t.string "webauthn_id"
     t.index ["agent_gateway_id"], name: "index_users_on_agent_gateway_id"
+    t.index ["desktop_preset_adapter"], name: "index_users_on_desktop_preset_adapter", unique: true, where: "desktop_preset_adapter IS NOT NULL"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["last_visited_creative_id"], name: "index_users_on_last_visited_creative_id"
     t.index ["searchable"], name: "index_users_on_searchable"

--- a/engines/collavre/app/assets/stylesheets/collavre/desktop_setup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/desktop_setup.css
@@ -1,0 +1,238 @@
+.desktop-setup {
+  max-width: 56rem;
+  margin: var(--space-7) auto;
+  color: var(--text-primary);
+}
+
+.desktop-setup__header {
+  text-align: center;
+  margin-bottom: var(--space-6);
+}
+.desktop-setup__header h1 {
+  font-size: var(--text-6);
+  margin: var(--space-1) 0 var(--space-2);
+}
+.desktop-setup__header p { color: var(--text-muted); }
+.desktop-setup__eyebrow, .desktop-setup__kicker {
+  color: var(--color-active);
+  font-size: var(--text-0);
+  font-weight: var(--weight-7);
+  letter-spacing: .08em;
+  margin: 0 0 var(--space-2);
+  text-transform: uppercase;
+}
+.desktop-setup__progress {
+  display: grid;
+  gap: var(--space-2);
+  grid-template-columns: repeat(4, 1fr);
+  list-style: none;
+  margin: 0 0 var(--space-5);
+  padding: 0;
+}
+.desktop-setup__progress li {
+  align-items: center;
+  color: var(--text-muted);
+  display: flex;
+  font-size: var(--text-0);
+  font-weight: var(--weight-6);
+  gap: var(--space-1);
+}
+.desktop-setup__progress span {
+  align-items: center;
+  border: var(--border-1) solid var(--border-color);
+  border-radius: var(--radius-round);
+  display: inline-flex;
+  height: 1.5rem;
+  justify-content: center;
+  width: 1.5rem;
+}
+.desktop-setup__progress .is-current, .desktop-setup__progress .is-complete { color: var(--text-primary); }
+.desktop-setup__progress .is-current span, .desktop-setup__progress .is-complete span {
+  background: var(--color-active);
+  border-color: var(--color-active);
+  color: white;
+}
+.desktop-setup__panel {
+  background: var(--surface-section);
+  border: var(--border-1) solid var(--border-color);
+  border-radius: var(--radius-4);
+  box-shadow: var(--shadow-2);
+  min-height: 23rem;
+  padding: var(--space-7);
+}
+.desktop-setup__panel h2 {
+  font-size: var(--text-5);
+  line-height: var(--leading-1);
+  margin: 0 0 var(--space-3);
+}
+.desktop-setup__lead {
+  color: var(--text-muted);
+  font-size: var(--text-2);
+  line-height: var(--leading-3);
+  margin: 0 0 var(--space-6);
+  max-width: 44rem;
+}
+.desktop-setup__cards {
+  display: grid;
+  gap: var(--space-3);
+  grid-template-columns: repeat(3, 1fr);
+}
+.desktop-setup__summary, .desktop-setup__adapter-list article {
+  background: var(--surface-secondary);
+  border: var(--border-1) solid var(--border-color);
+  border-radius: var(--radius-3);
+}
+.desktop-setup__adapter-list h3 {
+  font-size: var(--text-2);
+  margin: var(--space-3) 0 var(--space-1);
+}
+.desktop-setup__adapter-list p {
+  color: var(--text-muted);
+  font-size: var(--text-0);
+  line-height: var(--leading-2);
+}
+.desktop-setup__notice {
+  background: color-mix(in srgb, var(--color-active) 8%, transparent);
+  border-left: var(--border-3) solid var(--color-active);
+  border-radius: var(--radius-2);
+  color: var(--text-muted);
+  font-size: var(--text-0);
+  line-height: var(--leading-2);
+  margin-top: var(--space-5);
+  padding: var(--space-3);
+}
+.desktop-setup__summary {
+  display: grid;
+  margin-bottom: var(--space-5);
+}
+.desktop-setup__summary div {
+  display: grid;
+  gap: var(--space-3);
+  grid-template-columns: 9rem 1fr;
+  padding: var(--space-3) var(--space-4);
+}
+.desktop-setup__summary div + div { border-top: var(--border-1) solid var(--border-color); }
+.desktop-setup__summary strong { font-size: var(--text-1); }
+.desktop-setup__summary span { color: var(--text-muted); }
+.desktop-setup__consent {
+  align-items: flex-start;
+  display: flex;
+  font-weight: var(--weight-6);
+  gap: var(--space-2);
+}
+.desktop-setup__consent input { margin-top: .2rem; }
+.desktop-setup__hint {
+  color: var(--text-muted);
+  font-size: var(--text-0);
+  margin: var(--space-2) 0 0;
+}
+.desktop-setup__account-form {
+  display: grid;
+  gap: var(--space-4);
+}
+.desktop-setup__form-grid {
+  display: grid;
+  gap: var(--space-4);
+  grid-template-columns: 1fr 1fr;
+}
+.desktop-setup__field {
+  display: grid;
+  gap: var(--space-1);
+}
+.desktop-setup__field label {
+  font-size: var(--text-1);
+  font-weight: var(--weight-6);
+}
+.desktop-setup__field input {
+  background: var(--surface-secondary);
+  border: var(--border-1) solid var(--border-color);
+  border-radius: var(--radius-2);
+  color: var(--text-primary);
+  font: inherit;
+  padding: var(--space-2) var(--space-3);
+}
+.desktop-setup__field input:focus {
+  border-color: var(--color-active);
+  outline: var(--border-2) solid color-mix(in srgb, var(--color-active) 25%, transparent);
+}
+.desktop-setup__adapter-list {
+  display: grid;
+  gap: var(--space-3);
+}
+.desktop-setup__adapter-list article {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  padding: var(--space-4);
+}
+.desktop-setup__adapter-list h3 { margin-top: 0; }
+.desktop-setup__status {
+  background: color-mix(in srgb, var(--color-success) 12%, transparent);
+  border-radius: var(--radius-round);
+  color: var(--color-success);
+  font-size: var(--text-0);
+  font-weight: var(--weight-7);
+  padding: var(--space-1) var(--space-2);
+  white-space: nowrap;
+}
+.desktop-setup__ready-mark {
+  align-items: center;
+  background: var(--color-success);
+  border-radius: var(--radius-round);
+  color: white;
+  display: flex;
+  font-size: var(--text-4);
+  height: 3rem;
+  justify-content: center;
+  margin-bottom: var(--space-4);
+  width: 3rem;
+}
+.desktop-setup__checklist {
+  display: grid;
+  gap: var(--space-3);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.desktop-setup__checklist li {
+  background: color-mix(in srgb, var(--color-success) 8%, transparent);
+  border-radius: var(--radius-2);
+  color: var(--text-primary);
+  padding: var(--space-3);
+}
+.desktop-setup__actions {
+  display: flex;
+  justify-content: space-between;
+  margin-top: var(--space-5);
+}
+.desktop-setup__button {
+  background: var(--color-active);
+  border: var(--border-1) solid var(--color-active);
+  border-radius: var(--radius-2);
+  color: white;
+  font-weight: var(--weight-6);
+  padding: var(--space-2) var(--space-4);
+  text-decoration: none;
+}
+.desktop-setup__button--secondary {
+  background: transparent;
+  border-color: var(--border-color);
+  color: var(--text-primary);
+}
+.desktop-setup__button:hover { filter: brightness(var(--hover-brightness)); }
+
+@media (max-width: 640px) {
+  .desktop-setup { margin: var(--space-4) auto; }
+  .desktop-setup__progress { grid-template-columns: 1fr 1fr; }
+  .desktop-setup__panel { padding: var(--space-4); }
+  .desktop-setup__form-grid { grid-template-columns: 1fr; }
+  .desktop-setup__summary div {
+    gap: var(--space-1);
+    grid-template-columns: 1fr;
+  }
+  .desktop-setup__adapter-list article {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: var(--space-3);
+  }
+}

--- a/engines/collavre/app/controllers/collavre/desktop_gateway_registrations_controller.rb
+++ b/engines/collavre/app/controllers/collavre/desktop_gateway_registrations_controller.rb
@@ -11,8 +11,14 @@ module Collavre
       return unless require_desktop_mode!
       return unless require_loopback!
 
-      owner = registration_owner!
-      gateway = owner.owned_agent_gateways.find_or_initialize_by(name: DesktopSetupController::DESKTOP_GATEWAY_NAME)
+      registration_owner = registration_owner!
+      # A desktop has one local proxy, not one proxy per administrator. During
+      # recovery a different system administrator may be signed in, but the
+      # existing gateway (and its generated presets) must remain owned by the
+      # administrator that originally configured the desktop.
+      gateway = Collavre::AgentGateway.find_or_initialize_by(name: DesktopSetupController::DESKTOP_GATEWAY_NAME)
+      gateway.owner ||= registration_owner
+      owner = gateway.owner
       gateway.assign_attributes(
         base_url: "http://127.0.0.1:#{proxy_port}",
         admin_key: params.require(:admin_key),

--- a/engines/collavre/app/controllers/collavre/desktop_gateway_registrations_controller.rb
+++ b/engines/collavre/app/controllers/collavre/desktop_gateway_registrations_controller.rb
@@ -51,17 +51,20 @@ module Collavre
     def provision_preset!(owner, gateway, adapter)
       name, email, model = DesktopSetupController::PRESETS.fetch(adapter)
       agent = owner.created_ai_users.find_or_initialize_by(email: email)
-      agent.assign_attributes(
-        name: name,
-        password: SecureRandom.hex(36),
-        email_verified_at: Time.current,
-        llm_vendor: "cli_proxy",
-        llm_model: model,
-        agent_gateway: gateway,
-        searchable: false,
-        tools: []
-      )
-      agent.save!
+      if agent.new_record?
+        agent.assign_attributes(
+          name: name,
+          password: SecureRandom.hex(36),
+          email_verified_at: Time.current,
+          llm_vendor: "cli_proxy",
+          llm_model: model,
+          agent_gateway: gateway,
+          searchable: false,
+          tools: []
+        )
+        agent.save!
+      end
+      Collavre::Contact.ensure(user: owner, contact_user: agent)
     end
 
     def registration_owner!

--- a/engines/collavre/app/controllers/collavre/desktop_gateway_registrations_controller.rb
+++ b/engines/collavre/app/controllers/collavre/desktop_gateway_registrations_controller.rb
@@ -36,6 +36,13 @@ module Collavre
       render json: { gateway_id: gateway.id, adapters: detected_adapters }, status: :created
     rescue ActiveRecord::RecordInvalid => e
       render json: { error: e.record.errors.full_messages.to_sentence }, status: :unprocessable_entity
+    rescue ActiveRecord::RecordNotUnique
+      # Concurrent first-run handoffs can both observe no marked gateway. Once
+      # one creates it, reload that durable identity and apply this handoff.
+      raise if @retried_after_gateway_insert
+
+      @retried_after_gateway_insert = true
+      retry
     rescue ActionController::ParameterMissing, ActiveSupport::MessageVerifier::InvalidSignature => e
       render json: { error: e.message }, status: :unprocessable_entity
     end

--- a/engines/collavre/app/controllers/collavre/desktop_gateway_registrations_controller.rb
+++ b/engines/collavre/app/controllers/collavre/desktop_gateway_registrations_controller.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require "ipaddr"
+
+module Collavre
+  # Stateless, loopback-only native handoff for the desktop shell. It has no
+  # browser session or CSRF cookie; authorization is the signed, short-lived
+  # grant issued to the authenticated desktop webview.
+  class DesktopGatewayRegistrationsController < ActionController::API
+    def create
+      return unless require_desktop_mode!
+      return unless require_loopback!
+
+      owner = registration_owner!
+      gateway = owner.owned_agent_gateways.find_or_initialize_by(name: DesktopSetupController::DESKTOP_GATEWAY_NAME)
+      gateway.assign_attributes(
+        base_url: "http://127.0.0.1:#{proxy_port}",
+        admin_key: params.require(:admin_key),
+        completion_key: params.require(:completion_key),
+        identity_secret: params.require(:identity_secret),
+        tenant_id: "collavre-desktop",
+        workspace_mode: :shared,
+        active: true
+      )
+
+      Collavre::AgentGateway.transaction do
+        gateway.save!
+        detected_adapters.each { |adapter| provision_preset!(owner, gateway, adapter) }
+      end
+      render json: { gateway_id: gateway.id, adapters: detected_adapters }, status: :created
+    rescue ActiveRecord::RecordInvalid => e
+      render json: { error: e.record.errors.full_messages.to_sentence }, status: :unprocessable_entity
+    rescue ActionController::ParameterMissing, ActiveSupport::MessageVerifier::InvalidSignature => e
+      render json: { error: e.message }, status: :unprocessable_entity
+    end
+
+    private
+
+    def proxy_port
+      Integer(params.require(:proxy_port).to_s, 10).tap do |port|
+        raise ActionController::ParameterMissing, :proxy_port unless (1..65_535).cover?(port)
+      end
+    rescue ArgumentError
+      raise ActionController::ParameterMissing, :proxy_port
+    end
+
+    def detected_adapters
+      Array(params[:adapters]).map(&:to_s).intersection(DesktopSetupController::PRESETS.keys)
+    end
+
+    def provision_preset!(owner, gateway, adapter)
+      name, email, model = DesktopSetupController::PRESETS.fetch(adapter)
+      agent = owner.created_ai_users.find_or_initialize_by(email: email)
+      agent.assign_attributes(
+        name: name,
+        password: SecureRandom.hex(36),
+        email_verified_at: Time.current,
+        llm_vendor: "cli_proxy",
+        llm_model: model,
+        agent_gateway: gateway,
+        searchable: false,
+        tools: []
+      )
+      agent.save!
+    end
+
+    def registration_owner!
+      payload = Rails.application.message_verifier("desktop-gateway-registration").verify(params.require(:registration_token))
+      raise ActiveSupport::MessageVerifier::InvalidSignature if payload.fetch("expires_at").to_i < Time.current.to_i
+
+      Collavre::User.find(payload.fetch("user_id")).tap do |user|
+        raise ActiveSupport::MessageVerifier::InvalidSignature unless user.system_admin?
+      end
+    end
+
+    def require_loopback!
+      addr = IPAddr.new(request.remote_addr.to_s)
+      addr = addr.native if addr.respond_to?(:ipv4_mapped?) && addr.ipv4_mapped?
+      return true if addr.loopback?
+
+      head :forbidden
+      false
+    rescue IPAddr::InvalidAddressError
+      head :forbidden
+      false
+    end
+
+    def require_desktop_mode!
+      return true if Rails.application.config.x.desktop_proxy_setup == true
+
+      head :not_found
+      false
+    end
+  end
+end

--- a/engines/collavre/app/controllers/collavre/desktop_gateway_registrations_controller.rb
+++ b/engines/collavre/app/controllers/collavre/desktop_gateway_registrations_controller.rb
@@ -77,11 +77,12 @@ module Collavre
 
     def provision_preset!(owner, gateway, adapter)
       name, email, model = DesktopSetupController::PRESETS.fetch(adapter)
-      agent = owner.created_ai_users.find_or_initialize_by(email: email)
+      agent = owner.created_ai_users.find_or_initialize_by(desktop_preset_adapter: adapter)
       if agent.new_record?
         agent.assign_attributes(
           name: name,
           password: SecureRandom.hex(36),
+          email: available_desktop_preset_email(email, gateway),
           email_verified_at: Time.current,
           llm_vendor: "cli_proxy",
           llm_model: model,
@@ -92,6 +93,20 @@ module Collavre
         agent.save!
       end
       Collavre::Contact.ensure(user: owner, contact_user: agent)
+    end
+
+    def available_desktop_preset_email(email, gateway)
+      return email unless Collavre::User.exists?(email: email)
+
+      local_part, domain = email.split("@", 2)
+      base = "#{local_part}+desktop-#{gateway.id}"
+      candidate = "#{base}@#{domain}"
+      return candidate unless Collavre::User.exists?(email: candidate)
+
+      suffix = (2..).find do |number|
+        !Collavre::User.exists?(email: "#{base}-#{number}@#{domain}")
+      end
+      "#{base}-#{suffix}@#{domain}"
     end
 
     def available_desktop_gateway_name(owner)

--- a/engines/collavre/app/controllers/collavre/desktop_gateway_registrations_controller.rb
+++ b/engines/collavre/app/controllers/collavre/desktop_gateway_registrations_controller.rb
@@ -61,6 +61,25 @@ module Collavre
       render json: { error: e.message }, status: :unprocessable_entity
     end
 
+    # Native startup checks this before trusting its persisted `registered`
+    # flag. It proves that the Rails gateway still exists at this proxy port
+    # and still holds the Keychain credentials without exposing them to the
+    # webview or requiring a browser session.
+    def registered
+      return unless require_desktop_mode!
+      return unless require_loopback!
+
+      gateway = Collavre::AgentGateway.find_by(
+        desktop_managed: true,
+        base_url: "http://127.0.0.1:#{proxy_port}"
+      )
+      return head :not_found unless gateway && gateway_credentials_match?(gateway)
+
+      head :no_content
+    rescue ActionController::ParameterMissing => e
+      render json: { error: e.message }, status: :unprocessable_entity
+    end
+
     private
 
     def proxy_port
@@ -73,6 +92,12 @@ module Collavre
 
     def detected_adapters
       Array(params[:adapters]).map(&:to_s).intersection(DesktopSetupController::PRESETS.keys)
+    end
+
+    def gateway_credentials_match?(gateway)
+      %i[admin_key completion_key identity_secret].all? do |attribute|
+        ActiveSupport::SecurityUtils.secure_compare(gateway.public_send(attribute), params.require(attribute))
+      end
     end
 
     def provision_preset!(owner, gateway, adapter)

--- a/engines/collavre/app/controllers/collavre/desktop_gateway_registrations_controller.rb
+++ b/engines/collavre/app/controllers/collavre/desktop_gateway_registrations_controller.rb
@@ -17,7 +17,7 @@ module Collavre
       # user-editable display name and owner during recovery.
       gateway = Collavre::AgentGateway.find_or_initialize_by(desktop_managed: true)
       gateway.owner ||= registration_owner
-      gateway.name ||= DesktopSetupController::DESKTOP_GATEWAY_NAME
+      gateway.name ||= available_desktop_gateway_name(gateway.owner)
       owner = gateway.owner
       gateway.assign_attributes(
         base_url: "http://127.0.0.1:#{proxy_port}",
@@ -78,6 +78,14 @@ module Collavre
         agent.save!
       end
       Collavre::Contact.ensure(user: owner, contact_user: agent)
+    end
+
+    def available_desktop_gateway_name(owner)
+      base_name = DesktopSetupController::DESKTOP_GATEWAY_NAME
+      return base_name unless owner.owned_agent_gateways.exists?(name: base_name)
+
+      suffix = (2..).find { |number| !owner.owned_agent_gateways.exists?(name: "#{base_name} (#{number})") }
+      "#{base_name} (#{suffix})"
     end
 
     def registration_owner!

--- a/engines/collavre/app/controllers/collavre/desktop_gateway_registrations_controller.rb
+++ b/engines/collavre/app/controllers/collavre/desktop_gateway_registrations_controller.rb
@@ -12,12 +12,12 @@ module Collavre
       return unless require_loopback!
 
       registration_owner = registration_owner!
-      # A desktop has one local proxy, not one proxy per administrator. During
-      # recovery a different system administrator may be signed in, but the
-      # existing gateway (and its generated presets) must remain owned by the
-      # administrator that originally configured the desktop.
-      gateway = Collavre::AgentGateway.find_or_initialize_by(name: DesktopSetupController::DESKTOP_GATEWAY_NAME)
+      # A desktop has one local proxy, not one proxy per administrator. The
+      # persisted desktop_managed marker identifies it independently of its
+      # user-editable display name and owner during recovery.
+      gateway = Collavre::AgentGateway.find_or_initialize_by(desktop_managed: true)
       gateway.owner ||= registration_owner
+      gateway.name ||= DesktopSetupController::DESKTOP_GATEWAY_NAME
       owner = gateway.owner
       gateway.assign_attributes(
         base_url: "http://127.0.0.1:#{proxy_port}",

--- a/engines/collavre/app/controllers/collavre/desktop_gateway_registrations_controller.rb
+++ b/engines/collavre/app/controllers/collavre/desktop_gateway_registrations_controller.rb
@@ -33,7 +33,7 @@ module Collavre
       gateway.owner ||= registration_owner
       gateway.name ||= available_desktop_gateway_name(gateway.owner)
       owner = gateway.owner
-      gateway.assign_attributes(
+      gateway_attributes = {
         base_url: "http://127.0.0.1:#{proxy_port}",
         admin_key: params.require(:admin_key),
         completion_key: params.require(:completion_key),
@@ -41,10 +41,10 @@ module Collavre
         tenant_id: "collavre-desktop",
         workspace_mode: :shared,
         active: true
-      )
+      }
 
       Collavre::AgentGateway.transaction do
-        gateway.save!
+        gateway.update_from_desktop_registration!(gateway_attributes)
         detected_adapters.each { |adapter| provision_preset!(owner, gateway, adapter) }
       end
       render json: { gateway_id: gateway.id, adapters: detected_adapters }, status: :created

--- a/engines/collavre/app/controllers/collavre/desktop_gateway_registrations_controller.rb
+++ b/engines/collavre/app/controllers/collavre/desktop_gateway_registrations_controller.rb
@@ -7,6 +7,20 @@ module Collavre
   # browser session or CSRF cookie; authorization is the signed, short-lived
   # grant issued to the authenticated desktop webview.
   class DesktopGatewayRegistrationsController < ActionController::API
+    # Native code calls this before it creates Keychain credentials or starts
+    # the local proxy. The signed token is the administrator's short-lived
+    # setup consent and remains the sole authorization for the sessionless
+    # loopback handoff.
+    def validate_registration_grant
+      return unless require_desktop_mode!
+      return unless require_loopback!
+
+      registration_owner!
+      head :no_content
+    rescue ActionController::ParameterMissing, ActiveSupport::MessageVerifier::InvalidSignature => e
+      render json: { error: e.message }, status: :unprocessable_entity
+    end
+
     def create
       return unless require_desktop_mode!
       return unless require_loopback!

--- a/engines/collavre/app/controllers/collavre/desktop_setup_controller.rb
+++ b/engines/collavre/app/controllers/collavre/desktop_setup_controller.rb
@@ -5,8 +5,7 @@ module Collavre
   # local proxy process live in Tauri; this controller only persists the
   # resulting gateway after verifying a short-lived, local-only handoff token.
   class DesktopSetupController < ApplicationController
-    allow_unauthenticated_access only: %i[show create_account register_gateway]
-    skip_forgery_protection only: :register_gateway
+    allow_unauthenticated_access only: %i[show create_account]
 
     STEPS = %w[account install adapters ready].freeze
     DESKTOP_GATEWAY_NAME = "Collavre Desktop CLI Proxy"
@@ -31,11 +30,8 @@ module Collavre
     end
 
     def create_account
+      return unless require_desktop_mode!
       return unless require_loopback!
-      if Collavre::User.where(system_admin: true).exists?
-        redirect_to collavre.new_session_path, alert: t("collavre.desktop_setup.account.already_created")
-        return
-      end
 
       @user = Collavre::User.new(account_params)
       Collavre::User.transaction do
@@ -46,16 +42,22 @@ module Collavre
           return
         end
 
-        @user.update_columns(email_verified_at: Time.current, system_admin: true)
+        # The absence check is part of the UPDATE itself. Two overlapping local
+        # signups can both save, but only one can become the first administrator.
+        admin_exists = Collavre::User.where(system_admin: true).arel.exists
+        promoted = Collavre::User.where(id: @user.id)
+          .where(admin_exists.not)
+          .update_all(email_verified_at: Time.current, system_admin: true)
+        raise FirstAdministratorAlreadyCreated unless promoted == 1
       end
       start_new_session_for(@user)
       redirect_to collavre.desktop_setup_path(step: :install)
+    rescue FirstAdministratorAlreadyCreated
+      redirect_to collavre.new_session_path, alert: t("collavre.desktop_setup.account.already_created")
     end
 
-    # The browser receives only a signed, five-minute registration grant. The
-    # native command consumes it while sending Keychain-only secrets directly to
-    # this loopback endpoint; secrets never enter the DOM or JavaScript response.
     def registration_token
+      return unless require_desktop_mode!
       return unless require_loopback!
       unless Current.user&.system_admin?
         head :forbidden
@@ -65,76 +67,16 @@ module Collavre
       render json: { token: registration_verifier.generate({ user_id: Current.user.id, expires_at: 5.minutes.from_now.to_i }) }
     end
 
-    def register_gateway
-      return unless require_loopback!
-      owner = registration_owner!
-      gateway = owner.owned_agent_gateways.find_or_initialize_by(name: DESKTOP_GATEWAY_NAME)
-      gateway.assign_attributes(
-        base_url: "http://127.0.0.1:#{proxy_port}",
-        admin_key: params.require(:admin_key),
-        completion_key: params.require(:completion_key),
-        identity_secret: params.require(:identity_secret),
-        tenant_id: "collavre-desktop",
-        workspace_mode: :shared,
-        active: true
-      )
-
-      Collavre::AgentGateway.transaction do
-        gateway.save!
-        detected_adapters.each { |adapter| provision_preset!(owner, gateway, adapter) }
-      end
-      render json: { gateway_id: gateway.id, adapters: detected_adapters }, status: :created
-    rescue ActiveRecord::RecordInvalid => e
-      render json: { error: e.record.errors.full_messages.to_sentence }, status: :unprocessable_entity
-    rescue ActionController::ParameterMissing, ActiveSupport::MessageVerifier::InvalidSignature => e
-      render json: { error: e.message }, status: :unprocessable_entity
-    end
-
     private
+
+    FirstAdministratorAlreadyCreated = Class.new(StandardError)
 
     def account_params
       params.require(:admin).permit(:name, :email, :password, :password_confirmation)
     end
 
-    def proxy_port
-      Integer(params.require(:proxy_port).to_s, 10).tap do |port|
-        raise ActionController::ParameterMissing, :proxy_port unless (1..65_535).cover?(port)
-      end
-    rescue ArgumentError
-      raise ActionController::ParameterMissing, :proxy_port
-    end
-
-    def detected_adapters
-      Array(params[:adapters]).map(&:to_s).intersection(PRESETS.keys)
-    end
-
-    def provision_preset!(owner, gateway, adapter)
-      name, email, model = PRESETS.fetch(adapter)
-      agent = owner.created_ai_users.find_or_initialize_by(email: email)
-      agent.assign_attributes(
-        name: name,
-        password: SecureRandom.hex(36),
-        email_verified_at: Time.current,
-        llm_vendor: "cli_proxy",
-        llm_model: model,
-        agent_gateway: gateway,
-        searchable: false,
-        tools: []
-      )
-      agent.save!
-    end
-
     def registration_verifier
       Rails.application.message_verifier("desktop-gateway-registration")
-    end
-
-    def registration_owner!
-      payload = registration_verifier.verify(params.require(:registration_token))
-      raise ActiveSupport::MessageVerifier::InvalidSignature if payload.fetch("expires_at").to_i < Time.current.to_i
-
-      Collavre::User.find(payload.fetch("user_id")).tap do |user|
-        raise ActiveSupport::MessageVerifier::InvalidSignature unless user.system_admin?
-      end
     end
 
     def require_loopback!
@@ -146,6 +88,13 @@ module Collavre
       false
     rescue IPAddr::InvalidAddressError
       head :forbidden
+      false
+    end
+
+    def require_desktop_mode!
+      return true if Rails.application.config.x.desktop_proxy_setup == true
+
+      head :not_found
       false
     end
   end

--- a/engines/collavre/app/controllers/collavre/desktop_setup_controller.rb
+++ b/engines/collavre/app/controllers/collavre/desktop_setup_controller.rb
@@ -1,16 +1,141 @@
 # frozen_string_literal: true
 
 module Collavre
-  # Presentation-only first-run flow for the desktop CLI Proxy setup.
-  # Installation and credential generation are deliberately not wired here yet.
+  # First-run flow for the desktop CLI Proxy. Credential generation and the
+  # local proxy process live in Tauri; this controller only persists the
+  # resulting gateway after verifying a short-lived, local-only handoff token.
   class DesktopSetupController < ApplicationController
-    allow_unauthenticated_access
+    allow_unauthenticated_access only: %i[show create_account register_gateway]
+    skip_forgery_protection only: :register_gateway
 
     STEPS = %w[account install adapters ready].freeze
+    DESKTOP_GATEWAY_NAME = "Collavre Desktop CLI Proxy"
+    PRESETS = {
+      "claude" => [ "Claude Code", "collavre-desktop-claude-code@ai.local", "paperclip/claude_local" ],
+      "codex" => [ "Codex", "collavre-desktop-codex@ai.local", "paperclip/codex_local" ]
+    }.freeze
 
     def show
       @step = params[:step].to_s
       @step = STEPS.first unless STEPS.include?(@step)
+      @user = Current.user
+      @account_required = !Collavre::User.where(system_admin: true).exists?
+      redirect_to collavre.new_session_path unless @account_required || @user
+    end
+
+    def create_account
+      return unless require_loopback!
+      if Collavre::User.where(system_admin: true).exists?
+        redirect_to collavre.new_session_path, alert: t("collavre.desktop_setup.account.already_created")
+        return
+      end
+
+      @user = Collavre::User.new(account_params)
+      Collavre::User.transaction do
+        unless @user.save
+          @step = "account"
+          @account_required = true
+          render :show, status: :unprocessable_entity
+          return
+        end
+
+        @user.update_columns(email_verified_at: Time.current, system_admin: true)
+      end
+      start_new_session_for(@user)
+      redirect_to collavre.desktop_setup_path(step: :install)
+    end
+
+    # The browser receives only a signed, five-minute registration grant. The
+    # native command consumes it while sending Keychain-only secrets directly to
+    # this loopback endpoint; secrets never enter the DOM or JavaScript response.
+    def registration_token
+      return unless require_loopback!
+      require_system_admin!
+      render json: { token: registration_verifier.generate({ user_id: Current.user.id, expires_at: 5.minutes.from_now.to_i }) }
+    end
+
+    def register_gateway
+      return unless require_loopback!
+      owner = registration_owner!
+      gateway = owner.owned_agent_gateways.find_or_initialize_by(name: DESKTOP_GATEWAY_NAME)
+      gateway.assign_attributes(
+        base_url: "http://127.0.0.1:#{proxy_port}",
+        admin_key: params.require(:admin_key),
+        completion_key: params.require(:completion_key),
+        identity_secret: params.require(:identity_secret),
+        tenant_id: "collavre-desktop",
+        workspace_mode: :shared,
+        active: true
+      )
+
+      Collavre::AgentGateway.transaction do
+        gateway.save!
+        detected_adapters.each { |adapter| provision_preset!(owner, gateway, adapter) }
+      end
+      render json: { gateway_id: gateway.id, adapters: detected_adapters }, status: :created
+    rescue ActiveRecord::RecordInvalid => e
+      render json: { error: e.record.errors.full_messages.to_sentence }, status: :unprocessable_entity
+    rescue ActionController::ParameterMissing, ActiveSupport::MessageVerifier::InvalidSignature => e
+      render json: { error: e.message }, status: :unprocessable_entity
+    end
+
+    private
+
+    def account_params
+      params.require(:admin).permit(:name, :email, :password, :password_confirmation)
+    end
+
+    def proxy_port
+      Integer(params.require(:proxy_port).to_s, 10).tap do |port|
+        raise ActionController::ParameterMissing, :proxy_port unless (1..65_535).cover?(port)
+      end
+    rescue ArgumentError
+      raise ActionController::ParameterMissing, :proxy_port
+    end
+
+    def detected_adapters
+      Array(params[:adapters]).map(&:to_s).intersection(PRESETS.keys)
+    end
+
+    def provision_preset!(owner, gateway, adapter)
+      name, email, model = PRESETS.fetch(adapter)
+      agent = owner.created_ai_users.find_or_initialize_by(email: email)
+      agent.assign_attributes(
+        name: name,
+        password: SecureRandom.hex(36),
+        email_verified_at: Time.current,
+        llm_vendor: "cli_proxy",
+        llm_model: model,
+        agent_gateway: gateway,
+        searchable: false,
+        tools: []
+      )
+      agent.save!
+    end
+
+    def registration_verifier
+      Rails.application.message_verifier("desktop-gateway-registration")
+    end
+
+    def registration_owner!
+      payload = registration_verifier.verify(params.require(:registration_token))
+      raise ActiveSupport::MessageVerifier::InvalidSignature if payload.fetch("expires_at").to_i < Time.current.to_i
+
+      Collavre::User.find(payload.fetch("user_id")).tap do |user|
+        raise ActiveSupport::MessageVerifier::InvalidSignature unless user.system_admin?
+      end
+    end
+
+    def require_loopback!
+      addr = IPAddr.new(request.remote_addr.to_s)
+      addr = addr.native if addr.respond_to?(:ipv4_mapped?) && addr.ipv4_mapped?
+      return true if addr.loopback?
+
+      head :forbidden
+      false
+    rescue IPAddr::InvalidAddressError
+      head :forbidden
+      false
     end
   end
 end

--- a/engines/collavre/app/controllers/collavre/desktop_setup_controller.rb
+++ b/engines/collavre/app/controllers/collavre/desktop_setup_controller.rb
@@ -24,8 +24,17 @@ module Collavre
       # Recovery is entered without a step after native setup fails. An
       # authenticated owner must resume at installation rather than see the
       # sign-in-only account panel.
-      if @user
+      if @user&.system_admin?
         @step = "install" if @step == "account"
+        return
+      end
+
+      # A desktop in open mode can have an ordinary user signed in when native
+      # proxy recovery opens this page. That user cannot mint a registration
+      # token, so keep them on the account step where they can sign out and use
+      # the owner's account instead of presenting a broken install action.
+      if @user
+        @step = "account"
         return
       end
 

--- a/engines/collavre/app/controllers/collavre/desktop_setup_controller.rb
+++ b/engines/collavre/app/controllers/collavre/desktop_setup_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Collavre
+  # Presentation-only first-run flow for the desktop CLI Proxy setup.
+  # Installation and credential generation are deliberately not wired here yet.
+  class DesktopSetupController < ApplicationController
+    allow_unauthenticated_access
+
+    STEPS = %w[account install adapters ready].freeze
+
+    def show
+      @step = params[:step].to_s
+      @step = STEPS.first unless STEPS.include?(@step)
+    end
+  end
+end

--- a/engines/collavre/app/controllers/collavre/desktop_setup_controller.rb
+++ b/engines/collavre/app/controllers/collavre/desktop_setup_controller.rb
@@ -20,7 +20,14 @@ module Collavre
       @step = STEPS.first unless STEPS.include?(@step)
       @user = Current.user
       @account_required = !Collavre::User.where(system_admin: true).exists?
-      redirect_to collavre.new_session_path unless @account_required || @user
+      return if @account_required || @user
+
+      # A failed native registration leaves the proxy installed but incomplete.
+      # Preserve the exact setup destination through login so the local owner
+      # can retry without deleting Keychain entries or app data.
+      @step = "install" if @step == "account"
+      session[:return_to_after_authenticating] = collavre.desktop_setup_path(step: @step)
+      redirect_to collavre.new_session_path
     end
 
     def create_account
@@ -50,7 +57,11 @@ module Collavre
     # this loopback endpoint; secrets never enter the DOM or JavaScript response.
     def registration_token
       return unless require_loopback!
-      require_system_admin!
+      unless Current.user&.system_admin?
+        head :forbidden
+        return
+      end
+
       render json: { token: registration_verifier.generate({ user_id: Current.user.id, expires_at: 5.minutes.from_now.to_i }) }
     end
 

--- a/engines/collavre/app/controllers/collavre/desktop_setup_controller.rb
+++ b/engines/collavre/app/controllers/collavre/desktop_setup_controller.rb
@@ -19,7 +19,15 @@ module Collavre
       @step = STEPS.first unless STEPS.include?(@step)
       @user = Current.user
       @account_required = !Collavre::User.where(system_admin: true).exists?
-      return if @account_required || @user
+      return if @account_required
+
+      # Recovery is entered without a step after native setup fails. An
+      # authenticated owner must resume at installation rather than see the
+      # sign-in-only account panel.
+      if @user
+        @step = "install" if @step == "account"
+        return
+      end
 
       # A failed native registration leaves the proxy installed but incomplete.
       # Preserve the exact setup destination through login so the local owner

--- a/engines/collavre/app/controllers/collavre/desktop_setup_controller.rb
+++ b/engines/collavre/app/controllers/collavre/desktop_setup_controller.rb
@@ -34,6 +34,7 @@ module Collavre
       # token, so keep them on the account step where they can sign out and use
       # the owner's account instead of presenting a broken install action.
       if @user
+        session[:return_to_after_authenticating] = collavre.desktop_setup_path(step: @step)
         @step = "account"
         return
       end

--- a/engines/collavre/app/controllers/collavre/desktop_sidecar_health_controller.rb
+++ b/engines/collavre/app/controllers/collavre/desktop_sidecar_health_controller.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Collavre
+  # Authenticates the Rails child to the native shell before its webview is
+  # navigated to the local server. The secret is generated per launch by Tauri
+  # and exists only in this child process environment.
+  class DesktopSidecarHealthController < ActionController::API
+    def show
+      return unless require_loopback!
+
+      secret = ENV.fetch("COLLAVRE_DESKTOP_SIDECAR_SECRET", "")
+      return head :not_found if secret.blank?
+
+      challenge = params.require(:challenge)
+      digest = OpenSSL::HMAC.digest("SHA256", secret, challenge)
+      render plain: Base64.urlsafe_encode64(digest, padding: false), content_type: "text/plain"
+    rescue ActionController::ParameterMissing
+      head :bad_request
+    end
+
+    private
+
+    def require_loopback!
+      addr = IPAddr.new(request.remote_addr.to_s)
+      addr = addr.native if addr.respond_to?(:ipv4_mapped?) && addr.ipv4_mapped?
+      return true if addr.loopback?
+
+      head :forbidden
+      false
+    rescue IPAddr::InvalidAddressError
+      head :forbidden
+      false
+    end
+  end
+end

--- a/engines/collavre/app/javascript/controllers/__tests__/desktop_proxy_setup_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/desktop_proxy_setup_controller.test.js
@@ -1,0 +1,82 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { jest } from "@jest/globals"
+
+const csrfFetch = jest.fn()
+jest.unstable_mockModule("../../lib/api/csrf_fetch", () => ({ default: csrfFetch }))
+
+const { Application } = await import("@hotwired/stimulus")
+const { default: DesktopProxySetupController, setupNextUrl } = await import("../desktop_proxy_setup_controller")
+
+describe("DesktopProxySetupController", () => {
+  let application
+  let controller
+
+  beforeEach(async () => {
+    csrfFetch.mockReset()
+    document.body.innerHTML = `
+      <div data-controller="desktop-proxy-setup"
+           data-desktop-proxy-setup-token-url-value="/desktop/setup/registration_token"
+           data-desktop-proxy-setup-next-url-value="/desktop/setup?step=adapters"
+           data-desktop-proxy-setup-unavailable-value="Desktop support is unavailable"
+           data-desktop-proxy-setup-failed-value="Setup failed">
+        <input type="checkbox" data-desktop-proxy-setup-target="consent">
+        <button data-desktop-proxy-setup-target="submit"></button>
+        <p hidden data-desktop-proxy-setup-target="error"></p>
+      </div>`
+    application = Application.start()
+    application.register("desktop-proxy-setup", DesktopProxySetupController)
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    controller = application.getControllerForElementAndIdentifier(
+      document.querySelector("[data-controller='desktop-proxy-setup']"),
+      "desktop-proxy-setup",
+    )
+  })
+
+  afterEach(() => {
+    application.stop()
+    document.body.innerHTML = ""
+    delete window.__TAURI__
+    jest.restoreAllMocks()
+  })
+
+  test("preserves the setup step while appending detected adapters", () => {
+    expect(setupNextUrl("/desktop/setup?step=adapters", [ "claude", "codex" ]))
+      .toBe("/desktop/setup?step=adapters&claude=1&codex=1")
+  })
+
+  test("enables installation only after consent", () => {
+    controller.consentTarget.checked = false
+    controller.toggle()
+    expect(controller.submitTarget.disabled).toBe(true)
+
+    controller.consentTarget.checked = true
+    controller.toggle()
+    expect(controller.submitTarget.disabled).toBe(false)
+  })
+
+  test("registers through Tauri and retains the adapter step", async () => {
+    const invoke = jest.fn().mockResolvedValue({ adapters: [ "claude" ] })
+    window.__TAURI__ = { core: { invoke } }
+    csrfFetch.mockResolvedValue({ ok: true, json: async () => ({ token: "grant" }) })
+    const navigate = jest.spyOn(controller, "navigate").mockImplementation(() => {})
+
+    await controller.install()
+
+    expect(csrfFetch).toHaveBeenCalledWith("/desktop/setup/registration_token", { method: "POST" })
+    expect(invoke).toHaveBeenCalledWith("desktop_proxy_complete_setup", { registrationToken: "grant" })
+    expect(navigate).toHaveBeenCalledWith("/desktop/setup?step=adapters&claude=1")
+  })
+
+  test("shows a localized failure when native setup is unavailable", async () => {
+    controller.consentTarget.checked = true
+
+    await controller.install()
+
+    expect(controller.errorTarget.hidden).toBe(false)
+    expect(controller.errorTarget.textContent).toBe("Desktop support is unavailable")
+    expect(controller.submitTarget.disabled).toBe(false)
+  })
+})

--- a/engines/collavre/app/javascript/controllers/desktop_proxy_setup_controller.js
+++ b/engines/collavre/app/javascript/controllers/desktop_proxy_setup_controller.js
@@ -1,6 +1,12 @@
 import { Controller } from "@hotwired/stimulus"
 import csrfFetch from "../lib/api/csrf_fetch"
 
+export function setupNextUrl(nextUrlValue, adapters) {
+  const nextUrl = new URL(nextUrlValue, window.location.origin)
+  for (const adapter of adapters || []) nextUrl.searchParams.set(adapter, "1")
+  return `${nextUrl.pathname}${nextUrl.search}${nextUrl.hash}`
+}
+
 // The browser handles consent and a short-lived registration grant only. The
 // Tauri command keeps proxy secrets in Keychain and posts them directly to the
 // local Rails sidecar, so no secret is exposed to the DOM.
@@ -26,13 +32,15 @@ export default class extends Controller {
       const result = await invoke("desktop_proxy_complete_setup", {
         registrationToken: token,
       })
-      const query = new URLSearchParams()
-      for (const adapter of result.adapters || []) query.set(adapter, "1")
-      window.location.assign(`${this.nextUrlValue}?${query.toString()}`)
+      this.navigate(setupNextUrl(this.nextUrlValue, result.adapters))
     } catch (error) {
       this.errorTarget.textContent = error?.message || this.failedValue
       this.errorTarget.hidden = false
       this.submitTarget.disabled = !this.consentTarget.checked
     }
+  }
+
+  navigate(url) {
+    window.location.assign(url)
   }
 }

--- a/engines/collavre/app/javascript/controllers/desktop_proxy_setup_controller.js
+++ b/engines/collavre/app/javascript/controllers/desktop_proxy_setup_controller.js
@@ -25,7 +25,6 @@ export default class extends Controller {
       const { token } = await response.json()
       const result = await invoke("desktop_proxy_complete_setup", {
         registrationToken: token,
-        serverPort: Number(window.location.port),
       })
       const query = new URLSearchParams()
       for (const adapter of result.adapters || []) query.set(adapter, "1")

--- a/engines/collavre/app/javascript/controllers/desktop_proxy_setup_controller.js
+++ b/engines/collavre/app/javascript/controllers/desktop_proxy_setup_controller.js
@@ -1,0 +1,39 @@
+import { Controller } from "@hotwired/stimulus"
+import csrfFetch from "../lib/api/csrf_fetch"
+
+// The browser handles consent and a short-lived registration grant only. The
+// Tauri command keeps proxy secrets in Keychain and posts them directly to the
+// local Rails sidecar, so no secret is exposed to the DOM.
+export default class extends Controller {
+  static targets = ["consent", "submit", "error"]
+  static values = { tokenUrl: String, nextUrl: String, unavailable: String, failed: String }
+
+  toggle() {
+    this.submitTarget.disabled = !this.consentTarget.checked
+  }
+
+  async install() {
+    this.errorTarget.hidden = true
+    this.submitTarget.disabled = true
+
+    try {
+      const invoke = window.__TAURI__?.core?.invoke
+      if (!invoke) throw new Error(this.unavailableValue)
+
+      const response = await csrfFetch(this.tokenUrlValue, { method: "POST" })
+      if (!response.ok) throw new Error(this.failedValue)
+      const { token } = await response.json()
+      const result = await invoke("desktop_proxy_complete_setup", {
+        registrationToken: token,
+        serverPort: Number(window.location.port),
+      })
+      const query = new URLSearchParams()
+      for (const adapter of result.adapters || []) query.set(adapter, "1")
+      window.location.assign(`${this.nextUrlValue}?${query.toString()}`)
+    } catch (error) {
+      this.errorTarget.textContent = error?.message || this.failedValue
+      this.errorTarget.hidden = false
+      this.submitTarget.disabled = !this.consentTarget.checked
+    }
+  }
+}

--- a/engines/collavre/app/javascript/controllers/index.js
+++ b/engines/collavre/app/javascript/controllers/index.js
@@ -44,6 +44,7 @@ import WorkspaceTreeController from "./workspace_tree_controller"
 import GatewayCheckController from "./gateway_check_controller"
 import AgentConnectionController from "./agent_connection_controller"
 import AgentVendorController from "./agent_vendor_controller"
+import DesktopProxySetupController from "./desktop_proxy_setup_controller"
 
 // Export all controllers
 export {
@@ -86,7 +87,8 @@ export {
   WorkspaceTreeController,
   GatewayCheckController,
   AgentConnectionController,
-  AgentVendorController
+  AgentVendorController,
+  DesktopProxySetupController
 }
 
 // Registration function for use with a Stimulus application
@@ -135,4 +137,5 @@ export function registerControllers(application) {
   application.register("gateway-check", GatewayCheckController)
   application.register("agent-connection", AgentConnectionController)
   application.register("agent-vendor", AgentVendorController)
+  application.register("desktop-proxy-setup", DesktopProxySetupController)
 }

--- a/engines/collavre/app/models/collavre/agent_gateway.rb
+++ b/engines/collavre/app/models/collavre/agent_gateway.rb
@@ -27,6 +27,7 @@ module Collavre
     validate :base_url_is_http
     validate :base_url_is_safe_for_owner
     validate :desktop_managed_base_url_is_immutable
+    validate :desktop_managed_gateway_uses_shared_workspace
     validate :identity_secret_is_usable
     after_update :reconcile_workspaces_after_gateway_change, if: :workspace_credentials_changed?
 
@@ -96,6 +97,14 @@ module Collavre
       return if @desktop_registration_update
 
       errors.add(:base_url, :immutable)
+    end
+
+    # The macOS bundle deliberately runs one shared local proxy. Per-user
+    # routing requires a worker and identity secret that desktop never starts.
+    def desktop_managed_gateway_uses_shared_workspace
+      return unless desktop_managed? && !shared?
+
+      errors.add(:workspace_mode, :desktop_shared_only)
     end
 
     def identity_secret_is_usable

--- a/engines/collavre/app/models/collavre/agent_gateway.rb
+++ b/engines/collavre/app/models/collavre/agent_gateway.rb
@@ -40,6 +40,23 @@ module Collavre
       "#{proxy_base_url}#{suffix}"
     end
 
+    # Desktop-managed gateways are created only by the signed native setup
+    # handoff and always target the local proxy. They remain usable when their
+    # original owner later loses the system administrator role.
+    def desktop_loopback?
+      return false unless desktop_managed?
+
+      uri = URI.parse(base_url.to_s)
+      uri.scheme == "http" &&
+        uri.host == "127.0.0.1" &&
+        uri.port.present? &&
+        uri.userinfo.blank? &&
+        uri.query.blank? &&
+        uri.fragment.blank?
+    rescue URI::InvalidURIError
+      false
+    end
+
     private
 
     def proxy_base_url
@@ -57,6 +74,7 @@ module Collavre
 
     def base_url_is_safe_for_owner
       return if owner&.system_admin?
+      return if desktop_loopback?
       return if CliProxy::EndpointPolicy.new.safe_literal?(base_url)
 
       errors.add(:base_url, :unsafe)

--- a/engines/collavre/app/models/collavre/agent_gateway.rb
+++ b/engines/collavre/app/models/collavre/agent_gateway.rb
@@ -6,6 +6,7 @@ module Collavre
 
     # Must match the proxy's USER_IDENTITY_HMAC_SECRET.
     MIN_IDENTITY_SECRET_BYTES = 32
+    DESKTOP_NATIVE_CREDENTIAL_ATTRIBUTES = %i[admin_key completion_key identity_secret].freeze
 
     belongs_to :owner, class_name: "Collavre::User"
     has_many :agents, class_name: "Collavre::User", dependent: :restrict_with_error
@@ -27,6 +28,7 @@ module Collavre
     validate :base_url_is_http
     validate :base_url_is_safe_for_owner
     validate :desktop_managed_base_url_is_immutable
+    validate :desktop_managed_credentials_are_immutable
     validate :desktop_managed_gateway_uses_shared_workspace
     validate :identity_secret_is_usable
     after_update :reconcile_workspaces_after_gateway_change, if: :workspace_credentials_changed?
@@ -97,6 +99,20 @@ module Collavre
       return if @desktop_registration_update
 
       errors.add(:base_url, :immutable)
+    end
+
+    # Keychain is the source of truth for the local proxy credentials. The
+    # regular Rails settings form cannot synchronize it, so only the signed
+    # native registration handoff may rotate these values.
+    def desktop_managed_credentials_are_immutable
+      return unless persisted? && desktop_managed?
+      return if @desktop_registration_update
+
+      DESKTOP_NATIVE_CREDENTIAL_ATTRIBUTES.each do |attribute|
+        next unless public_send("will_save_change_to_#{attribute}?")
+
+        errors.add(attribute, :immutable)
+      end
     end
 
     # The macOS bundle deliberately runs one shared local proxy. Per-user

--- a/engines/collavre/app/models/collavre/agent_gateway.rb
+++ b/engines/collavre/app/models/collavre/agent_gateway.rb
@@ -26,6 +26,7 @@ module Collavre
     validates :tenant_id, format: { with: /\A[A-Za-z0-9][A-Za-z0-9._:@\/-]{0,199}\z/ }
     validate :base_url_is_http
     validate :base_url_is_safe_for_owner
+    validate :desktop_managed_base_url_is_immutable
     validate :identity_secret_is_usable
     after_update :reconcile_workspaces_after_gateway_change, if: :workspace_credentials_changed?
 
@@ -38,6 +39,16 @@ module Collavre
     def proxy_path(path)
       suffix = path.start_with?("/") ? path : "/#{path}"
       "#{proxy_base_url}#{suffix}"
+    end
+
+    # The signed native setup handoff is the only flow permitted to retarget a
+    # desktop-managed gateway. Its loopback exception must not be reusable by
+    # an owner editing the gateway through the regular settings UI.
+    def update_from_desktop_registration!(attributes)
+      @desktop_registration_update = true
+      update!(attributes)
+    ensure
+      @desktop_registration_update = false
     end
 
     # Desktop-managed gateways are created only by the signed native setup
@@ -78,6 +89,13 @@ module Collavre
       return if CliProxy::EndpointPolicy.new.safe_literal?(base_url)
 
       errors.add(:base_url, :unsafe)
+    end
+
+    def desktop_managed_base_url_is_immutable
+      return unless persisted? && desktop_managed? && will_save_change_to_base_url?
+      return if @desktop_registration_update
+
+      errors.add(:base_url, :immutable)
     end
 
     def identity_secret_is_usable

--- a/engines/collavre/app/services/collavre/ai_client.rb
+++ b/engines/collavre/app/services/collavre/ai_client.rb
@@ -326,7 +326,7 @@ module Collavre
         proc do |config|
           config.openai_api_key = api_key
           config.openai_api_base = base_url if base_url
-          if normalized_vendor == "cli_proxy" && !gateway.owner.system_admin?
+          if normalized_vendor == "cli_proxy" && !gateway.owner.system_admin? && !gateway.desktop_loopback?
             config.faraday_adapter = Collavre::CliProxy::SafeNetHttpAdapter
           end
         end

--- a/engines/collavre/app/services/collavre/cli_proxy/client.rb
+++ b/engines/collavre/app/services/collavre/cli_proxy/client.rb
@@ -80,7 +80,9 @@ module Collavre
       private
 
       def default_http_client
-        policy = EndpointPolicy.new unless @gateway.owner.system_admin?
+        requires_endpoint_policy = !@gateway.owner.system_admin? &&
+          !@gateway.desktop_loopback?
+        policy = EndpointPolicy.new if requires_endpoint_policy
         Collavre::HttpClient.new(open_timeout: 5, read_timeout: 35, endpoint_policy: policy)
       end
 

--- a/engines/collavre/app/views/collavre/desktop_setup/show.html.erb
+++ b/engines/collavre/app/views/collavre/desktop_setup/show.html.erb
@@ -7,7 +7,7 @@
 
 <section class="desktop-setup" aria-labelledby="desktop-setup-title">
   <header class="desktop-setup__header">
-    <p class="desktop-setup__eyebrow"><%= t("collavre.desktop_setup.preview") %></p>
+    <p class="desktop-setup__eyebrow"><%= t("collavre.desktop_setup.kicker") %></p>
     <h1 id="desktop-setup-title"><%= t("collavre.desktop_setup.title") %></h1>
     <p><%= t("collavre.desktop_setup.subtitle") %></p>
   </header>
@@ -26,27 +26,34 @@
       <p class="desktop-setup__kicker"><%= t("collavre.desktop_setup.account.kicker") %></p>
       <h2><%= t("collavre.desktop_setup.account.title") %></h2>
       <p class="desktop-setup__lead"><%= t("collavre.desktop_setup.account.body") %></p>
-      <form class="desktop-setup__account-form" aria-describedby="desktop-setup-account-hint">
-        <div class="desktop-setup__field">
-          <label for="desktop-setup-admin-name"><%= t("collavre.desktop_setup.account.name_label") %></label>
-          <input id="desktop-setup-admin-name" name="admin[name]" type="text" autocomplete="name" placeholder="<%= t("collavre.desktop_setup.account.name_placeholder") %>">
-        </div>
-        <div class="desktop-setup__field">
-          <label for="desktop-setup-admin-email"><%= t("collavre.desktop_setup.account.email_label") %></label>
-          <input id="desktop-setup-admin-email" name="admin[email]" type="email" autocomplete="email" placeholder="<%= t("collavre.desktop_setup.account.email_placeholder") %>">
-        </div>
-        <div class="desktop-setup__form-grid">
+      <% if @account_required %>
+        <% if @user&.errors&.any? %><p class="flash-alert"><%= @user.errors.full_messages.to_sentence %></p><% end %>
+        <%= form_with scope: :admin, url: collavre.desktop_setup_account_path, class: "desktop-setup__account-form", aria: { describedby: "desktop-setup-account-hint" } do |form| %>
           <div class="desktop-setup__field">
-            <label for="desktop-setup-admin-password"><%= t("collavre.desktop_setup.account.password_label") %></label>
-            <input id="desktop-setup-admin-password" name="admin[password]" type="password" autocomplete="new-password" placeholder="<%= t("collavre.desktop_setup.account.password_placeholder") %>">
+            <%= form.label :name, t("collavre.desktop_setup.account.name_label"), for: "desktop-setup-admin-name" %>
+            <%= form.text_field :name, id: "desktop-setup-admin-name", autocomplete: "name", placeholder: t("collavre.desktop_setup.account.name_placeholder"), required: true %>
           </div>
           <div class="desktop-setup__field">
-            <label for="desktop-setup-admin-password-confirmation"><%= t("collavre.desktop_setup.account.password_confirmation_label") %></label>
-            <input id="desktop-setup-admin-password-confirmation" name="admin[password_confirmation]" type="password" autocomplete="new-password" placeholder="<%= t("collavre.desktop_setup.account.password_confirmation_placeholder") %>">
+            <%= form.label :email, t("collavre.desktop_setup.account.email_label"), for: "desktop-setup-admin-email" %>
+            <%= form.email_field :email, id: "desktop-setup-admin-email", autocomplete: "email", placeholder: t("collavre.desktop_setup.account.email_placeholder"), required: true %>
           </div>
-        </div>
-      </form>
-      <p id="desktop-setup-account-hint" class="desktop-setup__hint"><%= t("collavre.desktop_setup.account.hint") %></p>
+          <div class="desktop-setup__form-grid">
+            <div class="desktop-setup__field">
+              <%= form.label :password, t("collavre.desktop_setup.account.password_label"), for: "desktop-setup-admin-password" %>
+              <%= form.password_field :password, id: "desktop-setup-admin-password", autocomplete: "new-password", placeholder: t("collavre.desktop_setup.account.password_placeholder"), required: true %>
+            </div>
+            <div class="desktop-setup__field">
+              <%= form.label :password_confirmation, t("collavre.desktop_setup.account.password_confirmation_label"), for: "desktop-setup-admin-password-confirmation" %>
+              <%= form.password_field :password_confirmation, id: "desktop-setup-admin-password-confirmation", autocomplete: "new-password", placeholder: t("collavre.desktop_setup.account.password_confirmation_placeholder"), required: true %>
+            </div>
+          </div>
+          <%= form.submit t("collavre.desktop_setup.account.continue"), class: "desktop-setup__button" %>
+        <% end %>
+        <p id="desktop-setup-account-hint" class="desktop-setup__hint"><%= t("collavre.desktop_setup.account.hint") %></p>
+      <% else %>
+        <p class="desktop-setup__lead"><%= t("collavre.desktop_setup.account.existing") %></p>
+        <%= link_to t("app.sign_in"), collavre.new_session_path, class: "desktop-setup__button" %>
+      <% end %>
       <aside class="desktop-setup__notice"><%= t("collavre.desktop_setup.account.notice") %></aside>
     <% when "install" %>
       <p class="desktop-setup__kicker"><%= t("collavre.desktop_setup.install.kicker") %></p>
@@ -57,17 +64,26 @@
           <div><strong><%= t("collavre.desktop_setup.install.items.#{item}.title") %></strong><span><%= t("collavre.desktop_setup.install.items.#{item}.body") %></span></div>
         <% end %>
       </div>
-      <label class="desktop-setup__consent"><input type="checkbox" disabled> <span><%= t("collavre.desktop_setup.install.consent") %></span></label>
-      <p class="desktop-setup__hint"><%= t("collavre.desktop_setup.install.hint") %></p>
+      <div data-controller="desktop-proxy-setup"
+           data-desktop-proxy-setup-token-url-value="<%= collavre.desktop_setup_registration_token_path %>"
+           data-desktop-proxy-setup-next-url-value="<%= collavre.desktop_setup_path(step: :adapters) %>"
+           data-desktop-proxy-setup-unavailable-value="<%= t("collavre.desktop_setup.install.unavailable") %>"
+           data-desktop-proxy-setup-failed-value="<%= t("collavre.desktop_setup.install.failed") %>">
+        <label class="desktop-setup__consent"><input type="checkbox" data-desktop-proxy-setup-target="consent" data-action="desktop-proxy-setup#toggle"> <span><%= t("collavre.desktop_setup.install.consent") %></span></label>
+        <p class="desktop-setup__hint"><%= t("collavre.desktop_setup.install.hint") %></p>
+        <p class="flash-alert" hidden data-desktop-proxy-setup-target="error"></p>
+        <button type="button" class="desktop-setup__button" disabled data-desktop-proxy-setup-target="submit" data-action="desktop-proxy-setup#install"><%= t("collavre.desktop_setup.install.continue") %></button>
+      </div>
     <% when "adapters" %>
       <p class="desktop-setup__kicker"><%= t("collavre.desktop_setup.adapters.kicker") %></p>
       <h2><%= t("collavre.desktop_setup.adapters.title") %></h2>
       <p class="desktop-setup__lead"><%= t("collavre.desktop_setup.adapters.body") %></p>
       <div class="desktop-setup__adapter-list">
         <% %w[claude codex].each do |adapter| %>
+          <% detected = params[adapter] == "1" %>
           <article>
             <div><h3><%= t("collavre.desktop_setup.adapters.#{adapter}.title") %></h3><p><%= t("collavre.desktop_setup.adapters.#{adapter}.body") %></p></div>
-            <span class="desktop-setup__status"><%= t("collavre.desktop_setup.adapters.status") %></span>
+            <span class="desktop-setup__status"><%= t("collavre.desktop_setup.adapters.#{detected ? "detected" : "not_detected"}") %></span>
           </article>
         <% end %>
       </div>
@@ -77,25 +93,19 @@
       <p class="desktop-setup__kicker"><%= t("collavre.desktop_setup.ready.kicker") %></p>
       <h2><%= t("collavre.desktop_setup.ready.title") %></h2>
       <p class="desktop-setup__lead"><%= t("collavre.desktop_setup.ready.body") %></p>
-      <ul class="desktop-setup__checklist">
-        <% %w[proxy gateway agents].each do |item| %>
-          <li>✓ <%= t("collavre.desktop_setup.ready.items.#{item}") %></li>
-        <% end %>
-      </ul>
+      <ul class="desktop-setup__checklist"><% %w[proxy gateway agents].each do |item| %><li>✓ <%= t("collavre.desktop_setup.ready.items.#{item}") %></li><% end %></ul>
       <aside class="desktop-setup__notice"><%= t("collavre.desktop_setup.ready.notice") %></aside>
     <% end %>
   </div>
 
   <footer class="desktop-setup__actions">
-    <% if current_index.positive? %>
-      <%= link_to t("collavre.desktop_setup.back"), collavre.desktop_setup_path(step: steps[current_index - 1]), class: "desktop-setup__button desktop-setup__button--secondary" %>
-    <% else %>
+    <% if current_index.positive? %><%= link_to t("collavre.desktop_setup.back"), collavre.desktop_setup_path(step: steps[current_index - 1]), class: "desktop-setup__button desktop-setup__button--secondary" %><% else %><span></span><% end %>
+    <% if @step == "account" || @step == "install" %>
       <span></span>
-    <% end %>
-    <% if current_index < steps.length - 1 %>
-      <%= link_to t("collavre.desktop_setup.next"), collavre.desktop_setup_path(step: steps[current_index + 1]), class: "desktop-setup__button" %>
+    <% elsif current_index < steps.length - 1 %>
+      <%= link_to t("collavre.desktop_setup.next"), collavre.desktop_setup_path(step: steps[current_index + 1], claude: params[:claude], codex: params[:codex]), class: "desktop-setup__button" %>
     <% else %>
-      <%= link_to t("collavre.desktop_setup.restart"), collavre.desktop_setup_path, class: "desktop-setup__button" %>
+      <%= link_to t("collavre.desktop_setup.ready.open"), main_app.root_path, class: "desktop-setup__button" %>
     <% end %>
   </footer>
 </section>

--- a/engines/collavre/app/views/collavre/desktop_setup/show.html.erb
+++ b/engines/collavre/app/views/collavre/desktop_setup/show.html.erb
@@ -52,6 +52,9 @@
         <p id="desktop-setup-account-hint" class="desktop-setup__hint"><%= t("collavre.desktop_setup.account.hint") %></p>
       <% else %>
         <p class="desktop-setup__lead"><%= t("collavre.desktop_setup.account.existing") %></p>
+        <% if @user %>
+          <%= button_to t("app.sign_out"), collavre.session_path, method: :delete, class: "desktop-setup__button desktop-setup__button--secondary" %>
+        <% end %>
         <%= link_to t("app.sign_in"), collavre.new_session_path, class: "desktop-setup__button" %>
       <% end %>
       <aside class="desktop-setup__notice"><%= t("collavre.desktop_setup.account.notice") %></aside>

--- a/engines/collavre/app/views/collavre/desktop_setup/show.html.erb
+++ b/engines/collavre/app/views/collavre/desktop_setup/show.html.erb
@@ -1,0 +1,101 @@
+<% content_for :head do %>
+  <%= stylesheet_link_tag "collavre/desktop_setup", "data-turbo-track": "reload" %>
+<% end %>
+
+<% steps = Collavre::DesktopSetupController::STEPS %>
+<% current_index = steps.index(@step) %>
+
+<section class="desktop-setup" aria-labelledby="desktop-setup-title">
+  <header class="desktop-setup__header">
+    <p class="desktop-setup__eyebrow"><%= t("collavre.desktop_setup.preview") %></p>
+    <h1 id="desktop-setup-title"><%= t("collavre.desktop_setup.title") %></h1>
+    <p><%= t("collavre.desktop_setup.subtitle") %></p>
+  </header>
+
+  <ol class="desktop-setup__progress" aria-label="<%= t("collavre.desktop_setup.progress_label") %>">
+    <% steps.each_with_index do |step, index| %>
+      <li class="<%= "is-current" if index == current_index %> <%= "is-complete" if index < current_index %>">
+        <span><%= index + 1 %></span><%= t("collavre.desktop_setup.steps.#{step}") %>
+      </li>
+    <% end %>
+  </ol>
+
+  <div class="desktop-setup__panel">
+    <% case @step %>
+    <% when "account" %>
+      <p class="desktop-setup__kicker"><%= t("collavre.desktop_setup.account.kicker") %></p>
+      <h2><%= t("collavre.desktop_setup.account.title") %></h2>
+      <p class="desktop-setup__lead"><%= t("collavre.desktop_setup.account.body") %></p>
+      <form class="desktop-setup__account-form" aria-describedby="desktop-setup-account-hint">
+        <div class="desktop-setup__field">
+          <label for="desktop-setup-admin-name"><%= t("collavre.desktop_setup.account.name_label") %></label>
+          <input id="desktop-setup-admin-name" name="admin[name]" type="text" autocomplete="name" placeholder="<%= t("collavre.desktop_setup.account.name_placeholder") %>">
+        </div>
+        <div class="desktop-setup__field">
+          <label for="desktop-setup-admin-email"><%= t("collavre.desktop_setup.account.email_label") %></label>
+          <input id="desktop-setup-admin-email" name="admin[email]" type="email" autocomplete="email" placeholder="<%= t("collavre.desktop_setup.account.email_placeholder") %>">
+        </div>
+        <div class="desktop-setup__form-grid">
+          <div class="desktop-setup__field">
+            <label for="desktop-setup-admin-password"><%= t("collavre.desktop_setup.account.password_label") %></label>
+            <input id="desktop-setup-admin-password" name="admin[password]" type="password" autocomplete="new-password" placeholder="<%= t("collavre.desktop_setup.account.password_placeholder") %>">
+          </div>
+          <div class="desktop-setup__field">
+            <label for="desktop-setup-admin-password-confirmation"><%= t("collavre.desktop_setup.account.password_confirmation_label") %></label>
+            <input id="desktop-setup-admin-password-confirmation" name="admin[password_confirmation]" type="password" autocomplete="new-password" placeholder="<%= t("collavre.desktop_setup.account.password_confirmation_placeholder") %>">
+          </div>
+        </div>
+      </form>
+      <p id="desktop-setup-account-hint" class="desktop-setup__hint"><%= t("collavre.desktop_setup.account.hint") %></p>
+      <aside class="desktop-setup__notice"><%= t("collavre.desktop_setup.account.notice") %></aside>
+    <% when "install" %>
+      <p class="desktop-setup__kicker"><%= t("collavre.desktop_setup.install.kicker") %></p>
+      <h2><%= t("collavre.desktop_setup.install.title") %></h2>
+      <p class="desktop-setup__lead"><%= t("collavre.desktop_setup.install.body") %></p>
+      <div class="desktop-setup__summary">
+        <% %w[installation keys registration].each do |item| %>
+          <div><strong><%= t("collavre.desktop_setup.install.items.#{item}.title") %></strong><span><%= t("collavre.desktop_setup.install.items.#{item}.body") %></span></div>
+        <% end %>
+      </div>
+      <label class="desktop-setup__consent"><input type="checkbox" disabled> <span><%= t("collavre.desktop_setup.install.consent") %></span></label>
+      <p class="desktop-setup__hint"><%= t("collavre.desktop_setup.install.hint") %></p>
+    <% when "adapters" %>
+      <p class="desktop-setup__kicker"><%= t("collavre.desktop_setup.adapters.kicker") %></p>
+      <h2><%= t("collavre.desktop_setup.adapters.title") %></h2>
+      <p class="desktop-setup__lead"><%= t("collavre.desktop_setup.adapters.body") %></p>
+      <div class="desktop-setup__adapter-list">
+        <% %w[claude codex].each do |adapter| %>
+          <article>
+            <div><h3><%= t("collavre.desktop_setup.adapters.#{adapter}.title") %></h3><p><%= t("collavre.desktop_setup.adapters.#{adapter}.body") %></p></div>
+            <span class="desktop-setup__status"><%= t("collavre.desktop_setup.adapters.status") %></span>
+          </article>
+        <% end %>
+      </div>
+      <aside class="desktop-setup__notice"><%= t("collavre.desktop_setup.adapters.notice") %></aside>
+    <% when "ready" %>
+      <div class="desktop-setup__ready-mark" aria-hidden="true">✓</div>
+      <p class="desktop-setup__kicker"><%= t("collavre.desktop_setup.ready.kicker") %></p>
+      <h2><%= t("collavre.desktop_setup.ready.title") %></h2>
+      <p class="desktop-setup__lead"><%= t("collavre.desktop_setup.ready.body") %></p>
+      <ul class="desktop-setup__checklist">
+        <% %w[proxy gateway agents].each do |item| %>
+          <li>✓ <%= t("collavre.desktop_setup.ready.items.#{item}") %></li>
+        <% end %>
+      </ul>
+      <aside class="desktop-setup__notice"><%= t("collavre.desktop_setup.ready.notice") %></aside>
+    <% end %>
+  </div>
+
+  <footer class="desktop-setup__actions">
+    <% if current_index.positive? %>
+      <%= link_to t("collavre.desktop_setup.back"), collavre.desktop_setup_path(step: steps[current_index - 1]), class: "desktop-setup__button desktop-setup__button--secondary" %>
+    <% else %>
+      <span></span>
+    <% end %>
+    <% if current_index < steps.length - 1 %>
+      <%= link_to t("collavre.desktop_setup.next"), collavre.desktop_setup_path(step: steps[current_index + 1]), class: "desktop-setup__button" %>
+    <% else %>
+      <%= link_to t("collavre.desktop_setup.restart"), collavre.desktop_setup_path, class: "desktop-setup__button" %>
+    <% end %>
+  </footer>
+</section>

--- a/engines/collavre/config/locales/agent_gateway.en.yml
+++ b/engines/collavre/config/locales/agent_gateway.en.yml
@@ -74,13 +74,12 @@ en:
       destroyed: Agent gateway was deleted.
       in_use: This gateway is assigned to an AI agent and cannot be deleted.
     desktop_setup:
-      preview: Preview only — no changes are made
+      kicker: First-run setup
       title: Set up local AI agents
       subtitle: A guided first-run experience for the Collavre Desktop app.
       progress_label: Setup progress
       back: Back
       next: Continue
-      restart: Review again
       steps:
         account: Administrator account
         install: Install
@@ -98,12 +97,15 @@ en:
         password_placeholder: Choose a password
         password_confirmation_label: Confirm password
         password_confirmation_placeholder: Enter the password again
-        hint: This preview accepts no data. The production Tauri wizard will validate and create this local administrator account only after you continue.
+        hint: This account is created only on this Mac and signs you in immediately.
         notice: Your password stays on this Mac. The wizard does not send it to an AI provider or use it to access existing CLI accounts.
+        continue: Create administrator account
+        existing: An administrator account already exists on this Mac. Sign in to continue setup.
+        already_created: An administrator account already exists on this Mac.
       install:
         kicker: Explicit consent
         title: Install and register the local proxy
-        body: The production wizard will ask once before making any local changes.
+        body: Your confirmation starts one bundled, loopback-only proxy and registers it to your local administrator account.
         items:
           installation:
             title: Installation
@@ -115,28 +117,33 @@ en:
             title: Registration
             body: Register that gateway automatically with the Collavre administrator account.
         consent: I understand that continuing will install and configure one local CLI Proxy service.
-        hint: The inactive control is intentional in this mockup. The real wizard must require this explicit confirmation.
+        hint: The proxy generates its credentials in macOS Keychain. Existing Claude Code and Codex credentials are not read or changed.
+        continue: Install and continue
+        unavailable: This action is available only in Collavre Desktop.
+        failed: The local proxy could not be installed. No gateway was registered; try again after reviewing the desktop log.
       adapters:
         kicker: Existing CLI tools
         title: Use the CLI tools you already signed in to
         body: Collavre will create suitable agent presets after checking whether the CLI executable is available.
-        status: Detected in mockup
+        detected: Detected — agent preset created
+        not_detected: Not detected — no preset created
         claude:
           title: Claude Code
           body: Uses your existing local Claude Code session. The wizard does not log in or read its credentials.
         codex:
           title: Codex
           body: Uses your existing local Codex session. The wizard does not log in or read its credentials.
-        notice: Only executable availability is checked in the planned flow. Existing credentials and configuration are neither read nor sent externally.
+        notice: Only executable availability is checked. Existing credentials and configuration are neither read nor sent externally.
       ready:
         kicker: Setup complete
         title: Your local AI gateway is ready
-        body: The real flow will return to Collavre after these steps succeed.
+        body: The local proxy and gateway are ready. Open Collavre to start using your configured agents.
         items:
           proxy: One local cli-openai-proxy instance is installed.
           gateway: The generated local gateway is registered to the Collavre administrator.
           agents: Ready-to-use Claude Code and Codex agent presets are available when supported.
-        notice: This completion state is illustrative only. No service or gateway has been created from this page.
+        notice: You can manage the gateway later from Agent Gateway settings. Removing it does not alter your Claude Code or Codex installation.
+        open: Open Collavre
     agent_connections:
       title: "%{agent} connection"
       card_title: Engine connection and provisioning

--- a/engines/collavre/config/locales/agent_gateway.en.yml
+++ b/engines/collavre/config/locales/agent_gateway.en.yml
@@ -73,6 +73,70 @@ en:
       updated: Agent gateway was updated.
       destroyed: Agent gateway was deleted.
       in_use: This gateway is assigned to an AI agent and cannot be deleted.
+    desktop_setup:
+      preview: Preview only — no changes are made
+      title: Set up local AI agents
+      subtitle: A guided first-run experience for the Collavre Desktop app.
+      progress_label: Setup progress
+      back: Back
+      next: Continue
+      restart: Review again
+      steps:
+        account: Administrator account
+        install: Install
+        adapters: CLI guidance
+        ready: Ready
+      account:
+        kicker: First-run setup
+        title: Create the first administrator account
+        body: Set up the local Collavre administrator before installing the AI gateway. No administrator account is seeded with the app.
+        name_label: Name
+        name_placeholder: Your name
+        email_label: Email
+        email_placeholder: you@example.com
+        password_label: Password
+        password_placeholder: Choose a password
+        password_confirmation_label: Confirm password
+        password_confirmation_placeholder: Enter the password again
+        hint: This preview accepts no data. The production Tauri wizard will validate and create this local administrator account only after you continue.
+        notice: Your password stays on this Mac. The wizard does not send it to an AI provider or use it to access existing CLI accounts.
+      install:
+        kicker: Explicit consent
+        title: Install and register the local proxy
+        body: The production wizard will ask once before making any local changes.
+        items:
+          installation:
+            title: Installation
+            body: Install cli-openai-proxy as a single local service for this Mac.
+          keys:
+            title: Secure keys
+            body: Generate one administrator key and one API key, then retain them only for the local gateway.
+          registration:
+            title: Registration
+            body: Register that gateway automatically with the Collavre administrator account.
+        consent: I understand that continuing will install and configure one local CLI Proxy service.
+        hint: The inactive control is intentional in this mockup. The real wizard must require this explicit confirmation.
+      adapters:
+        kicker: Existing CLI tools
+        title: Use the CLI tools you already signed in to
+        body: Collavre will create suitable agent presets after checking whether the CLI executable is available.
+        status: Detected in mockup
+        claude:
+          title: Claude Code
+          body: Uses your existing local Claude Code session. The wizard does not log in or read its credentials.
+        codex:
+          title: Codex
+          body: Uses your existing local Codex session. The wizard does not log in or read its credentials.
+        notice: Only executable availability is checked in the planned flow. Existing credentials and configuration are neither read nor sent externally.
+      ready:
+        kicker: Setup complete
+        title: Your local AI gateway is ready
+        body: The real flow will return to Collavre after these steps succeed.
+        items:
+          proxy: One local cli-openai-proxy instance is installed.
+          gateway: The generated local gateway is registered to the Collavre administrator.
+          agents: Ready-to-use Claude Code and Codex agent presets are available when supported.
+        notice: This completion state is illustrative only. No service or gateway has been created from this page.
     agent_connections:
       title: "%{agent} connection"
       card_title: Engine connection and provisioning

--- a/engines/collavre/config/locales/agent_gateway.en.yml
+++ b/engines/collavre/config/locales/agent_gateway.en.yml
@@ -20,6 +20,8 @@ en:
               invalid: "must be an http(s) origin without credentials, query or fragment"
               unsafe: "must use HTTPS and cannot target a local, private, or reserved network address"
               immutable: "cannot be changed for a desktop-managed gateway"
+            workspace_mode:
+              desktop_shared_only: "must remain shared for a desktop-managed gateway"
             tenant_id:
               invalid: "may only contain letters, digits and . _ : @ / -"
             identity_secret:

--- a/engines/collavre/config/locales/agent_gateway.en.yml
+++ b/engines/collavre/config/locales/agent_gateway.en.yml
@@ -19,6 +19,7 @@ en:
             base_url:
               invalid: "must be an http(s) origin without credentials, query or fragment"
               unsafe: "must use HTTPS and cannot target a local, private, or reserved network address"
+              immutable: "cannot be changed for a desktop-managed gateway"
             tenant_id:
               invalid: "may only contain letters, digits and . _ : @ / -"
             identity_secret:

--- a/engines/collavre/config/locales/agent_gateway.en.yml
+++ b/engines/collavre/config/locales/agent_gateway.en.yml
@@ -20,11 +20,16 @@ en:
               invalid: "must be an http(s) origin without credentials, query or fragment"
               unsafe: "must use HTTPS and cannot target a local, private, or reserved network address"
               immutable: "cannot be changed for a desktop-managed gateway"
+            admin_key:
+              immutable: "cannot be changed for a desktop-managed gateway"
+            completion_key:
+              immutable: "cannot be changed for a desktop-managed gateway"
             workspace_mode:
               desktop_shared_only: "must remain shared for a desktop-managed gateway"
             tenant_id:
               invalid: "may only contain letters, digits and . _ : @ / -"
             identity_secret:
+              immutable: "cannot be changed for a desktop-managed gateway"
               blank: "is required for per-user mode or a gateway assigned to multiple AI agents"
               too_short: "must contain at least %{count} bytes"
         collavre/user:

--- a/engines/collavre/config/locales/agent_gateway.ko.yml
+++ b/engines/collavre/config/locales/agent_gateway.ko.yml
@@ -19,6 +19,7 @@ ko:
             base_url:
               invalid: "은(는) 사용자 정보·쿼리·프래그먼트가 없는 http(s) 주소여야 합니다"
               unsafe: "은(는) HTTPS를 사용해야 하며 로컬·사설·예약된 네트워크 주소를 사용할 수 없습니다"
+              immutable: "은(는) 데스크탑 관리 게이트웨이에서 변경할 수 없습니다"
             tenant_id:
               invalid: "은(는) 영문·숫자와 . _ : @ / - 만 사용할 수 있습니다"
             identity_secret:

--- a/engines/collavre/config/locales/agent_gateway.ko.yml
+++ b/engines/collavre/config/locales/agent_gateway.ko.yml
@@ -73,6 +73,70 @@ ko:
       updated: Agent Gateway가 수정되었습니다.
       destroyed: Agent Gateway가 삭제되었습니다.
       in_use: AI Agent가 사용 중인 게이트웨이는 삭제할 수 없습니다.
+    desktop_setup:
+      preview: 목업 전용 — 실제 변경은 없습니다
+      title: 로컬 AI Agent 설정
+      subtitle: Collavre Desktop 앱의 첫 실행 안내 흐름입니다.
+      progress_label: 설정 진행 상황
+      back: 이전
+      next: 계속
+      restart: 다시 보기
+      steps:
+        account: 관리자 계정
+        install: 설치
+        adapters: CLI 안내
+        ready: 완료
+      account:
+        kicker: 첫 실행 설정
+        title: 첫 관리자 계정 만들기
+        body: AI Gateway를 설치하기 전에 로컬 Collavre 관리자를 설정합니다. 앱은 관리자 계정을 미리 생성하지 않습니다.
+        name_label: 이름
+        name_placeholder: 이름을 입력하세요
+        email_label: 이메일
+        email_placeholder: you@example.com
+        password_label: 비밀번호
+        password_placeholder: 비밀번호를 입력하세요
+        password_confirmation_label: 비밀번호 확인
+        password_confirmation_placeholder: 비밀번호를 다시 입력하세요
+        hint: 이 목업은 입력값을 저장하지 않습니다. 실제 Tauri 마법사는 계속하기 전에 값을 검증하고 이 Mac에만 첫 관리자 계정을 생성합니다.
+        notice: 비밀번호는 이 Mac에만 보관합니다. AI provider로 전송하거나 기존 CLI 계정에 접근하는 데 사용하지 않습니다.
+      install:
+        kicker: 명시적 동의
+        title: 로컬 프록시 설치 및 등록
+        body: 실제 마법사는 로컬 변경을 시작하기 전에 한 번만 동의를 요청합니다.
+        items:
+          installation:
+            title: 설치
+            body: 이 Mac에서 cli-openai-proxy를 단일 로컬 서비스로 설치합니다.
+          keys:
+            title: 보안 키
+            body: 관리자 키 하나와 API 키 하나를 생성하고 로컬 Gateway에만 보관합니다.
+          registration:
+            title: 등록
+            body: 해당 Gateway를 Collavre 관리자 계정에 자동 등록합니다.
+        consent: 계속하면 단일 로컬 CLI Proxy 서비스를 설치하고 설정한다는 점을 이해했습니다.
+        hint: 이 목업에서는 동의 제어가 비활성화되어 있습니다. 실제 마법사에서는 이 명시적 확인이 필수입니다.
+      adapters:
+        kicker: 기존 CLI 도구
+        title: 이미 로그인한 CLI 도구 사용
+        body: Collavre는 CLI 실행 파일을 사용할 수 있는지 확인한 뒤 알맞은 Agent 프리셋을 만듭니다.
+        status: 목업에서 감지됨
+        claude:
+          title: Claude Code
+          body: 기존 로컬 Claude Code 세션을 사용합니다. 마법사는 로그인하거나 자격 증명을 읽지 않습니다.
+        codex:
+          title: Codex
+          body: 기존 로컬 Codex 세션을 사용합니다. 마법사는 로그인하거나 자격 증명을 읽지 않습니다.
+        notice: 실제 흐름에서는 실행 파일 사용 가능 여부만 확인합니다. 기존 자격 증명과 설정을 읽거나 외부로 전송하지 않습니다.
+      ready:
+        kicker: 설정 완료
+        title: 로컬 AI Gateway 준비 완료
+        body: 실제 흐름은 이 단계가 성공하면 Collavre로 돌아갑니다.
+        items:
+          proxy: 로컬 cli-openai-proxy 인스턴스 하나가 설치됩니다.
+          gateway: 생성한 로컬 Gateway가 Collavre 관리자에게 등록됩니다.
+          agents: 지원되는 경우 즉시 사용할 수 있는 Claude Code와 Codex Agent 프리셋이 준비됩니다.
+        notice: 이 완료 상태는 예시입니다. 이 페이지에서는 서비스나 Gateway가 생성되지 않습니다.
     agent_connections:
       title: "%{agent} 연결"
       card_title: 엔진 연결 및 프로비저닝

--- a/engines/collavre/config/locales/agent_gateway.ko.yml
+++ b/engines/collavre/config/locales/agent_gateway.ko.yml
@@ -20,6 +20,8 @@ ko:
               invalid: "은(는) 사용자 정보·쿼리·프래그먼트가 없는 http(s) 주소여야 합니다"
               unsafe: "은(는) HTTPS를 사용해야 하며 로컬·사설·예약된 네트워크 주소를 사용할 수 없습니다"
               immutable: "은(는) 데스크탑 관리 게이트웨이에서 변경할 수 없습니다"
+            workspace_mode:
+              desktop_shared_only: "은(는) 데스크탑 관리 게이트웨이에서 공유 모드로 유지해야 합니다"
             tenant_id:
               invalid: "은(는) 영문·숫자와 . _ : @ / - 만 사용할 수 있습니다"
             identity_secret:

--- a/engines/collavre/config/locales/agent_gateway.ko.yml
+++ b/engines/collavre/config/locales/agent_gateway.ko.yml
@@ -74,13 +74,12 @@ ko:
       destroyed: Agent Gateway가 삭제되었습니다.
       in_use: AI Agent가 사용 중인 게이트웨이는 삭제할 수 없습니다.
     desktop_setup:
-      preview: 목업 전용 — 실제 변경은 없습니다
+      kicker: 첫 실행 설정
       title: 로컬 AI Agent 설정
       subtitle: Collavre Desktop 앱의 첫 실행 안내 흐름입니다.
       progress_label: 설정 진행 상황
       back: 이전
       next: 계속
-      restart: 다시 보기
       steps:
         account: 관리자 계정
         install: 설치
@@ -98,12 +97,15 @@ ko:
         password_placeholder: 비밀번호를 입력하세요
         password_confirmation_label: 비밀번호 확인
         password_confirmation_placeholder: 비밀번호를 다시 입력하세요
-        hint: 이 목업은 입력값을 저장하지 않습니다. 실제 Tauri 마법사는 계속하기 전에 값을 검증하고 이 Mac에만 첫 관리자 계정을 생성합니다.
+        hint: 이 계정은 이 Mac에만 생성되며, 생성 후 바로 로그인됩니다.
         notice: 비밀번호는 이 Mac에만 보관합니다. AI provider로 전송하거나 기존 CLI 계정에 접근하는 데 사용하지 않습니다.
+        continue: 관리자 계정 만들기
+        existing: 이 Mac에 관리자 계정이 이미 있습니다. 로그인하여 설정을 계속하세요.
+        already_created: 이 Mac에 관리자 계정이 이미 있습니다.
       install:
         kicker: 명시적 동의
         title: 로컬 프록시 설치 및 등록
-        body: 실제 마법사는 로컬 변경을 시작하기 전에 한 번만 동의를 요청합니다.
+        body: 동의하면 loopback으로만 동작하는 번들 프록시 하나를 시작하고 로컬 관리자 계정에 등록합니다.
         items:
           installation:
             title: 설치
@@ -115,28 +117,33 @@ ko:
             title: 등록
             body: 해당 Gateway를 Collavre 관리자 계정에 자동 등록합니다.
         consent: 계속하면 단일 로컬 CLI Proxy 서비스를 설치하고 설정한다는 점을 이해했습니다.
-        hint: 이 목업에서는 동의 제어가 비활성화되어 있습니다. 실제 마법사에서는 이 명시적 확인이 필수입니다.
+        hint: 프록시 자격 증명은 macOS 키체인에 생성합니다. 기존 Claude Code·Codex 자격 증명은 읽거나 변경하지 않습니다.
+        continue: 설치하고 계속하기
+        unavailable: 이 작업은 Collavre Desktop에서만 사용할 수 있습니다.
+        failed: 로컬 프록시를 설치하지 못했습니다. Gateway는 등록되지 않았습니다. 데스크탑 로그를 확인한 후 다시 시도하세요.
       adapters:
         kicker: 기존 CLI 도구
         title: 이미 로그인한 CLI 도구 사용
         body: Collavre는 CLI 실행 파일을 사용할 수 있는지 확인한 뒤 알맞은 Agent 프리셋을 만듭니다.
-        status: 목업에서 감지됨
+        detected: 감지됨 — Agent 프리셋 생성 완료
+        not_detected: 감지되지 않음 — 프리셋을 만들지 않음
         claude:
           title: Claude Code
           body: 기존 로컬 Claude Code 세션을 사용합니다. 마법사는 로그인하거나 자격 증명을 읽지 않습니다.
         codex:
           title: Codex
           body: 기존 로컬 Codex 세션을 사용합니다. 마법사는 로그인하거나 자격 증명을 읽지 않습니다.
-        notice: 실제 흐름에서는 실행 파일 사용 가능 여부만 확인합니다. 기존 자격 증명과 설정을 읽거나 외부로 전송하지 않습니다.
+        notice: 실행 파일 사용 가능 여부만 확인합니다. 기존 자격 증명과 설정을 읽거나 외부로 전송하지 않습니다.
       ready:
         kicker: 설정 완료
         title: 로컬 AI Gateway 준비 완료
-        body: 실제 흐름은 이 단계가 성공하면 Collavre로 돌아갑니다.
+        body: 로컬 프록시와 Gateway가 준비되었습니다. Collavre를 열어 설정된 Agent를 사용하세요.
         items:
           proxy: 로컬 cli-openai-proxy 인스턴스 하나가 설치됩니다.
           gateway: 생성한 로컬 Gateway가 Collavre 관리자에게 등록됩니다.
           agents: 지원되는 경우 즉시 사용할 수 있는 Claude Code와 Codex Agent 프리셋이 준비됩니다.
-        notice: 이 완료 상태는 예시입니다. 이 페이지에서는 서비스나 Gateway가 생성되지 않습니다.
+        notice: 이후 Agent Gateway 설정에서 관리할 수 있습니다. 제거해도 Claude Code나 Codex 설치에는 영향을 주지 않습니다.
+        open: Collavre 열기
     agent_connections:
       title: "%{agent} 연결"
       card_title: 엔진 연결 및 프로비저닝

--- a/engines/collavre/config/locales/agent_gateway.ko.yml
+++ b/engines/collavre/config/locales/agent_gateway.ko.yml
@@ -20,11 +20,16 @@ ko:
               invalid: "은(는) 사용자 정보·쿼리·프래그먼트가 없는 http(s) 주소여야 합니다"
               unsafe: "은(는) HTTPS를 사용해야 하며 로컬·사설·예약된 네트워크 주소를 사용할 수 없습니다"
               immutable: "은(는) 데스크탑 관리 게이트웨이에서 변경할 수 없습니다"
+            admin_key:
+              immutable: "은(는) 데스크탑 관리 게이트웨이에서 변경할 수 없습니다"
+            completion_key:
+              immutable: "은(는) 데스크탑 관리 게이트웨이에서 변경할 수 없습니다"
             workspace_mode:
               desktop_shared_only: "은(는) 데스크탑 관리 게이트웨이에서 공유 모드로 유지해야 합니다"
             tenant_id:
               invalid: "은(는) 영문·숫자와 . _ : @ / - 만 사용할 수 있습니다"
             identity_secret:
+              immutable: "은(는) 데스크탑 관리 게이트웨이에서 변경할 수 없습니다"
               blank: "은(는) 사용자별 모드 또는 여러 AI Agent가 사용하는 게이트웨이에서 필수입니다"
               too_short: "은(는) %{count}바이트 이상이어야 합니다"
         collavre/user:

--- a/engines/collavre/config/routes.rb
+++ b/engines/collavre/config/routes.rb
@@ -16,6 +16,9 @@ Collavre::Engine.routes.draw do
     post :check, on: :member
   end
   get "desktop/setup", to: "desktop_setup#show", as: :desktop_setup
+  post "desktop/setup/account", to: "desktop_setup#create_account", as: :desktop_setup_account
+  post "desktop/setup/registration-token", to: "desktop_setup#registration_token", as: :desktop_setup_registration_token
+  post "desktop/setup/register-gateway", to: "desktop_setup#register_gateway", as: :desktop_setup_register_gateway
   resources :users, only: [ :index, :new, :create, :show, :edit, :update, :destroy ] do
     collection do
       get :new_ai

--- a/engines/collavre/config/routes.rb
+++ b/engines/collavre/config/routes.rb
@@ -18,6 +18,7 @@ Collavre::Engine.routes.draw do
   get "desktop/setup", to: "desktop_setup#show", as: :desktop_setup
   post "desktop/setup/account", to: "desktop_setup#create_account", as: :desktop_setup_account
   post "desktop/setup/registration-token", to: "desktop_setup#registration_token", as: :desktop_setup_registration_token
+  get "desktop/setup/sidecar-health", to: "desktop_sidecar_health#show", as: :desktop_setup_sidecar_health
   post "desktop/setup/validate-registration-grant", to: "desktop_gateway_registrations#validate_registration_grant", as: :desktop_setup_validate_registration_grant
   post "desktop/setup/gateway-registered", to: "desktop_gateway_registrations#registered", as: :desktop_setup_gateway_registered
   post "desktop/setup/register-gateway", to: "desktop_gateway_registrations#create", as: :desktop_setup_register_gateway

--- a/engines/collavre/config/routes.rb
+++ b/engines/collavre/config/routes.rb
@@ -18,6 +18,7 @@ Collavre::Engine.routes.draw do
   get "desktop/setup", to: "desktop_setup#show", as: :desktop_setup
   post "desktop/setup/account", to: "desktop_setup#create_account", as: :desktop_setup_account
   post "desktop/setup/registration-token", to: "desktop_setup#registration_token", as: :desktop_setup_registration_token
+  post "desktop/setup/validate-registration-grant", to: "desktop_gateway_registrations#validate_registration_grant", as: :desktop_setup_validate_registration_grant
   post "desktop/setup/register-gateway", to: "desktop_gateway_registrations#create", as: :desktop_setup_register_gateway
   resources :users, only: [ :index, :new, :create, :show, :edit, :update, :destroy ] do
     collection do

--- a/engines/collavre/config/routes.rb
+++ b/engines/collavre/config/routes.rb
@@ -15,6 +15,7 @@ Collavre::Engine.routes.draw do
   resources :agent_gateways, path: "settings/agent-gateways", except: :show do
     post :check, on: :member
   end
+  get "desktop/setup", to: "desktop_setup#show", as: :desktop_setup
   resources :users, only: [ :index, :new, :create, :show, :edit, :update, :destroy ] do
     collection do
       get :new_ai

--- a/engines/collavre/config/routes.rb
+++ b/engines/collavre/config/routes.rb
@@ -18,7 +18,7 @@ Collavre::Engine.routes.draw do
   get "desktop/setup", to: "desktop_setup#show", as: :desktop_setup
   post "desktop/setup/account", to: "desktop_setup#create_account", as: :desktop_setup_account
   post "desktop/setup/registration-token", to: "desktop_setup#registration_token", as: :desktop_setup_registration_token
-  post "desktop/setup/register-gateway", to: "desktop_setup#register_gateway", as: :desktop_setup_register_gateway
+  post "desktop/setup/register-gateway", to: "desktop_gateway_registrations#create", as: :desktop_setup_register_gateway
   resources :users, only: [ :index, :new, :create, :show, :edit, :update, :destroy ] do
     collection do
       get :new_ai

--- a/engines/collavre/config/routes.rb
+++ b/engines/collavre/config/routes.rb
@@ -19,6 +19,7 @@ Collavre::Engine.routes.draw do
   post "desktop/setup/account", to: "desktop_setup#create_account", as: :desktop_setup_account
   post "desktop/setup/registration-token", to: "desktop_setup#registration_token", as: :desktop_setup_registration_token
   post "desktop/setup/validate-registration-grant", to: "desktop_gateway_registrations#validate_registration_grant", as: :desktop_setup_validate_registration_grant
+  post "desktop/setup/gateway-registered", to: "desktop_gateway_registrations#registered", as: :desktop_setup_gateway_registered
   post "desktop/setup/register-gateway", to: "desktop_gateway_registrations#create", as: :desktop_setup_register_gateway
   resources :users, only: [ :index, :new, :create, :show, :edit, :update, :destroy ] do
     collection do

--- a/engines/collavre/db/migrate/20260810100000_add_desktop_managed_to_agent_gateways.rb
+++ b/engines/collavre/db/migrate/20260810100000_add_desktop_managed_to_agent_gateways.rb
@@ -18,7 +18,6 @@ class AddDesktopManagedToAgentGateways < ActiveRecord::Migration[8.1]
     legacy_gateway_ids = select_values(<<~SQL.squish)
       SELECT id FROM agent_gateways
       WHERE desktop_managed = FALSE
-      AND name = 'Collavre Desktop CLI Proxy'
       AND tenant_id = 'collavre-desktop'
     SQL
     return unless legacy_gateway_ids.one?

--- a/engines/collavre/db/migrate/20260810100000_add_desktop_managed_to_agent_gateways.rb
+++ b/engines/collavre/db/migrate/20260810100000_add_desktop_managed_to_agent_gateways.rb
@@ -21,7 +21,6 @@ class AddDesktopManagedToAgentGateways < ActiveRecord::Migration[8.1]
     legacy_gateway_ids = select_values(<<~SQL.squish)
       SELECT id FROM agent_gateways
       WHERE desktop_managed = FALSE
-      AND tenant_id = 'collavre-desktop'
       AND base_url LIKE 'http://127.0.0.1:%'
       AND EXISTS (
         SELECT 1 FROM users

--- a/engines/collavre/db/migrate/20260810100000_add_desktop_managed_to_agent_gateways.rb
+++ b/engines/collavre/db/migrate/20260810100000_add_desktop_managed_to_agent_gateways.rb
@@ -1,14 +1,15 @@
 # frozen_string_literal: true
 
 class AddDesktopManagedToAgentGateways < ActiveRecord::Migration[8.1]
-  def change
+  def up
     add_column :agent_gateways, :desktop_managed, :boolean, default: false, null: false unless column_exists?(:agent_gateways, :desktop_managed)
-
-    reversible do |direction|
-      direction.up { backfill_legacy_desktop_gateway }
-    end
-
+    backfill_legacy_desktop_gateway
     add_index :agent_gateways, :desktop_managed, unique: true, where: "desktop_managed", name: "index_agent_gateways_on_desktop_managed" unless index_exists?(:agent_gateways, name: "index_agent_gateways_on_desktop_managed")
+  end
+
+  def down
+    remove_index :agent_gateways, name: "index_agent_gateways_on_desktop_managed" if index_exists?(:agent_gateways, name: "index_agent_gateways_on_desktop_managed")
+    remove_column :agent_gateways, :desktop_managed if column_exists?(:agent_gateways, :desktop_managed)
   end
 
   private

--- a/engines/collavre/db/migrate/20260810100000_add_desktop_managed_to_agent_gateways.rb
+++ b/engines/collavre/db/migrate/20260810100000_add_desktop_managed_to_agent_gateways.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddDesktopManagedToAgentGateways < ActiveRecord::Migration[8.1]
+  def change
+    add_column :agent_gateways, :desktop_managed, :boolean, default: false, null: false
+    add_index :agent_gateways, :desktop_managed, unique: true, where: "desktop_managed", name: "index_agent_gateways_on_desktop_managed"
+  end
+end

--- a/engines/collavre/db/migrate/20260810100000_add_desktop_managed_to_agent_gateways.rb
+++ b/engines/collavre/db/migrate/20260810100000_add_desktop_managed_to_agent_gateways.rb
@@ -15,10 +15,24 @@ class AddDesktopManagedToAgentGateways < ActiveRecord::Migration[8.1]
   private
 
   def backfill_legacy_desktop_gateway
+    # Legacy records have no dedicated marker. A generated CLI preset linked
+    # to the gateway is the durable signature; tenant ID and display fields
+    # alone remain user-editable and must not cause a gateway to be adopted.
     legacy_gateway_ids = select_values(<<~SQL.squish)
       SELECT id FROM agent_gateways
       WHERE desktop_managed = FALSE
       AND tenant_id = 'collavre-desktop'
+      AND base_url LIKE 'http://127.0.0.1:%'
+      AND EXISTS (
+        SELECT 1 FROM users
+        WHERE users.agent_gateway_id = agent_gateways.id
+        AND users.created_by_id = agent_gateways.owner_id
+        AND users.email IN (
+          'collavre-desktop-claude-code@ai.local',
+          'collavre-desktop-codex@ai.local'
+        )
+        AND users.llm_vendor = 'cli_proxy'
+      )
     SQL
     return unless legacy_gateway_ids.one?
 

--- a/engines/collavre/db/migrate/20260810100000_add_desktop_managed_to_agent_gateways.rb
+++ b/engines/collavre/db/migrate/20260810100000_add_desktop_managed_to_agent_gateways.rb
@@ -2,7 +2,26 @@
 
 class AddDesktopManagedToAgentGateways < ActiveRecord::Migration[8.1]
   def change
-    add_column :agent_gateways, :desktop_managed, :boolean, default: false, null: false
-    add_index :agent_gateways, :desktop_managed, unique: true, where: "desktop_managed", name: "index_agent_gateways_on_desktop_managed"
+    add_column :agent_gateways, :desktop_managed, :boolean, default: false, null: false unless column_exists?(:agent_gateways, :desktop_managed)
+
+    reversible do |direction|
+      direction.up { backfill_legacy_desktop_gateway }
+    end
+
+    add_index :agent_gateways, :desktop_managed, unique: true, where: "desktop_managed", name: "index_agent_gateways_on_desktop_managed" unless index_exists?(:agent_gateways, name: "index_agent_gateways_on_desktop_managed")
+  end
+
+  private
+
+  def backfill_legacy_desktop_gateway
+    legacy_gateway_ids = select_values(<<~SQL.squish)
+      SELECT id FROM agent_gateways
+      WHERE desktop_managed = FALSE
+      AND name = 'Collavre Desktop CLI Proxy'
+      AND tenant_id = 'collavre-desktop'
+    SQL
+    return unless legacy_gateway_ids.one?
+
+    execute "UPDATE agent_gateways SET desktop_managed = TRUE WHERE id = #{connection.quote(legacy_gateway_ids.first)}"
   end
 end

--- a/engines/collavre/db/migrate/20260810100001_add_desktop_preset_adapter_to_users.rb
+++ b/engines/collavre/db/migrate/20260810100001_add_desktop_preset_adapter_to_users.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+class AddDesktopPresetAdapterToUsers < ActiveRecord::Migration[8.1]
+  PRESET_EMAILS = {
+    "claude" => "collavre-desktop-claude-code@ai.local",
+    "codex" => "collavre-desktop-codex@ai.local"
+  }.freeze
+
+  def up
+    add_column :users, :desktop_preset_adapter, :string unless column_exists?(:users, :desktop_preset_adapter)
+    backfill_legacy_desktop_presets
+    add_index :users, :desktop_preset_adapter, unique: true,
+                                               where: "desktop_preset_adapter IS NOT NULL",
+                                               name: "index_users_on_desktop_preset_adapter" unless index_exists?(:users, name: "index_users_on_desktop_preset_adapter")
+  end
+
+  def down
+    remove_index :users, name: "index_users_on_desktop_preset_adapter" if index_exists?(:users, name: "index_users_on_desktop_preset_adapter")
+    remove_column :users, :desktop_preset_adapter if column_exists?(:users, :desktop_preset_adapter)
+  end
+
+  private
+
+  def backfill_legacy_desktop_presets
+    PRESET_EMAILS.each do |adapter, email|
+      execute <<~SQL.squish
+        UPDATE users
+        SET desktop_preset_adapter = #{connection.quote(adapter)}
+        WHERE desktop_preset_adapter IS NULL
+        AND email = #{connection.quote(email)}
+        AND llm_vendor = 'cli_proxy'
+        AND agent_gateway_id IN (
+          SELECT id FROM agent_gateways WHERE desktop_managed = TRUE
+        )
+      SQL
+    end
+  end
+end

--- a/engines/collavre/test/controllers/agent_gateways_controller_test.rb
+++ b/engines/collavre/test/controllers/agent_gateways_controller_test.rb
@@ -112,6 +112,35 @@ class AgentGatewaysControllerTest < ActionDispatch::IntegrationTest
     assert_equal "http://127.0.0.1:34567", desktop_gateway.reload.base_url
   end
 
+  test "owner cannot switch a desktop-managed gateway to per-user mode from settings" do
+    desktop_gateway = Collavre::AgentGateway.create!(
+      owner: @owner,
+      name: "Desktop proxy",
+      base_url: "http://127.0.0.1:34567",
+      admin_key: "desktop-admin",
+      completion_key: "desktop-completion",
+      identity_secret: "d" * 32,
+      desktop_managed: true
+    )
+    sign_in_as(@owner, password: "password")
+
+    patch collavre.agent_gateway_path(desktop_gateway), params: {
+      agent_gateway: {
+        name: desktop_gateway.name,
+        base_url: desktop_gateway.base_url,
+        admin_key: "",
+        completion_key: "",
+        identity_secret: "",
+        tenant_id: desktop_gateway.tenant_id,
+        workspace_mode: "per_user",
+        active: "1"
+      }
+    }
+
+    assert_response :unprocessable_entity
+    assert_predicate desktop_gateway.reload, :shared?
+  end
+
   test "connection check uses completion key as mapped user key" do
     sign_in_as(@owner, password: "password")
     arguments = []

--- a/engines/collavre/test/controllers/agent_gateways_controller_test.rb
+++ b/engines/collavre/test/controllers/agent_gateways_controller_test.rb
@@ -112,6 +112,38 @@ class AgentGatewaysControllerTest < ActionDispatch::IntegrationTest
     assert_equal "http://127.0.0.1:34567", desktop_gateway.reload.base_url
   end
 
+  test "owner cannot replace desktop-managed credentials from settings" do
+    desktop_gateway = Collavre::AgentGateway.create!(
+      owner: @owner,
+      name: "Desktop proxy",
+      base_url: "http://127.0.0.1:34567",
+      admin_key: "desktop-admin",
+      completion_key: "desktop-completion",
+      identity_secret: "d" * 32,
+      desktop_managed: true
+    )
+    sign_in_as(@owner, password: "password")
+
+    patch collavre.agent_gateway_path(desktop_gateway), params: {
+      agent_gateway: {
+        name: desktop_gateway.name,
+        base_url: desktop_gateway.base_url,
+        admin_key: "replacement-admin",
+        completion_key: "replacement-completion",
+        identity_secret: "r" * 32,
+        tenant_id: desktop_gateway.tenant_id,
+        workspace_mode: desktop_gateway.workspace_mode,
+        active: "1"
+      }
+    }
+
+    assert_response :unprocessable_entity
+    desktop_gateway.reload
+    assert_equal "desktop-admin", desktop_gateway.admin_key
+    assert_equal "desktop-completion", desktop_gateway.completion_key
+    assert_equal "d" * 32, desktop_gateway.identity_secret
+  end
+
   test "owner cannot switch a desktop-managed gateway to per-user mode from settings" do
     desktop_gateway = Collavre::AgentGateway.create!(
       owner: @owner,

--- a/engines/collavre/test/controllers/agent_gateways_controller_test.rb
+++ b/engines/collavre/test/controllers/agent_gateways_controller_test.rb
@@ -83,6 +83,35 @@ class AgentGatewaysControllerTest < ActionDispatch::IntegrationTest
     assert_equal "completion", @gateway.completion_key
   end
 
+  test "owner cannot retarget a desktop-managed gateway from settings" do
+    desktop_gateway = Collavre::AgentGateway.create!(
+      owner: @owner,
+      name: "Desktop proxy",
+      base_url: "http://127.0.0.1:34567",
+      admin_key: "desktop-admin",
+      completion_key: "desktop-completion",
+      identity_secret: "d" * 32,
+      desktop_managed: true
+    )
+    sign_in_as(@owner, password: "password")
+
+    patch collavre.agent_gateway_path(desktop_gateway), params: {
+      agent_gateway: {
+        name: desktop_gateway.name,
+        base_url: "http://127.0.0.1:45678",
+        admin_key: "",
+        completion_key: "",
+        identity_secret: "",
+        tenant_id: desktop_gateway.tenant_id,
+        workspace_mode: desktop_gateway.workspace_mode,
+        active: "1"
+      }
+    }
+
+    assert_response :unprocessable_entity
+    assert_equal "http://127.0.0.1:34567", desktop_gateway.reload.base_url
+  end
+
   test "connection check uses completion key as mapped user key" do
     sign_in_as(@owner, password: "password")
     arguments = []

--- a/engines/collavre/test/controllers/desktop_setup_controller_test.rb
+++ b/engines/collavre/test/controllers/desktop_setup_controller_test.rb
@@ -300,7 +300,7 @@ class DesktopSetupControllerTest < ActionDispatch::IntegrationTest
     assert_not_predicate ordinary_gateway.reload, :desktop_managed?
   end
 
-  test "migration marks a renamed legacy desktop gateway and its preset" do
+  test "migration marks a legacy desktop gateway with a customized tenant ID and its preset" do
     users(:one).update!(system_admin: true)
     legacy_gateway = Collavre::AgentGateway.create!(
       owner: users(:one),
@@ -309,7 +309,7 @@ class DesktopSetupControllerTest < ActionDispatch::IntegrationTest
       admin_key: "legacy-admin-key",
       completion_key: "legacy-completion-key",
       identity_secret: "l" * 48,
-      tenant_id: "collavre-desktop"
+      tenant_id: "my-custom-tenant"
     )
     preset = Collavre::User.create!(
       name: "Claude Code",

--- a/engines/collavre/test/controllers/desktop_setup_controller_test.rb
+++ b/engines/collavre/test/controllers/desktop_setup_controller_test.rb
@@ -267,10 +267,37 @@ class DesktopSetupControllerTest < ActionDispatch::IntegrationTest
       identity_secret: "l" * 48,
       tenant_id: "collavre-desktop"
     )
+    Collavre::User.create!(
+      name: "Claude Code",
+      email: "collavre-desktop-claude-code@ai.local",
+      password: "secure-password",
+      email_verified_at: Time.current,
+      llm_vendor: "cli_proxy",
+      llm_model: "paperclip/claude_local",
+      created_by_id: users(:one).id,
+      agent_gateway: legacy_gateway,
+      tools: []
+    )
 
     AddDesktopManagedToAgentGateways.new.migrate(:up)
 
     assert_predicate legacy_gateway.reload, :desktop_managed?
+  end
+
+  test "migration does not mark an ordinary gateway that only uses the legacy tenant ID" do
+    ordinary_gateway = Collavre::AgentGateway.create!(
+      owner: users(:one),
+      name: "Ordinary gateway",
+      base_url: "http://127.0.0.1:35000",
+      admin_key: "ordinary-admin-key",
+      completion_key: "ordinary-completion-key",
+      identity_secret: "o" * 48,
+      tenant_id: "collavre-desktop"
+    )
+
+    AddDesktopManagedToAgentGateways.new.migrate(:up)
+
+    assert_not_predicate ordinary_gateway.reload, :desktop_managed?
   end
 
   test "migration marks a renamed legacy desktop gateway and its preset" do

--- a/engines/collavre/test/controllers/desktop_setup_controller_test.rb
+++ b/engines/collavre/test/controllers/desktop_setup_controller_test.rb
@@ -90,6 +90,40 @@ class DesktopSetupControllerTest < ActionDispatch::IntegrationTest
     assert Collavre::Contact.exists?(user: owner, contact_user: existing)
   end
 
+  test "registration preserves an owner's ordinary gateway with the desktop gateway name" do
+    owner = users(:one)
+    ordinary_gateway = Collavre::AgentGateway.create!(
+      owner: owner,
+      name: Collavre::DesktopSetupController::DESKTOP_GATEWAY_NAME,
+      base_url: "https://ordinary.example.test",
+      admin_key: "ordinary-admin-key",
+      completion_key: "ordinary-completion-key",
+      identity_secret: "o" * 48,
+      tenant_id: "ordinary-gateway"
+    )
+    sign_in_as(owner, password: "password")
+
+    post collavre.desktop_setup_registration_token_path
+    token = response.parsed_body.fetch("token")
+    post collavre.desktop_setup_register_gateway_path, params: {
+      registration_token: token,
+      proxy_port: 34_567,
+      admin_key: "desktop-admin-key",
+      completion_key: "desktop-completion-key",
+      identity_secret: "i" * 48,
+      adapters: []
+    }, as: :json
+
+    assert_response :created
+    desktop_gateway = Collavre::AgentGateway.find_by!(desktop_managed: true)
+    assert_equal "#{Collavre::DesktopSetupController::DESKTOP_GATEWAY_NAME} (2)", desktop_gateway.name
+    assert_equal owner, desktop_gateway.owner
+    assert_equal "http://127.0.0.1:34567", desktop_gateway.base_url
+    ordinary_gateway.reload
+    assert_equal "https://ordinary.example.test", ordinary_gateway.base_url
+    assert_not_predicate ordinary_gateway, :desktop_managed?
+  end
+
   test "recovery updates the original desktop gateway when another administrator is signed in" do
     owner = users(:one)
     unrelated_gateway = Collavre::AgentGateway.create!(

--- a/engines/collavre/test/controllers/desktop_setup_controller_test.rb
+++ b/engines/collavre/test/controllers/desktop_setup_controller_test.rb
@@ -89,6 +89,46 @@ class DesktopSetupControllerTest < ActionDispatch::IntegrationTest
     assert Collavre::Contact.exists?(user: owner, contact_user: existing)
   end
 
+  test "recovery updates the original desktop gateway when another administrator is signed in" do
+    owner = users(:one)
+    sign_in_as(owner, password: "password")
+
+    post collavre.desktop_setup_registration_token_path
+    owner_token = response.parsed_body.fetch("token")
+    post collavre.desktop_setup_register_gateway_path, params: {
+      registration_token: owner_token,
+      proxy_port: 34_567,
+      admin_key: "owner-admin-key",
+      completion_key: "owner-completion-key",
+      identity_secret: "i" * 48,
+      adapters: [ "claude" ]
+    }, as: :json
+
+    gateway = owner.owned_agent_gateways.find_by!(name: Collavre::DesktopSetupController::DESKTOP_GATEWAY_NAME)
+    users(:two).update!(system_admin: true)
+    sign_in_as(users(:two), password: "password")
+
+    post collavre.desktop_setup_registration_token_path
+    recovery_token = response.parsed_body.fetch("token")
+    post collavre.desktop_setup_register_gateway_path, params: {
+      registration_token: recovery_token,
+      proxy_port: 45_678,
+      admin_key: "recovery-admin-key",
+      completion_key: "recovery-completion-key",
+      identity_secret: "s" * 48,
+      adapters: [ "claude" ]
+    }, as: :json
+
+    assert_response :created
+    assert_equal 1, Collavre::AgentGateway.where(name: Collavre::DesktopSetupController::DESKTOP_GATEWAY_NAME).count
+    gateway.reload
+    assert_equal owner, gateway.owner
+    assert_equal "http://127.0.0.1:45678", gateway.base_url
+    assert_equal "recovery-admin-key", gateway.admin_key
+    assert_equal [ "collavre-desktop-claude-code@ai.local" ], owner.created_ai_users.pluck(:email)
+    assert_empty users(:two).created_ai_users.where(email: "collavre-desktop-claude-code@ai.local")
+  end
+
   test "registration rejects a missing native grant" do
     post collavre.desktop_setup_register_gateway_path, params: { proxy_port: 34_567 }, as: :json
 

--- a/engines/collavre/test/controllers/desktop_setup_controller_test.rb
+++ b/engines/collavre/test/controllers/desktop_setup_controller_test.rb
@@ -155,6 +155,15 @@ class DesktopSetupControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to collavre.desktop_setup_path(step: :install)
   end
 
+  test "an authenticated administrator resumes recovery at installation" do
+    sign_in_as(users(:one), password: "password")
+
+    get collavre.desktop_setup_path
+
+    assert_response :success
+    assert_select "[data-controller='desktop-proxy-setup']"
+  end
+
   test "setup renders actual account controls and dynamic adapter statuses" do
     Collavre::User.where(system_admin: true).update_all(system_admin: false)
     get collavre.desktop_setup_path(step: :account, locale: :en)

--- a/engines/collavre/test/controllers/desktop_setup_controller_test.rb
+++ b/engines/collavre/test/controllers/desktop_setup_controller_test.rb
@@ -47,7 +47,46 @@ class DesktopSetupControllerTest < ActionDispatch::IntegrationTest
     assert_equal "admin-key", gateway.admin_key
     assert_equal "completion-key", gateway.completion_key
     assert_equal %w[paperclip/claude_local paperclip/codex_local], owner.created_ai_users.order(:llm_model).pluck(:llm_model)
+    assert_equal 2, Collavre::Contact.where(user: owner, contact_user: owner.created_ai_users).count
     assert_equal %w[claude codex], response.parsed_body.fetch("adapters")
+  end
+
+  test "repair preserves an existing desktop preset's custom attributes" do
+    owner = users(:one)
+    sign_in_as(owner, password: "password")
+
+    post collavre.desktop_setup_registration_token_path
+    token = response.parsed_body.fetch("token")
+    post collavre.desktop_setup_register_gateway_path, params: {
+      registration_token: token,
+      proxy_port: 34_567,
+      admin_key: "admin-key",
+      completion_key: "completion-key",
+      identity_secret: "i" * 48,
+      adapters: [ "claude" ]
+    }, as: :json
+
+    existing = owner.created_ai_users.find_by!(email: "collavre-desktop-claude-code@ai.local")
+    existing.update!(name: "Customized Claude", llm_model: "custom/model", searchable: true, tools: [ "web_search" ])
+
+    post collavre.desktop_setup_registration_token_path
+    token = response.parsed_body.fetch("token")
+    post collavre.desktop_setup_register_gateway_path, params: {
+      registration_token: token,
+      proxy_port: 34_567,
+      admin_key: "new-admin-key",
+      completion_key: "new-completion-key",
+      identity_secret: "i" * 48,
+      adapters: [ "claude" ]
+    }, as: :json
+
+    assert_response :created
+    existing.reload
+    assert_equal "Customized Claude", existing.name
+    assert_equal "custom/model", existing.llm_model
+    assert_predicate existing, :searchable?
+    assert_equal [ "web_search" ], existing.tools
+    assert Collavre::Contact.exists?(user: owner, contact_user: existing)
   end
 
   test "registration rejects a missing native grant" do

--- a/engines/collavre/test/controllers/desktop_setup_controller_test.rb
+++ b/engines/collavre/test/controllers/desktop_setup_controller_test.rb
@@ -177,6 +177,47 @@ class DesktopSetupControllerTest < ActionDispatch::IntegrationTest
     assert_not_predicate unrelated_gateway, :desktop_managed?
   end
 
+  test "recovery keeps the desktop gateway usable after its owner loses administrator rights" do
+    owner = users(:one)
+    sign_in_as(owner, password: "password")
+
+    post collavre.desktop_setup_registration_token_path
+    owner_token = response.parsed_body.fetch("token")
+    post collavre.desktop_setup_register_gateway_path, params: {
+      registration_token: owner_token,
+      proxy_port: 34_567,
+      admin_key: "owner-admin-key",
+      completion_key: "owner-completion-key",
+      identity_secret: "i" * 48,
+      adapters: [ "claude" ]
+    }, as: :json
+    assert_response :created
+
+    gateway = Collavre::AgentGateway.find_by!(desktop_managed: true)
+    users(:two).update!(system_admin: true)
+    owner.update!(system_admin: false)
+    sign_in_as(users(:two), password: "password")
+
+    post collavre.desktop_setup_registration_token_path
+    recovery_token = response.parsed_body.fetch("token")
+    post collavre.desktop_setup_register_gateway_path, params: {
+      registration_token: recovery_token,
+      proxy_port: 45_678,
+      admin_key: "recovery-admin-key",
+      completion_key: "recovery-completion-key",
+      identity_secret: "s" * 48,
+      adapters: [ "claude" ]
+    }, as: :json
+
+    assert_response :created
+    gateway.reload
+    assert_equal owner, gateway.owner
+    assert_equal "http://127.0.0.1:45678", gateway.base_url
+    assert_predicate gateway, :desktop_loopback?
+    assert_nil Collavre::CliProxy::Client.new(gateway: gateway).instance_variable_get(:@http_client).instance_variable_get(:@endpoint_policy)
+    assert_equal [ "collavre-desktop-claude-code@ai.local" ], owner.created_ai_users.pluck(:email)
+  end
+
   test "migration marks the unambiguous legacy desktop gateway" do
     users(:one).update!(system_admin: true)
     legacy_gateway = Collavre::AgentGateway.create!(

--- a/engines/collavre/test/controllers/desktop_setup_controller_test.rb
+++ b/engines/collavre/test/controllers/desktop_setup_controller_test.rb
@@ -1,6 +1,15 @@
 require "test_helper"
 
 class DesktopSetupControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @desktop_proxy_setup = Rails.application.config.x.desktop_proxy_setup
+    Rails.application.config.x.desktop_proxy_setup = true
+  end
+
+  teardown do
+    Rails.application.config.x.desktop_proxy_setup = @desktop_proxy_setup
+  end
+
   test "first desktop account is created locally and becomes the administrator" do
     Collavre::User.where(system_admin: true).update_all(system_admin: false)
 
@@ -56,6 +65,44 @@ class DesktopSetupControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :forbidden
     assert_nil Collavre::User.find_by(email: "remote@desktop.test")
+  end
+
+  test "first administrator creation is unavailable outside desktop mode" do
+    Collavre::User.where(system_admin: true).update_all(system_admin: false)
+    Rails.application.config.x.desktop_proxy_setup = false
+
+    post collavre.desktop_setup_account_path, params: {
+      admin: { name: "Web", email: "web@desktop.test", password: "secure-password", password_confirmation: "secure-password" }
+    }
+
+    assert_response :not_found
+    assert_nil Collavre::User.find_by(email: "web@desktop.test")
+  end
+
+  test "a second local signup cannot become another first administrator" do
+    post collavre.desktop_setup_account_path, params: {
+      admin: { name: "Second", email: "second@desktop.test", password: "secure-password", password_confirmation: "secure-password" }
+    }
+
+    assert_redirected_to collavre.new_session_path
+    assert_nil Collavre::User.find_by(email: "second@desktop.test")
+    assert_equal 1, Collavre::User.where(system_admin: true).count
+  end
+
+  test "non-administrators cannot obtain a desktop registration token" do
+    sign_in_as(users(:two), password: "password")
+
+    post collavre.desktop_setup_registration_token_path
+
+    assert_response :forbidden
+  end
+
+  test "registration tokens are limited to the local desktop webview" do
+    sign_in_as(users(:one), password: "password")
+
+    post collavre.desktop_setup_registration_token_path, headers: { "REMOTE_ADDR" => "10.0.0.25" }
+
+    assert_response :forbidden
   end
 
   test "an existing administrator returns to incomplete setup after login" do

--- a/engines/collavre/test/controllers/desktop_setup_controller_test.rb
+++ b/engines/collavre/test/controllers/desktop_setup_controller_test.rb
@@ -91,6 +91,15 @@ class DesktopSetupControllerTest < ActionDispatch::IntegrationTest
 
   test "recovery updates the original desktop gateway when another administrator is signed in" do
     owner = users(:one)
+    unrelated_gateway = Collavre::AgentGateway.create!(
+      owner: users(:two),
+      name: Collavre::DesktopSetupController::DESKTOP_GATEWAY_NAME,
+      base_url: "https://unrelated.example.test",
+      admin_key: "unrelated-admin-key",
+      completion_key: "unrelated-completion-key",
+      identity_secret: "u" * 48,
+      tenant_id: "unrelated-gateway"
+    )
     sign_in_as(owner, password: "password")
 
     post collavre.desktop_setup_registration_token_path
@@ -120,13 +129,17 @@ class DesktopSetupControllerTest < ActionDispatch::IntegrationTest
     }, as: :json
 
     assert_response :created
-    assert_equal 1, Collavre::AgentGateway.where(name: Collavre::DesktopSetupController::DESKTOP_GATEWAY_NAME).count
+    assert_equal 1, Collavre::AgentGateway.where(desktop_managed: true).count
     gateway.reload
     assert_equal owner, gateway.owner
     assert_equal "http://127.0.0.1:45678", gateway.base_url
     assert_equal "recovery-admin-key", gateway.admin_key
     assert_equal [ "collavre-desktop-claude-code@ai.local" ], owner.created_ai_users.pluck(:email)
     assert_empty users(:two).created_ai_users.where(email: "collavre-desktop-claude-code@ai.local")
+    unrelated_gateway.reload
+    assert_equal "https://unrelated.example.test", unrelated_gateway.base_url
+    assert_equal "unrelated-admin-key", unrelated_gateway.admin_key
+    assert_not_predicate unrelated_gateway, :desktop_managed?
   end
 
   test "registration rejects a missing native grant" do

--- a/engines/collavre/test/controllers/desktop_setup_controller_test.rb
+++ b/engines/collavre/test/controllers/desktop_setup_controller_test.rb
@@ -1,0 +1,41 @@
+require "test_helper"
+
+class DesktopSetupControllerTest < ActionDispatch::IntegrationTest
+  test "visitor can review every desktop setup mockup step in English" do
+    %w[account install adapters ready].each do |step|
+      get collavre.desktop_setup_path(step: step, locale: :en)
+
+      assert_response :success
+      assert_includes response.body, I18n.t("collavre.desktop_setup.preview", locale: :en)
+      assert_includes response.body, I18n.t("collavre.desktop_setup.steps.#{step}", locale: :en)
+    end
+  end
+
+  test "visitor can review the Korean CLI privacy guidance" do
+    get collavre.desktop_setup_path(step: :adapters, locale: :ko)
+
+    assert_response :success
+    assert_includes response.body, I18n.t("collavre.desktop_setup.adapters.notice", locale: :ko)
+    assert_includes response.body, I18n.t("collavre.desktop_setup.adapters.codex.body", locale: :ko)
+  end
+
+  test "visitor can review the administrator account form without an existing account" do
+    get collavre.desktop_setup_path
+
+    assert_response :success
+    assert_select "form.desktop-setup__account-form"
+    assert_select "input#desktop-setup-admin-name[name='admin[name]'][autocomplete='name']"
+    assert_select "input#desktop-setup-admin-email[name='admin[email]'][type='email']"
+    assert_select "input#desktop-setup-admin-password[type='password'][autocomplete='new-password']"
+    assert_select "input#desktop-setup-admin-password-confirmation[type='password'][autocomplete='new-password']"
+  end
+
+  test "unknown step falls back to the overview" do
+    sign_in_as(users(:one), password: "password")
+
+    get collavre.desktop_setup_path(step: "unsupported")
+
+    assert_response :success
+    assert_includes response.body, I18n.t("collavre.desktop_setup.account.title")
+  end
+end

--- a/engines/collavre/test/controllers/desktop_setup_controller_test.rb
+++ b/engines/collavre/test/controllers/desktop_setup_controller_test.rb
@@ -1,41 +1,63 @@
 require "test_helper"
 
 class DesktopSetupControllerTest < ActionDispatch::IntegrationTest
-  test "visitor can review every desktop setup mockup step in English" do
-    %w[account install adapters ready].each do |step|
-      get collavre.desktop_setup_path(step: step, locale: :en)
+  test "first desktop account is created locally and becomes the administrator" do
+    Collavre::User.where(system_admin: true).update_all(system_admin: false)
 
-      assert_response :success
-      assert_includes response.body, I18n.t("collavre.desktop_setup.preview", locale: :en)
-      assert_includes response.body, I18n.t("collavre.desktop_setup.steps.#{step}", locale: :en)
-    end
+    post collavre.desktop_setup_account_path, params: {
+      admin: { name: "Desktop owner", email: "owner@desktop.test", password: "secure-password", password_confirmation: "secure-password" }
+    }
+
+    owner = Collavre::User.find_by!(email: "owner@desktop.test")
+    assert owner.system_admin?
+    assert owner.email_verified?
+    assert_redirected_to collavre.desktop_setup_path(step: :install)
+    assert_not_nil cookies[:session_id]
   end
 
-  test "visitor can review the Korean CLI privacy guidance" do
-    get collavre.desktop_setup_path(step: :adapters, locale: :ko)
+  test "signed native registration creates the loopback gateway and detected presets" do
+    owner = users(:one)
+    sign_in_as(owner, password: "password")
 
+    post collavre.desktop_setup_registration_token_path
     assert_response :success
-    assert_includes response.body, I18n.t("collavre.desktop_setup.adapters.notice", locale: :ko)
-    assert_includes response.body, I18n.t("collavre.desktop_setup.adapters.codex.body", locale: :ko)
+    token = response.parsed_body.fetch("token")
+
+    post collavre.desktop_setup_register_gateway_path, params: {
+      registration_token: token,
+      proxy_port: 34_567,
+      admin_key: "admin-key",
+      completion_key: "completion-key",
+      identity_secret: "i" * 48,
+      adapters: %w[claude codex unsupported]
+    }, as: :json
+
+    assert_response :created
+    gateway = owner.owned_agent_gateways.find_by!(name: Collavre::DesktopSetupController::DESKTOP_GATEWAY_NAME)
+    assert_equal "http://127.0.0.1:34567", gateway.base_url
+    assert_equal "admin-key", gateway.admin_key
+    assert_equal "completion-key", gateway.completion_key
+    assert_equal %w[paperclip/claude_local paperclip/codex_local], owner.created_ai_users.order(:llm_model).pluck(:llm_model)
+    assert_equal %w[claude codex], response.parsed_body.fetch("adapters")
   end
 
-  test "visitor can review the administrator account form without an existing account" do
-    get collavre.desktop_setup_path
+  test "registration rejects a missing native grant" do
+    post collavre.desktop_setup_register_gateway_path, params: { proxy_port: 34_567 }, as: :json
+
+    assert_response :unprocessable_entity
+  end
+
+  test "setup renders actual account controls and dynamic adapter statuses" do
+    Collavre::User.where(system_admin: true).update_all(system_admin: false)
+    get collavre.desktop_setup_path(step: :account, locale: :en)
 
     assert_response :success
-    assert_select "form.desktop-setup__account-form"
-    assert_select "input#desktop-setup-admin-name[name='admin[name]'][autocomplete='name']"
-    assert_select "input#desktop-setup-admin-email[name='admin[email]'][type='email']"
+    assert_select "form[action='#{collavre.desktop_setup_account_path}']"
     assert_select "input#desktop-setup-admin-password[type='password'][autocomplete='new-password']"
-    assert_select "input#desktop-setup-admin-password-confirmation[type='password'][autocomplete='new-password']"
-  end
 
-  test "unknown step falls back to the overview" do
-    sign_in_as(users(:one), password: "password")
-
-    get collavre.desktop_setup_path(step: "unsupported")
-
+    get collavre.desktop_setup_path(step: :adapters, claude: 1, locale: :en)
     assert_response :success
-    assert_includes response.body, I18n.t("collavre.desktop_setup.account.title")
+    assert_includes response.body, I18n.t("collavre.desktop_setup.adapters.detected", locale: :en)
+    assert_includes response.body, I18n.t("collavre.desktop_setup.adapters.not_detected", locale: :en)
   end
 end

--- a/engines/collavre/test/controllers/desktop_setup_controller_test.rb
+++ b/engines/collavre/test/controllers/desktop_setup_controller_test.rb
@@ -1,5 +1,6 @@
 require "test_helper"
 require Rails.root.join("engines/collavre/db/migrate/20260810100000_add_desktop_managed_to_agent_gateways")
+require Rails.root.join("engines/collavre/db/migrate/20260810100001_add_desktop_preset_adapter_to_users")
 
 class DesktopSetupControllerTest < ActionDispatch::IntegrationTest
   setup do
@@ -88,6 +89,43 @@ class DesktopSetupControllerTest < ActionDispatch::IntegrationTest
     assert_predicate existing, :searchable?
     assert_equal [ "web_search" ], existing.tools
     assert Collavre::Contact.exists?(user: owner, contact_user: existing)
+  end
+
+  test "registration does not adopt an ordinary agent with a desktop preset email" do
+    owner = users(:one)
+    ordinary_agent = Collavre::User.create!(
+      name: "Ordinary Claude",
+      email: "collavre-desktop-claude-code@ai.local",
+      password: "secure-password",
+      email_verified_at: Time.current,
+      llm_vendor: "anthropic",
+      llm_model: "claude-sonnet-4-5",
+      created_by_id: owner.id,
+      searchable: true,
+      tools: [ "web_search" ]
+    )
+    sign_in_as(owner, password: "password")
+
+    post collavre.desktop_setup_registration_token_path
+    token = response.parsed_body.fetch("token")
+    post collavre.desktop_setup_register_gateway_path, params: {
+      registration_token: token,
+      proxy_port: 34_567,
+      admin_key: "admin-key",
+      completion_key: "completion-key",
+      identity_secret: "i" * 48,
+      adapters: [ "claude" ]
+    }, as: :json
+
+    assert_response :created
+    ordinary_agent.reload
+    assert_equal "anthropic", ordinary_agent.llm_vendor
+    assert_equal "claude-sonnet-4-5", ordinary_agent.llm_model
+    assert_predicate ordinary_agent, :searchable?
+    preset = owner.created_ai_users.find_by!(desktop_preset_adapter: "claude")
+    assert_equal "collavre-desktop-claude-code+desktop-#{preset.agent_gateway_id}@ai.local", preset.email
+    assert_equal "cli_proxy", preset.llm_vendor
+    assert_equal "paperclip/claude_local", preset.llm_model
   end
 
   test "registration preserves an owner's ordinary gateway with the desktop gateway name" do
@@ -233,6 +271,36 @@ class DesktopSetupControllerTest < ActionDispatch::IntegrationTest
     AddDesktopManagedToAgentGateways.new.migrate(:up)
 
     assert_predicate legacy_gateway.reload, :desktop_managed?
+  end
+
+  test "migration marks a renamed legacy desktop gateway and its preset" do
+    users(:one).update!(system_admin: true)
+    legacy_gateway = Collavre::AgentGateway.create!(
+      owner: users(:one),
+      name: "My renamed local proxy",
+      base_url: "http://127.0.0.1:35000",
+      admin_key: "legacy-admin-key",
+      completion_key: "legacy-completion-key",
+      identity_secret: "l" * 48,
+      tenant_id: "collavre-desktop"
+    )
+    preset = Collavre::User.create!(
+      name: "Claude Code",
+      email: "collavre-desktop-claude-code@ai.local",
+      password: "secure-password",
+      email_verified_at: Time.current,
+      llm_vendor: "cli_proxy",
+      llm_model: "custom/model",
+      created_by_id: users(:one).id,
+      agent_gateway: legacy_gateway,
+      tools: []
+    )
+
+    AddDesktopManagedToAgentGateways.new.migrate(:up)
+    AddDesktopPresetAdapterToUsers.new.migrate(:up)
+
+    assert_predicate legacy_gateway.reload, :desktop_managed?
+    assert_equal "claude", preset.reload.desktop_preset_adapter
   end
 
   test "registration rejects a missing native grant" do

--- a/engines/collavre/test/controllers/desktop_setup_controller_test.rb
+++ b/engines/collavre/test/controllers/desktop_setup_controller_test.rb
@@ -431,6 +431,18 @@ class DesktopSetupControllerTest < ActionDispatch::IntegrationTest
     assert_select "[data-controller='desktop-proxy-setup']", count: 0
   end
 
+  test "switching accounts during recovery returns the administrator to installation" do
+    owner = users(:one)
+    owner.update!(email_verified_at: Time.current)
+    sign_in_as(users(:two), password: "password")
+
+    get collavre.desktop_setup_path(step: :install)
+    delete collavre.session_path
+    post collavre.session_path, params: { email: owner.email, password: "password" }
+
+    assert_redirected_to collavre.desktop_setup_path(step: :install)
+  end
+
   test "setup renders actual account controls and dynamic adapter statuses" do
     Collavre::User.where(system_admin: true).update_all(system_admin: false)
     get collavre.desktop_setup_path(step: :account, locale: :en)

--- a/engines/collavre/test/controllers/desktop_setup_controller_test.rb
+++ b/engines/collavre/test/controllers/desktop_setup_controller_test.rb
@@ -1,4 +1,5 @@
 require "test_helper"
+require Rails.root.join("engines/collavre/db/migrate/20260810100000_add_desktop_managed_to_agent_gateways")
 
 class DesktopSetupControllerTest < ActionDispatch::IntegrationTest
   setup do
@@ -140,6 +141,23 @@ class DesktopSetupControllerTest < ActionDispatch::IntegrationTest
     assert_equal "https://unrelated.example.test", unrelated_gateway.base_url
     assert_equal "unrelated-admin-key", unrelated_gateway.admin_key
     assert_not_predicate unrelated_gateway, :desktop_managed?
+  end
+
+  test "migration marks the unambiguous legacy desktop gateway" do
+    users(:one).update!(system_admin: true)
+    legacy_gateway = Collavre::AgentGateway.create!(
+      owner: users(:one),
+      name: Collavre::DesktopSetupController::DESKTOP_GATEWAY_NAME,
+      base_url: "http://127.0.0.1:35000",
+      admin_key: "legacy-admin-key",
+      completion_key: "legacy-completion-key",
+      identity_secret: "l" * 48,
+      tenant_id: "collavre-desktop"
+    )
+
+    AddDesktopManagedToAgentGateways.new.migrate(:up)
+
+    assert_predicate legacy_gateway.reload, :desktop_managed?
   end
 
   test "registration rejects a missing native grant" do

--- a/engines/collavre/test/controllers/desktop_setup_controller_test.rb
+++ b/engines/collavre/test/controllers/desktop_setup_controller_test.rb
@@ -47,6 +47,28 @@ class DesktopSetupControllerTest < ActionDispatch::IntegrationTest
     assert_response :unprocessable_entity
   end
 
+  test "first administrator creation rejects non-loopback requests" do
+    Collavre::User.where(system_admin: true).update_all(system_admin: false)
+
+    post collavre.desktop_setup_account_path,
+         params: { admin: { name: "Remote", email: "remote@desktop.test", password: "secure-password", password_confirmation: "secure-password" } },
+         headers: { "REMOTE_ADDR" => "10.0.0.25" }
+
+    assert_response :forbidden
+    assert_nil Collavre::User.find_by(email: "remote@desktop.test")
+  end
+
+  test "an existing administrator returns to incomplete setup after login" do
+    owner = users(:one)
+    owner.update!(email_verified_at: Time.current)
+    get collavre.desktop_setup_path
+
+    assert_redirected_to collavre.new_session_path
+    post collavre.session_path, params: { email: owner.email, password: "password" }
+
+    assert_redirected_to collavre.desktop_setup_path(step: :install)
+  end
+
   test "setup renders actual account controls and dynamic adapter statuses" do
     Collavre::User.where(system_admin: true).update_all(system_admin: false)
     get collavre.desktop_setup_path(step: :account, locale: :en)

--- a/engines/collavre/test/controllers/desktop_setup_controller_test.rb
+++ b/engines/collavre/test/controllers/desktop_setup_controller_test.rb
@@ -164,6 +164,17 @@ class DesktopSetupControllerTest < ActionDispatch::IntegrationTest
     assert_select "[data-controller='desktop-proxy-setup']"
   end
 
+  test "an authenticated non-administrator can switch to the owner during recovery" do
+    sign_in_as(users(:two), password: "password")
+
+    get collavre.desktop_setup_path(step: :install)
+
+    assert_response :success
+    assert_select "form[action='#{collavre.session_path}'] input[name='_method'][value='delete']"
+    assert_select "a[href='#{collavre.new_session_path}']"
+    assert_select "[data-controller='desktop-proxy-setup']", count: 0
+  end
+
   test "setup renders actual account controls and dynamic adapter statuses" do
     Collavre::User.where(system_admin: true).update_all(system_admin: false)
     get collavre.desktop_setup_path(step: :account, locale: :en)

--- a/engines/collavre/test/controllers/desktop_setup_controller_test.rb
+++ b/engines/collavre/test/controllers/desktop_setup_controller_test.rb
@@ -351,6 +351,35 @@ class DesktopSetupControllerTest < ActionDispatch::IntegrationTest
     assert_response :unprocessable_entity
   end
 
+  test "native startup confirms the current desktop gateway credentials" do
+    gateway = Collavre::AgentGateway.create!(
+      owner: users(:one),
+      name: Collavre::DesktopSetupController::DESKTOP_GATEWAY_NAME,
+      base_url: "http://127.0.0.1:34567",
+      admin_key: "desktop-admin-key",
+      completion_key: "desktop-completion-key",
+      identity_secret: "i" * 48,
+      desktop_managed: true
+    )
+    params = {
+      proxy_port: 34_567,
+      admin_key: gateway.admin_key,
+      completion_key: gateway.completion_key,
+      identity_secret: gateway.identity_secret
+    }
+
+    post collavre.desktop_setup_gateway_registered_path, params: params, as: :json
+    assert_response :no_content
+
+    post collavre.desktop_setup_gateway_registered_path,
+         params: params.merge(completion_key: "replaced-key"), as: :json
+    assert_response :not_found
+
+    gateway.destroy!
+    post collavre.desktop_setup_gateway_registered_path, params: params, as: :json
+    assert_response :not_found
+  end
+
   test "first administrator creation rejects non-loopback requests" do
     Collavre::User.where(system_admin: true).update_all(system_admin: false)
 

--- a/engines/collavre/test/controllers/desktop_setup_controller_test.rb
+++ b/engines/collavre/test/controllers/desktop_setup_controller_test.rb
@@ -391,6 +391,18 @@ class DesktopSetupControllerTest < ActionDispatch::IntegrationTest
     assert_nil Collavre::User.find_by(email: "remote@desktop.test")
   end
 
+  test "first administrator creation rejects a forwarded loopback address from a LAN peer" do
+    Collavre::User.where(system_admin: true).update_all(system_admin: false)
+
+    post collavre.desktop_setup_account_path,
+      params: { admin: { name: "Spoofed", email: "spoofed@desktop.test", password: "secure-password", password_confirmation: "secure-password" } },
+      env: { "REMOTE_ADDR" => "192.168.1.50" },
+      headers: { "X-Forwarded-For" => "127.0.0.1" }
+
+    assert_response :forbidden
+    assert_nil Collavre::User.find_by(email: "spoofed@desktop.test")
+  end
+
   test "first administrator creation is unavailable outside desktop mode" do
     Collavre::User.where(system_admin: true).update_all(system_admin: false)
     Rails.application.config.x.desktop_proxy_setup = false

--- a/engines/collavre/test/controllers/desktop_setup_controller_test.rb
+++ b/engines/collavre/test/controllers/desktop_setup_controller_test.rb
@@ -200,6 +200,21 @@ class DesktopSetupControllerTest < ActionDispatch::IntegrationTest
     assert_response :unprocessable_entity
   end
 
+  test "native setup consent validation accepts only a current administrator grant" do
+    owner = users(:one)
+    sign_in_as(owner, password: "password")
+    post collavre.desktop_setup_registration_token_path
+    token = response.parsed_body.fetch("token")
+
+    post collavre.desktop_setup_validate_registration_grant_path,
+         params: { registration_token: token }, as: :json
+    assert_response :no_content
+
+    post collavre.desktop_setup_validate_registration_grant_path,
+         params: { registration_token: "invalid" }, as: :json
+    assert_response :unprocessable_entity
+  end
+
   test "first administrator creation rejects non-loopback requests" do
     Collavre::User.where(system_admin: true).update_all(system_admin: false)
 

--- a/engines/collavre/test/controllers/desktop_sidecar_health_controller_test.rb
+++ b/engines/collavre/test/controllers/desktop_sidecar_health_controller_test.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class DesktopSidecarHealthControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @previous_secret = ENV["COLLAVRE_DESKTOP_SIDECAR_SECRET"]
+    @secret = "desktop-sidecar-test-secret"
+    ENV["COLLAVRE_DESKTOP_SIDECAR_SECRET"] = @secret
+  end
+
+  teardown do
+    ENV["COLLAVRE_DESKTOP_SIDECAR_SECRET"] = @previous_secret
+  end
+
+  test "returns an HMAC proof for the native sidecar challenge" do
+    challenge = "native-challenge"
+
+    get collavre.desktop_setup_sidecar_health_path, params: { challenge: challenge }
+
+    assert_response :success
+    expected = Base64.urlsafe_encode64(OpenSSL::HMAC.digest("SHA256", @secret, challenge), padding: false)
+    assert_equal expected, response.body
+  end
+
+  test "rejects remote sidecar health requests" do
+    get collavre.desktop_setup_sidecar_health_path,
+        params: { challenge: "native-challenge" },
+        headers: { "REMOTE_ADDR" => "10.0.0.25" }
+
+    assert_response :forbidden
+  end
+end

--- a/engines/collavre/test/models/agent_gateway_test.rb
+++ b/engines/collavre/test/models/agent_gateway_test.rb
@@ -99,6 +99,23 @@ class AgentGatewayTest < ActiveSupport::TestCase
     assert admin_gateway.valid?, admin_gateway.errors.full_messages.to_sentence
   end
 
+  test "only the signed desktop registration flow can retarget a desktop-managed gateway" do
+    gateway = build_gateway(
+      base_url: "http://127.0.0.1:34567",
+      desktop_managed: true,
+      identity_secret: "i" * 32
+    )
+    gateway.save!
+
+    assert_not gateway.update(base_url: "http://127.0.0.1:45678")
+    assert_includes gateway.errors.details[:base_url].pluck(:error), :immutable
+    assert_equal "http://127.0.0.1:34567", gateway.reload.base_url
+
+    gateway.update_from_desktop_registration!(base_url: "http://127.0.0.1:45678")
+
+    assert_equal "http://127.0.0.1:45678", gateway.reload.base_url
+  end
+
   test "switching to shared replaces per-user workspaces with an isolated shared workspace" do
     gateway = build_gateway(identity_secret: "s" * 32)
     gateway.save!

--- a/engines/collavre/test/models/agent_gateway_test.rb
+++ b/engines/collavre/test/models/agent_gateway_test.rb
@@ -99,7 +99,7 @@ class AgentGatewayTest < ActiveSupport::TestCase
     assert admin_gateway.valid?, admin_gateway.errors.full_messages.to_sentence
   end
 
-  test "only the signed desktop registration flow can retarget a desktop-managed gateway" do
+  test "only the signed desktop registration flow can change desktop-managed native configuration" do
     gateway = build_gateway(
       base_url: "http://127.0.0.1:34567",
       desktop_managed: true,
@@ -111,9 +111,29 @@ class AgentGatewayTest < ActiveSupport::TestCase
     assert_includes gateway.errors.details[:base_url].pluck(:error), :immutable
     assert_equal "http://127.0.0.1:34567", gateway.reload.base_url
 
-    gateway.update_from_desktop_registration!(base_url: "http://127.0.0.1:45678")
+    assert_not gateway.update(
+      admin_key: "replacement-admin",
+      completion_key: "replacement-completion",
+      identity_secret: "r" * 32
+    )
+    %i[admin_key completion_key identity_secret].each do |attribute|
+      assert_includes gateway.errors.details[attribute].pluck(:error), :immutable
+    end
+    assert_equal "admin", gateway.reload.admin_key
+    assert_equal "completion", gateway.completion_key
+    assert_equal "i" * 32, gateway.identity_secret
+
+    gateway.update_from_desktop_registration!(
+      base_url: "http://127.0.0.1:45678",
+      admin_key: "replacement-admin",
+      completion_key: "replacement-completion",
+      identity_secret: "r" * 32
+    )
 
     assert_equal "http://127.0.0.1:45678", gateway.reload.base_url
+    assert_equal "replacement-admin", gateway.admin_key
+    assert_equal "replacement-completion", gateway.completion_key
+    assert_equal "r" * 32, gateway.identity_secret
   end
 
   test "desktop-managed gateways remain in shared workspace mode" do

--- a/engines/collavre/test/models/agent_gateway_test.rb
+++ b/engines/collavre/test/models/agent_gateway_test.rb
@@ -136,6 +136,30 @@ class AgentGatewayTest < ActiveSupport::TestCase
     assert_equal "r" * 32, gateway.identity_secret
   end
 
+  test "desktop-managed credential errors are translated in every supported locale" do
+    gateway = build_gateway(
+      base_url: "http://127.0.0.1:34567",
+      desktop_managed: true,
+      identity_secret: "i" * 32
+    )
+    gateway.save!
+
+    %i[en ko].each do |locale|
+      I18n.with_locale(locale) do
+        gateway.assign_attributes(
+          admin_key: "replacement-admin",
+          completion_key: "replacement-completion",
+          identity_secret: "r" * 32
+        )
+
+        assert_not gateway.valid?
+        gateway.errors.full_messages.each do |message|
+          assert_no_match(/translation missing/i, message, "untranslated desktop credential error in #{locale}: #{message}")
+        end
+      end
+    end
+  end
+
   test "desktop-managed gateways remain in shared workspace mode" do
     gateway = build_gateway(
       base_url: "http://127.0.0.1:34567",

--- a/engines/collavre/test/models/agent_gateway_test.rb
+++ b/engines/collavre/test/models/agent_gateway_test.rb
@@ -116,6 +116,19 @@ class AgentGatewayTest < ActiveSupport::TestCase
     assert_equal "http://127.0.0.1:45678", gateway.reload.base_url
   end
 
+  test "desktop-managed gateways remain in shared workspace mode" do
+    gateway = build_gateway(
+      base_url: "http://127.0.0.1:34567",
+      desktop_managed: true,
+      identity_secret: "i" * 32
+    )
+    gateway.save!
+
+    assert_not gateway.update(workspace_mode: :per_user)
+    assert_includes gateway.errors.details[:workspace_mode].pluck(:error), :desktop_shared_only
+    assert_predicate gateway.reload, :shared?
+  end
+
   test "switching to shared replaces per-user workspaces with an isolated shared workspace" do
     gateway = build_gateway(identity_secret: "s" * 32)
     gateway.save!

--- a/engines/collavre/test/services/ai_client_test.rb
+++ b/engines/collavre/test/services/ai_client_test.rb
@@ -709,6 +709,44 @@ class AiClientTest < ActiveSupport::TestCase
     assert_equal original_adapter, context_config.faraday_adapter
   end
 
+  test "desktop loopback CLI Proxy gateways retain the default HTTP adapter after owner demotion" do
+    owner = users(:two)
+    owner.update!(system_admin: true)
+    gateway = Collavre::AgentGateway.create!(
+      owner: owner,
+      name: "Demoted owner desktop proxy",
+      base_url: "http://127.0.0.1:3456",
+      admin_key: "admin",
+      completion_key: "completion-secret",
+      desktop_managed: true
+    )
+    agent = Collavre::User.create!(
+      name: "Desktop CLI client agent",
+      email: "desktop-cli-client-agent@ai.local",
+      password: SecureRandom.hex(24),
+      system_prompt: "Help",
+      llm_vendor: "cli_proxy",
+      llm_model: "paperclip/claude_local",
+      created_by_id: owner.id,
+      agent_gateway: gateway
+    )
+    owner.update!(system_admin: false)
+    client = AiClient.new(vendor: "cli_proxy", model: agent.llm_model, system_prompt: nil, context: { user: agent })
+    fake_chat = FakeConversation.new
+    context_config = RubyLLM.config.dup
+    original_adapter = context_config.faraday_adapter
+    mock_context = Object.new
+    mock_context.define_singleton_method(:chat) { |**| fake_chat }
+
+    RubyLLM.stub(:context, ->(&block) { block.call(context_config); mock_context }) do
+      client.send(:build_conversation)
+    end
+
+    assert_not_predicate gateway.owner.reload, :system_admin?
+    assert_equal "http://127.0.0.1:3456/v1", context_config.openai_api_base
+    assert_equal original_adapter, context_config.faraday_adapter
+  end
+
   private
 
   def build_conversation_with_context(context_hash = {})

--- a/tools/desktop-app/README.md
+++ b/tools/desktop-app/README.md
@@ -105,21 +105,25 @@ its supplied SHA-256, requires a Darwin ARM64 runtime, then resolves and locks
 the exact npm package before `npm ci` installs it. The generated lockfile keeps
 the resolved tarball integrity values inside the signed application bundle.
 
-Tauri exposes two internal setup commands for the first-run wizard:
+Tauri exposes internal setup commands for the first-run wizard:
 
 - `desktop_proxy_install` creates a persistent loopback port, creates the
   proxy's admin and completion keys in the macOS Keychain if needed, then starts
   the embedded proxy.
 - `desktop_proxy_status` returns installation/process status and the public
   port/version only. It never returns either secret.
+- `desktop_proxy_complete_setup` detects executable availability for Claude
+  Code/Codex without running either CLI, then sends Keychain-held proxy secrets
+  directly to a short-lived, loopback-only Rails registration endpoint. It
+  registers the local Gateway and creates presets only for detected adapters.
 
-The setup UI must call `desktop_proxy_install` only after explicit consent. On
-later launches, a previously approved proxy is restarted automatically. The
-proxy keeps the user's `HOME` and `PATH` so existing Claude/Codex logins remain
-usable, but its own mutable provision state stays under the Collavre app-data
-directory. Gateway registration is intentionally a separate authenticated Rails
-step: it must pass the locally held completion key to the selected Collavre
-administrator without logging or displaying it.
+The setup UI calls `desktop_proxy_complete_setup` only after explicit consent
+and a locally created or signed-in administrator account. On later launches, a
+registered proxy is restarted automatically and the normal Collavre home opens.
+The proxy keeps the user's `HOME` and an executable-only PATH so existing
+Claude/Codex logins remain usable, but its own mutable provision state stays
+under the Collavre app-data directory. No existing provider credential or
+configuration is read, displayed, or sent externally.
 
 ## Run without packaging (verified)
 

--- a/tools/desktop-app/README.md
+++ b/tools/desktop-app/README.md
@@ -55,6 +55,7 @@ tools/desktop-app/
   scripts/
     provision-secrets.rb     # first-run SECRET_KEY_BASE (stable; keys derive from it)
     bundle-ruby.sh           # vendor portable Ruby + app gems
+    bundle-proxy.sh          # bundle a pinned npm proxy + private Node runtime
     build-macos.sh           # stage app + precompile assets + tauri build
 ```
 
@@ -79,8 +80,46 @@ All mutable state lives under the OS app-data dir (the `.app` is read-only):
   storage/            # Active Storage blobs
   credentials/secret_key_base
   config.json         # optional: open-mode settings for a Finder-launched .app
+  proxy/config.json   # public proxy port + bundled version; never credentials
   log/desktop.log
+  log/desktop-proxy.log
 ```
+
+## cli-openai-proxy
+
+The desktop release embeds one Apple-Silicon Node runtime and one exact
+published `cli-openai-proxy` version. It does not use Homebrew, a global npm
+install, or the user's `node` binary at runtime.
+
+The release job supplies all of these build inputs:
+
+```bash
+CLI_OPENAI_PROXY_VERSION=0.1.0
+NODE_RUNTIME_URL=https://nodejs.org/dist/v<node-version>/node-v<node-version>-darwin-arm64.tar.xz
+NODE_RUNTIME_SHA256=<official-node-sha256>
+tools/desktop-app/scripts/build-macos.sh
+```
+
+`bundle-proxy.sh` downloads the official Node archive only over HTTPS, verifies
+its supplied SHA-256, requires a Darwin ARM64 runtime, then resolves and locks
+the exact npm package before `npm ci` installs it. The generated lockfile keeps
+the resolved tarball integrity values inside the signed application bundle.
+
+Tauri exposes two internal setup commands for the first-run wizard:
+
+- `desktop_proxy_install` creates a persistent loopback port, creates the
+  proxy's admin and completion keys in the macOS Keychain if needed, then starts
+  the embedded proxy.
+- `desktop_proxy_status` returns installation/process status and the public
+  port/version only. It never returns either secret.
+
+The setup UI must call `desktop_proxy_install` only after explicit consent. On
+later launches, a previously approved proxy is restarted automatically. The
+proxy keeps the user's `HOME` and `PATH` so existing Claude/Codex logins remain
+usable, but its own mutable provision state stays under the Collavre app-data
+directory. Gateway registration is intentionally a separate authenticated Rails
+step: it must pass the locally held completion key to the selected Collavre
+administrator without logging or displaying it.
 
 ## Run without packaging (verified)
 

--- a/tools/desktop-app/README.md
+++ b/tools/desktop-app/README.md
@@ -107,9 +107,6 @@ the resolved tarball integrity values inside the signed application bundle.
 
 Tauri exposes internal setup commands for the first-run wizard:
 
-- `desktop_proxy_install` creates a persistent loopback port, creates the
-  proxy's admin and completion keys in the macOS Keychain if needed, then starts
-  the embedded proxy.
 - `desktop_proxy_status` returns installation/process status and the public
   port/version only. It never returns either secret.
 - `desktop_proxy_complete_setup` detects executable availability for Claude

--- a/tools/desktop-app/scripts/build-macos.sh
+++ b/tools/desktop-app/scripts/build-macos.sh
@@ -149,6 +149,24 @@ BUNDLED_RUBY="$TAURI_TARGET_DIR/release/bundle/macos/Collavre Desktop.app/Conten
 }
 "$BUNDLED_RUBY" -v
 
+# ruby-build embeds the original build prefix in Ruby's default $LOAD_PATH.
+# Exercise the packaged runtime with only its copied standard library available;
+# otherwise a build Mac can hide this failure because its checkout still exists.
+PACKAGED_RUBY_ROOT="${BUNDLED_RUBY%/bin/ruby}"
+PACKAGED_RUBY_STDLIB_DIR="$(find "$PACKAGED_RUBY_ROOT/lib/ruby" -mindepth 1 -maxdepth 1 -type d -name '[0-9]*.[0-9]*.[0-9]*' -print -quit)"
+[ -n "$PACKAGED_RUBY_STDLIB_DIR" ] || {
+  echo "[build-macos] packaged Ruby standard library is missing" >&2
+  exit 1
+}
+PACKAGED_RUBY_ARCH_DIR="$(find "$PACKAGED_RUBY_STDLIB_DIR" -mindepth 1 -maxdepth 1 -type d -name '*-darwin*' -print -quit)"
+PACKAGED_RUBY_TEST_DATA="$(mktemp -d)"
+trap 'rm -rf "$PACKAGED_RUBY_TEST_DATA"' EXIT
+env -i \
+  PATH=/usr/bin:/bin \
+  COLLAVRE_DATA_DIR="$PACKAGED_RUBY_TEST_DATA" \
+  RUBYLIB="$PACKAGED_RUBY_STDLIB_DIR${PACKAGED_RUBY_ARCH_DIR:+:$PACKAGED_RUBY_ARCH_DIR}" \
+  "$BUNDLED_RUBY" "$APP_ROOT/tools/desktop-app/scripts/provision-secrets.rb" >/dev/null
+
 # A Ruby executable can start on the build Mac even when one of its Mach-O load
 # commands still names the checkout. Reject that non-relocatable bundle here,
 # before a DMG can be handed to another Mac.

--- a/tools/desktop-app/scripts/build-macos.sh
+++ b/tools/desktop-app/scripts/build-macos.sh
@@ -79,6 +79,11 @@ rsync -a --delete \
   --exclude 'tools/desktop-app/src-tauri/target' \
   "$APP_ROOT/" "$STAGING/"
 
+# Rails creates runtime files below Rails.root/tmp when starting the server.
+# The app bundle is read-only once distributed, so the directory itself must
+# already exist in the staged app even though its contents stay excluded.
+mkdir -p "$STAGING/tmp/pids"
+
 # tauri-build opens every staged file to bundle it as a resource; if any file is
 # not owner-readable the resource walk aborts with EACCES. A mode-only `chmod -R`
 # is not enough: on a managed/corporate Mac the checkout can carry inherited ACLs

--- a/tools/desktop-app/scripts/build-macos.sh
+++ b/tools/desktop-app/scripts/build-macos.sh
@@ -149,6 +149,14 @@ BUNDLED_RUBY="$TAURI_TARGET_DIR/release/bundle/macos/Collavre Desktop.app/Conten
 }
 "$BUNDLED_RUBY" -v
 
+# A Ruby executable can start on the build Mac even when one of its Mach-O load
+# commands still names the checkout. Reject that non-relocatable bundle here,
+# before a DMG can be handed to another Mac.
+if otool -L "$BUNDLED_RUBY" | grep -qF "$APP_ROOT/tools/desktop-app/vendor/ruby"; then
+  echo "[build-macos] packaged Ruby still references the build checkout" >&2
+  exit 1
+fi
+
 echo "[build-macos] done →"
 echo "  $DESKTOP_DIR/src-tauri/target/release/bundle/macos/Collavre Desktop.app"
 echo "Run it once via: right-click → Open (unsigned, Gatekeeper)."

--- a/tools/desktop-app/scripts/build-macos.sh
+++ b/tools/desktop-app/scripts/build-macos.sh
@@ -31,6 +31,15 @@ else
 fi
 export CARGO_TARGET_DIR="$TAURI_TARGET_DIR"
 
+# A custom target can live inside the source tree (for example, a relative
+# CARGO_TARGET_DIR). Exclude it from staging so a previous bundle's resource
+# copy is never embedded into the next application bundle.
+STAGING_EXCLUDES=()
+if [[ "$TAURI_TARGET_DIR" == "$APP_ROOT/"* ]]; then
+  TAURI_TARGET_STAGING_PATH="${TAURI_TARGET_DIR#"$APP_ROOT"/}"
+  STAGING_EXCLUDES+=(--exclude "/$TAURI_TARGET_STAGING_PATH/***")
+fi
+
 echo "[build-macos] 1/7 vendoring Ruby + gems"
 "$SCRIPT_DIR/bundle-ruby.sh"
 
@@ -90,6 +99,7 @@ rsync -a --delete \
   --exclude 'config/credentials/*.key' \
   --exclude 'tools/desktop-app/staging' \
   --exclude 'tools/desktop-app/src-tauri/target' \
+  "${STAGING_EXCLUDES[@]}" \
   "$APP_ROOT/" "$STAGING/"
 
 # Rails creates runtime files below Rails.root/tmp when starting the server.

--- a/tools/desktop-app/scripts/build-macos.sh
+++ b/tools/desktop-app/scripts/build-macos.sh
@@ -137,6 +137,15 @@ echo "[build-macos] 7/7 building the Tauri bundle"
   CI="${CI:-true}" cargo tauri build
 )
 
+# Verify the exact runtime copied into the .app, not merely the source vendor
+# directory. A desktop bundle must never rely on a target Mac's system Ruby.
+BUNDLED_RUBY="$DESKTOP_DIR/src-tauri/target/release/bundle/macos/Collavre Desktop.app/Contents/Resources/app/tools/desktop-app/vendor/ruby/bin/ruby"
+[ -x "$BUNDLED_RUBY" ] || {
+  echo "[build-macos] packaged Ruby is missing or not executable: $BUNDLED_RUBY" >&2
+  exit 1
+}
+"$BUNDLED_RUBY" -v
+
 echo "[build-macos] done →"
 echo "  $DESKTOP_DIR/src-tauri/target/release/bundle/macos/Collavre Desktop.app"
 echo "Run it once via: right-click → Open (unsigned, Gatekeeper)."

--- a/tools/desktop-app/scripts/build-macos.sh
+++ b/tools/desktop-app/scripts/build-macos.sh
@@ -66,6 +66,7 @@ rsync -a --delete \
   --exclude 'log/*' \
   --exclude 'tmp/*' \
   --exclude 'storage/*' \
+  --exclude '/tools/desktop-app/vendor/proxy/***' \
   --include 'tools/desktop-app/vendor/**' \
   --exclude 'test' \
   --exclude 'spec' \

--- a/tools/desktop-app/scripts/build-macos.sh
+++ b/tools/desktop-app/scripts/build-macos.sh
@@ -17,6 +17,9 @@ SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DESKTOP_DIR="$(cd -P "$SCRIPT_DIR/.." && pwd)"
 APP_ROOT="$(cd -P "$DESKTOP_DIR/../.." && pwd)"
 STAGING="$DESKTOP_DIR/staging/app"
+# An absolute CARGO_TARGET_DIR lets release builds reuse a verified Cargo cache
+# without changing where staging or the final bundle are resolved.
+TAURI_TARGET_DIR="${CARGO_TARGET_DIR:-$DESKTOP_DIR/src-tauri/target}"
 
 echo "[build-macos] 1/7 vendoring Ruby + gems"
 "$SCRIPT_DIR/bundle-ruby.sh"
@@ -122,7 +125,7 @@ ICON_SRC="$(ls "$APP_ROOT"/public/icon-*.png 2>/dev/null | head -1)"
 # which cargo never cleans. Make any prior copy tree owner-writable so the re-copy
 # can overwrite it. chmod (not rm): if the build script doesn't re-run, the existing
 # copies must stay in place or the bundle loses its resources.
-for app_copy in "$DESKTOP_DIR/src-tauri/target"/*/app; do
+for app_copy in "$TAURI_TARGET_DIR"/*/app; do
   [ -d "$app_copy" ] && chmod -R u+w "$app_copy" 2>/dev/null || true
 done
 
@@ -139,7 +142,7 @@ echo "[build-macos] 7/7 building the Tauri bundle"
 
 # Verify the exact runtime copied into the .app, not merely the source vendor
 # directory. A desktop bundle must never rely on a target Mac's system Ruby.
-BUNDLED_RUBY="$DESKTOP_DIR/src-tauri/target/release/bundle/macos/Collavre Desktop.app/Contents/Resources/app/tools/desktop-app/vendor/ruby/bin/ruby"
+BUNDLED_RUBY="$TAURI_TARGET_DIR/release/bundle/macos/Collavre Desktop.app/Contents/Resources/app/tools/desktop-app/vendor/ruby/bin/ruby"
 [ -x "$BUNDLED_RUBY" ] || {
   echo "[build-macos] packaged Ruby is missing or not executable: $BUNDLED_RUBY" >&2
   exit 1

--- a/tools/desktop-app/scripts/build-macos.sh
+++ b/tools/desktop-app/scripts/build-macos.sh
@@ -17,9 +17,19 @@ SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DESKTOP_DIR="$(cd -P "$SCRIPT_DIR/.." && pwd)"
 APP_ROOT="$(cd -P "$DESKTOP_DIR/../.." && pwd)"
 STAGING="$DESKTOP_DIR/staging/app"
-# An absolute CARGO_TARGET_DIR lets release builds reuse a verified Cargo cache
-# without changing where staging or the final bundle are resolved.
-TAURI_TARGET_DIR="${CARGO_TARGET_DIR:-$DESKTOP_DIR/src-tauri/target}"
+TAURI_SOURCE_DIR="$(cd -P "$DESKTOP_DIR/src-tauri" && pwd)"
+# Resolve a caller-provided relative CARGO_TARGET_DIR where Cargo resolves it:
+# from src-tauri. Export the normalized value too, so Cargo and the post-build
+# checks below always operate on the same directory.
+if [ -n "${CARGO_TARGET_DIR:-}" ]; then
+  case "$CARGO_TARGET_DIR" in
+    /*) TAURI_TARGET_DIR="$CARGO_TARGET_DIR" ;;
+    *) TAURI_TARGET_DIR="$TAURI_SOURCE_DIR/$CARGO_TARGET_DIR" ;;
+  esac
+else
+  TAURI_TARGET_DIR="$TAURI_SOURCE_DIR/target"
+fi
+export CARGO_TARGET_DIR="$TAURI_TARGET_DIR"
 
 echo "[build-macos] 1/7 vendoring Ruby + gems"
 "$SCRIPT_DIR/bundle-ruby.sh"
@@ -175,7 +185,7 @@ env -i \
   RAILS_ENV=desktop \
   SECRET_KEY_BASE=0123456789012345678901234567890123456789012345678901234567890123 \
   "$BUNDLED_RUBY" "$PACKAGED_APP_ROOT/bin/rails" runner \
-  'abort "stale Ruby load path" if $LOAD_PATH.any? { |path| path.start_with?(RbConfig::CONFIG.fetch("prefix")) }; abort "wrong Prism version" unless Gem.loaded_specs.fetch("prism").version.to_s == "1.9.0"' >/dev/null
+  'require "shellwords"; build_prefix = Shellwords.shellsplit(RbConfig::CONFIG.fetch("configure_args")).find { |argument| argument.start_with?("--prefix=") }&.delete_prefix("--prefix="); abort "Ruby build prefix is unavailable" unless build_prefix; abort "stale Ruby load path" if $LOAD_PATH.any? { |path| path == build_prefix || path.start_with?("#{build_prefix}/") }; abort "wrong Prism version" unless Gem.loaded_specs.fetch("prism").version.to_s == "1.9.0"' >/dev/null
 
 # A Ruby executable can start on the build Mac even when one of its Mach-O load
 # commands still names the checkout. Reject that non-relocatable bundle here,
@@ -186,5 +196,5 @@ if otool -L "$BUNDLED_RUBY" | grep -qF "$APP_ROOT/tools/desktop-app/vendor/ruby"
 fi
 
 echo "[build-macos] done →"
-echo "  $DESKTOP_DIR/src-tauri/target/release/bundle/macos/Collavre Desktop.app"
+echo "  $TAURI_TARGET_DIR/release/bundle/macos/Collavre Desktop.app"
 echo "Run it once via: right-click → Open (unsigned, Gatekeeper)."

--- a/tools/desktop-app/scripts/build-macos.sh
+++ b/tools/desktop-app/scripts/build-macos.sh
@@ -149,23 +149,33 @@ BUNDLED_RUBY="$TAURI_TARGET_DIR/release/bundle/macos/Collavre Desktop.app/Conten
 }
 "$BUNDLED_RUBY" -v
 
-# ruby-build embeds the original build prefix in Ruby's default $LOAD_PATH.
-# Exercise the packaged runtime with only its copied standard library available;
-# otherwise a build Mac can hide this failure because its checkout still exists.
+# Ruby is built with --enable-load-relative, so exercise the packaged runtime
+# with no RUBYLIB override. This verifies that it resolves its standard library
+# from inside the app without prioritizing Ruby's bundled Prism over Bundler's.
 PACKAGED_RUBY_ROOT="${BUNDLED_RUBY%/bin/ruby}"
-PACKAGED_RUBY_STDLIB_DIR="$(find "$PACKAGED_RUBY_ROOT/lib/ruby" -mindepth 1 -maxdepth 1 -type d -name '[0-9]*.[0-9]*.[0-9]*' -print -quit)"
-[ -n "$PACKAGED_RUBY_STDLIB_DIR" ] || {
-  echo "[build-macos] packaged Ruby standard library is missing" >&2
+PACKAGED_APP_ROOT="${PACKAGED_RUBY_ROOT%/tools/desktop-app/vendor/ruby}"
+packaged_load_relative="$("$BUNDLED_RUBY" -rrbconfig -e 'print RbConfig::CONFIG.fetch("LIBRUBY_RELATIVE")')"
+[ "$packaged_load_relative" = "yes" ] || {
+  echo "[build-macos] packaged Ruby is not self-relocating" >&2
   exit 1
 }
-PACKAGED_RUBY_ARCH_DIR="$(find "$PACKAGED_RUBY_STDLIB_DIR" -mindepth 1 -maxdepth 1 -type d -name '*-darwin*' -print -quit)"
 PACKAGED_RUBY_TEST_DATA="$(mktemp -d)"
 trap 'rm -rf "$PACKAGED_RUBY_TEST_DATA"' EXIT
 env -i \
   PATH=/usr/bin:/bin \
   COLLAVRE_DATA_DIR="$PACKAGED_RUBY_TEST_DATA" \
-  RUBYLIB="$PACKAGED_RUBY_STDLIB_DIR${PACKAGED_RUBY_ARCH_DIR:+:$PACKAGED_RUBY_ARCH_DIR}" \
-  "$BUNDLED_RUBY" "$APP_ROOT/tools/desktop-app/scripts/provision-secrets.rb" >/dev/null
+  "$BUNDLED_RUBY" "$PACKAGED_APP_ROOT/tools/desktop-app/scripts/provision-secrets.rb" >/dev/null
+env -i \
+  PATH="$PACKAGED_RUBY_ROOT/bin:/usr/bin:/bin" \
+  BUNDLE_GEMFILE="$PACKAGED_APP_ROOT/Gemfile" \
+  BUNDLE_PATH="$PACKAGED_APP_ROOT/tools/desktop-app/vendor/bundle" \
+  BUNDLE_WITHOUT="development:test:production" \
+  BUNDLE_WITH="desktop" \
+  COLLAVRE_DATA_DIR="$PACKAGED_RUBY_TEST_DATA" \
+  RAILS_ENV=desktop \
+  SECRET_KEY_BASE=0123456789012345678901234567890123456789012345678901234567890123 \
+  "$BUNDLED_RUBY" "$PACKAGED_APP_ROOT/bin/rails" runner \
+  'abort "stale Ruby load path" if $LOAD_PATH.any? { |path| path.start_with?(RbConfig::CONFIG.fetch("prefix")) }; abort "wrong Prism version" unless Gem.loaded_specs.fetch("prism").version.to_s == "1.9.0"' >/dev/null
 
 # A Ruby executable can start on the build Mac even when one of its Mach-O load
 # commands still names the checkout. Reject that non-relocatable bundle here,

--- a/tools/desktop-app/scripts/build-macos.sh
+++ b/tools/desktop-app/scripts/build-macos.sh
@@ -18,14 +18,45 @@ DESKTOP_DIR="$(cd -P "$SCRIPT_DIR/.." && pwd)"
 APP_ROOT="$(cd -P "$DESKTOP_DIR/../.." && pwd)"
 STAGING="$DESKTOP_DIR/staging/app"
 TAURI_SOURCE_DIR="$(cd -P "$DESKTOP_DIR/src-tauri" && pwd)"
+# Cargo accepts target directories that do not exist yet, so `realpath` cannot
+# normalize them reliably. Collapse lexical `.` and `..` components instead,
+# preserving Cargo's src-tauri-relative interpretation for both its output and
+# the staging exclusion below.
+normalize_target_dir() {
+	local path="$1"
+	local component
+	local last_index
+	local -a path_components=()
+	local -a normalized_components=()
+
+	[[ "$path" == /* ]] || path="$TAURI_SOURCE_DIR/$path"
+	IFS=/ read -r -a path_components <<< "$path"
+
+	for component in "${path_components[@]}"; do
+		case "$component" in
+			""|.) ;;
+			..)
+				if ((${#normalized_components[@]})); then
+					last_index=$((${#normalized_components[@]} - 1))
+					unset "normalized_components[$last_index]"
+				fi
+				;;
+			*) normalized_components+=("$component") ;;
+		esac
+	done
+
+	local normalized_path=""
+	for component in "${normalized_components[@]}"; do
+		normalized_path+="/$component"
+	done
+	printf '%s\n' "${normalized_path:-/}"
+}
+
 # Resolve a caller-provided relative CARGO_TARGET_DIR where Cargo resolves it:
 # from src-tauri. Export the normalized value too, so Cargo and the post-build
 # checks below always operate on the same directory.
 if [ -n "${CARGO_TARGET_DIR:-}" ]; then
-  case "$CARGO_TARGET_DIR" in
-    /*) TAURI_TARGET_DIR="$CARGO_TARGET_DIR" ;;
-    *) TAURI_TARGET_DIR="$TAURI_SOURCE_DIR/$CARGO_TARGET_DIR" ;;
-  esac
+  TAURI_TARGET_DIR="$(normalize_target_dir "$CARGO_TARGET_DIR")"
 else
   TAURI_TARGET_DIR="$TAURI_SOURCE_DIR/target"
 fi

--- a/tools/desktop-app/scripts/build-macos.sh
+++ b/tools/desktop-app/scripts/build-macos.sh
@@ -18,19 +18,22 @@ DESKTOP_DIR="$(cd -P "$SCRIPT_DIR/.." && pwd)"
 APP_ROOT="$(cd -P "$DESKTOP_DIR/../.." && pwd)"
 STAGING="$DESKTOP_DIR/staging/app"
 
-echo "[build-macos] 1/6 vendoring Ruby + gems"
+echo "[build-macos] 1/7 vendoring Ruby + gems"
 "$SCRIPT_DIR/bundle-ruby.sh"
+
+echo "[build-macos] 2/7 bundling cli-openai-proxy"
+"$SCRIPT_DIR/bundle-proxy.sh"
 
 # jsbundling-rails drives esbuild from node_modules during assets:precompile, so
 # the JS deps must be installed first (same as the Dockerfile/Render build). A
 # clean checkout or CI runner has no node_modules, so precompile fails without this.
-echo "[build-macos] 2/6 installing Node packages (npm ci)"
+echo "[build-macos] 3/7 installing Node packages (npm ci)"
 (
   cd "$APP_ROOT"
   npm ci
 )
 
-echo "[build-macos] 3/6 precompiling assets (desktop env)"
+echo "[build-macos] 4/7 precompiling assets (desktop env)"
 (
   cd "$APP_ROOT"
   export PATH="$DESKTOP_DIR/vendor/ruby/bin:$PATH"
@@ -41,7 +44,7 @@ echo "[build-macos] 3/6 precompiling assets (desktop env)"
     "$DESKTOP_DIR/vendor/ruby/bin/ruby" -S bundle exec rails assets:precompile
 )
 
-echo "[build-macos] 4/6 staging app tree into $STAGING"
+echo "[build-macos] 5/7 staging app tree into $STAGING"
 rm -rf "$DESKTOP_DIR/staging"
 mkdir -p "$STAGING"
 # Copy the app, excluding VCS, dev cruft, tests, and per-run state. The vendored
@@ -86,11 +89,17 @@ chmod -RN "$STAGING"                              # drop inherited/explicit ACLs
 chflags -R nouchg "$STAGING" 2>/dev/null || true  # clear immutable flags if present
 chmod -R u+rwX "$STAGING"                          # normalize POSIX mode bits
 
+# The proxy is a separate Tauri resource rather than part of the Rails source
+# tree. Its Node runtime and exact npm dependency tree are immutable after this
+# point and are covered by the same code signature as the final .app.
+mkdir -p "$STAGING/proxy"
+rsync -a --delete "$DESKTOP_DIR/vendor/proxy/" "$STAGING/proxy/"
+
 # Generate the Tauri icon set from the existing app icon. tauri.conf.json points
 # at src-tauri/icons/, which is .gitignored (generated, not committed) — without
 # this step `cargo tauri build` fails on a missing icon. Source of truth is the
 # app's own icon under public/, so the desktop app can't drift from the brand.
-echo "[build-macos] 5/6 generating app icons"
+echo "[build-macos] 6/7 generating app icons"
 ICON_SRC="$(ls "$APP_ROOT"/public/icon-*.png 2>/dev/null | head -1)"
 [ -n "$ICON_SRC" ] || { echo "no source icon at $APP_ROOT/public/icon-*.png"; exit 1; }
 (
@@ -111,7 +120,7 @@ for app_copy in "$DESKTOP_DIR/src-tauri/target"/*/app; do
   [ -d "$app_copy" ] && chmod -R u+w "$app_copy" 2>/dev/null || true
 done
 
-echo "[build-macos] 6/6 building the Tauri bundle"
+echo "[build-macos] 7/7 building the Tauri bundle"
 (
   cd "$DESKTOP_DIR/src-tauri"
   # CI=true makes Tauri's bundle_dmg.sh skip the AppleScript step that styles the

--- a/tools/desktop-app/scripts/bundle-proxy.sh
+++ b/tools/desktop-app/scripts/bundle-proxy.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Bundle the published cli-openai-proxy package and a private Node runtime into
+# the desktop app. This is a release-build step; it never installs a global npm
+# package and it never uses a user's Node installation at runtime.
+#
+# Required release inputs:
+#   CLI_OPENAI_PROXY_VERSION  Published, exact semver (defaults to 0.1.0)
+#   NODE_RUNTIME_URL          Official darwin-arm64 Node .tar.xz URL
+#   NODE_RUNTIME_SHA256       SHA-256 for exactly that archive
+#
+# NODE_RUNTIME_DIR may be supplied by a release job that has already fetched and
+# verified the runtime. It must contain bin/node and bin/npm. This is useful for
+# hermetic CI, but does not relax the npm lockfile verification below.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DESKTOP_DIR="$(cd -P "$SCRIPT_DIR/.." && pwd)"
+OUTPUT_DIR="$DESKTOP_DIR/vendor/proxy"
+PACKAGE_NAME="cli-openai-proxy"
+PACKAGE_VERSION="${CLI_OPENAI_PROXY_VERSION:-0.1.0}"
+NODE_RUNTIME_DIR="${NODE_RUNTIME_DIR:-}"
+NODE_RUNTIME_URL="${NODE_RUNTIME_URL:-}"
+NODE_RUNTIME_SHA256="${NODE_RUNTIME_SHA256:-}"
+
+fail() {
+  echo "[bundle-proxy] $*" >&2
+  exit 1
+}
+
+[[ "$PACKAGE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$ ]] || \
+  fail "CLI_OPENAI_PROXY_VERSION must be an exact semver, not a range"
+
+mkdir -p "$DESKTOP_DIR/vendor"
+stage="$(mktemp -d "$DESKTOP_DIR/vendor/.proxy.XXXXXX")"
+cleanup() { rm -rf "$stage"; }
+trap cleanup EXIT
+
+if [[ -n "$NODE_RUNTIME_DIR" ]]; then
+  [[ -x "$NODE_RUNTIME_DIR/bin/node" && -x "$NODE_RUNTIME_DIR/bin/npm" ]] || \
+    fail "NODE_RUNTIME_DIR must contain executable bin/node and bin/npm"
+  cp -R "$NODE_RUNTIME_DIR" "$stage/node"
+else
+  [[ -n "$NODE_RUNTIME_URL" && -n "$NODE_RUNTIME_SHA256" ]] || \
+    fail "NODE_RUNTIME_URL and NODE_RUNTIME_SHA256 are required when NODE_RUNTIME_DIR is not set"
+  [[ "$NODE_RUNTIME_URL" == https://nodejs.org/* ]] || \
+    fail "NODE_RUNTIME_URL must use the official nodejs.org HTTPS distribution"
+  archive="$stage/node-runtime.tar.xz"
+  curl --fail --location --proto '=https' --tlsv1.2 --output "$archive" "$NODE_RUNTIME_URL"
+  printf '%s  %s\n' "$NODE_RUNTIME_SHA256" "$archive" | shasum -a 256 -c -
+  tar -xJf "$archive" -C "$stage"
+  runtime_root="$(find "$stage" -mindepth 1 -maxdepth 1 -type d -name 'node-v*-darwin-arm64' -print -quit)"
+  [[ -n "$runtime_root" ]] || fail "Node archive is not a darwin-arm64 distribution"
+  mv "$runtime_root" "$stage/node"
+fi
+
+node_bin="$stage/node/bin/node"
+npm_bin="$stage/node/bin/npm"
+[[ "$("$node_bin" -p 'process.platform + ":" + process.arch')" == "darwin:arm64" ]] || \
+  fail "the bundled Node runtime must be darwin:arm64"
+node_version="$("$node_bin" --version)"
+export PATH="$stage/node/bin:$PATH"
+cd "$stage"
+
+# npm writes the release-local lockfile before installing. The subsequent install
+# uses that lockfile, including exact resolved tarball URLs and integrity values.
+cat > "$stage/package.json" <<EOF
+{
+  "private": true,
+  "name": "collavre-desktop-proxy-runtime",
+  "version": "1.0.0",
+  "dependencies": {
+    "$PACKAGE_NAME": "$PACKAGE_VERSION"
+  }
+}
+EOF
+
+# The registry is intentionally contacted only in the release build. The final
+# DMG contains the resolved dependency tree and has no first-run network install.
+"$npm_bin" install --package-lock-only --ignore-scripts
+"$npm_bin" install --omit=dev
+
+resolved_version="$("$node_bin" -p "require('./node_modules/$PACKAGE_NAME/package.json').version")"
+[[ "$resolved_version" == "$PACKAGE_VERSION" ]] || \
+  fail "npm resolved $PACKAGE_NAME@$resolved_version instead of $PACKAGE_VERSION"
+
+"$node_bin" -e '
+  const fs = require("fs");
+  const lock = JSON.parse(fs.readFileSync("package-lock.json", "utf8"));
+  const item = lock.packages && lock.packages["node_modules/cli-openai-proxy"];
+  if (!item || !item.resolved || !item.integrity) process.exit(1);
+'
+package_integrity="$("$node_bin" -p "JSON.parse(require('fs').readFileSync('package-lock.json', 'utf8')).packages['node_modules/$PACKAGE_NAME'].integrity")"
+
+cat > "$stage/manifest.json" <<EOF
+{
+  "package": "$PACKAGE_NAME",
+  "version": "$PACKAGE_VERSION",
+  "integrity": "$package_integrity",
+  "node": "$node_version",
+  "platform": "darwin-arm64"
+}
+EOF
+
+rm -rf "$OUTPUT_DIR"
+cd "$DESKTOP_DIR"
+mv "$stage" "$OUTPUT_DIR"
+trap - EXIT
+echo "[bundle-proxy] bundled $PACKAGE_NAME@$PACKAGE_VERSION with $node_version"

--- a/tools/desktop-app/scripts/bundle-proxy.sh
+++ b/tools/desktop-app/scripts/bundle-proxy.sh
@@ -48,6 +48,7 @@ else
   curl --fail --location --proto '=https' --tlsv1.2 --output "$archive" "$NODE_RUNTIME_URL"
   printf '%s  %s\n' "$NODE_RUNTIME_SHA256" "$archive" | shasum -a 256 -c -
   tar -xJf "$archive" -C "$stage"
+  rm -f "$archive"
   runtime_root="$(find "$stage" -mindepth 1 -maxdepth 1 -type d -name 'node-v*-darwin-arm64' -print -quit)"
   [[ -n "$runtime_root" ]] || fail "Node archive is not a darwin-arm64 distribution"
   mv "$runtime_root" "$stage/node"

--- a/tools/desktop-app/scripts/bundle-ruby.sh
+++ b/tools/desktop-app/scripts/bundle-ruby.sh
@@ -54,6 +54,13 @@ export GEM_PATH="$VENDOR_DIR/bundle"
 
 echo "[bundle-ruby] $("$VENDORED_RUBY" -v)"
 
+# A release bundle must not retain platform gems from an earlier install: when
+# source-only resolution replaces one, its stale native extension can still be
+# staged and reintroduce an unavailable dependency. This directory is generated
+# output, so rebuild it deterministically for every desktop package.
+rm -rf "$VENDOR_DIR/bundle"
+mkdir -p "$VENDOR_DIR/bundle"
+
 # Install bundler into the vendored Ruby, then install the app's gems there.
 "$VENDORED_RUBY" -S gem install bundler --no-document
 
@@ -67,6 +74,10 @@ export BUNDLE_GEMFILE="$APP_ROOT/Gemfile"
 export BUNDLE_PATH="$VENDOR_DIR/bundle"
 export BUNDLE_WITHOUT="development:test:production"
 export BUNDLE_WITH="desktop"
+# Platform gems may contain prebuilt native extensions with paths from their
+# release builder. Compile them for this Ruby instead so relocation can bundle
+# every dependency from the local build environment.
+export BUNDLE_FORCE_RUBY_PLATFORM=true
 "$VENDORED_RUBY" -S bundle install --jobs 4
 
 # Native gem extensions are compiled after the initial Ruby relocation and keep

--- a/tools/desktop-app/scripts/bundle-ruby.sh
+++ b/tools/desktop-app/scripts/bundle-ruby.sh
@@ -32,6 +32,8 @@ else
   ruby-build "$RUBY_VERSION" "$RUBY_PREFIX"
 fi
 
+"$SCRIPT_DIR/relocate-ruby.sh" "$RUBY_PREFIX"
+
 VENDORED_RUBY="$RUBY_PREFIX/bin/ruby"
 export PATH="$RUBY_PREFIX/bin:$PATH"
 export GEM_HOME="$VENDOR_DIR/bundle"

--- a/tools/desktop-app/scripts/bundle-ruby.sh
+++ b/tools/desktop-app/scripts/bundle-ruby.sh
@@ -26,15 +26,28 @@ command -v ruby-build >/dev/null 2>&1 || {
 mkdir -p "$VENDOR_DIR"
 
 if [ -x "$RUBY_PREFIX/bin/ruby" ]; then
-  echo "[bundle-ruby] reusing existing vendored Ruby at $RUBY_PREFIX"
-else
+  load_relative="$("$RUBY_PREFIX/bin/ruby" -rrbconfig -e 'print RbConfig::CONFIG.fetch("LIBRUBY_RELATIVE")')"
+  if [ "$load_relative" = "yes" ]; then
+    echo "[bundle-ruby] reusing self-relocating vendored Ruby at $RUBY_PREFIX"
+  else
+    echo "[bundle-ruby] replacing non-relocating vendored Ruby at $RUBY_PREFIX"
+    rm -rf "$RUBY_PREFIX" "$VENDOR_DIR/bundle"
+  fi
+fi
+
+if [ ! -x "$RUBY_PREFIX/bin/ruby" ]; then
   echo "[bundle-ruby] building Ruby $RUBY_VERSION into $RUBY_PREFIX (this is slow)…"
-  ruby-build "$RUBY_VERSION" "$RUBY_PREFIX"
+  RUBY_CONFIGURE_OPTS="${RUBY_CONFIGURE_OPTS:-} --enable-load-relative" ruby-build "$RUBY_VERSION" "$RUBY_PREFIX"
 fi
 
 "$SCRIPT_DIR/relocate-ruby.sh" "$RUBY_PREFIX"
 
 VENDORED_RUBY="$RUBY_PREFIX/bin/ruby"
+load_relative="$("$VENDORED_RUBY" -rrbconfig -e 'print RbConfig::CONFIG.fetch("LIBRUBY_RELATIVE")')"
+[ "$load_relative" = "yes" ] || {
+  echo "[bundle-ruby] Ruby was not built with --enable-load-relative" >&2
+  exit 1
+}
 export PATH="$RUBY_PREFIX/bin:$PATH"
 export GEM_HOME="$VENDOR_DIR/bundle"
 export GEM_PATH="$VENDOR_DIR/bundle"

--- a/tools/desktop-app/scripts/bundle-ruby.sh
+++ b/tools/desktop-app/scripts/bundle-ruby.sh
@@ -56,4 +56,9 @@ export BUNDLE_WITHOUT="development:test:production"
 export BUNDLE_WITH="desktop"
 "$VENDORED_RUBY" -S bundle install --jobs 4
 
+# Native gem extensions are compiled after the initial Ruby relocation and keep
+# the Ruby build prefix in their Mach-O load commands. Rewrite them as well so
+# the staged .app never depends on the build checkout.
+"$SCRIPT_DIR/relocate-ruby.sh" "$RUBY_PREFIX" "$VENDOR_DIR/bundle"
+
 echo "[bundle-ruby] done. Ruby: $RUBY_PREFIX  Gems: $VENDOR_DIR/bundle"

--- a/tools/desktop-app/scripts/bundle-ruby.sh
+++ b/tools/desktop-app/scripts/bundle-ruby.sh
@@ -26,9 +26,9 @@ command -v ruby-build >/dev/null 2>&1 || {
 mkdir -p "$VENDOR_DIR"
 
 if [ -x "$RUBY_PREFIX/bin/ruby" ]; then
-  load_relative="$("$RUBY_PREFIX/bin/ruby" -rrbconfig -e 'print RbConfig::CONFIG.fetch("LIBRUBY_RELATIVE")')"
-  if [ "$load_relative" = "yes" ]; then
-    echo "[bundle-ruby] reusing self-relocating vendored Ruby at $RUBY_PREFIX"
+  ruby_build_is_portable="$("$RUBY_PREFIX/bin/ruby" -rrbconfig -e 'print RbConfig::CONFIG.fetch("LIBRUBY_RELATIVE") == "yes"')"
+  if [ "$ruby_build_is_portable" = "true" ]; then
+    echo "[bundle-ruby] reusing portable vendored Ruby at $RUBY_PREFIX"
   else
     echo "[bundle-ruby] replacing non-relocating vendored Ruby at $RUBY_PREFIX"
     rm -rf "$RUBY_PREFIX" "$VENDOR_DIR/bundle"

--- a/tools/desktop-app/scripts/relocate-ruby.sh
+++ b/tools/desktop-app/scripts/relocate-ruby.sh
@@ -6,6 +6,12 @@
 set -euo pipefail
 
 RUBY_PREFIX="$1"
+shift
+MACHO_ROOTS=("$RUBY_PREFIX")
+for root in "$@"; do
+  [ -d "$root" ] || { echo "missing Mach-O root: $root" >&2; exit 1; }
+  MACHO_ROOTS+=("$root")
+done
 
 [ -x "$RUBY_PREFIX/bin/ruby" ] || { echo "missing Ruby executable: $RUBY_PREFIX/bin/ruby" >&2; exit 1; }
 RUBY_LIBRARY="$("$RUBY_PREFIX/bin/ruby" -rrbconfig -e 'puts File.join(RbConfig::CONFIG.fetch("libdir"), RbConfig::CONFIG.fetch("LIBRUBY_SO"))')"
@@ -36,7 +42,7 @@ relative_library_dir() {
 }
 
 ruby_macho_files() {
-  find "$RUBY_PREFIX" -type f \( -path "$RUBY_PREFIX/bin/ruby" -o -name '*.bundle' -o -name '*.dylib' \) ! -path '*.dSYM/*' -print0
+  find "${MACHO_ROOTS[@]}" -type f \( -path "$RUBY_PREFIX/bin/ruby" -o -name '*.bundle' -o -name '*.dylib' \) ! -path '*.dSYM/*' -print0
 }
 
 while IFS= read -r -d '' binary; do
@@ -84,4 +90,4 @@ else
   exit 1
 fi
 
-echo "[relocate-ruby] Ruby runtime is self-contained at $RUBY_PREFIX"
+echo "[relocate-ruby] Ruby runtime and native extensions are self-contained at $RUBY_PREFIX"

--- a/tools/desktop-app/scripts/relocate-ruby.sh
+++ b/tools/desktop-app/scripts/relocate-ruby.sh
@@ -28,8 +28,10 @@ if [[ "$gmp_load_command" = /* ]]; then
 fi
 [ -f "$gmp_destination" ] || { echo "missing bundled GMP library: $gmp_destination" >&2; exit 1; }
 
-# Convert the libraries' install names first. Consumers below use @rpath, with
-# an rpath calculated from the consumer's own directory.
+# Convert the libraries' install names first. The Ruby executable carries the
+# app-local lib rpath, and dyld applies it to extensions loaded by that process.
+# This avoids adding an rpath to every native gem — newly compiled extensions
+# may not reserve enough Mach-O header space for another load command.
 if ! otool -D "$RUBY_LIBRARY" | grep -Fxq "@rpath/$(basename "$RUBY_LIBRARY")"; then
   install_name_tool -id "@rpath/$(basename "$RUBY_LIBRARY")" "$RUBY_LIBRARY"
 fi
@@ -37,9 +39,19 @@ if ! otool -D "$gmp_destination" | grep -Fxq "@rpath/$gmp_name"; then
   install_name_tool -id "@rpath/$gmp_name" "$gmp_destination"
 fi
 
-relative_library_dir() {
-  /usr/bin/ruby -rpathname -e 'puts Pathname.new(ARGV[1]).relative_path_from(Pathname.new(ARGV[0]))' "$1" "$RUBY_PREFIX/lib"
+ensure_rpath() {
+  local binary="$1"
+  local rpath="$2"
+  if ! otool -l "$binary" | grep -A2 'LC_RPATH' | grep -Fq "path $rpath "; then
+    install_name_tool -add_rpath "$rpath" "$binary" >/dev/null 2>&1
+  fi
 }
+
+# The executable and libruby have enough header space for their app-local rpath.
+# Loaded native gems inherit this lookup path, so they do not need individual
+# rpaths (which recent gem builds may not have room to add).
+ensure_rpath "$RUBY_PREFIX/bin/ruby" "@loader_path/../lib"
+ensure_rpath "$RUBY_LIBRARY" "@loader_path/."
 
 ruby_macho_files() {
   find "${MACHO_ROOTS[@]}" -type f \( -path "$RUBY_PREFIX/bin/ruby" -o -name '*.bundle' -o -name '*.dylib' \) ! -path '*.dSYM/*' -print0
@@ -47,26 +59,11 @@ ruby_macho_files() {
 
 while IFS= read -r -d '' binary; do
   dependencies="$(otool -L "$binary" | awk 'NR > 1 { print $1 }')"
-  needs_rpath=false
   if printf '%s\n' "$dependencies" | grep -Fxq "$RUBY_LIBRARY"; then
-  install_name_tool -change "$RUBY_LIBRARY" "@rpath/$(basename "$RUBY_LIBRARY")" "$binary" >/dev/null 2>&1
-    needs_rpath=true
-  fi
-  if printf '%s\n' "$dependencies" | grep -Fxq "@rpath/$(basename "$RUBY_LIBRARY")"; then
-    needs_rpath=true
+    install_name_tool -change "$RUBY_LIBRARY" "@rpath/$(basename "$RUBY_LIBRARY")" "$binary" >/dev/null 2>&1
   fi
   if [[ "$gmp_load_command" = /* ]] && printf '%s\n' "$dependencies" | grep -Fxq "$gmp_load_command"; then
     install_name_tool -change "$gmp_load_command" "@rpath/$gmp_name" "$binary" >/dev/null 2>&1
-    needs_rpath=true
-  fi
-  if printf '%s\n' "$dependencies" | grep -Fxq "@rpath/$gmp_name"; then
-    needs_rpath=true
-  fi
-
-  [ "$needs_rpath" = true ] || continue
-  rpath="@loader_path/$(relative_library_dir "$(dirname "$binary")")"
-  if ! otool -l "$binary" | grep -A2 'LC_RPATH' | grep -Fq "path $rpath "; then
-    install_name_tool -add_rpath "$rpath" "$binary" >/dev/null 2>&1
   fi
 done < <(ruby_macho_files)
 

--- a/tools/desktop-app/scripts/relocate-ruby.sh
+++ b/tools/desktop-app/scripts/relocate-ruby.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Make the ruby-build output self-contained before it is copied into the .app.
+# ruby-build records its install prefix (and Homebrew's GMP path) in Mach-O load
+# commands. Those paths only exist on the build Mac, so rewrite them to rpaths
+# relative to each executable/native extension and ship the GMP dylib beside Ruby.
+set -euo pipefail
+
+RUBY_PREFIX="$1"
+RUBY_LIBRARY="$RUBY_PREFIX/lib/libruby.3.4.dylib"
+
+[ -x "$RUBY_PREFIX/bin/ruby" ] || { echo "missing Ruby executable: $RUBY_PREFIX/bin/ruby" >&2; exit 1; }
+[ -f "$RUBY_LIBRARY" ] || { echo "missing Ruby library: $RUBY_LIBRARY" >&2; exit 1; }
+
+gmp_load_command="$(otool -L "$RUBY_LIBRARY" | awk '/libgmp\.[0-9]+\.dylib / { print $1; exit }')"
+[ -n "$gmp_load_command" ] || { echo "Ruby was built without a GMP dylib" >&2; exit 1; }
+
+gmp_name="$(basename "$gmp_load_command")"
+gmp_destination="$RUBY_PREFIX/lib/$gmp_name"
+if [[ "$gmp_load_command" = /* ]]; then
+  [ -f "$gmp_load_command" ] || { echo "Ruby GMP dependency is unavailable: $gmp_load_command" >&2; exit 1; }
+  cp -pL "$gmp_load_command" "$gmp_destination"
+fi
+[ -f "$gmp_destination" ] || { echo "missing bundled GMP library: $gmp_destination" >&2; exit 1; }
+
+# Convert the libraries' install names first. Consumers below use @rpath, with
+# an rpath calculated from the consumer's own directory.
+if ! otool -D "$RUBY_LIBRARY" | grep -Fxq "@rpath/$(basename "$RUBY_LIBRARY")"; then
+  install_name_tool -id "@rpath/$(basename "$RUBY_LIBRARY")" "$RUBY_LIBRARY"
+fi
+if ! otool -D "$gmp_destination" | grep -Fxq "@rpath/$gmp_name"; then
+  install_name_tool -id "@rpath/$gmp_name" "$gmp_destination"
+fi
+
+relative_library_dir() {
+  /usr/bin/ruby -rpathname -e 'puts Pathname.new(ARGV[1]).relative_path_from(Pathname.new(ARGV[0]))' "$1" "$RUBY_PREFIX/lib"
+}
+
+ruby_macho_files() {
+  find "$RUBY_PREFIX" -type f \( -path "$RUBY_PREFIX/bin/ruby" -o -name '*.bundle' -o -name '*.dylib' \) ! -path '*.dSYM/*' -print0
+}
+
+while IFS= read -r -d '' binary; do
+  dependencies="$(otool -L "$binary" | awk 'NR > 1 { print $1 }')"
+  needs_rpath=false
+  if printf '%s\n' "$dependencies" | grep -Fxq "$RUBY_LIBRARY"; then
+  install_name_tool -change "$RUBY_LIBRARY" "@rpath/$(basename "$RUBY_LIBRARY")" "$binary" >/dev/null 2>&1
+    needs_rpath=true
+  fi
+  if printf '%s\n' "$dependencies" | grep -Fxq "@rpath/$(basename "$RUBY_LIBRARY")"; then
+    needs_rpath=true
+  fi
+  if [[ "$gmp_load_command" = /* ]] && printf '%s\n' "$dependencies" | grep -Fxq "$gmp_load_command"; then
+    install_name_tool -change "$gmp_load_command" "@rpath/$gmp_name" "$binary" >/dev/null 2>&1
+    needs_rpath=true
+  fi
+  if printf '%s\n' "$dependencies" | grep -Fxq "@rpath/$gmp_name"; then
+    needs_rpath=true
+  fi
+
+  [ "$needs_rpath" = true ] || continue
+  rpath="@loader_path/$(relative_library_dir "$(dirname "$binary")")"
+  if ! otool -l "$binary" | grep -A2 'LC_RPATH' | grep -Fq "path $rpath "; then
+    install_name_tool -add_rpath "$rpath" "$binary" >/dev/null 2>&1
+  fi
+done < <(ruby_macho_files)
+
+# install_name_tool invalidates the linker signatures that macOS enforces for
+# arm64 processes. Re-sign every Mach-O file before executing Ruby below; the
+# containing .app receives its release signature in the later packaging stage.
+while IFS= read -r -d '' binary; do
+  codesign --force --sign - "$binary" >/dev/null 2>&1
+done < <(ruby_macho_files)
+
+# Fail the build if any vendored Mach-O file still references the build host.
+if ruby_macho_files | while IFS= read -r -d '' binary; do
+  otool -L "$binary" | tail -n +2 | grep -F "$RUBY_PREFIX" && exit 1
+  if [[ "$gmp_load_command" = /* ]] && otool -L "$binary" | tail -n +2 | grep -F "$gmp_load_command"; then
+    exit 1
+  fi
+done; then
+  :
+else
+  echo "vendored Ruby still contains build-machine library paths" >&2
+  exit 1
+fi
+
+echo "[relocate-ruby] Ruby runtime is self-contained at $RUBY_PREFIX"

--- a/tools/desktop-app/scripts/relocate-ruby.sh
+++ b/tools/desktop-app/scripts/relocate-ruby.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # Make the ruby-build output self-contained before it is copied into the .app.
-# ruby-build records its install prefix (and Homebrew's GMP path) in Mach-O load
-# commands. Those paths only exist on the build Mac, so rewrite them to rpaths
-# relative to each executable/native extension and ship the GMP dylib beside Ruby.
+# ruby-build and native extensions can record their install prefix and Homebrew
+# dependencies in Mach-O load commands. Those paths only exist on the build Mac,
+# so rewrite them to app-local rpaths and ship every non-system dylib that Ruby
+# or an extension needs.
 set -euo pipefail
 
 RUBY_PREFIX="$1"
@@ -54,8 +55,75 @@ ensure_rpath "$RUBY_PREFIX/bin/ruby" "@loader_path/../lib"
 ensure_rpath "$RUBY_LIBRARY" "@loader_path/."
 
 ruby_macho_files() {
-  find "${MACHO_ROOTS[@]}" -type f \( -path "$RUBY_PREFIX/bin/ruby" -o -name '*.bundle' -o -name '*.dylib' \) ! -path '*.dSYM/*' -print0
+  # Source-built gems may retain their Rust/C build products below ext/*/target
+  # or ports/. They are never loaded by Ruby at runtime and can contain linker
+  # metadata for transient compiler artifacts, so only inspect shippable files.
+  find "${MACHO_ROOTS[@]}" -type f \( -path "$RUBY_PREFIX/bin/ruby" -o -name '*.bundle' -o -name '*.dylib' \) \
+    ! -path '*.dSYM/*' \
+    ! -path '*/ext/*/target/*' \
+    ! -path '*/ports/*' \
+    -print0
 }
+
+# Preserve the absolute dependency path below lib/external rather than using a
+# basename-only directory. Homebrew formulae can legitimately ship two dylibs
+# with the same basename; retaining the full path prevents one from replacing
+# the other during relocation.
+external_destination() {
+  local dependency="$1"
+  printf '%s/lib/external/%s\n' "$RUBY_PREFIX" "${dependency#/}"
+}
+
+is_system_dependency() {
+  case "$1" in
+    /usr/lib/*|/System/Library/*|/Library/Apple/System/Library/*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+copy_external_dependency() {
+  local binary="$1"
+  local dependency="$2"
+  local destination
+
+  [[ "$dependency" = /* ]] || return
+  is_system_dependency "$dependency" && return
+  [[ "$dependency" == "$RUBY_PREFIX/"* ]] && return
+  [[ "$dependency" == "$gmp_load_command" ]] && return
+
+  destination="$(external_destination "$dependency")"
+  [ -f "$destination" ] && return
+  [ -f "$dependency" ] || {
+    echo "non-system Ruby dependency is unavailable: $dependency (needed by $binary)" >&2
+    exit 1
+  }
+  mkdir -p "$(dirname "$destination")"
+  cp -pL "$dependency" "$destination"
+  copied_external_library=true
+}
+
+# First copy the complete transitive closure of non-system dylibs. A copied
+# Homebrew dylib can itself depend on another Homebrew dylib, so keep scanning
+# until no new library appears in lib/external.
+while :; do
+  copied_external_library=false
+  while IFS= read -r -d '' binary; do
+    while IFS= read -r dependency; do
+      copy_external_dependency "$binary" "$dependency"
+    done < <(otool -L "$binary" | awk 'NR > 1 { print $1 }')
+  done < <(ruby_macho_files)
+  "$copied_external_library" || break
+done
+
+# Assign app-local install names before rewriting callers. The Ruby/GMP names
+# remain stable for existing extensions; all other third-party libraries use
+# their path beneath lib/ so colliding basenames remain distinct.
+while IFS= read -r -d '' external_library; do
+  external_relative_path="${external_library#"$RUBY_PREFIX/lib/"}"
+  if ! otool -D "$external_library" | grep -Fxq "@rpath/$external_relative_path"; then
+    install_name_tool -id "@rpath/$external_relative_path" "$external_library"
+  fi
+done < <(find "$RUBY_PREFIX/lib/external" -type f -name '*.dylib' -print0 2>/dev/null || true)
 
 while IFS= read -r -d '' binary; do
   dependencies="$(otool -L "$binary" | awk 'NR > 1 { print $1 }')"
@@ -65,6 +133,14 @@ while IFS= read -r -d '' binary; do
   if [[ "$gmp_load_command" = /* ]] && printf '%s\n' "$dependencies" | grep -Fxq "$gmp_load_command"; then
     install_name_tool -change "$gmp_load_command" "@rpath/$gmp_name" "$binary" >/dev/null 2>&1
   fi
+  while IFS= read -r dependency; do
+    [[ "$dependency" = /* ]] || continue
+    is_system_dependency "$dependency" && continue
+    [[ "$dependency" == "$RUBY_PREFIX/"* ]] && continue
+    [[ "$dependency" == "$gmp_load_command" ]] && continue
+    external_relative_path="external/${dependency#/}"
+    install_name_tool -change "$dependency" "@rpath/$external_relative_path" "$binary" >/dev/null 2>&1
+  done <<< "$dependencies"
 done < <(ruby_macho_files)
 
 # install_name_tool invalidates the linker signatures that macOS enforces for
@@ -74,16 +150,20 @@ while IFS= read -r -d '' binary; do
   codesign --force --sign - "$binary" >/dev/null 2>&1
 done < <(ruby_macho_files)
 
-# Fail the build if any vendored Mach-O file still references the build host.
+# Fail the build if any vendored Mach-O file still references a non-system
+# absolute library. This catches the Ruby build prefix and all unbundled
+# Homebrew dependencies, including those from standard-library extensions.
 if ruby_macho_files | while IFS= read -r -d '' binary; do
-  otool -L "$binary" | tail -n +2 | grep -F "$RUBY_PREFIX" && exit 1
-  if [[ "$gmp_load_command" = /* ]] && otool -L "$binary" | tail -n +2 | grep -F "$gmp_load_command"; then
+  while IFS= read -r dependency; do
+    [[ "$dependency" = /* ]] || continue
+    is_system_dependency "$dependency" && continue
+    echo "$binary still references external dylib: $dependency" >&2
     exit 1
-  fi
+  done < <(otool -L "$binary" | awk 'NR > 1 { print $1 }')
 done; then
   :
 else
-  echo "vendored Ruby still contains build-machine library paths" >&2
+  echo "vendored Ruby still contains external library paths" >&2
   exit 1
 fi
 

--- a/tools/desktop-app/scripts/relocate-ruby.sh
+++ b/tools/desktop-app/scripts/relocate-ruby.sh
@@ -6,9 +6,9 @@
 set -euo pipefail
 
 RUBY_PREFIX="$1"
-RUBY_LIBRARY="$RUBY_PREFIX/lib/libruby.3.4.dylib"
 
 [ -x "$RUBY_PREFIX/bin/ruby" ] || { echo "missing Ruby executable: $RUBY_PREFIX/bin/ruby" >&2; exit 1; }
+RUBY_LIBRARY="$("$RUBY_PREFIX/bin/ruby" -rrbconfig -e 'puts File.join(RbConfig::CONFIG.fetch("libdir"), RbConfig::CONFIG.fetch("LIBRUBY_SO"))')"
 [ -f "$RUBY_LIBRARY" ] || { echo "missing Ruby library: $RUBY_LIBRARY" >&2; exit 1; }
 
 gmp_load_command="$(otool -L "$RUBY_LIBRARY" | awk '/libgmp\.[0-9]+\.dylib / { print $1; exit }')"

--- a/tools/desktop-app/src-tauri/Cargo.lock
+++ b/tools/desktop-app/src-tauri/Cargo.lock
@@ -327,9 +327,11 @@ version = "0.1.0"
 dependencies = [
  "base64 0.22.1",
  "getrandom 0.3.4",
+ "hmac",
  "security-framework",
  "serde",
  "serde_json",
+ "sha2",
  "tauri",
  "tauri-build",
  "tauri-plugin-shell",
@@ -561,6 +563,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1249,6 +1252,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "html5ever"
@@ -2989,6 +3001,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swift-rs"

--- a/tools/desktop-app/src-tauri/Cargo.lock
+++ b/tools/desktop-app/src-tauri/Cargo.lock
@@ -325,6 +325,11 @@ dependencies = [
 name = "collavre-desktop"
 version = "0.1.0"
 dependencies = [
+ "base64 0.22.1",
+ "getrandom 0.3.4",
+ "security-framework",
+ "serde",
+ "serde_json",
  "tauri",
  "tauri-build",
  "tauri-plugin-shell",
@@ -2597,6 +2602,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.13.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "selectors"

--- a/tools/desktop-app/src-tauri/Cargo.toml
+++ b/tools/desktop-app/src-tauri/Cargo.toml
@@ -20,6 +20,15 @@ tauri-plugin-shell = "2"
 # Parse the optional desktop config.json in the data dir. Already in the tree as
 # a transitive Tauri dependency; named here so the shell can read it directly.
 serde_json = "1"
+serde = { version = "1", features = ["derive"] }
+base64 = "0.22"
+getrandom = "0.3"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+# The desktop proxy's admin and completion keys must never be written to the
+# app bundle or application-support directory. macOS Keychain is the sole
+# persistent store for them.
+security-framework = "3.7"
 
 [features]
 # Default Tauri custom-protocol for production builds.

--- a/tools/desktop-app/src-tauri/Cargo.toml
+++ b/tools/desktop-app/src-tauri/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1"
 serde = { version = "1", features = ["derive"] }
 base64 = "0.22"
 getrandom = "0.3"
+hmac = "0.12"
+sha2 = "0.10"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 # The desktop proxy's admin and completion keys must never be written to the

--- a/tools/desktop-app/src-tauri/capabilities/default.json
+++ b/tools/desktop-app/src-tauri/capabilities/default.json
@@ -6,5 +6,9 @@
   "remote": {
     "urls": ["http://127.0.0.1:*", "http://localhost:*"]
   },
-  "permissions": ["core:default", "shell:default"]
+  "permissions": [
+    "core:default",
+    "shell:default",
+    "allow-desktop-proxy-complete-setup"
+  ]
 }

--- a/tools/desktop-app/src-tauri/capabilities/default.json
+++ b/tools/desktop-app/src-tauri/capabilities/default.json
@@ -3,5 +3,8 @@
   "identifier": "default",
   "description": "Core capabilities for the Collavre desktop shell.",
   "windows": ["main"],
+  "remote": {
+    "urls": ["http://127.0.0.1:*", "http://localhost:*"]
+  },
   "permissions": ["core:default", "shell:default"]
 }

--- a/tools/desktop-app/src-tauri/permissions/desktop-proxy.toml
+++ b/tools/desktop-app/src-tauri/permissions/desktop-proxy.toml
@@ -1,0 +1,8 @@
+# Allows the trusted loopback setup page to submit a user-approved registration
+# grant. The native command independently validates that short-lived grant
+# before it can create credentials, start the proxy, or register a gateway.
+
+[[permission]]
+identifier = "allow-desktop-proxy-complete-setup"
+description = "Allows completing the user-approved local proxy setup."
+commands.allow = ["desktop_proxy_complete_setup"]

--- a/tools/desktop-app/src-tauri/src/lib.rs
+++ b/tools/desktop-app/src-tauri/src/lib.rs
@@ -410,6 +410,25 @@ fn reap_orphan_proxy(data: &Path) {
     let _ = fs::remove_file(proxy_pidfile_path(data));
 }
 
+fn configure_desktop_proxy_environment(
+    command: &mut Command,
+    config: &ProxyConfig,
+    credentials: &ProxyCredentials,
+    state: &Path,
+) {
+    command
+        .env("HOST", "127.0.0.1")
+        .env("PORT", config.port.to_string())
+        .env("API_KEYS", &credentials.completion_key)
+        .env("AUTH_ADMIN_KEYS", &credentials.admin_key)
+        .env("PATH", desktop_cli_path())
+        .env("PROVISION_STATE_DIR", state.join("provision-state"))
+        .env_remove("USER_WORKER_MODE")
+        .env_remove("USER_WORKER_PROVISIONER_ENDPOINT")
+        .env_remove("USER_API_KEYS")
+        .env_remove("USER_IDENTITY_HMAC_SECRET");
+}
+
 fn spawn_proxy(
     app: &tauri::AppHandle,
     data: &Path,
@@ -433,19 +452,15 @@ fn spawn_proxy(
     let log_dir = data.join("log");
     fs::create_dir_all(&log_dir).ok();
     let mut command = Command::new(node);
-    command
-        .arg(entrypoint)
-        .current_dir(&state)
-        .env("HOST", "127.0.0.1")
-        .env("PORT", config.port.to_string())
-        .env("API_KEYS", credentials.completion_key)
-        .env("AUTH_ADMIN_KEYS", credentials.admin_key)
-        .env("USER_IDENTITY_HMAC_SECRET", credentials.identity_secret)
-        .env("PATH", desktop_cli_path())
-        .env("PROVISION_STATE_DIR", state.join("provision-state"));
+    command.arg(entrypoint).current_dir(&state);
+    configure_desktop_proxy_environment(&mut command, config, &credentials, &state);
 
     // The proxy inherits HOME and receives an expanded executable-only PATH:
     // the user's already logged-in Claude/Codex CLIs own their authentication.
+    // Desktop runs one macOS user's shared gateway. cli-openai-proxy reserves
+    // signed identity routing for its isolated per-user worker mode, which is
+    // not available on macOS; passing that secret here prevents the standalone
+    // gateway from starting at all.
     // The proxy-only keys above are captured and removed by cli-openai-proxy
     // before it starts a CLI child.
     if let Ok(log) = File::create(log_dir.join("desktop-proxy.log")) {
@@ -1081,13 +1096,22 @@ fn apply_desktop_config(data: &Path) {
 #[allow(clippy::items_after_test_module)]
 mod tests {
     use super::{
-        append_unique_paths, config_env_overrides, generate_proxy_key,
-        invalidate_proxy_registration_after_key_regeneration, managed_proxy_runs_on_port,
-        migrate_proxy_config, normalized_proxy_config, nvm_bin_paths, parse_bundled_proxy_manifest,
-        read_proxy_config, reap_orphan_proxy, replace_occupied_proxy_port,
-        wait_until_proxy_healthy, write_proxy_config, ManagedProxy, ProxyConfig, ProxySidecar,
+        append_unique_paths, config_env_overrides, configure_desktop_proxy_environment,
+        generate_proxy_key, invalidate_proxy_registration_after_key_regeneration,
+        managed_proxy_runs_on_port, migrate_proxy_config, normalized_proxy_config, nvm_bin_paths,
+        parse_bundled_proxy_manifest, read_proxy_config, reap_orphan_proxy,
+        replace_occupied_proxy_port, wait_until_proxy_healthy, write_proxy_config, ManagedProxy,
+        ProxyConfig, ProxyCredentials, ProxySidecar,
     };
-    use std::{env, fs, path::PathBuf, process, sync::Mutex, time::Duration};
+    use std::{
+        env,
+        ffi::{OsStr, OsString},
+        fs,
+        path::PathBuf,
+        process,
+        sync::Mutex,
+        time::Duration,
+    };
 
     fn pairs(json: &str) -> Vec<(&'static str, String)> {
         config_env_overrides(json)
@@ -1189,6 +1213,49 @@ mod tests {
             .all(|character| character.is_ascii_alphanumeric()
                 || character == '_'
                 || character == '-'));
+    }
+
+    #[test]
+    fn desktop_proxy_uses_shared_key_mode_without_worker_identity_environment() {
+        let config = ProxyConfig {
+            port: 34_567,
+            version: "0.1.0".to_string(),
+            registered: false,
+        };
+        let credentials = ProxyCredentials {
+            admin_key: "admin-key".to_string(),
+            completion_key: "completion-key".to_string(),
+            identity_secret: "identity-secret".to_string(),
+            regenerated: false,
+        };
+        let mut command = process::Command::new("true");
+        configure_desktop_proxy_environment(
+            &mut command,
+            &config,
+            &credentials,
+            PathBuf::from("/tmp/proxy").as_path(),
+        );
+
+        assert_eq!(
+            Some(OsString::from("completion-key")),
+            command
+                .get_envs()
+                .find(|(key, _)| *key == OsStr::new("API_KEYS"))
+                .and_then(|(_, value)| value.map(OsStr::to_os_string))
+        );
+        for key in [
+            "USER_WORKER_MODE",
+            "USER_WORKER_PROVISIONER_ENDPOINT",
+            "USER_API_KEYS",
+            "USER_IDENTITY_HMAC_SECRET",
+        ] {
+            assert!(matches!(
+                command
+                    .get_envs()
+                    .find(|(name, _)| *name == OsStr::new(key)),
+                Some((_, None))
+            ));
+        }
     }
 
     #[test]

--- a/tools/desktop-app/src-tauri/src/lib.rs
+++ b/tools/desktop-app/src-tauri/src/lib.rs
@@ -1122,19 +1122,55 @@ fn wait_until_authenticated_sidecar(sidecar: &Sidecar, port: u16, timeout: Durat
     false
 }
 
+/// Return whether macOS reports that the spawned proxy process owns the
+/// loopback listener. A successful HTTP response alone is not proof of
+/// ownership: another local process can bind the persisted port before Node
+/// reaches it and mimic the unauthenticated health endpoint.
+#[cfg(target_os = "macos")]
+fn proxy_child_owns_listener(child: &mut Child, port: u16) -> bool {
+    if child.try_wait().ok().flatten().is_some() {
+        return false;
+    }
+
+    let child_pid = child.id().to_string();
+    let listener = format!("-iTCP@127.0.0.1:{port}");
+    Command::new("/usr/sbin/lsof")
+        .args([
+            "-nP",
+            "-a",
+            "-p",
+            &child_pid,
+            &listener,
+            "-sTCP:LISTEN",
+            "-Fp",
+        ])
+        .output()
+        .map(|output| output.status.success() && lsof_reports_process(&output.stdout, &child_pid))
+        .unwrap_or(false)
+}
+
+/// Desktop releases are supported only on macOS. Other targets fail closed so
+/// an accidental cross-platform package cannot trust an unauthenticated port.
+#[cfg(not(target_os = "macos"))]
+fn proxy_child_owns_listener(_child: &mut Child, _port: u16) -> bool {
+    false
+}
+
+fn lsof_reports_process(output: &[u8], expected_pid: &str) -> bool {
+    let process_record = format!("p{expected_pid}");
+    output
+        .split(|byte| *byte == b'\n')
+        .any(|line| line == process_record.as_bytes())
+}
+
 fn wait_until_proxy_healthy(child: &mut Child, port: u16, timeout: Duration) -> bool {
     let deadline = Instant::now() + timeout;
     while Instant::now() < deadline {
         if child.try_wait().ok().flatten().is_some() {
             return false;
         }
-        if http_ok(port, "/health") {
-            // A different process can claim the persisted port in the small
-            // interval between our availability check and Node binding it. Do
-            // not accept that process's generic 200 response: give the child
-            // time to report the bind failure, then verify it is still alive.
-            std::thread::sleep(Duration::from_millis(500));
-            return child.try_wait().ok().flatten().is_none();
+        if http_ok(port, "/health") && proxy_child_owns_listener(child, port) {
+            return true;
         }
         std::thread::sleep(Duration::from_millis(250));
     }
@@ -1292,13 +1328,14 @@ mod tests {
     use super::{
         append_unique_paths, config_env_overrides, configure_desktop_proxy_environment,
         generate_proxy_key, invalidate_proxy_registration_after_key_regeneration,
-        invalidate_proxy_registration_when_gateway_is_missing, managed_proxy_runs_on_port,
-        migrate_proxy_config, normalized_proxy_config, nvm_bin_paths, parse_bundled_proxy_manifest,
-        read_proxy_config, reap_orphan_proxy, register_authenticated_gateway,
-        registered_authenticated_gateway_exists, replace_occupied_proxy_port,
-        revalidate_registered_gateway_after_rails_health, valid_sidecar_challenge_response,
-        wait_until_proxy_healthy, write_proxy_config, GatewayRegistration, HmacSha256,
-        ManagedProxy, ProxyConfig, ProxyCredentials, ProxySidecar, Sidecar, URL_SAFE_NO_PAD,
+        invalidate_proxy_registration_when_gateway_is_missing, lsof_reports_process,
+        managed_proxy_runs_on_port, migrate_proxy_config, normalized_proxy_config, nvm_bin_paths,
+        parse_bundled_proxy_manifest, read_proxy_config, reap_orphan_proxy,
+        register_authenticated_gateway, registered_authenticated_gateway_exists,
+        replace_occupied_proxy_port, revalidate_registered_gateway_after_rails_health,
+        valid_sidecar_challenge_response, wait_until_proxy_healthy, write_proxy_config,
+        GatewayRegistration, HmacSha256, ManagedProxy, ProxyConfig, ProxyCredentials, ProxySidecar,
+        Sidecar, URL_SAFE_NO_PAD,
     };
     use base64::Engine;
     use hmac::Mac;
@@ -1797,9 +1834,16 @@ mod tests {
         let _ = fs::remove_dir_all(&data);
     }
 
+    #[test]
+    fn lsof_listener_check_requires_the_expected_process() {
+        assert!(lsof_reports_process(b"p1234\n", "1234"));
+        assert!(!lsof_reports_process(b"p5678\n", "1234"));
+        assert!(!lsof_reports_process(b"", "1234"));
+    }
+
     #[cfg(unix)]
     #[test]
-    fn proxy_health_rejects_an_impostor_when_the_spawned_child_exits() {
+    fn proxy_health_rejects_an_impostor_while_the_spawned_child_is_alive() {
         use std::io::{Read, Write};
         use std::net::TcpListener;
         use std::process::Command;
@@ -1816,16 +1860,18 @@ mod tests {
                 .expect("respond as impostor");
         });
         let mut child = Command::new("sh")
-            .args(["-c", "sleep 0.1; exit 1"])
+            .args(["-c", "sleep 2"])
             .spawn()
-            .expect("spawn failed proxy process");
+            .expect("spawn unrelated child");
 
         assert!(!wait_until_proxy_healthy(
             &mut child,
             port,
-            Duration::from_secs(2)
+            Duration::from_millis(500)
         ));
         server.join().expect("health server joined");
+        let _ = child.kill();
+        let _ = child.wait();
     }
 
     #[test]

--- a/tools/desktop-app/src-tauri/src/lib.rs
+++ b/tools/desktop-app/src-tauri/src/lib.rs
@@ -22,7 +22,10 @@ use serde::{Deserialize, Serialize};
 use tauri::{Manager, RunEvent, WebviewUrl, WebviewWindowBuilder};
 
 /// Holds the sidecar child so we can stop it on exit.
-struct Sidecar(Mutex<Option<Child>>);
+struct Sidecar {
+    child: Mutex<Option<Child>>,
+    port: Mutex<Option<u16>>,
+}
 
 /// Holds the optional, user-approved cli-openai-proxy process. It is deliberately
 /// separate from the Rails sidecar: a failed or disabled proxy must never stop
@@ -433,13 +436,24 @@ fn proxy_status(app: &tauri::AppHandle, data: &Path, sidecar: &ProxySidecar) -> 
     let config = read_proxy_config(data);
     let manifest = bundled_proxy_manifest(app).ok();
     let installed = config.is_some() && manifest.is_some();
+    let running = sidecar
+        .0
+        .lock()
+        .map(|mut child| {
+            let exited = child
+                .as_mut()
+                .and_then(|process| process.try_wait().ok().flatten())
+                .is_some();
+            if exited {
+                child.take();
+                let _ = fs::remove_file(proxy_pidfile_path(data));
+            }
+            child.is_some()
+        })
+        .unwrap_or(false);
     ProxyStatus {
         installed,
-        running: sidecar
-            .0
-            .lock()
-            .map(|child| child.is_some())
-            .unwrap_or(false),
+        running,
         port: config.as_ref().map(|item| item.port),
         version: manifest.map(|item| item.version),
         registered: config.map(|item| item.registered).unwrap_or(false),
@@ -447,14 +461,22 @@ fn proxy_status(app: &tauri::AppHandle, data: &Path, sidecar: &ProxySidecar) -> 
 }
 
 fn start_proxy(app: &tauri::AppHandle, data: &Path, sidecar: &ProxySidecar) -> Result<(), String> {
-    if sidecar
+    let mut child = sidecar
         .0
         .lock()
-        .map_err(|_| "The desktop proxy process lock is unavailable.".to_string())?
-        .is_some()
-    {
+        .map_err(|_| "The desktop proxy process lock is unavailable.".to_string())?;
+    let exited = child
+        .as_mut()
+        .and_then(|process| process.try_wait().ok().flatten())
+        .is_some();
+    if exited {
+        child.take();
+        let _ = fs::remove_file(proxy_pidfile_path(data));
+    }
+    if child.is_some() {
         return Ok(());
     }
+    drop(child);
     let config = read_proxy_config(data)
         .ok_or_else(|| "Desktop proxy setup has not been approved.".to_string())?;
     let manifest = bundled_proxy_manifest(app)?;
@@ -525,8 +547,8 @@ fn install_proxy(app: &tauri::AppHandle, sidecar: &ProxySidecar) -> Result<Proxy
 fn desktop_proxy_complete_setup(
     app: tauri::AppHandle,
     sidecar: tauri::State<'_, ProxySidecar>,
+    rails_sidecar: tauri::State<'_, Sidecar>,
     registration_token: String,
-    server_port: u16,
 ) -> Result<ProxySetupResult, String> {
     install_proxy(&app, &sidecar)?;
     let data = data_dir(&app);
@@ -544,6 +566,11 @@ fn desktop_proxy_complete_setup(
         identity_secret: &identity_secret,
         adapters: &adapters,
     };
+    let server_port = rails_sidecar
+        .port
+        .lock()
+        .map_err(|_| "The local Collavre server port is unavailable.".to_string())?
+        .ok_or_else(|| "Collavre Desktop could not determine the local server port.".to_string())?;
     register_gateway(server_port, &request)?;
 
     let registered = ProxyConfig {
@@ -989,7 +1016,10 @@ mod tests {
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
-        .manage(Sidecar(Mutex::new(None)))
+        .manage(Sidecar {
+            child: Mutex::new(None),
+            port: Mutex::new(None),
+        })
         .manage(ProxySidecar(Mutex::new(None)))
         .invoke_handler(tauri::generate_handler![
             desktop_proxy_install,
@@ -1023,7 +1053,8 @@ pub fn run() {
             reap_orphan_sidecar(&data);
             let child = spawn_sidecar(&root, &data, port);
             let _ = fs::write(pidfile_path(&data), child.id().to_string());
-            app.state::<Sidecar>().0.lock().unwrap().replace(child);
+            app.state::<Sidecar>().child.lock().unwrap().replace(child);
+            app.state::<Sidecar>().port.lock().unwrap().replace(port);
 
             // A configured proxy means the user previously accepted its first
             // run setup. Migrate its expected bundled version before restarting
@@ -1086,7 +1117,7 @@ pub fn run() {
         .expect("build tauri app")
         .run(|app, event| {
             if let RunEvent::ExitRequested { .. } = event {
-                if let Some(mut child) = app.state::<Sidecar>().0.lock().unwrap().take() {
+                if let Some(mut child) = app.state::<Sidecar>().child.lock().unwrap().take() {
                     stop_sidecar(&mut child);
                 }
                 if let Some(mut child) = app.state::<ProxySidecar>().0.lock().unwrap().take() {

--- a/tools/desktop-app/src-tauri/src/lib.rs
+++ b/tools/desktop-app/src-tauri/src/lib.rs
@@ -948,6 +948,25 @@ fn invalidate_proxy_registration_when_gateway_is_missing(
     Ok(())
 }
 
+/// Do not treat a Rails connection failure during sidecar startup as evidence
+/// that a persisted gateway was removed. The definitive gateway check runs
+/// only after Rails has answered its health endpoint.
+fn revalidate_registered_gateway_after_rails_health(
+    rails_healthy: bool,
+    rails_port: u16,
+    data: &Path,
+    config: &mut ProxyConfig,
+    credentials: &ProxyCredentials,
+) -> Result<bool, String> {
+    if !rails_healthy || !config.registered {
+        return Ok(false);
+    }
+
+    let gateway_exists = registered_gateway_exists(rails_port, config, credentials);
+    invalidate_proxy_registration_when_gateway_is_missing(data, config, gateway_exists)?;
+    Ok(gateway_exists)
+}
+
 /// Ask Rails to validate the signed, short-lived setup consent grant before
 /// native installation mutates persistent state. This call deliberately sends
 /// no proxy credentials.
@@ -1164,8 +1183,8 @@ mod tests {
         invalidate_proxy_registration_when_gateway_is_missing, managed_proxy_runs_on_port,
         migrate_proxy_config, normalized_proxy_config, nvm_bin_paths, parse_bundled_proxy_manifest,
         read_proxy_config, reap_orphan_proxy, replace_occupied_proxy_port,
-        wait_until_proxy_healthy, write_proxy_config, ManagedProxy, ProxyConfig, ProxyCredentials,
-        ProxySidecar,
+        revalidate_registered_gateway_after_rails_health, wait_until_proxy_healthy,
+        write_proxy_config, ManagedProxy, ProxyConfig, ProxyCredentials, ProxySidecar,
     };
     use std::{
         env,
@@ -1542,6 +1561,39 @@ mod tests {
         assert!(!config.registered);
         assert!(!persisted.registered);
     }
+
+    #[test]
+    fn rails_startup_delay_does_not_invalidate_proxy_registration() {
+        let data = env::temp_dir().join(format!("collavre-proxy-rails-delay-{}", process::id()));
+        let _ = fs::remove_dir_all(&data);
+        let mut config = ProxyConfig {
+            port: 34_567,
+            version: "0.1.0".to_string(),
+            registered: true,
+        };
+        write_proxy_config(&data, &config).expect("write registered proxy configuration");
+        let credentials = ProxyCredentials {
+            admin_key: "admin".to_string(),
+            completion_key: "completion".to_string(),
+            identity_secret: "identity".to_string(),
+            regenerated: false,
+        };
+
+        let revalidated = revalidate_registered_gateway_after_rails_health(
+            false,
+            45_678,
+            &data,
+            &mut config,
+            &credentials,
+        )
+        .expect("skip gateway revalidation while Rails starts");
+        let persisted = read_proxy_config(&data).expect("persisted proxy configuration");
+        let _ = fs::remove_dir_all(&data);
+
+        assert!(!revalidated);
+        assert!(config.registered);
+        assert!(persisted.registered);
+    }
 }
 
 pub fn run() {
@@ -1604,32 +1656,39 @@ pub fn run() {
                 // it: otherwise an app update leaves the old version on disk and the
                 // restart is rejected forever. If migration or restart fails, open
                 // the setup recovery screen rather than silently navigating to home.
-                let first_run_complete = bundled_proxy_manifest(&handle)
+                let proxy_config = bundled_proxy_manifest(&handle)
                     .and_then(|manifest| migrate_proxy_config(&data, manifest.version))
                     .and_then(|config| match config {
                         Some(_) => {
                             start_proxy(&handle, &data, &handle.state::<ProxySidecar>())?;
-                            let mut config = read_proxy_config(&data).ok_or_else(|| {
-                                "Desktop proxy configuration is missing.".to_string()
-                            })?;
-                            if config.registered {
-                                let credentials = proxy_credentials()?;
-                                let gateway_exists =
-                                    registered_gateway_exists(port, &config, &credentials);
-                                invalidate_proxy_registration_when_gateway_is_missing(
-                                    &data,
-                                    &mut config,
-                                    gateway_exists,
-                                )?;
-                                Ok(gateway_exists)
-                            } else {
-                                Ok(false)
-                            }
+                            read_proxy_config(&data)
+                                .ok_or_else(|| {
+                                    "Desktop proxy configuration is missing.".to_string()
+                                })
+                                .map(Some)
                         }
-                        None => Ok(false),
+                        None => Ok(None),
+                    });
+                let healthy = wait_until_healthy(port, Duration::from_secs(120));
+                let first_run_complete = proxy_config
+                    .and_then(|config| {
+                        if !healthy {
+                            return Ok(false);
+                        }
+                        let mut config = match config {
+                            Some(config) => config,
+                            None => return Ok(false),
+                        };
+                        let credentials = proxy_credentials()?;
+                        revalidate_registered_gateway_after_rails_health(
+                            true,
+                            port,
+                            &data,
+                            &mut config,
+                            &credentials,
+                        )
                     })
                     .unwrap_or(false);
-                let healthy = wait_until_healthy(port, Duration::from_secs(120));
                 let Some(window) = handle.get_webview_window("main") else {
                     return;
                 };

--- a/tools/desktop-app/src-tauri/src/lib.rs
+++ b/tools/desktop-app/src-tauri/src/lib.rs
@@ -245,12 +245,20 @@ fn generate_proxy_key(prefix: &str) -> Result<String, String> {
     Ok(format!("{prefix}_{}", URL_SAFE_NO_PAD.encode(bytes)))
 }
 
+struct ProxyCredentials {
+    admin_key: String,
+    completion_key: String,
+    identity_secret: String,
+    regenerated: bool,
+}
+
 #[cfg(target_os = "macos")]
-fn keychain_proxy_key(account: &str, prefix: &str) -> Result<String, String> {
+fn keychain_proxy_key(account: &str, prefix: &str) -> Result<(String, bool), String> {
     use security_framework::passwords::{get_generic_password, set_generic_password};
 
     if let Ok(bytes) = get_generic_password(PROXY_KEYCHAIN_SERVICE, account) {
         return String::from_utf8(bytes)
+            .map(|key| (key, false))
             .map_err(|_| "The desktop proxy key in Keychain is invalid.".to_string());
     }
 
@@ -258,12 +266,41 @@ fn keychain_proxy_key(account: &str, prefix: &str) -> Result<String, String> {
     set_generic_password(PROXY_KEYCHAIN_SERVICE, account, key.as_bytes()).map_err(|_| {
         "Collavre needs Keychain access to store the desktop proxy key.".to_string()
     })?;
-    Ok(key)
+    Ok((key, true))
 }
 
 #[cfg(not(target_os = "macos"))]
-fn keychain_proxy_key(_account: &str, _prefix: &str) -> Result<String, String> {
+fn keychain_proxy_key(_account: &str, _prefix: &str) -> Result<(String, bool), String> {
     Err("Desktop proxy installation is currently supported on macOS only.".to_string())
+}
+
+fn proxy_credentials() -> Result<ProxyCredentials, String> {
+    let (admin_key, admin_key_regenerated) =
+        keychain_proxy_key(PROXY_ADMIN_KEY_ACCOUNT, "cop_admin")?;
+    let (completion_key, completion_key_regenerated) =
+        keychain_proxy_key(PROXY_COMPLETION_KEY_ACCOUNT, "cop_key")?;
+    let (identity_secret, identity_secret_regenerated) =
+        keychain_proxy_key(PROXY_IDENTITY_SECRET_ACCOUNT, "cop_identity")?;
+    Ok(ProxyCredentials {
+        admin_key,
+        completion_key,
+        identity_secret,
+        regenerated: admin_key_regenerated
+            || completion_key_regenerated
+            || identity_secret_regenerated,
+    })
+}
+
+fn invalidate_proxy_registration_after_key_regeneration(
+    data: &Path,
+    config: &mut ProxyConfig,
+    credentials_regenerated: bool,
+) -> Result<(), String> {
+    if credentials_regenerated && config.registered {
+        config.registered = false;
+        write_proxy_config(data, config)?;
+    }
+    Ok(())
 }
 
 /// File recording the live sidecar's PID, so a launch that follows a crash can
@@ -379,7 +416,12 @@ fn reap_orphan_proxy(data: &Path) {
     let _ = fs::remove_file(proxy_pidfile_path(data));
 }
 
-fn spawn_proxy(app: &tauri::AppHandle, data: &Path, config: &ProxyConfig) -> Result<Child, String> {
+fn spawn_proxy(
+    app: &tauri::AppHandle,
+    data: &Path,
+    config: &ProxyConfig,
+    credentials: ProxyCredentials,
+) -> Result<Child, String> {
     let root = proxy_root(app);
     let node = root.join("node/bin/node");
     let entrypoint = root.join("node_modules/cli-openai-proxy/dist/server/standalone.js");
@@ -390,9 +432,6 @@ fn spawn_proxy(app: &tauri::AppHandle, data: &Path, config: &ProxyConfig) -> Res
         );
     }
 
-    let admin_key = keychain_proxy_key(PROXY_ADMIN_KEY_ACCOUNT, "cop_admin")?;
-    let completion_key = keychain_proxy_key(PROXY_COMPLETION_KEY_ACCOUNT, "cop_key")?;
-    let identity_secret = keychain_proxy_key(PROXY_IDENTITY_SECRET_ACCOUNT, "cop_identity")?;
     let state = proxy_state_dir(data);
     fs::create_dir_all(state.join("provision-state"))
         .map_err(|_| "Could not create the desktop proxy state directory.".to_string())?;
@@ -405,9 +444,9 @@ fn spawn_proxy(app: &tauri::AppHandle, data: &Path, config: &ProxyConfig) -> Res
         .current_dir(&state)
         .env("HOST", "127.0.0.1")
         .env("PORT", config.port.to_string())
-        .env("API_KEYS", completion_key)
-        .env("AUTH_ADMIN_KEYS", admin_key)
-        .env("USER_IDENTITY_HMAC_SECRET", identity_secret)
+        .env("API_KEYS", credentials.completion_key)
+        .env("AUTH_ADMIN_KEYS", credentials.admin_key)
+        .env("USER_IDENTITY_HMAC_SECRET", credentials.identity_secret)
         .env("PATH", desktop_cli_path())
         .env("PROVISION_STATE_DIR", state.join("provision-state"));
 
@@ -477,14 +516,20 @@ fn start_proxy(app: &tauri::AppHandle, data: &Path, sidecar: &ProxySidecar) -> R
         return Ok(());
     }
     drop(child);
-    let config = read_proxy_config(data)
+    let mut config = read_proxy_config(data)
         .ok_or_else(|| "Desktop proxy setup has not been approved.".to_string())?;
     let manifest = bundled_proxy_manifest(app)?;
     if config.version != manifest.version {
         return Err("The desktop proxy version changed. Re-run desktop proxy setup.".to_string());
     }
+    let credentials = proxy_credentials()?;
+    invalidate_proxy_registration_after_key_regeneration(
+        data,
+        &mut config,
+        credentials.regenerated,
+    )?;
     reap_orphan_proxy(data);
-    let child = spawn_proxy(app, data, &config)?;
+    let child = spawn_proxy(app, data, &config, credentials)?;
     fs::write(proxy_pidfile_path(data), child.id().to_string())
         .map_err(|_| "Could not record the desktop proxy process.".to_string())?;
     sidecar
@@ -554,16 +599,14 @@ fn desktop_proxy_complete_setup(
     let data = data_dir(&app);
     let config = read_proxy_config(&data)
         .ok_or_else(|| "Desktop proxy configuration is missing after installation.".to_string())?;
-    let admin_key = keychain_proxy_key(PROXY_ADMIN_KEY_ACCOUNT, "cop_admin")?;
-    let completion_key = keychain_proxy_key(PROXY_COMPLETION_KEY_ACCOUNT, "cop_key")?;
-    let identity_secret = keychain_proxy_key(PROXY_IDENTITY_SECRET_ACCOUNT, "cop_identity")?;
+    let credentials = proxy_credentials()?;
     let adapters = detected_adapters();
     let request = GatewayRegistration {
         registration_token: &registration_token,
         proxy_port: config.port,
-        admin_key: &admin_key,
-        completion_key: &completion_key,
-        identity_secret: &identity_secret,
+        admin_key: &credentials.admin_key,
+        completion_key: &credentials.completion_key,
+        identity_secret: &credentials.identity_secret,
         adapters: &adapters,
     };
     let server_port = rails_sidecar
@@ -863,8 +906,10 @@ fn apply_desktop_config(data: &Path) {
 #[allow(clippy::items_after_test_module)]
 mod tests {
     use super::{
-        config_env_overrides, generate_proxy_key, migrate_proxy_config, normalized_proxy_config,
-        parse_bundled_proxy_manifest, read_proxy_config, write_proxy_config, ProxyConfig,
+        config_env_overrides, generate_proxy_key,
+        invalidate_proxy_registration_after_key_regeneration, migrate_proxy_config,
+        normalized_proxy_config, parse_bundled_proxy_manifest, read_proxy_config,
+        write_proxy_config, ProxyConfig,
     };
     use std::{env, fs, process};
 
@@ -1011,6 +1056,28 @@ mod tests {
         assert!(upgraded.registered);
         assert_eq!("0.2.0", persisted.version);
     }
+
+    #[test]
+    fn regenerated_keychain_credentials_require_gateway_reregistration() {
+        let data = env::temp_dir().join(format!("collavre-proxy-reregister-{}", process::id()));
+        let _ = fs::remove_dir_all(&data);
+        let mut config = ProxyConfig {
+            port: 34_567,
+            version: "0.1.0".to_string(),
+            registered: true,
+        };
+        write_proxy_config(&data, &config).expect("write registered proxy configuration");
+
+        invalidate_proxy_registration_after_key_regeneration(&data, &mut config, true)
+            .expect("invalidate stale gateway registration");
+        let persisted = read_proxy_config(&data).expect("persisted proxy configuration");
+        let _ = fs::remove_dir_all(&data);
+
+        assert!(!config.registered);
+        assert!(!persisted.registered);
+        assert_eq!(34_567, persisted.port);
+        assert_eq!("0.1.0", persisted.version);
+    }
 }
 
 pub fn run() {
@@ -1064,9 +1131,11 @@ pub fn run() {
             let first_run_complete = bundled_proxy_manifest(&handle)
                 .and_then(|manifest| migrate_proxy_config(&data, manifest.version))
                 .and_then(|config| match config {
-                    Some(config) => {
+                    Some(_) => {
                         start_proxy(&handle, &data, &app.state::<ProxySidecar>())?;
-                        Ok(config.registered)
+                        Ok(read_proxy_config(&data)
+                            .map(|config| config.registered)
+                            .unwrap_or(false))
                     }
                     None => Ok(false),
                 })

--- a/tools/desktop-app/src-tauri/src/lib.rs
+++ b/tools/desktop-app/src-tauri/src/lib.rs
@@ -188,6 +188,21 @@ fn read_proxy_config(data: &Path) -> Option<ProxyConfig> {
     (config.port > 0 && !config.version.is_empty()).then_some(config)
 }
 
+fn normalized_proxy_config(
+    existing: Option<ProxyConfig>,
+    version: String,
+    default_port: u16,
+) -> ProxyConfig {
+    match existing {
+        Some(config) => ProxyConfig { version, ..config },
+        None => ProxyConfig {
+            port: default_port,
+            version,
+            registered: false,
+        },
+    }
+}
+
 fn write_proxy_config(data: &Path, config: &ProxyConfig) -> Result<(), String> {
     let state_dir = proxy_state_dir(data);
     fs::create_dir_all(&state_dir)
@@ -481,11 +496,11 @@ fn install_proxy(app: &tauri::AppHandle, sidecar: &ProxySidecar) -> Result<Proxy
     fs::create_dir_all(&data)
         .map_err(|_| "Could not create the Collavre data directory.".to_string())?;
     let manifest = bundled_proxy_manifest(app)?;
-    let config = read_proxy_config(&data).unwrap_or(ProxyConfig {
-        port: free_port(),
-        version: manifest.version,
-        registered: false,
-    });
+    // A bundled proxy update keeps the existing loopback port, Keychain keys,
+    // and completed state, but advances the expected runtime version before the
+    // health check. Without this migration an upgrade can never restart or be
+    // repaired because start_proxy rejects the stale version first.
+    let config = normalized_proxy_config(read_proxy_config(&data), manifest.version, free_port());
     write_proxy_config(&data, &config)?;
     start_proxy(app, &data, sidecar)?;
     Ok(proxy_status(app, &data, sidecar))
@@ -808,7 +823,10 @@ fn apply_desktop_config(data: &Path) {
 #[cfg(test)]
 #[allow(clippy::items_after_test_module)]
 mod tests {
-    use super::{config_env_overrides, generate_proxy_key, parse_bundled_proxy_manifest};
+    use super::{
+        config_env_overrides, generate_proxy_key, normalized_proxy_config,
+        parse_bundled_proxy_manifest, ProxyConfig,
+    };
 
     fn pairs(json: &str) -> Vec<(&'static str, String)> {
         config_env_overrides(json)
@@ -910,6 +928,23 @@ mod tests {
             .all(|character| character.is_ascii_alphanumeric()
                 || character == '_'
                 || character == '-'));
+    }
+
+    #[test]
+    fn proxy_upgrade_keeps_the_existing_port_and_completion_state() {
+        let config = normalized_proxy_config(
+            Some(ProxyConfig {
+                port: 34_567,
+                version: "0.1.0".to_string(),
+                registered: true,
+            }),
+            "0.2.0".to_string(),
+            45_678,
+        );
+
+        assert_eq!(34_567, config.port);
+        assert_eq!("0.2.0", config.version);
+        assert!(config.registered);
     }
 }
 

--- a/tools/desktop-app/src-tauri/src/lib.rs
+++ b/tools/desktop-app/src-tauri/src/lib.rs
@@ -206,6 +206,17 @@ fn normalized_proxy_config(
     }
 }
 
+/// A persisted loopback port can later be claimed by another local process.
+/// Replacing it requires gateway re-registration because its URL has changed.
+fn replace_occupied_proxy_port(config: &mut ProxyConfig, replacement_port: u16) {
+    config.port = replacement_port;
+    config.registered = false;
+}
+
+fn proxy_port_available(port: u16) -> bool {
+    TcpListener::bind(("127.0.0.1", port)).is_ok()
+}
+
 /// Update only the proxy version tracked in local state when a new desktop
 /// bundle is installed. The port, registration state, and all Keychain-backed
 /// credentials remain untouched.
@@ -579,7 +590,15 @@ fn install_proxy(app: &tauri::AppHandle, sidecar: &ProxySidecar) -> Result<Proxy
     // and completed state, but advances the expected runtime version before the
     // health check. Without this migration an upgrade can never restart or be
     // repaired because start_proxy rejects the stale version first.
-    let config = normalized_proxy_config(read_proxy_config(&data), manifest.version, free_port());
+    let mut config =
+        normalized_proxy_config(read_proxy_config(&data), manifest.version, free_port());
+    // Clear a prior crashed proxy before probing its persisted port. If another
+    // process owns it, choose a fresh loopback port and require registration so
+    // Rails' gateway URL follows the repaired proxy.
+    reap_orphan_proxy(&data);
+    if !proxy_port_available(config.port) {
+        replace_occupied_proxy_port(&mut config, free_port());
+    }
     write_proxy_config(&data, &config)?;
     start_proxy(app, &data, sidecar)?;
     Ok(proxy_status(app, &data, sidecar))
@@ -688,10 +707,22 @@ fn desktop_cli_search_paths() -> Vec<PathBuf> {
             home.join(".npm-global/bin"),
             home.join(".volta/bin"),
         ]);
+        paths.extend(nvm_bin_paths(&home));
     }
     paths.sort();
     paths.dedup();
     paths
+}
+
+fn nvm_bin_paths(home: &Path) -> Vec<PathBuf> {
+    let versions = home.join(".nvm/versions/node");
+    fs::read_dir(versions)
+        .into_iter()
+        .flatten()
+        .filter_map(Result::ok)
+        .map(|entry| entry.path().join("bin"))
+        .filter(|path| path.is_dir())
+        .collect()
 }
 
 fn desktop_cli_path() -> std::ffi::OsString {
@@ -908,8 +939,8 @@ mod tests {
     use super::{
         config_env_overrides, generate_proxy_key,
         invalidate_proxy_registration_after_key_regeneration, migrate_proxy_config,
-        normalized_proxy_config, parse_bundled_proxy_manifest, read_proxy_config,
-        write_proxy_config, ProxyConfig,
+        normalized_proxy_config, nvm_bin_paths, parse_bundled_proxy_manifest, read_proxy_config,
+        replace_occupied_proxy_port, write_proxy_config, ProxyConfig,
     };
     use std::{env, fs, process};
 
@@ -1030,6 +1061,33 @@ mod tests {
         assert_eq!(34_567, config.port);
         assert_eq!("0.2.0", config.version);
         assert!(config.registered);
+    }
+
+    #[test]
+    fn occupied_proxy_port_is_replaced_and_requires_reregistration() {
+        let mut config = ProxyConfig {
+            port: 34_567,
+            version: "0.1.0".to_string(),
+            registered: true,
+        };
+
+        replace_occupied_proxy_port(&mut config, 45_678);
+
+        assert_eq!(45_678, config.port);
+        assert!(!config.registered);
+    }
+
+    #[test]
+    fn nvm_node_bins_are_included_in_desktop_cli_paths() {
+        let home = env::temp_dir().join(format!("collavre-nvm-paths-{}", process::id()));
+        let nvm_bin = home.join(".nvm/versions/node/v22.0.0/bin");
+        let _ = fs::remove_dir_all(&home);
+        fs::create_dir_all(&nvm_bin).expect("create NVM node bin");
+
+        let paths = nvm_bin_paths(&home);
+        let _ = fs::remove_dir_all(&home);
+
+        assert_eq!(vec![nvm_bin], paths);
     }
 
     #[test]

--- a/tools/desktop-app/src-tauri/src/lib.rs
+++ b/tools/desktop-app/src-tauri/src/lib.rs
@@ -203,6 +203,18 @@ fn normalized_proxy_config(
     }
 }
 
+/// Update only the proxy version tracked in local state when a new desktop
+/// bundle is installed. The port, registration state, and all Keychain-backed
+/// credentials remain untouched.
+fn migrate_proxy_config(data: &Path, version: String) -> Result<Option<ProxyConfig>, String> {
+    let Some(existing) = read_proxy_config(data) else {
+        return Ok(None);
+    };
+    let config = normalized_proxy_config(Some(existing), version, 0);
+    write_proxy_config(data, &config)?;
+    Ok(Some(config))
+}
+
 fn write_proxy_config(data: &Path, config: &ProxyConfig) -> Result<(), String> {
     let state_dir = proxy_state_dir(data);
     fs::create_dir_all(&state_dir)
@@ -824,9 +836,10 @@ fn apply_desktop_config(data: &Path) {
 #[allow(clippy::items_after_test_module)]
 mod tests {
     use super::{
-        config_env_overrides, generate_proxy_key, normalized_proxy_config,
-        parse_bundled_proxy_manifest, ProxyConfig,
+        config_env_overrides, generate_proxy_key, migrate_proxy_config, normalized_proxy_config,
+        parse_bundled_proxy_manifest, read_proxy_config, write_proxy_config, ProxyConfig,
     };
+    use std::{env, fs, process};
 
     fn pairs(json: &str) -> Vec<(&'static str, String)> {
         config_env_overrides(json)
@@ -946,6 +959,31 @@ mod tests {
         assert_eq!("0.2.0", config.version);
         assert!(config.registered);
     }
+
+    #[test]
+    fn startup_proxy_upgrade_persists_the_new_version() {
+        let data = env::temp_dir().join(format!("collavre-proxy-upgrade-{}", process::id()));
+        let _ = fs::remove_dir_all(&data);
+        write_proxy_config(
+            &data,
+            &ProxyConfig {
+                port: 34_567,
+                version: "0.1.0".to_string(),
+                registered: true,
+            },
+        )
+        .expect("write existing proxy configuration");
+
+        let upgraded = migrate_proxy_config(&data, "0.2.0".to_string())
+            .expect("migrate proxy configuration")
+            .expect("existing proxy configuration");
+        let persisted = read_proxy_config(&data).expect("persisted proxy configuration");
+        let _ = fs::remove_dir_all(&data);
+
+        assert_eq!(34_567, upgraded.port);
+        assert!(upgraded.registered);
+        assert_eq!("0.2.0", persisted.version);
+    }
 }
 
 pub fn run() {
@@ -988,14 +1026,19 @@ pub fn run() {
             app.state::<Sidecar>().0.lock().unwrap().replace(child);
 
             // A configured proxy means the user previously accepted its first
-            // run setup. Resume it opportunistically, but keep Collavre usable
-            // if Keychain access or the proxy itself fails; the setup wizard can
-            // surface the retry action and diagnostic log.
-            if read_proxy_config(&data).is_some() {
-                let _ = start_proxy(&handle, &data, &app.state::<ProxySidecar>());
-            }
-            let first_run_complete = read_proxy_config(&data)
-                .map(|config| config.registered)
+            // run setup. Migrate its expected bundled version before restarting
+            // it: otherwise an app update leaves the old version on disk and the
+            // restart is rejected forever. If migration or restart fails, open
+            // the setup recovery screen rather than silently navigating to home.
+            let first_run_complete = bundled_proxy_manifest(&handle)
+                .and_then(|manifest| migrate_proxy_config(&data, manifest.version))
+                .and_then(|config| match config {
+                    Some(config) => {
+                        start_proxy(&handle, &data, &app.state::<ProxySidecar>())?;
+                        Ok(config.registered)
+                    }
+                    None => Ok(false),
+                })
                 .unwrap_or(false);
 
             // Show the branded loading screen (dist/index.html) immediately so the

--- a/tools/desktop-app/src-tauri/src/lib.rs
+++ b/tools/desktop-app/src-tauri/src/lib.rs
@@ -83,6 +83,14 @@ struct GatewayRegistration<'a> {
     adapters: &'a [String],
 }
 
+#[derive(Serialize)]
+struct GatewayRegistrationStatus<'a> {
+    proxy_port: u16,
+    admin_key: &'a str,
+    completion_key: &'a str,
+    identity_secret: &'a str,
+}
+
 /// Bind to port 0 to let the OS hand us a free port, then release it. There is a
 /// tiny TOCTOU window before the sidecar grabs it, acceptable for a loopback
 /// single-user app.
@@ -779,7 +787,7 @@ fn nvm_bin_paths(home: &Path) -> Vec<PathBuf> {
         .map(|entry| entry.path().join("bin"))
         .filter(|path| path.is_dir())
         .collect::<Vec<_>>();
-    paths.sort_by(|left, right| nvm_version_sort_key(right).cmp(&nvm_version_sort_key(left)));
+    paths.sort_by_key(|path| std::cmp::Reverse(nvm_version_sort_key(path)));
     if let Some(default) = nvm_default_bin_path(home, &paths) {
         paths.retain(|path| path != &default);
         paths.insert(0, default);
@@ -883,6 +891,61 @@ fn register_gateway(port: u16, registration: &GatewayRegistration<'_>) -> Result
                 .to_string(),
         )
     }
+}
+
+/// Confirm that the Rails record backing the locally healthy proxy still
+/// exists and has the current Keychain credentials. A removed desktop owner
+/// deletes that record, so the persisted flag alone is never enough to skip
+/// recovery setup on a later launch.
+fn registered_gateway_exists(
+    rails_port: u16,
+    config: &ProxyConfig,
+    credentials: &ProxyCredentials,
+) -> bool {
+    if rails_port == 0 {
+        return false;
+    }
+    let body = match serde_json::to_vec(&GatewayRegistrationStatus {
+        proxy_port: config.port,
+        admin_key: &credentials.admin_key,
+        completion_key: &credentials.completion_key,
+        identity_secret: &credentials.identity_secret,
+    }) {
+        Ok(body) => body,
+        Err(_) => return false,
+    };
+    let address = format!("127.0.0.1:{rails_port}");
+    let Ok(mut stream) = TcpStream::connect(&address) else {
+        return false;
+    };
+    stream.set_read_timeout(Some(Duration::from_secs(10))).ok();
+    stream.set_write_timeout(Some(Duration::from_secs(10))).ok();
+    let request = format!(
+        "POST /desktop/setup/gateway-registered HTTP/1.1\r\nHost: {address}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+        body.len()
+    );
+    if stream
+        .write_all(request.as_bytes())
+        .and_then(|_| stream.write_all(&body))
+        .is_err()
+    {
+        return false;
+    }
+    let mut response = String::new();
+    stream.read_to_string(&mut response).is_ok()
+        && (response.starts_with("HTTP/1.1 204") || response.starts_with("HTTP/1.0 204"))
+}
+
+fn invalidate_proxy_registration_when_gateway_is_missing(
+    data: &Path,
+    config: &mut ProxyConfig,
+    gateway_exists: bool,
+) -> Result<(), String> {
+    if config.registered && !gateway_exists {
+        config.registered = false;
+        write_proxy_config(data, config)?;
+    }
+    Ok(())
 }
 
 /// Ask Rails to validate the signed, short-lived setup consent grant before
@@ -1098,10 +1161,11 @@ mod tests {
     use super::{
         append_unique_paths, config_env_overrides, configure_desktop_proxy_environment,
         generate_proxy_key, invalidate_proxy_registration_after_key_regeneration,
-        managed_proxy_runs_on_port, migrate_proxy_config, normalized_proxy_config, nvm_bin_paths,
-        parse_bundled_proxy_manifest, read_proxy_config, reap_orphan_proxy,
-        replace_occupied_proxy_port, wait_until_proxy_healthy, write_proxy_config, ManagedProxy,
-        ProxyConfig, ProxyCredentials, ProxySidecar,
+        invalidate_proxy_registration_when_gateway_is_missing, managed_proxy_runs_on_port,
+        migrate_proxy_config, normalized_proxy_config, nvm_bin_paths, parse_bundled_proxy_manifest,
+        read_proxy_config, reap_orphan_proxy, replace_occupied_proxy_port,
+        wait_until_proxy_healthy, write_proxy_config, ManagedProxy, ProxyConfig, ProxyCredentials,
+        ProxySidecar,
     };
     use std::{
         env,
@@ -1457,6 +1521,27 @@ mod tests {
         assert_eq!(34_567, persisted.port);
         assert_eq!("0.1.0", persisted.version);
     }
+
+    #[test]
+    fn missing_rails_gateway_requires_proxy_reregistration() {
+        let data =
+            env::temp_dir().join(format!("collavre-proxy-gateway-missing-{}", process::id()));
+        let _ = fs::remove_dir_all(&data);
+        let mut config = ProxyConfig {
+            port: 34_567,
+            version: "0.1.0".to_string(),
+            registered: true,
+        };
+        write_proxy_config(&data, &config).expect("write registered proxy configuration");
+
+        invalidate_proxy_registration_when_gateway_is_missing(&data, &mut config, false)
+            .expect("invalidate missing gateway registration");
+        let persisted = read_proxy_config(&data).expect("persisted proxy configuration");
+        let _ = fs::remove_dir_all(&data);
+
+        assert!(!config.registered);
+        assert!(!persisted.registered);
+    }
 }
 
 pub fn run() {
@@ -1524,9 +1609,22 @@ pub fn run() {
                     .and_then(|config| match config {
                         Some(_) => {
                             start_proxy(&handle, &data, &handle.state::<ProxySidecar>())?;
-                            Ok(read_proxy_config(&data)
-                                .map(|config| config.registered)
-                                .unwrap_or(false))
+                            let mut config = read_proxy_config(&data).ok_or_else(|| {
+                                "Desktop proxy configuration is missing.".to_string()
+                            })?;
+                            if config.registered {
+                                let credentials = proxy_credentials()?;
+                                let gateway_exists =
+                                    registered_gateway_exists(port, &config, &credentials);
+                                invalidate_proxy_registration_when_gateway_is_missing(
+                                    &data,
+                                    &mut config,
+                                    gateway_exists,
+                                )?;
+                                Ok(gateway_exists)
+                            } else {
+                                Ok(false)
+                            }
                         }
                         None => Ok(false),
                     })

--- a/tools/desktop-app/src-tauri/src/lib.rs
+++ b/tools/desktop-app/src-tauri/src/lib.rs
@@ -696,33 +696,52 @@ fn desktop_cli_search_paths() -> Vec<PathBuf> {
         .into_iter()
         .flat_map(|path| std::env::split_paths(&path).collect::<Vec<_>>())
         .collect::<Vec<_>>();
-    paths.extend([
-        PathBuf::from("/opt/homebrew/bin"),
-        PathBuf::from("/usr/local/bin"),
-    ]);
+    append_unique_paths(
+        &mut paths,
+        [
+            PathBuf::from("/opt/homebrew/bin"),
+            PathBuf::from("/usr/local/bin"),
+        ],
+    );
     if let Some(home) = std::env::var_os("HOME") {
         let home = PathBuf::from(home);
-        paths.extend([
-            home.join(".local/bin"),
-            home.join(".npm-global/bin"),
-            home.join(".volta/bin"),
-        ]);
-        paths.extend(nvm_bin_paths(&home));
+        append_unique_paths(
+            &mut paths,
+            [
+                home.join(".local/bin"),
+                home.join(".npm-global/bin"),
+                home.join(".volta/bin"),
+            ],
+        );
+        append_unique_paths(&mut paths, nvm_bin_paths(&home));
     }
-    paths.sort();
-    paths.dedup();
     paths
+}
+
+/// Preserve the inherited PATH order: it selects the CLI and Node version a
+/// user already chose in their shell. Appended fallback directories are only
+/// used when that PATH does not contain the executable.
+fn append_unique_paths(paths: &mut Vec<PathBuf>, candidates: impl IntoIterator<Item = PathBuf>) {
+    for candidate in candidates {
+        if !paths.contains(&candidate) {
+            paths.push(candidate);
+        }
+    }
 }
 
 fn nvm_bin_paths(home: &Path) -> Vec<PathBuf> {
     let versions = home.join(".nvm/versions/node");
-    fs::read_dir(versions)
+    let mut paths = fs::read_dir(versions)
         .into_iter()
         .flatten()
         .filter_map(Result::ok)
         .map(|entry| entry.path().join("bin"))
         .filter(|path| path.is_dir())
-        .collect()
+        .collect::<Vec<_>>();
+    // The inherited PATH, if any, was retained before these fallbacks. Keep
+    // the fallback order deterministic without disturbing that precedence.
+    paths.sort();
+    paths
 }
 
 fn desktop_cli_path() -> std::ffi::OsString {
@@ -781,7 +800,12 @@ fn wait_until_proxy_healthy(child: &mut Child, port: u16, timeout: Duration) -> 
             return false;
         }
         if http_ok(port, "/health") {
-            return true;
+            // A different process can claim the persisted port in the small
+            // interval between our availability check and Node binding it. Do
+            // not accept that process's generic 200 response: give the child
+            // time to report the bind failure, then verify it is still alive.
+            std::thread::sleep(Duration::from_millis(500));
+            return child.try_wait().ok().flatten().is_none();
         }
         std::thread::sleep(Duration::from_millis(250));
     }
@@ -937,12 +961,12 @@ fn apply_desktop_config(data: &Path) {
 #[allow(clippy::items_after_test_module)]
 mod tests {
     use super::{
-        config_env_overrides, generate_proxy_key,
+        append_unique_paths, config_env_overrides, generate_proxy_key,
         invalidate_proxy_registration_after_key_regeneration, migrate_proxy_config,
         normalized_proxy_config, nvm_bin_paths, parse_bundled_proxy_manifest, read_proxy_config,
-        replace_occupied_proxy_port, write_proxy_config, ProxyConfig,
+        replace_occupied_proxy_port, wait_until_proxy_healthy, write_proxy_config, ProxyConfig,
     };
-    use std::{env, fs, process};
+    use std::{env, fs, path::PathBuf, process, time::Duration};
 
     fn pairs(json: &str) -> Vec<(&'static str, String)> {
         config_env_overrides(json)
@@ -1088,6 +1112,55 @@ mod tests {
         let _ = fs::remove_dir_all(&home);
 
         assert_eq!(vec![nvm_bin], paths);
+    }
+
+    #[test]
+    fn fallback_paths_do_not_reorder_the_inherited_path() {
+        let inherited = PathBuf::from("/custom/node/bin");
+        let fallback = PathBuf::from("/opt/homebrew/bin");
+        let mut paths = vec![inherited.clone(), fallback.clone()];
+
+        append_unique_paths(&mut paths, [fallback, PathBuf::from("/usr/local/bin")]);
+
+        assert_eq!(
+            paths,
+            vec![
+                inherited,
+                PathBuf::from("/opt/homebrew/bin"),
+                PathBuf::from("/usr/local/bin"),
+            ]
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn proxy_health_rejects_an_impostor_when_the_spawned_child_exits() {
+        use std::io::{Read, Write};
+        use std::net::TcpListener;
+        use std::process::Command;
+        use std::thread;
+
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind impostor health server");
+        let port = listener.local_addr().expect("listener address").port();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept health request");
+            let mut request = [0_u8; 256];
+            let _ = stream.read(&mut request);
+            stream
+                .write_all(b"HTTP/1.0 200 OK\r\nContent-Length: 2\r\n\r\nok")
+                .expect("respond as impostor");
+        });
+        let mut child = Command::new("sh")
+            .args(["-c", "sleep 0.1; exit 1"])
+            .spawn()
+            .expect("spawn failed proxy process");
+
+        assert!(!wait_until_proxy_healthy(
+            &mut child,
+            port,
+            Duration::from_secs(2)
+        ));
+        server.join().expect("health server joined");
     }
 
     #[test]

--- a/tools/desktop-app/src-tauri/src/lib.rs
+++ b/tools/desktop-app/src-tauri/src/lib.rs
@@ -1242,40 +1242,36 @@ pub fn run() {
             app.state::<Sidecar>().child.lock().unwrap().replace(child);
             app.state::<Sidecar>().port.lock().unwrap().replace(port);
 
-            // A configured proxy means the user previously accepted its first
-            // run setup. Migrate its expected bundled version before restarting
-            // it: otherwise an app update leaves the old version on disk and the
-            // restart is rejected forever. If migration or restart fails, open
-            // the setup recovery screen rather than silently navigating to home.
-            let first_run_complete = bundled_proxy_manifest(&handle)
-                .and_then(|manifest| migrate_proxy_config(&data, manifest.version))
-                .and_then(|config| match config {
-                    Some(_) => {
-                        start_proxy(&handle, &data, &app.state::<ProxySidecar>())?;
-                        Ok(read_proxy_config(&data)
-                            .map(|config| config.registered)
-                            .unwrap_or(false))
-                    }
-                    None => Ok(false),
-                })
-                .unwrap_or(false);
-
             // Show the branded loading screen (dist/index.html) immediately so the
-            // user sees custom UI while the sidecar boots, instead of a blank or
-            // absent window. We used to block setup on the health check and only
-            // then create the window pointed at the Rails URL — meaning nothing was
-            // on screen during a cold first-run migration. Now we create the window
-            // first and health-gate on a background thread (below).
+            // user sees custom UI while the Rails sidecar and any previously
+            // configured proxy start. Proxy health checks can take up to 15 seconds
+            // after an update or failure, so they must not block window creation.
             WebviewWindowBuilder::new(&handle, "main", WebviewUrl::App("index.html".into()))
                 .title("Collavre Desktop")
                 .inner_size(1280.0, 860.0)
                 .build()?;
 
-            // Health-gate the sidecar OFF the UI thread so the splash keeps
-            // animating. On success, swap the splash for the live app; on timeout,
-            // surface a readable error in the splash instead of a frozen bar. 120s
-            // covers a cold first-run migration.
+            // Health-gate startup off the UI thread so the splash keeps animating.
+            // On success, swap it for the live app; on timeout, surface a readable
+            // error in place. 120s covers a cold first-run Rails migration.
             std::thread::spawn(move || {
+                // A configured proxy means the user previously accepted its first
+                // run setup. Migrate its expected bundled version before restarting
+                // it: otherwise an app update leaves the old version on disk and the
+                // restart is rejected forever. If migration or restart fails, open
+                // the setup recovery screen rather than silently navigating to home.
+                let first_run_complete = bundled_proxy_manifest(&handle)
+                    .and_then(|manifest| migrate_proxy_config(&data, manifest.version))
+                    .and_then(|config| match config {
+                        Some(_) => {
+                            start_proxy(&handle, &data, &handle.state::<ProxySidecar>())?;
+                            Ok(read_proxy_config(&data)
+                                .map(|config| config.registered)
+                                .unwrap_or(false))
+                        }
+                        None => Ok(false),
+                    })
+                    .unwrap_or(false);
                 let healthy = wait_until_healthy(port, Duration::from_secs(120));
                 let Some(window) = handle.get_webview_window("main") else {
                     return;

--- a/tools/desktop-app/src-tauri/src/lib.rs
+++ b/tools/desktop-app/src-tauri/src/lib.rs
@@ -397,13 +397,37 @@ fn spawn_sidecar(root: &Path, data: &Path, port: u16) -> Child {
 }
 
 #[cfg(unix)]
-fn reap_orphan_proxy(data: &Path) {
+fn proxy_process_matches_bundle(app: &tauri::AppHandle, pid: i32) -> bool {
+    let Ok(output) = Command::new("ps")
+        .args(["-p", &pid.to_string(), "-o", "command="])
+        .output()
+    else {
+        return false;
+    };
+    let command = String::from_utf8_lossy(&output.stdout);
+    proxy_command_matches_bundle(
+        &command,
+        &proxy_root(app).join("node/bin/node"),
+        &proxy_root(app).join("node_modules/cli-openai-proxy/dist/server/standalone.js"),
+    )
+}
+
+/// A pidfile can outlive the proxy process. Never signal a reused process group
+/// unless its leader is still the bundled Node proxy we started.
+#[cfg(unix)]
+fn proxy_command_matches_bundle(command: &str, node: &Path, entrypoint: &Path) -> bool {
+    command.contains(&node.to_string_lossy().to_string())
+        && command.contains(&entrypoint.to_string_lossy().to_string())
+}
+
+#[cfg(unix)]
+fn reap_orphan_proxy(app: &tauri::AppHandle, data: &Path) {
     let path = proxy_pidfile_path(data);
     let Ok(contents) = fs::read_to_string(&path) else {
         return;
     };
     if let Ok(pid) = contents.trim().parse::<i32>() {
-        if pid > 1 && unsafe { libc_kill(-pid, 0) } == 0 {
+        if pid > 1 && proxy_process_matches_bundle(app, pid) && unsafe { libc_kill(-pid, 0) } == 0 {
             unsafe {
                 libc_kill(-pid, 15);
             }
@@ -423,7 +447,7 @@ fn reap_orphan_proxy(data: &Path) {
 }
 
 #[cfg(not(unix))]
-fn reap_orphan_proxy(data: &Path) {
+fn reap_orphan_proxy(_app: &tauri::AppHandle, data: &Path) {
     let _ = fs::remove_file(proxy_pidfile_path(data));
 }
 
@@ -539,7 +563,7 @@ fn start_proxy(app: &tauri::AppHandle, data: &Path, sidecar: &ProxySidecar) -> R
         &mut config,
         credentials.regenerated,
     )?;
-    reap_orphan_proxy(data);
+    reap_orphan_proxy(app, data);
     let child = spawn_proxy(app, data, &config, credentials)?;
     fs::write(proxy_pidfile_path(data), child.id().to_string())
         .map_err(|_| "Could not record the desktop proxy process.".to_string())?;
@@ -584,7 +608,7 @@ fn install_proxy(app: &tauri::AppHandle, sidecar: &ProxySidecar) -> Result<Proxy
     // Clear a prior crashed proxy before probing its persisted port. If another
     // process owns it, choose a fresh loopback port and require registration so
     // Rails' gateway URL follows the repaired proxy.
-    reap_orphan_proxy(&data);
+    reap_orphan_proxy(app, &data);
     if !proxy_port_available(config.port) {
         replace_occupied_proxy_port(&mut config, free_port());
     }
@@ -603,6 +627,16 @@ fn desktop_proxy_complete_setup(
     rails_sidecar: tauri::State<'_, Sidecar>,
     registration_token: String,
 ) -> Result<ProxySetupResult, String> {
+    let server_port = rails_sidecar
+        .port
+        .lock()
+        .map_err(|_| "The local Collavre server port is unavailable.".to_string())?
+        .ok_or_else(|| "Collavre Desktop could not determine the local server port.".to_string())?;
+    // Validate the Rails-issued, short-lived consent grant before creating
+    // Keychain credentials, writing proxy state, or starting the proxy. The
+    // Tauri command is callable from loopback pages, so an arbitrary string
+    // must not be allowed to trigger those side effects.
+    validate_registration_grant(server_port, &registration_token)?;
     install_proxy(&app, &sidecar)?;
     let data = data_dir(&app);
     let config = read_proxy_config(&data)
@@ -617,11 +651,6 @@ fn desktop_proxy_complete_setup(
         identity_secret: &credentials.identity_secret,
         adapters: &adapters,
     };
-    let server_port = rails_sidecar
-        .port
-        .lock()
-        .map_err(|_| "The local Collavre server port is unavailable.".to_string())?
-        .ok_or_else(|| "Collavre Desktop could not determine the local server port.".to_string())?;
     register_gateway(server_port, &request)?;
 
     let registered = ProxyConfig {
@@ -765,6 +794,37 @@ fn register_gateway(port: u16, registration: &GatewayRegistration<'_>) -> Result
     } else {
         Err(
             "Collavre could not register the local gateway. No setup was marked complete."
+                .to_string(),
+        )
+    }
+}
+
+/// Ask Rails to validate the signed, short-lived setup consent grant before
+/// native installation mutates persistent state. This call deliberately sends
+/// no proxy credentials.
+fn validate_registration_grant(port: u16, registration_token: &str) -> Result<(), String> {
+    let body = serde_json::json!({ "registration_token": registration_token }).to_string();
+    let address = format!("127.0.0.1:{port}");
+    let mut stream = TcpStream::connect(&address)
+        .map_err(|_| "Could not connect to the local Collavre server.".to_string())?;
+    stream.set_read_timeout(Some(Duration::from_secs(10))).ok();
+    stream.set_write_timeout(Some(Duration::from_secs(10))).ok();
+    let request = format!(
+        "POST /desktop/setup/validate-registration-grant HTTP/1.1\r\nHost: {address}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        body.len()
+    );
+    stream
+        .write_all(request.as_bytes())
+        .map_err(|_| "Could not validate the desktop setup consent.".to_string())?;
+    let mut response = String::new();
+    stream
+        .read_to_string(&mut response)
+        .map_err(|_| "Could not read the desktop setup consent response.".to_string())?;
+    if response.starts_with("HTTP/1.1 204") || response.starts_with("HTTP/1.0 204") {
+        Ok(())
+    } else {
+        Err(
+            "Desktop proxy setup consent is invalid or has expired. Return to setup and try again."
                 .to_string(),
         )
     }
@@ -952,8 +1012,9 @@ mod tests {
     use super::{
         append_unique_paths, config_env_overrides, generate_proxy_key,
         invalidate_proxy_registration_after_key_regeneration, migrate_proxy_config,
-        normalized_proxy_config, nvm_bin_paths, parse_bundled_proxy_manifest, read_proxy_config,
-        replace_occupied_proxy_port, wait_until_proxy_healthy, write_proxy_config, ProxyConfig,
+        normalized_proxy_config, nvm_bin_paths, parse_bundled_proxy_manifest,
+        proxy_command_matches_bundle, read_proxy_config, replace_occupied_proxy_port,
+        wait_until_proxy_healthy, write_proxy_config, ProxyConfig,
     };
     use std::{env, fs, path::PathBuf, process, time::Duration};
 
@@ -1119,6 +1180,32 @@ mod tests {
                 PathBuf::from("/usr/local/bin"),
             ]
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn stale_proxy_pid_must_match_the_bundled_node_command_before_reaping() {
+        let node =
+            PathBuf::from("/Applications/Collavre.app/Contents/Resources/app/proxy/node/bin/node");
+        let entrypoint = PathBuf::from(
+            "/Applications/Collavre.app/Contents/Resources/app/proxy/node_modules/cli-openai-proxy/dist/server/standalone.js",
+        );
+
+        assert!(proxy_command_matches_bundle(
+            &format!("{} {}", node.display(), entrypoint.display()),
+            &node,
+            &entrypoint
+        ));
+        assert!(!proxy_command_matches_bundle(
+            "/usr/bin/sleep 30",
+            &node,
+            &entrypoint
+        ));
+        assert!(!proxy_command_matches_bundle(
+            &format!("{} unrelated.js", node.display()),
+            &node,
+            &entrypoint
+        ));
     }
 
     #[cfg(unix)]

--- a/tools/desktop-app/src-tauri/src/lib.rs
+++ b/tools/desktop-app/src-tauri/src/lib.rs
@@ -8,18 +8,52 @@
 //!   4. Show the app in a native webview at `http://127.0.0.1:<port>`.
 //!   5. Gracefully stop the sidecar (and its process group) on quit.
 
-use std::fs::{self, File};
+use std::fs::{self, File, OpenOptions};
 use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine;
+use serde::{Deserialize, Serialize};
 use tauri::{Manager, RunEvent, WebviewUrl, WebviewWindowBuilder};
 
 /// Holds the sidecar child so we can stop it on exit.
 struct Sidecar(Mutex<Option<Child>>);
+
+/// Holds the optional, user-approved cli-openai-proxy process. It is deliberately
+/// separate from the Rails sidecar: a failed or disabled proxy must never stop
+/// the local Collavre application from opening.
+struct ProxySidecar(Mutex<Option<Child>>);
+
+const PROXY_KEYCHAIN_SERVICE: &str = "net.collavre.desktop.cli-openai-proxy";
+const PROXY_ADMIN_KEY_ACCOUNT: &str = "admin-key";
+const PROXY_COMPLETION_KEY_ACCOUNT: &str = "completion-key";
+
+#[derive(Debug, Deserialize)]
+struct BundledProxyManifest {
+    package: String,
+    version: String,
+    integrity: String,
+    platform: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct ProxyConfig {
+    port: u16,
+    version: String,
+}
+
+#[derive(Debug, Serialize)]
+struct ProxyStatus {
+    installed: bool,
+    running: bool,
+    port: Option<u16>,
+    version: Option<String>,
+}
 
 /// Bind to port 0 to let the OS hand us a free port, then release it. There is a
 /// tiny TOCTOU window before the sidecar grabs it, acceptable for a loopback
@@ -57,9 +91,113 @@ fn data_dir(app: &tauri::AppHandle) -> PathBuf {
         .join("Collavre")
 }
 
+/// The installed proxy has no mutable content. Only a public port and its
+/// expected package version are persisted here; credentials live exclusively in
+/// Keychain and are never serialized into this directory or a log.
+fn proxy_state_dir(data: &Path) -> PathBuf {
+    data.join("proxy")
+}
+
+fn proxy_config_path(data: &Path) -> PathBuf {
+    proxy_state_dir(data).join("config.json")
+}
+
+fn proxy_pidfile_path(data: &Path) -> PathBuf {
+    proxy_state_dir(data).join("desktop-proxy.pid")
+}
+
+fn proxy_root(app: &tauri::AppHandle) -> PathBuf {
+    if let Ok(resource_dir) = app.path().resource_dir() {
+        let bundled = resource_dir.join("app/proxy");
+        if bundled.join("manifest.json").exists() {
+            return bundled;
+        }
+    }
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../vendor/proxy")
+}
+
+fn bundled_proxy_manifest(app: &tauri::AppHandle) -> Result<BundledProxyManifest, String> {
+    let root = proxy_root(app);
+    let manifest = fs::read_to_string(root.join("manifest.json")).map_err(|_| {
+        "The bundled cli-openai-proxy runtime is missing. Reinstall Collavre Desktop.".to_string()
+    })?;
+    parse_bundled_proxy_manifest(&manifest)
+}
+
+fn parse_bundled_proxy_manifest(manifest: &str) -> Result<BundledProxyManifest, String> {
+    let manifest: BundledProxyManifest = serde_json::from_str(manifest).map_err(|_| {
+        "The bundled cli-openai-proxy manifest is invalid. Reinstall Collavre Desktop.".to_string()
+    })?;
+    if manifest.package != "cli-openai-proxy"
+        || manifest.platform != "darwin-arm64"
+        || manifest.version.is_empty()
+        || !manifest.integrity.starts_with("sha512-")
+    {
+        return Err(
+            "The bundled cli-openai-proxy manifest is invalid. Reinstall Collavre Desktop."
+                .to_string(),
+        );
+    }
+    Ok(manifest)
+}
+
+fn read_proxy_config(data: &Path) -> Option<ProxyConfig> {
+    let json = fs::read_to_string(proxy_config_path(data)).ok()?;
+    let config: ProxyConfig = serde_json::from_str(&json).ok()?;
+    (config.port > 0 && !config.version.is_empty()).then_some(config)
+}
+
+fn write_proxy_config(data: &Path, config: &ProxyConfig) -> Result<(), String> {
+    let state_dir = proxy_state_dir(data);
+    fs::create_dir_all(&state_dir)
+        .map_err(|_| "Could not create the desktop proxy state directory.".to_string())?;
+    let temporary = state_dir.join("config.json.tmp");
+    let json = serde_json::to_vec(config)
+        .map_err(|_| "Could not write desktop proxy configuration.".to_string())?;
+    let mut file = OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .open(&temporary)
+        .map_err(|_| "Could not write desktop proxy configuration.".to_string())?;
+    file.write_all(&json)
+        .and_then(|_| file.sync_all())
+        .map_err(|_| "Could not write desktop proxy configuration.".to_string())?;
+    fs::rename(temporary, proxy_config_path(data))
+        .map_err(|_| "Could not finalize desktop proxy configuration.".to_string())
+}
+
+fn generate_proxy_key(prefix: &str) -> Result<String, String> {
+    let mut bytes = [0u8; 48];
+    getrandom::fill(&mut bytes)
+        .map_err(|_| "Could not generate a desktop proxy key.".to_string())?;
+    Ok(format!("{prefix}_{}", URL_SAFE_NO_PAD.encode(bytes)))
+}
+
+#[cfg(target_os = "macos")]
+fn keychain_proxy_key(account: &str, prefix: &str) -> Result<String, String> {
+    use security_framework::passwords::{get_generic_password, set_generic_password};
+
+    if let Ok(bytes) = get_generic_password(PROXY_KEYCHAIN_SERVICE, account) {
+        return String::from_utf8(bytes)
+            .map_err(|_| "The desktop proxy key in Keychain is invalid.".to_string());
+    }
+
+    let key = generate_proxy_key(prefix)?;
+    set_generic_password(PROXY_KEYCHAIN_SERVICE, account, key.as_bytes()).map_err(|_| {
+        "Collavre needs Keychain access to store the desktop proxy key.".to_string()
+    })?;
+    Ok(key)
+}
+
+#[cfg(not(target_os = "macos"))]
+fn keychain_proxy_key(_account: &str, _prefix: &str) -> Result<String, String> {
+    Err("Desktop proxy installation is currently supported on macOS only.".to_string())
+}
+
 /// File recording the live sidecar's PID, so a launch that follows a crash can
 /// reap the orphan the graceful exit handler never got to stop.
-fn pidfile_path(data: &PathBuf) -> PathBuf {
+fn pidfile_path(data: &Path) -> PathBuf {
     data.join("desktop-sidecar.pid")
 }
 
@@ -69,7 +207,7 @@ fn pidfile_path(data: &PathBuf) -> PathBuf {
 /// survives and keeps the SQLite write locks held (and a fixed PORT bound in
 /// open mode), which would wedge this launch. Signal that stale group first.
 #[cfg(unix)]
-fn reap_orphan_sidecar(data: &PathBuf) {
+fn reap_orphan_sidecar(data: &Path) {
     let path = pidfile_path(data);
     let Ok(contents) = fs::read_to_string(&path) else {
         return;
@@ -98,11 +236,11 @@ fn reap_orphan_sidecar(data: &PathBuf) {
 }
 
 #[cfg(not(unix))]
-fn reap_orphan_sidecar(data: &PathBuf) {
+fn reap_orphan_sidecar(data: &Path) {
     let _ = fs::remove_file(pidfile_path(data));
 }
 
-fn spawn_sidecar(root: &PathBuf, data: &PathBuf, port: u16) -> Child {
+fn spawn_sidecar(root: &Path, data: &Path, port: u16) -> Child {
     let launcher = root.join("bin/desktop-server");
     // Honor a caller-supplied bind host (open mode = 0.0.0.0 for LAN/Tailscale);
     // default to loopback. COLLAVRE_ALLOWED_HOSTS rides along via the inherited
@@ -139,11 +277,182 @@ fn spawn_sidecar(root: &PathBuf, data: &PathBuf, port: u16) -> Child {
     cmd.spawn().expect("spawn rails sidecar")
 }
 
+#[cfg(unix)]
+fn reap_orphan_proxy(data: &Path) {
+    let path = proxy_pidfile_path(data);
+    let Ok(contents) = fs::read_to_string(&path) else {
+        return;
+    };
+    if let Ok(pid) = contents.trim().parse::<i32>() {
+        if pid > 1 && unsafe { libc_kill(-pid, 0) } == 0 {
+            unsafe {
+                libc_kill(-pid, 15);
+            }
+            let deadline = Instant::now() + Duration::from_secs(5);
+            while Instant::now() < deadline {
+                if unsafe { libc_kill(-pid, 0) } != 0 {
+                    break;
+                }
+                std::thread::sleep(Duration::from_millis(100));
+            }
+            unsafe {
+                libc_kill(-pid, 9);
+            }
+        }
+    }
+    let _ = fs::remove_file(path);
+}
+
+#[cfg(not(unix))]
+fn reap_orphan_proxy(data: &Path) {
+    let _ = fs::remove_file(proxy_pidfile_path(data));
+}
+
+fn spawn_proxy(app: &tauri::AppHandle, data: &Path, config: &ProxyConfig) -> Result<Child, String> {
+    let root = proxy_root(app);
+    let node = root.join("node/bin/node");
+    let entrypoint = root.join("node_modules/cli-openai-proxy/dist/server/standalone.js");
+    if !node.is_file() || !entrypoint.is_file() {
+        return Err(
+            "The bundled cli-openai-proxy runtime is incomplete. Reinstall Collavre Desktop."
+                .to_string(),
+        );
+    }
+
+    let admin_key = keychain_proxy_key(PROXY_ADMIN_KEY_ACCOUNT, "cop_admin")?;
+    let completion_key = keychain_proxy_key(PROXY_COMPLETION_KEY_ACCOUNT, "cop_key")?;
+    let state = proxy_state_dir(data);
+    fs::create_dir_all(state.join("provision-state"))
+        .map_err(|_| "Could not create the desktop proxy state directory.".to_string())?;
+
+    let log_dir = data.join("log");
+    fs::create_dir_all(&log_dir).ok();
+    let mut command = Command::new(node);
+    command
+        .arg(entrypoint)
+        .current_dir(&state)
+        .env("HOST", "127.0.0.1")
+        .env("PORT", config.port.to_string())
+        .env("API_KEYS", completion_key)
+        .env("AUTH_ADMIN_KEYS", admin_key)
+        .env("PROVISION_STATE_DIR", state.join("provision-state"));
+
+    // The proxy deliberately inherits HOME and PATH: the user's already logged
+    // in Claude/Codex CLIs own their authentication. The proxy-only keys above
+    // are captured and removed by cli-openai-proxy before it starts a CLI child.
+    if let Ok(log) = File::create(log_dir.join("desktop-proxy.log")) {
+        if let Ok(error_log) = log.try_clone() {
+            command
+                .stdout(Stdio::from(log))
+                .stderr(Stdio::from(error_log));
+        }
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        command.process_group(0);
+    }
+    command
+        .spawn()
+        .map_err(|_| "Could not start cli-openai-proxy.".to_string())
+}
+
+fn proxy_status(app: &tauri::AppHandle, data: &Path, sidecar: &ProxySidecar) -> ProxyStatus {
+    let config = read_proxy_config(data);
+    let manifest = bundled_proxy_manifest(app).ok();
+    let installed = config.is_some() && manifest.is_some();
+    ProxyStatus {
+        installed,
+        running: sidecar
+            .0
+            .lock()
+            .map(|child| child.is_some())
+            .unwrap_or(false),
+        port: config.as_ref().map(|item| item.port),
+        version: manifest.map(|item| item.version),
+    }
+}
+
+fn start_proxy(app: &tauri::AppHandle, data: &Path, sidecar: &ProxySidecar) -> Result<(), String> {
+    if sidecar
+        .0
+        .lock()
+        .map_err(|_| "The desktop proxy process lock is unavailable.".to_string())?
+        .is_some()
+    {
+        return Ok(());
+    }
+    let config = read_proxy_config(data)
+        .ok_or_else(|| "Desktop proxy setup has not been approved.".to_string())?;
+    let manifest = bundled_proxy_manifest(app)?;
+    if config.version != manifest.version {
+        return Err("The desktop proxy version changed. Re-run desktop proxy setup.".to_string());
+    }
+    reap_orphan_proxy(data);
+    let child = spawn_proxy(app, data, &config)?;
+    fs::write(proxy_pidfile_path(data), child.id().to_string())
+        .map_err(|_| "Could not record the desktop proxy process.".to_string())?;
+    sidecar
+        .0
+        .lock()
+        .map_err(|_| "The desktop proxy process lock is unavailable.".to_string())?
+        .replace(child);
+    let healthy = sidecar
+        .0
+        .lock()
+        .ok()
+        .and_then(|mut guard| {
+            guard
+                .as_mut()
+                .map(|child| wait_until_proxy_healthy(child, config.port, Duration::from_secs(15)))
+        })
+        .unwrap_or(false);
+    if !healthy {
+        if let Some(mut child) = sidecar.0.lock().ok().and_then(|mut guard| guard.take()) {
+            stop_sidecar(&mut child);
+        }
+        let _ = fs::remove_file(proxy_pidfile_path(data));
+        return Err(
+            "cli-openai-proxy did not pass its health check. See desktop-proxy.log.".to_string(),
+        );
+    }
+    Ok(())
+}
+
+/// Invoked only after the user accepts the first-run proxy setup. The response
+/// intentionally contains no key material; Rails receives credentials during a
+/// separate authenticated gateway-registration step.
+#[tauri::command]
+fn desktop_proxy_install(
+    app: tauri::AppHandle,
+    sidecar: tauri::State<'_, ProxySidecar>,
+) -> Result<ProxyStatus, String> {
+    let data = data_dir(&app);
+    fs::create_dir_all(&data)
+        .map_err(|_| "Could not create the Collavre data directory.".to_string())?;
+    let manifest = bundled_proxy_manifest(&app)?;
+    let config = read_proxy_config(&data).unwrap_or(ProxyConfig {
+        port: free_port(),
+        version: manifest.version,
+    });
+    write_proxy_config(&data, &config)?;
+    start_proxy(&app, &data, &sidecar)?;
+    Ok(proxy_status(&app, &data, &sidecar))
+}
+
+#[tauri::command]
+fn desktop_proxy_status(
+    app: tauri::AppHandle,
+    sidecar: tauri::State<'_, ProxySidecar>,
+) -> ProxyStatus {
+    proxy_status(&app, &data_dir(&app), &sidecar)
+}
+
 /// Poll `GET /up` until it answers 200 or we give up.
 fn wait_until_healthy(port: u16, timeout: Duration) -> bool {
     let deadline = Instant::now() + timeout;
     while Instant::now() < deadline {
-        if http_up_ok(port) {
+        if http_ok(port, "/up") {
             return true;
         }
         std::thread::sleep(Duration::from_millis(250));
@@ -151,14 +460,28 @@ fn wait_until_healthy(port: u16, timeout: Duration) -> bool {
     false
 }
 
-/// Minimal dependency-free HTTP GET /up; true only on a `200` status line.
-fn http_up_ok(port: u16) -> bool {
+fn wait_until_proxy_healthy(child: &mut Child, port: u16, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if child.try_wait().ok().flatten().is_some() {
+            return false;
+        }
+        if http_ok(port, "/health") {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(250));
+    }
+    false
+}
+
+/// Minimal dependency-free HTTP GET; true only on a `200` status line.
+fn http_ok(port: u16, path: &str) -> bool {
     let addr = format!("127.0.0.1:{port}");
     let Ok(mut stream) = TcpStream::connect(&addr) else {
         return false;
     };
     let _ = stream.set_read_timeout(Some(Duration::from_millis(500)));
-    let req = format!("GET /up HTTP/1.0\r\nHost: {addr}\r\nConnection: close\r\n\r\n");
+    let req = format!("GET {path} HTTP/1.0\r\nHost: {addr}\r\nConnection: close\r\n\r\n");
     if stream.write_all(req.as_bytes()).is_err() {
         return false;
     }
@@ -284,7 +607,7 @@ fn config_env_overrides(json: &str) -> Vec<(&'static str, String)> {
 /// file once (alongside the DBs, secrets, and logs the app already keeps here)
 /// lets every later launch pick the settings up. No file is the normal
 /// closed-loopback case and a no-op.
-fn apply_desktop_config(data: &PathBuf) {
+fn apply_desktop_config(data: &Path) {
     let path = data.join("config.json");
     let Ok(json) = fs::read_to_string(&path) else {
         return;
@@ -297,8 +620,9 @@ fn apply_desktop_config(data: &PathBuf) {
 }
 
 #[cfg(test)]
+#[allow(clippy::items_after_test_module)]
 mod tests {
-    use super::config_env_overrides;
+    use super::{config_env_overrides, generate_proxy_key, parse_bundled_proxy_manifest};
 
     fn pairs(json: &str) -> Vec<(&'static str, String)> {
         config_env_overrides(json)
@@ -372,12 +696,46 @@ mod tests {
         assert!(pairs("").is_empty());
         assert!(pairs("[1,2,3]").is_empty());
     }
+
+    #[test]
+    fn bundled_proxy_manifest_accepts_only_the_expected_package_and_platform() {
+        let manifest = parse_bundled_proxy_manifest(
+            r#"{"package":"cli-openai-proxy","version":"0.1.0","integrity":"sha512-test","platform":"darwin-arm64"}"#,
+        )
+        .expect("valid manifest");
+        assert_eq!(manifest.version, "0.1.0");
+
+        assert!(parse_bundled_proxy_manifest(
+            r#"{"package":"other","version":"0.1.0","integrity":"sha512-test","platform":"darwin-arm64"}"#,
+        )
+        .is_err());
+        assert!(parse_bundled_proxy_manifest(
+            r#"{"package":"cli-openai-proxy","version":"0.1.0","integrity":"sha512-test","platform":"darwin-x64"}"#,
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn generated_proxy_keys_are_prefixed_and_url_safe() {
+        let key = generate_proxy_key("cop_key").expect("random key");
+        assert!(key.starts_with("cop_key_"));
+        assert!(key
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric()
+                || character == '_'
+                || character == '-'));
+    }
 }
 
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
         .manage(Sidecar(Mutex::new(None)))
+        .manage(ProxySidecar(Mutex::new(None)))
+        .invoke_handler(tauri::generate_handler![
+            desktop_proxy_install,
+            desktop_proxy_status
+        ])
         .setup(|app| {
             let handle = app.handle().clone();
             let root = app_root(&handle);
@@ -406,6 +764,14 @@ pub fn run() {
             let child = spawn_sidecar(&root, &data, port);
             let _ = fs::write(pidfile_path(&data), child.id().to_string());
             app.state::<Sidecar>().0.lock().unwrap().replace(child);
+
+            // A configured proxy means the user previously accepted its first
+            // run setup. Resume it opportunistically, but keep Collavre usable
+            // if Keychain access or the proxy itself fails; the setup wizard can
+            // surface the retry action and diagnostic log.
+            if read_proxy_config(&data).is_some() {
+                let _ = start_proxy(&handle, &data, &app.state::<ProxySidecar>());
+            }
 
             // Show the branded loading screen (dist/index.html) immediately so the
             // user sees custom UI while the sidecar boots, instead of a blank or
@@ -449,9 +815,13 @@ pub fn run() {
                 if let Some(mut child) = app.state::<Sidecar>().0.lock().unwrap().take() {
                     stop_sidecar(&mut child);
                 }
+                if let Some(mut child) = app.state::<ProxySidecar>().0.lock().unwrap().take() {
+                    stop_sidecar(&mut child);
+                }
                 // Clear the pidfile so the next launch doesn't try to reap a pid
                 // that is gone (or, worse, reused by an unrelated process).
                 let _ = fs::remove_file(pidfile_path(&data_dir(app)));
+                let _ = fs::remove_file(proxy_pidfile_path(&data_dir(app)));
             }
         });
 }

--- a/tools/desktop-app/src-tauri/src/lib.rs
+++ b/tools/desktop-app/src-tauri/src/lib.rs
@@ -570,17 +570,6 @@ fn start_proxy(app: &tauri::AppHandle, data: &Path, sidecar: &ProxySidecar) -> R
     Ok(())
 }
 
-/// Invoked only after the user accepts the first-run proxy setup. The response
-/// intentionally contains no key material; Rails receives credentials during a
-/// separate authenticated gateway-registration step.
-#[tauri::command]
-fn desktop_proxy_install(
-    app: tauri::AppHandle,
-    sidecar: tauri::State<'_, ProxySidecar>,
-) -> Result<ProxyStatus, String> {
-    install_proxy(&app, &sidecar)
-}
-
 fn install_proxy(app: &tauri::AppHandle, sidecar: &ProxySidecar) -> Result<ProxyStatus, String> {
     let data = data_dir(app);
     fs::create_dir_all(&data)
@@ -1220,7 +1209,6 @@ pub fn run() {
         })
         .manage(ProxySidecar(Mutex::new(None)))
         .invoke_handler(tauri::generate_handler![
-            desktop_proxy_install,
             desktop_proxy_complete_setup,
             desktop_proxy_status
         ])

--- a/tools/desktop-app/src-tauri/src/lib.rs
+++ b/tools/desktop-app/src-tauri/src/lib.rs
@@ -36,6 +36,7 @@ struct Sidecar {
 struct ManagedProxy {
     child: Child,
     port: u16,
+    credentials: ProxyCredentials,
 }
 
 struct ProxySidecar(Mutex<Option<ManagedProxy>>);
@@ -282,6 +283,7 @@ fn generate_sidecar_secret() -> Result<String, String> {
     Ok(URL_SAFE_NO_PAD.encode(bytes))
 }
 
+#[derive(Clone)]
 struct ProxyCredentials {
     admin_key: String,
     completion_key: String,
@@ -455,7 +457,7 @@ fn spawn_proxy(
     app: &tauri::AppHandle,
     data: &Path,
     config: &ProxyConfig,
-    credentials: ProxyCredentials,
+    credentials: &ProxyCredentials,
 ) -> Result<Child, String> {
     let root = proxy_root(app);
     let node = root.join("node/bin/node");
@@ -475,7 +477,7 @@ fn spawn_proxy(
     fs::create_dir_all(&log_dir).ok();
     let mut command = Command::new(node);
     command.arg(entrypoint).current_dir(&state);
-    configure_desktop_proxy_environment(&mut command, config, &credentials, &state);
+    configure_desktop_proxy_environment(&mut command, config, credentials, &state);
 
     // The proxy inherits HOME and receives an expanded executable-only PATH:
     // the user's already logged-in Claude/Codex CLIs own their authentication.
@@ -555,6 +557,24 @@ fn managed_proxy_port(sidecar: &ProxySidecar) -> Option<u16> {
         .flatten()
 }
 
+/// Return the credentials held by the live managed process, not a later
+/// Keychain read. A setup retry must register exactly the keys passed to the
+/// proxy's environment.
+fn managed_proxy_credentials(sidecar: &ProxySidecar) -> Result<Option<ProxyCredentials>, String> {
+    let mut proxy = sidecar
+        .0
+        .lock()
+        .map_err(|_| "The desktop proxy process lock is unavailable.".to_string())?;
+    let exited = proxy
+        .as_mut()
+        .and_then(|process| process.child.try_wait().ok().flatten())
+        .is_some();
+    if exited {
+        proxy.take();
+    }
+    Ok(proxy.as_ref().map(|process| process.credentials.clone()))
+}
+
 fn stop_managed_proxy(sidecar: &ProxySidecar) -> Result<(), String> {
     let mut proxy = sidecar
         .0
@@ -568,36 +588,38 @@ fn stop_managed_proxy(sidecar: &ProxySidecar) -> Result<(), String> {
 }
 
 fn start_proxy(app: &tauri::AppHandle, data: &Path, sidecar: &ProxySidecar) -> Result<(), String> {
-    let mut child = sidecar
-        .0
-        .lock()
-        .map_err(|_| "The desktop proxy process lock is unavailable.".to_string())?;
-    let exited = child
-        .as_mut()
-        .and_then(|process| process.child.try_wait().ok().flatten())
-        .is_some();
-    if exited {
-        child.take();
-        let _ = fs::remove_file(proxy_pidfile_path(data));
+    let credentials = proxy_credentials()?;
+    start_proxy_with_credentials(app, data, sidecar, credentials).map(|_| ())
+}
+
+fn start_proxy_with_credentials(
+    app: &tauri::AppHandle,
+    data: &Path,
+    sidecar: &ProxySidecar,
+    credentials: ProxyCredentials,
+) -> Result<ProxyCredentials, String> {
+    // A newly generated key cannot authenticate a proxy that is already
+    // running with its old environment. Stop it before deciding whether to
+    // reuse a child so the replacement receives all current Keychain values.
+    if credentials.regenerated {
+        stop_managed_proxy(sidecar)?;
     }
-    if child.is_some() {
-        return Ok(());
+    if let Some(credentials) = managed_proxy_credentials(sidecar)? {
+        return Ok(credentials);
     }
-    drop(child);
     let mut config = read_proxy_config(data)
         .ok_or_else(|| "Desktop proxy setup has not been approved.".to_string())?;
     let manifest = bundled_proxy_manifest(app)?;
     if config.version != manifest.version {
         return Err("The desktop proxy version changed. Re-run desktop proxy setup.".to_string());
     }
-    let credentials = proxy_credentials()?;
     invalidate_proxy_registration_after_key_regeneration(
         data,
         &mut config,
         credentials.regenerated,
     )?;
     reap_orphan_proxy(data);
-    let child = spawn_proxy(app, data, &config, credentials)?;
+    let child = spawn_proxy(app, data, &config, &credentials)?;
     fs::write(proxy_pidfile_path(data), child.id().to_string())
         .map_err(|_| "Could not record the desktop proxy process.".to_string())?;
     sidecar
@@ -607,6 +629,7 @@ fn start_proxy(app: &tauri::AppHandle, data: &Path, sidecar: &ProxySidecar) -> R
         .replace(ManagedProxy {
             child,
             port: config.port,
+            credentials: credentials.clone(),
         });
     let healthy = sidecar
         .0
@@ -627,10 +650,13 @@ fn start_proxy(app: &tauri::AppHandle, data: &Path, sidecar: &ProxySidecar) -> R
             "cli-openai-proxy did not pass its health check. See desktop-proxy.log.".to_string(),
         );
     }
-    Ok(())
+    Ok(credentials)
 }
 
-fn install_proxy(app: &tauri::AppHandle, sidecar: &ProxySidecar) -> Result<ProxyStatus, String> {
+fn install_proxy(
+    app: &tauri::AppHandle,
+    sidecar: &ProxySidecar,
+) -> Result<ProxyCredentials, String> {
     let data = data_dir(app);
     fs::create_dir_all(&data)
         .map_err(|_| "Could not create the Collavre data directory.".to_string())?;
@@ -658,8 +684,9 @@ fn install_proxy(app: &tauri::AppHandle, sidecar: &ProxySidecar) -> Result<Proxy
         replace_occupied_proxy_port(&mut config, free_port());
     }
     write_proxy_config(&data, &config)?;
-    start_proxy(app, &data, sidecar)?;
-    Ok(proxy_status(app, &data, sidecar))
+    let credentials = proxy_credentials()?;
+    let credentials = start_proxy_with_credentials(app, &data, sidecar, credentials)?;
+    Ok(credentials)
 }
 
 /// Complete the user-approved setup without exposing Keychain secrets to the
@@ -683,11 +710,10 @@ fn desktop_proxy_complete_setup(
     // Tauri command is callable from loopback pages, so an arbitrary string
     // must not be allowed to trigger those side effects.
     validate_registration_grant(server_port, &registration_token)?;
-    install_proxy(&app, &sidecar)?;
+    let credentials = install_proxy(&app, &sidecar)?;
     let data = data_dir(&app);
     let config = read_proxy_config(&data)
         .ok_or_else(|| "Desktop proxy configuration is missing after installation.".to_string())?;
-    let credentials = proxy_credentials()?;
     let adapters = detected_adapters();
     let request = GatewayRegistration {
         registration_token: &registration_token,
@@ -1329,9 +1355,9 @@ mod tests {
         append_unique_paths, config_env_overrides, configure_desktop_proxy_environment,
         generate_proxy_key, invalidate_proxy_registration_after_key_regeneration,
         invalidate_proxy_registration_when_gateway_is_missing, lsof_reports_process,
-        managed_proxy_runs_on_port, migrate_proxy_config, normalized_proxy_config, nvm_bin_paths,
-        parse_bundled_proxy_manifest, read_proxy_config, reap_orphan_proxy,
-        register_authenticated_gateway, registered_authenticated_gateway_exists,
+        managed_proxy_credentials, managed_proxy_runs_on_port, migrate_proxy_config,
+        normalized_proxy_config, nvm_bin_paths, parse_bundled_proxy_manifest, read_proxy_config,
+        reap_orphan_proxy, register_authenticated_gateway, registered_authenticated_gateway_exists,
         replace_occupied_proxy_port, revalidate_registered_gateway_after_rails_health,
         valid_sidecar_challenge_response, wait_until_proxy_healthy, write_proxy_config,
         GatewayRegistration, HmacSha256, ManagedProxy, ProxyConfig, ProxyCredentials, ProxySidecar,
@@ -1787,10 +1813,22 @@ mod tests {
         let sidecar = ProxySidecar(Mutex::new(Some(ManagedProxy {
             child,
             port: 34_567,
+            credentials: ProxyCredentials {
+                admin_key: "admin-key".to_string(),
+                completion_key: "completion-key".to_string(),
+                identity_secret: "identity-secret".to_string(),
+                regenerated: false,
+            },
         })));
 
         assert!(managed_proxy_runs_on_port(&sidecar, 34_567));
         assert!(!managed_proxy_runs_on_port(&sidecar, 45_678));
+        let credentials = managed_proxy_credentials(&sidecar)
+            .expect("read managed proxy credentials")
+            .expect("managed proxy credentials");
+        assert_eq!("admin-key", credentials.admin_key);
+        assert_eq!("completion-key", credentials.completion_key);
+        assert_eq!("identity-secret", credentials.identity_secret);
 
         let mut proxy = sidecar
             .0

--- a/tools/desktop-app/src-tauri/src/lib.rs
+++ b/tools/desktop-app/src-tauri/src/lib.rs
@@ -964,6 +964,19 @@ fn registered_gateway_exists(
         && (response.starts_with("HTTP/1.1 204") || response.starts_with("HTTP/1.0 204"))
 }
 
+/// Re-authenticate immediately before the startup gateway check. Keychain
+/// access can block after the initial startup health check, during which a
+/// different local process could claim the Rails port.
+fn registered_authenticated_gateway_exists(
+    sidecar: &Sidecar,
+    rails_port: u16,
+    config: &ProxyConfig,
+    credentials: &ProxyCredentials,
+) -> bool {
+    authenticate_rails_sidecar(sidecar, rails_port).is_ok()
+        && registered_gateway_exists(rails_port, config, credentials)
+}
+
 fn invalidate_proxy_registration_when_gateway_is_missing(
     data: &Path,
     config: &mut ProxyConfig,
@@ -981,6 +994,7 @@ fn invalidate_proxy_registration_when_gateway_is_missing(
 /// only after Rails has answered its health endpoint.
 fn revalidate_registered_gateway_after_rails_health(
     rails_healthy: bool,
+    sidecar: &Sidecar,
     rails_port: u16,
     data: &Path,
     config: &mut ProxyConfig,
@@ -990,7 +1004,8 @@ fn revalidate_registered_gateway_after_rails_health(
         return Ok(false);
     }
 
-    let gateway_exists = registered_gateway_exists(rails_port, config, credentials);
+    let gateway_exists =
+        registered_authenticated_gateway_exists(sidecar, rails_port, config, credentials);
     invalidate_proxy_registration_when_gateway_is_missing(data, config, gateway_exists)?;
     Ok(gateway_exists)
 }
@@ -1280,10 +1295,10 @@ mod tests {
         invalidate_proxy_registration_when_gateway_is_missing, managed_proxy_runs_on_port,
         migrate_proxy_config, normalized_proxy_config, nvm_bin_paths, parse_bundled_proxy_manifest,
         read_proxy_config, reap_orphan_proxy, register_authenticated_gateway,
-        replace_occupied_proxy_port, revalidate_registered_gateway_after_rails_health,
-        valid_sidecar_challenge_response, wait_until_proxy_healthy, write_proxy_config,
-        GatewayRegistration, HmacSha256, ManagedProxy, ProxyConfig, ProxyCredentials, ProxySidecar,
-        Sidecar, URL_SAFE_NO_PAD,
+        registered_authenticated_gateway_exists, replace_occupied_proxy_port,
+        revalidate_registered_gateway_after_rails_health, valid_sidecar_challenge_response,
+        wait_until_proxy_healthy, write_proxy_config, GatewayRegistration, HmacSha256,
+        ManagedProxy, ProxyConfig, ProxyCredentials, ProxySidecar, Sidecar, URL_SAFE_NO_PAD,
     };
     use base64::Engine;
     use hmac::Mac;
@@ -1291,6 +1306,7 @@ mod tests {
         env,
         ffi::{OsStr, OsString},
         fs,
+        io::Read,
         path::PathBuf,
         process,
         sync::Mutex,
@@ -1299,6 +1315,36 @@ mod tests {
 
     fn pairs(json: &str) -> Vec<(&'static str, String)> {
         config_env_overrides(json)
+    }
+
+    #[cfg(unix)]
+    fn read_request(stream: &mut std::net::TcpStream) -> String {
+        let mut bytes = Vec::new();
+        let mut buffer = [0_u8; 1024];
+        let mut expected_length = None;
+
+        loop {
+            let count = stream.read(&mut buffer).expect("read request");
+            assert!(count > 0, "request ended before its body was complete");
+            bytes.extend_from_slice(&buffer[..count]);
+
+            let Some(headers_end) = bytes.windows(4).position(|window| window == b"\r\n\r\n")
+            else {
+                continue;
+            };
+            let headers_end = headers_end + 4;
+            let body_length = *expected_length.get_or_insert_with(|| {
+                let headers = String::from_utf8_lossy(&bytes[..headers_end]);
+                headers
+                    .lines()
+                    .find_map(|line| line.strip_prefix("Content-Length: "))
+                    .and_then(|length| length.parse::<usize>().ok())
+                    .unwrap_or(0)
+            });
+            if bytes.len() >= headers_end + body_length {
+                return String::from_utf8(bytes).expect("UTF-8 request");
+            }
+        }
     }
 
     #[test]
@@ -1425,38 +1471,9 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn gateway_registration_reauthenticates_sidecar_before_sending_credentials() {
-        use std::io::{Read, Write};
+        use std::io::Write;
         use std::net::TcpListener;
         use std::thread;
-
-        fn read_request(stream: &mut std::net::TcpStream) -> String {
-            let mut bytes = Vec::new();
-            let mut buffer = [0_u8; 1024];
-            let mut expected_length = None;
-
-            loop {
-                let count = stream.read(&mut buffer).expect("read request");
-                assert!(count > 0, "request ended before its body was complete");
-                bytes.extend_from_slice(&buffer[..count]);
-
-                let Some(headers_end) = bytes.windows(4).position(|window| window == b"\r\n\r\n")
-                else {
-                    continue;
-                };
-                let headers_end = headers_end + 4;
-                let body_length = *expected_length.get_or_insert_with(|| {
-                    let headers = String::from_utf8_lossy(&bytes[..headers_end]);
-                    headers
-                        .lines()
-                        .find_map(|line| line.strip_prefix("Content-Length: "))
-                        .and_then(|length| length.parse::<usize>().ok())
-                        .unwrap_or(0)
-                });
-                if bytes.len() >= headers_end + body_length {
-                    return String::from_utf8(bytes).expect("UTF-8 request");
-                }
-            }
-        }
 
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind test listener");
         let port = listener.local_addr().expect("listener address").port();
@@ -1520,6 +1537,90 @@ mod tests {
         register_authenticated_gateway(&sidecar, port, &registration)
             .expect("authenticated registration");
         server.join().expect("test registration server");
+
+        let mut child = sidecar
+            .child
+            .lock()
+            .expect("sidecar lock")
+            .take()
+            .expect("sidecar child");
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn startup_gateway_check_reauthenticates_sidecar_before_sending_credentials() {
+        use std::io::Write;
+        use std::net::TcpListener;
+        use std::thread;
+
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind test listener");
+        let port = listener.local_addr().expect("listener address").port();
+        let secret = "sidecar-startup-secret".to_string();
+        let expected_secret = secret.clone();
+        let server = thread::spawn(move || {
+            let (mut health, _) = listener.accept().expect("accept sidecar challenge");
+            let health_request = read_request(&mut health);
+            let challenge = health_request
+                .split_whitespace()
+                .nth(1)
+                .and_then(|path| path.split("challenge=").nth(1))
+                .expect("sidecar challenge");
+            let mut mac =
+                HmacSha256::new_from_slice(expected_secret.as_bytes()).expect("valid HMAC key");
+            mac.update(challenge.as_bytes());
+            let proof = URL_SAFE_NO_PAD.encode(mac.finalize().into_bytes());
+            health
+                .write_all(
+                    format!(
+                        "HTTP/1.0 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{proof}",
+                        proof.len()
+                    )
+                    .as_bytes(),
+                )
+                .expect("write sidecar proof");
+            drop(health);
+
+            let (mut status, _) = listener.accept().expect("accept gateway status");
+            let status_request = read_request(&mut status);
+            assert!(status_request.starts_with("POST /desktop/setup/gateway-registered HTTP/1.1"));
+            assert!(status_request.contains("\"admin_key\":\"admin-key\""));
+            status
+                .write_all(
+                    b"HTTP/1.0 204 No Content\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+                )
+                .expect("write gateway status response");
+        });
+
+        let child = process::Command::new("sh")
+            .args(["-c", "sleep 5"])
+            .spawn()
+            .expect("spawn sidecar child");
+        let sidecar = Sidecar {
+            child: Mutex::new(Some(child)),
+            port: Mutex::new(Some(port)),
+            secret,
+        };
+        let config = ProxyConfig {
+            port: 34_567,
+            version: "0.1.0".to_string(),
+            registered: true,
+        };
+        let credentials = ProxyCredentials {
+            admin_key: "admin-key".to_string(),
+            completion_key: "completion-key".to_string(),
+            identity_secret: "identity-secret".to_string(),
+            regenerated: false,
+        };
+
+        assert!(registered_authenticated_gateway_exists(
+            &sidecar,
+            port,
+            &config,
+            &credentials,
+        ));
+        server.join().expect("test gateway status server");
 
         let mut child = sidecar
             .child
@@ -1814,6 +1915,11 @@ mod tests {
 
         let revalidated = revalidate_registered_gateway_after_rails_health(
             false,
+            &Sidecar {
+                child: Mutex::new(None),
+                port: Mutex::new(None),
+                secret: "unused".to_string(),
+            },
             45_678,
             &data,
             &mut config,
@@ -1921,6 +2027,7 @@ pub fn run() {
                         let credentials = proxy_credentials()?;
                         revalidate_registered_gateway_after_rails_health(
                             true,
+                            &handle.state::<Sidecar>(),
                             port,
                             &data,
                             &mut config,

--- a/tools/desktop-app/src-tauri/src/lib.rs
+++ b/tools/desktop-app/src-tauri/src/lib.rs
@@ -66,10 +66,25 @@ fn free_port() -> u16 {
         .port()
 }
 
+/// Locate the macOS application resource directory from its executable.
+///
+/// `PathResolver::resource_dir` is normally this directory, but can be absent
+/// when the app is launched directly from a copied `.app` during installation.
+/// Resolving relative to the executable keeps an installed build independent of
+/// the development checkout in that case.
+fn packaged_resource_dir() -> Option<PathBuf> {
+    let executable_dir = std::env::current_exe().ok()?.parent()?.to_path_buf();
+    let resources = executable_dir.parent()?.join("Resources");
+    resources.join("app").is_dir().then_some(resources)
+}
+
 /// Locate the bundled Rails app root. In a packaged `.app` the launcher and app
 /// tree live under `Contents/Resources/app`; in `tauri dev` they're resolved
 /// relative to the repo so the shell can be exercised without packaging.
 fn app_root(app: &tauri::AppHandle) -> PathBuf {
+    if let Some(resources) = packaged_resource_dir() {
+        return resources.join("app");
+    }
     if let Ok(res) = app.path().resource_dir() {
         let bundled = res.join("app");
         if bundled.join("bin/desktop-server").exists() {
@@ -107,6 +122,12 @@ fn proxy_pidfile_path(data: &Path) -> PathBuf {
 }
 
 fn proxy_root(app: &tauri::AppHandle) -> PathBuf {
+    if let Some(resources) = packaged_resource_dir() {
+        let bundled = resources.join("app/proxy");
+        if bundled.join("manifest.json").exists() {
+            return bundled;
+        }
+    }
     if let Ok(resource_dir) = app.path().resource_dir() {
         let bundled = resource_dir.join("app/proxy");
         if bundled.join("manifest.json").exists() {
@@ -794,7 +815,12 @@ pub fn run() {
                     return;
                 };
                 if healthy {
-                    if let Ok(url) = format!("http://127.0.0.1:{port}").parse::<tauri::Url>() {
+                    // The setup flow is currently a presentation-only mockup.
+                    // Open it directly after the sidecar is healthy so a fresh
+                    // desktop install can review the first-run experience.
+                    if let Ok(url) =
+                        format!("http://127.0.0.1:{port}/desktop/setup").parse::<tauri::Url>()
+                    {
                         let _ = window.navigate(url);
                     }
                 } else {

--- a/tools/desktop-app/src-tauri/src/lib.rs
+++ b/tools/desktop-app/src-tauri/src/lib.rs
@@ -18,13 +18,16 @@ use std::time::{Duration, Instant};
 
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::Engine;
+use hmac::{Hmac, Mac};
 use serde::{Deserialize, Serialize};
+use sha2::Sha256;
 use tauri::{Manager, RunEvent, WebviewUrl, WebviewWindowBuilder};
 
 /// Holds the sidecar child so we can stop it on exit.
 struct Sidecar {
     child: Mutex<Option<Child>>,
     port: Mutex<Option<u16>>,
+    secret: String,
 }
 
 /// Holds the optional, user-approved cli-openai-proxy process. It is deliberately
@@ -269,6 +272,16 @@ fn generate_proxy_key(prefix: &str) -> Result<String, String> {
     Ok(format!("{prefix}_{}", URL_SAFE_NO_PAD.encode(bytes)))
 }
 
+/// Generate the ephemeral secret that binds the native shell to the Rails
+/// child it launches. It is passed only through the child's environment and
+/// is never persisted or exposed to the webview.
+fn generate_sidecar_secret() -> Result<String, String> {
+    let mut bytes = [0u8; 48];
+    getrandom::fill(&mut bytes)
+        .map_err(|_| "Could not generate a desktop sidecar secret.".to_string())?;
+    Ok(URL_SAFE_NO_PAD.encode(bytes))
+}
+
 struct ProxyCredentials {
     admin_key: String,
     completion_key: String,
@@ -372,7 +385,7 @@ fn reap_orphan_sidecar(data: &Path) {
     let _ = fs::remove_file(pidfile_path(data));
 }
 
-fn spawn_sidecar(root: &Path, data: &Path, port: u16) -> Child {
+fn spawn_sidecar(root: &Path, data: &Path, port: u16, secret: &str) -> Child {
     let launcher = root.join("bin/desktop-server");
     // Honor a caller-supplied bind host (open mode = 0.0.0.0 for LAN/Tailscale);
     // default to loopback. COLLAVRE_ALLOWED_HOSTS rides along via the inherited
@@ -383,7 +396,8 @@ fn spawn_sidecar(root: &Path, data: &Path, port: u16) -> Child {
         .current_dir(root)
         .env("PORT", port.to_string())
         .env("COLLAVRE_DATA_DIR", data)
-        .env("COLLAVRE_BIND_HOST", bind_host);
+        .env("COLLAVRE_BIND_HOST", bind_host)
+        .env("COLLAVRE_DESKTOP_SIDECAR_SECRET", secret);
 
     // Capture the sidecar's stdout/stderr to a boot log. A Finder-launched .app has
     // no terminal, so without this any startup failure (db migrate/seed, Puma) is
@@ -663,6 +677,7 @@ fn desktop_proxy_complete_setup(
         .lock()
         .map_err(|_| "The local Collavre server port is unavailable.".to_string())?
         .ok_or_else(|| "Collavre Desktop could not determine the local server port.".to_string())?;
+    authenticate_rails_sidecar(&rails_sidecar, server_port)?;
     // Validate the Rails-issued, short-lived consent grant before creating
     // Keychain credentials, writing proxy state, or starting the proxy. The
     // Tauri command is callable from loopback pages, so an arbitrary string
@@ -998,11 +1013,80 @@ fn validate_registration_grant(port: u16, registration_token: &str) -> Result<()
     }
 }
 
-/// Poll `GET /up` until it answers 200 or we give up.
-fn wait_until_healthy(port: u16, timeout: Duration) -> bool {
+type HmacSha256 = Hmac<Sha256>;
+
+fn valid_sidecar_challenge_response(secret: &str, challenge: &str, response: &str) -> bool {
+    let Ok(signature) = URL_SAFE_NO_PAD.decode(response.trim()) else {
+        return false;
+    };
+    let Ok(mut mac) = HmacSha256::new_from_slice(secret.as_bytes()) else {
+        return false;
+    };
+    mac.update(challenge.as_bytes());
+    mac.verify_slice(&signature).is_ok()
+}
+
+/// Prove the listener knows the ephemeral secret injected into the Rails child.
+/// A listener that merely imitates `/up` cannot manufacture this HMAC response.
+fn sidecar_challenge_accepted(port: u16, secret: &str) -> bool {
+    let Ok(challenge) = generate_sidecar_secret() else {
+        return false;
+    };
+    let address = format!("127.0.0.1:{port}");
+    let Ok(mut stream) = TcpStream::connect(&address) else {
+        return false;
+    };
+    let _ = stream.set_read_timeout(Some(Duration::from_millis(500)));
+    let _ = stream.set_write_timeout(Some(Duration::from_millis(500)));
+    let request = format!(
+        "GET /desktop/setup/sidecar-health?challenge={challenge} HTTP/1.0\r\nHost: {address}\r\nConnection: close\r\n\r\n"
+    );
+    if stream.write_all(request.as_bytes()).is_err() {
+        return false;
+    }
+    let mut response = String::new();
+    if stream.read_to_string(&mut response).is_err() {
+        return false;
+    }
+    let Some((headers, body)) = response.split_once("\r\n\r\n") else {
+        return false;
+    };
+    headers.starts_with("HTTP/1.")
+        && headers.contains(" 200")
+        && valid_sidecar_challenge_response(secret, &challenge, body)
+}
+
+fn sidecar_is_running(sidecar: &Sidecar) -> bool {
+    sidecar
+        .child
+        .lock()
+        .ok()
+        .and_then(|mut child| {
+            child
+                .as_mut()
+                .map(|child| child.try_wait().ok().flatten().is_none())
+        })
+        .unwrap_or(false)
+}
+
+fn authenticate_rails_sidecar(sidecar: &Sidecar, port: u16) -> Result<(), String> {
+    if sidecar_is_running(sidecar)
+        && sidecar_challenge_accepted(port, &sidecar.secret)
+        && sidecar_is_running(sidecar)
+    {
+        return Ok(());
+    }
+
+    Err("The local Collavre server could not be authenticated. Restart Collavre Desktop and try again.".to_string())
+}
+
+/// Poll the authenticated sidecar challenge until the spawned Rails process is
+/// ready. Never navigate the capability-enabled webview to an unauthenticated
+/// listener that merely answers a generic health request.
+fn wait_until_authenticated_sidecar(sidecar: &Sidecar, port: u16, timeout: Duration) -> bool {
     let deadline = Instant::now() + timeout;
     while Instant::now() < deadline {
-        if http_ok(port, "/up") {
+        if authenticate_rails_sidecar(sidecar, port).is_ok() {
             return true;
         }
         std::thread::sleep(Duration::from_millis(250));
@@ -1183,9 +1267,12 @@ mod tests {
         invalidate_proxy_registration_when_gateway_is_missing, managed_proxy_runs_on_port,
         migrate_proxy_config, normalized_proxy_config, nvm_bin_paths, parse_bundled_proxy_manifest,
         read_proxy_config, reap_orphan_proxy, replace_occupied_proxy_port,
-        revalidate_registered_gateway_after_rails_health, wait_until_proxy_healthy,
-        write_proxy_config, ManagedProxy, ProxyConfig, ProxyCredentials, ProxySidecar,
+        revalidate_registered_gateway_after_rails_health, valid_sidecar_challenge_response,
+        wait_until_proxy_healthy, write_proxy_config, HmacSha256, ManagedProxy, ProxyConfig,
+        ProxyCredentials, ProxySidecar, URL_SAFE_NO_PAD,
     };
+    use base64::Engine;
+    use hmac::Mac;
     use std::{
         env,
         ffi::{OsStr, OsString},
@@ -1296,6 +1383,29 @@ mod tests {
             .all(|character| character.is_ascii_alphanumeric()
                 || character == '_'
                 || character == '-'));
+    }
+
+    #[test]
+    fn sidecar_health_requires_a_valid_hmac_challenge_response() {
+        let secret = "sidecar-secret";
+        let challenge = "native-challenge";
+        let mut mac = HmacSha256::new_from_slice(secret.as_bytes()).expect("valid HMAC key");
+        mac.update(challenge.as_bytes());
+        let response = URL_SAFE_NO_PAD.encode(mac.finalize().into_bytes());
+
+        assert!(valid_sidecar_challenge_response(
+            secret, challenge, &response
+        ));
+        assert!(!valid_sidecar_challenge_response(
+            secret,
+            "different-challenge",
+            &response
+        ));
+        assert!(!valid_sidecar_challenge_response(
+            secret,
+            challenge,
+            "not-a-signature"
+        ));
     }
 
     #[test]
@@ -1597,11 +1707,13 @@ mod tests {
 }
 
 pub fn run() {
+    let sidecar_secret = generate_sidecar_secret().expect("generate Rails sidecar secret");
     tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
         .manage(Sidecar {
             child: Mutex::new(None),
             port: Mutex::new(None),
+            secret: sidecar_secret,
         })
         .manage(ProxySidecar(Mutex::new(None)))
         .invoke_handler(tauri::generate_handler![
@@ -1633,7 +1745,7 @@ pub fn run() {
             // Reap any sidecar orphaned by a prior crash before we spawn — it
             // still holds this data dir's SQLite write locks.
             reap_orphan_sidecar(&data);
-            let child = spawn_sidecar(&root, &data, port);
+            let child = spawn_sidecar(&root, &data, port, &app.state::<Sidecar>().secret);
             let _ = fs::write(pidfile_path(&data), child.id().to_string());
             app.state::<Sidecar>().child.lock().unwrap().replace(child);
             app.state::<Sidecar>().port.lock().unwrap().replace(port);
@@ -1669,7 +1781,11 @@ pub fn run() {
                         }
                         None => Ok(None),
                     });
-                let healthy = wait_until_healthy(port, Duration::from_secs(120));
+                let healthy = wait_until_authenticated_sidecar(
+                    &handle.state::<Sidecar>(),
+                    port,
+                    Duration::from_secs(120),
+                );
                 let first_run_complete = proxy_config
                     .and_then(|config| {
                         if !healthy {

--- a/tools/desktop-app/src-tauri/src/lib.rs
+++ b/tools/desktop-app/src-tauri/src/lib.rs
@@ -396,58 +396,12 @@ fn spawn_sidecar(root: &Path, data: &Path, port: u16) -> Child {
     cmd.spawn().expect("spawn rails sidecar")
 }
 
-#[cfg(unix)]
-fn proxy_process_matches_bundle(app: &tauri::AppHandle, pid: i32) -> bool {
-    let Ok(output) = Command::new("ps")
-        .args(["-p", &pid.to_string(), "-o", "command="])
-        .output()
-    else {
-        return false;
-    };
-    let command = String::from_utf8_lossy(&output.stdout);
-    proxy_command_matches_bundle(
-        &command,
-        &proxy_root(app).join("node/bin/node"),
-        &proxy_root(app).join("node_modules/cli-openai-proxy/dist/server/standalone.js"),
-    )
-}
-
-/// A pidfile can outlive the proxy process. Never signal a reused process group
-/// unless its leader is still the bundled Node proxy we started.
-#[cfg(unix)]
-fn proxy_command_matches_bundle(command: &str, node: &Path, entrypoint: &Path) -> bool {
-    command.contains(&node.to_string_lossy().to_string())
-        && command.contains(&entrypoint.to_string_lossy().to_string())
-}
-
-#[cfg(unix)]
-fn reap_orphan_proxy(app: &tauri::AppHandle, data: &Path) {
-    let path = proxy_pidfile_path(data);
-    let Ok(contents) = fs::read_to_string(&path) else {
-        return;
-    };
-    if let Ok(pid) = contents.trim().parse::<i32>() {
-        if pid > 1 && proxy_process_matches_bundle(app, pid) && unsafe { libc_kill(-pid, 0) } == 0 {
-            unsafe {
-                libc_kill(-pid, 15);
-            }
-            let deadline = Instant::now() + Duration::from_secs(5);
-            while Instant::now() < deadline {
-                if unsafe { libc_kill(-pid, 0) } != 0 {
-                    break;
-                }
-                std::thread::sleep(Duration::from_millis(100));
-            }
-            unsafe {
-                libc_kill(-pid, 9);
-            }
-        }
-    }
-    let _ = fs::remove_file(path);
-}
-
-#[cfg(not(unix))]
-fn reap_orphan_proxy(_app: &tauri::AppHandle, data: &Path) {
+/// A pidfile contains no unforgeable process identity. Never signal a process
+/// group from it: even a matching command can exit and have its numeric PID
+/// reused before a signal is delivered. Clean shutdown uses the `Child` handle
+/// held in memory; after a crash, discard the stale file and let repair select
+/// a new port if the abandoned proxy still owns the old one.
+fn reap_orphan_proxy(data: &Path) {
     let _ = fs::remove_file(proxy_pidfile_path(data));
 }
 
@@ -563,7 +517,7 @@ fn start_proxy(app: &tauri::AppHandle, data: &Path, sidecar: &ProxySidecar) -> R
         &mut config,
         credentials.regenerated,
     )?;
-    reap_orphan_proxy(app, data);
+    reap_orphan_proxy(data);
     let child = spawn_proxy(app, data, &config, credentials)?;
     fs::write(proxy_pidfile_path(data), child.id().to_string())
         .map_err(|_| "Could not record the desktop proxy process.".to_string())?;
@@ -608,7 +562,7 @@ fn install_proxy(app: &tauri::AppHandle, sidecar: &ProxySidecar) -> Result<Proxy
     // Clear a prior crashed proxy before probing its persisted port. If another
     // process owns it, choose a fresh loopback port and require registration so
     // Rails' gateway URL follows the repaired proxy.
-    reap_orphan_proxy(app, &data);
+    reap_orphan_proxy(&data);
     if !proxy_port_available(config.port) {
         replace_occupied_proxy_port(&mut config, free_port());
     }
@@ -1012,9 +966,9 @@ mod tests {
     use super::{
         append_unique_paths, config_env_overrides, generate_proxy_key,
         invalidate_proxy_registration_after_key_regeneration, migrate_proxy_config,
-        normalized_proxy_config, nvm_bin_paths, parse_bundled_proxy_manifest,
-        proxy_command_matches_bundle, read_proxy_config, replace_occupied_proxy_port,
-        wait_until_proxy_healthy, write_proxy_config, ProxyConfig,
+        normalized_proxy_config, nvm_bin_paths, parse_bundled_proxy_manifest, read_proxy_config,
+        reap_orphan_proxy, replace_occupied_proxy_port, wait_until_proxy_healthy,
+        write_proxy_config, ProxyConfig,
     };
     use std::{env, fs, path::PathBuf, process, time::Duration};
 
@@ -1182,30 +1136,18 @@ mod tests {
         );
     }
 
-    #[cfg(unix)]
     #[test]
-    fn stale_proxy_pid_must_match_the_bundled_node_command_before_reaping() {
-        let node =
-            PathBuf::from("/Applications/Collavre.app/Contents/Resources/app/proxy/node/bin/node");
-        let entrypoint = PathBuf::from(
-            "/Applications/Collavre.app/Contents/Resources/app/proxy/node_modules/cli-openai-proxy/dist/server/standalone.js",
-        );
+    fn orphan_proxy_reaping_only_discards_the_untrusted_pidfile() {
+        let data = env::temp_dir().join(format!("collavre-proxy-pidfile-{}", process::id()));
+        let pidfile = super::proxy_pidfile_path(&data);
+        let _ = fs::remove_dir_all(&data);
+        fs::create_dir_all(pidfile.parent().expect("pidfile parent")).expect("create state");
+        fs::write(&pidfile, "12345").expect("write stale pidfile");
 
-        assert!(proxy_command_matches_bundle(
-            &format!("{} {}", node.display(), entrypoint.display()),
-            &node,
-            &entrypoint
-        ));
-        assert!(!proxy_command_matches_bundle(
-            "/usr/bin/sleep 30",
-            &node,
-            &entrypoint
-        ));
-        assert!(!proxy_command_matches_bundle(
-            &format!("{} unrelated.js", node.display()),
-            &node,
-            &entrypoint
-        ));
+        reap_orphan_proxy(&data);
+
+        assert!(!pidfile.exists());
+        let _ = fs::remove_dir_all(&data);
     }
 
     #[cfg(unix)]

--- a/tools/desktop-app/src-tauri/src/lib.rs
+++ b/tools/desktop-app/src-tauri/src/lib.rs
@@ -697,7 +697,7 @@ fn desktop_proxy_complete_setup(
         identity_secret: &credentials.identity_secret,
         adapters: &adapters,
     };
-    register_gateway(server_port, &request)?;
+    register_authenticated_gateway(&rails_sidecar, server_port, &request)?;
 
     let registered = ProxyConfig {
         registered: true,
@@ -906,6 +906,19 @@ fn register_gateway(port: u16, registration: &GatewayRegistration<'_>) -> Result
                 .to_string(),
         )
     }
+}
+
+/// Re-authenticate immediately before the credential-bearing registration
+/// request. Proxy installation can wait for Keychain or health checks, during
+/// which the Rails child could exit and its port could be claimed by another
+/// loopback process.
+fn register_authenticated_gateway(
+    sidecar: &Sidecar,
+    port: u16,
+    registration: &GatewayRegistration<'_>,
+) -> Result<(), String> {
+    authenticate_rails_sidecar(sidecar, port)?;
+    register_gateway(port, registration)
 }
 
 /// Confirm that the Rails record backing the locally healthy proxy still
@@ -1266,10 +1279,11 @@ mod tests {
         generate_proxy_key, invalidate_proxy_registration_after_key_regeneration,
         invalidate_proxy_registration_when_gateway_is_missing, managed_proxy_runs_on_port,
         migrate_proxy_config, normalized_proxy_config, nvm_bin_paths, parse_bundled_proxy_manifest,
-        read_proxy_config, reap_orphan_proxy, replace_occupied_proxy_port,
-        revalidate_registered_gateway_after_rails_health, valid_sidecar_challenge_response,
-        wait_until_proxy_healthy, write_proxy_config, HmacSha256, ManagedProxy, ProxyConfig,
-        ProxyCredentials, ProxySidecar, URL_SAFE_NO_PAD,
+        read_proxy_config, reap_orphan_proxy, register_authenticated_gateway,
+        replace_occupied_proxy_port, revalidate_registered_gateway_after_rails_health,
+        valid_sidecar_challenge_response, wait_until_proxy_healthy, write_proxy_config,
+        GatewayRegistration, HmacSha256, ManagedProxy, ProxyConfig, ProxyCredentials, ProxySidecar,
+        Sidecar, URL_SAFE_NO_PAD,
     };
     use base64::Engine;
     use hmac::Mac;
@@ -1406,6 +1420,115 @@ mod tests {
             challenge,
             "not-a-signature"
         ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn gateway_registration_reauthenticates_sidecar_before_sending_credentials() {
+        use std::io::{Read, Write};
+        use std::net::TcpListener;
+        use std::thread;
+
+        fn read_request(stream: &mut std::net::TcpStream) -> String {
+            let mut bytes = Vec::new();
+            let mut buffer = [0_u8; 1024];
+            let mut expected_length = None;
+
+            loop {
+                let count = stream.read(&mut buffer).expect("read request");
+                assert!(count > 0, "request ended before its body was complete");
+                bytes.extend_from_slice(&buffer[..count]);
+
+                let Some(headers_end) = bytes.windows(4).position(|window| window == b"\r\n\r\n")
+                else {
+                    continue;
+                };
+                let headers_end = headers_end + 4;
+                let body_length = *expected_length.get_or_insert_with(|| {
+                    let headers = String::from_utf8_lossy(&bytes[..headers_end]);
+                    headers
+                        .lines()
+                        .find_map(|line| line.strip_prefix("Content-Length: "))
+                        .and_then(|length| length.parse::<usize>().ok())
+                        .unwrap_or(0)
+                });
+                if bytes.len() >= headers_end + body_length {
+                    return String::from_utf8(bytes).expect("UTF-8 request");
+                }
+            }
+        }
+
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind test listener");
+        let port = listener.local_addr().expect("listener address").port();
+        let secret = "sidecar-registration-secret".to_string();
+        let expected_secret = secret.clone();
+        let server = thread::spawn(move || {
+            let (mut health, _) = listener.accept().expect("accept sidecar challenge");
+            let health_request = read_request(&mut health);
+            let challenge = health_request
+                .split_whitespace()
+                .nth(1)
+                .and_then(|path| path.split("challenge=").nth(1))
+                .expect("sidecar challenge");
+            let mut mac =
+                HmacSha256::new_from_slice(expected_secret.as_bytes()).expect("valid HMAC key");
+            mac.update(challenge.as_bytes());
+            let proof = URL_SAFE_NO_PAD.encode(mac.finalize().into_bytes());
+            health
+                .write_all(
+                    format!(
+                        "HTTP/1.0 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{proof}",
+                        proof.len()
+                    )
+                    .as_bytes(),
+                )
+                .expect("write sidecar proof");
+            drop(health);
+
+            let (mut registration, _) = listener.accept().expect("accept registration");
+            let registration_request = read_request(&mut registration);
+            assert!(
+                registration_request.starts_with("POST /desktop/setup/register-gateway HTTP/1.1")
+            );
+            assert!(registration_request.contains("\"admin_key\":\"admin-key\""));
+            registration
+                .write_all(
+                    b"HTTP/1.0 201 Created\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+                )
+                .expect("write registration response");
+        });
+
+        let child = process::Command::new("sh")
+            .args(["-c", "sleep 5"])
+            .spawn()
+            .expect("spawn sidecar child");
+        let sidecar = Sidecar {
+            child: Mutex::new(Some(child)),
+            port: Mutex::new(Some(port)),
+            secret,
+        };
+        let adapters = vec!["claude".to_string()];
+        let registration = GatewayRegistration {
+            registration_token: "registration-token",
+            proxy_port: 34_567,
+            admin_key: "admin-key",
+            completion_key: "completion-key",
+            identity_secret: "identity-secret",
+            adapters: &adapters,
+        };
+
+        register_authenticated_gateway(&sidecar, port, &registration)
+            .expect("authenticated registration");
+        server.join().expect("test registration server");
+
+        let mut child = sidecar
+            .child
+            .lock()
+            .expect("sidecar lock")
+            .take()
+            .expect("sidecar child");
+        let _ = child.kill();
+        let _ = child.wait();
     }
 
     #[test]

--- a/tools/desktop-app/src-tauri/src/lib.rs
+++ b/tools/desktop-app/src-tauri/src/lib.rs
@@ -32,6 +32,7 @@ struct ProxySidecar(Mutex<Option<Child>>);
 const PROXY_KEYCHAIN_SERVICE: &str = "net.collavre.desktop.cli-openai-proxy";
 const PROXY_ADMIN_KEY_ACCOUNT: &str = "admin-key";
 const PROXY_COMPLETION_KEY_ACCOUNT: &str = "completion-key";
+const PROXY_IDENTITY_SECRET_ACCOUNT: &str = "identity-secret";
 
 #[derive(Debug, Deserialize)]
 struct BundledProxyManifest {
@@ -45,6 +46,8 @@ struct BundledProxyManifest {
 struct ProxyConfig {
     port: u16,
     version: String,
+    #[serde(default)]
+    registered: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -53,6 +56,23 @@ struct ProxyStatus {
     running: bool,
     port: Option<u16>,
     version: Option<String>,
+    registered: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct ProxySetupResult {
+    status: ProxyStatus,
+    adapters: Vec<String>,
+}
+
+#[derive(Serialize)]
+struct GatewayRegistration<'a> {
+    registration_token: &'a str,
+    proxy_port: u16,
+    admin_key: &'a str,
+    completion_key: &'a str,
+    identity_secret: &'a str,
+    adapters: &'a [String],
 }
 
 /// Bind to port 0 to let the OS hand us a free port, then release it. There is a
@@ -342,6 +362,7 @@ fn spawn_proxy(app: &tauri::AppHandle, data: &Path, config: &ProxyConfig) -> Res
 
     let admin_key = keychain_proxy_key(PROXY_ADMIN_KEY_ACCOUNT, "cop_admin")?;
     let completion_key = keychain_proxy_key(PROXY_COMPLETION_KEY_ACCOUNT, "cop_key")?;
+    let identity_secret = keychain_proxy_key(PROXY_IDENTITY_SECRET_ACCOUNT, "cop_identity")?;
     let state = proxy_state_dir(data);
     fs::create_dir_all(state.join("provision-state"))
         .map_err(|_| "Could not create the desktop proxy state directory.".to_string())?;
@@ -356,11 +377,14 @@ fn spawn_proxy(app: &tauri::AppHandle, data: &Path, config: &ProxyConfig) -> Res
         .env("PORT", config.port.to_string())
         .env("API_KEYS", completion_key)
         .env("AUTH_ADMIN_KEYS", admin_key)
+        .env("USER_IDENTITY_HMAC_SECRET", identity_secret)
+        .env("PATH", desktop_cli_path())
         .env("PROVISION_STATE_DIR", state.join("provision-state"));
 
-    // The proxy deliberately inherits HOME and PATH: the user's already logged
-    // in Claude/Codex CLIs own their authentication. The proxy-only keys above
-    // are captured and removed by cli-openai-proxy before it starts a CLI child.
+    // The proxy inherits HOME and receives an expanded executable-only PATH:
+    // the user's already logged-in Claude/Codex CLIs own their authentication.
+    // The proxy-only keys above are captured and removed by cli-openai-proxy
+    // before it starts a CLI child.
     if let Ok(log) = File::create(log_dir.join("desktop-proxy.log")) {
         if let Ok(error_log) = log.try_clone() {
             command
@@ -391,6 +415,7 @@ fn proxy_status(app: &tauri::AppHandle, data: &Path, sidecar: &ProxySidecar) -> 
             .unwrap_or(false),
         port: config.as_ref().map(|item| item.port),
         version: manifest.map(|item| item.version),
+        registered: config.map(|item| item.registered).unwrap_or(false),
     }
 }
 
@@ -448,17 +473,61 @@ fn desktop_proxy_install(
     app: tauri::AppHandle,
     sidecar: tauri::State<'_, ProxySidecar>,
 ) -> Result<ProxyStatus, String> {
-    let data = data_dir(&app);
+    install_proxy(&app, &sidecar)
+}
+
+fn install_proxy(app: &tauri::AppHandle, sidecar: &ProxySidecar) -> Result<ProxyStatus, String> {
+    let data = data_dir(app);
     fs::create_dir_all(&data)
         .map_err(|_| "Could not create the Collavre data directory.".to_string())?;
-    let manifest = bundled_proxy_manifest(&app)?;
+    let manifest = bundled_proxy_manifest(app)?;
     let config = read_proxy_config(&data).unwrap_or(ProxyConfig {
         port: free_port(),
         version: manifest.version,
+        registered: false,
     });
     write_proxy_config(&data, &config)?;
-    start_proxy(&app, &data, &sidecar)?;
-    Ok(proxy_status(&app, &data, &sidecar))
+    start_proxy(app, &data, sidecar)?;
+    Ok(proxy_status(app, &data, sidecar))
+}
+
+/// Complete the user-approved setup without exposing Keychain secrets to the
+/// webview. The registration grant is short-lived and Rails accepts it only
+/// over its loopback socket.
+#[tauri::command]
+fn desktop_proxy_complete_setup(
+    app: tauri::AppHandle,
+    sidecar: tauri::State<'_, ProxySidecar>,
+    registration_token: String,
+    server_port: u16,
+) -> Result<ProxySetupResult, String> {
+    install_proxy(&app, &sidecar)?;
+    let data = data_dir(&app);
+    let config = read_proxy_config(&data)
+        .ok_or_else(|| "Desktop proxy configuration is missing after installation.".to_string())?;
+    let admin_key = keychain_proxy_key(PROXY_ADMIN_KEY_ACCOUNT, "cop_admin")?;
+    let completion_key = keychain_proxy_key(PROXY_COMPLETION_KEY_ACCOUNT, "cop_key")?;
+    let identity_secret = keychain_proxy_key(PROXY_IDENTITY_SECRET_ACCOUNT, "cop_identity")?;
+    let adapters = detected_adapters();
+    let request = GatewayRegistration {
+        registration_token: &registration_token,
+        proxy_port: config.port,
+        admin_key: &admin_key,
+        completion_key: &completion_key,
+        identity_secret: &identity_secret,
+        adapters: &adapters,
+    };
+    register_gateway(server_port, &request)?;
+
+    let registered = ProxyConfig {
+        registered: true,
+        ..config
+    };
+    write_proxy_config(&data, &registered)?;
+    Ok(ProxySetupResult {
+        status: proxy_status(&app, &data, &sidecar),
+        adapters,
+    })
 }
 
 #[tauri::command]
@@ -467,6 +536,102 @@ fn desktop_proxy_status(
     sidecar: tauri::State<'_, ProxySidecar>,
 ) -> ProxyStatus {
     proxy_status(&app, &data_dir(&app), &sidecar)
+}
+
+/// Detect executables only. In particular, do not invoke a CLI or inspect its
+/// configuration, credential files, Keychain items, or login state.
+fn detected_adapters() -> Vec<String> {
+    ["claude", "codex"]
+        .into_iter()
+        .filter(|binary| executable_on_path(binary))
+        .map(str::to_owned)
+        .collect()
+}
+
+#[cfg(unix)]
+fn executable_on_path(binary: &str) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+
+    desktop_cli_search_paths()
+        .into_iter()
+        .map(|directory| directory.join(binary))
+        .any(|candidate| {
+            candidate
+                .metadata()
+                .map(|metadata| metadata.is_file() && metadata.permissions().mode() & 0o111 != 0)
+                .unwrap_or(false)
+        })
+}
+
+#[cfg(not(unix))]
+fn executable_on_path(binary: &str) -> bool {
+    desktop_cli_search_paths()
+        .into_iter()
+        .map(|directory| directory.join(binary))
+        .any(|candidate| candidate.is_file())
+}
+
+// Finder launches do not reliably inherit shell PATH additions. Check the
+// conventional user-install locations as well, then give the proxy that same
+// PATH so a detected CLI is actually executable. This is path discovery only;
+// it does not run a CLI or inspect provider configuration.
+fn desktop_cli_search_paths() -> Vec<PathBuf> {
+    let mut paths = std::env::var_os("PATH")
+        .into_iter()
+        .flat_map(|path| std::env::split_paths(&path).collect::<Vec<_>>())
+        .collect::<Vec<_>>();
+    paths.extend([
+        PathBuf::from("/opt/homebrew/bin"),
+        PathBuf::from("/usr/local/bin"),
+    ]);
+    if let Some(home) = std::env::var_os("HOME") {
+        let home = PathBuf::from(home);
+        paths.extend([
+            home.join(".local/bin"),
+            home.join(".npm-global/bin"),
+            home.join(".volta/bin"),
+        ]);
+    }
+    paths.sort();
+    paths.dedup();
+    paths
+}
+
+fn desktop_cli_path() -> std::ffi::OsString {
+    std::env::join_paths(desktop_cli_search_paths()).unwrap_or_else(|_| std::ffi::OsString::new())
+}
+
+fn register_gateway(port: u16, registration: &GatewayRegistration<'_>) -> Result<(), String> {
+    if port == 0 {
+        return Err("Collavre Desktop could not determine the local server port.".to_string());
+    }
+    let body = serde_json::to_vec(registration)
+        .map_err(|_| "Could not prepare the local gateway registration.".to_string())?;
+    let address = format!("127.0.0.1:{port}");
+    let mut stream = TcpStream::connect(&address)
+        .map_err(|_| "Could not connect to the local Collavre server.".to_string())?;
+    stream.set_read_timeout(Some(Duration::from_secs(10))).ok();
+    stream.set_write_timeout(Some(Duration::from_secs(10))).ok();
+    let request = format!(
+        "POST /desktop/setup/register-gateway HTTP/1.1\r\nHost: {address}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+        body.len()
+    );
+    stream
+        .write_all(request.as_bytes())
+        .and_then(|_| stream.write_all(&body))
+        .map_err(|_| "Could not send the local gateway registration.".to_string())?;
+    let mut response = String::new();
+    stream
+        .read_to_string(&mut response)
+        .map_err(|_| "Could not read the local gateway registration response.".to_string())?;
+    if response.starts_with("HTTP/1.1 201") || response.starts_with("HTTP/1.0 201") {
+        Ok(())
+    } else {
+        Err(
+            "Collavre could not register the local gateway. No setup was marked complete."
+                .to_string(),
+        )
+    }
 }
 
 /// Poll `GET /up` until it answers 200 or we give up.
@@ -755,6 +920,7 @@ pub fn run() {
         .manage(ProxySidecar(Mutex::new(None)))
         .invoke_handler(tauri::generate_handler![
             desktop_proxy_install,
+            desktop_proxy_complete_setup,
             desktop_proxy_status
         ])
         .setup(|app| {
@@ -793,6 +959,9 @@ pub fn run() {
             if read_proxy_config(&data).is_some() {
                 let _ = start_proxy(&handle, &data, &app.state::<ProxySidecar>());
             }
+            let first_run_complete = read_proxy_config(&data)
+                .map(|config| config.registered)
+                .unwrap_or(false);
 
             // Show the branded loading screen (dist/index.html) immediately so the
             // user sees custom UI while the sidecar boots, instead of a blank or
@@ -815,11 +984,12 @@ pub fn run() {
                     return;
                 };
                 if healthy {
-                    // The setup flow is currently a presentation-only mockup.
-                    // Open it directly after the sidecar is healthy so a fresh
-                    // desktop install can review the first-run experience.
-                    if let Ok(url) =
-                        format!("http://127.0.0.1:{port}/desktop/setup").parse::<tauri::Url>()
+                    let path = if first_run_complete {
+                        "/"
+                    } else {
+                        "/desktop/setup"
+                    };
+                    if let Ok(url) = format!("http://127.0.0.1:{port}{path}").parse::<tauri::Url>()
                     {
                         let _ = window.navigate(url);
                     }

--- a/tools/desktop-app/src-tauri/src/lib.rs
+++ b/tools/desktop-app/src-tauri/src/lib.rs
@@ -30,7 +30,12 @@ struct Sidecar {
 /// Holds the optional, user-approved cli-openai-proxy process. It is deliberately
 /// separate from the Rails sidecar: a failed or disabled proxy must never stop
 /// the local Collavre application from opening.
-struct ProxySidecar(Mutex<Option<Child>>);
+struct ManagedProxy {
+    child: Child,
+    port: u16,
+}
+
+struct ProxySidecar(Mutex<Option<ManagedProxy>>);
 
 const PROXY_KEYCHAIN_SERVICE: &str = "net.collavre.desktop.cli-openai-proxy";
 const PROXY_ADMIN_KEY_ACCOUNT: &str = "admin-key";
@@ -470,7 +475,7 @@ fn proxy_status(app: &tauri::AppHandle, data: &Path, sidecar: &ProxySidecar) -> 
         .map(|mut child| {
             let exited = child
                 .as_mut()
-                .and_then(|process| process.try_wait().ok().flatten())
+                .and_then(|process| process.child.try_wait().ok().flatten())
                 .is_some();
             if exited {
                 child.take();
@@ -488,6 +493,43 @@ fn proxy_status(app: &tauri::AppHandle, data: &Path, sidecar: &ProxySidecar) -> 
     }
 }
 
+/// A live child is authoritative for the port it was spawned with. During a
+/// retry, that port must not be treated as an unrelated listener and replaced
+/// beneath the running proxy.
+fn managed_proxy_runs_on_port(sidecar: &ProxySidecar, port: u16) -> bool {
+    managed_proxy_port(sidecar) == Some(port)
+}
+
+fn managed_proxy_port(sidecar: &ProxySidecar) -> Option<u16> {
+    sidecar
+        .0
+        .lock()
+        .map(|mut proxy| {
+            let exited = proxy
+                .as_mut()
+                .and_then(|process| process.child.try_wait().ok().flatten())
+                .is_some();
+            if exited {
+                proxy.take();
+            }
+            proxy.as_ref().map(|process| process.port)
+        })
+        .ok()
+        .flatten()
+}
+
+fn stop_managed_proxy(sidecar: &ProxySidecar) -> Result<(), String> {
+    let mut proxy = sidecar
+        .0
+        .lock()
+        .map_err(|_| "The desktop proxy process lock is unavailable.".to_string())?
+        .take();
+    if let Some(proxy) = proxy.as_mut() {
+        stop_sidecar(&mut proxy.child);
+    }
+    Ok(())
+}
+
 fn start_proxy(app: &tauri::AppHandle, data: &Path, sidecar: &ProxySidecar) -> Result<(), String> {
     let mut child = sidecar
         .0
@@ -495,7 +537,7 @@ fn start_proxy(app: &tauri::AppHandle, data: &Path, sidecar: &ProxySidecar) -> R
         .map_err(|_| "The desktop proxy process lock is unavailable.".to_string())?;
     let exited = child
         .as_mut()
-        .and_then(|process| process.try_wait().ok().flatten())
+        .and_then(|process| process.child.try_wait().ok().flatten())
         .is_some();
     if exited {
         child.take();
@@ -525,20 +567,23 @@ fn start_proxy(app: &tauri::AppHandle, data: &Path, sidecar: &ProxySidecar) -> R
         .0
         .lock()
         .map_err(|_| "The desktop proxy process lock is unavailable.".to_string())?
-        .replace(child);
+        .replace(ManagedProxy {
+            child,
+            port: config.port,
+        });
     let healthy = sidecar
         .0
         .lock()
         .ok()
         .and_then(|mut guard| {
-            guard
-                .as_mut()
-                .map(|child| wait_until_proxy_healthy(child, config.port, Duration::from_secs(15)))
+            guard.as_mut().map(|proxy| {
+                wait_until_proxy_healthy(&mut proxy.child, config.port, Duration::from_secs(15))
+            })
         })
         .unwrap_or(false);
     if !healthy {
-        if let Some(mut child) = sidecar.0.lock().ok().and_then(|mut guard| guard.take()) {
-            stop_sidecar(&mut child);
+        if let Some(mut proxy) = sidecar.0.lock().ok().and_then(|mut guard| guard.take()) {
+            stop_sidecar(&mut proxy.child);
         }
         let _ = fs::remove_file(proxy_pidfile_path(data));
         return Err(
@@ -559,11 +604,20 @@ fn install_proxy(app: &tauri::AppHandle, sidecar: &ProxySidecar) -> Result<Proxy
     // repaired because start_proxy rejects the stale version first.
     let mut config =
         normalized_proxy_config(read_proxy_config(&data), manifest.version, free_port());
-    // Clear a prior crashed proxy before probing its persisted port. If another
-    // process owns it, choose a fresh loopback port and require registration so
-    // Rails' gateway URL follows the repaired proxy.
-    reap_orphan_proxy(&data);
-    if !proxy_port_available(config.port) {
+    // A live managed child owns this port and can continue serving a recovery
+    // retry. Only discard an orphaned pidfile and replace a claimed port when
+    // no managed proxy is already running there.
+    let managed_proxy_owns_port = managed_proxy_runs_on_port(sidecar, config.port);
+    if !managed_proxy_owns_port && managed_proxy_port(sidecar).is_some() {
+        // A live managed process for a different port cannot satisfy this
+        // configuration. Stop it through its retained Child handle before
+        // changing state and spawning a replacement.
+        stop_managed_proxy(sidecar)?;
+    }
+    if !managed_proxy_owns_port {
+        reap_orphan_proxy(&data);
+    }
+    if !managed_proxy_owns_port && !proxy_port_available(config.port) {
         replace_occupied_proxy_port(&mut config, free_port());
     }
     write_proxy_config(&data, &config)?;
@@ -710,10 +764,73 @@ fn nvm_bin_paths(home: &Path) -> Vec<PathBuf> {
         .map(|entry| entry.path().join("bin"))
         .filter(|path| path.is_dir())
         .collect::<Vec<_>>();
-    // The inherited PATH, if any, was retained before these fallbacks. Keep
-    // the fallback order deterministic without disturbing that precedence.
-    paths.sort();
+    paths.sort_by(|left, right| nvm_version_sort_key(right).cmp(&nvm_version_sort_key(left)));
+    if let Some(default) = nvm_default_bin_path(home, &paths) {
+        paths.retain(|path| path != &default);
+        paths.insert(0, default);
+    }
     paths
+}
+
+/// Resolve NVM's configured default before trying other installed versions.
+/// Finder normally has neither NVM_DIR nor NVM_BIN in its environment, but NVM
+/// persists this alias for shells and desktop launches alike.
+fn nvm_default_bin_path(home: &Path, paths: &[PathBuf]) -> Option<PathBuf> {
+    let mut alias = fs::read_to_string(home.join(".nvm/alias/default"))
+        .ok()?
+        .trim()
+        .to_string();
+    for _ in 0..8 {
+        if let Some(path) = nvm_matching_bin_path(paths, &alias) {
+            return Some(path);
+        }
+        let relative_alias = Path::new(&alias);
+        if relative_alias.is_absolute()
+            || relative_alias
+                .components()
+                .any(|component| matches!(component, std::path::Component::ParentDir))
+        {
+            return None;
+        }
+        alias = fs::read_to_string(home.join(".nvm/alias").join(relative_alias))
+            .ok()?
+            .trim()
+            .to_string();
+    }
+    None
+}
+
+fn nvm_matching_bin_path(paths: &[PathBuf], alias: &str) -> Option<PathBuf> {
+    let requested = alias.trim().trim_start_matches('v');
+    if matches!(requested, "node" | "stable" | "*") {
+        return paths.first().cloned();
+    }
+    paths.iter().find_map(|path| {
+        let version = path
+            .parent()?
+            .file_name()?
+            .to_str()?
+            .trim_start_matches('v');
+        (version == requested
+            || (requested
+                .split('.')
+                .all(|part| !part.is_empty() && part.bytes().all(|byte| byte.is_ascii_digit()))
+                && version
+                    .strip_prefix(requested)
+                    .is_some_and(|suffix| suffix.is_empty() || suffix.starts_with('.'))))
+        .then(|| path.clone())
+    })
+}
+
+fn nvm_version_sort_key(path: &Path) -> Vec<u64> {
+    path.parent()
+        .and_then(Path::file_name)
+        .and_then(|name| name.to_str())
+        .unwrap_or_default()
+        .trim_start_matches('v')
+        .split('.')
+        .map(|part| part.parse().unwrap_or(0))
+        .collect()
 }
 
 fn desktop_cli_path() -> std::ffi::OsString {
@@ -965,12 +1082,12 @@ fn apply_desktop_config(data: &Path) {
 mod tests {
     use super::{
         append_unique_paths, config_env_overrides, generate_proxy_key,
-        invalidate_proxy_registration_after_key_regeneration, migrate_proxy_config,
-        normalized_proxy_config, nvm_bin_paths, parse_bundled_proxy_manifest, read_proxy_config,
-        reap_orphan_proxy, replace_occupied_proxy_port, wait_until_proxy_healthy,
-        write_proxy_config, ProxyConfig,
+        invalidate_proxy_registration_after_key_regeneration, managed_proxy_runs_on_port,
+        migrate_proxy_config, normalized_proxy_config, nvm_bin_paths, parse_bundled_proxy_manifest,
+        read_proxy_config, reap_orphan_proxy, replace_occupied_proxy_port,
+        wait_until_proxy_healthy, write_proxy_config, ManagedProxy, ProxyConfig, ProxySidecar,
     };
-    use std::{env, fs, path::PathBuf, process, time::Duration};
+    use std::{env, fs, path::PathBuf, process, sync::Mutex, time::Duration};
 
     fn pairs(json: &str) -> Vec<(&'static str, String)> {
         config_env_overrides(json)
@@ -1116,6 +1233,52 @@ mod tests {
         let _ = fs::remove_dir_all(&home);
 
         assert_eq!(vec![nvm_bin], paths);
+    }
+
+    #[test]
+    fn nvm_default_alias_precedes_other_installed_versions() {
+        let home = env::temp_dir().join(format!("collavre-nvm-default-{}", process::id()));
+        let default_alias = home.join(".nvm/alias/default");
+        let older = home.join(".nvm/versions/node/v20.10.0/bin");
+        let selected = home.join(".nvm/versions/node/v22.16.0/bin");
+        let _ = fs::remove_dir_all(&home);
+        fs::create_dir_all(default_alias.parent().expect("alias directory"))
+            .expect("create alias directory");
+        fs::create_dir_all(&older).expect("create old node bin");
+        fs::create_dir_all(&selected).expect("create default node bin");
+        fs::write(&default_alias, "22\n").expect("write default alias");
+
+        let paths = nvm_bin_paths(&home);
+        let _ = fs::remove_dir_all(&home);
+
+        assert_eq!(vec![selected, older], paths);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn live_managed_proxy_keeps_its_persisted_port_during_recovery() {
+        use std::process::Command;
+
+        let child = Command::new("sh")
+            .args(["-c", "sleep 2"])
+            .spawn()
+            .expect("spawn managed proxy");
+        let sidecar = ProxySidecar(Mutex::new(Some(ManagedProxy {
+            child,
+            port: 34_567,
+        })));
+
+        assert!(managed_proxy_runs_on_port(&sidecar, 34_567));
+        assert!(!managed_proxy_runs_on_port(&sidecar, 45_678));
+
+        let mut proxy = sidecar
+            .0
+            .lock()
+            .expect("proxy lock")
+            .take()
+            .expect("managed proxy");
+        let _ = proxy.child.kill();
+        let _ = proxy.child.wait();
     }
 
     #[test]
@@ -1333,8 +1496,8 @@ pub fn run() {
                 if let Some(mut child) = app.state::<Sidecar>().child.lock().unwrap().take() {
                     stop_sidecar(&mut child);
                 }
-                if let Some(mut child) = app.state::<ProxySidecar>().0.lock().unwrap().take() {
-                    stop_sidecar(&mut child);
+                if let Some(mut proxy) = app.state::<ProxySidecar>().0.lock().unwrap().take() {
+                    stop_sidecar(&mut proxy.child);
                 }
                 // Clear the pidfile so the next launch doesn't try to reap a pid
                 // that is gone (or, worse, reused by an unrelated process).

--- a/tools/desktop-app/src-tauri/tauri.conf.json
+++ b/tools/desktop-app/src-tauri/tauri.conf.json
@@ -7,7 +7,7 @@
     "frontendDist": "./dist"
   },
   "app": {
-    "withGlobalTauri": false,
+    "withGlobalTauri": true,
     "windows": [],
     "security": {
       "csp": null


### PR DESCRIPTION
## What changed

- turns the desktop setup screen into a real first-run flow: local administrator creation, explicit proxy consent, and automatic sign-in
- starts the bundled loopback-only cli-openai-proxy with Keychain-held administrator, completion, and internal identity credentials
- registers the local Gateway through a short-lived loopback-only native handoff and creates Claude Code/Codex presets only when their executables are detected
- opens the wizard only until registration succeeds; later launches return to Collavre

## Security

- proxy secrets never enter the webview or logs
- the native registration endpoint accepts only loopback requests with an expiring signed grant
- existing CLI credentials and configuration are neither read nor changed

## Validation

- `npm run build`
- `bin/rails test engines/collavre/test/controllers/desktop_setup_controller_test.rb`
- `cargo clippy --tests -- -D warnings`
- `cargo test` (10 passed)