### PR TITLE
feat: open archived topics from the topic strip

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -1709,9 +1709,33 @@ body.chat-fullscreen {
 .topic-archived-toggle:hover {
     opacity: 1;
 }
+/* Archived topics still receive messages. When the section is collapsed there is
+   no chip to badge, so the toggle carries the unread dot instead. */
+.topic-archived-toggle.has-new-messages {
+    position: relative;
+    opacity: 1;
+    border-color: var(--color-active);
+}
+.topic-archived-toggle.has-new-messages::after {
+    content: "";
+    position: absolute;
+    top: -3px;
+    right: -3px;
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background-color: var(--color-danger);
+}
 .topic-tag.topic-archived {
     opacity: 0.5;
     font-style: italic;
+    cursor: pointer;
+}
+/* Archived topics are readable and selectable — the dimming marks them as
+   archived, it must not make the one you are reading illegible. */
+.topic-tag.topic-archived:hover,
+.topic-tag.topic-archived.active {
+    opacity: 1;
 }
 
 /* Topic list popup button (pinned right of the scrolling tab bar) */

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/list_controller_deep_link_topic.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/list_controller_deep_link_topic.test.js
@@ -1,0 +1,194 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { jest } from '@jest/globals'
+
+// selectTopic persists the selection through the topics API; stub it so the
+// tests stay offline and the debounce timer has nothing to flush.
+jest.unstable_mockModule('../../../lib/api/topics', () => ({
+  fetchNextTopicName: jest.fn(),
+  createTopicWithComments: jest.fn(),
+  saveLastTopic: jest.fn().mockResolvedValue(undefined),
+}))
+
+const { Application } = await import('@hotwired/stimulus')
+const TopicsController = (await import('../topics_controller')).default
+const CommentsListController = (await import('../list_controller')).default
+
+const TOPICS = [{ id: 1, name: 'Main' }, { id: 2, name: 'Alpha' }]
+const ARCHIVED = [{ id: 3, name: 'Zeta' }]
+
+// CommentsController#index answers a deep link (around_comment_id) with the
+// topic the target comment actually lives in.
+const commentsResponse = (topicId) => ({
+  ok: true,
+  headers: { get: (name) => (name === 'X-Topic-Id' ? topicId : null) },
+  text: async () => '',
+})
+
+const buildListController = ({ currentTopicId = '', topicsController = null, element = null } = {}) => {
+  const controller = Object.create(CommentsListController.prototype)
+  controller.creativeId = '42'
+  controller.currentTopicId = currentTopicId
+  controller.manualSearchQuery = null
+
+  const list = document.createElement('div')
+  Object.defineProperty(controller, 'listTarget', { value: list })
+  Object.defineProperty(controller, 'element', { value: element || document.createElement('div') })
+  Object.defineProperty(controller, 'popupController', {
+    value: topicsController ? { topicsController } : null,
+  })
+
+  return controller
+}
+
+describe('CommentsListController deep-linked topic resolution', () => {
+  beforeEach(() => {
+    document.head.innerHTML = '<meta name="csrf-token" content="test-csrf">'
+  })
+
+  afterEach(() => {
+    document.head.innerHTML = ''
+    jest.clearAllMocks()
+  })
+
+  // updateSelectionUI only repaints chips: it neither expands the archived
+  // section nor tells form_controller which conversation the reply belongs to.
+  test('routes the server-resolved topic through selectTopic', async () => {
+    const topicsController = {
+      setOverrideTopicId: jest.fn(),
+      selectTopic: jest.fn(),
+      updateSelectionUI: jest.fn(),
+    }
+    const controller = buildListController({ currentTopicId: '2', topicsController })
+    global.fetch = jest.fn().mockResolvedValue(commentsResponse('3'))
+
+    await controller.fetchComments({ around_comment_id: 55 })
+
+    expect(topicsController.setOverrideTopicId).toHaveBeenCalledWith('3')
+    expect(topicsController.selectTopic).toHaveBeenCalledWith('3')
+    expect(controller.currentTopicId).toBe('3')
+    expect(controller.listTarget.dataset.currentTopicId).toBe('3')
+  })
+
+  test('leaves the topics controller alone when the server confirms the current topic', async () => {
+    const topicsController = {
+      setOverrideTopicId: jest.fn(),
+      selectTopic: jest.fn(),
+      updateSelectionUI: jest.fn(),
+    }
+    const controller = buildListController({ currentTopicId: '3', topicsController })
+    global.fetch = jest.fn().mockResolvedValue(commentsResponse('3'))
+
+    await controller.fetchComments({ around_comment_id: 55 })
+
+    expect(topicsController.selectTopic).not.toHaveBeenCalled()
+    expect(controller.listTarget.dataset.currentTopicId).toBe('3')
+  })
+})
+
+describe('CommentsListController deep link into an archived topic', () => {
+  let application
+  let topicsController
+  let changeEvents
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div id="chat-popup">
+        <div id="topics" data-controller="comments--topics" data-topic-main-text="All Messages">
+          <div data-comments--topics-target="list"></div>
+        </div>
+      </div>
+    `
+    // jsdom has no layout, so scrollIntoView is undefined on elements.
+    Element.prototype.scrollIntoView = jest.fn()
+    document.head.innerHTML = '<meta name="csrf-token" content="test-csrf">'
+
+    application = Application.start()
+    application.register('comments--topics', TopicsController)
+
+    changeEvents = []
+    document.addEventListener('comments--topics:change', (e) => changeEvents.push(e.detail))
+
+    return new Promise((resolve) => setTimeout(resolve, 0)).then(() => {
+      topicsController = application.getControllerForElementAndIdentifier(
+        document.getElementById('topics'), 'comments--topics'
+      )
+      topicsController.creativeIdValue = '42'
+      topicsController.topics = TOPICS
+      topicsController.archivedTopics = ARCHIVED
+      topicsController.mainTopicId = '1'
+      topicsController.canManageTopics = true
+      topicsController.showingArchived = false
+      topicsController.serverLastTopicId = ''
+      topicsController.renderTopics(TOPICS, true)
+    })
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+    document.head.innerHTML = ''
+    application.stop()
+    jest.clearAllMocks()
+  })
+
+  const deepLinkTo = async (topicId, { currentTopicId = '2' } = {}) => {
+    const controller = buildListController({
+      currentTopicId,
+      topicsController,
+      element: document.getElementById('chat-popup'),
+    })
+    global.fetch = jest.fn().mockResolvedValue(commentsResponse(topicId))
+    await controller.fetchComments({ around_comment_id: 55 })
+    return controller
+  }
+
+  // A collapsed archived section renders no chips, so the resolved topic would
+  // be open with nothing in the strip showing which one it is.
+  test('expands the archived section and marks the chip active', async () => {
+    await deepLinkTo('3')
+
+    expect(topicsController.showingArchived).toBe(true)
+    const chip = topicsController.listTarget.querySelector('.topic-archived[data-id="3"]')
+    expect(chip).not.toBeNull()
+    expect(chip.classList.contains('active')).toBe(true)
+  })
+
+  // form_controller reads the active topic only from this event; without it a
+  // reply typed under the deep link posts into the previously selected topic.
+  test('dispatches change so the form follows the resolved topic', async () => {
+    await deepLinkTo('3')
+
+    expect(changeEvents.at(-1).topicId).toBe('3')
+  })
+
+  test('follows a deep link into a live topic without expanding the archived section', async () => {
+    await deepLinkTo('2', { currentTopicId: '' })
+
+    expect(changeEvents.at(-1).topicId).toBe('2')
+    expect(topicsController.showingArchived).toBe(false)
+  })
+
+  // The change event reaches list_controller's own handler; it must not restart
+  // the load, which would throw away the comment the deep link is scrolling to.
+  test('keeps the highlight window instead of reloading from latest', async () => {
+    const controller = buildListController({
+      currentTopicId: '2',
+      topicsController,
+      element: document.getElementById('chat-popup'),
+    })
+    controller.handleTopicChange = CommentsListController.prototype.handleTopicChange.bind(controller)
+    controller.element.addEventListener('comments--topics:change', controller.handleTopicChange)
+    controller.highlightAfterLoad = 55
+    controller.highlightCreativeId = '42'
+    controller.resetToLatest = jest.fn()
+
+    global.fetch = jest.fn().mockResolvedValue(commentsResponse('3'))
+    await controller.fetchComments({ around_comment_id: 55 })
+
+    expect(controller.resetToLatest).not.toHaveBeenCalled()
+    expect(controller.highlightAfterLoad).toBe(55)
+    expect(controller.highlightCreativeId).toBe('42')
+  })
+})

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/list_controller_deep_link_topic.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/list_controller_deep_link_topic.test.js
@@ -37,8 +37,11 @@ const buildListController = ({ currentTopicId = '', topicsController = null, ele
   Object.defineProperty(controller, 'listTarget', { value: list })
   Object.defineProperty(controller, 'element', { value: element || document.createElement('div') })
   Object.defineProperty(controller, 'popupController', {
-    value: topicsController ? { topicsController } : null,
+    value: topicsController ? { topicsController, updatePosition: () => {} } : null,
   })
+  // Both are prototype getters that reach into a Stimulus application; own
+  // properties shadow them without standing one up.
+  Object.defineProperty(controller, 'formController', { value: null })
 
   return controller
 }
@@ -70,6 +73,58 @@ describe('CommentsListController deep-linked topic resolution', () => {
     expect(topicsController.selectTopic).toHaveBeenCalledWith('3')
     expect(controller.currentTopicId).toBe('3')
     expect(controller.listTarget.dataset.currentTopicId).toBe('3')
+  })
+
+  // loadInitialComments drops responses whose topic no longer matches the one it
+  // requested, to survive creative switches. A server-resolved deep link trips
+  // that guard with its own answer and the list never leaves "Loading...".
+  test('renders a response that switched topic instead of discarding it as stale', async () => {
+    const topicsController = { setOverrideTopicId: jest.fn(), selectTopic: jest.fn() }
+    const controller = buildListController({ currentTopicId: '2', topicsController })
+    controller.selection = new Set()
+    controller._loadCommentsVersion = 0
+    controller.prevMsgNavigator = { reset: jest.fn() }
+    controller.highlightAfterLoad = 55
+    controller.highlightComment = jest.fn()
+    controller.markCommentsRead = jest.fn()
+    controller.scrollToBottom = jest.fn()
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      headers: { get: (name) => (name === 'X-Topic-Id' ? '3' : null) },
+      text: async () => '<div id="comment_55" class="comment-item">deep linked</div>',
+    })
+
+    controller.loadInitialComments()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(controller.listTarget.innerHTML).toContain('comment_55')
+    expect(controller.highlightComment).toHaveBeenCalledWith(55)
+  })
+
+  // The allowance is scoped to the one request the server answered: a newer load
+  // must still be able to discard this one.
+  test('still discards a response superseded by a newer load', async () => {
+    const topicsController = { setOverrideTopicId: jest.fn(), selectTopic: jest.fn() }
+    const controller = buildListController({ currentTopicId: '2', topicsController })
+    controller.selection = new Set()
+    controller._loadCommentsVersion = 0
+    controller.prevMsgNavigator = { reset: jest.fn() }
+    controller.highlightComment = jest.fn()
+    controller.markCommentsRead = jest.fn()
+    controller.scrollToBottom = jest.fn()
+    global.fetch = jest.fn().mockImplementation(async () => {
+      controller._loadCommentsVersion += 1 // a newer load starts mid-flight
+      return {
+        ok: true,
+        headers: { get: (name) => (name === 'X-Topic-Id' ? '3' : null) },
+        text: async () => '<div id="comment_55">stale</div>',
+      }
+    })
+
+    controller.loadInitialComments()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(controller.listTarget.innerHTML).not.toContain('comment_55')
   })
 
   test('leaves the topics controller alone when the server confirms the current topic', async () => {

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/list_controller_deep_link_topic.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/list_controller_deep_link_topic.test.js
@@ -141,6 +141,80 @@ describe('CommentsListController deep-linked topic resolution', () => {
     expect(topicsController.selectTopic).not.toHaveBeenCalled()
     expect(controller.listTarget.dataset.currentTopicId).toBe('3')
   })
+
+  // A deep link that loses the race still gets its X-Topic-Id answered. Acting on
+  // it would move the selection to a topic nobody is looking at any more, and the
+  // load that replaced it would render into that wrong selection.
+  const raceDeepLinkAgainstSelection = () => {
+    const topicsController = { setOverrideTopicId: jest.fn(), selectTopic: jest.fn() }
+    const controller = buildListController({ currentTopicId: '2', topicsController })
+    controller.selection = new Set()
+    controller._loadCommentsVersion = 0
+    controller.prevMsgNavigator = { reset: jest.fn() }
+    controller.highlightComment = jest.fn()
+    controller.markCommentsRead = jest.fn()
+    controller.scrollToBottom = jest.fn()
+
+    let releaseDeepLink
+    let releaseSelected
+    const deepLinkGate = new Promise((resolve) => { releaseDeepLink = resolve })
+    const selectedGate = new Promise((resolve) => { releaseSelected = resolve })
+
+    global.fetch = jest.fn()
+      .mockImplementationOnce(async () => {
+        await deepLinkGate
+        return {
+          ok: true,
+          headers: { get: (name) => (name === 'X-Topic-Id' ? '3' : null) },
+          text: async () => '<div id="comment_55" class="comment-item">deep linked</div>',
+        }
+      })
+      .mockImplementationOnce(async () => {
+        await selectedGate
+        return {
+          ok: true,
+          headers: { get: () => null },
+          text: async () => '<div id="comment_99" class="comment-item">topic nine</div>',
+        }
+      })
+
+    controller.highlightAfterLoad = 55
+    controller.loadInitialComments()
+
+    // The user picks another topic before the deep link comes back.
+    controller.highlightAfterLoad = null
+    controller.currentTopicId = '9'
+    controller.loadInitialComments()
+
+    const flush = () => new Promise((resolve) => setTimeout(resolve, 0))
+    return { controller, topicsController, releaseDeepLink, releaseSelected, flush }
+  }
+
+  test('ignores the X-Topic-Id of a load that was already superseded', async () => {
+    const { controller, topicsController, releaseDeepLink, flush } = raceDeepLinkAgainstSelection()
+
+    releaseDeepLink()
+    await flush()
+
+    expect(controller.currentTopicId).toBe('9')
+    expect(topicsController.selectTopic).not.toHaveBeenCalled()
+    expect(topicsController.setOverrideTopicId).not.toHaveBeenCalled()
+  })
+
+  test('does not pass the topic-guard exemption to the load that superseded it', async () => {
+    const { controller, releaseDeepLink, releaseSelected, flush } = raceDeepLinkAgainstSelection()
+
+    releaseDeepLink()
+    await flush()
+    releaseSelected()
+    await flush()
+
+    expect(controller.isServerResolvedTopic(2)).toBe(false)
+    // The surviving load rendered its own topic, and the selection it renders
+    // under is the one the user picked.
+    expect(controller.listTarget.innerHTML).toContain('comment_99')
+    expect(controller.listTarget.dataset.currentTopicId).toBe('9')
+  })
 })
 
 describe('CommentsListController deep link into an archived topic', () => {

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/list_controller_deep_link_topic.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/list_controller_deep_link_topic.test.js
@@ -215,6 +215,73 @@ describe('CommentsListController deep-linked topic resolution', () => {
     expect(controller.listTarget.innerHTML).toContain('comment_99')
     expect(controller.listTarget.dataset.currentTopicId).toBe('9')
   })
+
+  // The exemption is only for a load the server retopiced. A load the server
+  // said nothing about is still subject to the plain stale-topic guard, on both
+  // the success and the failure path.
+  describe('a load the server did not retopic', () => {
+    const buildPendingLoad = () => {
+      const topicsController = { setOverrideTopicId: jest.fn(), selectTopic: jest.fn() }
+      const controller = buildListController({ currentTopicId: '2', topicsController })
+      controller.selection = new Set()
+      controller._loadCommentsVersion = 0
+      controller.prevMsgNavigator = { reset: jest.fn() }
+      controller.highlightComment = jest.fn()
+      controller.markCommentsRead = jest.fn()
+      controller.scrollToBottom = jest.fn()
+      return controller
+    }
+
+    const flush = () => new Promise((resolve) => setTimeout(resolve, 0))
+
+    test('discards its HTML when the topic moved while it was in flight', async () => {
+      const controller = buildPendingLoad()
+      global.fetch = jest.fn().mockImplementation(async () => {
+        controller.currentTopicId = '9' // the user switched mid-flight
+        return {
+          ok: true,
+          headers: { get: () => null },
+          text: async () => '<div id="comment_55">topic two</div>',
+        }
+      })
+
+      controller.loadInitialComments()
+      await flush()
+
+      expect(controller.listTarget.innerHTML).not.toContain('comment_55')
+    })
+
+    test('discards its error when the topic moved while it was in flight', async () => {
+      const controller = buildPendingLoad()
+      global.fetch = jest.fn().mockImplementation(async () => {
+        controller.currentTopicId = '9'
+        return {
+          ok: false,
+          headers: { get: () => null },
+          json: async () => ({ error: 'No permission' }),
+        }
+      })
+
+      controller.loadInitialComments()
+      await flush()
+
+      expect(controller.listTarget.innerHTML).toBe('')
+    })
+
+    test('still renders its error when the topic did not move', async () => {
+      const controller = buildPendingLoad()
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: false,
+        headers: { get: () => null },
+        json: async () => ({ error: 'No permission' }),
+      })
+
+      controller.loadInitialComments()
+      await flush()
+
+      expect(controller.listTarget.innerHTML).toContain('No permission')
+    })
+  })
 })
 
 describe('CommentsListController deep link into an archived topic', () => {

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/list_controller_stream_archived.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/list_controller_stream_archived.test.js
@@ -19,9 +19,9 @@ const comment = (topicId) =>
 
 // currentTopicId "" is the All Messages view. archivedIds stands in for the
 // topics controller's archived_topics, which is what the real lookup reads.
-const buildController = ({ currentTopicId = '', archivedIds = [], withPopup = true } = {}) => {
+const buildController = ({ currentTopicId = '', archivedIds = [], withPopup = true, searchQuery = null } = {}) => {
   const controller = Object.create(CommentsListController.prototype)
-  controller.manualSearchQuery = null
+  controller.manualSearchQuery = searchQuery
   controller.currentTopicId = currentTopicId
   controller.allNewerLoaded = true
 
@@ -114,5 +114,52 @@ describe('CommentsListController archived streams in All Messages', () => {
 
     expect(event.preventDefault).not.toHaveBeenCalled()
     expect(badgeEvents).toEqual([])
+  })
+
+  // An active search blocks every append, so the badge is the only thing left
+  // that can report traffic in a topic the user cannot see. It has to survive
+  // the search block, not be swallowed by it.
+  describe('while a search filter is active', () => {
+    test('badges an archived topic even though the append is blocked', () => {
+      const controller = buildController({ archivedIds: [7], searchQuery: 'deploy' })
+      const event = streamEvent({ html: comment(7) })
+
+      controller.handleStreamRender(event)
+
+      expect(event.preventDefault).toHaveBeenCalledTimes(1)
+      expect(badgeEvents).toEqual([{ topicId: '7' }])
+    })
+
+    test('badges a foreign topic while searching inside a specific topic', () => {
+      const controller = buildController({ currentTopicId: '2', searchQuery: 'deploy' })
+      const event = streamEvent({ html: comment(5) })
+
+      controller.handleStreamRender(event)
+
+      expect(event.preventDefault).toHaveBeenCalledTimes(1)
+      expect(badgeEvents).toEqual([{ topicId: '5' }])
+    })
+
+    // The search block still owns everything the topic routing lets past: the
+    // result set is a server-side match and a live append carries no verdict.
+    test('still blocks a message for the topic in view, without badging it', () => {
+      const controller = buildController({ currentTopicId: '2', searchQuery: 'deploy' })
+      const event = streamEvent({ html: comment(2) })
+
+      controller.handleStreamRender(event)
+
+      expect(event.preventDefault).toHaveBeenCalledTimes(1)
+      expect(badgeEvents).toEqual([])
+    })
+
+    test('still blocks a live-topic message in All Messages, without badging it', () => {
+      const controller = buildController({ archivedIds: [7], searchQuery: 'deploy' })
+      const event = streamEvent({ html: comment(2) })
+
+      controller.handleStreamRender(event)
+
+      expect(event.preventDefault).toHaveBeenCalledTimes(1)
+      expect(badgeEvents).toEqual([])
+    })
   })
 })

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/list_controller_stream_archived.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/list_controller_stream_archived.test.js
@@ -1,0 +1,118 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { jest } from '@jest/globals'
+import CommentsListController from '../list_controller'
+
+const streamEvent = ({ action = 'append', target = 'comments-list', html = '' } = {}) => {
+  const template = document.createElement('template')
+  template.innerHTML = html
+  return {
+    preventDefault: jest.fn(),
+    target: { action, target, templateContent: template.content },
+  }
+}
+
+const comment = (topicId) =>
+  `<div id="comment_9" class="comment-item" data-topic-id="${topicId}">hello</div>`
+
+// currentTopicId "" is the All Messages view. archivedIds stands in for the
+// topics controller's archived_topics, which is what the real lookup reads.
+const buildController = ({ currentTopicId = '', archivedIds = [], withPopup = true } = {}) => {
+  const controller = Object.create(CommentsListController.prototype)
+  controller.manualSearchQuery = null
+  controller.currentTopicId = currentTopicId
+  controller.allNewerLoaded = true
+
+  // popupController is a prototype getter reaching into this.application; an
+  // own property shadows it without standing up a Stimulus application.
+  Object.defineProperty(controller, 'popupController', {
+    value: withPopup
+      ? {
+          topicsController: {
+            isArchivedTopic: (id) => archivedIds.some((a) => String(a) === String(id)),
+          },
+        }
+      : null,
+  })
+
+  return controller
+}
+
+describe('CommentsListController archived streams in All Messages', () => {
+  let badgeEvents
+  const onBadge = (e) => badgeEvents.push(e.detail)
+
+  beforeEach(() => {
+    badgeEvents = []
+    window.addEventListener('comments--topics:new-message', onBadge)
+  })
+
+  afterEach(() => {
+    window.removeEventListener('comments--topics:new-message', onBadge)
+  })
+
+  // CommentsController#index excludes archived-topic comments from All Messages,
+  // so appending one live would show a message that disappears on reload.
+  test('blocks an archived-topic message and badges the topic instead', () => {
+    const controller = buildController({ archivedIds: [7] })
+    const event = streamEvent({ html: comment(7) })
+
+    controller.handleStreamRender(event)
+
+    expect(event.preventDefault).toHaveBeenCalledTimes(1)
+    expect(badgeEvents).toEqual([{ topicId: '7' }])
+  })
+
+  test('lets a live topic message through', () => {
+    const controller = buildController({ archivedIds: [7] })
+    const event = streamEvent({ html: comment(2) })
+
+    controller.handleStreamRender(event)
+
+    expect(event.preventDefault).not.toHaveBeenCalled()
+    expect(badgeEvents).toEqual([])
+  })
+
+  test('lets a topic-less comment through without consulting the topics controller', () => {
+    const controller = buildController({ archivedIds: [7], withPopup: false })
+    const event = streamEvent({ html: comment('') })
+
+    controller.handleStreamRender(event)
+
+    expect(event.preventDefault).not.toHaveBeenCalled()
+    expect(badgeEvents).toEqual([])
+  })
+
+  // The archived section may not have loaded yet on a docked chat; a missing
+  // topics controller must not break live appends.
+  test('appends normally when the topics controller is unavailable', () => {
+    const controller = buildController({ archivedIds: [7], withPopup: false })
+    const event = streamEvent({ html: comment(7) })
+
+    controller.handleStreamRender(event)
+
+    expect(event.preventDefault).not.toHaveBeenCalled()
+  })
+
+  test('still blocks a foreign topic when viewing a specific topic', () => {
+    const controller = buildController({ currentTopicId: '2', archivedIds: [] })
+    const event = streamEvent({ html: comment(5) })
+
+    controller.handleStreamRender(event)
+
+    expect(event.preventDefault).toHaveBeenCalledTimes(1)
+    expect(badgeEvents).toEqual([{ topicId: '5' }])
+  })
+
+  test('appends a message for the archived topic the user is actually viewing', () => {
+    const controller = buildController({ currentTopicId: '7', archivedIds: [7] })
+    const event = streamEvent({ html: comment(7) })
+
+    controller.handleStreamRender(event)
+
+    expect(event.preventDefault).not.toHaveBeenCalled()
+    expect(badgeEvents).toEqual([])
+  })
+})

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_archived.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_archived.test.js
@@ -478,6 +478,54 @@ describe('TopicsController archived topic messages', () => {
       expect(changeEvents.at(-1).topicId).toBe('2')
     })
 
+    // ?topic_id= outranks the saved preference in the currentTopicId getter and
+    // survives every reload, so it has to be cleared too — otherwise the guard
+    // is the only thing holding the selection back, and it lifts the moment the
+    // preference save lands.
+    describe('when the URL names the archived topic', () => {
+      beforeEach(() => {
+        window.history.replaceState({}, '', '/?topic_id=2')
+      })
+
+      afterEach(() => {
+        window.history.replaceState({}, '', '/')
+      })
+
+      test('drops the query parameter', async () => {
+        render()
+        stubFetch(2)
+
+        await archive('2')
+
+        expect(new URLSearchParams(window.location.search).get('topic_id')).toBeNull()
+        expect(controller.currentTopicId).toBe('1')
+      })
+
+      test('a later reload does not put the user back into it', async () => {
+        render()
+        stubFetch(2)
+        await archive('2')
+
+        // The preference save has landed by now, so the guard's old lift
+        // condition would fire here.
+        stubFetch(null)
+        await controller.loadTopics()
+
+        expect(changeEvents.at(-1).topicId).toBe('1')
+        expect(controller.showingArchived).toBe(false)
+      })
+
+      test('leaves a query parameter naming a different topic alone', async () => {
+        controller.topics = [...TOPICS, { id: 5, name: 'Beta' }]
+        render()
+        stubFetch(2)
+
+        await archive('5')
+
+        expect(new URLSearchParams(window.location.search).get('topic_id')).toBe('2')
+      })
+    })
+
     test('archiving a topic that is not in view leaves the selection alone', async () => {
       controller.topics = [...TOPICS, { id: 5, name: 'Beta' }]
       controller.serverLastTopicId = '2'

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_archived.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_archived.test.js
@@ -307,6 +307,31 @@ describe('TopicsController archived topic messages', () => {
       expect(controller.archivedWithNewMessages.size).toBe(0)
     })
 
+    // popup_controller.handleCreativeClick re-opens the *same* creative when a
+    // docked chat receives a workspace-sync event carrying a highlightId. These
+    // marks are transient — loadTopics() cannot rebuild them — so following a
+    // comment deep link must not wipe the other archived topics' unread state.
+    test('re-opening the same creative keeps its unread marks', async () => {
+      render()
+      newMessage('3')
+      newMessage('4')
+
+      await switchCreative('42')
+
+      expect([...controller.archivedWithNewMessages].sort()).toEqual(['3', '4'])
+    })
+
+    test('the toggle stays badged after re-opening the same creative', async () => {
+      render()
+      newMessage('3')
+
+      await switchCreative('42')
+      render()
+
+      expect(controller.listTarget.querySelector('.topic-archived-toggle').classList)
+        .toContain('has-new-messages')
+    })
+
     test("the new creative's archived toggle renders unbadged after a switch", async () => {
       render()
       newMessage('3')

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_archived.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_archived.test.js
@@ -1,0 +1,285 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { jest } from '@jest/globals'
+
+// selectTopic persists the selection through the topics API; stub it so the
+// tests stay offline and the debounce timer has nothing to flush.
+jest.unstable_mockModule('../../../lib/api/topics', () => ({
+  fetchNextTopicName: jest.fn(),
+  createTopicWithComments: jest.fn(),
+  saveLastTopic: jest.fn().mockResolvedValue(undefined),
+}))
+
+const { Application } = await import('@hotwired/stimulus')
+const TopicsController = (await import('../topics_controller')).default
+
+const TOPICS = [{ id: 1, name: 'Main' }, { id: 2, name: 'Alpha' }]
+const ARCHIVED = [{ id: 3, name: 'Zeta' }, { id: 4, name: 'Omega' }]
+
+describe('TopicsController archived topic messages', () => {
+  let application
+  let controller
+  let changeEvents
+
+  const render = () => controller.renderTopics(controller.topics, controller.canManageTopics)
+
+  // Stimulus binds actions on freshly inserted nodes via a MutationObserver, so
+  // a click dispatched in the same tick as the render would hit nothing.
+  const renderAndBind = async () => {
+    render()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  }
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div id="topics" data-controller="comments--topics" data-topic-main-text="All Messages">
+        <div data-comments--topics-target="list"></div>
+      </div>
+    `
+    // jsdom has no layout, so scrollIntoView is undefined on elements.
+    Element.prototype.scrollIntoView = jest.fn()
+    document.head.innerHTML = '<meta name="csrf-token" content="test-csrf">'
+
+    application = Application.start()
+    application.register('comments--topics', TopicsController)
+
+    changeEvents = []
+    document.addEventListener('comments--topics:change', (e) => changeEvents.push(e.detail))
+
+    return new Promise((resolve) => setTimeout(resolve, 0)).then(() => {
+      controller = application.getControllerForElementAndIdentifier(
+        document.getElementById('topics'), 'comments--topics'
+      )
+      controller.creativeIdValue = '42'
+      controller.topics = TOPICS
+      controller.archivedTopics = ARCHIVED
+      controller.mainTopicId = '1'
+      controller.canManageTopics = true
+      controller.showingArchived = false
+      controller.serverLastTopicId = ''
+    })
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+    document.head.innerHTML = ''
+    application.stop()
+    jest.clearAllMocks()
+  })
+
+  describe('selecting an archived topic', () => {
+    test('archived chips carry the select action so clicking one opens it', () => {
+      controller.showingArchived = true
+      render()
+
+      const chip = controller.listTarget.querySelector('.topic-archived[data-id="3"]')
+      expect(chip.dataset.action).toContain('click->comments--topics#select')
+    })
+
+    test('clicking an archived chip dispatches change with its topic id', async () => {
+      controller.showingArchived = true
+      await renderAndBind()
+
+      controller.listTarget.querySelector('.topic-archived[data-id="3"]').click()
+
+      expect(changeEvents.at(-1).topicId).toBe('3')
+    })
+
+    test('the selected archived chip renders as active', () => {
+      controller.showingArchived = true
+      controller.serverLastTopicId = '3'
+      render()
+
+      expect(controller.listTarget.querySelector('.topic-archived[data-id="3"]').classList)
+        .toContain('active')
+    })
+
+    test('clicking Restore unarchives without also selecting the topic', async () => {
+      const fetchMock = jest.fn().mockResolvedValue({ ok: true })
+      global.fetch = fetchMock
+      controller.loadTopics = jest.fn()
+      controller.showingArchived = true
+      await renderAndBind()
+
+      controller.listTarget.querySelector('.unarchive-topic-btn[data-id="3"]').click()
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/creatives/42/topics/3/unarchive',
+        expect.objectContaining({ method: 'PATCH' })
+      )
+      expect(changeEvents).toHaveLength(0)
+    })
+  })
+
+  describe('restoreSelection', () => {
+    test('keeps an archived topic selected instead of falling back to Main', () => {
+      controller.serverLastTopicId = '3'
+      render()
+
+      controller.restoreSelection()
+
+      expect(changeEvents.at(-1).topicId).toBe('3')
+    })
+
+    test('expands the archived section so the selected topic is visible', () => {
+      controller.serverLastTopicId = '3'
+      render()
+      expect(controller.listTarget.querySelector('.topic-archived[data-id="3"]')).toBeNull()
+
+      controller.restoreSelection()
+
+      expect(controller.showingArchived).toBe(true)
+      expect(controller.listTarget.querySelector('.topic-archived[data-id="3"]')).not.toBeNull()
+    })
+
+    test('keeps a live topic selected without expanding the archived section', () => {
+      controller.serverLastTopicId = '2'
+      render()
+
+      controller.restoreSelection()
+
+      expect(changeEvents.at(-1).topicId).toBe('2')
+      expect(controller.showingArchived).toBe(false)
+    })
+
+    test('falls back to Main for a topic id that no longer exists', () => {
+      controller.serverLastTopicId = '999'
+      render()
+
+      controller.restoreSelection()
+
+      expect(changeEvents.at(-1).topicId).toBe('1')
+    })
+
+    test('falls back to Main when there are no archived topics at all', () => {
+      controller.archivedTopics = []
+      controller.serverLastTopicId = '3'
+      render()
+
+      controller.restoreSelection()
+
+      expect(changeEvents.at(-1).topicId).toBe('1')
+    })
+  })
+
+  describe('revealing the archived section', () => {
+    test('selecting an archived topic from the topic-list popup expands the section', () => {
+      render()
+      expect(controller.listTarget.querySelector('.topic-archived[data-id="3"]')).toBeNull()
+
+      // What openTopicListPopup hands the popup as its pick callback.
+      controller.selectTopic('3')
+
+      expect(controller.showingArchived).toBe(true)
+      expect(controller.listTarget.querySelector('.topic-archived[data-id="3"]').classList)
+        .toContain('active')
+    })
+
+    test('selecting a live topic leaves the archived section collapsed', () => {
+      render()
+
+      controller.selectTopic('2')
+
+      expect(controller.showingArchived).toBe(false)
+    })
+
+    test('collapsing the section stays collapsed while an archived topic is open', () => {
+      controller.serverLastTopicId = '3'
+      controller.showingArchived = true
+      render()
+
+      controller.toggleArchivedTopics({ stopPropagation: jest.fn() })
+
+      expect(controller.showingArchived).toBe(false)
+      expect(controller.listTarget.querySelector('.topic-archived[data-id="3"]')).toBeNull()
+    })
+
+    test('toggling the section does not reload the message list', () => {
+      controller.showingArchived = true
+      render()
+
+      controller.toggleArchivedTopics({ stopPropagation: jest.fn() })
+
+      expect(changeEvents).toHaveLength(0)
+    })
+  })
+
+  describe('new message badges', () => {
+    const newMessage = (topicId) => controller.handleNewMessage({ detail: { topicId } })
+
+    test('badges the archived toggle when the section is collapsed', () => {
+      render()
+
+      newMessage('3')
+
+      expect(controller.listTarget.querySelector('.topic-archived-toggle').classList)
+        .toContain('has-new-messages')
+    })
+
+    test('badges both the chip and the toggle when the section is expanded', () => {
+      controller.showingArchived = true
+      render()
+
+      newMessage('3')
+
+      expect(controller.listTarget.querySelector('.topic-archived[data-id="3"]').classList)
+        .toContain('has-new-messages')
+      expect(controller.listTarget.querySelector('.topic-archived-toggle').classList)
+        .toContain('has-new-messages')
+    })
+
+    test('the toggle badge survives a re-render', () => {
+      render()
+      newMessage('3')
+
+      render()
+
+      expect(controller.listTarget.querySelector('.topic-archived-toggle').classList)
+        .toContain('has-new-messages')
+    })
+
+    test('a live topic does not badge the archived toggle', () => {
+      render()
+
+      newMessage('2')
+
+      expect(controller.listTarget.querySelector('.topic-archived-toggle').classList)
+        .not.toContain('has-new-messages')
+    })
+
+    test('the toggle badge stays while another archived topic is still unread', () => {
+      render()
+      newMessage('3')
+      newMessage('4')
+
+      controller.selectTopic('3')
+
+      expect(controller.listTarget.querySelector('.topic-archived-toggle').classList)
+        .toContain('has-new-messages')
+    })
+
+    test('the toggle badge clears once every archived topic has been read', () => {
+      render()
+      newMessage('3')
+      newMessage('4')
+
+      controller.selectTopic('3')
+      controller.selectTopic('4')
+
+      expect(controller.listTarget.querySelector('.topic-archived-toggle').classList)
+        .not.toContain('has-new-messages')
+    })
+
+    test('ignores a message for the topic already being viewed', () => {
+      controller.serverLastTopicId = '3'
+      render()
+
+      newMessage('3')
+
+      expect(controller.listTarget.querySelector('.topic-archived-toggle').classList)
+        .not.toContain('has-new-messages')
+    })
+  })
+})

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_archived.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_archived.test.js
@@ -742,4 +742,92 @@ describe('TopicsController archived topic messages', () => {
       })
     })
   })
+
+  // list_controller asks isArchivedTopic for every incoming stream, and the
+  // reload that follows an archive/unarchive only refreshes the cache when its
+  // fetch resolves. Between the two, membership has to already be right.
+  describe('archive membership before the reload lands', () => {
+    // Hold the topics reload open so every assertion runs inside the window.
+    const stubPendingReload = () => {
+      global.fetch = jest.fn(() => new Promise(() => {}))
+    }
+
+    const broadcast = (action, topic) =>
+      controller.handleTopicMessage({ action, topic })
+
+    test('an archived broadcast marks the topic archived immediately', () => {
+      stubPendingReload()
+
+      broadcast('archived', { id: 2, name: 'Alpha' })
+
+      expect(controller.isArchivedTopic('2')).toBe(true)
+    })
+
+    test('an unarchived broadcast unmarks it immediately', () => {
+      stubPendingReload()
+
+      broadcast('unarchived', { id: 3, name: 'Zeta' })
+
+      expect(controller.isArchivedTopic('3')).toBe(false)
+    })
+
+    test('an unarchived broadcast clears the unread badge it can no longer show', () => {
+      stubPendingReload()
+      controller.archivedWithNewMessages.add('3')
+
+      broadcast('unarchived', { id: 3, name: 'Zeta' })
+
+      expect(controller.archivedWithNewMessages.has('3')).toBe(false)
+    })
+
+    test('an unarchived broadcast keeps another archived topic unread', () => {
+      stubPendingReload()
+      controller.archivedWithNewMessages.add('3')
+      controller.archivedWithNewMessages.add('4')
+
+      broadcast('unarchived', { id: 3, name: 'Zeta' })
+
+      expect(controller.archivedWithNewMessages.has('4')).toBe(true)
+    })
+
+    // loadTopics() empties this.topics on its way out, so the archived cache is
+    // the only one still readable in this window — and the only one routing
+    // consults.
+    test('a broadcast with no topic payload leaves the archived cache alone', () => {
+      stubPendingReload()
+
+      controller.handleTopicMessage({ action: 'archived' })
+
+      expect(controller.archivedTopics.map((t) => t.id)).toEqual([3, 4])
+    })
+
+    // The actor's own reload has the same window as every receiver's.
+    test('archiving locally marks the topic archived immediately', async () => {
+      global.fetch = jest.fn((url) => {
+        if (String(url).includes('/archive')) return Promise.resolve({ ok: true })
+        return new Promise(() => {})
+      })
+
+      await controller.archiveTopic({
+        stopPropagation: jest.fn(),
+        currentTarget: { dataset: { id: '2' } },
+      })
+
+      expect(controller.isArchivedTopic('2')).toBe(true)
+    })
+
+    test('restoring locally unmarks the topic immediately', async () => {
+      global.fetch = jest.fn((url) => {
+        if (String(url).includes('/unarchive')) return Promise.resolve({ ok: true })
+        return new Promise(() => {})
+      })
+
+      await controller.unarchiveTopic({
+        stopPropagation: jest.fn(),
+        currentTarget: { dataset: { id: '3' } },
+      })
+
+      expect(controller.isArchivedTopic('3')).toBe(false)
+    })
+  })
 })

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_archived.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_archived.test.js
@@ -282,4 +282,78 @@ describe('TopicsController archived topic messages', () => {
         .not.toContain('has-new-messages')
     })
   })
+
+  // The toggle badge is derived from the unread set's size, so any id left in it
+  // that no longer belongs to an archived topic lights the toggle with no chip
+  // to click and clear it.
+  describe('stale unread state', () => {
+    const newMessage = (topicId) => controller.handleNewMessage({ detail: { topicId } })
+
+    // popup_controller._navigateToEntry reuses open()/openForCreative() on this
+    // same instance, so no onPopupClosed runs between two creatives.
+    const switchCreative = async (creativeId) => {
+      controller.subscribe = jest.fn()
+      controller.loadTopics = jest.fn().mockResolvedValue(undefined)
+      await controller.onPopupOpened({ creativeId })
+    }
+
+    test('switching creatives drops the previous creative unread marks', async () => {
+      render()
+      newMessage('3')
+      expect(controller.archivedWithNewMessages.size).toBe(1)
+
+      await switchCreative('99')
+
+      expect(controller.archivedWithNewMessages.size).toBe(0)
+    })
+
+    test("the new creative's archived toggle renders unbadged after a switch", async () => {
+      render()
+      newMessage('3')
+
+      await switchCreative('99')
+      controller.topics = [{ id: 10, name: 'Main' }]
+      controller.archivedTopics = [{ id: 11, name: 'Other' }]
+      render()
+
+      expect(controller.listTarget.querySelector('.topic-archived-toggle').classList)
+        .not.toContain('has-new-messages')
+    })
+
+    test('loadTopics drops unread marks for topics that are no longer archived', async () => {
+      render()
+      newMessage('3')
+      newMessage('4')
+
+      // Topic 3 was restored to the live strip; only 4 is still archived.
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          topics: [{ id: 1, name: 'Main' }, { id: 3, name: 'Zeta' }],
+          archived_topics: [{ id: 4, name: 'Omega' }],
+          can_manage: true,
+          main_topic_id: 1,
+        }),
+      })
+
+      await controller.loadTopics()
+
+      expect([...controller.archivedWithNewMessages]).toEqual(['4'])
+      expect(controller.listTarget.querySelector('.topic-archived-toggle').classList)
+        .toContain('has-new-messages')
+    })
+
+    test('the toggle badge clears when the only unread topic is unarchived', () => {
+      render()
+      newMessage('3')
+
+      controller.archivedTopics = [{ id: 4, name: 'Omega' }]
+      controller.pruneArchivedBadges()
+      render()
+
+      expect(controller.listTarget.querySelector('.topic-archived-toggle').classList)
+        .not.toContain('has-new-messages')
+    })
+  })
 })

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_archived.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_archived.test.js
@@ -204,6 +204,73 @@ describe('TopicsController archived topic messages', () => {
 
       expect(changeEvents).toHaveLength(0)
     })
+
+    describe('after the user collapses the section on the topic they are in', () => {
+      const collapse = () => controller.toggleArchivedTopics({ stopPropagation: jest.fn() })
+      const rename = () => controller.updateTopicInList({ id: 2, name: 'Alpha renamed' })
+
+      beforeEach(() => {
+        controller.serverLastTopicId = '3'
+        controller.showingArchived = true
+        render()
+        collapse()
+      })
+
+      test('an unrelated rename does not reopen it', () => {
+        rename()
+
+        expect(controller.showingArchived).toBe(false)
+        expect(controller.listTarget.querySelector('.topic-archived[data-id="3"]')).toBeNull()
+      })
+
+      test('a reorder does not reopen it', () => {
+        controller.reorderTopicsFromServer([2, 1])
+
+        expect(controller.showingArchived).toBe(false)
+      })
+
+      test('the hidden topic stays selected', () => {
+        rename()
+
+        expect(String(controller.currentTopicId)).toBe('3')
+      })
+
+      test('deliberately reselecting the topic reopens the section', () => {
+        controller.selectTopic('3')
+
+        expect(controller.showingArchived).toBe(true)
+        expect(controller.listTarget.querySelector('.topic-archived[data-id="3"]').classList)
+          .toContain('active')
+      })
+
+      test('a rename after that reselection leaves the section open', () => {
+        controller.selectTopic('3')
+
+        rename()
+
+        expect(controller.showingArchived).toBe(true)
+      })
+
+      test('re-expanding by hand also drops the suppression', () => {
+        collapse()
+
+        rename()
+
+        expect(controller.showingArchived).toBe(true)
+      })
+    })
+
+    test('collapsing while a live topic is open still reveals a restored archived one', () => {
+      controller.serverLastTopicId = '2'
+      controller.showingArchived = true
+      render()
+
+      controller.toggleArchivedTopics({ stopPropagation: jest.fn() })
+      controller.serverLastTopicId = '3'
+      controller.restoreSelection()
+
+      expect(controller.showingArchived).toBe(true)
+    })
   })
 
   describe('new message badges', () => {

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_archived.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_archived.test.js
@@ -550,4 +550,81 @@ describe('TopicsController archived topic messages', () => {
       expect(changeEvents.at(-1).topicId).toBe('2')
     })
   })
+
+  // The "deleted" broadcast is the one removal path that runs without a
+  // loadTopics(), so it is the only thing that can prune the archived cache
+  // when an admin deletes an archived topic from another client or the API.
+  describe('a deleted broadcast for an archived topic', () => {
+    const deleteBroadcast = (topicId) =>
+      controller.handleTopicMessage({ action: 'deleted', topic_id: topicId })
+
+    test('drops it from the archived cache', () => {
+      deleteBroadcast(3)
+
+      expect(controller.archivedTopics.map((t) => t.id)).toEqual([4])
+    })
+
+    test('removes its chip so it can no longer be opened', () => {
+      controller.showingArchived = true
+      render()
+      expect(controller.listTarget.querySelector('.topic-archived[data-id="3"]')).not.toBeNull()
+
+      deleteBroadcast(3)
+
+      expect(controller.listTarget.querySelector('.topic-archived[data-id="3"]')).toBeNull()
+      expect(controller.listTarget.querySelector('.topic-archived[data-id="4"]')).not.toBeNull()
+    })
+
+    test('moves the viewer out of it instead of leaving them on a dead conversation', () => {
+      controller.serverLastTopicId = '3'
+
+      deleteBroadcast(3)
+
+      expect(changeEvents.at(-1).topicId).toBe('1')
+      expect(controller.serverLastTopicId).toBe('1')
+    })
+
+    test('clears the toggle badge it was holding', () => {
+      render()
+      controller.handleNewMessage({ detail: { topicId: '3' } })
+      expect(controller.archivedWithNewMessages.has('3')).toBe(true)
+      expect(controller.listTarget.querySelector('.topic-archived-toggle').classList)
+        .toContain('has-new-messages')
+
+      deleteBroadcast(3)
+
+      expect(controller.archivedWithNewMessages.has('3')).toBe(false)
+      expect(controller.listTarget.querySelector('.topic-archived-toggle').classList)
+        .not.toContain('has-new-messages')
+    })
+
+    // Another archived topic still unread keeps the toggle lit — the badge
+    // aggregates the whole section.
+    test('leaves the toggle lit when another archived topic is still unread', () => {
+      render()
+      controller.handleNewMessage({ detail: { topicId: '3' } })
+      controller.handleNewMessage({ detail: { topicId: '4' } })
+
+      deleteBroadcast(3)
+
+      expect([...controller.archivedWithNewMessages]).toEqual(['4'])
+      expect(controller.listTarget.querySelector('.topic-archived-toggle').classList)
+        .toContain('has-new-messages')
+    })
+
+    test('still removes a live topic', () => {
+      deleteBroadcast(2)
+
+      expect(controller.topics.map((t) => t.id)).toEqual([1])
+      expect(controller.archivedTopics.map((t) => t.id)).toEqual([3, 4])
+    })
+
+    test('does nothing for an id in neither list', () => {
+      deleteBroadcast(99)
+
+      expect(controller.topics.map((t) => t.id)).toEqual([1, 2])
+      expect(controller.archivedTopics.map((t) => t.id)).toEqual([3, 4])
+      expect(changeEvents).toEqual([])
+    })
+  })
 })

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_archived.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_archived.test.js
@@ -626,5 +626,53 @@ describe('TopicsController archived topic messages', () => {
       expect(controller.archivedTopics.map((t) => t.id)).toEqual([3, 4])
       expect(changeEvents).toEqual([])
     })
+
+    // Assigning "" only moves the preference, and both deep-link sources outrank
+    // it in the currentTopicId getter, so the deleted id would keep answering
+    // for every later restoreSelection().
+    describe('while a deep link still names it', () => {
+      test('clears an overrideTopicId pointing at it', () => {
+        controller.setOverrideTopicId('3')
+
+        deleteBroadcast(3)
+
+        expect(controller.currentTopicId).toBe('1')
+      })
+
+      test('drops a ?topic_id= naming it', () => {
+        window.history.replaceState({}, '', '/?topic_id=3')
+
+        deleteBroadcast(3)
+
+        expect(new URLSearchParams(window.location.search).get('topic_id')).toBeNull()
+        expect(controller.currentTopicId).toBe('1')
+
+        window.history.replaceState({}, '', '/')
+      })
+
+      // The point of clearing them: a re-render must not throw away the topic
+      // the user picked after the deletion.
+      test('a later re-render keeps the topic the user chose instead', () => {
+        controller.setOverrideTopicId('3')
+        deleteBroadcast(3)
+
+        controller.selectTopic('2')
+        controller.renderTopics(controller.topics, controller.canManageTopics)
+        controller.restoreSelection()
+
+        expect(controller.currentTopicId).toBe('2')
+        expect(changeEvents.at(-1).topicId).toBe('2')
+      })
+
+      test('leaves a deep link pointing at a different topic alone', () => {
+        window.history.replaceState({}, '', '/?topic_id=4')
+
+        deleteBroadcast(3)
+
+        expect(new URLSearchParams(window.location.search).get('topic_id')).toBe('4')
+
+        window.history.replaceState({}, '', '/')
+      })
+    })
   })
 })

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_archived.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_archived.test.js
@@ -381,4 +381,125 @@ describe('TopicsController archived topic messages', () => {
         .not.toContain('has-new-messages')
     })
   })
+
+  // Archiving the topic in view switches to All Messages, but the preference
+  // save is debounced 500ms — so the topics reload it triggers (and the one the
+  // "archived" broadcast triggers) still reads the archived topic as
+  // last_topic_id. restoreSelection accepts archived ids now, so nothing else
+  // stops it from putting the user back where they just left.
+  describe('archiving the topic in view', () => {
+    // Route by URL: the archive PATCH and the topics reload both go through
+    // the same global fetch. lastTopicId is what the server preference still
+    // reports at reload time.
+    const stubFetch = (lastTopicId) => {
+      global.fetch = jest.fn((url) => {
+        if (String(url).includes('/archive')) return Promise.resolve({ ok: true })
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            topics: [{ id: 1, name: 'Main' }],
+            archived_topics: [{ id: 2, name: 'Alpha' }, ...ARCHIVED],
+            can_manage: true,
+            main_topic_id: 1,
+            last_topic_id: lastTopicId,
+          }),
+        })
+      })
+    }
+
+    // archiveTopic fires loadTopics without awaiting it.
+    const archive = async (topicId) => {
+      await controller.archiveTopic({
+        stopPropagation: jest.fn(),
+        currentTarget: { dataset: { id: topicId } },
+      })
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    }
+
+    test('does not reselect the topic the reload still reports as last_topic_id', async () => {
+      controller.serverLastTopicId = '2'
+      render()
+      stubFetch(2)
+
+      await archive('2')
+
+      expect(changeEvents.at(-1).topicId).toBe('1')
+      expect(controller.currentTopicId).toBe('1')
+    })
+
+    test('leaves the archived section collapsed instead of revealing the archived topic', async () => {
+      controller.serverLastTopicId = '2'
+      render()
+      stubFetch(2)
+
+      await archive('2')
+
+      expect(controller.showingArchived).toBe(false)
+      expect(controller.listTarget.querySelector('.topic-archived[data-id="2"]')).toBeNull()
+    })
+
+    test('a deep-link override does not keep reporting the archived topic as current', async () => {
+      controller.setOverrideTopicId('2')
+      render()
+      stubFetch(2)
+
+      await archive('2')
+
+      expect(controller.overrideTopicId).toBeUndefined()
+      expect(controller.currentTopicId).toBe('1')
+    })
+
+    test('the user can still go back into the topic they just archived', async () => {
+      controller.serverLastTopicId = '2'
+      render()
+      stubFetch(2)
+      await archive('2')
+
+      controller.selectTopic('2')
+      controller.restoreSelection()
+
+      expect(changeEvents.at(-1).topicId).toBe('2')
+      expect(controller.showingArchived).toBe(true)
+    })
+
+    test('the guard lifts once the server preference stops naming the topic', async () => {
+      controller.serverLastTopicId = '2'
+      render()
+      stubFetch(2)
+      await archive('2')
+
+      stubFetch(null)
+      await controller.loadTopics()
+      // Reselected elsewhere — another tab, or a deep link.
+      stubFetch(2)
+      await controller.loadTopics()
+
+      expect(changeEvents.at(-1).topicId).toBe('2')
+    })
+
+    test('archiving a topic that is not in view leaves the selection alone', async () => {
+      controller.topics = [...TOPICS, { id: 5, name: 'Beta' }]
+      controller.serverLastTopicId = '2'
+      render()
+      global.fetch = jest.fn((url) => {
+        if (String(url).includes('/archive')) return Promise.resolve({ ok: true })
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            topics: TOPICS,
+            archived_topics: [{ id: 5, name: 'Beta' }, ...ARCHIVED],
+            can_manage: true,
+            main_topic_id: 1,
+            last_topic_id: 2,
+          }),
+        })
+      })
+
+      await archive('5')
+
+      expect(changeEvents.at(-1).topicId).toBe('2')
+    })
+  })
 })

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_delete.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_delete.test.js
@@ -91,4 +91,46 @@ describe('TopicsController#deleteTopic', () => {
 
     expect(fetchMock).not.toHaveBeenCalled()
   })
+
+  // Assigning "" only moves serverLastTopicId, and both deep-link sources
+  // outrank it in the currentTopicId getter — so without the release the
+  // deleted id keeps answering for every later restoreSelection().
+  describe('deleting the topic in view while a deep link names it', () => {
+    const deleteTopicInView = async (topicId) => {
+      global.fetch = jest.fn().mockResolvedValue({ ok: true })
+      const button = document.createElement('button')
+      button.dataset.id = topicId
+      confirmDialog.mockResolvedValue(true)
+
+      await controller.deleteTopic({ stopPropagation: jest.fn(), currentTarget: button })
+    }
+
+    test('clears an overrideTopicId pointing at it', async () => {
+      controller.setOverrideTopicId('99')
+
+      await deleteTopicInView('99')
+
+      expect(controller.currentTopicId).toBe('')
+    })
+
+    test('drops a ?topic_id= naming it', async () => {
+      window.history.replaceState({}, '', '/?topic_id=99')
+
+      await deleteTopicInView('99')
+
+      expect(new URLSearchParams(window.location.search).get('topic_id')).toBeNull()
+
+      window.history.replaceState({}, '', '/')
+    })
+
+    test('leaves a ?topic_id= pointing at a different topic alone', async () => {
+      window.history.replaceState({}, '', '/?topic_id=7')
+
+      await deleteTopicInView('99')
+
+      expect(new URLSearchParams(window.location.search).get('topic_id')).toBe('7')
+
+      window.history.replaceState({}, '', '/')
+    })
+  })
 })

--- a/engines/collavre/app/javascript/controllers/comments/list_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/list_controller.js
@@ -349,8 +349,15 @@ export default class extends Controller {
             // Deep link / around_comment_id resolution from server must win over
             // saved topic state for the current popup session.
             this.popupController.topicsController.setOverrideTopicId(serverTopicId)
-            // Update UI and local state without dispatching change event (to avoid loop)
-            this.popupController.topicsController.updateSelectionUI(serverTopicId)
+            // Go through selectTopic, not updateSelectionUI: a deep link can resolve
+            // to an archived topic, whose chip exists only while the archived section
+            // is expanded, and form_controller learns the active topic solely from the
+            // change event — without it a reply posts into the previously selected
+            // conversation. The reload this event would normally trigger is already
+            // ruled out: this.currentTopicId was set to serverTopicId just above, so
+            // handleTopicChange's equality guard returns before resetToLatest() can
+            // discard the highlight window.
+            this.popupController.topicsController.selectTopic(serverTopicId)
 
             // Also update data attribute for CSS scoping
             this.listTarget.dataset.currentTopicId = serverTopicId || ""

--- a/engines/collavre/app/javascript/controllers/comments/list_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/list_controller.js
@@ -214,7 +214,13 @@ export default class extends Controller {
       // the old creative's comments to overwrite the new creative's list.
       if (requestVersion !== this._loadCommentsVersion) return
       if (this.creativeId !== requestCreativeId) return
-      if (String(this.currentTopicId || "") !== String(requestTopicId)) return
+      // A server-resolved deep link moves currentTopicId off the topic this
+      // request asked for. That is this request's own answer, not a stale one,
+      // so the topic guard has to let it through — otherwise the list sits on
+      // "Loading..." forever for every comment link pointing outside the
+      // restored topic.
+      if (!this.isServerResolvedTopic(requestVersion) &&
+          String(this.currentTopicId || "") !== String(requestTopicId)) return
 
       this.listTarget.innerHTML = html
       this.listTarget.dataset.currentTopicId = this.currentTopicId || ""
@@ -243,9 +249,18 @@ export default class extends Controller {
     }).catch((error) => {
       if (requestVersion !== this._loadCommentsVersion) return
       if (this.creativeId !== requestCreativeId) return
-      if (String(this.currentTopicId || "") !== String(requestTopicId)) return
+      if (!this.isServerResolvedTopic(requestVersion) &&
+          String(this.currentTopicId || "") !== String(requestTopicId)) return
       this.listTarget.innerHTML = `<div class="comments-list-error">${error.message}</div>`
     })
+  }
+
+  // fetchComments stamps the load version whose response carried an X-Topic-Id
+  // that moved the selection. Only that one request may ignore the stale-topic
+  // guard; a later load bumps _loadCommentsVersion and stops matching.
+  isServerResolvedTopic(requestVersion) {
+    return this._serverTopicRequestVersion !== undefined &&
+      this._serverTopicRequestVersion === requestVersion
   }
 
   loadOlderComments() {
@@ -340,6 +355,12 @@ export default class extends Controller {
 
         if (currentStr !== serverStr) {
           this.currentTopicId = serverTopicId
+          // Tell loadInitialComments' stale-topic guard that this switch is the
+          // answer to the load it is still awaiting. Deep links are the only
+          // requests the server answers with X-Topic-Id, and only
+          // loadInitialComments sends them, so the in-flight load version
+          // identifies it.
+          this._serverTopicRequestVersion = this._loadCommentsVersion
           // Notify topics controller to update UI
           const event = new CustomEvent("comments--topics:update-selection", { detail: { topicId: serverTopicId } })
           window.dispatchEvent(event)

--- a/engines/collavre/app/javascript/controllers/comments/list_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/list_controller.js
@@ -208,7 +208,7 @@ export default class extends Controller {
     const requestTopicId = this.currentTopicId || ""
     const requestCreativeId = this.creativeId
 
-    this.fetchComments(params).then((html) => {
+    this.fetchComments(params, { loadVersion: requestVersion }).then((html) => {
       // Discard stale responses if creative or topic changed while fetching.
       // This prevents a race condition where switching creatives causes
       // the old creative's comments to overwrite the new creative's list.
@@ -255,9 +255,9 @@ export default class extends Controller {
     })
   }
 
-  // fetchComments stamps the load version whose response carried an X-Topic-Id
-  // that moved the selection. Only that one request may ignore the stale-topic
-  // guard; a later load bumps _loadCommentsVersion and stops matching.
+  // fetchComments stamps the version of the request whose own response carried
+  // an X-Topic-Id that moved the selection. Only that request may ignore the
+  // stale-topic guard; every other load compares unequal and stays guarded.
   isServerResolvedTopic(requestVersion) {
     return this._serverTopicRequestVersion !== undefined &&
       this._serverTopicRequestVersion === requestVersion
@@ -320,7 +320,7 @@ export default class extends Controller {
       })
   }
 
-  fetchComments(params = {}) {
+  fetchComments(params = {}, { loadVersion } = {}) {
     const urlParams = new URLSearchParams(params)
     if (this.manualSearchQuery) {
       urlParams.set('search', this.manualSearchQuery)
@@ -345,7 +345,12 @@ export default class extends Controller {
       }
 
       const serverTopicId = response.headers.get("X-Topic-Id")
-      if (serverTopicId !== null && serverTopicId !== undefined) {
+      // A load superseded while in flight must not retopic anything: its own HTML
+      // is dropped, so moving currentTopicId (and the strip, and the form) to its
+      // answer would leave the surviving load rendering into a selection it never
+      // asked for.
+      const superseded = loadVersion !== undefined && loadVersion !== this._loadCommentsVersion
+      if (serverTopicId !== null && serverTopicId !== undefined && !superseded) {
         // Server says we are in this topic. 
         // If it differs from current, update state.
 
@@ -356,11 +361,11 @@ export default class extends Controller {
         if (currentStr !== serverStr) {
           this.currentTopicId = serverTopicId
           // Tell loadInitialComments' stale-topic guard that this switch is the
-          // answer to the load it is still awaiting. Deep links are the only
-          // requests the server answers with X-Topic-Id, and only
-          // loadInitialComments sends them, so the in-flight load version
-          // identifies it.
-          this._serverTopicRequestVersion = this._loadCommentsVersion
+          // answer to the load it is still awaiting. Stamp the version of the
+          // request that actually carried the header, not the controller's
+          // latest: reading the latest would hand the exemption to a newer load
+          // that never asked for a topic switch.
+          this._serverTopicRequestVersion = loadVersion
           // Notify topics controller to update UI
           const event = new CustomEvent("comments--topics:update-selection", { detail: { topicId: serverTopicId } })
           window.dispatchEvent(event)

--- a/engines/collavre/app/javascript/controllers/comments/list_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/list_controller.js
@@ -529,6 +529,13 @@ export default class extends Controller {
     // Actually form_controller handleSubmit calls this list controller? No, distinct.
   }
 
+  // A comment with no topic is never archived, so the empty check also keeps
+  // this off the topics controller for the common case.
+  isArchivedTopicMessage(topicId) {
+    if (!topicId) return false
+    return Boolean(this.popupController?.topicsController?.isArchivedTopic?.(topicId))
+  }
+
   handleStreamRender(event) {
     // Only care about streams targeting our list
     if (event.target.target !== 'comments-list') return
@@ -555,8 +562,17 @@ export default class extends Controller {
         const currentTopicId = this.currentTopicId || ""
 
         // If we are in a specific topic (currentTopicId is set)
-        // AND the message is for a different topic
-        if (currentTopicId && String(currentTopicId) !== String(messageTopicId)) {
+        // AND the message is for a different topic.
+        //
+        // All Messages (currentTopicId === "") takes everything except archived
+        // topics: CommentsController#index filters those out of this view, so
+        // letting a live one in would show a message that vanishes on reload.
+        // Both cases badge the topic instead of appending.
+        const isForeignTopic = currentTopicId
+          ? String(currentTopicId) !== String(messageTopicId)
+          : this.isArchivedTopicMessage(messageTopicId)
+
+        if (isForeignTopic) {
           event.preventDefault()
           // Dispatch event for topics controller to show badge
           const customEvent = new CustomEvent("comments--topics:new-message", {

--- a/engines/collavre/app/javascript/controllers/comments/list_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/list_controller.js
@@ -575,21 +575,14 @@ export default class extends Controller {
 
     // Deduplication: If manually appended by form_controller, block the stream echo.
     if (event.target.action === 'append') {
-      // A search-filtered list is the result set of a query, and the match runs
-      // server-side over the raw content. A live append carries no verdict on
-      // whether it matches, so letting it in drops an unrelated message into the
-      // results — and, when there were none, takes the "no results" notice with
-      // it (comments--placeholder clears on any .comment-item arriving). Blocked
-      // like history mode below; the next search or reset re-queries the server.
-      if (this.manualSearchQuery) {
-        event.preventDefault()
-        return
-      }
-
       const templateContent = event.target.templateContent || event.target.querySelector('template')?.content
       const firstChild = templateContent?.firstElementChild
 
-      // Check for topic context mismatch
+      // Check for topic context mismatch. Runs ahead of the search block below:
+      // both block the append, but only this one badges, and the badge is the
+      // sole notice that an out-of-view conversation moved. Search suppressing
+      // it would hide an archived topic's traffic completely, since the archived
+      // section carries no other signal.
       if (firstChild && firstChild.dataset.topicId !== undefined) {
         const messageTopicId = firstChild.dataset.topicId
         const currentTopicId = this.currentTopicId || ""
@@ -614,6 +607,17 @@ export default class extends Controller {
           window.dispatchEvent(customEvent)
           return
         }
+      }
+
+      // A search-filtered list is the result set of a query, and the match runs
+      // server-side over the raw content. A live append carries no verdict on
+      // whether it matches, so letting it in drops an unrelated message into the
+      // results — and, when there were none, takes the "no results" notice with
+      // it (comments--placeholder clears on any .comment-item arriving). Blocked
+      // like history mode below; the next search or reset re-queries the server.
+      if (this.manualSearchQuery) {
+        event.preventDefault()
+        return
       }
 
       if (firstChild && firstChild.id && document.getElementById(firstChild.id)) {

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -55,7 +55,18 @@ export default class extends Controller {
         this.creativeIdValue = null
         this.topics = []
         this.mainTopicId = null
+        this.archivedWithNewMessages.clear()
         delete this.element.dataset.effectiveCreativeId
+    }
+
+    // Archived topics still accept messages, but their chips only exist in the
+    // DOM while the archived section is expanded. Remember which ones have
+    // unread traffic so the badge can live on the collapsed toggle and survive
+    // re-renders. Created lazily: a docked controller can receive popup
+    // lifecycle callbacks before connect() has run.
+    get archivedWithNewMessages() {
+        if (!this._archivedWithNewMessages) this._archivedWithNewMessages = new Set()
+        return this._archivedWithNewMessages
     }
 
     get creativeId() {
@@ -132,15 +143,31 @@ export default class extends Controller {
     restoreSelection() {
         const lastTopicId = this.currentTopicId
         if (lastTopicId) {
-            // Validate it exists in list
-            const exists = this.listTarget.querySelector(`[data-id="${lastTopicId}"]`)
-            if (exists) {
+            // Validate against the topic data, not the rendered DOM. An archived
+            // topic is still readable and writable — archiving hides it from the
+            // strip, it does not close the conversation. A DOM lookup would bounce
+            // the user back to Main every time the archived section is collapsed,
+            // because collapsed chips are never rendered. selectTopic expands the
+            // section when the selection lands inside it.
+            const known = [ ...(this.topics || []), ...(this.archivedTopics || []) ]
+            if (known.some(t => String(t.id) === String(lastTopicId))) {
                 this.selectTopic(lastTopicId)
                 return
             }
         }
 
         this.selectTopic(this.mainTopicId || "")
+    }
+
+    // An archived topic can be opened from the topic strip, the topic-list popup,
+    // a deep link, or a restored last-topic. Expand the archived section from this
+    // one choke point so the strip always shows which topic is open.
+    revealArchivedTopic(id) {
+        if (!id || this.showingArchived) return
+        if (!(this.archivedTopics || []).some(t => String(t.id) === String(id))) return
+
+        this.showingArchived = true
+        this.renderTopics(this.topics, this.canManageTopics, this.canCreateTopic, this.canSetPrimaryAgent)
     }
 
     renderTopics(topics, canManage = false, canCreateTopic = canManage, canSetPrimaryAgent = canManage) {
@@ -192,12 +219,19 @@ export default class extends Controller {
 
         // Archived topics section
         if (this.archivedTopics && this.archivedTopics.length > 0) {
-            html += `<span class="topic-archived-toggle" data-action="click->comments--topics#toggleArchivedTopics">
+            // Badges are re-applied from state on every render because innerHTML
+            // below wipes the classes set by handleNewMessage.
+            const toggleBadge = this.archivedWithNewMessages.size > 0 ? ' has-new-messages' : ''
+            html += `<span class="topic-archived-toggle${toggleBadge}" data-action="click->comments--topics#toggleArchivedTopics">
                       ${ICON_ARCHIVE} ${this.archivedTopics.length}
                      </span>`
             if (this.showingArchived) {
                 this.archivedTopics.forEach(topic => {
-                    html += `<span class="topic-tag topic-archived" data-id="${topic.id}">
+                    const isActive = String(this.currentTopicId) === String(topic.id) ? ' active' : ''
+                    const hasNew = this.archivedWithNewMessages.has(String(topic.id)) ? ' has-new-messages' : ''
+                    html += `<span class="topic-tag topic-archived${isActive}${hasNew}"
+                                   data-action="click->comments--topics#select"
+                                   data-id="${topic.id}">
                               #${topic.name}
                               ${canManage ? `<button class="unarchive-topic-btn" data-action="click->comments--topics#unarchiveTopic" data-id="${topic.id}" title="Restore">${ICON_RESTORE}</button>` : ''}
                              </span>`
@@ -502,8 +536,11 @@ export default class extends Controller {
     toggleArchivedTopics(event) {
         event.stopPropagation()
         this.showingArchived = !this.showingArchived
+        // No restoreSelection() here: toggling cannot invalidate the selection, and
+        // renderTopics already re-applies the active class. Re-selecting would
+        // re-expand the section the user just collapsed (selectTopic reveals an
+        // archived selection) and pointlessly reload the message list.
         this.renderTopics(this.topics, this.canManageTopics, this.canCreateTopic, this.canSetPrimaryAgent)
-        this.restoreSelection()
     }
 
     openTopicListPopup(event) {
@@ -618,6 +655,7 @@ export default class extends Controller {
     }
 
     selectTopic(id) {
+        this.revealArchivedTopic(id)
         this.updateSelectionUI(id)
         if (id) {
             this.clearNewMessageBadge(id)
@@ -753,9 +791,16 @@ export default class extends Controller {
         // Don't show badge if we are currently in this topic (shouldn't happen due to list_controller logic, but safety check)
         if (String(this.currentTopicId) === String(topicId)) return
 
+        const isArchived = (this.archivedTopics || []).some(t => String(t.id) === String(topicId))
+        if (isArchived) this.archivedWithNewMessages.add(String(topicId))
+
         const topicEl = this.listTarget.querySelector(`.topic-tag[data-id="${topicId}"]`)
-        if (topicEl) {
-            topicEl.classList.add('has-new-messages')
+        if (topicEl) topicEl.classList.add('has-new-messages')
+
+        // A collapsed archived section has no chip to badge, so the toggle carries
+        // the notice — otherwise a message in an archived topic is invisible.
+        if (isArchived) {
+            this.listTarget.querySelector('.topic-archived-toggle')?.classList.add('has-new-messages')
         }
     }
 
@@ -763,6 +808,12 @@ export default class extends Controller {
         const topicEl = this.listTarget.querySelector(`.topic-tag[data-id="${topicId}"]`)
         if (topicEl) {
             topicEl.classList.remove('has-new-messages')
+        }
+
+        // The toggle aggregates every archived topic, so it only clears once none
+        // of them is left unread.
+        if (this.archivedWithNewMessages.delete(String(topicId)) && this.archivedWithNewMessages.size === 0) {
+            this.listTarget.querySelector('.topic-archived-toggle')?.classList.remove('has-new-messages')
         }
     }
 

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -35,6 +35,7 @@ export default class extends Controller {
     }
 
     onPopupOpened({ creativeId }) {
+        const previousCreativeId = this.creativeIdValue
         this.creativeIdValue = creativeId
         // Clear stale cached state from the previous creative — otherwise
         // chat-context autofill (command_menu) reads stale values during the
@@ -49,8 +50,13 @@ export default class extends Controller {
         // (popup_controller._navigateToEntry calls open()/openForCreative()
         // again), so unread marks from the previous creative would badge the new
         // creative's archived toggle — and never clear, since those ids are not
-        // among its topics.
-        this.archivedWithNewMessages.clear()
+        // among its topics. Only on an actual switch, though: a docked chat
+        // re-opens the *same* creative when a workspace-sync event carries a
+        // highlightId (popup_controller.handleCreativeClick), and these marks are
+        // transient — loadTopics() cannot rebuild them.
+        if (String(previousCreativeId || '') !== String(creativeId || '')) {
+            this.archivedWithNewMessages.clear()
+        }
         this.subscribe()
         return this.loadTopics()
     }
@@ -73,6 +79,14 @@ export default class extends Controller {
     get archivedWithNewMessages() {
         if (!this._archivedWithNewMessages) this._archivedWithNewMessages = new Set()
         return this._archivedWithNewMessages
+    }
+
+    // list_controller asks this before appending a live message to All Messages:
+    // CommentsController#index leaves archived-topic comments out of that view,
+    // so a stream must not put one there either.
+    isArchivedTopic(id) {
+        if (!id) return false
+        return (this.archivedTopics || []).some(t => String(t.id) === String(id))
     }
 
     // The toggle badge is derived from set size, so an id that is no longer
@@ -182,7 +196,7 @@ export default class extends Controller {
     // one choke point so the strip always shows which topic is open.
     revealArchivedTopic(id) {
         if (!id || this.showingArchived) return
-        if (!(this.archivedTopics || []).some(t => String(t.id) === String(id))) return
+        if (!this.isArchivedTopic(id)) return
 
         this.showingArchived = true
         this.renderTopics(this.topics, this.canManageTopics, this.canCreateTopic, this.canSetPrimaryAgent)
@@ -809,7 +823,7 @@ export default class extends Controller {
         // Don't show badge if we are currently in this topic (shouldn't happen due to list_controller logic, but safety check)
         if (String(this.currentTopicId) === String(topicId)) return
 
-        const isArchived = (this.archivedTopics || []).some(t => String(t.id) === String(topicId))
+        const isArchived = this.isArchivedTopic(topicId)
         if (isArchived) this.archivedWithNewMessages.add(String(topicId))
 
         const topicEl = this.listTarget.querySelector(`.topic-tag[data-id="${topicId}"]`)

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -1104,10 +1104,19 @@ export default class extends Controller {
         if (!topicId) return
 
         const topics = this.topics || []
+        const archivedTopics = this.archivedTopics || []
         const nextTopics = topics.filter((topic) => String(topic.id) !== String(topicId))
-        if (nextTopics.length === topics.length) return
+        // An archived topic is deletable and now selectable, so the "deleted"
+        // broadcast has to reach this cache too — nothing else does. It is the
+        // only removal path that runs without a loadTopics(), so a topic dropped
+        // from here would keep an openable chip and, through pruneArchivedBadges
+        // never running, a lit toggle for a conversation that no longer exists.
+        const nextArchivedTopics = archivedTopics.filter((topic) => String(topic.id) !== String(topicId))
+        if (nextTopics.length === topics.length && nextArchivedTopics.length === archivedTopics.length) return
 
         this.topics = nextTopics
+        this.archivedTopics = nextArchivedTopics
+        this.pruneArchivedBadges()
         if (String(this.currentTopicId) === String(topicId)) {
             this.currentTopicId = ""
             this.dispatch("change", { detail: { topicId: "", mainTopicId: this.mainTopicId } })

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -154,11 +154,13 @@ export default class extends Controller {
                 this.archivedTopics = data.archived_topics || []
                 this.pruneArchivedBadges()
                 this.serverLastTopicId = data.last_topic_id ? String(data.last_topic_id) : ""
-                // The archive guard only has to outlive the stale preference.
-                // Once the server stops naming that topic the transition is
-                // over, so a later reselection (another tab, a deep link) is
-                // honoured normally.
-                if (this.archivedAwayTopicId && this.serverLastTopicId !== this.archivedAwayTopicId) {
+                // The archive guard only has to outlive the sources that still
+                // name the topic. Test the effective selection, not just the
+                // preference: an unchanged ?topic_id= outranks it in the getter,
+                // so keying on serverLastTopicId would drop the guard while the
+                // URL was still pointing at the archived topic. Once nothing
+                // names it, a later reselection is honoured normally.
+                if (this.archivedAwayTopicId && String(this.currentTopicId) !== this.archivedAwayTopicId) {
                     this.archivedAwayTopicId = null
                 }
                 this.isInbox = !!data.is_inbox
@@ -553,10 +555,13 @@ export default class extends Controller {
                     // flushing the save: the broadcast reload cannot be ordered
                     // behind the flush, only ignored.
                     this.archivedAwayTopicId = String(topicId)
-                    // A deep link pins currentTopicId through overrideTopicId,
-                    // which outranks serverLastTopicId in the getter — leaving it
-                    // set would keep reporting the archived topic as current.
+                    // Both sources that outrank serverLastTopicId in the
+                    // currentTopicId getter have to go too, or the archived
+                    // topic stays the effective selection no matter what the
+                    // preference says: overrideTopicId (deep link) and the
+                    // ?topic_id= query parameter.
                     this.clearOverrideTopicId()
+                    this.clearUrlTopicId(topicId)
                     this.currentTopicId = ""
                     this.dispatch("change", { detail: { topicId: "", mainTopicId: this.mainTopicId } })
                 }
@@ -928,6 +933,18 @@ export default class extends Controller {
         if (urlTopicId) return urlTopicId
 
         return this.serverLastTopicId || ""
+    }
+
+    // Drop ?topic_id= when it names the topic being archived. It is a selection
+    // source in its own right and survives every reload, so leaving it would
+    // re-select the topic the user just archived out of. replaceState, not a
+    // navigation: the chat state around it must stay put.
+    clearUrlTopicId(topicId) {
+        const url = new URL(window.location.href)
+        if (url.searchParams.get('topic_id') !== String(topicId)) return
+
+        url.searchParams.delete('topic_id')
+        window.history.replaceState(window.history.state, '', url.toString())
     }
 
     setOverrideTopicId(id) {

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -56,6 +56,9 @@ export default class extends Controller {
         // transient — loadTopics() cannot rebuild them.
         if (String(previousCreativeId || '') !== String(creativeId || '')) {
             this.archivedWithNewMessages.clear()
+            // Scoped to the creative it was archived in; a topic id from another
+            // creative must not veto this one's restored selection.
+            this.archivedAwayTopicId = null
         }
         this.subscribe()
         return this.loadTopics()
@@ -68,6 +71,7 @@ export default class extends Controller {
         this.topics = []
         this.mainTopicId = null
         this.archivedWithNewMessages.clear()
+        this.archivedAwayTopicId = null
         delete this.element.dataset.effectiveCreativeId
     }
 
@@ -150,6 +154,13 @@ export default class extends Controller {
                 this.archivedTopics = data.archived_topics || []
                 this.pruneArchivedBadges()
                 this.serverLastTopicId = data.last_topic_id ? String(data.last_topic_id) : ""
+                // The archive guard only has to outlive the stale preference.
+                // Once the server stops naming that topic the transition is
+                // over, so a later reselection (another tab, a deep link) is
+                // honoured normally.
+                if (this.archivedAwayTopicId && this.serverLastTopicId !== this.archivedAwayTopicId) {
+                    this.archivedAwayTopicId = null
+                }
                 this.isInbox = !!data.is_inbox
                 this.systemTopicId = data.system_topic_id ? String(data.system_topic_id) : null
                 this.mainTopicId = data.main_topic_id ? String(data.main_topic_id) : null
@@ -174,7 +185,10 @@ export default class extends Controller {
 
     restoreSelection() {
         const lastTopicId = this.currentTopicId
-        if (lastTopicId) {
+        // archiveTopic() switched away from this topic on purpose. The server
+        // preference still names it until the debounced save lands, so accept
+        // the local intent over the stale server answer for that window.
+        if (lastTopicId && String(lastTopicId) !== this.archivedAwayTopicId) {
             // Validate against the topic data, not the rendered DOM. An archived
             // topic is still readable and writable — archiving hides it from the
             // strip, it does not close the conversation. A DOM lookup would bounce
@@ -530,6 +544,19 @@ export default class extends Controller {
 
             if (response.ok) {
                 if (String(this.currentTopicId) === String(topicId)) {
+                    // Archiving the topic in view switches to All Messages, but
+                    // the preference save is debounced 500ms and both this
+                    // reload and the "archived" broadcast's own reload can beat
+                    // it. restoreSelection() accepts archived ids now, so the
+                    // stale last_topic_id would drop the user straight back into
+                    // the topic they just archived out of. Flag it instead of
+                    // flushing the save: the broadcast reload cannot be ordered
+                    // behind the flush, only ignored.
+                    this.archivedAwayTopicId = String(topicId)
+                    // A deep link pins currentTopicId through overrideTopicId,
+                    // which outranks serverLastTopicId in the getter — leaving it
+                    // set would keep reporting the archived topic as current.
+                    this.clearOverrideTopicId()
                     this.currentTopicId = ""
                     this.dispatch("change", { detail: { topicId: "", mainTopicId: this.mainTopicId } })
                 }
@@ -687,6 +714,12 @@ export default class extends Controller {
     }
 
     selectTopic(id) {
+        // Only restoreSelection() is guarded, so reaching selectTopic with this
+        // id means the user deliberately went back into the archived topic.
+        // The transition is over.
+        if (this.archivedAwayTopicId && String(id) === this.archivedAwayTopicId) {
+            this.archivedAwayTopicId = null
+        }
         this.revealArchivedTopic(id)
         this.updateSelectionUI(id)
         if (id) {

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -45,6 +45,12 @@ export default class extends Controller {
         // effective_creative_id. loadTopics() repopulates both.
         delete this.element.dataset.effectiveCreativeId
         this.mainTopicId = null
+        // Switching creatives reuses this instance without an onPopupClosed
+        // (popup_controller._navigateToEntry calls open()/openForCreative()
+        // again), so unread marks from the previous creative would badge the new
+        // creative's archived toggle — and never clear, since those ids are not
+        // among its topics.
+        this.archivedWithNewMessages.clear()
         this.subscribe()
         return this.loadTopics()
     }
@@ -67,6 +73,17 @@ export default class extends Controller {
     get archivedWithNewMessages() {
         if (!this._archivedWithNewMessages) this._archivedWithNewMessages = new Set()
         return this._archivedWithNewMessages
+    }
+
+    // The toggle badge is derived from set size, so an id that is no longer
+    // archived — unarchived, deleted, or left behind by a creative switch —
+    // would keep it lit with no chip to click and clear it.
+    pruneArchivedBadges() {
+        if (this.archivedWithNewMessages.size === 0) return
+        const archivedIds = new Set((this.archivedTopics || []).map(t => String(t.id)))
+        this.archivedWithNewMessages.forEach(id => {
+            if (!archivedIds.has(id)) this.archivedWithNewMessages.delete(id)
+        })
     }
 
     get creativeId() {
@@ -117,6 +134,7 @@ export default class extends Controller {
                 this.canCreateTopic = canCreateTopic
                 this.canSetPrimaryAgent = canSetPrimaryAgent
                 this.archivedTopics = data.archived_topics || []
+                this.pruneArchivedBadges()
                 this.serverLastTopicId = data.last_topic_id ? String(data.last_topic_id) : ""
                 this.isInbox = !!data.is_inbox
                 this.systemTopicId = data.system_topic_id ? String(data.system_topic_id) : null

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -199,7 +199,12 @@ export default class extends Controller {
             // section when the selection lands inside it.
             const known = [ ...(this.topics || []), ...(this.archivedTopics || []) ]
             if (known.some(t => String(t.id) === String(lastTopicId))) {
-                this.selectTopic(lastTopicId)
+                // Restoring is not a navigation, so it must not undo a collapse
+                // the user chose while sitting in this very topic. Only
+                // restoreSelection is suppressed; every other selectTopic caller
+                // is the user going somewhere, and reveals normally.
+                const reveal = this.archivedCollapsedTopicId !== String(lastTopicId)
+                this.selectTopic(lastTopicId, { reveal })
                 return
             }
         }
@@ -214,6 +219,9 @@ export default class extends Controller {
         if (!id || this.showingArchived) return
         if (!this.isArchivedTopic(id)) return
 
+        // Reaching here is a deliberate navigation into the section, so an
+        // earlier collapse no longer describes what the user wants.
+        this.archivedCollapsedTopicId = null
         this.showingArchived = true
         this.renderTopics(this.topics, this.canManageTopics, this.canCreateTopic, this.canSetPrimaryAgent)
     }
@@ -603,6 +611,13 @@ export default class extends Controller {
     toggleArchivedTopics(event) {
         event.stopPropagation()
         this.showingArchived = !this.showingArchived
+        // Collapsing while the open topic lives in this section is a deliberate
+        // choice to hide it, so record it. Every re-render runs restoreSelection
+        // → selectTopic → revealArchivedTopic, which would otherwise reopen the
+        // section on any unrelated rename, reorder, or topic broadcast.
+        this.archivedCollapsedTopicId = !this.showingArchived && this.isArchivedTopic(this.currentTopicId)
+            ? String(this.currentTopicId)
+            : null
         // No restoreSelection() here: toggling cannot invalidate the selection, and
         // renderTopics already re-applies the active class. Re-selecting would
         // re-expand the section the user just collapsed (selectTopic reveals an
@@ -721,14 +736,14 @@ export default class extends Controller {
         this.selectTopic(id)
     }
 
-    selectTopic(id) {
+    selectTopic(id, { reveal = true } = {}) {
         // Only restoreSelection() is guarded, so reaching selectTopic with this
         // id means the user deliberately went back into the archived topic.
         // The transition is over.
         if (this.archivedAwayTopicId && String(id) === this.archivedAwayTopicId) {
             this.archivedAwayTopicId = null
         }
-        this.revealArchivedTopic(id)
+        if (reveal) this.revealArchivedTopic(id)
         this.updateSelectionUI(id)
         if (id) {
             this.clearNewMessageBadge(id)

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -93,6 +93,33 @@ export default class extends Controller {
         return (this.archivedTopics || []).some(t => String(t.id) === String(id))
     }
 
+    // Move a topic between the live and archived caches without waiting for the
+    // reload. Every caller follows with loadTopics(), which clears this.topics
+    // synchronously and refills both lists when its fetch lands — so this only
+    // has to be right for the window in between, which is exactly the window
+    // isArchivedTopic is consulted in.
+    applyArchiveTransition(action, topic) {
+        const id = topic && topic.id
+        if (!id) return
+
+        const key = String(id)
+        const known = [ ...(this.topics || []), ...(this.archivedTopics || []) ]
+            .find(t => String(t.id) === key)
+        const entry = { ...(known || {}), ...topic }
+
+        this.topics = (this.topics || []).filter(t => String(t.id) !== key)
+        this.archivedTopics = (this.archivedTopics || []).filter(t => String(t.id) !== key)
+
+        if (action === "archived") {
+            this.archivedTopics = [ ...this.archivedTopics, entry ]
+        } else {
+            this.topics = [ ...this.topics, entry ]
+            // Nothing archived is left to clear the badge from, so drop it here
+            // rather than leaving the toggle lit until the reload lands.
+            this.pruneArchivedBadges()
+        }
+    }
+
     // The toggle badge is derived from set size, so an id that is no longer
     // archived — unarchived, deleted, or left behind by a creative switch —
     // would keep it lit with no chip to click and clear it.
@@ -576,6 +603,9 @@ export default class extends Controller {
                     this.currentTopicId = ""
                     this.dispatch("change", { detail: { topicId: "", mainTopicId: this.mainTopicId } })
                 }
+                // The actor has the same stale-membership window as everyone
+                // receiving the broadcast, so close it on this side too.
+                this.applyArchiveTransition("archived", { id: topicId })
                 this.loadTopics()
             } else {
                 alertDialog(this._i18n("archive_error"))
@@ -599,6 +629,7 @@ export default class extends Controller {
             })
 
             if (response.ok) {
+                this.applyArchiveTransition("unarchived", { id: topicId })
                 this.loadTopics()
             } else {
                 alertDialog(this._i18n("restore_error"))
@@ -1066,6 +1097,12 @@ export default class extends Controller {
         }
 
         if (action === "archived" || action === "unarchived") {
+            // loadTopics() only refreshes archivedTopics when its fetch resolves,
+            // and list_controller routes every incoming stream through
+            // isArchivedTopic in the meantime. The broadcast already carries the
+            // membership change, so apply it now rather than letting that window
+            // route on the old answer.
+            this.applyArchiveTransition(action, data.topic || { id: data.topic_id })
             this.loadTopics()
             return
         }

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -519,6 +519,10 @@ export default class extends Controller {
 
             if (response.ok) {
                 if (String(this.currentTopicId) === String(topicId)) {
+                    // Same deep-link hazard as the "deleted" broadcast: this
+                    // path reaches restoreSelection through loadTopics instead
+                    // of removeTopic, but the getter is the same one.
+                    this.releaseDeepLinkSelection(topicId)
                     this.currentTopicId = "" // Switch to Main
                     this.dispatch("change", { detail: { topicId: "", mainTopicId: this.mainTopicId } })
                 }
@@ -560,8 +564,7 @@ export default class extends Controller {
                     // topic stays the effective selection no matter what the
                     // preference says: overrideTopicId (deep link) and the
                     // ?topic_id= query parameter.
-                    this.clearOverrideTopicId()
-                    this.clearUrlTopicId(topicId)
+                    this.releaseDeepLinkSelection(topicId)
                     this.currentTopicId = ""
                     this.dispatch("change", { detail: { topicId: "", mainTopicId: this.mainTopicId } })
                 }
@@ -935,6 +938,16 @@ export default class extends Controller {
         return this.serverLastTopicId || ""
     }
 
+    // A topic leaving the strip — archived or deleted — has to leave both
+    // sources that outrank serverLastTopicId in the currentTopicId getter.
+    // Assigning "" only touches the preference, so on its own the getter goes
+    // on naming the gone topic and every later restoreSelection() finds it
+    // unknown and resets to Main, discarding whatever the user picked instead.
+    releaseDeepLinkSelection(topicId) {
+        this.clearOverrideTopicId()
+        this.clearUrlTopicId(topicId)
+    }
+
     // Drop ?topic_id= when it names the topic being archived. It is a selection
     // source in its own right and survives every reload, so leaving it would
     // re-select the topic the user just archived out of. replaceState, not a
@@ -1118,6 +1131,7 @@ export default class extends Controller {
         this.archivedTopics = nextArchivedTopics
         this.pruneArchivedBadges()
         if (String(this.currentTopicId) === String(topicId)) {
+            this.releaseDeepLinkSelection(topicId)
             this.currentTopicId = ""
             this.dispatch("change", { detail: { topicId: "", mainTopicId: this.mainTopicId } })
         }

--- a/engines/collavre/test/controllers/comments_controller_test.rb
+++ b/engines/collavre/test/controllers/comments_controller_test.rb
@@ -727,6 +727,43 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
     assert_not_includes @response.body, "comment-topic-switch"
   end
 
+  # Archiving a topic hides it from the topic strip; it does not close the
+  # conversation. The topic bar links straight to an archived topic, so these
+  # two tests pin the read and write paths the frontend depends on.
+  test "topic view shows comments of an archived topic when it is selected explicitly" do
+    topic = @creative.topics.create!(name: "Design", user: @user)
+    archived_comment = @creative.comments.create!(content: "Archived lane comment", user: @user, topic: topic)
+    topic.update!(archived_at: Time.current)
+
+    get creative_comments_path(@creative), params: { topic_id: topic.id }
+
+    assert_response :success
+    assert_includes @response.body, archived_comment.content
+  end
+
+  test "posting a comment to an archived topic is accepted" do
+    topic = @creative.topics.create!(name: "Design", user: @user)
+    topic.update!(archived_at: Time.current)
+
+    assert_difference("Comment.count", 1) do
+      post creative_comments_path(@creative),
+           params: { comment: { content: "Still writing here", topic_id: topic.id } }
+    end
+
+    assert_equal topic.id, Comment.order(:id).last.topic_id
+  end
+
+  test "the main view keeps hiding comments that live in an archived topic" do
+    topic = @creative.topics.create!(name: "Design", user: @user)
+    archived_comment = @creative.comments.create!(content: "Archived lane comment", user: @user, topic: topic)
+    topic.update!(archived_at: Time.current)
+
+    get creative_comments_path(@creative)
+
+    assert_response :success
+    assert_not_includes @response.body, archived_comment.content
+  end
+
 
   test "approve returns 422 for missing action" do
     comment = @creative.comments.create!(content: "No action", user: @user, approver: @user)


### PR DESCRIPTION
## Problem

The topic bar and the topic-list popup both list archived topics, but clicking one never opens its messages.

The server was never the blocker — `comments#index` only filters archived topics out of the **All Messages** view. When `topic_id` is passed explicitly it returns the topic's comments regardless of archived state. Everything blocking this was in the frontend:

1. **The archived chip had no click action.** `renderTopics` emitted `<span class="topic-tag topic-archived" data-id=...>` with no `data-action`, so clicking it did nothing.
2. **`restoreSelection()` validated the selection with a DOM lookup.** Archived chips are only rendered while the section is expanded, so a selected archived topic was bounced back to Main. This ran on every topic broadcast, rename, and reorder, so the selection could not survive even when it was set another way.
3. **No active highlight**, because the chip never survived long enough to be selected.

## Approach

Archived topics stay **writable**. Archiving hides a topic from the strip; it does not close the conversation. That keeps the change small — no read-only enforcement, no form disabling, no server change.

The cost of that choice is one real UX hole: a message posted to an archived topic is invisible to anyone whose archived section is collapsed. There is no chip to badge, and the main view filters archived comments out. So unread archived topics now badge the **archived toggle** instead, tracked in controller state so the badge survives re-renders (`renderTopics` wipes `innerHTML`) and clears only once every archived topic has been read.

### Changes

- `restoreSelection()` validates against topic **data** (`topics` + `archivedTopics`) instead of the rendered DOM.
- `selectTopic()` is the single choke point that expands the archived section — covering the topic strip, the topic-list popup, deep links, and last-topic restore.
- `toggleArchivedTopics()` no longer calls `restoreSelection()`. It would re-expand the section the user just collapsed, and it reloaded the message list on every toggle for no reason. `renderTopics` already re-applies the active class.
- The archived chip gets the `select` action, an `active` state, and a per-topic unread badge.
- CSS: the selected/hovered archived chip is no longer dimmed to 0.5 opacity, and the toggle gets an unread dot.

## Tests

- **20 controller tests** (`topics_controller_archived.test.js`): selection, restore, section reveal/collapse, and badge lifecycle.
- **3 request tests** (`comments_controller_test.rb`) pinning the behaviour the frontend now depends on: an archived topic's comments are returned when selected explicitly, posting to an archived topic is accepted, and the main view still hides archived comments.

Full JS suite: 1295 passing. Rubocop and stylelint clean on the changed files (stylelint's remaining warnings are pre-existing and outside the diff).