### PR TITLE
fix(popup): fit anchored popups to the space beside the caret

### DIFF
--- a/app/javascript/controllers/llm_model_controller.js
+++ b/app/javascript/controllers/llm_model_controller.js
@@ -1,5 +1,5 @@
 import { Controller } from '@hotwired/stimulus'
-import CommonPopup from 'collavre/lib/common_popup.js'
+import CommonPopup, { elementAnchor } from 'collavre/lib/common_popup.js'
 import csrfFetch, { refreshCsrfToken } from 'collavre/lib/api/csrf_fetch.js'
 import { alertDialog } from 'collavre/lib/utils/dialog.js'
 
@@ -96,7 +96,7 @@ export default class extends Controller {
 
         this.popup.setItems(filtered)
         this.bindDeleteButtons()
-        this.popup.showAt(this.inputTarget.getBoundingClientRect())
+        this.popup.showAt(elementAnchor(this.inputTarget))
     }
 
     hide() {

--- a/engines/collavre/app/assets/stylesheets/collavre/popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/popup.css
@@ -105,6 +105,20 @@ body.chat-fullscreen #topic-list-modal {
   display: flex;
   flex-direction: column;
   max-width: 90vw;
+  /* CommonPopup sets max-height inline from the space available beside the
+     anchor. Border-box keeps that number the rendered height (it is measured
+     back via offsetHeight), and hiding overflow stops content from spilling
+     past the cap instead of scrolling inside it. */
+  box-sizing: border-box;
+  overflow: hidden;
+}
+
+/* The scrollable list is what gives when the popup is capped: flex items do not
+   shrink past their content by default, so without this the list keeps its
+   max-height and the bottom of it is simply clipped away. */
+.common-popup-list {
+  flex: 1 1 auto;
+  min-height: 0;
 }
 
 .common-popup input[type="text"] {

--- a/engines/collavre/app/javascript/controllers/__tests__/link_creative_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/link_creative_controller.test.js
@@ -555,4 +555,144 @@ describe('LinkCreativeController picker', () => {
 
     application.stop()
   })
+
+  // The popup is placed one frame after open(), while the list is still the
+  // "Loading…" placeholder. Anchored to a caret in a bottom-pinned composer,
+  // that measurement is what left only one tree row visible, so every render
+  // that resizes the list has to ask the popup to place itself again.
+  describe('re-placing the popup as its content changes', () => {
+    const openWithSpy = async () => {
+      const installed = await installController()
+      const reposition = jest.spyOn(installed.controller.popup, 'reposition')
+      return { ...installed, reposition }
+    }
+
+    test('re-places after the browse tree renders', async () => {
+      browse.mockResolvedValue([{ id: 1, description: 'Root', progress: 0, has_children: false }])
+
+      const { application, controller, reposition } = await openWithSpy()
+      controller.open(rect, jest.fn(), jest.fn())
+      await flush()
+
+      expect(document.querySelectorAll('.link-tree-item')).toHaveLength(1)
+      expect(reposition).toHaveBeenCalled()
+
+      application.stop()
+    })
+
+    test('re-places after the loading and empty placeholders render', async () => {
+      browse.mockResolvedValue([])
+
+      const { application, controller, reposition } = await openWithSpy()
+      controller.open(rect, jest.fn(), jest.fn())
+      await flush()
+
+      // "Loading…" then "Empty" — two renders, both resizing the list.
+      expect(document.querySelector('.link-popup-message').textContent).toBe('Empty')
+      expect(reposition.mock.calls.length).toBeGreaterThanOrEqual(2)
+
+      application.stop()
+    })
+
+    test('re-places after search results render', async () => {
+      browse.mockResolvedValue([])
+      search.mockResolvedValue([{ id: 9, description: 'Found', progress: 0, path: [] }])
+
+      const { application, controller, reposition } = await openWithSpy()
+      controller.open(rect, jest.fn(), jest.fn())
+      await flush()
+      reposition.mockClear()
+
+      controller.inputTarget.value = 'fo'
+      controller.search()
+      await flush()
+
+      expect(document.querySelectorAll('.link-result-item')).toHaveLength(1)
+      expect(reposition).toHaveBeenCalled()
+
+      application.stop()
+    })
+
+    test('re-places when a node is expanded, re-expanded from cache, and collapsed', async () => {
+      browse.mockImplementation((parentId) => {
+        if (parentId === null) {
+          return Promise.resolve([{ id: 1, description: 'Root', progress: 0, has_children: true }])
+        }
+        return Promise.resolve([{ id: 2, description: 'Child', progress: 0, has_children: false }])
+      })
+
+      const { application, controller, reposition } = await openWithSpy()
+      controller.open(rect, jest.fn(), jest.fn())
+      await flush()
+
+      const item = document.querySelector('.link-tree-item[data-id="1"]')
+
+      reposition.mockClear()
+      await controller._expandNode(item)
+      await flush()
+      expect(document.querySelectorAll('.link-tree-item[data-id="2"]')).toHaveLength(1)
+      expect(reposition).toHaveBeenCalled()
+
+      // Collapsing removes the children from the flow.
+      reposition.mockClear()
+      controller._collapseNode(item)
+      expect(reposition).toHaveBeenCalled()
+
+      // Re-expanding serves the already-loaded children without a fetch.
+      reposition.mockClear()
+      await controller._expandNode(item)
+      expect(reposition).toHaveBeenCalled()
+
+      application.stop()
+    })
+
+    test('re-places when an expanded node turns out to have no children', async () => {
+      browse.mockImplementation((parentId) =>
+        Promise.resolve(
+          parentId === null
+            ? [{ id: 1, description: 'Root', progress: 0, has_children: true }]
+            : [],
+        ),
+      )
+
+      const { application, controller, reposition } = await openWithSpy()
+      controller.open(rect, jest.fn(), jest.fn())
+      await flush()
+
+      const item = document.querySelector('.link-tree-item[data-id="1"]')
+      reposition.mockClear()
+      await controller._expandNode(item)
+      await flush()
+
+      expect(item.querySelector('.link-tree-empty').textContent).toBe('Empty')
+      expect(reposition).toHaveBeenCalled()
+
+      application.stop()
+    })
+
+    test('re-places when loading a node\'s children fails', async () => {
+      browse.mockImplementation((parentId) => {
+        if (parentId === null) {
+          return Promise.resolve([{ id: 1, description: 'Root', progress: 0, has_children: true }])
+        }
+        return Promise.reject(new Error('boom'))
+      })
+
+      const { application, controller, reposition } = await openWithSpy()
+      controller.open(rect, jest.fn(), jest.fn())
+      await flush()
+
+      const item = document.querySelector('.link-tree-item[data-id="1"]')
+      reposition.mockClear()
+      await controller._expandNode(item)
+      await flush()
+
+      // The failed load is retryable and the placeholder row is gone, so the
+      // popup is a different size than it was mid-fetch.
+      expect(item.dataset.loaded).toBe('0')
+      expect(reposition).toHaveBeenCalled()
+
+      application.stop()
+    })
+  })
 })

--- a/engines/collavre/app/javascript/controllers/comment_controller.js
+++ b/engines/collavre/app/javascript/controllers/comment_controller.js
@@ -329,7 +329,9 @@ export default class extends Controller {
       renderItem: () => reviewLabel,
     })
 
-    // Position below the selection end
+    // Position below the selection end. A derived rect rather than one of
+    // showAt's live anchor providers: selecting inside the popup clears this
+    // selection, so there would be nothing left to re-measure.
     const belowRect = {
       left: anchorRect.left,
       right: anchorRect.right,

--- a/engines/collavre/app/javascript/controllers/common_popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/common_popup_controller.js
@@ -22,8 +22,8 @@ export default class extends Controller {
         this.popup = null
     }
 
-    open(anchorRect, boundsElement = null) {
-        this.popup.showAt(anchorRect, boundsElement)
+    open(anchor, boundsElement = null) {
+        this.popup.showAt(anchor, boundsElement)
     }
 
     close() {

--- a/engines/collavre/app/javascript/controllers/link_creative_controller.js
+++ b/engines/collavre/app/javascript/controllers/link_creative_controller.js
@@ -34,7 +34,7 @@ export default class extends CommonPopupController {
         super.disconnect()
     }
 
-    open(anchorRect, onSelectCallback, onCloseCallback, { allowCreate = false } = {}) {
+    open(anchor, onSelectCallback, onCloseCallback, { allowCreate = false } = {}) {
         this._openGeneration++
         this.onSelectCallback = onSelectCallback
         this.onCloseCallback = onCloseCallback
@@ -46,7 +46,7 @@ export default class extends CommonPopupController {
         this.inputTarget.value = ''
         // Clear any CommonPopup item state; we render our own DOM into the list.
         this.popup.setItems([])
-        super.open(anchorRect)
+        super.open(anchor)
 
         requestAnimationFrame(() => {
             this.inputTarget.focus()

--- a/engines/collavre/app/javascript/controllers/link_creative_controller.js
+++ b/engines/collavre/app/javascript/controllers/link_creative_controller.js
@@ -179,6 +179,16 @@ export default class extends CommonPopupController {
         }
         nodes.forEach((node) => this.listTarget.appendChild(this._buildTreeItem(node, 0)))
         this._resetActive()
+        this._reposition()
+    }
+
+    // The popup is positioned one frame after open(), while the list still shows
+    // "Loading…". Every render that changes the list's height has to re-run that
+    // placement, or the popup keeps the size the placeholder implied — which,
+    // with the caret near the bottom of the screen, leaves a single tree row
+    // visible under the search box.
+    _reposition() {
+        this.popup?.reposition()
     }
 
     _buildTreeItem(node, level) {
@@ -254,6 +264,7 @@ export default class extends CommonPopupController {
         if (childrenUl) childrenUl.hidden = true
         const toggle = li.querySelector(':scope > .link-tree-row > .link-tree-toggle')
         if (toggle && !toggle.classList.contains('link-tree-toggle-empty')) toggle.innerHTML = CHEVRON_COLLAPSED
+        this._reposition()
     }
 
     // Returns a promise that resolves once the node is expanded (children loaded
@@ -268,7 +279,10 @@ export default class extends CommonPopupController {
         childrenUl.hidden = false
         if (toggle && !toggle.classList.contains('link-tree-toggle-empty')) toggle.innerHTML = CHEVRON_EXPANDED
 
-        if (li.dataset.loaded === '1') return Promise.resolve()
+        if (li.dataset.loaded === '1') {
+            this._reposition()
+            return Promise.resolve()
+        }
 
         const level = parseInt(li.dataset.level, 10) + 1
         li.dataset.loaded = '1'
@@ -280,13 +294,15 @@ export default class extends CommonPopupController {
                 const list = Array.isArray(nodes) ? nodes : []
                 if (list.length === 0) {
                     childrenUl.innerHTML = `<li class="link-tree-empty">${this._escape(this._text('emptyText'))}</li>`
-                    return
+                } else {
+                    list.forEach((child) => childrenUl.appendChild(this._buildTreeItem(child, level)))
                 }
-                list.forEach((child) => childrenUl.appendChild(this._buildTreeItem(child, level)))
+                this._reposition()
             })
             .catch(() => {
                 li.dataset.loaded = '0'
                 childrenUl.innerHTML = ''
+                this._reposition()
             })
     }
 
@@ -327,6 +343,7 @@ export default class extends CommonPopupController {
             this.listTarget.appendChild(this._buildCreateItem(query))
         }
         this._resetActive()
+        this._reposition()
     }
 
     _buildCreateItem(query) {
@@ -548,6 +565,7 @@ export default class extends CommonPopupController {
         this.listTarget.innerHTML = ''
         this._appendMessage(text)
         this._activeEl = null
+        this._reposition()
     }
 
     _appendMessage(text) {

--- a/engines/collavre/app/javascript/controllers/share_user_search_controller.js
+++ b/engines/collavre/app/javascript/controllers/share_user_search_controller.js
@@ -1,5 +1,5 @@
 import { Controller } from '@hotwired/stimulus'
-import CommonPopup from '../lib/common_popup'
+import CommonPopup, { elementAnchor } from '../lib/common_popup'
 
 export default class extends Controller {
     static targets = ['input']
@@ -78,7 +78,7 @@ export default class extends Controller {
 
             if (items.length > 0) {
                 this.popup?.setItems(items)
-                this.popup?.showAt(this.inputTarget.getBoundingClientRect())
+                this.popup?.showAt(elementAnchor(this.inputTarget))
             } else {
                 this.popup?.hide()
             }

--- a/engines/collavre/app/javascript/lib/__tests__/common_popup_bounds.test.js
+++ b/engines/collavre/app/javascript/lib/__tests__/common_popup_bounds.test.js
@@ -41,9 +41,11 @@ describe('CommonPopup bounds clamping', () => {
         const popup = build({ popupWidth: 320, popupHeight: 400 })
         popup._boundsElement = boundsElement
         popup.updatePosition({ left: 200, bottom: 200 })
-        // inner box = dimension - 2*pad
+        // inner box = width - 2*pad
         expect(element.style.maxWidth).toBe('384px')
-        expect(element.style.maxHeight).toBe('584px')
+        // Height is capped to the space under the anchor rather than the whole
+        // box (700 - 8 - 204), so content arriving later cannot spill past it.
+        expect(element.style.maxHeight).toBe('488px')
     })
 
     test('falls back to viewport clamping when no bounds element is set', () => {
@@ -52,7 +54,10 @@ describe('CommonPopup bounds clamping', () => {
         // jsdom viewport defaults 1024x768; anchor at 0 → left clamps to padding 8, parent 0
         Object.defineProperty(element, 'offsetParent', { value: null, configurable: true })
         popup.updatePosition({ left: 0, bottom: 0 })
-        expect(element.style.maxHeight).toBe('')
+        // Space below the anchor inside the viewport: 768 - 8 - 4.
+        expect(element.style.maxHeight).toBe('756px')
         expect(element.style.left).toBe('8px')
+        // maxWidth stays a stylesheet concern when unbounded.
+        expect(element.style.maxWidth).toBe('')
     })
 })

--- a/engines/collavre/app/javascript/lib/__tests__/common_popup_placement.test.js
+++ b/engines/collavre/app/javascript/lib/__tests__/common_popup_placement.test.js
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 import { jest } from '@jest/globals'
-import CommonPopup from '../common_popup'
+import CommonPopup, { elementAnchor } from '../common_popup'
 
 // Viewport-fit placement: a popup anchored to a caret sitting just above the
 // chat composer has almost no room below it. updatePosition must flip above the
@@ -239,6 +239,136 @@ describe('CommonPopup viewport-fit placement', () => {
             expect(placeSpy).toHaveBeenCalledWith({ left: 200, top: 700, bottom: 720 })
             expect(element.style.top).toBe('296px')
             placeSpy.mockRestore()
+        })
+    })
+
+    // A rect captured at open time stops describing the anchor as soon as the
+    // anchor moves, and the one event that reliably moves it is the same one
+    // that triggers a re-place: the on-screen keyboard shrinks the viewport and
+    // comments--presence pushes the composer up off the keyboard on that very
+    // resize. Callers that can re-measure pass a provider instead of a rect.
+    describe('live anchor providers', () => {
+        let realRaf
+        let realCancelRaf
+
+        beforeEach(() => {
+            jest.useFakeTimers()
+            realRaf = window.requestAnimationFrame
+            realCancelRaf = window.cancelAnimationFrame
+            window.requestAnimationFrame = (cb) => setTimeout(cb, 0)
+            window.cancelAnimationFrame = (handle) => clearTimeout(handle)
+        })
+
+        afterEach(() => {
+            window.requestAnimationFrame = realRaf
+            window.cancelAnimationFrame = realCancelRaf
+            jest.useRealTimers()
+        })
+
+        const openAndSettle = (popup, anchor) => {
+            popup.showAt(anchor)
+            jest.advanceTimersByTime(20)
+        }
+
+        test('re-measures the anchor on every reposition', () => {
+            const popup = build({ popupHeight: 300 })
+            let caret = { left: 200, top: 300, bottom: 320 }
+            openAndSettle(popup, () => caret)
+            expect(element.style.top).toBe('324px')
+
+            // The composer scrolled: the caret is 120px higher than at open.
+            caret = { left: 200, top: 180, bottom: 200 }
+            popup.reposition()
+
+            expect(element.style.top).toBe('204px')
+        })
+
+        test('follows the anchor the keyboard pushed up, not its opening rect', () => {
+            const listeners = stubVisualViewport(768)
+            const popup = build({ popupHeight: 300 })
+            // Caret on a composer pinned to the bottom of a full-height viewport.
+            let caret = { left: 200, top: 700, bottom: 720 }
+            openAndSettle(popup, () => caret)
+            expect(element.style.top).toBe('396px')
+
+            // The keyboard takes the bottom 368px. comments--presence lifts the
+            // composer clear of it on the same resize, so the caret rides up
+            // with it — its opening rect now sits *under* the keyboard.
+            window.visualViewport.height = 400
+            caret = { left: 200, top: 332, bottom: 352 }
+            listeners.resize()
+
+            // Flipped above the lifted caret: 332 - 4 - 300.
+            expect(element.style.top).toBe('28px')
+        })
+
+        test('keeps the last measured rect when the anchor disappears', () => {
+            const popup = build({ popupHeight: 300 })
+            let caret = { left: 200, top: 300, bottom: 320 }
+            openAndSettle(popup, () => caret)
+            expect(element.style.top).toBe('324px')
+
+            // Turbo tore the textarea out: nothing left to measure. Reading a
+            // detached element's rect would report all zeros and fling the
+            // popup into the top-left corner.
+            caret = null
+            popup.reposition()
+
+            expect(element.style.top).toBe('324px')
+        })
+
+        test('keeps the last measured rect when the provider throws', () => {
+            const popup = build({ popupHeight: 300 })
+            let broken = false
+            openAndSettle(popup, () => {
+                if (broken) throw new Error('anchor gone')
+                return { left: 200, top: 300, bottom: 320 }
+            })
+            expect(element.style.top).toBe('324px')
+
+            broken = true
+            expect(() => popup.reposition()).not.toThrow()
+            expect(element.style.top).toBe('324px')
+        })
+
+        test('drops the provider on hide so the next open cannot reuse it', () => {
+            const popup = build({ popupHeight: 300 })
+            const provider = jest.fn(() => ({ left: 200, top: 300, bottom: 320 }))
+            openAndSettle(popup, provider)
+            popup.hide()
+
+            const callsWhileOpen = provider.mock.calls.length
+            openAndSettle(popup, { left: 200, top: 100, bottom: 120 })
+            popup.reposition()
+
+            expect(provider).toHaveBeenCalledTimes(callsWhileOpen)
+            expect(element.style.top).toBe('124px')
+        })
+
+        describe('elementAnchor', () => {
+            test('measures the element live', () => {
+                const anchor = document.createElement('button')
+                document.body.appendChild(anchor)
+                anchor.getBoundingClientRect = () => ({ left: 10, top: 500, bottom: 540 })
+                const provider = elementAnchor(anchor)
+
+                expect(provider().top).toBe(500)
+                anchor.getBoundingClientRect = () => ({ left: 10, top: 200, bottom: 240 })
+                expect(provider().top).toBe(200)
+            })
+
+            test('returns nothing once the element has left the document', () => {
+                const anchor = document.createElement('button')
+                document.body.appendChild(anchor)
+                const provider = elementAnchor(anchor)
+                anchor.remove()
+
+                expect(provider()).toBeNull()
+            })
+
+            test('returns nothing when there is no element at all', () => {
+                expect(elementAnchor(null)()).toBeNull()
+            })
         })
     })
 })

--- a/engines/collavre/app/javascript/lib/__tests__/common_popup_placement.test.js
+++ b/engines/collavre/app/javascript/lib/__tests__/common_popup_placement.test.js
@@ -110,15 +110,23 @@ describe('CommonPopup viewport-fit placement', () => {
 
     describe('reposition after async content', () => {
         let realRaf
+        let realCancelRaf
 
         beforeEach(() => {
             jest.useFakeTimers()
             realRaf = window.requestAnimationFrame
+            realCancelRaf = window.cancelAnimationFrame
+            // Stubbed as a pair: the timer id doubles as the frame handle, so
+            // cancelAnimationFrame actually drops the pending callback the way
+            // the browser would. Stubbing only requestAnimationFrame would make
+            // cancellation silently no-op and hide regressions.
             window.requestAnimationFrame = (cb) => setTimeout(cb, 0)
+            window.cancelAnimationFrame = (handle) => clearTimeout(handle)
         })
 
         afterEach(() => {
             window.requestAnimationFrame = realRaf
+            window.cancelAnimationFrame = realCancelRaf
             jest.useRealTimers()
         })
 
@@ -180,6 +188,57 @@ describe('CommonPopup viewport-fit placement', () => {
 
             popup.hide()
             expect(listeners.resize).toBeUndefined()
+        })
+
+        // The placement frame runs a tick after showAt, so a close that lands in
+        // between must not leave document/visualViewport holding this popup:
+        // hide()'s removeEventListener calls run before the additions would.
+        test('registers nothing when the popup is closed before its placement frame runs', () => {
+            const listeners = stubVisualViewport(768)
+            const addSpy = jest.spyOn(document, 'addEventListener')
+            const popup = build({ popupHeight: 400 })
+
+            popup.showAt({ left: 200, top: 300, bottom: 320 })
+            popup.hide()
+            jest.advanceTimersByTime(20)
+
+            expect(listeners.resize).toBeUndefined()
+            expect(addSpy.mock.calls.some(([type]) => type === 'mousedown' || type === 'touchstart')).toBe(false)
+            // The cancelled frame must not re-show what hide() closed.
+            expect(element.style.display).toBe('none')
+            addSpy.mockRestore()
+        })
+
+        // Turbo swaps the page without closing the popup: the element is gone
+        // from the document but still reads display:block.
+        test('registers nothing when the element is detached before its placement frame runs', () => {
+            const listeners = stubVisualViewport(768)
+            const addSpy = jest.spyOn(document, 'addEventListener')
+            const popup = build({ popupHeight: 400 })
+
+            popup.showAt({ left: 200, top: 300, bottom: 320 })
+            element.remove()
+            jest.advanceTimersByTime(20)
+
+            expect(listeners.resize).toBeUndefined()
+            expect(addSpy.mock.calls.some(([type]) => type === 'mousedown' || type === 'touchstart')).toBe(false)
+            addSpy.mockRestore()
+        })
+
+        // Reopening before the first frame fires must drop the superseded one,
+        // so the popup is never placed against the anchor it has abandoned.
+        test('supersedes a pending placement frame when reopened', () => {
+            const popup = build({ popupHeight: 400 })
+            const placeSpy = jest.spyOn(popup, 'updatePosition')
+
+            popup.showAt({ left: 200, top: 300, bottom: 320 })
+            popup.showAt({ left: 200, top: 700, bottom: 720 })
+            jest.advanceTimersByTime(20)
+
+            expect(placeSpy).toHaveBeenCalledTimes(1)
+            expect(placeSpy).toHaveBeenCalledWith({ left: 200, top: 700, bottom: 720 })
+            expect(element.style.top).toBe('296px')
+            placeSpy.mockRestore()
         })
     })
 })

--- a/engines/collavre/app/javascript/lib/__tests__/common_popup_placement.test.js
+++ b/engines/collavre/app/javascript/lib/__tests__/common_popup_placement.test.js
@@ -1,0 +1,185 @@
+/**
+ * @jest-environment jsdom
+ */
+import { jest } from '@jest/globals'
+import CommonPopup from '../common_popup'
+
+// Viewport-fit placement: a popup anchored to a caret sitting just above the
+// chat composer has almost no room below it. updatePosition must flip above the
+// anchor, cap the popup to the space it actually has, and re-run once async
+// content (the creative mini-tree) has replaced the "Loading…" placeholder.
+describe('CommonPopup viewport-fit placement', () => {
+    const VIEWPORT_WIDTH = 1024
+
+    let element
+
+    // offsetHeight is mutable so a test can simulate the popup growing after its
+    // async content lands, which is the whole point of reposition().
+    const build = ({ popupWidth = 320, popupHeight = 400 } = {}) => {
+        element = document.createElement('div')
+        Object.defineProperty(element, 'offsetParent', { value: null, configurable: true })
+        Object.defineProperty(element, 'offsetWidth', { get: () => popupWidth, configurable: true })
+        Object.defineProperty(element, 'offsetHeight', {
+            get: () => element._testHeight,
+            configurable: true,
+        })
+        element._testHeight = popupHeight
+        document.body.appendChild(element)
+        return new CommonPopup(element, { listElement: document.createElement('ul') })
+    }
+
+    const stubVisualViewport = (height) => {
+        const listeners = {}
+        window.visualViewport = {
+            offsetLeft: 0,
+            offsetTop: 0,
+            width: VIEWPORT_WIDTH,
+            height,
+            addEventListener: (type, fn) => { listeners[type] = fn },
+            removeEventListener: (type) => { delete listeners[type] },
+        }
+        return listeners
+    }
+
+    afterEach(() => {
+        document.body.innerHTML = ''
+        delete window.visualViewport
+    })
+
+    test('flips above the anchor when the popup does not fit below it', () => {
+        const popup = build({ popupHeight: 400 })
+        // Caret on the last line of a composer pinned to the bottom: only 48px
+        // of viewport under it, far less than the popup's 400px.
+        popup.updatePosition({ left: 200, top: 700, bottom: 720 })
+
+        // top = anchorTop - gap - height = 700 - 4 - 400
+        expect(element.style.top).toBe('296px')
+        // Space above = 700 - 4 - 8 = 688, and the popup fits in it untouched.
+        expect(element.style.maxHeight).toBe('688px')
+    })
+
+    test('stays below the anchor when there is room for the popup', () => {
+        const popup = build({ popupHeight: 400 })
+        popup.updatePosition({ left: 200, top: 80, bottom: 100 })
+
+        expect(element.style.top).toBe('104px')
+        // Capped to the space below (768 - 8 - 104) so later growth still fits.
+        expect(element.style.maxHeight).toBe('656px')
+    })
+
+    test('caps the popup to the larger side when it fits on neither', () => {
+        const popup = build({ popupHeight: 400 })
+        // spaceBelow = 768 - 8 - 564 = 196; spaceAbove = 360 - 4 - 8 = 348.
+        popup.updatePosition({ left: 200, top: 360, bottom: 560 })
+
+        expect(element.style.maxHeight).toBe('348px')
+        // Rendered height is now the cap, so the top edge sits at the padding.
+        expect(element.style.top).toBe('8px')
+    })
+
+    test('never shrinks the popup below a usable minimum', () => {
+        const popup = build({ popupHeight: 400 })
+        // Anchor pinned to the very bottom: nothing below, 8px above.
+        popup.updatePosition({ left: 200, top: 20, bottom: 760 })
+
+        expect(element.style.maxHeight).toBe('160px')
+    })
+
+    test('measures the popup unconstrained so a stale cap cannot stick', () => {
+        const popup = build({ popupHeight: 400 })
+        // A previous placement left a tiny cap behind.
+        element.style.maxHeight = '130px'
+        popup.updatePosition({ left: 200, top: 700, bottom: 720 })
+
+        // Had the 130px cap been read back as the popup's height, it would have
+        // "fit" below the caret and stayed pinned there.
+        expect(element.style.top).toBe('296px')
+    })
+
+    test('measures the visual viewport, not the layout viewport', () => {
+        // The on-screen keyboard covers the bottom 300px of a 768px window.
+        stubVisualViewport(468)
+        const popup = build({ popupHeight: 400 })
+        popup.updatePosition({ left: 200, top: 400, bottom: 420 })
+
+        // spaceBelow against the keyboard top = 468 - 8 - 424 = 36, so it flips;
+        // spaceAbove = 400 - 4 - 8 = 388, which becomes the cap.
+        expect(element.style.maxHeight).toBe('388px')
+        expect(element.style.top).toBe('8px')
+    })
+
+    describe('reposition after async content', () => {
+        let realRaf
+
+        beforeEach(() => {
+            jest.useFakeTimers()
+            realRaf = window.requestAnimationFrame
+            window.requestAnimationFrame = (cb) => setTimeout(cb, 0)
+        })
+
+        afterEach(() => {
+            window.requestAnimationFrame = realRaf
+            jest.useRealTimers()
+        })
+
+        const openAndSettle = (popup, anchorRect) => {
+            popup.showAt(anchorRect)
+            // showAt defers positioning by one animation frame.
+            jest.advanceTimersByTime(20)
+        }
+
+        test('re-places the popup once its content has grown', () => {
+            const popup = build({ popupHeight: 400 })
+            // Opens while still showing "Loading…": header + input only.
+            element._testHeight = 130
+            openAndSettle(popup, { left: 200, top: 700, bottom: 720 })
+            expect(element.style.top).toBe('566px')
+
+            // The mini-tree lands and the popup grows to its full height.
+            element._testHeight = 400
+            popup.reposition()
+
+            expect(element.style.top).toBe('296px')
+        })
+
+        test('keeps the popup above the anchor once flipped, even if it later shrinks', () => {
+            const popup = build({ popupHeight: 400 })
+            openAndSettle(popup, { left: 200, top: 700, bottom: 720 })
+            expect(element.style.top).toBe('296px')
+
+            // Collapsing every tree node shrinks the popup back to a size that
+            // would fit below — hopping across the caret would be jarring.
+            element._testHeight = 120
+            popup.reposition()
+
+            expect(element.style.top).toBe('576px')
+        })
+
+        test('does nothing when the popup is closed', () => {
+            const popup = build({ popupHeight: 400 })
+            popup.reposition()
+            expect(element.style.top).toBe('')
+        })
+
+        test('re-places on visual viewport resize while open, and unbinds on hide', () => {
+            const listeners = stubVisualViewport(768)
+            const popup = build({ popupHeight: 400 })
+            openAndSettle(popup, { left: 200, top: 300, bottom: 320 })
+            // spaceBelow = 768 - 8 - 324 = 436, enough for 400px.
+            expect(element.style.top).toBe('324px')
+            expect(element.style.maxHeight).toBe('436px')
+            expect(typeof listeners.resize).toBe('function')
+
+            // The on-screen keyboard opens and eats the bottom of the viewport.
+            window.visualViewport.height = 400
+            listeners.resize()
+
+            // spaceBelow = 400 - 8 - 324 = 68; spaceAbove = 300 - 4 - 8 = 288.
+            expect(element.style.maxHeight).toBe('288px')
+            expect(element.style.top).toBe('8px')
+
+            popup.hide()
+            expect(listeners.resize).toBeUndefined()
+        })
+    })
+})

--- a/engines/collavre/app/javascript/lib/common_popup.js
+++ b/engines/collavre/app/javascript/lib/common_popup.js
@@ -1,3 +1,12 @@
+// Gap between the anchor (caret, button) and the popup edge.
+const ANCHOR_GAP = 4
+// Breathing room kept between the popup and the edge of its region.
+const BOUNDS_PADDING = 8
+// Floor for the space-derived max-height. Header + search input already eat
+// ~90px, so anything under this leaves no list at all; overflowing the region
+// slightly beats rendering a sliver.
+const MIN_POPUP_HEIGHT = 160
+
 export default class CommonPopup {
   constructor(element, { listElement, onSelect, renderItem, onClose, closeOnOutsideClick = true } = {}) {
     this.element = element
@@ -10,6 +19,7 @@ export default class CommonPopup {
     this.activeIndex = -1
 
     this.handleOutsideClick = this.handleOutsideClick.bind(this)
+    this.handleViewportResize = this.handleViewportResize.bind(this)
   }
 
   showAt(anchorRect, boundsElement = null) {
@@ -18,6 +28,10 @@ export default class CommonPopup {
     // When set, the popup is caged inside this element's rect (e.g. the chat
     // box) instead of the viewport — see updatePosition.
     this._boundsElement = boundsElement
+    // Kept so reposition() can re-place against the same anchor after the
+    // popup's content has changed size.
+    this._anchorRect = anchorRect
+    this._placedAbove = false
 
     // Re-opening while already open (e.g. clicking the same typo mark twice):
     // a listener from the previous open is still live, so the opening mousedown
@@ -43,42 +57,89 @@ export default class CommonPopup {
         document.addEventListener('mousedown', this.handleOutsideClick)
         document.addEventListener('touchstart', this.handleOutsideClick)
       }
+      // The on-screen keyboard shrinks the visual viewport without firing a
+      // window resize, and it opens *after* showAt (the consumer focuses its
+      // input a frame later), so the placement made here is already stale.
+      window.visualViewport?.addEventListener('resize', this.handleViewportResize)
     })
+  }
+
+  // Re-run placement against the anchor showAt was given. Call this whenever the
+  // popup's content changes size: showAt measures one frame after opening, so a
+  // popup whose body arrives asynchronously (a fetched tree, search results) was
+  // sized while it still read "Loading…" and would otherwise keep the placement
+  // that placeholder height implied.
+  reposition() {
+    if (!this.isOpen()) return
+    this.updatePosition(this._anchorRect)
+  }
+
+  handleViewportResize() {
+    this.reposition()
+  }
+
+  // The region the popup must stay inside: an explicit bounds element (the chat
+  // box) when caged, otherwise the visual viewport. window.innerHeight is the
+  // wrong number on mobile — it still counts the strip the keyboard covers.
+  regionRect() {
+    const bounds = this._boundsElement?.getBoundingClientRect?.()
+    if (bounds) return bounds
+
+    const viewport = window.visualViewport
+    const left = viewport?.offsetLeft || 0
+    const top = viewport?.offsetTop || 0
+    const width = viewport?.width || window.innerWidth
+    const height = viewport?.height || window.innerHeight
+    return { left, top, right: left + width, bottom: top + height, width, height }
   }
 
   updatePosition(anchorRect) {
     if (!this.element) return
 
-    const scrollX = window.scrollX || window.pageXOffset || 0
-    const scrollY = window.scrollY || window.pageYOffset || 0
     const offsetParent = this.element.offsetParent
     const parentRect = offsetParent?.getBoundingClientRect?.() || { left: 0, top: 0 }
     const parentScrollX = offsetParent?.scrollLeft || 0
     const parentScrollY = offsetParent?.scrollTop || 0
-    const boundsPadding = 8
     const rect = anchorRect || this.element.getBoundingClientRect()
+    const anchorTop = rect?.top || 0
+    const anchorBottom = rect?.bottom || 0
 
-    let viewportLeft = (rect?.left || 0)
-    let viewportTop = (rect?.bottom || 0) + 4
-
+    // Measure unconstrained. A max-height left behind by an earlier placement
+    // would make offsetHeight report that cap instead of the content height, so
+    // every later call would agree the popup "fits" wherever it was first put.
+    this.element.style.maxHeight = ''
     const { offsetWidth: width, offsetHeight: height } = this.element
 
-    // Clamp within a container's rect when bounded (keeps the popup caged inside
-    // the chat box), otherwise within the viewport.
-    const bounds = this._boundsElement?.getBoundingClientRect?.()
-    let minLeft = boundsPadding
-    let minTop = boundsPadding
-    let maxLeft = window.innerWidth - width - boundsPadding
-    let maxTop = window.innerHeight - height - boundsPadding
-    if (bounds) {
-      minLeft = bounds.left + boundsPadding
-      minTop = bounds.top + boundsPadding
-      maxLeft = bounds.right - width - boundsPadding
-      maxTop = bounds.bottom - height - boundsPadding
-      // Cap size so a long list scrolls inside the box instead of spilling past it.
-      this.element.style.maxWidth = `${bounds.width - boundsPadding * 2}px`
-      this.element.style.maxHeight = `${bounds.height - boundsPadding * 2}px`
+    const region = this.regionRect()
+    const spaceBelow = region.bottom - BOUNDS_PADDING - (anchorBottom + ANCHOR_GAP)
+    const spaceAbove = (anchorTop - ANCHOR_GAP) - (region.top + BOUNDS_PADDING)
+
+    // Flip above the anchor when the popup genuinely does not fit below it and
+    // there is more room up there — a chat composer pinned to the bottom of the
+    // screen leaves almost nothing under the caret. Once flipped, stay flipped
+    // for the rest of this open: content that shrinks again (collapsing tree
+    // nodes) must not make the popup hop back across the anchor.
+    const placeAbove = this._placedAbove || (height > spaceBelow && spaceAbove > spaceBelow)
+    this._placedAbove = placeAbove
+
+    // Cap to the space actually available so the list scrolls inside the popup
+    // instead of running off-screen, both now and if the content grows later.
+    const available = Math.max(placeAbove ? spaceAbove : spaceBelow, MIN_POPUP_HEIGHT)
+    this.element.style.maxHeight = `${available}px`
+    if (this._boundsElement) {
+      this.element.style.maxWidth = `${region.width - BOUNDS_PADDING * 2}px`
     }
+    const renderedHeight = Math.min(height, available)
+
+    let viewportLeft = rect?.left || 0
+    let viewportTop = placeAbove
+      ? anchorTop - ANCHOR_GAP - renderedHeight
+      : anchorBottom + ANCHOR_GAP
+
+    const minLeft = region.left + BOUNDS_PADDING
+    const maxLeft = region.right - width - BOUNDS_PADDING
+    const minTop = region.top + BOUNDS_PADDING
+    const maxTop = region.bottom - renderedHeight - BOUNDS_PADDING
 
     viewportLeft = Math.max(minLeft, Math.min(viewportLeft, maxLeft))
     viewportTop = Math.max(minTop, Math.min(viewportTop, maxTop))
@@ -208,6 +269,8 @@ export default class CommonPopup {
 
     document.removeEventListener('mousedown', this.handleOutsideClick)
     document.removeEventListener('touchstart', this.handleOutsideClick)
+    window.visualViewport?.removeEventListener('resize', this.handleViewportResize)
+    this._anchorRect = null
 
     if (typeof this.onClose === 'function') {
       this.onClose(reason)

--- a/engines/collavre/app/javascript/lib/common_popup.js
+++ b/engines/collavre/app/javascript/lib/common_popup.js
@@ -17,6 +17,8 @@ export default class CommonPopup {
     this.closeOnOutsideClick = closeOnOutsideClick
     this.items = []
     this.activeIndex = -1
+    // Pending showAt placement frame, so hide() can cancel it.
+    this._openFrame = null
 
     this.handleOutsideClick = this.handleOutsideClick.bind(this)
     this.handleViewportResize = this.handleViewportResize.bind(this)
@@ -44,7 +46,17 @@ export default class CommonPopup {
     this.element.style.display = 'block'
     this.element.style.visibility = 'hidden'
 
-    requestAnimationFrame(() => {
+    cancelAnimationFrame(this._openFrame)
+    this._openFrame = requestAnimationFrame(() => {
+      this._openFrame = null
+      // The popup can be gone before this frame runs: hide() on a rapid
+      // open/close, or a Turbo navigation that tears the element out of the
+      // document without closing the popup. Registering here regardless would
+      // leave document/visualViewport holding this popup and its detached
+      // element forever, and hide()'s removals already ran against listeners
+      // that did not exist yet.
+      if (!this.isOpen() || !this.element.isConnected) return
+
       this.updatePosition(anchorRect)
       this.element.style.visibility = 'visible'
       // Register the outside-click listeners only after the opening event has
@@ -261,6 +273,10 @@ export default class CommonPopup {
 
   hide(reason = 'manual') {
     if (!this.element || !this.isOpen()) return
+    // Drop a placement frame that has not run yet, so it cannot re-show and
+    // re-register listeners after this close.
+    cancelAnimationFrame(this._openFrame)
+    this._openFrame = null
     this.element.style.display = 'none'
     this.element.style.visibility = ''
     this.items = []

--- a/engines/collavre/app/javascript/lib/common_popup.js
+++ b/engines/collavre/app/javascript/lib/common_popup.js
@@ -7,6 +7,14 @@ const BOUNDS_PADDING = 8
 // slightly beats rendering a sliver.
 const MIN_POPUP_HEIGHT = 160
 
+// Anchor provider for a popup hung off a live element. Pass this to showAt
+// instead of the element's rect so placement can re-measure it later; returns
+// null once the element leaves the document, where its rect would read as all
+// zeros and drag the popup into the top-left corner.
+export function elementAnchor(element) {
+  return () => (element?.isConnected ? element.getBoundingClientRect() : null)
+}
+
 export default class CommonPopup {
   constructor(element, { listElement, onSelect, renderItem, onClose, closeOnOutsideClick = true } = {}) {
     this.element = element
@@ -19,20 +27,32 @@ export default class CommonPopup {
     this.activeIndex = -1
     // Pending showAt placement frame, so hide() can cancel it.
     this._openFrame = null
+    // Set by showAt when the caller can re-measure its anchor — see anchorRect.
+    this._anchorProvider = null
+    this._anchorRect = null
 
     this.handleOutsideClick = this.handleOutsideClick.bind(this)
     this.handleViewportResize = this.handleViewportResize.bind(this)
   }
 
-  showAt(anchorRect, boundsElement = null) {
+  // `anchor` is either a rect or a function returning one. Prefer the function
+  // (see elementAnchor / caretAnchor): a rect is a snapshot, and the anchor can
+  // move while the popup is open — the on-screen keyboard shrinks the viewport
+  // and comments--presence lifts the composer clear of it on that same resize,
+  // so by the time we re-place, the opening rect points under the keyboard.
+  // Rects stay supported for anchors with nothing to re-measure, such as one
+  // derived from a text selection that has since been cleared.
+  showAt(anchor, boundsElement = null) {
     if (!this.element) return
 
     // When set, the popup is caged inside this element's rect (e.g. the chat
     // box) instead of the viewport — see updatePosition.
     this._boundsElement = boundsElement
-    // Kept so reposition() can re-place against the same anchor after the
-    // popup's content has changed size.
-    this._anchorRect = anchorRect
+    this._anchorProvider = typeof anchor === 'function' ? anchor : null
+    // Last known anchor geometry, so reposition() can re-place after the
+    // popup's content has changed size, and so a provider that stops resolving
+    // has something to fall back on.
+    this._anchorRect = this._anchorProvider ? null : anchor
     this._placedAbove = false
 
     // Re-opening while already open (e.g. clicking the same typo mark twice):
@@ -57,7 +77,7 @@ export default class CommonPopup {
       // that did not exist yet.
       if (!this.isOpen() || !this.element.isConnected) return
 
-      this.updatePosition(anchorRect)
+      this.updatePosition(this.anchorRect())
       this.element.style.visibility = 'visible'
       // Register the outside-click listeners only after the opening event has
       // finished propagating. When a popup is opened from a mousedown handler
@@ -83,7 +103,24 @@ export default class CommonPopup {
   // that placeholder height implied.
   reposition() {
     if (!this.isOpen()) return
-    this.updatePosition(this._anchorRect)
+    this.updatePosition(this.anchorRect())
+  }
+
+  // The anchor's geometry now, not as it was when showAt ran.
+  anchorRect() {
+    if (!this._anchorProvider) return this._anchorRect
+
+    let rect = null
+    try {
+      rect = this._anchorProvider()
+    } catch {
+      rect = null
+    }
+    // The anchor can go away mid-open (Turbo swap, a textarea replaced by a
+    // stream update). Keep the last place we saw it rather than collapsing to
+    // the origin.
+    if (rect) this._anchorRect = rect
+    return this._anchorRect
   }
 
   handleViewportResize() {
@@ -287,6 +324,7 @@ export default class CommonPopup {
     document.removeEventListener('touchstart', this.handleOutsideClick)
     window.visualViewport?.removeEventListener('resize', this.handleViewportResize)
     this._anchorRect = null
+    this._anchorProvider = null
 
     if (typeof this.onClose === 'function') {
       this.onClose(reason)

--- a/engines/collavre/app/javascript/modules/command_menu.js
+++ b/engines/collavre/app/javascript/modules/command_menu.js
@@ -1,5 +1,5 @@
 import CommonPopup from '../lib/common_popup'
-import { getCaretClientRect } from '../utils/caret_position'
+import { caretAnchor } from '../utils/caret_position'
 import CommandArgsForm from './command_args_form'
 import { openCreativeLinkPicker } from './creative_link_picker'
 
@@ -171,8 +171,7 @@ if (!commandMenuInitialized) {
       }
 
       popupMenu.setItems(filtered)
-      const caretRect = getCaretClientRect(textarea) || textarea.getBoundingClientRect()
-      popupMenu.showAt(caretRect)
+      popupMenu.showAt(caretAnchor(textarea))
     }
 
     function openCreativePicker(textarea) {

--- a/engines/collavre/app/javascript/modules/creative_link_picker.js
+++ b/engines/collavre/app/javascript/modules/creative_link_picker.js
@@ -1,4 +1,4 @@
-import { getCaretClientRect } from '../utils/caret_position'
+import { caretAnchor } from '../utils/caret_position'
 
 const MARKDOWN_SPECIAL = /[\\`*_\[\]()<>~]/g
 
@@ -46,9 +46,8 @@ export function openCreativeLinkPicker(textarea, {
     textarea.dispatchEvent(new Event('input', { bubbles: true }))
   }
 
-  const caretRect = getCaretClientRect(textarea) || textarea.getBoundingClientRect()
   controller.open(
-    caretRect,
+    caretAnchor(textarea),
     (item) => insertMarkdownCreativeLink(textarea, item),
     () => textarea.focus(),
     { allowCreate }

--- a/engines/collavre/app/javascript/modules/mention_menu.js
+++ b/engines/collavre/app/javascript/modules/mention_menu.js
@@ -1,5 +1,5 @@
 import CommonPopup from '../lib/common_popup'
-import { getCaretClientRect } from '../utils/caret_position'
+import { caretAnchor } from '../utils/caret_position'
 
 let mentionMenuInitialized = false
 
@@ -42,8 +42,7 @@ if (!mentionMenuInitialized) {
         return
       }
       popupMenu.setItems(users)
-      const caretRect = getCaretClientRect(textarea) || textarea.getBoundingClientRect()
-      popupMenu.showAt(caretRect)
+      popupMenu.showAt(caretAnchor(textarea))
     }
 
     textarea.addEventListener('keydown', function (event) {

--- a/engines/collavre/app/javascript/modules/typo_corrector.js
+++ b/engines/collavre/app/javascript/modules/typo_corrector.js
@@ -15,7 +15,7 @@
 // document, so Enter = keep. Typing adds the typed word as an always-present,
 // auto-selected custom option.
 
-import CommonPopup from '../lib/common_popup'
+import CommonPopup, { elementAnchor } from '../lib/common_popup'
 import csrfFetch from '../lib/api/csrf_fetch'
 import {
   detectDevice,
@@ -421,7 +421,7 @@ export class TypoCorrector {
     this._activeEdit = edit
     this.popupInput.value = edit.currentValue
     this._refreshPopupItems('')
-    this.popup.showAt(anchorEl.getBoundingClientRect())
+    this.popup.showAt(elementAnchor(anchorEl))
     // Desktop: focus + select-all so a keystroke immediately replaces the word.
     // Mobile keyboard is left to an explicit tap on the input (no auto-focus) —
     // chip taps are the primary path.

--- a/engines/collavre/app/javascript/utils/__tests__/caret_anchor.test.js
+++ b/engines/collavre/app/javascript/utils/__tests__/caret_anchor.test.js
@@ -1,0 +1,75 @@
+/**
+ * @jest-environment jsdom
+ */
+import { caretAnchor } from '../caret_position'
+
+// caretAnchor is what a caret-anchored popup hands to CommonPopup.showAt in
+// place of a rect: the caret is not an element, so the only way placement can
+// re-measure it later is to re-derive it from the input each time.
+describe('caretAnchor', () => {
+    let textarea
+
+    // jsdom measures every element as a zeroed rect, so the mirror-div path in
+    // getCaretClientRect cannot produce distinguishable coordinates. Dropping
+    // selectionStart takes the documented fallback branch instead, where the
+    // rect is the input's own and therefore stubbable.
+    const useInputRectFallback = () => {
+        Object.defineProperty(textarea, 'selectionStart', { value: null, configurable: true })
+    }
+
+    beforeEach(() => {
+        textarea = document.createElement('textarea')
+        textarea.value = 'hello'
+        document.body.appendChild(textarea)
+    })
+
+    afterEach(() => {
+        document.body.innerHTML = ''
+    })
+
+    test('re-derives the rect on every call, so a moved input moves the anchor', () => {
+        useInputRectFallback()
+        const anchor = caretAnchor(textarea)
+
+        textarea.getBoundingClientRect = () => ({ left: 10, top: 500, bottom: 540 })
+        const before = anchor()
+        // The keyboard opens and the composer is lifted clear of it.
+        textarea.getBoundingClientRect = () => ({ left: 10, top: 200, bottom: 240 })
+        const after = anchor()
+
+        expect(before.top).toBe(500)
+        expect(after.top).toBe(200)
+    })
+
+    test('falls back to the input rect when the caret cannot be located', () => {
+        const inputRect = { left: 10, top: 200, bottom: 240 }
+        textarea.getBoundingClientRect = () => inputRect
+        useInputRectFallback()
+
+        expect(caretAnchor(textarea)()).toBe(inputRect)
+    })
+
+    test('measures the caret, not the whole input, when the caret is locatable', () => {
+        const inputRect = { left: 10, top: 200, bottom: 240 }
+        textarea.getBoundingClientRect = () => inputRect
+        textarea.setSelectionRange(3, 3)
+
+        const rect = caretAnchor(textarea)()
+
+        expect(rect).not.toBe(inputRect)
+        expect(rect).not.toBeNull()
+    })
+
+    test('returns nothing once the input has left the document', () => {
+        const anchor = caretAnchor(textarea)
+        textarea.remove()
+
+        // A detached input measures as all zeros, which would pin the popup to
+        // the top-left corner; CommonPopup keeps its last rect on a null.
+        expect(anchor()).toBeNull()
+    })
+
+    test('returns nothing when there is no input at all', () => {
+        expect(caretAnchor(null)()).toBeNull()
+    })
+})

--- a/engines/collavre/app/javascript/utils/caret_position.js
+++ b/engines/collavre/app/javascript/utils/caret_position.js
@@ -1,3 +1,13 @@
+// Anchor provider for a popup hung off the caret of `input`, for CommonPopup's
+// showAt. The caret has no element to hold on to, so its rect has to be
+// re-derived from the input's live geometry every time placement runs.
+export function caretAnchor(input) {
+  return () => {
+    if (!input?.isConnected) return null
+    return getCaretClientRect(input) || input.getBoundingClientRect()
+  }
+}
+
 export function getCaretClientRect(input) {
   if (!input || typeof input.selectionStart !== 'number') return null
 


### PR DESCRIPTION
## Problem

Running `/creative` from a chat composer pinned to the bottom of the screen opened the link picker as a ~130px sliver: the title, the search box, and a single tree row. Everything else rendered below the viewport.

## Root cause

`CommonPopup.updatePosition` had two problems that only combine when the anchor is near the bottom edge:

1. **It measured too early.** `showAt` positions the popup one animation frame after opening. At that point the link picker's list is still the "Loading…" placeholder, so `offsetHeight` is ~130px, not the ~400px the loaded tree needs. `maxTop = innerHeight - height - padding` was computed from that placeholder height, so the popup was pinned ~138px above the viewport bottom. When the tree arrived it grew downward, off-screen. Nothing re-ran placement.
2. **It only ever placed the popup below the anchor.** There was no flip-up path and no max-height derived from the available space, so a caret with 40px under it got a popup that needed 400px.

## Fix

`engines/collavre/app/javascript/lib/common_popup.js`

- Flip above the anchor when the popup does not fit below it and there is more room above. The flip is **sticky for the life of one open** so collapsing tree nodes cannot make the popup hop back across the caret.
- Cap `max-height` to the space actually available (floored at 160px, below which the popup is unusable) so the list scrolls inside the popup instead of running off-screen — now and if the content grows later.
- Clear `max-height` before measuring. Otherwise `offsetHeight` reports the previous cap rather than the content height, and every subsequent call agrees the popup "fits" wherever it was first placed.
- Measure against `visualViewport` rather than `window.innerHeight`, so the region excludes the strip the on-screen keyboard covers. A new `reposition()` is bound to `visualViewport` resize while the popup is open (the keyboard opens *after* `showAt`, because consumers focus their input a frame later).
- Unify the bounded (caged-in-chat-box) and viewport paths through one region rect.

`engines/collavre/app/javascript/controllers/link_creative_controller.js`

- Call `reposition()` after every render that changes the list's height: tree render, search results, loading/empty/creating placeholders, node expand (fresh fetch, cached re-expand, and failure), and collapse.

`engines/collavre/app/assets/stylesheets/collavre/popup.css`

- `.common-popup` gets `box-sizing: border-box` (the inline `max-height` is measured back via `offsetHeight`) and `overflow: hidden`.
- `.common-popup-list` becomes `flex: 1 1 auto; min-height: 0` so it shrinks inside a capped popup instead of being clipped.

## Verification

Manual, against a local preview at 1280x720 with 13 root creatives:

| | popup rect | visible rows |
|---|---|---|
| before | `top 568 → bottom 924` (viewport is 720) | 1 |
| after | `top 184 → bottom 540` | 7, list scrolls |

Also checked:

- **High anchor** (contexts "add" button, anchor bottom 149): still opens *below* at top 153. No regression.
- **Expand a node** (13 → 19 rows): popup height and bottom edge unchanged, list scrolls internally.
- **Search then clear**: popup shrinks to fit its results, bottom edge stays anchored above the caret.
- **480px-tall viewport**: popup occupies `8 → 301`, fully on screen.
- **Bounded popup** (topic list, caged in the chat box): unchanged placement.
- **Mention menu / command menu**: both now flip or clamp correctly instead of overflowing.

Tests: `npm test` — 103 suites, 1294 tests, all pass.

- New `engines/collavre/app/javascript/lib/__tests__/common_popup_placement.test.js` (10 tests): flip-up, stay-below, cap-to-larger-side, minimum height, stale-cap measurement, visualViewport measurement, reposition-after-growth, sticky flip, no-op when closed, viewport-resize rebind/unbind.
- `common_popup_bounds.test.js` updated for the space-derived cap.
- `link_creative_controller.test.js` +6 tests covering every reposition call site.

100% of the changed lines in both JS files are covered (remaining uncovered lines in each file are pre-existing and untouched). `stylelint` reports the same 103 pre-existing problems before and after the CSS change.