### PR TITLE
fix: keep the Solid Cable listener alive after database errors

### DIFF
--- a/config/cable.yml
+++ b/config/cable.yml
@@ -15,6 +15,17 @@ production: &production
       writing: cable
   polling_interval: 0.1.seconds
   message_retention: 1.day
+  # Backoff (seconds) between retries when the listener thread hits an
+  # ActiveRecord connection error. solid_cable defaults to a single immediate
+  # retry, after which the polling thread exits silently and the process stops
+  # delivering every broadcast until it is restarted. The attempt counter
+  # resets after any successful poll, so this list is effectively an unlimited
+  # retry with a 30s ceiling.
+  #
+  # `SolidCableListenerResilience` normally catches these first (and covers
+  # non-connection errors too); this is the fallback if that patch is ever
+  # removed or fails to install.
+  reconnect_attempts: [ 0.1, 0.5, 1, 2, 5, 10, 30 ]
 
 # Desktop app reuses the production Solid Cable setup verbatim.
 desktop: *production

--- a/config/initializers/solid_cable_resilience.rb
+++ b/config/initializers/solid_cable_resilience.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# Guard solid_cable's polling thread against silent death. See
+# `lib/solid_cable_listener_resilience.rb` for the failure mode this covers.
+Rails.application.config.after_initialize do
+  SolidCableListenerResilience.install_if_configured!
+end

--- a/lib/solid_cable_listener_resilience.rb
+++ b/lib/solid_cable_listener_resilience.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+# Keeps the Solid Cable listener thread alive across *any* runtime error.
+#
+# solid_cable polls `solid_cable_messages` from one dedicated thread per
+# process, and that thread is the only thing that pushes a broadcast out to
+# connected WebSocket clients. The gem wraps it like this:
+#
+#   @thread = Thread.new do
+#     begin
+#       listen
+#     rescue *CONNECTION_ERRORS
+#       retry if retry_connecting?
+#     end
+#   end
+#
+# So the loop survives `reconnect_attempts` ActiveRecord connection errors
+# (default: 1, with no delay) and nothing else. Once it gives up, the thread
+# exits without a log line while the process keeps happily accepting
+# subscriptions: every broadcast still INSERTs into `solid_cable_messages`,
+# nobody ever reads it back out, and the whole app looks like it lost realtime
+# until someone restarts the container. A single DB restart or pool timeout is
+# enough to trigger it, and at a 0.1s polling interval the thread checks out a
+# connection ten times a second.
+#
+# Prepended onto the listener, this retries the polling loop forever with a
+# bounded backoff and logs every failure, so the outage is both self-healing
+# and visible.
+module SolidCableListenerResilience
+  # Seconds to wait before the Nth consecutive retry; the last entry is the
+  # ceiling for every failure after that.
+  BACKOFF = [ 0.1, 0.5, 1, 2, 5, 10, 30 ].freeze
+
+  # A quiet stretch this long means the loop recovered, so the next failure
+  # starts the backoff over instead of resuming at the ceiling.
+  RESET_AFTER = 60.0
+
+  class << self
+    # Installs only for environments that actually run the solid_cable
+    # adapter. Development uses `async` and test uses `test`; neither has a
+    # listener thread to guard.
+    def install_if_configured!(listener_class = default_listener_class)
+      return false unless cable_adapter == "solid_cable"
+
+      install!(listener_class)
+    end
+
+    def cable_adapter
+      Rails.application.config_for(:cable)[:adapter].to_s
+    rescue StandardError
+      nil
+    end
+
+    # Prepends this module onto solid_cable's listener. Returns true when it
+    # installed, false when there was nothing to patch or it was already
+    # installed, so a gem upgrade that moves the class can never break boot.
+    def install!(listener_class = default_listener_class)
+      return false unless listener_class.is_a?(Module)
+      return false if listener_class.ancestors.include?(self)
+
+      listener_class.prepend(self)
+      true
+    end
+
+    def default_listener_class
+      return nil unless defined?(::ActionCable::SubscriptionAdapter::SolidCable::Listener)
+
+      ::ActionCable::SubscriptionAdapter::SolidCable::Listener
+    end
+
+    def report(error, failures:, delay:)
+      Rails.logger&.error(
+        "[solid_cable] listener loop crashed (consecutive failure ##{failures}), " \
+        "retrying in #{delay}s: #{error.class}: #{error.message}"
+      )
+      Rails.logger&.error(error.backtrace.first(20).join("\n")) if error.backtrace
+
+      Rails.error&.report(error, handled: true, source: "solid_cable") if Rails.respond_to?(:error)
+    rescue StandardError
+      # Never let reporting take down the retry loop itself.
+      nil
+    end
+  end
+
+  def listen
+    failures = 0
+    last_failure_at = nil
+
+    begin
+      super
+    rescue StandardError => error
+      # `Stop` (raised by `shutdown`) descends from Exception, not
+      # StandardError, so an orderly shutdown still ends the thread here.
+      now = monotonic_now
+      failures = 0 if last_failure_at && (now - last_failure_at) > RESET_AFTER
+      last_failure_at = now
+      failures += 1
+
+      delay = BACKOFF[[ failures, BACKOFF.size ].min - 1]
+      SolidCableListenerResilience.report(error, failures: failures, delay: delay)
+      reclaim_critical_permit
+
+      sleep delay
+      retry
+    end
+  end
+
+  private
+
+    def monotonic_now
+      Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    end
+
+    # `listen`'s own `ensure` releases the critical-section permit on its way
+    # out, which is right when the thread is about to die and wrong when it is
+    # about to restart. Take the permit back so `shutdown` keeps waiting for a
+    # safe interruption point instead of raising into the middle of a poll.
+    def reclaim_critical_permit
+      return unless defined?(@critical) && @critical.respond_to?(:try_acquire)
+
+      @critical.try_acquire
+    rescue StandardError
+      nil
+    end
+end

--- a/test/lib/solid_cable_listener_resilience_test.rb
+++ b/test/lib/solid_cable_listener_resilience_test.rb
@@ -1,0 +1,275 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "yaml"
+
+class SolidCableListenerResilienceTest < ActiveSupport::TestCase
+  # solid_cable runs the polling loop that feeds every WebSocket client from a
+  # single thread and only rescues connection errors, `reconnect_attempts`
+  # times. When it gives up the thread exits without a log line, broadcasts
+  # keep landing in `solid_cable_messages`, and nothing reads them back out —
+  # realtime is dead process-wide until a restart. These cases pin the
+  # retry-forever-and-say-so behaviour that replaces it.
+
+  # Stands in for `ActionCable::SubscriptionAdapter::SolidCable::Listener`:
+  # `listen` raises the scripted errors in order, then returns like the real
+  # one does after `shutdown`.
+  class FakeListener
+    attr_reader :listen_calls, :slept
+
+    def initialize(errors: [], critical: nil)
+      @errors = errors.dup
+      @critical = critical unless critical.nil?
+      @listen_calls = 0
+      @slept = []
+    end
+
+    def listen
+      @listen_calls += 1
+      error = @errors.shift
+      raise error if error
+
+      :stopped
+    end
+
+    # Shadows Kernel#sleep so the backoff is observable and instant.
+    def sleep(seconds)
+      @slept << seconds
+    end
+  end
+
+  class PermitSpy
+    attr_reader :try_acquire_calls
+
+    def initialize(&on_acquire)
+      @try_acquire_calls = 0
+      @on_acquire = on_acquire
+    end
+
+    def try_acquire
+      @try_acquire_calls += 1
+      @on_acquire&.call
+      true
+    end
+  end
+
+  class NullReporter
+    attr_reader :reported
+
+    def initialize
+      @reported = []
+    end
+
+    def report(error, **options)
+      @reported << [ error, options ]
+    end
+  end
+
+  setup do
+    @original_logger = Rails.logger
+    @log = StringIO.new
+    Rails.logger = ActiveSupport::Logger.new(@log)
+  end
+
+  teardown do
+    Rails.logger = @original_logger
+  end
+
+  test "restarts the polling loop after a crash instead of letting the thread die" do
+    listener = build_listener(errors: [ RuntimeError.new("boom") ])
+
+    assert_equal :stopped, listener.listen
+    assert_equal 2, listener.listen_calls
+    assert_equal [ 0.1 ], listener.slept
+  end
+
+  test "recovers from the connection errors that solid_cable gives up on" do
+    errors = [
+      ActiveRecord::ConnectionNotEstablished.new("gone"),
+      ActiveRecord::ConnectionTimeoutError.new("pool exhausted"),
+      ActiveRecord::ConnectionFailed.new("reset")
+    ]
+    listener = build_listener(errors: errors)
+
+    assert_equal :stopped, listener.listen
+    assert_equal 4, listener.listen_calls
+  end
+
+  test "escalates the backoff and holds it at the ceiling" do
+    listener = build_listener(errors: Array.new(9) { RuntimeError.new("boom") })
+
+    listener.listen
+
+    assert_equal [ 0.1, 0.5, 1, 2, 5, 10, 30, 30, 30 ], listener.slept
+  end
+
+  test "restarts the backoff once the loop has been healthy again" do
+    # Failures 1 and 2 are back to back; failure 3 lands after a quiet stretch.
+    clock = [ 0.0, 0.5, 0.5 + SolidCableListenerResilience::RESET_AFTER + 1 ]
+    listener = build_listener(errors: Array.new(3) { RuntimeError.new("boom") }, clock: clock)
+
+    listener.listen
+
+    assert_equal [ 0.1, 0.5, 0.1 ], listener.slept
+  end
+
+  test "logs the failure and the backtrace so the outage is not silent" do
+    error = RuntimeError.new("boom")
+    error.set_backtrace([ "app/models/thing.rb:1:in `poll'" ])
+
+    build_listener(errors: [ error ]).listen
+
+    assert_match(/\[solid_cable\] listener loop crashed \(consecutive failure #1\)/, @log.string)
+    assert_match(/retrying in 0\.1s: RuntimeError: boom/, @log.string)
+    assert_match(/app\/models\/thing\.rb:1/, @log.string)
+  end
+
+  test "reports the failure to the error reporter" do
+    reporter = NullReporter.new
+    error = RuntimeError.new("boom")
+
+    Rails.stub(:error, reporter) do
+      build_listener(errors: [ error ]).listen
+    end
+
+    assert_equal 1, reporter.reported.size
+    reported_error, options = reporter.reported.first
+    assert_same error, reported_error
+    assert_equal true, options[:handled]
+    assert_equal "solid_cable", options[:source]
+  end
+
+  test "keeps retrying when there is no error reporter" do
+    listener = build_listener(errors: [ RuntimeError.new("boom") ])
+
+    Rails.stub(:error, nil) do
+      assert_equal :stopped, listener.listen
+    end
+
+    assert_equal 2, listener.listen_calls
+  end
+
+  test "keeps retrying when reporting itself blows up" do
+    reporter = Object.new
+    def reporter.report(*) = raise("reporter down")
+    listener = build_listener(errors: [ RuntimeError.new("boom") ])
+
+    Rails.stub(:error, reporter) do
+      assert_equal :stopped, listener.listen
+    end
+
+    assert_equal 2, listener.listen_calls
+  end
+
+  test "lets an orderly shutdown end the thread" do
+    stop = Class.new(Exception)
+    listener = build_listener(errors: [ stop.new("stop") ])
+
+    assert_raises(stop) { listener.listen }
+    assert_equal 1, listener.listen_calls
+    assert_empty listener.slept
+  end
+
+  test "takes back the critical-section permit before restarting the loop" do
+    permit = PermitSpy.new
+    listener = build_listener(errors: [ RuntimeError.new("boom") ], critical: permit)
+
+    listener.listen
+
+    assert_equal 1, permit.try_acquire_calls
+  end
+
+  test "restarts the loop even when the permit cannot be reclaimed" do
+    permit = PermitSpy.new { raise "semaphore down" }
+    listener = build_listener(errors: [ RuntimeError.new("boom") ], critical: permit)
+
+    assert_equal :stopped, listener.listen
+    assert_equal 1, permit.try_acquire_calls
+  end
+
+  test "restarts the loop when the listener has no semaphore to reclaim" do
+    listener = build_listener(errors: [ RuntimeError.new("boom") ], critical: Object.new)
+
+    assert_equal :stopped, listener.listen
+    assert_equal 2, listener.listen_calls
+  end
+
+  test "installs onto a listener class exactly once" do
+    listener_class = Class.new(FakeListener)
+
+    assert SolidCableListenerResilience.install!(listener_class)
+    assert_not SolidCableListenerResilience.install!(listener_class)
+    assert_includes listener_class.ancestors, SolidCableListenerResilience
+  end
+
+  test "does nothing when the listener class is missing" do
+    assert_not SolidCableListenerResilience.install!(nil)
+  end
+
+  test "points at the solid_cable listener class by default" do
+    assert_equal ActionCable::SubscriptionAdapter::SolidCable::Listener,
+                 SolidCableListenerResilience.default_listener_class
+  end
+
+  # Canaries: a solid_cable upgrade that renames either of these turns the
+  # patch into a no-op, which would only show up in production as realtime
+  # silently dying again.
+  test "solid_cable still runs the loop in the method this wraps" do
+    assert SolidCableListenerResilience.default_listener_class.method_defined?(:listen)
+  end
+
+  test "solid_cable's shutdown signal still bypasses the retry" do
+    stop = SolidCableListenerResilience.default_listener_class::Stop
+
+    assert_operator stop, :<, Exception
+    assert_not stop <= StandardError, "Stop must not be rescued as a retryable error"
+  end
+
+  test "installs only for the solid_cable adapter" do
+    listener_class = Class.new(FakeListener)
+
+    SolidCableListenerResilience.stub(:cable_adapter, "test") do
+      assert_not SolidCableListenerResilience.install_if_configured!(listener_class)
+    end
+    assert_not_includes listener_class.ancestors, SolidCableListenerResilience
+
+    SolidCableListenerResilience.stub(:cable_adapter, "solid_cable") do
+      assert SolidCableListenerResilience.install_if_configured!(listener_class)
+    end
+    assert_includes listener_class.ancestors, SolidCableListenerResilience
+  end
+
+  test "reads the adapter from the cable config" do
+    assert_equal "test", SolidCableListenerResilience.cable_adapter
+  end
+
+  test "treats an unreadable cable config as no adapter" do
+    Rails.application.stub(:config_for, ->(*) { raise "no such file" }) do
+      assert_nil SolidCableListenerResilience.cable_adapter
+    end
+  end
+
+  test "production retries connection errors with a backoff instead of giving up" do
+    cable = YAML.load_file(Rails.root.join("config/cable.yml"), aliases: true)
+
+    # An Integer here would mean "N retries with no delay"; the gem only treats
+    # an Array as a backoff schedule. The counter resets after any successful
+    # poll, so this is effectively unlimited retries with a 30s ceiling.
+    attempts = cable.dig("production", "reconnect_attempts")
+    assert_kind_of Array, attempts
+    assert_equal [ 0.1, 0.5, 1, 2, 5, 10, 30 ], attempts
+    assert_equal cable["production"], cable["desktop"]
+  end
+
+  private
+
+    def build_listener(errors:, critical: nil, clock: nil)
+      klass = Class.new(FakeListener)
+      SolidCableListenerResilience.install!(klass)
+      listener = klass.new(errors: errors, critical: critical)
+      # A singleton method wins over the prepended module, so this is the one
+      # seam that can pin the clock without stubbing Process globally.
+      listener.define_singleton_method(:monotonic_now) { clock.shift } if clock
+      listener
+    end
+end


### PR DESCRIPTION
## Problem

Realtime updates stopped working in production: chat messages, unread badges and every other Turbo Stream update only appeared after a manual refresh.

Traced to the Solid Cable listener thread being dead inside the Puma web process. Evidence gathered on the production container:

- A real WebSocket client authenticated, connected and subscribed successfully (`confirm_subscription` received for three `Turbo::StreamsChannel` streams) — the CDN/proxy/auth path was fine.
- Broadcasting to those exact streams delivered nothing to the connected client.
- The Puma process had no `solid_cable_listener` thread.
- In `pg_stat_activity`, `INSERT INTO solid_cable_messages` and the `MAX(id)` lookup from `add_channel` were present, but the listener's `SELECT ... WHERE channel_hash = $1 AND id > ...` poll never appeared. A control subscription from a separate process made that poll show up immediately, confirming the probe itself was valid.

Manual refresh kept working because page rendering and `InboxBadgeChannel#subscribed`'s snapshot `transmit` are in-process paths that never touch pubsub.

## Root cause

`solid_cable` (4.0.2) runs the polling loop that feeds every WebSocket client from one thread per process:

```ruby
@thread = Thread.new do
  begin
    listen
  rescue *CONNECTION_ERRORS      # ConnectionFailed / ConnectionTimeoutError / ConnectionNotEstablished
    retry if retry_connecting?
  end                            # false => thread exits, no log, no exception report
end
```

`reconnect_attempts` defaults to `1`, so the loop survives exactly one `ActiveRecord` connection error with no delay and then the thread exits silently. Anything that is not a connection error is not rescued at all.

The process keeps accepting subscriptions afterwards. Broadcasts still `INSERT` into `solid_cable_messages`; nothing ever reads them back out. Realtime is dead process-wide until a restart, with nothing in the logs — which matches the production container having zero `solid_cable` log lines.

At a `polling_interval` of 0.1s the thread checks out a connection ten times a second, so a single database restart, failover or pool timeout is enough to trigger it.

## Fix

- `lib/solid_cable_listener_resilience.rb` — prepended onto the listener. Retries the polling loop forever with a bounded backoff (`0.1, 0.5, 1, 2, 5, 10, 30`, resetting after a 60s healthy stretch), logs every failure and reports it to `Rails.error`. Covers non-connection errors too. `Stop` (raised by `shutdown`) descends from `Exception`, not `StandardError`, so an orderly shutdown still ends the thread.
- Takes back the critical-section permit that `listen`'s `ensure` releases on its way out, so `shutdown` keeps waiting for a safe interruption point instead of raising into the middle of a poll.
- `config/initializers/solid_cable_resilience.rb` — installs it only when the configured adapter is `solid_cable` (development uses `async`, test uses `test`, neither has a listener thread). `install!` no-ops if the gem ever moves the class, so a gem upgrade cannot break boot.
- `config/cable.yml` — sets `reconnect_attempts` to the same backoff list as a fallback for the un-patched path. The gem resets the counter after any successful poll, so a list is effectively unlimited retries with a 30s ceiling.

## Tests

`test/lib/solid_cable_listener_resilience_test.rb` — 21 tests, 100% line coverage of the new file:

- restarts the loop after a crash, including the three `ActiveRecord` connection errors the gem gives up on
- backoff escalation, ceiling, and reset after a healthy stretch
- logs the failure with a backtrace and reports it to `Rails.error`
- keeps retrying when there is no error reporter, when reporting raises, and when the semaphore cannot be reclaimed
- lets an orderly shutdown (`Stop`) end the thread
- `install!` idempotency, adapter gating, unreadable-config handling
- canaries that fail loudly if a `solid_cable` upgrade renames `listen` or reparents `Stop`, since either would silently turn the patch into a no-op
- asserts `reconnect_attempts` in `config/cable.yml` is an Array (an Integer would mean "N retries with no delay") and that `desktop` still inherits it

Also verified against the real `ActionCable::SubscriptionAdapter::SolidCable::Listener`: with the module installed, `listen` survives two connection errors plus one `ArgumentError` and keeps polling, then exits cleanly on `Stop`, with the critical-section permit balanced.

## Deployment note

Production was already restarted to recover the current outage, and the listener thread and its polling query are confirmed back. This PR prevents it from recurring.

## Follow-ups (not in this PR)

- A pubsub round-trip health check (broadcast → receive) so a stuck-but-alive listener is also detectable.
- Revisit the web process DB pool sizing against the 0.1s polling interval and the AI agent workload.
