### PR TITLE
fix: retain macOS desktop native gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -292,6 +292,7 @@ GEM
     ffi (1.17.4-aarch64-linux-musl)
     ffi (1.17.4-arm-linux-gnu)
     ffi (1.17.4-arm-linux-musl)
+    ffi (1.17.4-arm64-darwin)
     ffi (1.17.4-x86_64-linux-gnu)
     ffi (1.17.4-x86_64-linux-musl)
     fugit (1.13.0)
@@ -421,6 +422,8 @@ GEM
       racc (~> 1.4)
     nokogiri (1.19.4-arm-linux-musl)
       racc (~> 1.4)
+    nokogiri (1.19.4-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.19.4-x86_64-linux-gnu)
       racc (~> 1.4)
     nokogiri (1.19.4-x86_64-linux-musl)
@@ -468,6 +471,7 @@ GEM
     pg (1.6.3)
     pg (1.6.3-aarch64-linux)
     pg (1.6.3-aarch64-linux-musl)
+    pg (1.6.3-arm64-darwin)
     pg (1.6.3-x86_64-linux)
     pg (1.6.3-x86_64-linux-musl)
     pp (0.6.4)
@@ -642,6 +646,7 @@ GEM
     sqlite3 (2.9.5-aarch64-linux-musl)
     sqlite3 (2.9.5-arm-linux-gnu)
     sqlite3 (2.9.5-arm-linux-musl)
+    sqlite3 (2.9.5-arm64-darwin)
     sqlite3 (2.9.5-x86_64-linux-gnu)
     sqlite3 (2.9.5-x86_64-linux-musl)
     sshkit (1.25.0)
@@ -657,6 +662,7 @@ GEM
     thor (1.5.0)
     thruster (0.1.23)
     thruster (0.1.23-aarch64-linux)
+    thruster (0.1.23-arm64-darwin)
     thruster (0.1.23-x86_64-linux)
     timeout (0.6.1)
     tpm-key_attestation (0.14.1)
@@ -715,6 +721,7 @@ PLATFORMS
   aarch64-linux-musl
   arm-linux-gnu
   arm-linux-musl
+  arm64-darwin
   ruby
   x86_64-linux
   x86_64-linux-gnu

--- a/tools/desktop-app/scripts/bundle-ruby.sh
+++ b/tools/desktop-app/scripts/bundle-ruby.sh
@@ -74,14 +74,9 @@ export BUNDLE_GEMFILE="$APP_ROOT/Gemfile"
 export BUNDLE_PATH="$VENDOR_DIR/bundle"
 export BUNDLE_WITHOUT="development:test:production"
 export BUNDLE_WITH="desktop"
-# Platform gems may contain prebuilt native extensions with paths from their
-# release builder. Compile them for this Ruby instead so relocation can bundle
-# every dependency from the local build environment.
-export BUNDLE_FORCE_RUBY_PLATFORM=true
-# Nokogiri's bundled-library probe compiles Ruby 3.4 headers with `-Werror` and
-# fails on current Xcode. Build it against the local system libraries instead;
-# relocate-ruby.sh collects their non-system dylib dependencies into the app.
-export NOKOGIRI_USE_SYSTEM_LIBRARIES="${NOKOGIRI_USE_SYSTEM_LIBRARIES:-true}"
+# The lockfile retains the macOS platform gems for extensions such as Nokogiri.
+# relocate-ruby.sh rewrites their native dependencies after installation so the
+# precompiled package cannot retain a release-builder library path.
 "$VENDORED_RUBY" -S bundle install --jobs 4
 
 # Native gem extensions are compiled after the initial Ruby relocation and keep

--- a/tools/desktop-app/scripts/bundle-ruby.sh
+++ b/tools/desktop-app/scripts/bundle-ruby.sh
@@ -78,6 +78,10 @@ export BUNDLE_WITH="desktop"
 # release builder. Compile them for this Ruby instead so relocation can bundle
 # every dependency from the local build environment.
 export BUNDLE_FORCE_RUBY_PLATFORM=true
+# Nokogiri's bundled-library probe compiles Ruby 3.4 headers with `-Werror` and
+# fails on current Xcode. Build it against the local system libraries instead;
+# relocate-ruby.sh collects their non-system dylib dependencies into the app.
+export NOKOGIRI_USE_SYSTEM_LIBRARIES="${NOKOGIRI_USE_SYSTEM_LIBRARIES:-true}"
 "$VENDORED_RUBY" -S bundle install --jobs 4
 
 # Native gem extensions are compiled after the initial Ruby relocation and keep

--- a/tools/desktop-app/scripts/relocate-ruby.sh
+++ b/tools/desktop-app/scripts/relocate-ruby.sh
@@ -86,10 +86,10 @@ copy_external_dependency() {
   local dependency="$2"
   local destination
 
-  [[ "$dependency" = /* ]] || return
-  is_system_dependency "$dependency" && return
-  [[ "$dependency" == "$RUBY_PREFIX/"* ]] && return
-  [[ "$dependency" == "$gmp_load_command" ]] && return
+  [[ "$dependency" = /* ]] || return 0
+  is_system_dependency "$dependency" && return 0
+  [[ "$dependency" == "$RUBY_PREFIX/"* ]] && return 0
+  [[ "$dependency" == "$gmp_load_command" ]] && return 0
 
   destination="$(external_destination "$dependency")"
   [ -f "$destination" ] && return


### PR DESCRIPTION
## Summary

Retains the macOS Apple Silicon platform variants for desktop Ruby dependencies and uses them during the desktop bundle build.

## Why

The desktop DMG must ship native extensions compatible with the vendored Ruby on Apple Silicon. Forcing the generic Ruby platform discarded the macOS variants and also required a Nokogiri source build that can fail with current Xcode headers.

## Changes

- keep `arm64-darwin` variants for ffi, nokogiri, pg, sqlite3, and thruster in `Gemfile.lock`
- allow Bundler to select the macOS platform gems
- preserve successful relocation flow when no external dependencies require copying

## Validation

- `bash -n tools/desktop-app/scripts/bundle-ruby.sh tools/desktop-app/scripts/relocate-ruby.sh tools/desktop-app/scripts/build-macos.sh`
- `mise exec ruby@3.4.4 -- bundle lock --add-platform arm64-darwin` with no lockfile diff
- lockfile assertion for the required `arm64-darwin` gems
- `git diff --check origin/main...HEAD`

Rails tests were not run: this checkout is missing `commonmarker`, `rb_sys`, and `rake-compiler-dock`. A full signed DMG build remains required on the Apple Silicon release runner.