### PR TITLE
fix: disable unconsented desktop gateway setup

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/desktop_setup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/desktop_setup.css
@@ -220,6 +220,14 @@
   color: var(--text-primary);
 }
 .desktop-setup__button:hover { filter: brightness(var(--hover-brightness)); }
+.desktop-setup__button:disabled {
+  background: var(--surface-secondary);
+  border-color: var(--border-color);
+  color: var(--text-muted);
+  cursor: not-allowed;
+  opacity: .65;
+}
+.desktop-setup__button:disabled:hover { filter: none; }
 
 @media (max-width: 640px) {
   .desktop-setup { margin: var(--space-4) auto; }

--- a/engines/collavre/app/javascript/controllers/__tests__/desktop_proxy_setup_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/desktop_proxy_setup_controller.test.js
@@ -23,7 +23,7 @@ describe("DesktopProxySetupController", () => {
            data-desktop-proxy-setup-unavailable-value="Desktop support is unavailable"
            data-desktop-proxy-setup-failed-value="Setup failed">
         <input type="checkbox" data-desktop-proxy-setup-target="consent">
-        <button data-desktop-proxy-setup-target="submit"></button>
+      <button disabled data-desktop-proxy-setup-target="submit"></button>
         <p hidden data-desktop-proxy-setup-target="error"></p>
       </div>`
     application = Application.start()
@@ -48,6 +48,8 @@ describe("DesktopProxySetupController", () => {
   })
 
   test("enables installation only after consent", () => {
+    expect(controller.submitTarget.disabled).toBe(true)
+
     controller.consentTarget.checked = false
     controller.toggle()
     expect(controller.submitTarget.disabled).toBe(true)
@@ -57,9 +59,21 @@ describe("DesktopProxySetupController", () => {
     expect(controller.submitTarget.disabled).toBe(false)
   })
 
+  test("does not start installation without consent", async () => {
+    const invoke = jest.fn()
+    window.__TAURI__ = { core: { invoke } }
+
+    await controller.install()
+
+    expect(csrfFetch).not.toHaveBeenCalled()
+    expect(invoke).not.toHaveBeenCalled()
+    expect(controller.submitTarget.disabled).toBe(true)
+  })
+
   test("registers through Tauri and retains the adapter step", async () => {
     const invoke = jest.fn().mockResolvedValue({ adapters: [ "claude" ] })
     window.__TAURI__ = { core: { invoke } }
+    controller.consentTarget.checked = true
     csrfFetch.mockResolvedValue({ ok: true, json: async () => ({ token: "grant" }) })
     const navigate = jest.spyOn(controller, "navigate").mockImplementation(() => {})
 

--- a/engines/collavre/app/javascript/controllers/desktop_proxy_setup_controller.js
+++ b/engines/collavre/app/javascript/controllers/desktop_proxy_setup_controller.js
@@ -19,6 +19,11 @@ export default class extends Controller {
   }
 
   async install() {
+    if (!this.consentTarget.checked) {
+      this.submitTarget.disabled = true
+      return
+    }
+
     this.errorTarget.hidden = true
     this.submitTarget.disabled = true
 


### PR DESCRIPTION
## Summary

- show the desktop gateway installation button as disabled until consent is checked
- block direct controller invocation before consent, so no registration token or native command is requested
- cover the initial state, unconsented invocation, and consented installation path

## Why

The disabled installation button used the same visual styling as an enabled button, making it appear actionable before consent was granted.

## Validation

- `npm test -- --runInBand engines/collavre/app/javascript/controllers/__tests__/desktop_proxy_setup_controller.test.js`
- `npx stylelint engines/collavre/app/assets/stylesheets/collavre/desktop_setup.css` (one pre-existing duplicate-selector warning)
- `mise exec ruby@3.4.4 -- bin/rails test engines/collavre/test/controllers/desktop_setup_controller_test.rb`
- `mise exec ruby@3.4.4 -- ./bin/rubocop -a`

`bin/rails test` is blocked by 11 pre-existing GitHub webhook test errors because `active_record_encryption.primary_key` is unavailable in this local environment.