### PR TITLE
fix: support Tauri desktop drag and drop

### DIFF
--- a/docs/superpowers/specs/2026-06-11-desktop-tauri-macos-design.md
+++ b/docs/superpowers/specs/2026-06-11-desktop-tauri-macos-design.md
@@ -1,7 +1,7 @@
 # Collavre Desktop (Tauri, macOS) — Design
 
 Date: 2026-06-11
-Status: Draft (awaiting approval)
+Status: Implemented baseline; update this document with desktop architecture decisions
 Worktree: `plan42-worktree221` / branch `feat/desktop-tauri-macos`
 
 ## Goal
@@ -35,11 +35,17 @@ Two units with one clear interface (HTTP over loopback):
 
 ### 1. Tauri shell (Rust)
 - Minimal window using the OS webview. No custom frontend.
-- On launch: choose a free ephemeral port, spawn the Rails **sidecar**
-  (`externalBin`), poll `GET /up` until healthy, then load
-  `http://127.0.0.1:<port>`.
+- On launch: use the stable `127.0.0.1:4000` default, spawn the Rails
+  **sidecar** (`externalBin`), poll `GET /up` until healthy, then load
+  `http://127.0.0.1:4000`. A valid, explicitly configured `PORT` may override
+  that default.
+- Never silently select an ephemeral fallback when the configured port is
+  occupied. The stable loopback origin is required for local firewall rules and
+  future PKCE/loopback OAuth callback registration; an alternate port must be
+  explicitly configured and registered before use.
 - On quit: graceful shutdown of the sidecar (SIGTERM, then SIGKILL fallback).
-- Owns: window lifecycle, port selection, health-gating, process supervision.
+- Owns: window lifecycle, fixed-port configuration, health-gating, process
+  supervision.
 
 ### 2. Rails sidecar (bundled Ruby + app)
 - Runs in a new **`desktop` Rails environment** that inherits production
@@ -119,7 +125,7 @@ risk with Rails runtime paths / asset pipeline — deferred.)
 
 1. **Headless boot** — add `desktop` env; boot Rails with sqlite + local storage
    + no SSL + generated secret, data under app-support. Confirm the full app
-   works at `http://127.0.0.1:<port>`. No Tauri yet. ← validates everything.
+   works at `http://127.0.0.1:4000`. No Tauri yet. ← validates everything.
 2. **Vendored Ruby boot** — vendor portable arm64 Ruby + standalone bundle; boot
    the same with vendored Ruby instead of rbenv.
 3. **Tauri shell** — spawn sidecar, health-gate `/up`, webview, graceful quit.

--- a/engines/collavre/app/helpers/collavre/application_helper.rb
+++ b/engines/collavre/app/helpers/collavre/application_helper.rb
@@ -83,6 +83,12 @@ module Collavre
         !@auto_fullscreen
     end
 
+    # Identifies requests made by the packaged Tauri shell. Desktop-only UI
+    # fallbacks should use this rather than attempting platform browser checks.
+    def desktop?
+      request.user_agent.to_s.start_with?("CollavreDesktop/")
+    end
+
     # Renders CSS for admin-configured default themes (light/dark mode)
     # Only applies when the user has no personal theme set
     def default_theme_styles

--- a/engines/collavre/test/helpers/application_helper_test.rb
+++ b/engines/collavre/test/helpers/application_helper_test.rb
@@ -36,4 +36,16 @@ class Collavre::ApplicationHelperTest < ActionView::TestCase
     Current.user = nil
     assert_equal "", body_theme_class
   end
+
+  test "desktop? recognizes the packaged desktop user agent" do
+    @request.headers["HTTP_USER_AGENT"] = "CollavreDesktop/0.1.0"
+
+    assert_predicate self, :desktop?
+  end
+
+  test "desktop? ignores browser user agents" do
+    @request.headers["HTTP_USER_AGENT"] = "Mozilla/5.0"
+
+    assert_not desktop?
+  end
 end

--- a/tools/desktop-app/README.md
+++ b/tools/desktop-app/README.md
@@ -40,6 +40,20 @@ commas):
 A missing or malformed file is the normal closed-loopback case and is ignored
 (the app never fails to launch over a bad config).
 
+## Port policy
+
+The desktop shell uses `http://127.0.0.1:4000` when no valid `PORT` setting is
+provided. This origin is deliberately stable so local firewall rules and future
+PKCE/loopback OAuth callback registrations can target one URL. A valid `PORT`
+environment variable or `config.json` `port` value is an explicit override; an
+OAuth client using one must register that alternate callback URL.
+
+The shell never silently falls back to an ephemeral port when the selected port
+is occupied. Starting on a different port would appear to work while breaking
+registered callbacks and firewall rules. Port-collision recovery is a separate
+user-facing concern and must preserve an explicitly configured, registered
+origin.
+
 ## Layout
 
 ```

--- a/tools/desktop-app/README.md
+++ b/tools/desktop-app/README.md
@@ -35,7 +35,7 @@ commas):
 
 - `allowed_hosts` — a JSON array, or a `"a,b"` comma-separated string.
 - `bind_host` — omit to stay on loopback (`127.0.0.1`); set `"0.0.0.0"` to open.
-- `port` — omit for an ephemeral port.
+- `port` — omit to use the stable default, `4000`.
 
 A missing or malformed file is the normal closed-loopback case and is ignored
 (the app never fails to launch over a bad config).
@@ -49,7 +49,7 @@ tools/desktop-app/
     Cargo.toml
     tauri.conf.json
     build.rs
-    src/{main,lib}.rs        # free port → spawn sidecar → health-gate /up → webview
+    src/{main,lib}.rs        # stable port → spawn sidecar → health-gate /up → webview
     capabilities/default.json
     dist/index.html          # placeholder (real UI is the server-rendered app)
   scripts/

--- a/tools/desktop-app/src-tauri/src/lib.rs
+++ b/tools/desktop-app/src-tauri/src/lib.rs
@@ -1,7 +1,7 @@
 //! Collavre Desktop shell.
 //!
 //! Responsibilities (and nothing else — the UI is the server-rendered Rails app):
-//!   1. Pick a free loopback port.
+//!   1. Start the sidecar on a stable loopback port.
 //!   2. Spawn the bundled Rails sidecar (`bin/desktop-server`) pointed at a
 //!      writable data dir under the OS app-data location.
 //!   3. Health-gate `GET /up` until the server is ready.
@@ -22,6 +22,9 @@ use hmac::{Hmac, Mac};
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;
 use tauri::{Manager, RunEvent, WebviewUrl, WebviewWindowBuilder};
+
+const DEFAULT_PORT: u16 = 4000;
+const DESKTOP_USER_AGENT: &str = concat!("CollavreDesktop/", env!("CARGO_PKG_VERSION"));
 
 /// Holds the sidecar child so we can stop it on exit.
 struct Sidecar {
@@ -104,6 +107,13 @@ fn free_port() -> u16 {
         .local_addr()
         .expect("local addr")
         .port()
+}
+
+/// Returns a valid configured port or the stable desktop default.
+fn desktop_port(port: Option<&str>) -> u16 {
+    port.and_then(|value| value.parse::<u16>().ok())
+        .filter(|port| *port != 0)
+        .unwrap_or(DEFAULT_PORT)
 }
 
 /// Locate the macOS application resource directory from its executable.
@@ -1353,7 +1363,7 @@ fn apply_desktop_config(data: &Path) {
 mod tests {
     use super::{
         append_unique_paths, config_env_overrides, configure_desktop_proxy_environment,
-        generate_proxy_key, invalidate_proxy_registration_after_key_regeneration,
+        desktop_port, generate_proxy_key, invalidate_proxy_registration_after_key_regeneration,
         invalidate_proxy_registration_when_gateway_is_missing, lsof_reports_process,
         managed_proxy_credentials, managed_proxy_runs_on_port, migrate_proxy_config,
         normalized_proxy_config, nvm_bin_paths, parse_bundled_proxy_manifest, read_proxy_config,
@@ -1361,7 +1371,7 @@ mod tests {
         replace_occupied_proxy_port, revalidate_registered_gateway_after_rails_health,
         valid_sidecar_challenge_response, wait_until_proxy_healthy, write_proxy_config,
         GatewayRegistration, HmacSha256, ManagedProxy, ProxyConfig, ProxyCredentials, ProxySidecar,
-        Sidecar, URL_SAFE_NO_PAD,
+        Sidecar, DEFAULT_PORT, DESKTOP_USER_AGENT, URL_SAFE_NO_PAD,
     };
     use base64::Engine;
     use hmac::Mac;
@@ -1378,6 +1388,23 @@ mod tests {
 
     fn pairs(json: &str) -> Vec<(&'static str, String)> {
         config_env_overrides(json)
+    }
+
+    #[test]
+    fn desktop_port_defaults_to_the_stable_port() {
+        assert_eq!(desktop_port(None), DEFAULT_PORT);
+        assert_eq!(desktop_port(Some("not-a-port")), DEFAULT_PORT);
+        assert_eq!(desktop_port(Some("0")), DEFAULT_PORT);
+    }
+
+    #[test]
+    fn desktop_port_honors_a_valid_override() {
+        assert_eq!(desktop_port(Some("47821")), 47_821);
+    }
+
+    #[test]
+    fn desktop_user_agent_has_a_stable_prefix() {
+        assert!(DESKTOP_USER_AGENT.starts_with("CollavreDesktop/"));
     }
 
     #[cfg(unix)]
@@ -2047,14 +2074,11 @@ pub fn run() {
             // read below so the values actually take effect this launch.
             apply_desktop_config(&data);
 
-            // Honor a caller-supplied PORT so open mode gets a stable URL/firewall
-            // rule; fall back to an ephemeral loopback port for the default
-            // single-user case. The same `port` feeds the sidecar, health check,
-            // and webview URL, so reading it here keeps all three consistent.
-            let port = std::env::var("PORT")
-                .ok()
-                .and_then(|p| p.parse::<u16>().ok())
-                .unwrap_or_else(free_port);
+            // Keep the default URL stable for loopback OAuth callbacks and local
+            // firewall rules. A valid caller-supplied PORT still wins. The same
+            // value feeds the sidecar, health check, and webview URL.
+            let configured_port = std::env::var("PORT").ok();
+            let port = desktop_port(configured_port.as_deref());
             // Reap any sidecar orphaned by a prior crash before we spawn — it
             // still holds this data dir's SQLite write locks.
             reap_orphan_sidecar(&data);
@@ -2074,6 +2098,11 @@ pub fn run() {
                 // handler. Returning true accepts its suggested destination and
                 // filename, including downloads triggered by `<a download>`.
                 .on_download(|_, _| true)
+                // Let browser-level drag and drop reach the Rails application.
+                .disable_drag_drop_handler()
+                // Lets Rails tailor desktop-only fallbacks without depending on
+                // platform-specific browser detection.
+                .user_agent(DESKTOP_USER_AGENT)
                 .build()?;
 
             // Health-gate startup off the UI thread so the splash keeps animating.


### PR DESCRIPTION
## Summary
- Use port 4000 by default for the desktop sidecar while preserving valid `PORT` overrides.
- Disable Tauri's native drag-and-drop handler so Rails HTML5 drag-and-drop receives events.
- Send a desktop-specific user agent and add the Rails `desktop?` helper for future desktop fallbacks.

## Why
The desktop shell previously selected an ephemeral default port and intercepted drag-and-drop events before the Rails UI could process them.

## Validation
- `cargo test` (30 passed)
- `bin/rails test engines/collavre/test/helpers/application_helper_test.rb` (7 passed)
- `./bin/rubocop -a` (no offenses)

`bin/rails test` is blocked by missing Active Record encryption credentials in existing GitHub integration tests. `bin/rails test:system` is blocked because this checkout has no `test/system` directory.