### PR TITLE
feat(desktop): add release script

### DIFF
--- a/script/release-desktop.sh
+++ b/script/release-desktop.sh
@@ -1,0 +1,274 @@
+#!/usr/bin/env bash
+# Build, notarize, and publish one signed Apple-Silicon Collavre Desktop DMG.
+#
+# The Tauri config is the canonical desktop version. Cargo.toml is kept in sync
+# because Cargo requires a package version too. This script is deliberately
+# interactive: it proposes a semver bump, but never creates a version commit or
+# a GitHub Release until an operator confirms the exact version.
+set -euo pipefail
+
+PROJECT_ROOT="$(cd -P "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DESKTOP_DIR="$PROJECT_ROOT/tools/desktop-app"
+TAURI_DIR="$DESKTOP_DIR/src-tauri"
+TAURI_CONFIG="$TAURI_DIR/tauri.conf.json"
+CARGO_TOML="$TAURI_DIR/Cargo.toml"
+CARGO_LOCK="$TAURI_DIR/Cargo.lock"
+TAG_PREFIX="desktop-v"
+ARTIFACT_DIR="$PROJECT_ROOT/build/desktop-release"
+RELEASE_ARTIFACT=""
+
+die() {
+  echo "[release-desktop] $*" >&2
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || die "required command is unavailable: $1"
+}
+
+valid_semver() {
+  [[ "$1" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]
+}
+
+bump_version() {
+  local version="$1"
+  local level="$2"
+  local major minor patch
+  version="${version%%+*}"
+  version="${version%%-*}"
+  IFS=. read -r major minor patch <<< "$version"
+
+  case "$level" in
+    major) printf '%s.0.0\n' "$((major + 1))" ;;
+    minor) printf '%s.%s.0\n' "$major" "$((minor + 1))" ;;
+    patch) printf '%s.%s.%s\n' "$major" "$minor" "$((patch + 1))" ;;
+    *) die "unknown semver bump level: $level" ;;
+  esac
+}
+
+version_bump_level() {
+  local range="$1"
+  local messages
+  messages="$(git log --format=%B "$range" -- "$DESKTOP_DIR")"
+
+  if grep -Eq '(^|\n)(BREAKING CHANGE:|[A-Za-z]+(\([^)]+\))?!:)' <<< "$messages"; then
+    printf 'major\n'
+  elif grep -Eq '(^|\n)feat(\([^)]+\))?:' <<< "$messages"; then
+    printf 'minor\n'
+  else
+    printf 'patch\n'
+  fi
+}
+
+desktop_version() {
+  ruby -rjson -e 'print JSON.parse(File.read(ARGV.fetch(0))).fetch("version")' "$TAURI_CONFIG"
+}
+
+cargo_version() {
+  ruby -e '
+    content = File.read(ARGV.fetch(0))
+    match = content.match(/\[package\][\s\S]*?^version = "([^"]+)"/)
+    abort "Cargo package version is missing" unless match
+    print match[1]
+  ' "$CARGO_TOML"
+}
+
+cargo_lock_version() {
+  ruby -e '
+    content = File.read(ARGV.fetch(0))
+    match = content.match(/\[\[package\]\]\s+name = "collavre-desktop"\s+version = "([^"]+)"/)
+    abort "Cargo lock package version is missing" unless match
+    print match[1]
+  ' "$CARGO_LOCK"
+}
+
+update_versions() {
+  local version="$1"
+  ruby -rjson -e '
+    path, version = ARGV
+    config = JSON.parse(File.read(path))
+    config["version"] = version
+    File.write(path, JSON.pretty_generate(config) + "\n")
+  ' "$TAURI_CONFIG" "$version"
+  ruby -e '
+    path, version = ARGV
+    content = File.read(path)
+    updated = content.sub(/(\[package\][\s\S]*?^version = ")[^"]+(")/) { "#{$1}#{version}#{$2}" }
+    abort "Cargo package version is missing" if updated == content
+    File.write(path, updated)
+  ' "$CARGO_TOML" "$version"
+  ruby -e '
+    path, version = ARGV
+    content = File.read(path)
+    updated = content.sub(/(\[\[package\]\]\s+name = "collavre-desktop"\s+version = ")[^"]+(")/) { "#{$1}#{version}#{$2}" }
+    abort "Cargo lock package version is missing" if updated == content
+    File.write(path, updated)
+  ' "$CARGO_LOCK" "$version"
+}
+
+release_notes() {
+  local range="$1"
+  local version="$2"
+
+  {
+    printf '# Collavre Desktop %s\n\n' "$version"
+    printf '## Changes\n\n'
+    git log --format='- %s (%h)' "$range" -- "$DESKTOP_DIR"
+  } > "$ARTIFACT_DIR/release-notes.md"
+}
+
+check_prerequisites() {
+  [[ "$(uname -s)" == "Darwin" ]] || die "desktop releases must run on macOS"
+  [[ "$(uname -m)" == "arm64" ]] || die "desktop releases must run on Apple Silicon (arm64)"
+  [[ "$(git branch --show-current)" == "main" ]] || die "run from the main branch"
+  [[ -z "$(git status --porcelain)" ]] || die "working tree is not clean"
+
+  for command in git gh ruby npm bundle cargo codesign security spctl xcrun shasum hdiutil; do
+    require_command "$command"
+  done
+
+  [[ -n "${APPLE_SIGNING_IDENTITY:-}" ]] || die "APPLE_SIGNING_IDENTITY is required"
+  [[ -n "${APPLE_ID:-}" ]] || die "APPLE_ID is required"
+  [[ -n "${APPLE_APP_SPECIFIC_PASSWORD:-}" ]] || die "APPLE_APP_SPECIFIC_PASSWORD is required"
+  [[ -n "${APPLE_TEAM_ID:-}" ]] || die "APPLE_TEAM_ID is required"
+  [[ -n "${NODE_RUNTIME_DIR:-}" || ( -n "${NODE_RUNTIME_URL:-}" && -n "${NODE_RUNTIME_SHA256:-}" ) ]] || \
+    die "set NODE_RUNTIME_DIR or both NODE_RUNTIME_URL and NODE_RUNTIME_SHA256"
+
+  security find-identity -v -p codesigning | grep -Fq "$APPLE_SIGNING_IDENTITY" || \
+    die "APPLE_SIGNING_IDENTITY is not available in this keychain"
+  gh auth status >/dev/null 2>&1 || die "GitHub CLI is not authenticated"
+}
+
+run_checks() {
+  (
+    local staging_dir="$DESKTOP_DIR/staging/app"
+    local remove_staging=0
+    if [[ ! -d "$staging_dir" ]]; then
+      mkdir -p "$staging_dir"
+      remove_staging=1
+    fi
+    trap 'if ((remove_staging)); then rm -rf "$DESKTOP_DIR/staging"; fi' EXIT
+
+    local icon_source
+    icon_source="$(find "$PROJECT_ROOT/public" -maxdepth 1 -type f -name 'icon-*.png' -print -quit)"
+    [[ -n "$icon_source" ]] || die "desktop source icon is missing from public/"
+    (
+      cd "$TAURI_DIR"
+      cargo tauri icon "$icon_source"
+    )
+
+    echo "[release-desktop] Running desktop Rust tests..."
+    cargo test --manifest-path "$CARGO_TOML"
+  )
+  echo "[release-desktop] Building Rails test assets..."
+  npm ci
+  npm run build
+  echo "[release-desktop] Running Rails tests..."
+  bundle exec rake test
+  bundle exec rake test:system
+}
+
+build_notarized_dmg() {
+  local version="$1"
+  local source_dmg app_path artifact checksum
+
+  echo "[release-desktop] Building signed DMG..."
+  rm -rf "$TAURI_DIR/target/release/bundle/dmg"
+  "$DESKTOP_DIR/scripts/build-macos.sh"
+
+  app_path="$TAURI_DIR/target/release/bundle/macos/Collavre Desktop.app"
+  [[ -d "$app_path" ]] || die "Tauri app bundle was not created: $app_path"
+  codesign --verify --deep --strict --verbose=2 "$app_path"
+
+  source_dmg="$(find "$TAURI_DIR/target/release/bundle/dmg" -maxdepth 1 -type f -name '*.dmg' -print -quit 2>/dev/null || true)"
+  [[ -n "$source_dmg" ]] || die "Tauri DMG was not created"
+  artifact="$ARTIFACT_DIR/Collavre-Desktop_${version}_aarch64.dmg"
+  cp "$source_dmg" "$artifact"
+
+  echo "[release-desktop] Submitting DMG to Apple notarization..."
+  xcrun notarytool submit "$artifact" --wait \
+    --apple-id "$APPLE_ID" \
+    --password "$APPLE_APP_SPECIFIC_PASSWORD" \
+    --team-id "$APPLE_TEAM_ID"
+  xcrun stapler staple "$artifact"
+  xcrun stapler validate "$artifact"
+
+  local mount_dir
+  mount_dir="$(mktemp -d)"
+  trap 'hdiutil detach "$mount_dir" -quiet 2>/dev/null || true; rmdir "$mount_dir" 2>/dev/null || true' RETURN
+  hdiutil attach "$artifact" -readonly -nobrowse -mountpoint "$mount_dir" >/dev/null
+  [[ -d "$mount_dir/Collavre Desktop.app" ]] || die "DMG does not contain Collavre Desktop.app"
+  codesign --verify --deep --strict --verbose=2 "$mount_dir/Collavre Desktop.app"
+  spctl --assess --type execute --verbose=4 "$mount_dir/Collavre Desktop.app"
+  hdiutil detach "$mount_dir" -quiet
+  rmdir "$mount_dir"
+  trap - RETURN
+
+  checksum="$ARTIFACT_DIR/Collavre-Desktop_${version}_aarch64.dmg.sha256"
+  shasum -a 256 "$artifact" > "$checksum"
+  RELEASE_ARTIFACT="$artifact"
+}
+
+main() {
+  cd "$PROJECT_ROOT"
+  check_prerequisites
+
+  git fetch origin main --tags
+  git pull --ff-only origin main
+
+  local current_version previous_tag range bump suggested_version selected_version tag artifact
+  current_version="$(desktop_version)"
+  valid_semver "$current_version" || die "Tauri version is not valid semver: $current_version"
+  [[ "$current_version" == "$(cargo_version)" && "$current_version" == "$(cargo_lock_version)" ]] || \
+    die "Tauri, Cargo manifest, and Cargo lock versions must match"
+
+  previous_tag="$(git tag --list "${TAG_PREFIX}*" --sort=-v:refname | head -1)"
+  if [[ -n "$previous_tag" ]]; then
+    range="$previous_tag..HEAD"
+    if [[ -z "$(git log --oneline "$range" -- "$DESKTOP_DIR")" ]]; then
+      die "no desktop changes since $previous_tag"
+    fi
+  else
+    range="HEAD"
+  fi
+  bump="$(version_bump_level "$range")"
+  suggested_version="$(bump_version "$current_version" "$bump")"
+
+  printf 'Current version: %s\n' "$current_version"
+  printf 'Suggested version: %s (%s bump)\n' "$suggested_version" "$bump"
+  read -r -p "Release version [$suggested_version]: " selected_version
+  selected_version="${selected_version:-$suggested_version}"
+  valid_semver "$selected_version" || die "release version must be valid semver"
+  tag="${TAG_PREFIX}${selected_version}"
+  git rev-parse -q --verify "refs/tags/$tag" >/dev/null && die "tag already exists locally: $tag"
+  git ls-remote --exit-code --tags origin "refs/tags/$tag" >/dev/null 2>&1 && die "tag already exists on origin: $tag"
+
+  printf '\nDesktop commits included in this release:\n'
+  git log --oneline "$range" -- "$DESKTOP_DIR"
+  read -r -p "Commit version $selected_version, build, notarize, and publish $tag? [y/N] " confirm
+  [[ "$confirm" =~ ^[Yy]$ ]] || die "release cancelled"
+
+  mkdir -p "$ARTIFACT_DIR"
+  release_notes "$range" "$selected_version"
+  update_versions "$selected_version"
+  git add "$TAURI_CONFIG" "$CARGO_TOML" "$CARGO_LOCK"
+  git commit -m "chore(desktop): release v$selected_version"
+
+  run_checks
+  build_notarized_dmg "$selected_version"
+  artifact="$RELEASE_ARTIFACT"
+
+  git tag -a "$tag" -m "Collavre Desktop $selected_version"
+  git push origin main
+  git push origin "$tag"
+  gh release create "$tag" "$artifact" "${artifact}.sha256" \
+    --title "Collavre Desktop $selected_version" \
+    --notes-file "$ARTIFACT_DIR/release-notes.md" \
+    --verify-tag
+
+  echo "[release-desktop] Published $tag"
+}
+
+if [[ "${RELEASE_DESKTOP_LIB_ONLY:-0}" != "1" ]]; then
+  main "$@"
+fi

--- a/script/release-desktop.sh
+++ b/script/release-desktop.sh
@@ -27,7 +27,20 @@ require_command() {
 }
 
 valid_semver() {
-  [[ "$1" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]
+  local version="$1"
+  local prerelease identifier
+
+  [[ "$version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]] || return 1
+
+  prerelease="${version%%+*}"
+  [[ "$prerelease" == *-* ]] || return 0
+  prerelease="${prerelease#*-}"
+  IFS=. read -r -a prerelease <<< "$prerelease"
+  for identifier in "${prerelease[@]}"; do
+    # SemVer permits a numeric prerelease identifier of 0, but not 01, 002,
+    # and so on. Cargo enforces the same rule, so reject before committing.
+    [[ ! "$identifier" =~ ^[0-9]+$ || "$identifier" == "0" || "$identifier" != 0* ]] || return 1
+  done
 }
 
 # Print -1, 0, or 1 when the first SemVer has lower, equal, or higher
@@ -235,6 +248,13 @@ write_checksum() {
     cd "$artifact_dir"
     shasum -a 256 "$artifact_name"
   ) > "$checksum"
+}
+
+prepare_artifact_dir() {
+  # build-macos stages PROJECT_ROOT into the app. Remove artifacts from a prior
+  # release attempt before staging so a DMG never embeds another DMG/app.
+  rm -rf "$ARTIFACT_DIR"
+  mkdir -p "$ARTIFACT_DIR"
 }
 
 cleanup_mounted_dmg() {
@@ -520,7 +540,7 @@ main() {
   fi
   [[ "$confirm" =~ ^[Yy]$ ]] || die "release cancelled"
 
-  mkdir -p "$ARTIFACT_DIR"
+  prepare_artifact_dir
   release_notes "$range" "$selected_version"
   if [[ -z "$resume_version" ]]; then
     update_versions "$selected_version"

--- a/script/release-desktop.sh
+++ b/script/release-desktop.sh
@@ -421,7 +421,7 @@ check_prerequisites() {
   [[ "$(git branch --show-current)" == "main" ]] || die "run from the main branch"
   [[ -z "$(git status --porcelain)" ]] || die "working tree is not clean"
 
-  for command in git gh ruby npm bundle cargo codesign security spctl xcrun shasum hdiutil; do
+  for command in git gh ruby node npm bundle cargo codesign security spctl xcrun shasum hdiutil curl tar; do
     require_command "$command"
   done
   check_desktop_build_prerequisites
@@ -430,12 +430,8 @@ check_prerequisites() {
   [[ -n "${APPLE_ID:-}" ]] || die "APPLE_ID is required"
   [[ -n "${APPLE_APP_SPECIFIC_PASSWORD:-}" ]] || die "APPLE_APP_SPECIFIC_PASSWORD is required"
   [[ -n "${APPLE_TEAM_ID:-}" ]] || die "APPLE_TEAM_ID is required"
-  if [[ -z "${NODE_RUNTIME_DIR:-}" ]]; then
-    if [[ -n "${NODE_RUNTIME_URL:-}" || -n "${NODE_RUNTIME_SHA256:-}" ]]; then
-      [[ -n "${NODE_RUNTIME_URL:-}" && -n "${NODE_RUNTIME_SHA256:-}" ]] || die "set both NODE_RUNTIME_URL and NODE_RUNTIME_SHA256"
-    else
-      require_command node
-    fi
+  if [[ -z "${NODE_RUNTIME_DIR:-}" && ( -n "${NODE_RUNTIME_URL:-}" || -n "${NODE_RUNTIME_SHA256:-}" ) ]]; then
+    [[ -n "${NODE_RUNTIME_URL:-}" && -n "${NODE_RUNTIME_SHA256:-}" ]] || die "set both NODE_RUNTIME_URL and NODE_RUNTIME_SHA256"
   fi
 
   security find-identity -v -p codesigning | grep -Fq "$APPLE_SIGNING_IDENTITY" || \

--- a/script/release-desktop.sh
+++ b/script/release-desktop.sh
@@ -30,6 +30,54 @@ valid_semver() {
   [[ "$1" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]
 }
 
+# Print -1, 0, or 1 when the first SemVer has lower, equal, or higher
+# precedence than the second. Build metadata intentionally has no precedence.
+semver_compare() {
+  ruby -e '
+    def parse(version)
+      core_and_pre = version.split("+", 2).first
+      core, prerelease = core_and_pre.split("-", 2)
+      [core.split(".").map(&:to_i), prerelease&.split(".")]
+    end
+
+    def compare_identifiers(left, right)
+      left.zip(right).each do |a, b|
+	return -1 if a.nil?
+	return 1 if b.nil?
+	next if a == b
+
+	a_numeric = /\A\d+\z/.match?(a)
+	b_numeric = /\A\d+\z/.match?(b)
+	return a.to_i <=> b.to_i if a_numeric && b_numeric
+	return -1 if a_numeric
+	return 1 if b_numeric
+
+	return a <=> b
+      end
+      0
+    end
+
+    left_core, left_pre = parse(ARGV.fetch(0))
+    right_core, right_pre = parse(ARGV.fetch(1))
+    core_comparison = left_core <=> right_core
+    if core_comparison != 0
+      puts core_comparison
+    elsif left_pre.nil? && right_pre.nil?
+      puts 0
+    elsif left_pre.nil?
+      puts 1
+    elsif right_pre.nil?
+      puts(-1)
+    else
+      puts compare_identifiers(left_pre, right_pre)
+    end
+  ' "$1" "$2"
+}
+
+version_advances() {
+  [[ "$(semver_compare "$1" "$2")" -gt 0 ]]
+}
+
 bump_version() {
   local version="$1"
   local level="$2"
@@ -121,6 +169,43 @@ is_prerelease() {
   [[ "${1%%+*}" == *-* ]]
 }
 
+# Keep target-directory resolution identical to build-macos.sh. Cargo resolves
+# a relative CARGO_TARGET_DIR from src-tauri, and the release verifier must look
+# in that same location after the build completes.
+normalize_tauri_target_dir() {
+  local path="$1"
+  local component last_index normalized_path=""
+  local -a path_components=()
+  local -a normalized_components=()
+
+  [[ "$path" == /* ]] || path="$TAURI_DIR/$path"
+  IFS=/ read -r -a path_components <<< "$path"
+  for component in "${path_components[@]}"; do
+    case "$component" in
+      ""|.) ;;
+      ..)
+	if ((${#normalized_components[@]})); then
+	  last_index=$((${#normalized_components[@]} - 1))
+	  unset "normalized_components[$last_index]"
+	fi
+	;;
+      *) normalized_components+=("$component") ;;
+    esac
+  done
+  for component in "${normalized_components[@]}"; do
+    normalized_path+="/$component"
+  done
+  printf '%s\n' "${normalized_path:-/}"
+}
+
+tauri_target_dir() {
+  if [[ -n "${CARGO_TARGET_DIR:-}" ]]; then
+    normalize_tauri_target_dir "$CARGO_TARGET_DIR"
+  else
+    printf '%s\n' "$TAURI_DIR/target"
+  fi
+}
+
 write_checksum() {
   local artifact="$1"
   local checksum="$2"
@@ -153,6 +238,35 @@ ensure_release_tag() {
   else
     git tag -a "$tag" -m "Collavre Desktop $version"
   fi
+}
+
+reconcile_resumed_release() {
+  local tag="$1"
+  local version="$2"
+  local expected_message remote_tag
+  expected_message="$(release_commit_message "$version")"
+
+  [[ "$(git log -1 --format=%s HEAD)" == "$expected_message" ]] || \
+    die "resume requires HEAD to be the release commit: $expected_message"
+
+  # If the release commit is already on origin/main, keep it as the immutable
+  # release source even when newer commits have landed after it.
+  if git merge-base --is-ancestor HEAD origin/main; then
+    return
+  fi
+
+  remote_tag="$(git ls-remote --refs origin "refs/tags/$tag")"
+  [[ -z "$remote_tag" ]] || \
+    die "cannot rebase resumed release: $tag is already published on origin"
+
+  # A rejected main push leaves exactly the local release commit ahead of an
+  # advancing origin/main. Rebase it before rebuilding and recreate its local
+  # tag so the tag always names the rebuilt release commit.
+  [[ "$(git rev-list --count origin/main..HEAD)" == "1" ]] || \
+    die "resume requires exactly one unpushed release commit above origin/main"
+  git tag -d "$tag" >/dev/null 2>&1 || true
+  git rebase origin/main
+  ensure_release_tag "$tag" "$version"
 }
 
 publish_release() {
@@ -248,17 +362,18 @@ run_checks() {
 
 build_notarized_dmg() {
   local version="$1"
-  local source_dmg app_path artifact checksum
+  local source_dmg app_path artifact checksum target_dir
 
   echo "[release-desktop] Building signed DMG..."
-  rm -rf "$TAURI_DIR/target/release/bundle/dmg"
+  target_dir="$(tauri_target_dir)"
+  rm -rf "$target_dir/release/bundle/dmg"
   "$DESKTOP_DIR/scripts/build-macos.sh"
 
-  app_path="$TAURI_DIR/target/release/bundle/macos/Collavre Desktop.app"
+  app_path="$target_dir/release/bundle/macos/Collavre Desktop.app"
   [[ -d "$app_path" ]] || die "Tauri app bundle was not created: $app_path"
   codesign --verify --deep --strict --verbose=2 "$app_path"
 
-  source_dmg="$(find "$TAURI_DIR/target/release/bundle/dmg" -maxdepth 1 -type f -name '*.dmg' -print -quit 2>/dev/null || true)"
+  source_dmg="$(find "$target_dir/release/bundle/dmg" -maxdepth 1 -type f -name '*.dmg' -print -quit 2>/dev/null || true)"
   [[ -n "$source_dmg" ]] || die "Tauri DMG was not created"
   artifact="$ARTIFACT_DIR/Collavre-Desktop_${version}_aarch64.dmg"
   cp "$source_dmg" "$artifact"
@@ -291,9 +406,6 @@ main() {
   cd "$PROJECT_ROOT"
   check_prerequisites
 
-  git fetch origin main --tags
-  git pull --ff-only origin main
-
   local current_version previous_tag range bump suggested_version selected_version tag artifact resume_version=""
   if (($#)); then
     [[ $# -eq 2 && "$1" == "--resume" ]] || die "usage: $0 [--resume VERSION]"
@@ -301,10 +413,26 @@ main() {
     valid_semver "$resume_version" || die "resume version must be valid semver"
   fi
 
+  git fetch origin main --tags
+  if [[ -z "$resume_version" ]]; then
+    git pull --ff-only origin main
+  fi
+
   current_version="$(desktop_version)"
   valid_semver "$current_version" || die "Tauri version is not valid semver: $current_version"
   [[ "$current_version" == "$(cargo_version)" && "$current_version" == "$(cargo_lock_version)" ]] || \
     die "Tauri, Cargo manifest, and Cargo lock versions must match"
+
+  if [[ -n "$resume_version" ]]; then
+    selected_version="$resume_version"
+    [[ "$current_version" == "$selected_version" ]] || \
+      die "resume version $selected_version does not match current version $current_version"
+    tag="${TAG_PREFIX}${selected_version}"
+    reconcile_resumed_release "$tag" "$selected_version"
+    current_version="$(desktop_version)"
+    [[ "$current_version" == "$selected_version" ]] || \
+      die "resume version $selected_version does not match the rebased release commit"
+  fi
 
   previous_tag="$(git tag --list "${TAG_PREFIX}*" --sort=-v:refname)"
   if [[ -n "$resume_version" ]]; then
@@ -320,11 +448,7 @@ main() {
   else
     range="HEAD"
   fi
-  if [[ -n "$resume_version" ]]; then
-    selected_version="$resume_version"
-    [[ "$current_version" == "$selected_version" ]] || \
-      die "resume version $selected_version does not match current version $current_version"
-  else
+  if [[ -z "$resume_version" ]]; then
     bump="$(version_bump_level "$range")"
     suggested_version="$(bump_version "$current_version" "$bump")"
 
@@ -334,13 +458,15 @@ main() {
     selected_version="${selected_version:-$suggested_version}"
   fi
   valid_semver "$selected_version" || die "release version must be valid semver"
-  tag="${TAG_PREFIX}${selected_version}"
+  tag="${tag:-${TAG_PREFIX}${selected_version}}"
   if [[ -z "$resume_version" ]]; then
     git rev-parse -q --verify "refs/tags/$tag" >/dev/null && die "tag already exists locally: $tag"
     git ls-remote --exit-code --tags origin "refs/tags/$tag" >/dev/null 2>&1 && die "tag already exists on origin: $tag"
+    version_advances "$selected_version" "$current_version" || \
+      die "release version must advance current version $current_version"
   fi
 
-  printf '\nDesktop commits included in this release:\n'
+  printf '\nBundled source commits included in this release:\n'
   git log --oneline "$range"
   if [[ -n "$resume_version" ]]; then
     read -r -p "Rebuild, notarize, and resume publishing $tag? [y/N] " confirm
@@ -364,8 +490,7 @@ main() {
   artifact="$RELEASE_ARTIFACT"
 
   ensure_release_tag "$tag" "$selected_version"
-  git push origin main
-  git push origin "$tag"
+  git push --atomic origin HEAD:main "refs/tags/$tag"
   publish_release "$tag" "$selected_version" "$artifact"
 
   echo "[release-desktop] Published $tag"

--- a/script/release-desktop.sh
+++ b/script/release-desktop.sh
@@ -49,7 +49,7 @@ bump_version() {
 version_bump_level() {
   local range="$1"
   local messages
-  messages="$(git log --format=%B "$range" -- "$DESKTOP_DIR")"
+  messages="$(git log --format=%B "$range")"
 
   if grep -Eq '(^|\n)(BREAKING CHANGE:|[A-Za-z]+(\([^)]+\))?!:)' <<< "$messages"; then
     printf 'major\n'
@@ -113,8 +113,86 @@ release_notes() {
   {
     printf '# Collavre Desktop %s\n\n' "$version"
     printf '## Changes\n\n'
-    git log --format='- %s (%h)' "$range" -- "$DESKTOP_DIR"
+    git log --format='- %s (%h)' "$range"
   } > "$ARTIFACT_DIR/release-notes.md"
+}
+
+is_prerelease() {
+  [[ "${1%%+*}" == *-* ]]
+}
+
+write_checksum() {
+  local artifact="$1"
+  local checksum="$2"
+  local artifact_dir artifact_name
+  artifact_dir="$(dirname "$artifact")"
+  artifact_name="$(basename "$artifact")"
+  (
+    cd "$artifact_dir"
+    shasum -a 256 "$artifact_name"
+  ) > "$checksum"
+}
+
+release_commit_message() {
+  local version="$1"
+  printf 'chore(desktop): release v%s' "$version"
+}
+
+ensure_release_tag() {
+  local tag="$1"
+  local version="$2"
+  local expected_message
+  expected_message="$(release_commit_message "$version")"
+
+  [[ "$(git log -1 --format=%s HEAD)" == "$expected_message" ]] || \
+    die "resume requires HEAD to be the release commit: $expected_message"
+
+  if git rev-parse -q --verify "refs/tags/$tag" >/dev/null; then
+    [[ "$(git rev-parse "$tag^{commit}")" == "$(git rev-parse HEAD)" ]] || \
+      die "existing tag $tag does not point to the release commit"
+  else
+    git tag -a "$tag" -m "Collavre Desktop $version"
+  fi
+}
+
+publish_release() {
+  local tag="$1"
+  local version="$2"
+  local artifact="$3"
+  local checksum="${artifact}.sha256"
+  local -a prerelease_flag=()
+
+  if is_prerelease "$version"; then
+    prerelease_flag+=(--prerelease)
+  fi
+
+  if gh release view "$tag" >/dev/null 2>&1; then
+    local -a missing_assets=()
+    local asset release_is_draft
+    release_is_draft="$(gh release view "$tag" --json isDraft --jq .isDraft)"
+    for asset in "$(basename "$artifact")" "$(basename "$checksum")"; do
+      if ! gh release view "$tag" --json assets --jq ".assets[].name | select(. == \"$asset\")" | grep -Fxq "$asset"; then
+	missing_assets+=("$ARTIFACT_DIR/$asset")
+      fi
+    done
+
+    if ((${#missing_assets[@]})); then
+      gh release upload "$tag" "${missing_assets[@]}"
+    fi
+    if [[ "$release_is_draft" == "true" ]]; then
+      gh release edit "$tag" --draft=false \
+	--title "Collavre Desktop $version" \
+	--notes-file "$ARTIFACT_DIR/release-notes.md" \
+	"${prerelease_flag[@]}"
+    fi
+    return
+  fi
+
+  gh release create "$tag" "$artifact" "$checksum" \
+    --title "Collavre Desktop $version" \
+    --notes-file "$ARTIFACT_DIR/release-notes.md" \
+    --verify-tag \
+    "${prerelease_flag[@]}"
 }
 
 check_prerequisites() {
@@ -205,7 +283,7 @@ build_notarized_dmg() {
   trap - RETURN
 
   checksum="$ARTIFACT_DIR/Collavre-Desktop_${version}_aarch64.dmg.sha256"
-  shasum -a 256 "$artifact" > "$checksum"
+  write_checksum "$artifact" "$checksum"
   RELEASE_ARTIFACT="$artifact"
 }
 
@@ -216,55 +294,79 @@ main() {
   git fetch origin main --tags
   git pull --ff-only origin main
 
-  local current_version previous_tag range bump suggested_version selected_version tag artifact
+  local current_version previous_tag range bump suggested_version selected_version tag artifact resume_version=""
+  if (($#)); then
+    [[ $# -eq 2 && "$1" == "--resume" ]] || die "usage: $0 [--resume VERSION]"
+    resume_version="$2"
+    valid_semver "$resume_version" || die "resume version must be valid semver"
+  fi
+
   current_version="$(desktop_version)"
   valid_semver "$current_version" || die "Tauri version is not valid semver: $current_version"
   [[ "$current_version" == "$(cargo_version)" && "$current_version" == "$(cargo_lock_version)" ]] || \
     die "Tauri, Cargo manifest, and Cargo lock versions must match"
 
-  previous_tag="$(git tag --list "${TAG_PREFIX}*" --sort=-v:refname | head -1)"
+  previous_tag="$(git tag --list "${TAG_PREFIX}*" --sort=-v:refname)"
+  if [[ -n "$resume_version" ]]; then
+    previous_tag="$(grep -Fxv "${TAG_PREFIX}${resume_version}" <<< "$previous_tag" | head -1 || true)"
+  else
+    previous_tag="$(head -1 <<< "$previous_tag")"
+  fi
   if [[ -n "$previous_tag" ]]; then
     range="$previous_tag..HEAD"
-    if [[ -z "$(git log --oneline "$range" -- "$DESKTOP_DIR")" ]]; then
+    if [[ -z "$(git log --oneline "$range")" ]]; then
       die "no desktop changes since $previous_tag"
     fi
   else
     range="HEAD"
   fi
-  bump="$(version_bump_level "$range")"
-  suggested_version="$(bump_version "$current_version" "$bump")"
+  if [[ -n "$resume_version" ]]; then
+    selected_version="$resume_version"
+    [[ "$current_version" == "$selected_version" ]] || \
+      die "resume version $selected_version does not match current version $current_version"
+  else
+    bump="$(version_bump_level "$range")"
+    suggested_version="$(bump_version "$current_version" "$bump")"
 
-  printf 'Current version: %s\n' "$current_version"
-  printf 'Suggested version: %s (%s bump)\n' "$suggested_version" "$bump"
-  read -r -p "Release version [$suggested_version]: " selected_version
-  selected_version="${selected_version:-$suggested_version}"
+    printf 'Current version: %s\n' "$current_version"
+    printf 'Suggested version: %s (%s bump)\n' "$suggested_version" "$bump"
+    read -r -p "Release version [$suggested_version]: " selected_version
+    selected_version="${selected_version:-$suggested_version}"
+  fi
   valid_semver "$selected_version" || die "release version must be valid semver"
   tag="${TAG_PREFIX}${selected_version}"
-  git rev-parse -q --verify "refs/tags/$tag" >/dev/null && die "tag already exists locally: $tag"
-  git ls-remote --exit-code --tags origin "refs/tags/$tag" >/dev/null 2>&1 && die "tag already exists on origin: $tag"
+  if [[ -z "$resume_version" ]]; then
+    git rev-parse -q --verify "refs/tags/$tag" >/dev/null && die "tag already exists locally: $tag"
+    git ls-remote --exit-code --tags origin "refs/tags/$tag" >/dev/null 2>&1 && die "tag already exists on origin: $tag"
+  fi
 
   printf '\nDesktop commits included in this release:\n'
-  git log --oneline "$range" -- "$DESKTOP_DIR"
-  read -r -p "Commit version $selected_version, build, notarize, and publish $tag? [y/N] " confirm
+  git log --oneline "$range"
+  if [[ -n "$resume_version" ]]; then
+    read -r -p "Rebuild, notarize, and resume publishing $tag? [y/N] " confirm
+  else
+    read -r -p "Commit version $selected_version, build, notarize, and publish $tag? [y/N] " confirm
+  fi
   [[ "$confirm" =~ ^[Yy]$ ]] || die "release cancelled"
 
   mkdir -p "$ARTIFACT_DIR"
   release_notes "$range" "$selected_version"
-  update_versions "$selected_version"
-  git add "$TAURI_CONFIG" "$CARGO_TOML" "$CARGO_LOCK"
-  git commit -m "chore(desktop): release v$selected_version"
+  if [[ -z "$resume_version" ]]; then
+    update_versions "$selected_version"
+    git add "$TAURI_CONFIG" "$CARGO_TOML" "$CARGO_LOCK"
+    git commit -m "$(release_commit_message "$selected_version")"
+  else
+    ensure_release_tag "$tag" "$selected_version"
+  fi
 
   run_checks
   build_notarized_dmg "$selected_version"
   artifact="$RELEASE_ARTIFACT"
 
-  git tag -a "$tag" -m "Collavre Desktop $selected_version"
+  ensure_release_tag "$tag" "$selected_version"
   git push origin main
   git push origin "$tag"
-  gh release create "$tag" "$artifact" "${artifact}.sha256" \
-    --title "Collavre Desktop $selected_version" \
-    --notes-file "$ARTIFACT_DIR/release-notes.md" \
-    --verify-tag
+  publish_release "$tag" "$selected_version" "$artifact"
 
   echo "[release-desktop] Published $tag"
 }

--- a/script/release-desktop.sh
+++ b/script/release-desktop.sh
@@ -356,6 +356,26 @@ push_release_refs() {
   git push --atomic origin "${refs[@]}"
 }
 
+wait_for_release_ci() {
+  local commit run_id="" attempts=0
+  commit="$(git rev-parse HEAD)"
+
+  echo "[release-desktop] Waiting for CI on $commit..."
+  # The push event can take a few seconds to create a workflow run. Limit the
+  # polling window so an unavailable Actions service cannot leave a release
+  # process hanging indefinitely.
+  while ((attempts < 60)); do
+    run_id="$(gh run list --workflow CI --commit "$commit" --json databaseId --jq '.[0].databaseId')"
+    [[ -n "$run_id" ]] && break
+    ((attempts += 1))
+    sleep 5
+  done
+  [[ -n "$run_id" ]] || die "CI workflow did not start for release commit $commit"
+
+  gh run watch "$run_id" --exit-status || \
+    die "CI failed for release commit $commit; GitHub Release was not published"
+}
+
 ensure_main_matches_origin() {
   [[ "$(git rev-parse HEAD)" == "$(git rev-parse origin/main)" ]] || \
     die "local main must exactly match origin/main before creating a release"
@@ -621,6 +641,7 @@ main() {
 
   ensure_release_tag "$tag" "$selected_version"
   push_release_refs "$tag"
+  wait_for_release_ci
   publish_release "$tag" "$selected_version" "$artifact"
 
   echo "[release-desktop] Published $tag"

--- a/script/release-desktop.sh
+++ b/script/release-desktop.sh
@@ -182,6 +182,22 @@ is_prerelease() {
   [[ "${1%%+*}" == *-* ]]
 }
 
+stable_version() {
+  local version="${1%%+*}"
+  printf '%s\n' "${version%%-*}"
+}
+
+# A prerelease can be promoted to its matching stable version without a new
+# source commit, but only when the current HEAD is exactly that prerelease.
+can_promote_prerelease_at_head() {
+  local version="$1"
+  local tag="$2"
+
+  is_prerelease "$version" || return 1
+  [[ "$tag" == "${TAG_PREFIX}${version}" ]] || return 1
+  [[ "$(git rev-parse "$tag^{commit}")" == "$(git rev-parse HEAD)" ]]
+}
+
 # Git's version sort does not implement SemVer prerelease precedence (for
 # example, it can order 1.0.0-rc.1 ahead of 1.0.0). Select release tags using
 # the same comparator used for release-version validation instead.
@@ -478,7 +494,7 @@ main() {
   cd "$PROJECT_ROOT"
   check_prerequisites
 
-  local current_version previous_tag range bump suggested_version selected_version tag artifact resume_version=""
+  local current_version previous_tag range bump suggested_version selected_version tag artifact resume_version="" prerelease_promotion=0
   if (($#)); then
     [[ $# -eq 2 && "$1" == "--resume" ]] || die "usage: $0 [--resume VERSION]"
     resume_version="$2"
@@ -511,14 +527,23 @@ main() {
   if [[ -n "$previous_tag" ]]; then
     range="$previous_tag..HEAD"
     if [[ -z "$(git log --oneline "$range")" ]]; then
+      if [[ -z "$resume_version" ]] && can_promote_prerelease_at_head "$current_version" "$previous_tag"; then
+      prerelease_promotion=1
+      else
       die "no desktop changes since $previous_tag"
+      fi
     fi
   else
     range="HEAD"
   fi
   if [[ -z "$resume_version" ]]; then
-    bump="$(version_bump_level "$range")"
-    suggested_version="$(bump_version "$current_version" "$bump")"
+    if ((prerelease_promotion)); then
+      bump="prerelease promotion"
+      suggested_version="$(stable_version "$current_version")"
+    else
+      bump="$(version_bump_level "$range")"
+      suggested_version="$(bump_version "$current_version" "$bump")"
+    fi
 
     printf 'Current version: %s\n' "$current_version"
     printf 'Suggested version: %s (%s bump)\n' "$suggested_version" "$bump"
@@ -530,8 +555,13 @@ main() {
   if [[ -z "$resume_version" ]]; then
     git rev-parse -q --verify "refs/tags/$tag" >/dev/null && die "tag already exists locally: $tag"
     git ls-remote --exit-code --tags origin "refs/tags/$tag" >/dev/null 2>&1 && die "tag already exists on origin: $tag"
-    version_advances "$selected_version" "$current_version" || \
+    if ((prerelease_promotion)); then
+      [[ "$selected_version" == "$suggested_version" ]] || \
+      die "unchanged prerelease source can only promote to $suggested_version"
+    else
+      version_advances "$selected_version" "$current_version" || \
       die "release version must advance current version $current_version"
+    fi
   fi
 
   printf '\nBundled source commits included in this release:\n'

--- a/script/release-desktop.sh
+++ b/script/release-desktop.sh
@@ -430,8 +430,13 @@ check_prerequisites() {
   [[ -n "${APPLE_ID:-}" ]] || die "APPLE_ID is required"
   [[ -n "${APPLE_APP_SPECIFIC_PASSWORD:-}" ]] || die "APPLE_APP_SPECIFIC_PASSWORD is required"
   [[ -n "${APPLE_TEAM_ID:-}" ]] || die "APPLE_TEAM_ID is required"
-  [[ -n "${NODE_RUNTIME_DIR:-}" || ( -n "${NODE_RUNTIME_URL:-}" && -n "${NODE_RUNTIME_SHA256:-}" ) ]] || \
-    die "set NODE_RUNTIME_DIR or both NODE_RUNTIME_URL and NODE_RUNTIME_SHA256"
+  if [[ -z "${NODE_RUNTIME_DIR:-}" ]]; then
+    if [[ -n "${NODE_RUNTIME_URL:-}" || -n "${NODE_RUNTIME_SHA256:-}" ]]; then
+      [[ -n "${NODE_RUNTIME_URL:-}" && -n "${NODE_RUNTIME_SHA256:-}" ]] || die "set both NODE_RUNTIME_URL and NODE_RUNTIME_SHA256"
+    else
+      require_command node
+    fi
+  fi
 
   security find-identity -v -p codesigning | grep -Fq "$APPLE_SIGNING_IDENTITY" || \
     die "APPLE_SIGNING_IDENTITY is not available in this keychain"

--- a/script/release-desktop.sh
+++ b/script/release-desktop.sh
@@ -112,7 +112,7 @@ version_bump_level() {
   local messages
   messages="$(git log --format=%B "$range")"
 
-  if grep -Eq '(^|\n)(BREAKING CHANGE:|[A-Za-z]+(\([^)]+\))?!:)' <<< "$messages"; then
+  if grep -Eq '(^|\n)(BREAKING[ -]CHANGE:|[A-Za-z]+(\([^)]+\))?!:)' <<< "$messages"; then
     printf 'major\n'
   elif grep -Eq '(^|\n)feat(\([^)]+\))?:' <<< "$messages"; then
     printf 'minor\n'
@@ -341,39 +341,42 @@ publish_release() {
   local version="$2"
   local artifact="$3"
   local checksum="${artifact}.sha256"
-  local -a prerelease_flag=()
+  local -a create_args=(release create "$tag" --draft
+    --title "Collavre Desktop $version"
+    --notes-file "$ARTIFACT_DIR/release-notes.md"
+    --verify-tag)
 
-  if is_prerelease "$version"; then
-    prerelease_flag+=(--prerelease)
-  fi
+  is_prerelease "$version" && create_args+=(--prerelease)
 
   if gh release view "$tag" >/dev/null 2>&1; then
-    local -a missing_assets=()
-    local asset release_is_draft
+    local release_is_draft
     release_is_draft="$(gh release view "$tag" --json isDraft --jq .isDraft)"
-    for asset in "$(basename "$artifact")" "$(basename "$checksum")"; do
-      if ! gh release view "$tag" --json assets --jq ".assets[].name | select(. == \"$asset\")" | grep -Fxq "$asset"; then
-	missing_assets+=("$ARTIFACT_DIR/$asset")
-      fi
-    done
-
-    if ((${#missing_assets[@]})); then
-      gh release upload "$tag" "${missing_assets[@]}"
-    fi
     if [[ "$release_is_draft" == "true" ]]; then
-      gh release edit "$tag" --draft=false \
-	--title "Collavre Desktop $version" \
-	--notes-file "$ARTIFACT_DIR/release-notes.md" \
-	"${prerelease_flag[@]}"
+      # A failed upload can leave a draft with only one stale asset. Replace
+      # both artifacts from this build before publishing so the checksum and
+      # DMG always describe the same release output.
+      gh release upload "$tag" "$artifact" "$checksum" --clobber
+      publish_draft_release "$tag" "$version"
     fi
     return
   fi
 
-  gh release create "$tag" "$artifact" "$checksum" \
-    --title "Collavre Desktop $version" \
-    --notes-file "$ARTIFACT_DIR/release-notes.md" \
-    --verify-tag \
-    "${prerelease_flag[@]}"
+  # Create a draft first. A retry can then replace both assets atomically at
+  # the release level before the draft is made public.
+  gh "${create_args[@]}"
+  gh release upload "$tag" "$artifact" "$checksum" --clobber
+  publish_draft_release "$tag" "$version"
+}
+
+publish_draft_release() {
+  local tag="$1"
+  local version="$2"
+  local -a edit_args=(release edit "$tag" --draft=false
+    --title "Collavre Desktop $version"
+    --notes-file "$ARTIFACT_DIR/release-notes.md")
+
+  is_prerelease "$version" && edit_args+=(--prerelease)
+  gh "${edit_args[@]}"
 }
 
 check_prerequisites() {

--- a/script/release-desktop.sh
+++ b/script/release-desktop.sh
@@ -237,6 +237,16 @@ write_checksum() {
   ) > "$checksum"
 }
 
+cleanup_mounted_dmg() {
+  local mount_dir="$1"
+  local attached="$2"
+
+  if [[ "$attached" == "1" ]]; then
+    hdiutil detach "$mount_dir" -quiet 2>/dev/null || true
+  fi
+  rmdir "$mount_dir" 2>/dev/null || true
+}
+
 release_commit_message() {
   local version="$1"
   printf 'chore(desktop): release v%s' "$version"
@@ -299,6 +309,11 @@ push_release_refs() {
     refs=(HEAD:main "${refs[@]}")
   fi
   git push --atomic origin "${refs[@]}"
+}
+
+ensure_main_matches_origin() {
+  [[ "$(git rev-parse HEAD)" == "$(git rev-parse origin/main)" ]] || \
+    die "local main must exactly match origin/main before creating a release"
 }
 
 publish_release() {
@@ -418,16 +433,18 @@ build_notarized_dmg() {
   xcrun stapler staple "$artifact"
   xcrun stapler validate "$artifact"
 
-  local mount_dir
+  local mount_dir dmg_attached=0
   mount_dir="$(mktemp -d)"
-  trap 'hdiutil detach "$mount_dir" -quiet 2>/dev/null || true; rmdir "$mount_dir" 2>/dev/null || true' RETURN
-  hdiutil attach "$artifact" -readonly -nobrowse -mountpoint "$mount_dir" >/dev/null
-  [[ -d "$mount_dir/Collavre Desktop.app" ]] || die "DMG does not contain Collavre Desktop.app"
-  codesign --verify --deep --strict --verbose=2 "$mount_dir/Collavre Desktop.app"
-  spctl --assess --type execute --verbose=4 "$mount_dir/Collavre Desktop.app"
-  hdiutil detach "$mount_dir" -quiet
-  rmdir "$mount_dir"
-  trap - RETURN
+  # Validate in a subshell so its EXIT trap also runs when set -e aborts a
+  # failed app-presence, signature, or Gatekeeper check.
+  (
+    trap 'cleanup_mounted_dmg "$mount_dir" "$dmg_attached"' EXIT
+    hdiutil attach "$artifact" -readonly -nobrowse -mountpoint "$mount_dir" >/dev/null
+    dmg_attached=1
+    [[ -d "$mount_dir/Collavre Desktop.app" ]] || die "DMG does not contain Collavre Desktop.app"
+    codesign --verify --deep --strict --verbose=2 "$mount_dir/Collavre Desktop.app"
+    spctl --assess --type execute --verbose=4 "$mount_dir/Collavre Desktop.app"
+  )
 
   checksum="$ARTIFACT_DIR/Collavre-Desktop_${version}_aarch64.dmg.sha256"
   write_checksum "$artifact" "$checksum"
@@ -448,6 +465,7 @@ main() {
   git fetch origin main --tags
   if [[ -z "$resume_version" ]]; then
     git pull --ff-only origin main
+    ensure_main_matches_origin
   fi
 
   current_version="$(desktop_version)"

--- a/script/release-desktop.sh
+++ b/script/release-desktop.sh
@@ -169,6 +169,25 @@ is_prerelease() {
   [[ "${1%%+*}" == *-* ]]
 }
 
+# Git's version sort does not implement SemVer prerelease precedence (for
+# example, it can order 1.0.0-rc.1 ahead of 1.0.0). Select release tags using
+# the same comparator used for release-version validation instead.
+previous_release_tag() {
+  local excluded_tag="${1:-}" tag version latest_tag="" latest_version=""
+
+  while IFS= read -r tag; do
+    [[ "$tag" != "$excluded_tag" ]] || continue
+    version="${tag#"$TAG_PREFIX"}"
+    valid_semver "$version" || continue
+    if [[ -z "$latest_version" ]] || version_advances "$version" "$latest_version"; then
+      latest_tag="$tag"
+      latest_version="$version"
+    fi
+  done < <(git tag --list "${TAG_PREFIX}*")
+
+  printf '%s\n' "$latest_tag"
+}
+
 # Keep target-directory resolution identical to build-macos.sh. Cargo resolves
 # a relative CARGO_TARGET_DIR from src-tauri, and the release verifier must look
 # in that same location after the build completes.
@@ -267,6 +286,19 @@ reconcile_resumed_release() {
   git tag -d "$tag" >/dev/null 2>&1 || true
   git rebase origin/main
   ensure_release_tag "$tag" "$version"
+}
+
+push_release_refs() {
+  local tag="$1"
+  local -a refs=("refs/tags/$tag")
+
+  # A previous attempt may already have pushed the release commit. Avoid
+  # sending HEAD:main in that case: newer commits may legitimately be on main
+  # while the tag and GitHub Release still need to be published.
+  if ! git merge-base --is-ancestor HEAD origin/main; then
+    refs=(HEAD:main "${refs[@]}")
+  fi
+  git push --atomic origin "${refs[@]}"
 }
 
 publish_release() {
@@ -434,12 +466,7 @@ main() {
       die "resume version $selected_version does not match the rebased release commit"
   fi
 
-  previous_tag="$(git tag --list "${TAG_PREFIX}*" --sort=-v:refname)"
-  if [[ -n "$resume_version" ]]; then
-    previous_tag="$(grep -Fxv "${TAG_PREFIX}${resume_version}" <<< "$previous_tag" | head -1 || true)"
-  else
-    previous_tag="$(head -1 <<< "$previous_tag")"
-  fi
+  previous_tag="$(previous_release_tag "${TAG_PREFIX}${resume_version}")"
   if [[ -n "$previous_tag" ]]; then
     range="$previous_tag..HEAD"
     if [[ -z "$(git log --oneline "$range")" ]]; then
@@ -490,7 +517,7 @@ main() {
   artifact="$RELEASE_ARTIFACT"
 
   ensure_release_tag "$tag" "$selected_version"
-  git push --atomic origin HEAD:main "refs/tags/$tag"
+  push_release_refs "$tag"
   publish_release "$tag" "$selected_version" "$artifact"
 
   echo "[release-desktop] Published $tag"

--- a/script/release-desktop.sh
+++ b/script/release-desktop.sh
@@ -26,6 +26,15 @@ require_command() {
   command -v "$1" >/dev/null 2>&1 || die "required command is unavailable: $1"
 }
 
+check_desktop_build_prerequisites() {
+  # `cargo` can be installed without its separately-installed Tauri CLI
+  # subcommand. Check both build-only dependencies before making a version
+  # commit, so a failed local build is never left to recover with --resume.
+  require_command ruby-build
+  cargo tauri --version >/dev/null 2>&1 || \
+    die "Tauri CLI is unavailable; install it with: cargo install tauri-cli --version '^2'"
+}
+
 valid_semver() {
   local version="$1"
   local prerelease identifier
@@ -404,6 +413,7 @@ check_prerequisites() {
   for command in git gh ruby npm bundle cargo codesign security spctl xcrun shasum hdiutil; do
     require_command "$command"
   done
+  check_desktop_build_prerequisites
 
   [[ -n "${APPLE_SIGNING_IDENTITY:-}" ]] || die "APPLE_SIGNING_IDENTITY is required"
   [[ -n "${APPLE_ID:-}" ]] || die "APPLE_ID is required"

--- a/script/release-desktop.sh
+++ b/script/release-desktop.sh
@@ -361,6 +361,17 @@ ensure_main_matches_origin() {
     die "local main must exactly match origin/main before creating a release"
 }
 
+# Return 10 after a successful fast-forward so the caller can restart this
+# script from the updated checkout. Bash reads function definitions at startup;
+# continuing here would otherwise use stale release logic against new source.
+sync_main_with_origin() {
+  local head_before head_after
+  head_before="$(git rev-parse HEAD)"
+  git pull --ff-only origin main || return $?
+  head_after="$(git rev-parse HEAD)"
+  [[ "$head_before" == "$head_after" ]] || return 10
+}
+
 publish_release() {
   local tag="$1"
   local version="$2"
@@ -513,7 +524,17 @@ main() {
 
   git fetch origin main --tags
   if [[ -z "$resume_version" ]]; then
-    git pull --ff-only origin main
+    local sync_status
+    if sync_main_with_origin; then
+      :
+    else
+      sync_status=$?
+      if ((sync_status == 10)); then
+	echo "[release-desktop] main advanced; restarting from the updated checkout..."
+	exec bash "$PROJECT_ROOT/script/release-desktop.sh" "$@"
+      fi
+      return "$sync_status"
+    fi
     ensure_main_matches_origin
   fi
 

--- a/script/test/build_macos_test.sh
+++ b/script/test/build_macos_test.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_ROOT="$(cd -P "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+fixture_dir="$(mktemp -d)"
+trap 'rm -rf "$fixture_dir"' EXIT
+
+app_root="$fixture_dir/app-root"
+desktop_dir="$app_root/tools/desktop-app"
+mkdir -p "$app_root/app/assets/builds" "$app_root/public/assets" \
+  "$app_root/.claude" "$app_root/coverage" "$desktop_dir/vendor/ruby"
+
+cat > "$app_root/.gitignore" <<'EOF'
+/public/assets
+/app/assets/builds/*
+!/app/assets/builds/.keep
+/.claude
+/coverage
+EOF
+printf '%s\n' 'tracked app file' > "$app_root/README.md"
+: > "$app_root/app/assets/builds/.keep"
+printf '%s\n' '{"application.js":{"digested_path":"application-test.js"}}' \
+  > "$app_root/public/assets/.manifest.json"
+printf '%s\n' 'compiled JavaScript' > "$app_root/app/assets/builds/application.js"
+printf '%s\n' 'digested JavaScript' > "$app_root/public/assets/application-test.js"
+printf '%s\n' 'release-machine secret' > "$app_root/.claude/settings.json"
+printf '%s\n' 'ignored coverage' > "$app_root/coverage/index.html"
+printf '%s\n' 'vendored ruby' > "$desktop_dir/vendor/ruby/README"
+
+git -C "$app_root" init --quiet
+git -C "$app_root" add .gitignore README.md app/assets/builds/.keep
+
+"$PROJECT_ROOT/tools/desktop-app/scripts/stage-app-tree.sh" "$app_root" "$desktop_dir"
+
+staging="$desktop_dir/staging/app"
+[[ -f "$staging/README.md" ]] || { echo "tracked source was not staged" >&2; exit 1; }
+[[ -f "$staging/public/assets/.manifest.json" ]] || { echo "asset manifest was not staged" >&2; exit 1; }
+[[ -f "$staging/public/assets/application-test.js" ]] || { echo "digested asset was not staged" >&2; exit 1; }
+[[ -f "$staging/app/assets/builds/application.js" ]] || { echo "compiled JavaScript was not staged" >&2; exit 1; }
+[[ -f "$staging/tools/desktop-app/vendor/ruby/README" ]] || { echo "vendored Ruby was not staged" >&2; exit 1; }
+[[ ! -e "$staging/.claude/settings.json" ]] || { echo "ignored credential was staged" >&2; exit 1; }
+[[ ! -e "$staging/coverage/index.html" ]] || { echo "ignored coverage was staged" >&2; exit 1; }
+
+echo "build_macos_test: passed"

--- a/script/test/bundle_proxy_test.sh
+++ b/script/test/bundle_proxy_test.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_ROOT="$(cd -P "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+fixture_dir="$(mktemp -d)"
+trap 'rm -rf "$fixture_dir"' EXIT
+
+desktop_dir="$fixture_dir/desktop-app"
+mkdir -p "$desktop_dir/scripts" "$fixture_dir/node-runtime/bin"
+cp "$PROJECT_ROOT/tools/desktop-app/scripts/bundle-proxy.sh" "$desktop_dir/scripts/bundle-proxy.sh"
+
+cat > "$fixture_dir/node-runtime/bin/node" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${1:-}" in
+  --version) printf '%s\n' 'v22.15.0' ;;
+  -p)
+    case "${2:-}" in
+      *realpathSync*) printf '%s/node\n' "$(cd -P "$(dirname "$0")" && pwd)" ;;
+      *process.platform*) printf '%s\n' 'darwin:arm64' ;;
+      *package.json*version*) printf '%s\n' '0.1.0' ;;
+      *integrity*) printf '%s\n' 'sha512-test-integrity' ;;
+      *) exit 1 ;;
+    esac
+    ;;
+  -e) ;;
+  *) exit 1 ;;
+esac
+EOF
+cat > "$fixture_dir/node-runtime/bin/npm" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+mkdir -p node_modules/cli-openai-proxy
+printf '%s\n' '{"version":"0.1.0"}' > node_modules/cli-openai-proxy/package.json
+printf '%s\n' '{"packages":{"node_modules/cli-openai-proxy":{"resolved":"https://registry.npmjs.org/cli-openai-proxy/-/cli-openai-proxy-0.1.0.tgz","integrity":"sha512-test-integrity"}}}' > package-lock.json
+EOF
+chmod +x "$fixture_dir/node-runtime/bin/node" "$fixture_dir/node-runtime/bin/npm"
+
+PATH="$fixture_dir/node-runtime/bin:$PATH" \
+  env -u NODE_RUNTIME_DIR -u NODE_RUNTIME_URL -u NODE_RUNTIME_SHA256 \
+  "$desktop_dir/scripts/bundle-proxy.sh" >/dev/null
+
+[[ -x "$desktop_dir/vendor/proxy/node/bin/node" ]] || {
+  echo "discovered Node runtime was not bundled" >&2
+  exit 1
+}
+[[ "$("$desktop_dir/vendor/proxy/node/bin/node" --version)" == "v22.15.0" ]] || {
+  echo "bundled Node runtime differs from the discovered runtime" >&2
+  exit 1
+}
+grep -Fq '"node": "v22.15.0"' "$desktop_dir/vendor/proxy/manifest.json"

--- a/script/test/bundle_proxy_test.sh
+++ b/script/test/bundle_proxy_test.sh
@@ -6,10 +6,12 @@ fixture_dir="$(mktemp -d)"
 trap 'rm -rf "$fixture_dir"' EXIT
 
 desktop_dir="$fixture_dir/desktop-app"
-mkdir -p "$desktop_dir/scripts" "$fixture_dir/node-runtime/bin"
+runtime_dir="$fixture_dir/node-runtime"
+fake_bin="$fixture_dir/fake-bin"
+mkdir -p "$desktop_dir/scripts" "$runtime_dir/bin" "$fake_bin"
 cp "$PROJECT_ROOT/tools/desktop-app/scripts/bundle-proxy.sh" "$desktop_dir/scripts/bundle-proxy.sh"
 
-cat > "$fixture_dir/node-runtime/bin/node" <<'EOF'
+cat > "$runtime_dir/bin/node" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 
@@ -28,7 +30,7 @@ case "${1:-}" in
   *) exit 1 ;;
 esac
 EOF
-cat > "$fixture_dir/node-runtime/bin/npm" <<'EOF'
+cat > "$runtime_dir/bin/npm" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 
@@ -36,18 +38,57 @@ mkdir -p node_modules/cli-openai-proxy
 printf '%s\n' '{"version":"0.1.0"}' > node_modules/cli-openai-proxy/package.json
 printf '%s\n' '{"packages":{"node_modules/cli-openai-proxy":{"resolved":"https://registry.npmjs.org/cli-openai-proxy/-/cli-openai-proxy-0.1.0.tgz","integrity":"sha512-test-integrity"}}}' > package-lock.json
 EOF
-chmod +x "$fixture_dir/node-runtime/bin/node" "$fixture_dir/node-runtime/bin/npm"
+chmod +x "$runtime_dir/bin/node" "$runtime_dir/bin/npm"
 
-PATH="$fixture_dir/node-runtime/bin:$PATH" \
+cat > "$fake_bin/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+output=""
+url=""
+while (($#)); do
+  case "$1" in
+    --output) output="$2"; shift 2 ;;
+    *) url="$1"; shift ;;
+  esac
+done
+[[ "$url" == "https://nodejs.org/dist/v22.13.0/node-v22.13.0-darwin-arm64.tar.xz" ]]
+: > "$output"
+EOF
+cat > "$fake_bin/shasum" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+read -r checksum archive
+[[ "$checksum" == "71b0893ef6a55295994f38002fada15c9a76a3cedeb36745fde0403741d183c6" ]]
+[[ "$archive" == *"node-runtime.tar.xz" ]]
+EOF
+cat > "$fake_bin/tar" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+destination=""
+while (($#)); do
+  case "$1" in
+    -C) destination="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+mkdir -p "$destination/node-v22.13.0-darwin-arm64"
+cp -R "$NODE_RUNTIME_FIXTURE_DIR/." "$destination/node-v22.13.0-darwin-arm64/"
+EOF
+chmod +x "$fake_bin/curl" "$fake_bin/shasum" "$fake_bin/tar"
+
+NODE_RUNTIME_FIXTURE_DIR="$runtime_dir" PATH="$fake_bin:$PATH" \
   env -u NODE_RUNTIME_DIR -u NODE_RUNTIME_URL -u NODE_RUNTIME_SHA256 \
   "$desktop_dir/scripts/bundle-proxy.sh" >/dev/null
 
 [[ -x "$desktop_dir/vendor/proxy/node/bin/node" ]] || {
-  echo "discovered Node runtime was not bundled" >&2
+  echo "default Node runtime was not bundled" >&2
   exit 1
 }
 [[ "$("$desktop_dir/vendor/proxy/node/bin/node" --version)" == "v22.15.0" ]] || {
-  echo "bundled Node runtime differs from the discovered runtime" >&2
+  echo "bundled Node runtime differs from the official archive fixture" >&2
   exit 1
 }
 grep -Fq '"node": "v22.15.0"' "$desktop_dir/vendor/proxy/manifest.json"

--- a/script/test/release_desktop_test.sh
+++ b/script/test/release_desktop_test.sh
@@ -23,6 +23,11 @@ fi
 assert_equal "1.0.0" "$(bump_version "0.9.7" major)"
 assert_equal "0.10.0" "$(bump_version "0.9.7" minor)"
 assert_equal "0.9.8" "$(bump_version "0.9.7" patch)"
+is_prerelease "1.2.3-beta.1"
+if is_prerelease "1.2.3" || is_prerelease "1.2.3+build-1"; then
+  echo "stable version was treated as a prerelease" >&2
+  exit 1
+fi
 
 fixture_dir="$(mktemp -d)"
 trap 'rm -rf "$fixture_dir"' EXIT
@@ -50,7 +55,13 @@ git -C "$repo_dir" add .
 git -C "$repo_dir" commit --quiet -m "feat(desktop): add sharing"
 (
   cd "$repo_dir"
-  DESKTOP_DIR="$repo_dir/tools/desktop-app"
+  assert_equal "minor" "$(version_bump_level HEAD)"
+)
+printf 'rails feature\n' > "$repo_dir/README.md"
+git -C "$repo_dir" add .
+git -C "$repo_dir" commit --quiet -m "feat: add bundled Rails feature"
+(
+  cd "$repo_dir"
   assert_equal "minor" "$(version_bump_level HEAD)"
 )
 printf 'breaking\n' >> "$repo_dir/tools/desktop-app/README.md"
@@ -58,8 +69,20 @@ git -C "$repo_dir" add .
 git -C "$repo_dir" commit --quiet -m "feat(desktop)!: remove legacy setup"
 (
   cd "$repo_dir"
-  DESKTOP_DIR="$repo_dir/tools/desktop-app"
   assert_equal "major" "$(version_bump_level HEAD)"
 )
+git -C "$repo_dir" commit --quiet --allow-empty -m "$(release_commit_message "2.3.4")"
+(
+  cd "$repo_dir"
+  ensure_release_tag "desktop-v2.3.4" "2.3.4"
+  assert_equal "$(git rev-parse HEAD)" "$(git rev-parse desktop-v2.3.4^{commit})"
+)
+
+artifact_dir="$fixture_dir/artifacts"
+mkdir -p "$artifact_dir"
+printf 'dmg fixture\n' > "$artifact_dir/Collavre-Desktop_2.3.4_aarch64.dmg"
+write_checksum "$artifact_dir/Collavre-Desktop_2.3.4_aarch64.dmg" "$artifact_dir/Collavre-Desktop_2.3.4_aarch64.dmg.sha256"
+assert_equal "Collavre-Desktop_2.3.4_aarch64.dmg" "$(awk '{print $2}' "$artifact_dir/Collavre-Desktop_2.3.4_aarch64.dmg.sha256")"
+(cd "$artifact_dir" && shasum -a 256 -c "Collavre-Desktop_2.3.4_aarch64.dmg.sha256" >/dev/null)
 
 echo "release_desktop_test: passed"

--- a/script/test/release_desktop_test.sh
+++ b/script/test/release_desktop_test.sh
@@ -268,4 +268,18 @@ publish_release "desktop-v2.3.4" "2.3.4" "$artifact_dir/Collavre-Desktop_2.3.4_a
 grep -Fqx "release upload desktop-v2.3.4 $artifact_dir/Collavre-Desktop_2.3.4_aarch64.dmg $artifact_dir/Collavre-Desktop_2.3.4_aarch64.dmg.sha256 --clobber" "$gh_log"
 grep -Fqx "release edit desktop-v2.3.4 --draft=false --title Collavre Desktop 2.3.4 --notes-file $artifact_dir/release-notes.md" "$gh_log"
 
+ci_log="$fixture_dir/ci.log"
+gh() {
+  printf '%s\n' "$*" >> "$ci_log"
+  if [[ "$1 $2" == "run list" ]]; then
+    printf '12345\n'
+  fi
+}
+(
+  cd "$repo_dir"
+  wait_for_release_ci
+)
+grep -Fqx "run list --workflow CI --commit $(git -C "$repo_dir" rev-parse HEAD) --json databaseId --jq .[0].databaseId" "$ci_log"
+grep -Fqx "run watch 12345 --exit-status" "$ci_log"
+
 echo "release_desktop_test: passed"

--- a/script/test/release_desktop_test.sh
+++ b/script/test/release_desktop_test.sh
@@ -94,6 +94,12 @@ git -C "$repo_dir" commit --quiet --allow-empty -m "$(release_commit_message "2.
   ensure_release_tag "desktop-v2.3.4" "2.3.4"
   assert_equal "$(git rev-parse HEAD)" "$(git rev-parse desktop-v2.3.4^{commit})"
 )
+git -C "$repo_dir" tag -a desktop-v2.3.4-rc.1 -m "Collavre Desktop 2.3.4 RC"
+(
+  cd "$repo_dir"
+  assert_equal "desktop-v2.3.4" "$(previous_release_tag)"
+  assert_equal "desktop-v2.3.4-rc.1" "$(previous_release_tag desktop-v2.3.4)"
+)
 
 origin_dir="$fixture_dir/origin.git"
 git init --bare --quiet "$origin_dir"
@@ -115,6 +121,19 @@ git -C "$remote_clone" push --quiet origin main
   reconcile_resumed_release "desktop-v2.3.5" "2.3.5"
   assert_equal "$(git rev-parse HEAD)" "$(git rev-parse desktop-v2.3.5^{commit})"
   assert_equal "$(release_commit_message "2.3.5")" "$(git log -1 --format=%s HEAD)"
+  git push --quiet --atomic origin HEAD:main refs/tags/desktop-v2.3.5
+)
+git -C "$remote_clone" pull --quiet --ff-only origin main
+printf 'later remote change\n' > "$remote_clone/LATER_REMOTE_CHANGE"
+git -C "$remote_clone" add LATER_REMOTE_CHANGE
+git -C "$remote_clone" commit --quiet -m "fix: advance main again"
+git -C "$remote_clone" push --quiet origin main
+(
+  cd "$repo_dir"
+  git fetch --quiet origin main
+  push_release_refs "desktop-v2.3.5"
+  git fetch --quiet origin main
+  git merge-base --is-ancestor HEAD origin/main
 )
 
 artifact_dir="$fixture_dir/artifacts"

--- a/script/test/release_desktop_test.sh
+++ b/script/test/release_desktop_test.sh
@@ -28,6 +28,22 @@ if is_prerelease "1.2.3" || is_prerelease "1.2.3+build-1"; then
   echo "stable version was treated as a prerelease" >&2
   exit 1
 fi
+assert_equal "-1" "$(semver_compare "1.2.3-alpha.2" "1.2.3-alpha.10")"
+assert_equal "-1" "$(semver_compare "1.2.3-beta.1" "1.2.3")"
+assert_equal "0" "$(semver_compare "1.2.3+build.1" "1.2.3+build.2")"
+version_advances "1.2.3" "1.2.3-rc.1"
+if version_advances "1.2.2" "1.2.3" || version_advances "1.2.3-beta.1" "1.2.3"; then
+  echo "non-advancing version was accepted" >&2
+  exit 1
+fi
+
+unset CARGO_TARGET_DIR
+assert_equal "$TAURI_DIR/target" "$(tauri_target_dir)"
+CARGO_TARGET_DIR="../release-target/./nested/.."
+assert_equal "$DESKTOP_DIR/release-target" "$(tauri_target_dir)"
+CARGO_TARGET_DIR="/tmp/collavre-target/../release-target"
+assert_equal "/tmp/release-target" "$(tauri_target_dir)"
+unset CARGO_TARGET_DIR
 
 fixture_dir="$(mktemp -d)"
 trap 'rm -rf "$fixture_dir"' EXIT
@@ -50,6 +66,7 @@ git -C "$repo_dir" config user.email "release-script-test@example.test"
 printf 'initial\n' > "$repo_dir/tools/desktop-app/README.md"
 git -C "$repo_dir" add .
 git -C "$repo_dir" commit --quiet -m "chore: initial desktop"
+git -C "$repo_dir" branch -M main
 printf 'feature\n' >> "$repo_dir/tools/desktop-app/README.md"
 git -C "$repo_dir" add .
 git -C "$repo_dir" commit --quiet -m "feat(desktop): add sharing"
@@ -76,6 +93,28 @@ git -C "$repo_dir" commit --quiet --allow-empty -m "$(release_commit_message "2.
   cd "$repo_dir"
   ensure_release_tag "desktop-v2.3.4" "2.3.4"
   assert_equal "$(git rev-parse HEAD)" "$(git rev-parse desktop-v2.3.4^{commit})"
+)
+
+origin_dir="$fixture_dir/origin.git"
+git init --bare --quiet "$origin_dir"
+git -C "$repo_dir" remote add origin "$origin_dir"
+git -C "$repo_dir" push --quiet origin main
+git -C "$repo_dir" commit --quiet --allow-empty -m "$(release_commit_message "2.3.5")"
+git -C "$repo_dir" tag -a desktop-v2.3.5 -m "Collavre Desktop 2.3.5"
+remote_clone="$fixture_dir/remote-clone"
+git clone --quiet --branch main "$origin_dir" "$remote_clone"
+git -C "$remote_clone" config user.name "Release Script Test"
+git -C "$remote_clone" config user.email "release-script-test@example.test"
+printf 'remote change\n' > "$remote_clone/REMOTE_CHANGE"
+git -C "$remote_clone" add REMOTE_CHANGE
+git -C "$remote_clone" commit --quiet -m "fix: advance main"
+git -C "$remote_clone" push --quiet origin main
+(
+  cd "$repo_dir"
+  git fetch --quiet origin main
+  reconcile_resumed_release "desktop-v2.3.5" "2.3.5"
+  assert_equal "$(git rev-parse HEAD)" "$(git rev-parse desktop-v2.3.5^{commit})"
+  assert_equal "$(release_commit_message "2.3.5")" "$(git log -1 --format=%s HEAD)"
 )
 
 artifact_dir="$fixture_dir/artifacts"

--- a/script/test/release_desktop_test.sh
+++ b/script/test/release_desktop_test.sh
@@ -30,6 +30,7 @@ if is_prerelease "1.2.3" || is_prerelease "1.2.3+build-1"; then
   echo "stable version was treated as a prerelease" >&2
   exit 1
 fi
+assert_equal "1.2.3" "$(stable_version "1.2.3-rc.1+build.7")"
 assert_equal "-1" "$(semver_compare "1.2.3-alpha.2" "1.2.3-alpha.10")"
 assert_equal "-1" "$(semver_compare "1.2.3-beta.1" "1.2.3")"
 assert_equal "0" "$(semver_compare "1.2.3+build.1" "1.2.3+build.2")"
@@ -108,6 +109,27 @@ git -C "$repo_dir" tag -a desktop-v2.3.4-rc.1 -m "Collavre Desktop 2.3.4 RC"
   cd "$repo_dir"
   assert_equal "desktop-v2.3.4" "$(previous_release_tag)"
   assert_equal "desktop-v2.3.4-rc.1" "$(previous_release_tag desktop-v2.3.4)"
+)
+
+promotion_repo="$fixture_dir/promotion-repo"
+git clone --quiet "$repo_dir" "$promotion_repo"
+git -C "$promotion_repo" checkout --quiet main
+git -C "$promotion_repo" config user.name "Release Script Test"
+git -C "$promotion_repo" config user.email "release-script-test@example.test"
+git -C "$promotion_repo" commit --quiet --allow-empty -m "chore(desktop): release v2.3.5-rc.1"
+git -C "$promotion_repo" tag -a desktop-v2.3.5-rc.1 -m "Collavre Desktop 2.3.5 RC"
+(
+  cd "$promotion_repo"
+  can_promote_prerelease_at_head "2.3.5-rc.1" "desktop-v2.3.5-rc.1"
+  if can_promote_prerelease_at_head "2.3.5" "desktop-v2.3.5-rc.1"; then
+    echo "stable release was accepted as a prerelease promotion" >&2
+    exit 1
+  fi
+  git commit --quiet --allow-empty -m "fix: source change after release candidate"
+  if can_promote_prerelease_at_head "2.3.5-rc.1" "desktop-v2.3.5-rc.1"; then
+    echo "prerelease promotion was accepted after a source change" >&2
+    exit 1
+  fi
 )
 
 origin_dir="$fixture_dir/origin.git"

--- a/script/test/release_desktop_test.sh
+++ b/script/test/release_desktop_test.sh
@@ -90,6 +90,13 @@ git -C "$repo_dir" commit --quiet -m "feat(desktop)!: remove legacy setup"
   cd "$repo_dir"
   assert_equal "major" "$(version_bump_level HEAD)"
 )
+git -C "$repo_dir" commit --quiet --allow-empty \
+  -m "fix(desktop): change desktop protocol" \
+  -m "BREAKING-CHANGE: desktop protocol is incompatible with earlier releases"
+(
+  cd "$repo_dir"
+  assert_equal "major" "$(version_bump_level HEAD~1..HEAD)"
+)
 git -C "$repo_dir" commit --quiet --allow-empty -m "$(release_commit_message "2.3.4")"
 (
   cd "$repo_dir"
@@ -191,5 +198,19 @@ printf 'dmg fixture\n' > "$artifact_dir/Collavre-Desktop_2.3.4_aarch64.dmg"
 write_checksum "$artifact_dir/Collavre-Desktop_2.3.4_aarch64.dmg" "$artifact_dir/Collavre-Desktop_2.3.4_aarch64.dmg.sha256"
 assert_equal "Collavre-Desktop_2.3.4_aarch64.dmg" "$(awk '{print $2}' "$artifact_dir/Collavre-Desktop_2.3.4_aarch64.dmg.sha256")"
 (cd "$artifact_dir" && shasum -a 256 -c "Collavre-Desktop_2.3.4_aarch64.dmg.sha256" >/dev/null)
+
+gh_log="$fixture_dir/gh.log"
+gh() {
+  printf '%s\n' "$*" >> "$gh_log"
+  if [[ "$1 $2 $3" == "release view desktop-v2.3.4" ]]; then
+    if [[ "${4:-}" == "--json" ]]; then
+      printf 'true\n'
+    fi
+    return 0
+  fi
+}
+publish_release "desktop-v2.3.4" "2.3.4" "$artifact_dir/Collavre-Desktop_2.3.4_aarch64.dmg"
+grep -Fqx "release upload desktop-v2.3.4 $artifact_dir/Collavre-Desktop_2.3.4_aarch64.dmg $artifact_dir/Collavre-Desktop_2.3.4_aarch64.dmg.sha256 --clobber" "$gh_log"
+grep -Fqx "release edit desktop-v2.3.4 --draft=false --title Collavre Desktop 2.3.4 --notes-file $artifact_dir/release-notes.md" "$gh_log"
 
 echo "release_desktop_test: passed"

--- a/script/test/release_desktop_test.sh
+++ b/script/test/release_desktop_test.sh
@@ -192,6 +192,24 @@ git -C "$remote_clone" push --quiet origin main
   fi
 )
 
+sync_repo="$fixture_dir/sync-repo"
+git clone --quiet --branch main "$origin_dir" "$sync_repo"
+git -C "$sync_repo" config user.name "Release Script Test"
+git -C "$sync_repo" config user.email "release-script-test@example.test"
+git -C "$remote_clone" commit --quiet --allow-empty -m "fix: advance main before release"
+git -C "$remote_clone" push --quiet origin main
+(
+  cd "$sync_repo"
+  git fetch --quiet origin main
+  if sync_main_with_origin; then
+    echo "fast-forward did not request a release-script restart" >&2
+    exit 1
+  else
+    assert_equal "10" "$?"
+  fi
+  assert_equal "$(git rev-parse origin/main)" "$(git rev-parse HEAD)"
+)
+
 dmg_detach_log="$fixture_dir/dmg-detach.log"
 hdiutil() {
   printf '%s\n' "$*" >> "$dmg_detach_log"

--- a/script/test/release_desktop_test.sh
+++ b/script/test/release_desktop_test.sh
@@ -135,6 +135,45 @@ git -C "$remote_clone" push --quiet origin main
   git fetch --quiet origin main
   git merge-base --is-ancestor HEAD origin/main
 )
+(
+  cd "$remote_clone"
+  git fetch --quiet origin main
+  ensure_main_matches_origin
+  git commit --quiet --allow-empty -m "fix: local-only change"
+  if (ensure_main_matches_origin); then
+    echo "local main ahead of origin/main was accepted" >&2
+    exit 1
+  fi
+)
+
+dmg_detach_log="$fixture_dir/dmg-detach.log"
+hdiutil() {
+  printf '%s\n' "$*" >> "$dmg_detach_log"
+}
+mount_dir="$fixture_dir/mounted-dmg"
+mkdir "$mount_dir"
+cleanup_mounted_dmg "$mount_dir" 1
+[[ ! -d "$mount_dir" ]] || {
+  echo "mounted DMG directory was not removed" >&2
+  exit 1
+}
+assert_equal "detach $mount_dir -quiet" "$(<"$dmg_detach_log")"
+
+failed_mount_dir="$fixture_dir/failed-mounted-dmg"
+mkdir "$failed_mount_dir"
+if (
+  dmg_attached=1
+  trap 'cleanup_mounted_dmg "$failed_mount_dir" "$dmg_attached"' EXIT
+  false
+); then
+  echo "failed DMG verification was accepted" >&2
+  exit 1
+fi
+[[ ! -d "$failed_mount_dir" ]] || {
+  echo "failed DMG verification did not clean up the mount directory" >&2
+  exit 1
+}
+assert_equal "detach $failed_mount_dir -quiet" "$(tail -n 1 "$dmg_detach_log")"
 
 artifact_dir="$fixture_dir/artifacts"
 mkdir -p "$artifact_dir"

--- a/script/test/release_desktop_test.sh
+++ b/script/test/release_desktop_test.sh
@@ -15,7 +15,9 @@ assert_equal() {
 
 valid_semver "0.1.0"
 valid_semver "1.2.3-beta.1+build.8"
-if valid_semver "1.02.3" || valid_semver "v1.2.3" || valid_semver "1.2"; then
+valid_semver "1.2.3-0+build.01"
+if valid_semver "1.02.3" || valid_semver "v1.2.3" || valid_semver "1.2" || \
+  valid_semver "1.2.3-01" || valid_semver "1.2.3-alpha.01"; then
   echo "invalid semver was accepted" >&2
   exit 1
 fi
@@ -177,6 +179,14 @@ assert_equal "detach $failed_mount_dir -quiet" "$(tail -n 1 "$dmg_detach_log")"
 
 artifact_dir="$fixture_dir/artifacts"
 mkdir -p "$artifact_dir"
+printf 'stale DMG\n' > "$artifact_dir/previous-release.dmg"
+printf 'stale checksum\n' > "$artifact_dir/previous-release.dmg.sha256"
+ARTIFACT_DIR="$artifact_dir"
+prepare_artifact_dir
+[[ -z "$(find "$artifact_dir" -mindepth 1 -print -quit)" ]] || {
+  echo "previous release artifacts were not removed before staging" >&2
+  exit 1
+}
 printf 'dmg fixture\n' > "$artifact_dir/Collavre-Desktop_2.3.4_aarch64.dmg"
 write_checksum "$artifact_dir/Collavre-Desktop_2.3.4_aarch64.dmg" "$artifact_dir/Collavre-Desktop_2.3.4_aarch64.dmg.sha256"
 assert_equal "Collavre-Desktop_2.3.4_aarch64.dmg" "$(awk '{print $2}' "$artifact_dir/Collavre-Desktop_2.3.4_aarch64.dmg.sha256")"

--- a/script/test/release_desktop_test.sh
+++ b/script/test/release_desktop_test.sh
@@ -13,6 +13,21 @@ assert_equal() {
   }
 }
 
+build_prerequisite_command="$(
+  require_command() { printf '%s\n' "$1"; }
+  cargo() { [[ "$1" == "tauri" && "$2" == "--version" ]]; }
+  check_desktop_build_prerequisites
+)"
+assert_equal "ruby-build" "$build_prerequisite_command"
+if (
+  require_command() { :; }
+  cargo() { return 1; }
+  check_desktop_build_prerequisites
+) 2>/dev/null; then
+  echo "missing Tauri CLI was accepted" >&2
+  exit 1
+fi
+
 valid_semver "0.1.0"
 valid_semver "1.2.3-beta.1+build.8"
 valid_semver "1.2.3-0+build.01"

--- a/script/test/release_desktop_test.sh
+++ b/script/test/release_desktop_test.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RELEASE_DESKTOP_LIB_ONLY=1 source "$SCRIPT_DIR/../release-desktop.sh"
+
+assert_equal() {
+  local expected="$1"
+  local actual="$2"
+  [[ "$expected" == "$actual" ]] || {
+    echo "expected '$expected', got '$actual'" >&2
+    exit 1
+  }
+}
+
+valid_semver "0.1.0"
+valid_semver "1.2.3-beta.1+build.8"
+if valid_semver "1.02.3" || valid_semver "v1.2.3" || valid_semver "1.2"; then
+  echo "invalid semver was accepted" >&2
+  exit 1
+fi
+
+assert_equal "1.0.0" "$(bump_version "0.9.7" major)"
+assert_equal "0.10.0" "$(bump_version "0.9.7" minor)"
+assert_equal "0.9.8" "$(bump_version "0.9.7" patch)"
+
+fixture_dir="$(mktemp -d)"
+trap 'rm -rf "$fixture_dir"' EXIT
+cp "$TAURI_CONFIG" "$fixture_dir/tauri.conf.json"
+cp "$CARGO_TOML" "$fixture_dir/Cargo.toml"
+cp "$CARGO_LOCK" "$fixture_dir/Cargo.lock"
+TAURI_CONFIG="$fixture_dir/tauri.conf.json"
+CARGO_TOML="$fixture_dir/Cargo.toml"
+CARGO_LOCK="$fixture_dir/Cargo.lock"
+update_versions "2.3.4"
+assert_equal "2.3.4" "$(desktop_version)"
+assert_equal "2.3.4" "$(cargo_version)"
+assert_equal "2.3.4" "$(cargo_lock_version)"
+
+repo_dir="$fixture_dir/repo"
+mkdir -p "$repo_dir/tools/desktop-app"
+git -C "$repo_dir" init --quiet
+git -C "$repo_dir" config user.name "Release Script Test"
+git -C "$repo_dir" config user.email "release-script-test@example.test"
+printf 'initial\n' > "$repo_dir/tools/desktop-app/README.md"
+git -C "$repo_dir" add .
+git -C "$repo_dir" commit --quiet -m "chore: initial desktop"
+printf 'feature\n' >> "$repo_dir/tools/desktop-app/README.md"
+git -C "$repo_dir" add .
+git -C "$repo_dir" commit --quiet -m "feat(desktop): add sharing"
+(
+  cd "$repo_dir"
+  DESKTOP_DIR="$repo_dir/tools/desktop-app"
+  assert_equal "minor" "$(version_bump_level HEAD)"
+)
+printf 'breaking\n' >> "$repo_dir/tools/desktop-app/README.md"
+git -C "$repo_dir" add .
+git -C "$repo_dir" commit --quiet -m "feat(desktop)!: remove legacy setup"
+(
+  cd "$repo_dir"
+  DESKTOP_DIR="$repo_dir/tools/desktop-app"
+  assert_equal "major" "$(version_bump_level HEAD)"
+)
+
+echo "release_desktop_test: passed"

--- a/tools/desktop-app/README.md
+++ b/tools/desktop-app/README.md
@@ -91,7 +91,7 @@ The desktop release embeds one Apple-Silicon Node runtime and one exact
 published `cli-openai-proxy` version. It does not use Homebrew, a global npm
 install, or the user's `node` binary at runtime.
 
-The release job supplies all of these build inputs:
+For a reproducible release build, supply the official archive and its checksum:
 
 ```bash
 CLI_OPENAI_PROXY_VERSION=0.1.0
@@ -104,6 +104,12 @@ tools/desktop-app/scripts/build-macos.sh
 its supplied SHA-256, requires a Darwin ARM64 runtime, then resolves and locks
 the exact npm package before `npm ci` installs it. The generated lockfile keeps
 the resolved tarball integrity values inside the signed application bundle.
+
+For a local DMG build, no Node runtime environment variables are required. The
+script automatically bundles the Apple-Silicon Node installation found on
+`PATH`; it resolves Homebrew and version-manager symlinks before copying only
+that Node runtime. Set `NODE_RUNTIME_DIR` to override discovery, or set both
+`NODE_RUNTIME_URL` and `NODE_RUNTIME_SHA256` to use a verified archive.
 
 Tauri exposes internal setup commands for the first-run wizard:
 
@@ -175,10 +181,12 @@ export APPLE_SIGNING_IDENTITY='Developer ID Application: Example, Inc. (TEAMID)'
 export APPLE_ID='releases@example.com'
 export APPLE_APP_SPECIFIC_PASSWORD='xxxx-xxxx-xxxx-xxxx'
 export APPLE_TEAM_ID='TEAMID'
-export NODE_RUNTIME_URL='https://nodejs.org/dist/v<node-version>/node-v<node-version>-darwin-arm64.tar.xz'
-export NODE_RUNTIME_SHA256='<official-node-sha256>'
 script/release-desktop.sh
 ```
+
+The release script defaults to the Apple-Silicon Node runtime found on `PATH`.
+To pin the runtime archive, set both `NODE_RUNTIME_URL` and
+`NODE_RUNTIME_SHA256` before running it.
 
 The Apple signing identity and App Store app-specific password must be stored
 only in the protected release environment or the release operator's keychain;

--- a/tools/desktop-app/README.md
+++ b/tools/desktop-app/README.md
@@ -106,10 +106,10 @@ the exact npm package before `npm ci` installs it. The generated lockfile keeps
 the resolved tarball integrity values inside the signed application bundle.
 
 For a local DMG build, no Node runtime environment variables are required. The
-script automatically bundles the Apple-Silicon Node installation found on
-`PATH`; it resolves Homebrew and version-manager symlinks before copying only
-that Node runtime. Set `NODE_RUNTIME_DIR` to override discovery, or set both
-`NODE_RUNTIME_URL` and `NODE_RUNTIME_SHA256` to use a verified archive.
+script downloads and verifies its pinned official Apple-Silicon Node archive
+(`v22.13.0`). Set `NODE_RUNTIME_DIR` only for a pre-verified expanded official
+archive, or set both `NODE_RUNTIME_URL` and `NODE_RUNTIME_SHA256` to use a
+different verified official archive.
 
 Tauri exposes internal setup commands for the first-run wizard:
 
@@ -184,8 +184,8 @@ export APPLE_TEAM_ID='TEAMID'
 script/release-desktop.sh
 ```
 
-The release script defaults to the Apple-Silicon Node runtime found on `PATH`.
-To pin the runtime archive, set both `NODE_RUNTIME_URL` and
+The release script defaults to a pinned, verified official Apple-Silicon Node
+archive. To use a different runtime archive, set both `NODE_RUNTIME_URL` and
 `NODE_RUNTIME_SHA256` before running it.
 
 The Apple signing identity and App Store app-specific password must be stored

--- a/tools/desktop-app/README.md
+++ b/tools/desktop-app/README.md
@@ -155,15 +155,18 @@ and notarized distribution build.
 
 `script/release-desktop.sh` is the single operator entry point. The canonical
 version is `src-tauri/tauri.conf.json`; the script keeps Cargo's manifest and
-lockfile package versions in sync, proposes a semantic bump from desktop commit
-messages, then requires an explicit version and final confirmation before
-creating the version commit.
+lockfile package versions in sync, proposes a semantic bump from all bundled
+source commits, then requires an explicit version that advances the current
+version and final confirmation before creating the version commit.
 
 It runs the desktop Rust and Rails test suites, creates the Apple-Silicon DMG,
 checks its code signature, submits and staples it with Apple notarization,
 writes a SHA-256 checksum, and only then creates a GitHub Release. The Git tag
-format is `desktop-v<semver>` and release notes are generated from desktop
-commits since the preceding desktop tag.
+format is `desktop-v<semver>` and release notes are generated from bundled
+source commits since the preceding desktop tag. If publication fails after the
+version commit, rerun `script/release-desktop.sh --resume <version>` from that clean
+release checkout; it safely rebases an unpushed release commit onto current
+`origin/main` before rebuilding.
 
 Run it only from a clean, current `main` checkout on an Apple-Silicon Mac:
 

--- a/tools/desktop-app/README.md
+++ b/tools/desktop-app/README.md
@@ -148,7 +148,39 @@ drives esbuild from `node_modules` — Node.js is a build prerequisite.
 The app icon is generated during the build from `public/icon-*.png` (the app's
 own brand icon) into the git-ignored `src-tauri/icons/` — nothing to prepare.
 
-First launch: right-click → **Open** (the build is unsigned; Gatekeeper).
+This is a local development build. Use the release script below for a signed
+and notarized distribution build.
+
+## Publish a desktop release
+
+`script/release-desktop.sh` is the single operator entry point. The canonical
+version is `src-tauri/tauri.conf.json`; the script keeps Cargo's manifest and
+lockfile package versions in sync, proposes a semantic bump from desktop commit
+messages, then requires an explicit version and final confirmation before
+creating the version commit.
+
+It runs the desktop Rust and Rails test suites, creates the Apple-Silicon DMG,
+checks its code signature, submits and staples it with Apple notarization,
+writes a SHA-256 checksum, and only then creates a GitHub Release. The Git tag
+format is `desktop-v<semver>` and release notes are generated from desktop
+commits since the preceding desktop tag.
+
+Run it only from a clean, current `main` checkout on an Apple-Silicon Mac:
+
+```bash
+export APPLE_SIGNING_IDENTITY='Developer ID Application: Example, Inc. (TEAMID)'
+export APPLE_ID='releases@example.com'
+export APPLE_APP_SPECIFIC_PASSWORD='xxxx-xxxx-xxxx-xxxx'
+export APPLE_TEAM_ID='TEAMID'
+export NODE_RUNTIME_URL='https://nodejs.org/dist/v<node-version>/node-v<node-version>-darwin-arm64.tar.xz'
+export NODE_RUNTIME_SHA256='<official-node-sha256>'
+script/release-desktop.sh
+```
+
+The Apple signing identity and App Store app-specific password must be stored
+only in the protected release environment or the release operator's keychain;
+they are never committed. The GitHub CLI must already be authenticated with
+permission to push `main`, tags, and releases.
 
 ## Known follow-ups (out of v1 scope)
 
@@ -156,7 +188,7 @@ First launch: right-click → **Open** (the build is unsigned; Gatekeeper).
   variants in the `desktop` env.
 - **OAuth** — client secrets can't ship in a distributed binary; desktop v1 uses
   password auth (PKCE/loopback OAuth later).
-- **Signing / notarization / .dmg / auto-update** — deferred.
+- **Auto-update** — deferred.
 - **Windows / Linux** — deferred (the Rust shell and Rails env are already
   cross-platform; packaging scripts are macOS-only for now).
 - **Relocatable Ruby** — the vendored Ruby is happiest when the app lives at a

--- a/tools/desktop-app/scripts/build-macos.sh
+++ b/tools/desktop-app/scripts/build-macos.sh
@@ -62,15 +62,6 @@ else
 fi
 export CARGO_TARGET_DIR="$TAURI_TARGET_DIR"
 
-# A custom target can live inside the source tree (for example, a relative
-# CARGO_TARGET_DIR). Exclude it from staging so a previous bundle's resource
-# copy is never embedded into the next application bundle.
-STAGING_EXCLUDES=()
-if [[ "$TAURI_TARGET_DIR" == "$APP_ROOT/"* ]]; then
-  TAURI_TARGET_STAGING_PATH="${TAURI_TARGET_DIR#"$APP_ROOT"/}"
-  STAGING_EXCLUDES+=(--exclude "/$TAURI_TARGET_STAGING_PATH/***")
-fi
-
 echo "[build-macos] 1/7 vendoring Ruby + gems"
 "$SCRIPT_DIR/bundle-ruby.sh"
 
@@ -100,38 +91,16 @@ echo "[build-macos] 4/7 precompiling assets (desktop env)"
 echo "[build-macos] 5/7 staging app tree into $STAGING"
 rm -rf "$DESKTOP_DIR/staging"
 mkdir -p "$STAGING"
-# Copy the app, excluding VCS, dev cruft, tests, and per-run state. The vendored
-# Ruby/gems under tools/desktop-app/vendor ARE included (the app needs them) — the
-# --include below protects that whole tree from the unanchored test/spec excludes:
-# rsync matches a bare 'test'/'spec' at ANY depth, which otherwise strips real gem
-# library code living under a dir named test/ (e.g. rack-test's lib/rack/test/ —
-# cookie_jar.rb), corrupting the bundle and crashing boot with a LoadError.
-# Secrets are excluded so a developer's local credentials never get baked into a
-# distributable .app: the desktop env provisions its own SECRET_KEY_BASE at first
-# run and never decrypts credentials, so any config/*.key / .env* are pure liability
-# (.gitignore treats every /config/*.key as a local secret, not just master.key).
-# .bundle is excluded too: a developer's local `bundle config set --local` writes
-# .bundle/config, which outranks the launcher's BUNDLE_PATH env and would point the
-# packaged app at a dev-only gem path. The launcher sets all bundler env at runtime.
-rsync -a --delete \
-  --exclude '.git' \
-  --exclude 'node_modules' \
-  --exclude 'log/*' \
-  --exclude 'tmp/*' \
-  --exclude 'storage/*' \
-  --exclude '/tools/desktop-app/vendor/proxy/***' \
-  --include 'tools/desktop-app/vendor/**' \
-  --exclude 'test' \
-  --exclude 'spec' \
-  --exclude '.env' \
-  --exclude '.env.*' \
-  --exclude '.bundle' \
-  --exclude 'config/*.key' \
-  --exclude 'config/credentials/*.key' \
-  --exclude 'tools/desktop-app/staging' \
-  --exclude 'tools/desktop-app/src-tauri/target' \
-  "${STAGING_EXCLUDES[@]}" \
-  "$APP_ROOT/" "$STAGING/"
+# Stage only Git-tracked application files. An exclusion list inevitably misses
+# newly ignored files (including developer credentials), while this allowlist
+# keeps release-machine state out of the signed application by construction.
+# The generated Ruby/gem tree is the sole intentional untracked input; the
+# immutable proxy is copied separately below after its runtime is bundled.
+git -C "$APP_ROOT" ls-files -z | \
+  rsync -a --from0 --files-from=- "$APP_ROOT/" "$STAGING/"
+mkdir -p "$STAGING/tools/desktop-app/vendor"
+rsync -a --delete --exclude 'proxy/***' \
+  "$DESKTOP_DIR/vendor/" "$STAGING/tools/desktop-app/vendor/"
 
 # Rails creates runtime files below Rails.root/tmp when starting the server.
 # The app bundle is read-only once distributed, so the directory itself must

--- a/tools/desktop-app/scripts/build-macos.sh
+++ b/tools/desktop-app/scripts/build-macos.sh
@@ -89,34 +89,7 @@ echo "[build-macos] 4/7 precompiling assets (desktop env)"
 )
 
 echo "[build-macos] 5/7 staging app tree into $STAGING"
-rm -rf "$DESKTOP_DIR/staging"
-mkdir -p "$STAGING"
-# Stage only Git-tracked application files. An exclusion list inevitably misses
-# newly ignored files (including developer credentials), while this allowlist
-# keeps release-machine state out of the signed application by construction.
-# The generated Ruby/gem tree is the sole intentional untracked input; the
-# immutable proxy is copied separately below after its runtime is bundled.
-git -C "$APP_ROOT" ls-files -z | \
-  rsync -a --from0 --files-from=- "$APP_ROOT/" "$STAGING/"
-mkdir -p "$STAGING/tools/desktop-app/vendor"
-rsync -a --delete --exclude 'proxy/***' \
-  "$DESKTOP_DIR/vendor/" "$STAGING/tools/desktop-app/vendor/"
-
-# Rails creates runtime files below Rails.root/tmp when starting the server.
-# The app bundle is read-only once distributed, so the directory itself must
-# already exist in the staged app even though its contents stay excluded.
-mkdir -p "$STAGING/tmp/pids"
-
-# tauri-build opens every staged file to bundle it as a resource; if any file is
-# not owner-readable the resource walk aborts with EACCES. A mode-only `chmod -R`
-# is not enough: on a managed/corporate Mac the checkout can carry inherited ACLs
-# (and rarely file flags) that deny owner access and SURVIVE chmod's mode bits, so
-# the walk still fails after a mode fix. Strip ACLs and flags first, then normalize
-# mode — those three are the only things that can deny owner read. The staging tree
-# is a throwaway copy that becomes read-only .app resources, so this is safe.
-chmod -RN "$STAGING"                              # drop inherited/explicit ACLs
-chflags -R nouchg "$STAGING" 2>/dev/null || true  # clear immutable flags if present
-chmod -R u+rwX "$STAGING"                          # normalize POSIX mode bits
+"$SCRIPT_DIR/stage-app-tree.sh" "$APP_ROOT" "$DESKTOP_DIR"
 
 # The proxy is a separate Tauri resource rather than part of the Rails source
 # tree. Its Node runtime and exact npm dependency tree are immutable after this

--- a/tools/desktop-app/scripts/bundle-proxy.sh
+++ b/tools/desktop-app/scripts/bundle-proxy.sh
@@ -9,10 +9,10 @@
 #   NODE_RUNTIME_SHA256       SHA-256 for exactly that archive
 #
 # NODE_RUNTIME_DIR may be supplied by a release job that has already fetched and
-# verified the runtime. It must contain bin/node and bin/npm. This is useful for
-# hermetic CI, but does not relax the npm lockfile verification below. When none
-# of the Node runtime inputs are set, the script bundles the Node installation
-# found on PATH. The packaged app never uses that installation at runtime.
+# verified the official runtime archive. It must contain bin/node and bin/npm.
+# When no runtime input is set, a pinned official Node distribution is downloaded
+# and verified. The packaged app never uses a developer's Node installation at
+# runtime.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -23,24 +23,12 @@ PACKAGE_VERSION="${CLI_OPENAI_PROXY_VERSION:-0.1.0}"
 NODE_RUNTIME_DIR="${NODE_RUNTIME_DIR:-}"
 NODE_RUNTIME_URL="${NODE_RUNTIME_URL:-}"
 NODE_RUNTIME_SHA256="${NODE_RUNTIME_SHA256:-}"
+DEFAULT_NODE_RUNTIME_URL="https://nodejs.org/dist/v22.13.0/node-v22.13.0-darwin-arm64.tar.xz"
+DEFAULT_NODE_RUNTIME_SHA256="71b0893ef6a55295994f38002fada15c9a76a3cedeb36745fde0403741d183c6"
 
 fail() {
   echo "[bundle-proxy] $*" >&2
   exit 1
-}
-
-node_runtime_dir_from_path() {
-  local node_command node_binary
-
-  node_command="$(command -v node || true)"
-  [[ -n "$node_command" ]] || return 1
-
-  # `command -v node` is commonly /opt/homebrew/bin/node, a symlink into a
-  # versioned Cellar directory. Resolve the executable itself before taking its
-  # parent so copying the runtime cannot accidentally copy the whole prefix.
-  node_binary="$("$node_command" -p 'require("fs").realpathSync(process.execPath)')" || return 1
-  [[ -x "$node_binary" ]] || return 1
-  cd -P "$(dirname "$node_binary")/.." && pwd
 }
 
 [[ "$PACKAGE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$ ]] || \
@@ -55,9 +43,14 @@ if [[ -n "$NODE_RUNTIME_DIR" ]]; then
   [[ -x "$NODE_RUNTIME_DIR/bin/node" && -x "$NODE_RUNTIME_DIR/bin/npm" ]] || \
     fail "NODE_RUNTIME_DIR must contain executable bin/node and bin/npm"
   cp -R "$NODE_RUNTIME_DIR" "$stage/node"
-elif [[ -n "$NODE_RUNTIME_URL" || -n "$NODE_RUNTIME_SHA256" ]]; then
-  [[ -n "$NODE_RUNTIME_URL" && -n "$NODE_RUNTIME_SHA256" ]] || \
-    fail "set both NODE_RUNTIME_URL and NODE_RUNTIME_SHA256"
+else
+  if [[ -n "$NODE_RUNTIME_URL" || -n "$NODE_RUNTIME_SHA256" ]]; then
+    [[ -n "$NODE_RUNTIME_URL" && -n "$NODE_RUNTIME_SHA256" ]] || \
+      fail "set both NODE_RUNTIME_URL and NODE_RUNTIME_SHA256"
+  else
+    NODE_RUNTIME_URL="$DEFAULT_NODE_RUNTIME_URL"
+    NODE_RUNTIME_SHA256="$DEFAULT_NODE_RUNTIME_SHA256"
+  fi
   [[ "$NODE_RUNTIME_URL" == https://nodejs.org/* ]] || \
     fail "NODE_RUNTIME_URL must use the official nodejs.org HTTPS distribution"
   archive="$stage/node-runtime.tar.xz"
@@ -68,13 +61,6 @@ elif [[ -n "$NODE_RUNTIME_URL" || -n "$NODE_RUNTIME_SHA256" ]]; then
   runtime_root="$(find "$stage" -mindepth 1 -maxdepth 1 -type d -name 'node-v*-darwin-arm64' -print -quit)"
   [[ -n "$runtime_root" ]] || fail "Node archive is not a darwin-arm64 distribution"
   mv "$runtime_root" "$stage/node"
-else
-  NODE_RUNTIME_DIR="$(node_runtime_dir_from_path)" || \
-    fail "Node is not available; install Node or set NODE_RUNTIME_DIR or both NODE_RUNTIME_URL and NODE_RUNTIME_SHA256"
-  [[ -x "$NODE_RUNTIME_DIR/bin/node" && -x "$NODE_RUNTIME_DIR/bin/npm" ]] || \
-    fail "the Node installation on PATH must contain executable bin/node and bin/npm"
-  echo "[bundle-proxy] using Node runtime from $NODE_RUNTIME_DIR"
-  cp -R "$NODE_RUNTIME_DIR" "$stage/node"
 fi
 
 node_bin="$stage/node/bin/node"

--- a/tools/desktop-app/scripts/bundle-proxy.sh
+++ b/tools/desktop-app/scripts/bundle-proxy.sh
@@ -3,14 +3,16 @@
 # the desktop app. This is a release-build step; it never installs a global npm
 # package and it never uses a user's Node installation at runtime.
 #
-# Required release inputs:
+# Optional release inputs:
 #   CLI_OPENAI_PROXY_VERSION  Published, exact semver (defaults to 0.1.0)
 #   NODE_RUNTIME_URL          Official darwin-arm64 Node .tar.xz URL
 #   NODE_RUNTIME_SHA256       SHA-256 for exactly that archive
 #
 # NODE_RUNTIME_DIR may be supplied by a release job that has already fetched and
 # verified the runtime. It must contain bin/node and bin/npm. This is useful for
-# hermetic CI, but does not relax the npm lockfile verification below.
+# hermetic CI, but does not relax the npm lockfile verification below. When none
+# of the Node runtime inputs are set, the script bundles the Node installation
+# found on PATH. The packaged app never uses that installation at runtime.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -27,6 +29,20 @@ fail() {
   exit 1
 }
 
+node_runtime_dir_from_path() {
+  local node_command node_binary
+
+  node_command="$(command -v node || true)"
+  [[ -n "$node_command" ]] || return 1
+
+  # `command -v node` is commonly /opt/homebrew/bin/node, a symlink into a
+  # versioned Cellar directory. Resolve the executable itself before taking its
+  # parent so copying the runtime cannot accidentally copy the whole prefix.
+  node_binary="$("$node_command" -p 'require("fs").realpathSync(process.execPath)')" || return 1
+  [[ -x "$node_binary" ]] || return 1
+  cd -P "$(dirname "$node_binary")/.." && pwd
+}
+
 [[ "$PACKAGE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$ ]] || \
   fail "CLI_OPENAI_PROXY_VERSION must be an exact semver, not a range"
 
@@ -39,9 +55,9 @@ if [[ -n "$NODE_RUNTIME_DIR" ]]; then
   [[ -x "$NODE_RUNTIME_DIR/bin/node" && -x "$NODE_RUNTIME_DIR/bin/npm" ]] || \
     fail "NODE_RUNTIME_DIR must contain executable bin/node and bin/npm"
   cp -R "$NODE_RUNTIME_DIR" "$stage/node"
-else
+elif [[ -n "$NODE_RUNTIME_URL" || -n "$NODE_RUNTIME_SHA256" ]]; then
   [[ -n "$NODE_RUNTIME_URL" && -n "$NODE_RUNTIME_SHA256" ]] || \
-    fail "NODE_RUNTIME_URL and NODE_RUNTIME_SHA256 are required when NODE_RUNTIME_DIR is not set"
+    fail "set both NODE_RUNTIME_URL and NODE_RUNTIME_SHA256"
   [[ "$NODE_RUNTIME_URL" == https://nodejs.org/* ]] || \
     fail "NODE_RUNTIME_URL must use the official nodejs.org HTTPS distribution"
   archive="$stage/node-runtime.tar.xz"
@@ -52,6 +68,13 @@ else
   runtime_root="$(find "$stage" -mindepth 1 -maxdepth 1 -type d -name 'node-v*-darwin-arm64' -print -quit)"
   [[ -n "$runtime_root" ]] || fail "Node archive is not a darwin-arm64 distribution"
   mv "$runtime_root" "$stage/node"
+else
+  NODE_RUNTIME_DIR="$(node_runtime_dir_from_path)" || \
+    fail "Node is not available; install Node or set NODE_RUNTIME_DIR or both NODE_RUNTIME_URL and NODE_RUNTIME_SHA256"
+  [[ -x "$NODE_RUNTIME_DIR/bin/node" && -x "$NODE_RUNTIME_DIR/bin/npm" ]] || \
+    fail "the Node installation on PATH must contain executable bin/node and bin/npm"
+  echo "[bundle-proxy] using Node runtime from $NODE_RUNTIME_DIR"
+  cp -R "$NODE_RUNTIME_DIR" "$stage/node"
 fi
 
 node_bin="$stage/node/bin/node"

--- a/tools/desktop-app/scripts/stage-app-tree.sh
+++ b/tools/desktop-app/scripts/stage-app-tree.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Stage the files that the desktop app needs without copying arbitrary ignored
+# files from the release checkout. Generated asset outputs are intentional
+# untracked inputs: Rails resolves them in production through the manifest.
+set -euo pipefail
+
+if (($# != 2)); then
+  echo "usage: $0 APP_ROOT DESKTOP_DIR" >&2
+  exit 64
+fi
+
+APP_ROOT="$1"
+DESKTOP_DIR="$2"
+STAGING="$DESKTOP_DIR/staging/app"
+
+rm -rf "$DESKTOP_DIR/staging"
+mkdir -p "$STAGING"
+
+# Stage only Git-tracked application files. An exclusion list inevitably misses
+# newly ignored files (including developer credentials), while this allowlist
+# keeps release-machine state out of the signed application by construction.
+git -C "$APP_ROOT" ls-files -z | \
+  rsync -a --from0 --files-from=- "$APP_ROOT/" "$STAGING/"
+
+# assets:precompile deliberately writes these two directories outside Git.
+# They must be included after the tracked-file export: Propshaft serves the
+# manifest/digested assets from public/assets, and the generated JavaScript is
+# an asset input that must remain available to the packaged Rails app.
+for generated_assets in public/assets app/assets/builds; do
+  source_dir="$APP_ROOT/$generated_assets"
+  destination_dir="$STAGING/$generated_assets"
+  if [[ ! -d "$source_dir" ]]; then
+    echo "[stage-app-tree] missing generated asset directory: $source_dir" >&2
+    exit 1
+  fi
+  mkdir -p "$destination_dir"
+  rsync -a --delete "$source_dir/" "$destination_dir/"
+done
+
+# The generated Ruby/gem tree is the sole other intentional untracked input;
+# the immutable proxy is copied separately below after its runtime is bundled.
+mkdir -p "$STAGING/tools/desktop-app/vendor"
+rsync -a --delete --exclude 'proxy/***' \
+  "$DESKTOP_DIR/vendor/" "$STAGING/tools/desktop-app/vendor/"
+
+# Rails creates runtime files below Rails.root/tmp when starting the server.
+# The app bundle is read-only once distributed, so the directory itself must
+# already exist in the staged app even though its contents stay excluded.
+mkdir -p "$STAGING/tmp/pids"
+
+# tauri-build opens every staged file to bundle it as a resource; if any file is
+# not owner-readable the resource walk aborts with EACCES. A mode-only `chmod -R`
+# is not enough: on a managed/corporate Mac the checkout can carry inherited ACLs
+# (and rarely file flags) that deny owner access and SURVIVE chmod's mode bits, so
+# the walk still fails after a mode fix. Strip ACLs and flags first, then normalize
+# mode — those three are the only things that can deny owner read. The staging tree
+# is a throwaway copy that becomes read-only .app resources, so this is safe.
+chmod -RN "$STAGING"                              # drop inherited/explicit ACLs
+chflags -R nouchg "$STAGING" 2>/dev/null || true  # clear immutable flags if present
+chmod -R u+rwX "$STAGING"                          # normalize POSIX mode bits


### PR DESCRIPTION
## Summary
- add an interactive desktop release script with semantic-version suggestion, final confirmation, and a version commit
- synchronize Tauri and Cargo versions, build/sign/notarize/staple a DMG, generate a SHA-256 checksum, and publish immutable GitHub Release assets only after verification
- document release prerequisites and add focused release-script coverage

## Why
Provide a repeatable, gated macOS Apple Silicon desktop release path that prevents publishing unverified artifacts.

## Validation
- `./script/test/release_desktop_test.sh`
- Rust desktop tests: 27 passed (run before this PR update)

## Notes
Apple signing/notarization and GitHub Release publication require repository secrets and were not executed locally.