### PR TITLE
fix: support desktop confirmations and downloads

### DIFF
--- a/engines/collavre/app/views/collavre/user_themes/index.html.erb
+++ b/engines/collavre/app/views/collavre/user_themes/index.html.erb
@@ -51,7 +51,7 @@
                 <% unless Current.user.theme == theme.id.to_s %>
                 <%= button_to t('collavre.themes.apply'), collavre.apply_user_theme_path(theme), method: :post, class: "btn btn-xs" %>
               <% end %>
-              <%= button_to t('collavre.themes.delete'), collavre.user_theme_path(theme), method: :delete, class: "btn btn-xs btn-danger", form_class: "inline-block", onclick: "return confirm('#{t('collavre.themes.confirm_delete')}')" %>
+              <%= button_to t('collavre.themes.delete'), collavre.user_theme_path(theme), method: :delete, class: "btn btn-xs btn-danger", form: { class: "inline-block", data: { turbo_confirm: t('collavre.themes.confirm_delete') } } %>
               </div>
             </td>
           </tr>

--- a/engines/collavre/test/controllers/user_themes_controller_test.rb
+++ b/engines/collavre/test/controllers/user_themes_controller_test.rb
@@ -10,4 +10,16 @@ class UserThemesControllerTest < ActionDispatch::IntegrationTest
     get collavre.user_themes_url
     assert_response :success
   end
+
+  test "uses the in-app Turbo confirmation for theme deletion" do
+    @user.user_themes.create!(name: "Forest", variables: { "--surface-bg" => "#0f2d1f" })
+
+    get collavre.user_themes_url
+
+    assert_select "form[data-turbo-confirm=?]", I18n.t("collavre.themes.confirm_delete") do
+      assert_select "input[name='_method'][value='delete']"
+      assert_select "button.btn-danger", text: I18n.t("collavre.themes.delete")
+    end
+    assert_select "button[onclick*='confirm']", count: 0
+  end
 end

--- a/tools/desktop-app/src-tauri/src/lib.rs
+++ b/tools/desktop-app/src-tauri/src/lib.rs
@@ -2070,6 +2070,10 @@ pub fn run() {
             WebviewWindowBuilder::new(&handle, "main", WebviewUrl::App("index.html".into()))
                 .title("Collavre Desktop")
                 .inner_size(1280.0, 860.0)
+                // WKWebView only delegates downloads when the shell registers a
+                // handler. Returning true accepts its suggested destination and
+                // filename, including downloads triggered by `<a download>`.
+                .on_download(|_, _| true)
                 .build()?;
 
             // Health-gate startup off the UI thread so the splash keeps animating.


### PR DESCRIPTION
## Summary
- route custom-theme deletion through the existing Turbo in-app confirmation dialog
- register the Tauri download handler so WKWebView accepts attachment downloads with its suggested filename and destination
- add a view assertion covering the declarative confirmation hook

## Why
Native `window.confirm()` silently fails in the Tauri WKWebView, and downloads require a registered Tauri handler.

## Validation
- `mise exec ruby@3.4.4 -- ./bin/rubocop -a`
- `mise exec ruby@3.4.4 -- bundle exec rake test`
- `mise exec ruby@3.4.4 -- bundle exec bin/rails test engines/collavre/test/controllers/user_themes_controller_test.rb`
- `cargo fmt --check`
- `cargo test` (27 tests)

`bin/rails test:system` cannot run because this checkout has no `test/system` directory; Rails raises `LoadError` while loading that path.