### PR TITLE
fix(desktop): reduce Keychain access prompts

### DIFF
--- a/tools/desktop-app/src-tauri/src/lib.rs
+++ b/tools/desktop-app/src-tauri/src/lib.rs
@@ -345,31 +345,47 @@ fn generate_proxy_credentials() -> Result<ProxyCredentials, String> {
     })
 }
 
+/// Preserve a complete legacy set during migration. A partially written set
+/// cannot authenticate the existing gateway, so replace it as if it were a
+/// fresh installation; the `regenerated` flag subsequently invalidates the
+/// stale gateway registration.
+fn legacy_proxy_credentials_from_entries(
+    admin_key: Option<Vec<u8>>,
+    completion_key: Option<Vec<u8>>,
+    identity_secret: Option<Vec<u8>>,
+) -> Result<Option<ProxyCredentials>, String> {
+    match (admin_key, completion_key, identity_secret) {
+        (None, None, None) => Ok(None),
+        (Some(admin_key), Some(completion_key), Some(identity_secret)) => {
+            Ok(Some(ProxyCredentials {
+                admin_key: String::from_utf8(admin_key)
+                    .map_err(|_| "The desktop proxy key in Keychain is invalid.".to_string())?,
+                completion_key: String::from_utf8(completion_key)
+                    .map_err(|_| "The desktop proxy key in Keychain is invalid.".to_string())?,
+                identity_secret: String::from_utf8(identity_secret)
+                    .map_err(|_| "The desktop proxy key in Keychain is invalid.".to_string())?,
+                regenerated: false,
+            }))
+        }
+        _ => generate_proxy_credentials().map(Some),
+    }
+}
+
 #[cfg(target_os = "macos")]
 fn legacy_proxy_credentials() -> Result<Option<ProxyCredentials>, String> {
     use security_framework::passwords::get_generic_password;
 
-    let admin_key = match get_generic_password(PROXY_KEYCHAIN_SERVICE, PROXY_ADMIN_KEY_ACCOUNT) {
-        Ok(bytes) => String::from_utf8(bytes)
-            .map_err(|_| "The desktop proxy key in Keychain is invalid.".to_string())?,
-        Err(error) if error.code() == ERR_SEC_ITEM_NOT_FOUND => return Ok(None),
-        Err(_) => {
-            return Err("Collavre needs Keychain access for the desktop proxy key.".to_string());
-        }
+    let read_entry = |account| match get_generic_password(PROXY_KEYCHAIN_SERVICE, account) {
+        Ok(bytes) => Ok(Some(bytes)),
+        Err(error) if error.code() == ERR_SEC_ITEM_NOT_FOUND => Ok(None),
+        Err(_) => Err("Collavre needs Keychain access for the desktop proxy key.".to_string()),
     };
-    let completion_key = get_generic_password(PROXY_KEYCHAIN_SERVICE, PROXY_COMPLETION_KEY_ACCOUNT)
-        .map_err(|_| "The desktop proxy keys in Keychain are incomplete.".to_string())?;
-    let identity_secret =
-        get_generic_password(PROXY_KEYCHAIN_SERVICE, PROXY_IDENTITY_SECRET_ACCOUNT)
-            .map_err(|_| "The desktop proxy keys in Keychain are incomplete.".to_string())?;
-    Ok(Some(ProxyCredentials {
-        admin_key,
-        completion_key: String::from_utf8(completion_key)
-            .map_err(|_| "The desktop proxy key in Keychain is invalid.".to_string())?,
-        identity_secret: String::from_utf8(identity_secret)
-            .map_err(|_| "The desktop proxy key in Keychain is invalid.".to_string())?,
-        regenerated: false,
-    }))
+
+    legacy_proxy_credentials_from_entries(
+        read_entry(PROXY_ADMIN_KEY_ACCOUNT)?,
+        read_entry(PROXY_COMPLETION_KEY_ACCOUNT)?,
+        read_entry(PROXY_IDENTITY_SECRET_ACCOUNT)?,
+    )
 }
 
 #[cfg(target_os = "macos")]
@@ -1435,10 +1451,11 @@ mod tests {
         append_unique_paths, config_env_overrides, configure_desktop_proxy_environment,
         decode_proxy_credentials, desktop_port, encode_proxy_credentials, generate_proxy_key,
         invalidate_proxy_registration_after_key_regeneration,
-        invalidate_proxy_registration_when_gateway_is_missing, lsof_reports_process,
-        managed_proxy_credentials, managed_proxy_runs_on_port, migrate_proxy_config,
-        normalized_proxy_config, nvm_bin_paths, parse_bundled_proxy_manifest, read_proxy_config,
-        reap_orphan_proxy, register_authenticated_gateway, registered_authenticated_gateway_exists,
+        invalidate_proxy_registration_when_gateway_is_missing,
+        legacy_proxy_credentials_from_entries, lsof_reports_process, managed_proxy_credentials,
+        managed_proxy_runs_on_port, migrate_proxy_config, normalized_proxy_config, nvm_bin_paths,
+        parse_bundled_proxy_manifest, read_proxy_config, reap_orphan_proxy,
+        register_authenticated_gateway, registered_authenticated_gateway_exists,
         replace_occupied_proxy_port, revalidate_registered_gateway_after_rails_health,
         valid_sidecar_challenge_response, wait_until_proxy_healthy, write_proxy_config,
         GatewayRegistration, HmacSha256, ManagedProxy, ProxyConfig, ProxyCredentials, ProxySidecar,
@@ -1631,6 +1648,40 @@ mod tests {
             br#"{"admin_key":"admin","completion_key":"","identity_secret":"identity"}"#
         )
         .is_err());
+    }
+
+    #[test]
+    fn incomplete_legacy_keychain_credentials_are_regenerated() {
+        let credentials = legacy_proxy_credentials_from_entries(
+            Some(b"legacy-admin-key".to_vec()),
+            None,
+            Some(b"legacy-identity-secret".to_vec()),
+        )
+        .expect("regenerate incomplete credentials")
+        .expect("credentials");
+
+        assert!(credentials.regenerated);
+        assert_ne!("legacy-admin-key", credentials.admin_key);
+        assert_ne!("legacy-identity-secret", credentials.identity_secret);
+        assert!(credentials.admin_key.starts_with("cop_admin_"));
+        assert!(credentials.completion_key.starts_with("cop_key_"));
+        assert!(credentials.identity_secret.starts_with("cop_identity_"));
+    }
+
+    #[test]
+    fn complete_legacy_keychain_credentials_are_preserved() {
+        let credentials = legacy_proxy_credentials_from_entries(
+            Some(b"legacy-admin-key".to_vec()),
+            Some(b"legacy-completion-key".to_vec()),
+            Some(b"legacy-identity-secret".to_vec()),
+        )
+        .expect("read complete credentials")
+        .expect("credentials");
+
+        assert_eq!("legacy-admin-key", credentials.admin_key);
+        assert_eq!("legacy-completion-key", credentials.completion_key);
+        assert_eq!("legacy-identity-secret", credentials.identity_secret);
+        assert!(!credentials.regenerated);
     }
 
     #[test]

--- a/tools/desktop-app/src-tauri/src/lib.rs
+++ b/tools/desktop-app/src-tauri/src/lib.rs
@@ -371,6 +371,16 @@ fn legacy_proxy_credentials_from_entries(
     }
 }
 
+fn legacy_or_new_proxy_credentials(
+    legacy: Option<ProxyCredentials>,
+    generate: impl FnOnce() -> Result<ProxyCredentials, String>,
+) -> Result<ProxyCredentials, String> {
+    match legacy {
+        Some(credentials) => Ok(credentials),
+        None => generate(),
+    }
+}
+
 #[cfg(target_os = "macos")]
 fn legacy_proxy_credentials() -> Result<Option<ProxyCredentials>, String> {
     use security_framework::passwords::get_generic_password;
@@ -403,7 +413,8 @@ fn keychain_proxy_credentials() -> Result<ProxyCredentials, String> {
     // Older desktop builds stored each secret in its own Keychain entry. Read
     // those entries only during this one-time migration, then keep all three
     // values in one entry so a launch makes one Keychain access request.
-    let credentials = legacy_proxy_credentials()?.unwrap_or(generate_proxy_credentials()?);
+    let credentials =
+        legacy_or_new_proxy_credentials(legacy_proxy_credentials()?, generate_proxy_credentials)?;
     let serialized = encode_proxy_credentials(&credentials)?;
     set_generic_password(
         PROXY_KEYCHAIN_SERVICE,
@@ -1451,7 +1462,7 @@ mod tests {
         append_unique_paths, config_env_overrides, configure_desktop_proxy_environment,
         decode_proxy_credentials, desktop_port, encode_proxy_credentials, generate_proxy_key,
         invalidate_proxy_registration_after_key_regeneration,
-        invalidate_proxy_registration_when_gateway_is_missing,
+        invalidate_proxy_registration_when_gateway_is_missing, legacy_or_new_proxy_credentials,
         legacy_proxy_credentials_from_entries, lsof_reports_process, managed_proxy_credentials,
         managed_proxy_runs_on_port, migrate_proxy_config, normalized_proxy_config, nvm_bin_paths,
         parse_bundled_proxy_manifest, read_proxy_config, reap_orphan_proxy,
@@ -1681,6 +1692,24 @@ mod tests {
         assert_eq!("legacy-admin-key", credentials.admin_key);
         assert_eq!("legacy-completion-key", credentials.completion_key);
         assert_eq!("legacy-identity-secret", credentials.identity_secret);
+        assert!(!credentials.regenerated);
+    }
+
+    #[test]
+    fn complete_legacy_credentials_do_not_generate_a_fallback() {
+        let legacy = ProxyCredentials {
+            admin_key: "legacy-admin-key".to_string(),
+            completion_key: "legacy-completion-key".to_string(),
+            identity_secret: "legacy-identity-secret".to_string(),
+            regenerated: false,
+        };
+
+        let credentials = legacy_or_new_proxy_credentials(Some(legacy), || {
+            Err("fallback must not be generated".to_string())
+        })
+        .expect("preserve legacy credentials without generating a fallback");
+
+        assert_eq!("legacy-admin-key", credentials.admin_key);
         assert!(!credentials.regenerated);
     }
 

--- a/tools/desktop-app/src-tauri/src/lib.rs
+++ b/tools/desktop-app/src-tauri/src/lib.rs
@@ -45,9 +45,11 @@ struct ManagedProxy {
 struct ProxySidecar(Mutex<Option<ManagedProxy>>);
 
 const PROXY_KEYCHAIN_SERVICE: &str = "net.collavre.desktop.cli-openai-proxy";
+const PROXY_CREDENTIALS_ACCOUNT: &str = "credentials";
 const PROXY_ADMIN_KEY_ACCOUNT: &str = "admin-key";
 const PROXY_COMPLETION_KEY_ACCOUNT: &str = "completion-key";
 const PROXY_IDENTITY_SECRET_ACCOUNT: &str = "identity-secret";
+const ERR_SEC_ITEM_NOT_FOUND: i32 = -25_300;
 
 #[derive(Debug, Deserialize)]
 struct BundledProxyManifest {
@@ -301,43 +303,108 @@ struct ProxyCredentials {
     regenerated: bool,
 }
 
+#[derive(Deserialize, Serialize)]
+struct StoredProxyCredentials {
+    admin_key: String,
+    completion_key: String,
+    identity_secret: String,
+}
+
+fn encode_proxy_credentials(credentials: &ProxyCredentials) -> Result<Vec<u8>, String> {
+    serde_json::to_vec(&StoredProxyCredentials {
+        admin_key: credentials.admin_key.clone(),
+        completion_key: credentials.completion_key.clone(),
+        identity_secret: credentials.identity_secret.clone(),
+    })
+    .map_err(|_| "Could not prepare the desktop proxy keys for Keychain.".to_string())
+}
+
+fn decode_proxy_credentials(bytes: &[u8]) -> Result<ProxyCredentials, String> {
+    let credentials: StoredProxyCredentials = serde_json::from_slice(bytes)
+        .map_err(|_| "The desktop proxy keys in Keychain are invalid.".to_string())?;
+    if credentials.admin_key.is_empty()
+        || credentials.completion_key.is_empty()
+        || credentials.identity_secret.is_empty()
+    {
+        return Err("The desktop proxy keys in Keychain are invalid.".to_string());
+    }
+    Ok(ProxyCredentials {
+        admin_key: credentials.admin_key,
+        completion_key: credentials.completion_key,
+        identity_secret: credentials.identity_secret,
+        regenerated: false,
+    })
+}
+
+fn generate_proxy_credentials() -> Result<ProxyCredentials, String> {
+    Ok(ProxyCredentials {
+        admin_key: generate_proxy_key("cop_admin")?,
+        completion_key: generate_proxy_key("cop_key")?,
+        identity_secret: generate_proxy_key("cop_identity")?,
+        regenerated: true,
+    })
+}
+
 #[cfg(target_os = "macos")]
-fn keychain_proxy_key(account: &str, prefix: &str) -> Result<(String, bool), String> {
+fn legacy_proxy_credentials() -> Result<Option<ProxyCredentials>, String> {
+    use security_framework::passwords::get_generic_password;
+
+    let admin_key = match get_generic_password(PROXY_KEYCHAIN_SERVICE, PROXY_ADMIN_KEY_ACCOUNT) {
+        Ok(bytes) => String::from_utf8(bytes)
+            .map_err(|_| "The desktop proxy key in Keychain is invalid.".to_string())?,
+        Err(error) if error.code() == ERR_SEC_ITEM_NOT_FOUND => return Ok(None),
+        Err(_) => {
+            return Err("Collavre needs Keychain access for the desktop proxy key.".to_string());
+        }
+    };
+    let completion_key = get_generic_password(PROXY_KEYCHAIN_SERVICE, PROXY_COMPLETION_KEY_ACCOUNT)
+        .map_err(|_| "The desktop proxy keys in Keychain are incomplete.".to_string())?;
+    let identity_secret =
+        get_generic_password(PROXY_KEYCHAIN_SERVICE, PROXY_IDENTITY_SECRET_ACCOUNT)
+            .map_err(|_| "The desktop proxy keys in Keychain are incomplete.".to_string())?;
+    Ok(Some(ProxyCredentials {
+        admin_key,
+        completion_key: String::from_utf8(completion_key)
+            .map_err(|_| "The desktop proxy key in Keychain is invalid.".to_string())?,
+        identity_secret: String::from_utf8(identity_secret)
+            .map_err(|_| "The desktop proxy key in Keychain is invalid.".to_string())?,
+        regenerated: false,
+    }))
+}
+
+#[cfg(target_os = "macos")]
+fn keychain_proxy_credentials() -> Result<ProxyCredentials, String> {
     use security_framework::passwords::{get_generic_password, set_generic_password};
 
-    if let Ok(bytes) = get_generic_password(PROXY_KEYCHAIN_SERVICE, account) {
-        return String::from_utf8(bytes)
-            .map(|key| (key, false))
-            .map_err(|_| "The desktop proxy key in Keychain is invalid.".to_string());
+    match get_generic_password(PROXY_KEYCHAIN_SERVICE, PROXY_CREDENTIALS_ACCOUNT) {
+        Ok(bytes) => return decode_proxy_credentials(&bytes),
+        Err(error) if error.code() != ERR_SEC_ITEM_NOT_FOUND => {
+            return Err("Collavre needs Keychain access for the desktop proxy.".to_string());
+        }
+        Err(_) => {}
     }
 
-    let key = generate_proxy_key(prefix)?;
-    set_generic_password(PROXY_KEYCHAIN_SERVICE, account, key.as_bytes()).map_err(|_| {
-        "Collavre needs Keychain access to store the desktop proxy key.".to_string()
-    })?;
-    Ok((key, true))
+    // Older desktop builds stored each secret in its own Keychain entry. Read
+    // those entries only during this one-time migration, then keep all three
+    // values in one entry so a launch makes one Keychain access request.
+    let credentials = legacy_proxy_credentials()?.unwrap_or(generate_proxy_credentials()?);
+    let serialized = encode_proxy_credentials(&credentials)?;
+    set_generic_password(
+        PROXY_KEYCHAIN_SERVICE,
+        PROXY_CREDENTIALS_ACCOUNT,
+        &serialized,
+    )
+    .map_err(|_| "Collavre needs Keychain access to store the desktop proxy keys.".to_string())?;
+    Ok(credentials)
 }
 
 #[cfg(not(target_os = "macos"))]
-fn keychain_proxy_key(_account: &str, _prefix: &str) -> Result<(String, bool), String> {
+fn keychain_proxy_credentials() -> Result<ProxyCredentials, String> {
     Err("Desktop proxy installation is currently supported on macOS only.".to_string())
 }
 
 fn proxy_credentials() -> Result<ProxyCredentials, String> {
-    let (admin_key, admin_key_regenerated) =
-        keychain_proxy_key(PROXY_ADMIN_KEY_ACCOUNT, "cop_admin")?;
-    let (completion_key, completion_key_regenerated) =
-        keychain_proxy_key(PROXY_COMPLETION_KEY_ACCOUNT, "cop_key")?;
-    let (identity_secret, identity_secret_regenerated) =
-        keychain_proxy_key(PROXY_IDENTITY_SECRET_ACCOUNT, "cop_identity")?;
-    Ok(ProxyCredentials {
-        admin_key,
-        completion_key,
-        identity_secret,
-        regenerated: admin_key_regenerated
-            || completion_key_regenerated
-            || identity_secret_regenerated,
-    })
+    keychain_proxy_credentials()
 }
 
 fn invalidate_proxy_registration_after_key_regeneration(
@@ -598,6 +665,9 @@ fn stop_managed_proxy(sidecar: &ProxySidecar) -> Result<(), String> {
 }
 
 fn start_proxy(app: &tauri::AppHandle, data: &Path, sidecar: &ProxySidecar) -> Result<(), String> {
+    if managed_proxy_credentials(sidecar)?.is_some() {
+        return Ok(());
+    }
     let credentials = proxy_credentials()?;
     start_proxy_with_credentials(app, data, sidecar, credentials).map(|_| ())
 }
@@ -1363,7 +1433,8 @@ fn apply_desktop_config(data: &Path) {
 mod tests {
     use super::{
         append_unique_paths, config_env_overrides, configure_desktop_proxy_environment,
-        desktop_port, generate_proxy_key, invalidate_proxy_registration_after_key_regeneration,
+        decode_proxy_credentials, desktop_port, encode_proxy_credentials, generate_proxy_key,
+        invalidate_proxy_registration_after_key_regeneration,
         invalidate_proxy_registration_when_gateway_is_missing, lsof_reports_process,
         managed_proxy_credentials, managed_proxy_runs_on_port, migrate_proxy_config,
         normalized_proxy_config, nvm_bin_paths, parse_bundled_proxy_manifest, read_proxy_config,
@@ -1533,6 +1604,33 @@ mod tests {
             .all(|character| character.is_ascii_alphanumeric()
                 || character == '_'
                 || character == '-'));
+    }
+
+    #[test]
+    fn proxy_credentials_are_stored_as_one_keychain_value() {
+        let credentials = ProxyCredentials {
+            admin_key: "admin-key".to_string(),
+            completion_key: "completion-key".to_string(),
+            identity_secret: "identity-secret".to_string(),
+            regenerated: true,
+        };
+
+        let serialized = encode_proxy_credentials(&credentials).expect("serialize credentials");
+        let decoded = decode_proxy_credentials(&serialized).expect("decode credentials");
+
+        assert_eq!("admin-key", decoded.admin_key);
+        assert_eq!("completion-key", decoded.completion_key);
+        assert_eq!("identity-secret", decoded.identity_secret);
+        assert!(!decoded.regenerated);
+    }
+
+    #[test]
+    fn proxy_credentials_reject_invalid_or_incomplete_keychain_values() {
+        assert!(decode_proxy_credentials(b"not-json").is_err());
+        assert!(decode_proxy_credentials(
+            br#"{"admin_key":"admin","completion_key":"","identity_secret":"identity"}"#
+        )
+        .is_err());
     }
 
     #[test]
@@ -2141,7 +2239,16 @@ pub fn run() {
                             Some(config) => config,
                             None => return Ok(false),
                         };
-                        let credentials = proxy_credentials()?;
+                        // `start_proxy` retains the credentials it used in the
+                        // managed child. Reuse them for the registration check
+                        // instead of asking Keychain for the same secrets again.
+                        let credentials = managed_proxy_credentials(
+                            &handle.state::<ProxySidecar>(),
+                        )?
+                        .ok_or_else(|| {
+                            "The desktop proxy stopped before registration could be verified."
+                                .to_string()
+                        })?;
                         revalidate_registered_gateway_after_rails_health(
                             true,
                             &handle.state::<Sidecar>(),


### PR DESCRIPTION
## Summary
- Store desktop proxy credentials in one Keychain record instead of three separate records.
- Reuse credentials retained by the managed proxy during startup registration checks.
- Preserve existing installations with a one-time legacy Keychain migration.

## Root cause
Startup read each proxy secret separately and read them again for gateway registration validation, which could trigger repeated macOS Keychain access prompts.

## Validation
- `cargo test` (32 passed)
- `cargo clippy --tests -- -D warnings`
- `cargo fmt --check`
- `bundle exec bin/rails test engines/collavre/test/controllers/desktop_setup_controller_test.rb` (blocked: missing generated `application.js` asset in this worktree; 4 pre-existing rendering errors)