### PR TITLE
fix: make agent gateway completion key optional

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_10_100001) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_11_000000) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -56,7 +56,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_10_100001) do
     t.boolean "active", default: true, null: false
     t.text "admin_key", null: false
     t.string "base_url", null: false
-    t.text "completion_key", null: false
+    t.text "completion_key"
     t.datetime "created_at", null: false
     t.boolean "desktop_managed", default: false, null: false
     t.text "identity_secret"

--- a/engines/collavre/app/controllers/collavre/agent_gateways_controller.rb
+++ b/engines/collavre/app/controllers/collavre/agent_gateways_controller.rb
@@ -21,11 +21,15 @@ module Collavre
       end
     end
 
-    def edit; end
+    def edit
+      @has_stored_completion_key = @agent_gateway.completion_key.present?
+    end
 
     def update
       attributes = gateway_params
       clear_completion_key = ActiveModel::Type::Boolean.new.cast(attributes.delete(:clear_completion_key))
+      @has_stored_completion_key = @agent_gateway.completion_key.present?
+      @clear_completion_key = clear_completion_key
 
       if clear_completion_key
         attributes[:completion_key] = nil

--- a/engines/collavre/app/controllers/collavre/agent_gateways_controller.rb
+++ b/engines/collavre/app/controllers/collavre/agent_gateways_controller.rb
@@ -25,7 +25,15 @@ module Collavre
 
     def update
       attributes = gateway_params
-      %i[admin_key completion_key identity_secret].each do |key|
+      clear_completion_key = ActiveModel::Type::Boolean.new.cast(attributes.delete(:clear_completion_key))
+
+      if clear_completion_key
+        attributes[:completion_key] = nil
+      elsif attributes[:completion_key].blank?
+        attributes.delete(:completion_key)
+      end
+
+      %i[admin_key identity_secret].each do |key|
         attributes.delete(key) if attributes[key].blank?
       end
 
@@ -66,7 +74,7 @@ module Collavre
     def gateway_params
       params.require(:agent_gateway).permit(
         :name, :base_url, :admin_key, :completion_key, :identity_secret,
-        :tenant_id, :workspace_mode, :active
+        :tenant_id, :workspace_mode, :active, :clear_completion_key
       )
     end
 

--- a/engines/collavre/app/controllers/concerns/collavre/users_controller/ai_user_management.rb
+++ b/engines/collavre/app/controllers/concerns/collavre/users_controller/ai_user_management.rb
@@ -11,7 +11,7 @@ module Collavre
     def new_ai
       @available_tools = load_available_tools
       @llm_models = Collavre::LlmModel.suggestions
-      @agent_gateways = Current.user.owned_agent_gateways.active.order(:name)
+      @agent_gateways = chat_capable_agent_gateways(Current.user)
 
       if params[:copy_from].present?
         source = Collavre::User.find_by(id: params[:copy_from])
@@ -60,7 +60,7 @@ module Collavre
         flash.now[:alert] = @user.errors.full_messages.to_sentence
         @available_tools = load_available_tools
         @llm_models = Collavre::LlmModel.suggestions
-        @agent_gateways = Current.user.owned_agent_gateways.active.order(:name)
+        @agent_gateways = chat_capable_agent_gateways(Current.user)
         render :new_ai, status: :unprocessable_entity
       end
     end
@@ -148,7 +148,12 @@ module Collavre
 
     def editable_agent_gateways(agent)
       gateways = gateway_owner_for(agent).owned_agent_gateways
-      gateways.active.or(gateways.where(id: agent.agent_gateway_id)).order(:name)
+      selected_gateway = gateways.find_by(id: agent.agent_gateway_id)
+      (chat_capable_agent_gateways(gateway_owner_for(agent)) + [ selected_gateway ]).compact.uniq.sort_by(&:name)
+    end
+
+    def chat_capable_agent_gateways(owner)
+      owner.owned_agent_gateways.active.order(:name).select(&:chat_capable?)
     end
 
     def set_user_for_ai_actions

--- a/engines/collavre/app/models/collavre/agent_gateway.rb
+++ b/engines/collavre/app/models/collavre/agent_gateway.rb
@@ -22,7 +22,7 @@ module Collavre
     normalizes :base_url, with: ->(value) { value.to_s.strip.sub(%r{/+\z}, "") }
     normalizes :tenant_id, with: ->(value) { value.to_s.strip }
 
-    validates :name, :base_url, :admin_key, :completion_key, :tenant_id, presence: true
+    validates :name, :base_url, :admin_key, :tenant_id, presence: true
     validates :name, uniqueness: { scope: :owner_id }
     validates :tenant_id, format: { with: /\A[A-Za-z0-9][A-Za-z0-9._:@\/-]{0,199}\z/ }
     validate :base_url_is_http

--- a/engines/collavre/app/models/collavre/agent_gateway.rb
+++ b/engines/collavre/app/models/collavre/agent_gateway.rb
@@ -31,9 +31,14 @@ module Collavre
     validate :desktop_managed_credentials_are_immutable
     validate :desktop_managed_gateway_uses_shared_workspace
     validate :identity_secret_is_usable
+    validate :completion_key_is_present_when_assigned_to_agents
     after_update :reconcile_workspaces_after_gateway_change, if: :workspace_credentials_changed?
 
     scope :active, -> { where(active: true) }
+
+    def chat_capable?
+      completion_key.present?
+    end
 
     def completion_base_url
       "#{proxy_base_url}/v1"
@@ -133,6 +138,12 @@ module Collavre
       return if identity_secret.to_s.bytesize >= MIN_IDENTITY_SECRET_BYTES
 
       errors.add(:identity_secret, :too_short, count: MIN_IDENTITY_SECRET_BYTES)
+    end
+
+    def completion_key_is_present_when_assigned_to_agents
+      return if completion_key.present? || !agents.exists?
+
+      errors.add(:completion_key, :required_for_agents)
     end
 
     def workspace_credentials_changed?

--- a/engines/collavre/app/models/collavre/agent_gateway.rb
+++ b/engines/collavre/app/models/collavre/agent_gateway.rb
@@ -32,6 +32,8 @@ module Collavre
     validate :desktop_managed_gateway_uses_shared_workspace
     validate :identity_secret_is_usable
     validate :completion_key_is_present_when_assigned_to_agents
+    around_update :serialize_completion_key_removal
+    before_update :validate_completion_key_removal_under_lock
     after_update :reconcile_workspaces_after_gateway_change, if: :workspace_credentials_changed?
 
     scope :active, -> { where(active: true) }
@@ -144,6 +146,30 @@ module Collavre
       return if completion_key.present? || !agents.exists?
 
       errors.add(:completion_key, :required_for_agents)
+    end
+
+    # An agent assignment and key removal both depend on the same invariant.
+    # Re-check under the gateway row lock so two requests that validated a
+    # previously key-bearing, unassigned gateway cannot both commit.
+    def serialize_completion_key_removal
+      return yield unless will_save_change_to_completion_key? && completion_key.blank?
+
+      locked_gateway = self.class.find(id)
+      locked_gateway.with_lock do
+        begin
+          @completion_key_removal_lock = locked_gateway
+          yield
+        ensure
+          @completion_key_removal_lock = nil
+        end
+      end
+    end
+
+    def validate_completion_key_removal_under_lock
+      return unless @completion_key_removal_lock&.agents&.exists?
+
+      errors.add(:completion_key, :required_for_agents)
+      throw :abort
     end
 
     def workspace_credentials_changed?

--- a/engines/collavre/app/models/collavre/user.rb
+++ b/engines/collavre/app/models/collavre/user.rb
@@ -288,6 +288,8 @@ module Collavre
               length: { maximum: Collavre::LlmModel::MAX_NAME_LENGTH },
               if: :will_save_change_to_llm_model?
     validate :cli_proxy_gateway_belongs_to_creator
+    around_save :serialize_cli_proxy_gateway_assignment
+    before_save :validate_cli_proxy_gateway_assignment_under_lock
     validate :theme_accessibility
     validate :password_meets_minimum_length
     validates :timezone,
@@ -302,18 +304,46 @@ module Collavre
     def cli_proxy_gateway_belongs_to_creator
       return unless llm_vendor == "cli_proxy"
 
-      if agent_gateway.nil?
-        errors.add(:agent_gateway, :blank)
-      elsif agent_gateway.owner_id != created_by_id
-        errors.add(:agent_gateway, :invalid)
-      elsif !agent_gateway.chat_capable?
-        errors.add(:agent_gateway, :completion_key_required)
-      elsif agent_gateway.identity_secret.blank?
-        agent_gateway.with_lock do
-          if agent_gateway.per_user? || agent_gateway.agents.where.not(id: id).exists?
-            errors.add(:agent_gateway, :identity_required)
-          end
+      validate_cli_proxy_gateway(agent_gateway)
+    end
+
+    # See AgentGateway#serialize_completion_key_removal. This repeats the
+    # gateway checks immediately before writing the agent while holding the
+    # same row lock used by a completion-key removal.
+    def serialize_cli_proxy_gateway_assignment
+      return yield unless llm_vendor == "cli_proxy" && agent_gateway_id.present?
+
+      gateway = AgentGateway.find_by(id: agent_gateway_id)
+      return yield unless gateway
+
+      gateway.with_lock do
+        begin
+          @cli_proxy_gateway_assignment_lock = gateway
+          yield
+        ensure
+          @cli_proxy_gateway_assignment_lock = nil
         end
+      end
+    end
+
+    def validate_cli_proxy_gateway_assignment_under_lock
+      gateway = @cli_proxy_gateway_assignment_lock
+      return unless gateway
+
+      error_count = errors.count
+      validate_cli_proxy_gateway(gateway)
+      throw :abort if errors.count > error_count
+    end
+
+    def validate_cli_proxy_gateway(gateway)
+      if gateway.nil?
+        errors.add(:agent_gateway, :blank)
+      elsif gateway.owner_id != created_by_id
+        errors.add(:agent_gateway, :invalid)
+      elsif !gateway.chat_capable?
+        errors.add(:agent_gateway, :completion_key_required)
+      elsif gateway.identity_secret.blank? && (gateway.per_user? || gateway.agents.where.not(id: id).exists?)
+        errors.add(:agent_gateway, :identity_required)
       end
     end
 

--- a/engines/collavre/app/models/collavre/user.rb
+++ b/engines/collavre/app/models/collavre/user.rb
@@ -306,6 +306,8 @@ module Collavre
         errors.add(:agent_gateway, :blank)
       elsif agent_gateway.owner_id != created_by_id
         errors.add(:agent_gateway, :invalid)
+      elsif !agent_gateway.chat_capable?
+        errors.add(:agent_gateway, :completion_key_required)
       elsif agent_gateway.identity_secret.blank?
         agent_gateway.with_lock do
           if agent_gateway.per_user? || agent_gateway.agents.where.not(id: id).exists?

--- a/engines/collavre/app/views/collavre/agent_gateways/_form.html.erb
+++ b/engines/collavre/app/views/collavre/agent_gateways/_form.html.erb
@@ -31,10 +31,10 @@
     <%= form.label :completion_key, t("collavre.agent_gateways.completion_key") %>
     <%= masked_secret_field form, :completion_key, value: nil, class: "stacked-form-control", placeholder: secret_placeholder %>
     <small class="form-text text-muted"><%= t("collavre.agent_gateways.completion_key_help") %></small>
-    <% if agent_gateway.persisted? && agent_gateway.completion_key.present? %>
+    <% if agent_gateway.persisted? && @has_stored_completion_key %>
       <div class="form-check mt-2">
-        <%= form.check_box :clear_completion_key, class: "form-check-input" %>
-        <%= form.label :clear_completion_key, t("collavre.agent_gateways.clear_completion_key_label"), class: "form-check-label" %>
+        <%= check_box_tag "agent_gateway[clear_completion_key]", "1", @clear_completion_key, id: "agent_gateway_clear_completion_key", class: "form-check-input" %>
+        <%= label_tag "agent_gateway_clear_completion_key", t("collavre.agent_gateways.clear_completion_key_label"), class: "form-check-label" %>
       </div>
       <small class="form-text text-muted"><%= t("collavre.agent_gateways.clear_completion_key_help") %></small>
     <% end %>

--- a/engines/collavre/app/views/collavre/agent_gateways/_form.html.erb
+++ b/engines/collavre/app/views/collavre/agent_gateways/_form.html.erb
@@ -29,7 +29,8 @@
   </div>
   <div class="form-group">
     <%= form.label :completion_key, t("collavre.agent_gateways.completion_key") %>
-    <%= masked_secret_field form, :completion_key, value: nil, required: agent_gateway.new_record?, class: "stacked-form-control", placeholder: secret_placeholder %>
+    <%= masked_secret_field form, :completion_key, value: nil, class: "stacked-form-control", placeholder: secret_placeholder %>
+    <small class="form-text text-muted"><%= t("collavre.agent_gateways.completion_key_help") %></small>
   </div>
   <div class="form-group">
     <%= form.label :identity_secret, t("collavre.agent_gateways.identity_secret") %>

--- a/engines/collavre/app/views/collavre/agent_gateways/_form.html.erb
+++ b/engines/collavre/app/views/collavre/agent_gateways/_form.html.erb
@@ -31,6 +31,13 @@
     <%= form.label :completion_key, t("collavre.agent_gateways.completion_key") %>
     <%= masked_secret_field form, :completion_key, value: nil, class: "stacked-form-control", placeholder: secret_placeholder %>
     <small class="form-text text-muted"><%= t("collavre.agent_gateways.completion_key_help") %></small>
+    <% if agent_gateway.persisted? && agent_gateway.completion_key.present? %>
+      <div class="form-check mt-2">
+        <%= form.check_box :clear_completion_key, class: "form-check-input" %>
+        <%= form.label :clear_completion_key, t("collavre.agent_gateways.clear_completion_key_label"), class: "form-check-label" %>
+      </div>
+      <small class="form-text text-muted"><%= t("collavre.agent_gateways.clear_completion_key_help") %></small>
+    <% end %>
   </div>
   <div class="form-group">
     <%= form.label :identity_secret, t("collavre.agent_gateways.identity_secret") %>

--- a/engines/collavre/config/locales/agent_gateway.en.yml
+++ b/engines/collavre/config/locales/agent_gateway.en.yml
@@ -24,6 +24,7 @@ en:
               immutable: "cannot be changed for a desktop-managed gateway"
             completion_key:
               immutable: "cannot be changed for a desktop-managed gateway"
+              required_for_agents: "is required while the gateway is assigned to an AI agent"
             workspace_mode:
               desktop_shared_only: "must remain shared for a desktop-managed gateway"
             tenant_id:
@@ -36,6 +37,7 @@ en:
           attributes:
             agent_gateway:
               identity_required: "requires an identity secret when shared with another AI agent"
+              completion_key_required: "requires a completion key for AI agent chat"
   collavre:
     agent_gateways:
       title: My Agent Gateways

--- a/engines/collavre/config/locales/agent_gateway.en.yml
+++ b/engines/collavre/config/locales/agent_gateway.en.yml
@@ -55,6 +55,8 @@ en:
       admin_key_help: A value from the proxy AUTH_ADMIN_KEYS setting. Used only by the Collavre server.
       completion_key: Completion key
       completion_key_help: Optional. Required only for AI agent chat completions.
+      clear_completion_key_label: Remove stored completion key
+      clear_completion_key_help: After saving, this gateway can be used only for provisioning until a new completion key is added.
       identity_secret: Identity secret
       identity_secret_help: Must match USER_IDENTITY_HMAC_SECRET and contain at least 32 bytes. Required for per-user mode or multiple AI agents.
       tenant_id: Tenant ID

--- a/engines/collavre/config/locales/agent_gateway.en.yml
+++ b/engines/collavre/config/locales/agent_gateway.en.yml
@@ -52,6 +52,7 @@ en:
       admin_key: Admin key
       admin_key_help: A value from the proxy AUTH_ADMIN_KEYS setting. Used only by the Collavre server.
       completion_key: Completion key
+      completion_key_help: Optional. Required only for AI agent chat completions.
       identity_secret: Identity secret
       identity_secret_help: Must match USER_IDENTITY_HMAC_SECRET and contain at least 32 bytes. Required for per-user mode or multiple AI agents.
       tenant_id: Tenant ID

--- a/engines/collavre/config/locales/agent_gateway.ko.yml
+++ b/engines/collavre/config/locales/agent_gateway.ko.yml
@@ -55,6 +55,8 @@ ko:
       admin_key_help: 프록시 AUTH_ADMIN_KEYS 값입니다. Collavre 서버에서만 사용합니다.
       completion_key: Completion key
       completion_key_help: 선택 사항입니다. AI Agent 채팅 완료 요청에만 필요합니다.
+      clear_completion_key_label: 저장된 Completion key 삭제
+      clear_completion_key_help: 저장 후 새 Completion key를 추가하기 전까지 이 게이트웨이는 프로비저닝 전용으로만 사용할 수 있습니다.
       identity_secret: Identity secret
       identity_secret_help: USER_IDENTITY_HMAC_SECRET과 같아야 하며 32바이트 이상이어야 합니다. 사용자별 모드 또는 여러 AI Agent가 사용할 때 필수입니다.
       tenant_id: Tenant ID

--- a/engines/collavre/config/locales/agent_gateway.ko.yml
+++ b/engines/collavre/config/locales/agent_gateway.ko.yml
@@ -24,6 +24,7 @@ ko:
               immutable: "은(는) 데스크탑 관리 게이트웨이에서 변경할 수 없습니다"
             completion_key:
               immutable: "은(는) 데스크탑 관리 게이트웨이에서 변경할 수 없습니다"
+              required_for_agents: "은(는) AI Agent에 할당되어 있는 동안 필요합니다"
             workspace_mode:
               desktop_shared_only: "은(는) 데스크탑 관리 게이트웨이에서 공유 모드로 유지해야 합니다"
             tenant_id:
@@ -36,6 +37,7 @@ ko:
           attributes:
             agent_gateway:
               identity_required: "은(는) 다른 AI Agent와 게이트웨이를 공유할 때 Identity secret이 필요합니다"
+              completion_key_required: "은(는) AI Agent 채팅에 Completion key가 필요합니다"
   collavre:
     agent_gateways:
       title: 내 Agent Gateway

--- a/engines/collavre/config/locales/agent_gateway.ko.yml
+++ b/engines/collavre/config/locales/agent_gateway.ko.yml
@@ -52,6 +52,7 @@ ko:
       admin_key: Admin key
       admin_key_help: 프록시 AUTH_ADMIN_KEYS 값입니다. Collavre 서버에서만 사용합니다.
       completion_key: Completion key
+      completion_key_help: 선택 사항입니다. AI Agent 채팅 완료 요청에만 필요합니다.
       identity_secret: Identity secret
       identity_secret_help: USER_IDENTITY_HMAC_SECRET과 같아야 하며 32바이트 이상이어야 합니다. 사용자별 모드 또는 여러 AI Agent가 사용할 때 필수입니다.
       tenant_id: Tenant ID

--- a/engines/collavre/db/migrate/20260811000000_make_agent_gateway_completion_key_nullable.rb
+++ b/engines/collavre/db/migrate/20260811000000_make_agent_gateway_completion_key_nullable.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class MakeAgentGatewayCompletionKeyNullable < ActiveRecord::Migration[8.0]
+  def change
+    change_column_null :agent_gateways, :completion_key, true
+  end
+end

--- a/engines/collavre/test/controllers/agent_gateways_controller_test.rb
+++ b/engines/collavre/test/controllers/agent_gateways_controller_test.rb
@@ -135,6 +135,30 @@ class AgentGatewaysControllerTest < ActionDispatch::IntegrationTest
     assert_select "label[for='agent_gateway_clear_completion_key']", I18n.t("collavre.agent_gateways.clear_completion_key_label")
   end
 
+  test "gateway edit preserves completion key removal intent after validation failure" do
+    sign_in_as(@owner, password: "password")
+    @gateway.update!(completion_key: "stored-completion-secret")
+
+    patch collavre.agent_gateway_path(@gateway), params: {
+      agent_gateway: {
+        name: "",
+        base_url: @gateway.base_url,
+        admin_key: "",
+        completion_key: "",
+        clear_completion_key: "1",
+        identity_secret: "",
+        tenant_id: @gateway.tenant_id,
+        workspace_mode: @gateway.workspace_mode,
+        active: "1"
+      }
+    }
+
+    assert_response :unprocessable_entity
+    assert_select "input[type='checkbox'][name='agent_gateway[clear_completion_key]'][checked='checked']"
+    assert_equal "stored-completion-secret", @gateway.reload.completion_key
+    assert_not_includes response.body, "stored-completion-secret"
+  end
+
   test "owner cannot retarget a desktop-managed gateway from settings" do
     desktop_gateway = Collavre::AgentGateway.create!(
       owner: @owner,

--- a/engines/collavre/test/controllers/agent_gateways_controller_test.rb
+++ b/engines/collavre/test/controllers/agent_gateways_controller_test.rb
@@ -44,11 +44,32 @@ class AgentGatewaysControllerTest < ActionDispatch::IntegrationTest
     assert @owner.owned_agent_gateways.exists?(name: "Second proxy")
   end
 
+  test "owner can create a gateway without a completion key" do
+    sign_in_as(@owner, password: "password")
+
+    post collavre.agent_gateways_path, params: {
+      agent_gateway: {
+        name: "Provisioning-only proxy",
+        base_url: "https://provisioning.example.com",
+        admin_key: "admin-2",
+        completion_key: "",
+        tenant_id: "collavre",
+        workspace_mode: "shared",
+        active: "1"
+      }
+    }
+
+    assert_redirected_to collavre.agent_gateways_path
+    assert_predicate @owner.owned_agent_gateways.find_by!(name: "Provisioning-only proxy").completion_key, :blank?
+  end
+
   test "gateway form explains the owner-specific endpoint policy" do
     sign_in_as(@owner, password: "password")
     get collavre.new_agent_gateway_path
     assert_response :success
     assert_includes response.body, I18n.t("collavre.agent_gateways.base_url_help")
+    assert_includes response.body, I18n.t("collavre.agent_gateways.completion_key_help")
+    assert_select "input[name='agent_gateway[completion_key]'][required]", count: 0
 
     sign_out
     sign_in_as(users(:one), password: "password")

--- a/engines/collavre/test/controllers/agent_gateways_controller_test.rb
+++ b/engines/collavre/test/controllers/agent_gateways_controller_test.rb
@@ -104,6 +104,37 @@ class AgentGatewaysControllerTest < ActionDispatch::IntegrationTest
     assert_equal "completion", @gateway.completion_key
   end
 
+  test "owner can explicitly clear an unassigned gateway completion key" do
+    sign_in_as(@owner, password: "password")
+
+    patch collavre.agent_gateway_path(@gateway), params: {
+      agent_gateway: {
+        name: @gateway.name,
+        base_url: @gateway.base_url,
+        admin_key: "",
+        completion_key: "",
+        clear_completion_key: "1",
+        identity_secret: "",
+        tenant_id: @gateway.tenant_id,
+        workspace_mode: @gateway.workspace_mode,
+        active: "1"
+      }
+    }
+
+    assert_redirected_to collavre.agent_gateways_path
+    assert_nil @gateway.reload.completion_key
+  end
+
+  test "gateway edit form offers to clear an existing completion key" do
+    sign_in_as(@owner, password: "password")
+
+    get collavre.edit_agent_gateway_path(@gateway)
+
+    assert_response :success
+    assert_select "input[type='checkbox'][name='agent_gateway[clear_completion_key]'][value='1']"
+    assert_select "label[for='agent_gateway_clear_completion_key']", I18n.t("collavre.agent_gateways.clear_completion_key_label")
+  end
+
   test "owner cannot retarget a desktop-managed gateway from settings" do
     desktop_gateway = Collavre::AgentGateway.create!(
       owner: @owner,

--- a/engines/collavre/test/controllers/users_controller_ai_test.rb
+++ b/engines/collavre/test/controllers/users_controller_ai_test.rb
@@ -96,6 +96,32 @@ class UsersControllerAiTest < ActionDispatch::IntegrationTest
     assert_equal @admin.id, agent.created_by_id
   end
 
+  test "does not offer or assign a provisioning-only gateway to a CLI Proxy agent" do
+    gateway = Collavre::AgentGateway.create!(
+      owner: @admin,
+      name: "Provisioning-only proxy",
+      base_url: "https://proxy.example.com",
+      admin_key: "admin"
+    )
+
+    get new_ai_users_url
+    assert_response :success
+    assert_select "select[name='agent_gateway_id'] option[value='#{gateway.id}']", count: 0
+
+    assert_no_difference("Collavre::User.count") do
+      post create_ai_users_url, params: {
+        ai_id: "keyless_proxy_bot",
+        name: "Keyless Proxy Bot",
+        system_prompt: "Help",
+        llm_vendor: "cli_proxy",
+        llm_model: "paperclip/claude_local",
+        agent_gateway_id: gateway.id
+      }
+    end
+
+    assert_response :unprocessable_entity
+  end
+
   test "rejects another user's gateway for a CLI Proxy agent" do
     foreign_gateway = Collavre::AgentGateway.create!(
       owner: users(:two),

--- a/engines/collavre/test/models/agent_gateway_test.rb
+++ b/engines/collavre/test/models/agent_gateway_test.rb
@@ -46,7 +46,9 @@ class AgentGatewayTest < ActiveSupport::TestCase
   test "completion key is optional" do
     gateway = build_gateway(completion_key: nil)
 
-    assert gateway.valid?, gateway.errors.full_messages.to_sentence
+    gateway.save!
+
+    assert_nil gateway.reload.completion_key
   end
 
   test "identity secret is required before a shared gateway can serve multiple agents" do

--- a/engines/collavre/test/models/agent_gateway_test.rb
+++ b/engines/collavre/test/models/agent_gateway_test.rb
@@ -62,6 +62,17 @@ class AgentGatewayTest < ActiveSupport::TestCase
     assert_includes gateway.errors.details[:completion_key].pluck(:error), :required_for_agents
   end
 
+  test "completion key removal rechecks assignments while saving" do
+    gateway = build_gateway
+    gateway.save!
+    create_agent(gateway)
+    gateway.completion_key = nil
+
+    assert_not gateway.save(validate: false)
+    assert_includes gateway.errors.details[:completion_key].pluck(:error), :required_for_agents
+    assert_equal "completion", gateway.reload.completion_key
+  end
+
   test "identity secret is required before a shared gateway can serve multiple agents" do
     gateway = build_gateway(identity_secret: "s" * 32)
     gateway.save!

--- a/engines/collavre/test/models/agent_gateway_test.rb
+++ b/engines/collavre/test/models/agent_gateway_test.rb
@@ -43,6 +43,12 @@ class AgentGatewayTest < ActiveSupport::TestCase
     assert_includes gateway.errors.details[:identity_secret].pluck(:error), :too_short
   end
 
+  test "completion key is optional" do
+    gateway = build_gateway(completion_key: nil)
+
+    assert gateway.valid?, gateway.errors.full_messages.to_sentence
+  end
+
   test "identity secret is required before a shared gateway can serve multiple agents" do
     gateway = build_gateway(identity_secret: "s" * 32)
     gateway.save!

--- a/engines/collavre/test/models/agent_gateway_test.rb
+++ b/engines/collavre/test/models/agent_gateway_test.rb
@@ -51,6 +51,17 @@ class AgentGatewayTest < ActiveSupport::TestCase
     assert_nil gateway.reload.completion_key
   end
 
+  test "completion key cannot be removed while assigned to an AI agent" do
+    gateway = build_gateway
+    gateway.save!
+    create_agent(gateway)
+
+    gateway.completion_key = nil
+
+    assert_not gateway.valid?
+    assert_includes gateway.errors.details[:completion_key].pluck(:error), :required_for_agents
+  end
+
   test "identity secret is required before a shared gateway can serve multiple agents" do
     gateway = build_gateway(identity_secret: "s" * 32)
     gateway.save!

--- a/engines/collavre/test/models/user_test.rb
+++ b/engines/collavre/test/models/user_test.rb
@@ -133,6 +133,28 @@ class UserTest < ActiveSupport::TestCase
     assert agent.errors.of_kind?(:agent_gateway, :invalid)
   end
 
+  test "CLI Proxy agents require a gateway completion key" do
+    owner = users(:two)
+    gateway = Collavre::AgentGateway.create!(
+      owner: owner,
+      name: "Provisioning-only gateway",
+      base_url: "https://proxy.example.com",
+      admin_key: "admin"
+    )
+    agent = Collavre::User.new(
+      name: "Keyless CLI agent",
+      email: "keyless-cli-agent@ai.local",
+      password: SecureRandom.hex(24),
+      llm_vendor: "cli_proxy",
+      llm_model: "paperclip/claude_local",
+      created_by_id: owner.id,
+      agent_gateway: gateway
+    )
+
+    assert_not agent.valid?
+    assert agent.errors.of_kind?(:agent_gateway, :completion_key_required)
+  end
+
   test "a secretless shared gateway cannot be assigned to a second CLI Proxy agent" do
     owner = users(:two)
     gateway = Collavre::AgentGateway.create!(

--- a/engines/collavre/test/models/user_test.rb
+++ b/engines/collavre/test/models/user_test.rb
@@ -155,6 +155,31 @@ class UserTest < ActiveSupport::TestCase
     assert agent.errors.of_kind?(:agent_gateway, :completion_key_required)
   end
 
+  test "CLI Proxy agent assignment rechecks its completion key while saving" do
+    owner = users(:two)
+    gateway = Collavre::AgentGateway.create!(
+      owner: owner,
+      name: "Concurrent provisioning gateway",
+      base_url: "https://proxy.example.com",
+      admin_key: "admin",
+      completion_key: "completion"
+    )
+    agent = Collavre::User.new(
+      name: "Concurrent CLI agent",
+      email: "concurrent-cli-agent@ai.local",
+      password: SecureRandom.hex(24),
+      llm_vendor: "cli_proxy",
+      llm_model: "paperclip/claude_local",
+      created_by_id: owner.id,
+      agent_gateway: gateway
+    )
+
+    gateway.update!(completion_key: nil)
+
+    assert_not agent.save(validate: false)
+    assert agent.errors.of_kind?(:agent_gateway, :completion_key_required)
+  end
+
   test "a secretless shared gateway cannot be assigned to a second CLI Proxy agent" do
     owner = users(:two)
     gateway = Collavre::AgentGateway.create!(


### PR DESCRIPTION
## Summary

- allow provisioning-only Agent Gateways to be saved without a completion key
- remove the browser-required constraint and explain that the key is needed only for AI chat completions
- cover the optional-key model and form behavior with regression tests

## Why

Authentication and provisioning use the admin key; a completion key is only required when an AI agent sends chat completions.

## Validation

- `mise exec -- bundle exec rails test engines/collavre/test/models/agent_gateway_test.rb engines/collavre/test/controllers/agent_gateways_controller_test.rb`
- `mise exec -- bundle exec rubocop engines/collavre/app/models/collavre/agent_gateway.rb engines/collavre/test/models/agent_gateway_test.rb engines/collavre/test/controllers/agent_gateways_controller_test.rb`