### PR TITLE
fix(desktop): use 45173 as the stable default port

### DIFF
--- a/bin/desktop-server
+++ b/bin/desktop-server
@@ -7,7 +7,7 @@
 # runnable directly from a dev checkout to validate the desktop env without
 # packaging:
 #
-#   PORT=4000 bin/desktop-server
+#   PORT=45173 bin/desktop-server
 #
 # Env knobs:
 #   COLLAVRE_DATA_DIR   where DBs/blobs/secrets/logs live

--- a/docs/superpowers/specs/2026-06-11-desktop-tauri-macos-design.md
+++ b/docs/superpowers/specs/2026-06-11-desktop-tauri-macos-design.md
@@ -35,9 +35,9 @@ Two units with one clear interface (HTTP over loopback):
 
 ### 1. Tauri shell (Rust)
 - Minimal window using the OS webview. No custom frontend.
-- On launch: use the stable `127.0.0.1:4000` default, spawn the Rails
+- On launch: use the stable `127.0.0.1:45173` default, spawn the Rails
   **sidecar** (`externalBin`), poll `GET /up` until healthy, then load
-  `http://127.0.0.1:4000`. A valid, explicitly configured `PORT` may override
+  `http://127.0.0.1:45173`. A valid, explicitly configured `PORT` may override
   that default.
 - Never silently select an ephemeral fallback when the configured port is
   occupied. The stable loopback origin is required for local firewall rules and
@@ -125,7 +125,7 @@ risk with Rails runtime paths / asset pipeline — deferred.)
 
 1. **Headless boot** — add `desktop` env; boot Rails with sqlite + local storage
    + no SSL + generated secret, data under app-support. Confirm the full app
-   works at `http://127.0.0.1:4000`. No Tauri yet. ← validates everything.
+   works at `http://127.0.0.1:45173`. No Tauri yet. ← validates everything.
 2. **Vendored Ruby boot** — vendor portable arm64 Ruby + standalone bundle; boot
    the same with vendored Ruby instead of rbenv.
 3. **Tauri shell** — spawn sidecar, health-gate `/up`, webview, graceful quit.

--- a/tools/desktop-app/README.md
+++ b/tools/desktop-app/README.md
@@ -29,20 +29,20 @@ commas):
 {
   "allowed_hosts": ["xxx.tailadceed.ts.net"],
   "bind_host": "0.0.0.0",
-  "port": 4000
+  "port": 45173
 }
 ```
 
 - `allowed_hosts` — a JSON array, or a `"a,b"` comma-separated string.
 - `bind_host` — omit to stay on loopback (`127.0.0.1`); set `"0.0.0.0"` to open.
-- `port` — omit to use the stable default, `4000`.
+- `port` — omit to use the stable default, `45173`.
 
 A missing or malformed file is the normal closed-loopback case and is ignored
 (the app never fails to launch over a bad config).
 
 ## Port policy
 
-The desktop shell uses `http://127.0.0.1:4000` when no valid `PORT` setting is
+The desktop shell uses `http://127.0.0.1:45173` when no valid `PORT` setting is
 provided. This origin is deliberately stable so local firewall rules and future
 PKCE/loopback OAuth callback registrations can target one URL. A valid `PORT`
 environment variable or `config.json` `port` value is an explicit override; an
@@ -147,7 +147,7 @@ configuration is read, displayed, or sent externally.
 The whole desktop env runs from a dev checkout — no Tauri, no vendored Ruby:
 
 ```bash
-PORT=4000 bin/desktop-server
+PORT=45173 bin/desktop-server
 # → boots RAILS_ENV=desktop on SQLite, /up returns 200, no https redirect
 ```
 

--- a/tools/desktop-app/src-tauri/src/lib.rs
+++ b/tools/desktop-app/src-tauri/src/lib.rs
@@ -23,7 +23,7 @@ use serde::{Deserialize, Serialize};
 use sha2::Sha256;
 use tauri::{Manager, RunEvent, WebviewUrl, WebviewWindowBuilder};
 
-const DEFAULT_PORT: u16 = 4000;
+const DEFAULT_PORT: u16 = 45173;
 const DESKTOP_USER_AGENT: &str = concat!("CollavreDesktop/", env!("CARGO_PKG_VERSION"));
 
 /// Holds the sidecar child so we can stop it on exit.
@@ -1391,7 +1391,7 @@ fn json_to_host_list(v: &serde_json::Value) -> Option<String> {
 /// Recognized keys — all optional, unknown keys and wrong-typed values ignored:
 ///   "allowed_hosts": ["host", ...] | "host,host"  -> COLLAVRE_ALLOWED_HOSTS
 ///   "bind_host":      "0.0.0.0"                    -> COLLAVRE_BIND_HOST
-///   "port":           4000 | "4000"               -> PORT
+///   "port":           45173 | "45173"             -> PORT
 ///
 /// Malformed JSON (or a non-object top level) yields no overrides: a bad config
 /// file degrades to the built-in closed-loopback defaults rather than failing
@@ -1491,7 +1491,8 @@ mod tests {
 
     #[test]
     fn desktop_port_defaults_to_the_stable_port() {
-        assert_eq!(desktop_port(None), DEFAULT_PORT);
+        assert_eq!(desktop_port(None), 45_173);
+        assert_eq!(DEFAULT_PORT, 45_173);
         assert_eq!(desktop_port(Some("not-a-port")), DEFAULT_PORT);
         assert_eq!(desktop_port(Some("0")), DEFAULT_PORT);
     }
@@ -1563,24 +1564,24 @@ mod tests {
     #[test]
     fn port_number_and_string_both_map() {
         assert_eq!(
-            pairs(r#"{"port": 4000}"#),
-            vec![("PORT", "4000".to_string())]
+            pairs(r#"{"port": 45173}"#),
+            vec![("PORT", "45173".to_string())]
         );
         assert_eq!(
-            pairs(r#"{"port": "4000"}"#),
-            vec![("PORT", "4000".to_string())]
+            pairs(r#"{"port": "45173"}"#),
+            vec![("PORT", "45173".to_string())]
         );
     }
 
     #[test]
     fn all_three_keys_preserve_a_stable_order() {
-        let got = pairs(r#"{"port": 4000, "bind_host": "0.0.0.0", "allowed_hosts": ["h"]}"#);
+        let got = pairs(r#"{"port": 45173, "bind_host": "0.0.0.0", "allowed_hosts": ["h"]}"#);
         assert_eq!(
             got,
             vec![
                 ("COLLAVRE_ALLOWED_HOSTS", "h".to_string()),
                 ("COLLAVRE_BIND_HOST", "0.0.0.0".to_string()),
-                ("PORT", "4000".to_string()),
+                ("PORT", "45173".to_string()),
             ]
         );
     }


### PR DESCRIPTION
## Summary

- change the Tauri desktop default loopback port from `4000` to `45173`
- keep explicit `PORT` and `config.json` overrides unchanged
- align the desktop README, server command example, and Tauri design specification
- add a regression assertion for the exact default port

## Why

Port `4000` is a common local development-server default. `45173` lowers the chance of collisions while preserving a stable loopback origin for firewall rules and future OAuth callbacks.

## Validation

- `cargo fmt --check`
- `cargo test --lib` (35 passed)
- `git diff --check`