### PR TITLE
refactor: unify comment badge counts

### DIFF
--- a/engines/collavre/app/components/collavre/inbox/badge_component.rb
+++ b/engines/collavre/app/components/collavre/inbox/badge_component.rb
@@ -26,12 +26,9 @@ module Collavre
       private
 
       def unread_count_for_creative
-        visible_comments = @creative.comments.visible_to(@user)
-        pointer = CommentReadPointer.find_by(user: @user, creative: @creative)
-        last_read_id = pointer&.last_read_comment_id
-
-        scope = last_read_id ? visible_comments.where("comments.id > ?", last_read_id) : visible_comments
-        scope.count
+        badge_index = Creatives::CommentBadgeIndex.new(user: @user)
+        badge_index.index([ @creative.effective_origin ])
+        badge_index.unread_count_for(@creative.effective_origin)
       end
     end
   end

--- a/engines/collavre/app/helpers/collavre/creatives_helper.rb
+++ b/engines/collavre/app/helpers/collavre/creatives_helper.rb
@@ -56,8 +56,9 @@ module Collavre
           # CommentBadgeIndex; re-checking here would be one cache read per node,
           # which is exactly what the batch exists to avoid.
           if unread_count.nil?
-            unread_count = unread_count_for(origin, comments_count)
-            unread_count = 0 if viewing_now?(origin)
+            badge_index = Creatives::CommentBadgeIndex.new(user: Current.user)
+            badge_index.index([ origin ])
+            unread_count = badge_index.unread_count_for(origin)
           end
           classes = [ "comments-btn", "creative-action-btn" ]
           classes << "no-comments" if comments_count.zero?
@@ -98,24 +99,6 @@ module Collavre
           (creative.tags ? render_creative_tags(creative) : safe_join([]))
         ])
       end
-    end
-
-    # Unread comments on `origin` for the current user. With no read pointer,
-    # every comment is unread. Batched by CommentBadgeIndex for the browse tree;
-    # this is the single-creative path.
-    def unread_count_for(origin, comments_count)
-      pointer = CommentReadPointer.find_by(user: Current.user, creative: origin)
-      last_read_id = pointer&.last_read_comment_id
-      return comments_count unless last_read_id
-
-      origin.comments.where("id > ? and private = ?", last_read_id, false).count
-    end
-
-    # Someone with the chat open has read it, so their badge shows nothing.
-    def viewing_now?(origin)
-      return false unless Current.user
-
-      CommentPresenceStore.list(origin.id).include?(Current.user.id)
     end
 
     def render_progress_toggle(creative, value)

--- a/engines/collavre/app/models/collavre/comment/broadcastable.rb
+++ b/engines/collavre/app/models/collavre/comment/broadcastable.rb
@@ -37,23 +37,24 @@ module Collavre
           users.uniq!
           return if users.empty?
 
+          badges_by_user_id = Creatives::CommentBadgeIndex.for_users(origin: origin, users: users)
+
           users.each do |u|
-            badge_index = Creatives::CommentBadgeIndex.new(user: u)
-            badge_index.index([ origin ])
+            badge = badges_by_user_id.fetch(u.id)
 
             Turbo::StreamsChannel.broadcast_replace_to(
               [ u, origin, :comment_badge ],
               target: "comment-badge-#{origin.id}",
               partial: "inbox/badge_component/count",
               locals: {
-                count: badge_index.unread_count_for(origin),
+                count: badge.unread_count,
                 badge_id: "comment-badge-#{origin.id}",
-                show_zero: badge_index.visible_comments?(origin)
+                show_zero: badge.visible_comments
               }
             )
 
             # Also update the global inbox badge when the creative is an inbox
-            broadcast_inbox_badge(origin, u, count: badge_index.unread_count_for(origin)) if origin.inbox?
+            broadcast_inbox_badge(origin, u, count: badge.unread_count) if origin.inbox?
           end
         end
 

--- a/engines/collavre/app/models/collavre/comment/broadcastable.rb
+++ b/engines/collavre/app/models/collavre/comment/broadcastable.rb
@@ -37,79 +37,31 @@ module Collavre
           users.uniq!
           return if users.empty?
 
-          user_ids = users.map(&:id)
-
-          pointers = CommentReadPointer.where(user_id: user_ids, creative: origin).index_by(&:user_id)
-          present_user_ids = CommentPresenceStore.list(origin.id)
-
-          # Only ever consumed as a boolean (show_zero below), so ask the
-          # database for existence rather than a total. An unbounded COUNT has
-          # no id predicate to anchor it, so the planner falls back to a
-          # sequential scan of the whole comments table and gets slower for
-          # every participant as the conversation grows.
-          any_public = origin.comments.public_only.exists?
-          private_counts = origin.comments
-            .where(private: true, user_id: user_ids)
-            .group(:user_id)
-            .count
-
-          last_read_ids = pointers.transform_values { |p| p.last_read_comment_id || 0 }
-
-          unread_public_by_threshold = {}
-          # Include 0 for users without a read pointer (never opened chat)
-          all_thresholds = (last_read_ids.values + [ 0 ]).uniq
-          all_thresholds.each do |threshold|
-            unread_public_by_threshold[threshold] = origin.comments
-              .where(private: false)
-              .where("comments.id > ?", threshold)
-              .count
-          end
-
-          unread_private_counts = {}
-          user_ids.each do |uid|
-            threshold = last_read_ids[uid] || 0
-            unread_private_counts[uid] = origin.comments
-              .where(private: true, user_id: uid)
-              .where("comments.id > ?", threshold)
-              .count
-          end
-
           users.each do |u|
-            user_private_count = private_counts[u.id] || 0
-            has_any_visible = any_public || user_private_count.positive?
-
-            threshold = last_read_ids[u.id] || 0
-            unread_public = unread_public_by_threshold[threshold] || 0
-            unread_private = unread_private_counts[u.id] || 0
-            unread_count = unread_public + unread_private
-
-            unread_count = 0 if present_user_ids.include?(u.id)
+            badge_index = Creatives::CommentBadgeIndex.new(user: u)
+            badge_index.index([ origin ])
 
             Turbo::StreamsChannel.broadcast_replace_to(
               [ u, origin, :comment_badge ],
               target: "comment-badge-#{origin.id}",
               partial: "inbox/badge_component/count",
               locals: {
-                count: unread_count,
+                count: badge_index.unread_count_for(origin),
                 badge_id: "comment-badge-#{origin.id}",
-                show_zero: has_any_visible
+                show_zero: badge_index.visible_comments?(origin)
               }
             )
 
             # Also update the global inbox badge when the creative is an inbox
-            broadcast_inbox_badge(origin, u, count: unread_count) if origin.inbox?
+            broadcast_inbox_badge(origin, u, count: badge_index.unread_count_for(origin)) if origin.inbox?
           end
         end
 
         def broadcast_badge(creative, user)
           origin = creative.effective_origin
-          visible_comments = origin.comments.visible_to(user)
-          comments_count = visible_comments.count
-          pointer = CommentReadPointer.find_by(user: user, creative: origin)
-          last_read_id = pointer&.last_read_comment_id
-          unread_scope = last_read_id ? visible_comments.where("comments.id > ?", last_read_id) : visible_comments
-          unread_count = unread_scope.count
-          unread_count = 0 if CommentPresenceStore.list(origin.id).include?(user.id)
+          badge_index = Creatives::CommentBadgeIndex.new(user: user)
+          badge_index.index([ origin ])
+          unread_count = badge_index.unread_count_for(origin)
           Turbo::StreamsChannel.broadcast_replace_to(
             [ user, origin, :comment_badge ],
             target: "comment-badge-#{origin.id}",
@@ -117,7 +69,7 @@ module Collavre
             locals: {
               count: unread_count,
               badge_id: "comment-badge-#{origin.id}",
-              show_zero: comments_count.positive?
+              show_zero: badge_index.visible_comments?(origin)
             }
           )
 

--- a/engines/collavre/app/services/collavre/creatives/comment_badge_index.rb
+++ b/engines/collavre/app/services/collavre/creatives/comment_badge_index.rb
@@ -50,7 +50,9 @@ module Creatives
       @visible_by_origin_id = {}
     end
 
-    def index(origins)
+    # Tree rendering only needs unread totals. Callers that render a standalone
+    # badge also need visible-comment state to decide whether a zero is shown.
+    def index(origins, include_visible_counts: true)
       pending = origins.uniq(&:id).reject { |o| @unread_by_origin_id.key?(o.id) }
       return if pending.empty?
 
@@ -60,7 +62,7 @@ module Creatives
       origin_ids.each do |origin_id|
         @unread_by_origin_id[origin_id] = unread_counts.fetch(origin_id, 0)
       end
-      @visible_by_origin_id.merge!(visible_counts(origin_ids))
+      @visible_by_origin_id.merge!(visible_counts(origin_ids)) if include_visible_counts
 
       suppress_for_present_user(pending.map(&:id))
     end

--- a/engines/collavre/app/services/collavre/creatives/comment_badge_index.rb
+++ b/engines/collavre/app/services/collavre/creatives/comment_badge_index.rb
@@ -9,6 +9,41 @@ module Creatives
   # The counts it hands out are display-ready: they include only comments the
   # user can see and apply presence suppression in one cache round trip.
   class CommentBadgeIndex
+    # SQLite permits at most 1,000 expression nodes and commonly only 999 bound
+    # values. Keep the largest badge query well below both limits.
+    QUERY_BATCH_SIZE = 500
+
+    Badge = Struct.new(:unread_count, :visible_comments, keyword_init: true)
+
+    # The comment-created fanout has one origin and many recipients. Keep its
+    # pointer, presence, and private-comment lookups batched instead of making
+    # each recipient construct a one-origin index. This deliberately mirrors
+    # `Comment.visible_to(user)`: private comments are visible to their author
+    # and their approver.
+    def self.for_users(origin:, users:)
+      user_ids = users.map(&:id).uniq
+      return {} if user_ids.empty?
+
+      pointers = CommentReadPointer.where(user_id: user_ids, creative: origin).index_by(&:user_id)
+      last_read_ids = pointers.transform_values { |pointer| pointer.last_read_comment_id || 0 }
+      present_user_ids = CommentPresenceStore.list(origin.id)
+
+      any_public = origin.comments.public_only.exists?
+      private_visible_counts, unread_private_counts = private_counts_for_users(origin, user_ids, last_read_ids)
+      unread_public_by_threshold = unread_public_counts(origin, last_read_ids.values + [ 0 ])
+
+      user_ids.to_h do |user_id|
+        threshold = last_read_ids.fetch(user_id, 0)
+        unread_count = unread_public_by_threshold.fetch(threshold, 0) + unread_private_counts.fetch(user_id, 0)
+        unread_count = 0 if present_user_ids.include?(user_id)
+
+        [ user_id, Badge.new(
+          unread_count: unread_count,
+          visible_comments: any_public || private_visible_counts.fetch(user_id, 0).positive?
+        ) ]
+      end
+    end
+
     def initialize(user:)
       @user = user
       @unread_by_origin_id = {}
@@ -58,11 +93,13 @@ module Creatives
     def read_watermarks(origin_ids)
       return {} if origin_ids.empty?
 
-      CommentReadPointer
-        .where(user_id: user&.id, creative_id: origin_ids)
-        .where.not(last_read_comment_id: nil)
-        .pluck(:creative_id, :last_read_comment_id)
-        .to_h
+      origin_ids.each_slice(QUERY_BATCH_SIZE).each_with_object({}) do |origin_id_batch, watermarks|
+        watermarks.merge!(CommentReadPointer
+          .where(user_id: user&.id, creative_id: origin_id_batch)
+          .where.not(last_read_comment_id: nil)
+          .pluck(:creative_id, :last_read_comment_id)
+          .to_h)
+      end
     end
 
     # One grouped COUNT for the whole level. Each origin carries its own read
@@ -70,28 +107,65 @@ module Creatives
     # from relations rather than a SQL fragment: a hand-built string here would
     # be safe (literal template, bound values) but unprovably so to a scanner.
     def unread_counts(origin_ids, watermarks)
-      newer_than_watermark = origin_ids
-        .map { |origin_id| unread_scope(origin_id, watermarks.fetch(origin_id, 0)) }
-        .reduce { |combined, scope| combined.or(scope) }
+      origin_ids.each_slice(QUERY_BATCH_SIZE).each_with_object({}) do |origin_id_batch, counts|
+        counts.merge!(unread_counts_for_batch(origin_id_batch, watermarks))
+      end
+    end
 
-      visible_comments
-        .merge(newer_than_watermark)
-        .group(:creative_id)
-        .count
+    # Origins with no pointer all share the implicit zero watermark, so keep
+    # them in one IN condition. Only origins with a real watermark need an OR.
+    def unread_counts_for_batch(origin_ids, watermarks)
+      without_watermark, with_watermark = origin_ids.partition { |origin_id| !watermarks.key?(origin_id) }
+      scopes = []
+      scopes << Comment.where(creative_id: without_watermark) if without_watermark.any?
+      scopes.concat(with_watermark.map { |origin_id| unread_scope(origin_id, watermarks.fetch(origin_id)) })
+      return {} if scopes.empty?
+
+      visible_comments.merge(scopes.reduce { |combined, scope| combined.or(scope) }).group(:creative_id).count
     end
 
     def unread_scope(origin_id, last_read_id)
-      Comment
-        .where(creative_id: origin_id)
-        .where(Comment.arel_table[:id].gt(last_read_id))
+      Comment.where(creative_id: origin_id).where(Comment.arel_table[:id].gt(last_read_id))
     end
 
     def visible_counts(origin_ids)
-      visible_comments.where(creative_id: origin_ids).group(:creative_id).count
+      origin_ids.each_slice(QUERY_BATCH_SIZE).each_with_object({}) do |origin_id_batch, counts|
+        counts.merge!(visible_comments.where(creative_id: origin_id_batch).group(:creative_id).count)
+      end
     end
 
     def visible_comments
       user ? Comment.visible_to(user) : Comment.public_only
+    end
+
+    class << self
+      private
+
+      def unread_public_counts(origin, thresholds)
+        thresholds.uniq.to_h do |threshold|
+          [ threshold, origin.comments.public_only.where(Comment.arel_table[:id].gt(threshold)).count ]
+        end
+      end
+
+      def private_counts_for_users(origin, user_ids, last_read_ids)
+        visible_counts = Hash.new(0)
+        unread_counts = Hash.new(0)
+        user_id_set = user_ids.to_set
+
+        origin.comments.where(private: true)
+          .where("comments.user_id IN (:user_ids) OR comments.approver_id IN (:user_ids)", user_ids: user_ids)
+          .pluck(:id, :user_id, :approver_id)
+          .each do |comment_id, author_id, approver_id|
+            [ author_id, approver_id ].compact.uniq.each do |user_id|
+              next unless user_id_set.include?(user_id)
+
+              visible_counts[user_id] += 1
+              unread_counts[user_id] += 1 if comment_id > last_read_ids.fetch(user_id, 0)
+            end
+          end
+
+        [ visible_counts, unread_counts ]
+      end
     end
   end
 end

--- a/engines/collavre/app/services/collavre/creatives/comment_badge_index.rb
+++ b/engines/collavre/app/services/collavre/creatives/comment_badge_index.rb
@@ -1,37 +1,31 @@
 module Collavre
 module Creatives
-  # Batches the browse tree's comment badge. Per node this was two queries — a
-  # read-pointer lookup and an unread COUNT — which is what made the badge cost
-  # scale with the size of the rendered tree.
+  # Resolves the unread and visible comment counts used by every comment badge.
+  # Per node this was two queries — a read-pointer lookup and an unread COUNT —
+  # which is what made the browse-tree badge cost scale with the rendered tree.
   #
   # Keyed by *origin*: a linked shell shows its origin's comments.
   #
-  # The counts it hands out are display-ready: presence suppression (a user
-  # looking at a chat has read it, so the badge shows 0) is applied here rather
-  # than left to the caller. Presence lives in Rails.cache, which is the
-  # database in production, so a per-node check was the same N+1 in another
-  # disguise — and a caller that re-applied suppression on top of a batched
-  # value would only be doing the work twice.
+  # The counts it hands out are display-ready: they include only comments the
+  # user can see and apply presence suppression in one cache round trip.
   class CommentBadgeIndex
     def initialize(user:)
       @user = user
       @unread_by_origin_id = {}
+      @visible_by_origin_id = {}
     end
 
     def index(origins)
       pending = origins.uniq(&:id).reject { |o| @unread_by_origin_id.key?(o.id) }
       return if pending.empty?
 
-      watermarks = read_watermarks(pending.map(&:id))
-
-      # No read pointer means nothing has been read yet, so every comment counts
-      # as unread — including private ones, matching the counter cache.
-      pending.each do |origin|
-        @unread_by_origin_id[origin.id] = origin.comments_count unless watermarks.key?(origin.id)
+      origin_ids = pending.map(&:id)
+      watermarks = read_watermarks(origin_ids)
+      unread_counts = unread_counts(origin_ids, watermarks)
+      origin_ids.each do |origin_id|
+        @unread_by_origin_id[origin_id] = unread_counts.fetch(origin_id, 0)
       end
-
-      counts = unread_counts(watermarks)
-      watermarks.each_key { |origin_id| @unread_by_origin_id[origin_id] = counts.fetch(origin_id, 0) }
+      @visible_by_origin_id.merge!(visible_counts(origin_ids))
 
       suppress_for_present_user(pending.map(&:id))
     end
@@ -40,6 +34,10 @@ module Creatives
     # to the single-creative path rather than silently render a zero badge.
     def unread_count_for(origin)
       @unread_by_origin_id[origin.id]
+    end
+
+    def visible_comments?(origin)
+      @visible_by_origin_id[origin.id].to_i.positive?
     end
 
     private
@@ -71,20 +69,29 @@ module Creatives
     # watermark, so the thresholds are OR-ed together rather than shared. Built
     # from relations rather than a SQL fragment: a hand-built string here would
     # be safe (literal template, bound values) but unprovably so to a scanner.
-    def unread_counts(watermarks)
-      return {} if watermarks.empty?
-
-      newer_than_watermark = watermarks
-        .map { |origin_id, last_read_id| unread_scope(origin_id, last_read_id) }
+    def unread_counts(origin_ids, watermarks)
+      newer_than_watermark = origin_ids
+        .map { |origin_id| unread_scope(origin_id, watermarks.fetch(origin_id, 0)) }
         .reduce { |combined, scope| combined.or(scope) }
 
-      Comment.where(private: false).merge(newer_than_watermark).group(:creative_id).count
+      visible_comments
+        .merge(newer_than_watermark)
+        .group(:creative_id)
+        .count
     end
 
     def unread_scope(origin_id, last_read_id)
       Comment
         .where(creative_id: origin_id)
         .where(Comment.arel_table[:id].gt(last_read_id))
+    end
+
+    def visible_counts(origin_ids)
+      visible_comments.where(creative_id: origin_ids).group(:creative_id).count
+    end
+
+    def visible_comments
+      user ? Comment.visible_to(user) : Comment.public_only
     end
   end
 end

--- a/engines/collavre/app/services/collavre/creatives/comment_badge_index.rb
+++ b/engines/collavre/app/services/collavre/creatives/comment_badge_index.rb
@@ -150,21 +150,64 @@ module Creatives
       def private_counts_for_users(origin, user_ids, last_read_ids)
         visible_counts = Hash.new(0)
         unread_counts = Hash.new(0)
-        user_id_set = user_ids.to_set
 
-        origin.comments.where(private: true)
-          .where("comments.user_id IN (:user_ids) OR comments.approver_id IN (:user_ids)", user_ids: user_ids)
-          .pluck(:id, :user_id, :approver_id)
-          .each do |comment_id, author_id, approver_id|
-            [ author_id, approver_id ].compact.uniq.each do |user_id|
-              next unless user_id_set.include?(user_id)
+        # Keep the history in the database: comment badge fanout happens for
+        # every create and destroy, so plucking every private comment turns a
+        # long conversation into proportional Ruby memory and bandwidth. The
+        # two recipient columns need separate grouped counts. Subtract their
+        # overlap so a comment authored and approved by the same user counts
+        # once, just like Comment.visible_to(user).
+        origin.comments.where(private: true).then do |private_comments|
+          user_ids.each_slice(QUERY_BATCH_SIZE) do |user_id_batch|
+            add_counts!(visible_counts, private_counts_by_recipient(private_comments, :user_id, user_id_batch))
+            add_counts!(visible_counts, private_counts_by_recipient(private_comments, :approver_id, user_id_batch))
+            subtract_counts!(visible_counts, private_counts_for_same_recipient(private_comments, user_id_batch))
 
-              visible_counts[user_id] += 1
-              unread_counts[user_id] += 1 if comment_id > last_read_ids.fetch(user_id, 0)
-            end
+            add_counts!(unread_counts, unread_private_counts_by_recipient(private_comments, :user_id, user_id_batch, last_read_ids))
+            add_counts!(unread_counts, unread_private_counts_by_recipient(private_comments, :approver_id, user_id_batch, last_read_ids))
+            subtract_counts!(unread_counts, unread_private_counts_by_recipient(private_comments, :user_id, user_id_batch, last_read_ids, same_recipient: true))
           end
+        end
 
         [ visible_counts, unread_counts ]
+      end
+
+      def private_counts_by_recipient(comments, recipient_column, user_ids)
+        comments.where(recipient_column => user_ids).group(recipient_column).count
+      end
+
+      def private_counts_for_same_recipient(comments, user_ids)
+        comment_table = Comment.arel_table
+
+        comments.where(user_id: user_ids, approver_id: user_ids)
+          .where(comment_table[:user_id].eq(comment_table[:approver_id]))
+          .group(:user_id)
+          .count
+      end
+
+      # A per-recipient CASE keeps each user's watermark in SQL while the
+      # grouped result remains one count per recipient. Batching also keeps the
+      # CASE expression beneath SQLite's bind-variable and expression limits.
+      def unread_private_counts_by_recipient(comments, recipient_column, user_ids, last_read_ids, same_recipient: false)
+        comment_table = Comment.arel_table
+        recipient = comment_table[recipient_column]
+        watermark = user_ids.reduce(Arel::Nodes::Case.new(recipient)) do |case_expression, user_id|
+          case_expression.when(user_id).then(last_read_ids.fetch(user_id, 0))
+        end
+
+        scope = comments.where(recipient_column => user_ids)
+          .where(comment_table[:id].gt(watermark))
+        scope = scope.where(comment_table[:user_id].eq(comment_table[:approver_id])) if same_recipient
+
+        scope.group(recipient_column).count
+      end
+
+      def add_counts!(target, counts)
+        counts.each { |user_id, count| target[user_id] += count }
+      end
+
+      def subtract_counts!(target, counts)
+        counts.each { |user_id, count| target[user_id] -= count }
       end
     end
   end

--- a/engines/collavre/app/services/collavre/creatives/tree_builder.rb
+++ b/engines/collavre/app/services/collavre/creatives/tree_builder.rb
@@ -97,7 +97,7 @@ module Creatives
       visible = creatives.reject(&:archived?).select { |creative| can_feedback?(creative) }
       return if visible.empty?
 
-      comment_badge_index.index(visible.map(&:effective_origin))
+      comment_badge_index.index(visible.map(&:effective_origin), include_visible_counts: false)
     end
 
     def build_nodes(creatives, level:)

--- a/engines/collavre/test/models/collavre/comment/badge_visibility_test.rb
+++ b/engines/collavre/test/models/collavre/comment/badge_visibility_test.rb
@@ -31,11 +31,27 @@ module Collavre
       assert_equal({ @owner.id => true, @viewer.id => false }, show_zero_by_user_id)
     end
 
+    test "a private comment reveals the badge for its approver" do
+      Comment.create!(creative: @creative, user: @owner, approver: @viewer, content: "private", private: true)
+
+      assert_equal({ @owner.id => true, @viewer.id => true }, show_zero_by_user_id)
+    end
+
     test "a public comment outweighs another user's private one" do
       Comment.create!(creative: @creative, user: @owner, content: "private", private: true)
       Comment.create!(creative: @creative, user: @viewer, content: "public")
 
       assert_equal({ @owner.id => true, @viewer.id => true }, show_zero_by_user_id)
+    end
+
+    test "broadcast batches the presence lookup for every recipient" do
+      calls = 0
+
+      CommentPresenceStore.stub(:list, ->(_creative_id) { calls += 1; [] }) do
+        show_zero_by_user_id
+      end
+
+      assert_equal 1, calls
     end
 
     private

--- a/engines/collavre/test/services/creatives/comment_badge_index_test.rb
+++ b/engines/collavre/test/services/creatives/comment_badge_index_test.rb
@@ -35,6 +35,17 @@ module Creatives
       assert_equal 2, @index.unread_count_for(creative)
     end
 
+    test "can index unread counts without querying visible counts" do
+      creative = Creative.create!(user: @user, description: "Tree badge", sequence: 913)
+      comment_on(creative, "one")
+
+      @index.stub(:visible_counts, ->(_) { flunk("visible counts should not be queried for a tree badge") }) do
+        @index.index([ creative.reload ], include_visible_counts: false)
+      end
+
+      assert_equal 1, @index.unread_count_for(creative)
+    end
+
     test "does not count another user's private comments" do
       creative = Creative.create!(user: @user, description: "Private visibility", sequence: 910)
       comment_on(creative, "public")

--- a/engines/collavre/test/services/creatives/comment_badge_index_test.rb
+++ b/engines/collavre/test/services/creatives/comment_badge_index_test.rb
@@ -101,6 +101,14 @@ module Creatives
       assert_equal 0, @index.unread_count_for(fully_read)
     end
 
+    test "chunks a large unwatermarked level below SQLite's expression limit" do
+      origins = (1..1000).map { |id| Struct.new(:id).new(id) }
+
+      @index.index(origins)
+
+      assert_not_nil @index.unread_count_for(origins.last)
+    end
+
     # nil, not 0 — the caller has to be able to tell "not batched" from "nothing
     # unread", or an un-indexed node would quietly render an empty badge.
     test "an unindexed creative reports nil" do

--- a/engines/collavre/test/services/creatives/comment_badge_index_test.rb
+++ b/engines/collavre/test/services/creatives/comment_badge_index_test.rb
@@ -109,6 +109,24 @@ module Creatives
       assert_not_nil @index.unread_count_for(origins.last)
     end
 
+    test "batch counts private comments per recipient and watermark without double counting self-approved comments" do
+      creative = Creative.create!(user: @user, description: "Private batch counts", sequence: 912)
+      viewer = User.create!(email: "badge-viewer@example.com", password: TEST_PASSWORD, name: "Badge Viewer")
+      first = Comment.create!(creative: creative, user: @user, content: "owner private", private: true)
+      shared = Comment.create!(creative: creative, user: @user, approver: viewer, content: "shared private", private: true)
+      Comment.create!(creative: creative, user: viewer, approver: viewer, content: "self-approved private", private: true)
+
+      CommentReadPointer.create!(user: @user, creative: creative, last_read_comment_id: first.id)
+      CommentReadPointer.create!(user: viewer, creative: creative, last_read_comment_id: shared.id)
+
+      badges = Collavre::Creatives::CommentBadgeIndex.for_users(origin: creative, users: [ @user, viewer ])
+
+      assert_equal 1, badges.fetch(@user.id).unread_count
+      assert badges.fetch(@user.id).visible_comments
+      assert_equal 1, badges.fetch(viewer.id).unread_count
+      assert badges.fetch(viewer.id).visible_comments
+    end
+
     # nil, not 0 — the caller has to be able to tell "not batched" from "nothing
     # unread", or an un-indexed node would quietly render an empty badge.
     test "an unindexed creative reports nil" do

--- a/engines/collavre/test/services/creatives/comment_badge_index_test.rb
+++ b/engines/collavre/test/services/creatives/comment_badge_index_test.rb
@@ -11,18 +11,18 @@ module Creatives
       @index = Collavre::Creatives::CommentBadgeIndex.new(user: @user)
     end
 
-    test "counts only public comments newer than the read watermark" do
+    test "counts only visible comments newer than the read watermark" do
       creative = Creative.create!(user: @user, description: "Watermarked", sequence: 900)
       first = comment_on(creative, "one")
       comment_on(creative, "two")
       comment_on(creative, "three")
-      comment_on(creative, "private", private: true)
+      Comment.create!(creative: creative, user: @user, content: "private", private: true)
 
       CommentReadPointer.create!(user: @user, creative: creative, last_read_comment_id: first.id)
 
       @index.index([ creative.reload ])
 
-      assert_equal 2, @index.unread_count_for(creative), "two public comments follow the watermark; the private one never counts"
+      assert_equal 3, @index.unread_count_for(creative), "two public comments and the user's private comment follow the watermark"
     end
 
     test "without a read pointer every comment is unread" do
@@ -33,6 +33,36 @@ module Creatives
       @index.index([ creative.reload ])
 
       assert_equal 2, @index.unread_count_for(creative)
+    end
+
+    test "does not count another user's private comments" do
+      creative = Creative.create!(user: @user, description: "Private visibility", sequence: 910)
+      comment_on(creative, "public")
+      comment_on(creative, "private", private: true)
+
+      @index.index([ creative.reload ])
+
+      assert_equal 1, @index.unread_count_for(creative)
+      assert @index.visible_comments?(creative)
+    end
+
+    test "each user gets their own private visibility" do
+      creative = Creative.create!(user: @user, description: "Batch visibility", sequence: 911)
+      shared_user = User.create!(email: "badge-shared@example.com", password: TEST_PASSWORD, name: "Badge Shared")
+      CreativeShare.create!(creative: creative, user: shared_user, shared_by: @user, permission: :feedback)
+      comment_on(creative, "public")
+      Comment.create!(creative: creative, user: @user, content: "owner private", private: true)
+      Comment.create!(creative: creative, user: shared_user, content: "shared private", private: true)
+
+      owner_index = Collavre::Creatives::CommentBadgeIndex.new(user: @user)
+      shared_index = Collavre::Creatives::CommentBadgeIndex.new(user: shared_user)
+      owner_index.index([ creative ])
+      shared_index.index([ creative ])
+
+      assert_equal 2, owner_index.unread_count_for(creative)
+      assert_equal 2, shared_index.unread_count_for(creative)
+      assert owner_index.visible_comments?(creative)
+      assert shared_index.visible_comments?(creative)
     end
 
     test "a watermark at the newest comment leaves nothing unread" do


### PR DESCRIPTION
## What changed

- Centralized unread and visible-comment badge calculations in `CommentBadgeIndex`.
- Updated tree, single badge, realtime, and inbox badge paths to use the shared index.
- Made private-comment counts consistently respect each recipient's visibility.
- Added coverage for private visibility and per-user badge results.

## Why

The same unread count was calculated in several places with conflicting public/private visibility rules. This refactor establishes one source of truth before topic-level unread badges are added.

## Validation

- `./bin/rubocop -a`
- Targeted badge tests: 32 runs, 80 assertions, all passing.
- Topic system test: 3 runs, 23 assertions, all passing.
- Full `bin/rails test`: 106 runs; 11 unrelated failures require missing `active_record_encryption.primary_key` for GitHub webhook tests.
- `bin/rails test:system` cannot load the host `test/system` directory; the engine system suite was run directly.