### PR TITLE
feat: add unread counts to topic badges

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -1524,6 +1524,21 @@ body.chat-fullscreen {
     border-color: var(--color-secondary-active);
 }
 
+.topic-unread-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 1.3em;
+    height: 1.3em;
+    padding: 0 0.35em;
+    border-radius: 999px;
+    background: var(--color-danger);
+    color: var(--color-badge-text);
+    font-size: 0.75em;
+    font-weight: bold;
+    line-height: 1;
+}
+
 .topic-tag.has-new-messages {
     position: relative;
     border-color: var(--color-active);

--- a/engines/collavre/app/controllers/collavre/topics_controller.rb
+++ b/engines/collavre/app/controllers/collavre/topics_controller.rb
@@ -25,7 +25,9 @@ module Collavre
       system_topic = @creative.inbox? ? @creative.system_topic(fallback_user: Current.user) : nil
 
       active_topics = @creative.topics.active.includes(primary_agent: { avatar_attachment: :blob }).order(:created_at).to_a
-      archived_topics = @creative.topics.archived.order(:created_at)
+      archived_topics = @creative.topics.archived.includes(primary_agent: { avatar_attachment: :blob }).order(:created_at).to_a
+      unread_counts_by_topic = Creatives::CommentBadgeIndex.new(user: Current.user)
+        .unread_counts_by_topic(@creative)
 
       last_topic_id = if Current.user
                         UserCreativePreference
@@ -37,8 +39,8 @@ module Collavre
       main_topic_id = main_topic.id
 
       render json: {
-        topics: active_topics.map { |t| topic_json(t) },
-        archived_topics: archived_topics,
+        topics: active_topics.map { |t| topic_json(t, unread_count: unread_counts_by_topic.fetch(t.id, 0)) },
+        archived_topics: archived_topics.map { |t| topic_json(t, unread_count: unread_counts_by_topic.fetch(t.id, 0)) },
         can_manage: can_manage,
         can_create_topic: can_write,
         can_set_primary_agent: can_write,
@@ -382,12 +384,14 @@ module Collavre
       "#{prefix}#{next_number}"
     end
 
-    def topic_json(topic)
+    def topic_json(topic, unread_count: nil)
       data = topic.slice(:id, :name, :source_topic_id)
       if topic.primary_agent
         data[:primary_agent] = agent_json(topic.primary_agent)
       end
       data[:agent_locked] = topic.session_id.present?
+      data[:archived_at] = topic.archived_at if topic.archived_at
+      data[:unread_count] = unread_count unless unread_count.nil?
       data
     end
 

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/list_controller_read_pointer.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/list_controller_read_pointer.test.js
@@ -1,0 +1,48 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { jest } from '@jest/globals'
+import CommentsListController from '../list_controller'
+
+describe('CommentsListController read pointer updates', () => {
+  let controller
+  let topicsController
+
+  beforeEach(() => {
+    jest.useFakeTimers()
+    document.head.innerHTML = '<meta name="csrf-token" content="test-csrf">'
+    topicsController = { loadTopics: jest.fn() }
+    controller = Object.create(CommentsListController.prototype)
+    controller.creativeId = '42'
+    Object.defineProperty(controller, 'element', { value: document.createElement('div') })
+    document.body.appendChild(controller.element)
+    Object.defineProperty(controller, 'popupController', { value: { topicsController } })
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+    document.head.innerHTML = ''
+    jest.useRealTimers()
+    jest.clearAllMocks()
+  })
+
+  test('reloads topic unread counts after a successful read pointer update', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: true })
+
+    controller.markCommentsRead()
+    await jest.advanceTimersByTimeAsync(2000)
+
+    expect(global.fetch).toHaveBeenCalledWith('/comment_read_pointers/update', expect.objectContaining({ method: 'POST' }))
+    expect(topicsController.loadTopics).toHaveBeenCalledTimes(1)
+  })
+
+  test('does not reload topic unread counts after a failed read pointer update', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: false })
+
+    controller.markCommentsRead()
+    await jest.advanceTimersByTimeAsync(2000)
+
+    expect(topicsController.loadTopics).not.toHaveBeenCalled()
+  })
+})

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_archived.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_archived.test.js
@@ -70,6 +70,18 @@ describe('TopicsController archived topic messages', () => {
   })
 
   describe('selecting an archived topic', () => {
+    test('renders unread counts on active and archived topic chips', () => {
+      controller.topics = [{ id: 1, name: 'Main', unread_count: 2 }, { id: 2, name: 'Alpha', unread_count: 0 }]
+      controller.archivedTopics = [{ id: 3, name: 'Zeta', unread_count: 4 }]
+      controller.showingArchived = true
+
+      render()
+
+      expect(controller.listTarget.querySelector('.topic-tag[data-id="1"] .topic-unread-badge').textContent).toBe('2')
+      expect(controller.listTarget.querySelector('.topic-tag[data-id="2"] .topic-unread-badge')).toBeNull()
+      expect(controller.listTarget.querySelector('.topic-archived[data-id="3"] .topic-unread-badge').textContent).toBe('4')
+    })
+
     test('archived chips carry the select action so clicking one opens it', () => {
       controller.showingArchived = true
       render()

--- a/engines/collavre/app/javascript/controllers/comments/list_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/list_controller.js
@@ -452,6 +452,13 @@ export default class extends Controller {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({ creative_id: creativeId }),
+      }).then((response) => {
+        if (!response.ok || !this.element.isConnected || this.creativeId !== creativeId) return
+
+        // Read pointers are creative-wide, so a successful update changes every
+        // topic's count. Reload the chips immediately instead of leaving their
+        // initial unread numbers on screen until another topic event occurs.
+        this.popupController?.topicsController?.loadTopics?.()
       }).catch(() => { /* ignore — creative may have been deleted */ })
     }, 2000);
   }

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -280,11 +280,14 @@ export default class extends Controller {
                 ? this.renderAgentAvatar(topic.primary_agent, releasableTopicId)
                 : ''
             const branchIcon = topic.source_topic_id ? '<span class="topic-branch-icon" title="Branched">↗</span>' : ''
+            const unreadBadge = topic.unread_count > 0
+                ? `<span class="topic-unread-badge">${topic.unread_count}</span>`
+                : ''
             const isMainTopic = this.mainTopicId && String(topic.id) === String(this.mainTopicId)
             let s = `<span class="topic-tag topic-drop-target ${isActive}" ${draggable}
                           data-action="click->comments--topics#select ${dropActions} ${dragActions} ${topicDropActions}"
                           data-id="${topic.id}"${topic.source_topic_id ? ` data-source-topic-id="${topic.source_topic_id}"` : ''}>
-                        ${agentAvatar}${branchIcon}#${topic.name}`
+                        ${agentAvatar}${branchIcon}#${topic.name}${unreadBadge}`
             if (canManage && !isMainTopic) {
                 s += `<button class="archive-topic-btn" data-action="click->comments--topics#archiveTopic" data-id="${topic.id}" title="Archive">${ICON_ARCHIVE}</button>`
                 s += `<button class="delete-topic-btn" data-action="click->comments--topics#deleteTopic" data-id="${topic.id}">&times;</button>`
@@ -312,10 +315,13 @@ export default class extends Controller {
                 this.archivedTopics.forEach(topic => {
                     const isActive = String(this.currentTopicId) === String(topic.id) ? ' active' : ''
                     const hasNew = this.archivedWithNewMessages.has(String(topic.id)) ? ' has-new-messages' : ''
+                    const unreadBadge = topic.unread_count > 0
+                        ? `<span class="topic-unread-badge">${topic.unread_count}</span>`
+                        : ''
                     html += `<span class="topic-tag topic-archived${isActive}${hasNew}"
                                    data-action="click->comments--topics#select"
                                    data-id="${topic.id}">
-                              #${topic.name}
+                              #${topic.name}${unreadBadge}
                               ${canManage ? `<button class="unarchive-topic-btn" data-action="click->comments--topics#unarchiveTopic" data-id="${topic.id}" title="Restore">${ICON_RESTORE}</button>` : ''}
                              </span>`
                 })

--- a/engines/collavre/app/services/collavre/creatives/comment_badge_index.rb
+++ b/engines/collavre/app/services/collavre/creatives/comment_badge_index.rb
@@ -77,6 +77,21 @@ module Creatives
       @visible_by_origin_id[origin.id].to_i.positive?
     end
 
+    # The topic strip needs the same display-ready unread state as the creative
+    # badge, split by topic. The read pointer remains creative-wide for now, so
+    # opening any topic clears every topic count together.
+    def unread_counts_by_topic(origin)
+      return {} if user && CommentPresenceStore.list(origin.id).include?(user.id)
+
+      last_read_id = CommentReadPointer.where(user: user, creative: origin)
+        .pick(:last_read_comment_id).to_i
+
+      visible_comments.where(creative: origin)
+        .where(Comment.arel_table[:id].gt(last_read_id))
+        .group(:topic_id)
+        .count
+    end
+
     private
 
     attr_reader :user

--- a/engines/collavre/test/controllers/topics_controller_test.rb
+++ b/engines/collavre/test/controllers/topics_controller_test.rb
@@ -15,6 +15,22 @@ class TopicsControllerTest < ActionDispatch::IntegrationTest
     assert_equal @creative.id, json["effective_creative_id"]
   end
 
+  test "index includes unread counts for active and archived topics" do
+    archived_topic = @creative.topics.create!(name: "Archived", user: @user)
+    archived_topic.archive!
+    read_comment = Collavre::Comment.create!(creative: @creative, topic: @topic, user: users(:two), content: "read")
+    Collavre::Comment.create!(creative: @creative, topic: @topic, user: users(:two), content: "active unread")
+    Collavre::Comment.create!(creative: @creative, topic: archived_topic, user: users(:two), content: "archived unread")
+    Collavre::CommentReadPointer.create!(user: @user, creative: @creative, last_read_comment_id: read_comment.id)
+
+    get collavre.creative_topics_url(@creative), as: :json
+
+    assert_response :success
+    json = JSON.parse(response.body)
+    assert_equal 1, json["topics"].find { |topic| topic["id"] == @topic.id }["unread_count"]
+    assert_equal 1, json["archived_topics"].find { |topic| topic["id"] == archived_topic.id }["unread_count"]
+  end
+
   test "index returns effective_creative_id for linked creative (origin id)" do
     linked = Collavre::Creative.create!(user: @user, description: "linked wrapper", origin: @creative)
     get collavre.creative_topics_url(linked), as: :json

--- a/engines/collavre/test/services/creatives/comment_badge_index_test.rb
+++ b/engines/collavre/test/services/creatives/comment_badge_index_test.rb
@@ -88,6 +88,30 @@ module Creatives
       assert_equal 0, @index.unread_count_for(creative)
     end
 
+    test "groups visible unread comments by topic using the creative read pointer" do
+      creative = Creative.create!(user: @user, description: "Topic badges", sequence: 914)
+      first_topic = creative.topics.create!(name: "First", user: @user)
+      second_topic = creative.topics.create!(name: "Second", user: @user)
+      read_comment = Comment.create!(creative: creative, topic: first_topic, user: @author, content: "read")
+      Comment.create!(creative: creative, topic: first_topic, user: @author, content: "unread")
+      Comment.create!(creative: creative, topic: second_topic, user: @user, content: "private", private: true)
+      Comment.create!(creative: creative, topic: second_topic, user: @author, content: "hidden", private: true)
+      CommentReadPointer.create!(user: @user, creative: creative, last_read_comment_id: read_comment.id)
+
+      assert_equal({ first_topic.id => 1, second_topic.id => 1 }, @index.unread_counts_by_topic(creative))
+    end
+
+    test "suppresses topic unread counts while the user is present" do
+      creative = Creative.create!(user: @user, description: "Present topic badges", sequence: 915)
+      topic = creative.topics.create!(name: "Updates", user: @user)
+      Comment.create!(creative: creative, topic: topic, user: @author, content: "unread")
+      Collavre::CommentPresenceStore.add(creative.id, @user.id)
+
+      assert_empty @index.unread_counts_by_topic(creative)
+    ensure
+      Rails.cache.delete(Collavre::CommentPresenceStore.key(creative.id))
+    end
+
     # The batch is one query for the whole level, so a per-origin watermark must
     # not leak across origins.
     test "each origin is counted against its own watermark" do


### PR DESCRIPTION
## Summary
- Add per-topic unread counts to the topics endpoint using the shared comment badge visibility and read-pointer rules.
- Render a numeric unread badge on active and archived topic chips.
- Cover topic aggregation, endpoint payloads, and chip rendering.

## Why
Opening a chat showed that unread messages existed, but not which topic contained them.

## Validation
- `bin/rails test engines/collavre/test/services/creatives/comment_badge_index_test.rb engines/collavre/test/controllers/topics_controller_test.rb`
- `npm test -- --runInBand engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_archived.test.js`
- `./bin/rubocop -a`

`bin/rails test` is currently blocked by 11 pre-existing GitHub test errors caused by missing Active Record encryption credentials. `bin/rails test:system` cannot run because this checkout has no `test/system` directory.