### PR TITLE
fix: contain unbreakable creative content inside the workspace column

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/workspace.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/workspace.css
@@ -28,7 +28,8 @@ body.creative-workspace > nav {
     min-width: 0;
 }
 
-body.creative-workspace .creative-content {
+body.creative-workspace .creative-content,
+body.creative-workspace .creative-title-content {
     min-width: 0;
     max-width: none;
 }
@@ -38,9 +39,15 @@ body.creative-workspace .creative-content {
    keep their default min-width: auto, so they refuse to shrink below the
    min-content width of their contents. Text still wraps (min-content is one
    word), but unbreakable blocks -- code blocks and tables -- overflow the
-   column. Zeroing min-width lets the flex chain shrink to the column. */
+   column. Zeroing min-width lets the flex chain shrink to the column.
+
+   The title row (the root creative) has its own chain: .creative-row-start >
+   h1.page-title > .creative-title-content. Shrinking only .creative-row-start
+   would let the title's min-content width paint through the shrunken parent,
+   so .page-title belongs in the same list. */
 body.creative-workspace .creative-row-start,
 body.creative-workspace .creative-tree-li,
+body.creative-workspace .page-title,
 body.creative-workspace .indent1,
 body.creative-workspace .indent2,
 body.creative-workspace .indent3 {

--- a/engines/collavre/app/assets/stylesheets/collavre/workspace.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/workspace.css
@@ -33,6 +33,20 @@ body.creative-workspace .creative-content {
     max-width: none;
 }
 
+/* The rule above drops the viewport-based max-width that used to cap row width.
+   Without it, the flex wrappers between the grid column and .creative-content
+   keep their default min-width: auto, so they refuse to shrink below the
+   min-content width of their contents. Text still wraps (min-content is one
+   word), but unbreakable blocks -- code blocks and tables -- overflow the
+   column. Zeroing min-width lets the flex chain shrink to the column. */
+body.creative-workspace .creative-row-start,
+body.creative-workspace .creative-tree-li,
+body.creative-workspace .indent1,
+body.creative-workspace .indent2,
+body.creative-workspace .indent3 {
+    min-width: 0;
+}
+
 .creative-workspace-tree-region {
     grid-column: 1;
     min-width: 0;

--- a/engines/collavre/test/system/workspace_content_wrap_test.rb
+++ b/engines/collavre/test/system/workspace_content_wrap_test.rb
@@ -28,7 +28,14 @@ class WorkspaceContentWrapTest < ApplicationSystemTestCase
       notifications_enabled: false,
       creative_workspace_enabled: true
     )
-    @root = Creative.create!(description: "Wrap fixtures", user: @user)
+    # The root's description renders as the title row, which has its own flex
+    # chain (.creative-row-start > h1.page-title > .creative-title-content) and
+    # its own content class. Give it the unbreakable shapes too so the title
+    # chain is held to the same containment rule as the child rows.
+    @root = Creative.create!(
+      description: "<p>Wrap fixtures</p><pre><code>#{CODE_LINE}</code></pre>#{wide_table_html}",
+      user: @user
+    )
 
     # One child per content shape. Code blocks and tables are the shapes that
     # regressed; the prose and URL rows guard the cases that kept working, so a
@@ -79,7 +86,13 @@ class WorkspaceContentWrapTest < ApplicationSystemTestCase
   test "the flex wrappers between the column and the content can shrink" do
     visit_workspace(THREE_PANEL_WIDTH)
 
-    [ ".creative-row-start", ".creative-tree-li", ".indent1" ].each do |selector|
+    [
+      ".creative-row-start",
+      ".creative-tree-li",
+      ".indent1",
+      ".creative-tree-title .page-title",
+      ".creative-title-content"
+    ].each do |selector|
       next if page.evaluate_script("document.querySelectorAll('main #{selector}').length").zero?
 
       assert_equal "0px", computed_style(selector, "min-width"),
@@ -113,7 +126,9 @@ class WorkspaceContentWrapTest < ApplicationSystemTestCase
         var style = getComputedStyle(main);
         var limit = main.getBoundingClientRect().left + main.clientWidth -
                     parseFloat(style.paddingLeft || 0);
-        return Array.from(document.querySelectorAll('main .creative-content'))
+        return Array.from(document.querySelectorAll(
+          'main .creative-content, main .creative-title-content'
+        ))
           .filter(function (el) {
             return el.getBoundingClientRect().right > limit + #{OVERFLOW_TOLERANCE_PX};
           })

--- a/engines/collavre/test/system/workspace_content_wrap_test.rb
+++ b/engines/collavre/test/system/workspace_content_wrap_test.rb
@@ -1,0 +1,142 @@
+require_relative "../application_system_test_case"
+
+# Creative rows used to be capped by a viewport-based `max-width` on
+# `.creative-content`. The three-panel workspace drops that cap (`max-width:
+# none`) because a viewport width means nothing inside a grid column — but the
+# flex wrappers between the column and the content kept their default
+# `min-width: auto`, so they could not shrink below their contents' min-content
+# width. Prose still wrapped (min-content is one word) while unbreakable blocks
+# — code blocks and tables — burst out of the column and were clipped by the
+# chat panel. These lock every content shape inside its column.
+class WorkspaceContentWrapTest < ApplicationSystemTestCase
+  THREE_PANEL_WIDTH = 1400
+  TWO_PANEL_WIDTH = 1000
+
+  # Sub-pixel layout rounding, not slack for a genuinely overflowing row.
+  OVERFLOW_TOLERANCE_PX = 1
+
+  LONG_URL = "https://example.com/#{'very-long-path-segment/' * 12}index.html".freeze
+  LONG_KOREAN = ("이것은 줄바꿈이 제대로 되는지 확인하기 위한 아주 긴 한국어 문장입니다. " * 6).freeze
+  CODE_LINE = "const #{'reallyLongIdentifierName' * 8} = computeSomethingExpensive();".freeze
+
+  setup do
+    @user = User.create!(
+      email: "content-wrap@example.com",
+      password: SystemHelpers::PASSWORD,
+      name: "Content Wrap",
+      email_verified_at: Time.current,
+      notifications_enabled: false,
+      creative_workspace_enabled: true
+    )
+    @root = Creative.create!(description: "Wrap fixtures", user: @user)
+
+    # One child per content shape. Code blocks and tables are the shapes that
+    # regressed; the prose and URL rows guard the cases that kept working, so a
+    # future fix for one cannot quietly break the other.
+    [
+      LONG_KOREAN,
+      LONG_URL,
+      "<pre><code>#{CODE_LINE}</code></pre>",
+      wide_table_html
+    ].each_with_index do |description, index|
+      Creative.create!(description: description, user: @user, parent: @root, sequence: index)
+    end
+
+    sign_in_via_ui(@user)
+  end
+
+  [ THREE_PANEL_WIDTH, TWO_PANEL_WIDTH ].each do |width|
+    test "no creative content overflows its column at #{width}px" do
+      visit_workspace(width)
+
+      overflowing = overflowing_rows
+
+      assert_empty overflowing,
+        "content overflows the workspace column at #{width}px: #{overflowing.inspect}"
+    end
+  end
+
+  # The overflow check passes trivially if the rows never rendered, so prove the
+  # fixtures are on screen and that the flex chain actually collapsed to the
+  # column rather than the old 800px viewport cap.
+  test "every fixture row renders and shares the column width" do
+    visit_workspace(THREE_PANEL_WIDTH)
+
+    widths = page.evaluate_script(<<~JS)
+      Array.from(document.querySelectorAll('main .creative-content')).map(function (el) {
+        return Math.round(el.getBoundingClientRect().width);
+      });
+    JS
+
+    assert_operator widths.size, :>=, 4, "expected the four fixture rows to render"
+    assert_operator widths.max, :<=, column_width.round,
+      "a row is wider than the content column"
+  end
+
+  # The wrappers the fix touches are the ones that must reach `min-width: 0`;
+  # asserting the computed value catches a regression even if a future layout
+  # change happens to hide the overflow some other way.
+  test "the flex wrappers between the column and the content can shrink" do
+    visit_workspace(THREE_PANEL_WIDTH)
+
+    [ ".creative-row-start", ".creative-tree-li", ".indent1" ].each do |selector|
+      next if page.evaluate_script("document.querySelectorAll('main #{selector}').length").zero?
+
+      assert_equal "0px", computed_style(selector, "min-width"),
+        "#{selector} keeps min-width: auto, so it cannot shrink to the column"
+    end
+  end
+
+  private
+
+  def wide_table_html
+    cells = (1..8).map { |i| "<td>column value #{i}</td>" }.join
+    headers = (1..8).map { |i| "<th>Column header #{i}</th>" }.join
+    "<table><thead><tr>#{headers}</tr></thead><tbody><tr>#{cells}</tr></tbody></table>"
+  end
+
+  def visit_workspace(width)
+    resize_window_to(width, 900)
+    visit collavre.creative_path(@root)
+    assert_selector ".creative-workspace-shell"
+    assert_selector "main .creative-content", minimum: 4, wait: 10
+    wait_for_network_idle(timeout: 10)
+  end
+
+  # Compare against main's *padding box* rather than its border box: a row that
+  # ends exactly on the padding edge is correctly contained, and main scrolls,
+  # so its border box can be wider than what the user sees.
+  def overflowing_rows
+    page.evaluate_script(<<~JS)
+      (function () {
+        var main = document.querySelector('.creative-workspace-shell > main');
+        var style = getComputedStyle(main);
+        var limit = main.getBoundingClientRect().left + main.clientWidth -
+                    parseFloat(style.paddingLeft || 0);
+        return Array.from(document.querySelectorAll('main .creative-content'))
+          .filter(function (el) {
+            return el.getBoundingClientRect().right > limit + #{OVERFLOW_TOLERANCE_PX};
+          })
+          .map(function (el) {
+            return {
+              text: (el.textContent || '').trim().slice(0, 40),
+              right: Math.round(el.getBoundingClientRect().right),
+              limit: Math.round(limit)
+            };
+          });
+      })();
+    JS
+  end
+
+  def column_width
+    page.evaluate_script(
+      "document.querySelector('.creative-workspace-shell > main').clientWidth"
+    )
+  end
+
+  def computed_style(selector, property)
+    page.evaluate_script(<<~JS)
+      getComputedStyle(document.querySelector('main #{selector}')).getPropertyValue(#{property.to_json});
+    JS
+  end
+end


### PR DESCRIPTION
## Problem

Creative list rows stopped wrapping inside the three-panel workspace. Code blocks and tables burst out of the content column and were clipped by the chat panel, while plain prose and long URLs kept wrapping — which made the symptom look inconsistent and hard to pin down.

This is a recurrence: long text/URL wrapping was originally fixed in `3d8a6097d` (2025-12-15), and that rule is still in place. The regression is a different mechanism affecting a different set of content shapes.

## When it broke

| Commit | Date | What |
|---|---|---|
| `3d8a6097d` | 2025-12-15 | Original fix — `overflow-wrap: anywhere; word-break: break-word` on `.creative-content` (still present) |
| `7698e44b3` (#1482) | 2026-08-07 | **Regression introduced** — three-column creative workspace |
| `e28522c1b` (#1503) | 2026-08-09 | Workspace became the default, surfacing the symptom for everyone |

## Root cause

Before #1482, `.creative-content` carried `max-width: calc(min(100vw, var(--max-width)) - 160px)` — effectively an 800px cap. That cap was what contained content `overflow-wrap` cannot break.

#1482 moved the list into a grid column, where a viewport-based width means nothing, so it added:

```css
body.creative-workspace .creative-content { min-width: 0; max-width: none; }
```

`max-width: none` removed the only bound on row width. Width is then decided by the flex chain above:

`.creative-row` → `.creative-row-start` → `.indent1/2/3` or `.creative-tree-li`

Those wrappers are all `display: flex` but have no `min-width: 0`, so the flex-item default `min-width: auto` prevents them from shrinking below their contents' **min-content** width:

- Prose / URLs — min-content is one word (or one breakable chunk), so they still wrapped. Looked fine.
- Code blocks / tables — min-content is the entire unbroken line, so the wrapper refused to shrink and the row overflowed the column.

## Fix

```css
body.creative-workspace .creative-row-start,
body.creative-workspace .creative-tree-li,
body.creative-workspace .indent1,
body.creative-workspace .indent2,
body.creative-workspace .indent3 { min-width: 0; }
```

Scoped to the workspace so the legacy single-column layout is untouched. Overflow inside code blocks and tables then falls to their own scroll containers instead of escaping the column.

## Measurements (1400px viewport, content column limit 834px)

| Content | Before | After |
|---|---|---|
| Korean long text | contained | contained |
| Long URL | contained | contained |
| Code block | **right edge 2039px — overflows by 1205px** | contained |
| Wide table | **right edge 1390px — overflows by 556px** | contained |

## Tests

New `engines/collavre/test/system/workspace_content_wrap_test.rb` (4 tests):

- No `.creative-content` extends past main's padding edge, at three-panel (1400px) and two-panel (1000px) widths
- All four fixture rows render and stay within the column width
- The flex wrappers actually compute to `min-width: 0`

Verified red/green: **4/4 fail** with the CSS fix reverted (code block and table flagged at both widths), **4/4 pass** with it applied.

Regression check — `workspace_tree_drawer_test`, `creative_empty_state_typography_test`, `creative_inline_edit_test`, `creative_expansion_actions_test`: **28 runs, 189 assertions, 0 failures**. Rubocop clean.

## Out of scope

Korean text breaks mid-word (`한국|어`) because of the 2025-12 `word-break: break-word`. It reproduces in both the old and new layouts, so it is not part of this regression. `word-break: keep-all` — already used for empty-state labels at `creatives.css:1175` — would be the fix. Happy to do it here or in a follow-up.