### PR TITLE
Show checkboxes for binary leaf creative progress

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/creatives.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/creatives.css
@@ -334,65 +334,20 @@ creative-tree-row.show-edit .creative-row {
     color: var(--text-muted);
 }
 
-/* Progress toggle (hover-to-complete) */
+/* Leaf creatives with binary progress are directly actionable. */
 .progress-toggle-wrap {
-    position: relative;
     cursor: pointer;
     display: inline-flex;
     align-items: center;
     padding-top: 4px;
 }
 
-.progress-toggle-wrap .creative-progress-complete,
-.progress-toggle-wrap .creative-progress-incomplete {
-    padding-top: 0;
-}
-
 .progress-toggle-checkbox {
-    position: absolute;
-    inset: 0;
-    width: 100%;
-    height: 100%;
-    opacity: 0;
-    cursor: pointer;
+    width: 1em;
+    height: 1em;
     margin: 0;
-    z-index: 1;
-}
-
-/* Desktop: show checkbox on row hover (same pattern as edit-btn, comments-btn) */
-@media (hover: hover) {
-    .progress-toggle-checkbox {
-        width: 1em;
-        height: 1em;
-        visibility: hidden;
-        opacity: 0;
-        position: absolute;
-        margin: auto;
-        pointer-events: none;
-    }
-
-    .creative-row:hover .progress-toggle-wrap .creative-progress-complete,
-    .creative-row:hover .progress-toggle-wrap .creative-progress-incomplete {
-        visibility: hidden;
-    }
-
-    .creative-row:hover .progress-toggle-checkbox {
-        visibility: visible;
-        opacity: 1;
-        position: absolute;
-        inset: 0;
-        margin: auto;
-        pointer-events: auto;
-        accent-color: var(--color-brand);
-    }
-}
-
-/* Touch devices: always show both text and clickable area */
-@media (hover: none) {
-    .progress-toggle-checkbox {
-        opacity: 0;
-        pointer-events: auto;
-    }
+    cursor: pointer;
+    accent-color: var(--color-brand);
 }
 
 .progress-toggle-saving {

--- a/engines/collavre/app/helpers/collavre/creatives_helper.rb
+++ b/engines/collavre/app/helpers/collavre/creatives_helper.rb
@@ -86,11 +86,13 @@ module Collavre
         end
         is_leaf = has_children.nil? ? !creative.children.exists? : !has_children
         can_write = creative.has_permission?(Current.user, :write) if can_write.nil?
-        progress_part = if is_leaf && can_write && !select_mode
-          render_progress_toggle(creative, progress_value)
-        else
-          render_progress_value(progress_value)
-        end
+        progress_part = render_progress_control(
+          creative,
+          progress_value,
+          has_children: !is_leaf,
+          can_write: can_write,
+          select_mode: select_mode
+        )
 
         safe_join([
           progress_part,
@@ -98,6 +100,14 @@ module Collavre
           tag.br,
           (creative.tags ? render_creative_tags(creative) : safe_join([]))
         ])
+      end
+    end
+
+    def render_progress_control(creative, value, has_children:, can_write:, select_mode: false)
+      if !has_children && can_write && !select_mode && progress_toggleable?(value)
+        render_progress_toggle(creative, value)
+      else
+        render_progress_value(value)
       end
     end
 
@@ -112,7 +122,9 @@ module Collavre
           progress_toggle: true,
           creative_id: creative.id,
           current_progress: value,
-          new_progress: new_value
+          new_progress: new_value,
+          mark_complete: t("collavre.creatives.index.mark_complete"),
+          mark_incomplete: t("collavre.creatives.index.mark_incomplete")
         },
         title: tooltip
       ) do
@@ -123,8 +135,12 @@ module Collavre
           tabindex: -1,
           "aria-label": tooltip
         )
-        safe_join([ render_progress_value(value), checkbox ])
+        checkbox
       end
+    end
+
+    def progress_toggleable?(value)
+      value == 0 || value == 1
     end
 
     def render_progress_value(value)

--- a/engines/collavre/app/javascript/components/__tests__/creative_tree_row_progress_toggle.test.js
+++ b/engines/collavre/app/javascript/components/__tests__/creative_tree_row_progress_toggle.test.js
@@ -1,0 +1,77 @@
+/**
+ * @jest-environment jsdom
+ */
+import { jest } from '@jest/globals'
+
+const csrfFetch = jest.fn()
+
+jest.unstable_mockModule('../../lib/api/csrf_fetch', () => ({
+  default: csrfFetch,
+}))
+
+beforeAll(() => {
+  if (typeof globalThis.customElements === 'undefined') {
+    globalThis.customElements = window.customElements
+  }
+})
+
+async function mountRow(progressHtml) {
+  await import('../creative_tree_row.js')
+  const row = document.createElement('creative-tree-row')
+  row.creativeId = '7'
+  row.progressHtml = progressHtml
+  document.body.appendChild(row)
+  await row.updateComplete
+  return row
+}
+
+const INCOMPLETE_TOGGLE = '<span class="progress-toggle-wrap" data-progress-toggle="true" data-creative-id="7" data-current-progress="0" data-new-progress="1" data-mark-complete="Mark complete" data-mark-incomplete="Mark incomplete" title="Mark complete"><input type="checkbox" class="progress-toggle-checkbox" aria-label="Mark complete"></span>'
+
+afterEach(() => {
+  csrfFetch.mockReset()
+  document.body.innerHTML = ''
+})
+
+test('updates checkbox metadata and ancestor progress after a successful toggle', async () => {
+  csrfFetch.mockResolvedValue({
+    ok: true,
+    json: async () => ({
+      progress: 1,
+      progress_html: INCOMPLETE_TOGGLE.replace('data-current-progress="0"', 'data-current-progress="1"'),
+      has_children: false,
+      ancestors: [{
+        id: '42',
+        progress: 0.5,
+        progress_html: '<span class="creative-progress-incomplete">50%</span>',
+      }],
+    }),
+  })
+  const ancestor = document.createElement('creative-tree-row')
+  ancestor.setAttribute('creative-id', '42')
+  document.body.appendChild(ancestor)
+  const row = await mountRow(INCOMPLETE_TOGGLE)
+
+  row.querySelector('[data-progress-toggle]').click()
+  await Promise.resolve()
+  await row.updateComplete
+
+  expect(csrfFetch).toHaveBeenCalledWith('/creatives/7', expect.objectContaining({ method: 'PATCH' }))
+  expect(row.dataset.progressValue).toBe('1')
+  expect(ancestor.progressHtml).toContain('50%')
+})
+
+test('restores checkbox metadata when a toggle request fails', async () => {
+  jest.spyOn(console, 'error').mockImplementation(() => {})
+  csrfFetch.mockResolvedValue({ ok: false, status: 422 })
+  const row = await mountRow(INCOMPLETE_TOGGLE)
+  const toggle = row.querySelector('[data-progress-toggle]')
+
+  toggle.click()
+  await Promise.resolve()
+  await row.updateComplete
+
+  expect(toggle.dataset.currentProgress).toBe('0')
+  expect(toggle.dataset.newProgress).toBe('1')
+  expect(toggle.title).toBe('Mark complete')
+  expect(toggle.querySelector('input').getAttribute('aria-label')).toBe('Mark complete')
+})

--- a/engines/collavre/app/javascript/components/creative_tree_row.js
+++ b/engines/collavre/app/javascript/components/creative_tree_row.js
@@ -547,13 +547,20 @@ class CreativeTreeRow extends LitElement {
     const newProgress = wrap.dataset.newProgress;
     if (!creativeId || newProgress == null) return;
 
-    // Optimistic UI: toggle checkbox and class immediately
+    // Optimistic UI: toggle the always-visible checkbox immediately.
     const checkbox = wrap.querySelector(".progress-toggle-checkbox");
-    const progressSpan = wrap.querySelector("[class^='creative-progress-']");
     const wasComplete = checkbox?.checked;
+    const previousCurrentProgress = wrap.dataset.currentProgress;
+    const previousNewProgress = wrap.dataset.newProgress;
+    const previousTitle = wrap.title;
     if (checkbox) checkbox.checked = !wasComplete;
-    if (progressSpan) {
-      progressSpan.className = newProgress === "1" ? "creative-progress-complete" : "creative-progress-incomplete";
+    const complete = newProgress === "1";
+    wrap.dataset.currentProgress = newProgress;
+    wrap.dataset.newProgress = complete ? "0" : "1";
+    const label = complete ? wrap.dataset.markIncomplete : wrap.dataset.markComplete;
+    if (label) {
+      wrap.title = label;
+      if (checkbox) checkbox.setAttribute("aria-label", label);
     }
     wrap.classList.add("progress-toggle-saving");
 
@@ -598,9 +605,10 @@ class CreativeTreeRow extends LitElement {
     } catch (err) {
       // Revert optimistic UI
       if (checkbox) checkbox.checked = wasComplete;
-      if (progressSpan) {
-        progressSpan.className = wasComplete ? "creative-progress-complete" : "creative-progress-incomplete";
-      }
+      wrap.dataset.currentProgress = previousCurrentProgress;
+      wrap.dataset.newProgress = previousNewProgress;
+      wrap.title = previousTitle;
+      if (checkbox) checkbox.setAttribute("aria-label", previousTitle);
       console.error("Progress toggle failed:", err);
     } finally {
       wrap.classList.remove("progress-toggle-saving");

--- a/engines/collavre/app/javascript/creatives/__tests__/tree_renderer.test.js
+++ b/engines/collavre/app/javascript/creatives/__tests__/tree_renderer.test.js
@@ -1,7 +1,9 @@
 /**
  * @jest-environment jsdom
  */
-import { updateProgressHtml } from '../tree_renderer'
+import { jest } from '@jest/globals'
+
+import { applyRowProperties, replaceProgressControl, updateProgressHtml } from '../tree_renderer'
 
 const TOGGLE_HTML = '<span class="progress-toggle-wrap" data-progress-toggle="true" data-current-progress="0" data-new-progress="1" data-mark-complete="Mark complete" data-mark-incomplete="Mark incomplete" title="Mark complete"><input type="checkbox" class="progress-toggle-checkbox" aria-label="Mark complete"></span>'
 
@@ -24,4 +26,31 @@ test('keeps percentage markup working for non-interactive progress', () => {
 
   expect(updateProgressHtml(html, 0.5, '50%')).toBe('<span class="creative-progress-incomplete">50%</span>')
   expect(updateProgressHtml(html, 1, '✓')).toBe('<span class="creative-progress-complete">✓</span>')
+})
+
+test('replaces only the progress control while preserving row-end content', () => {
+  const html = '<div class="creative-row-end">' + TOGGLE_HTML + '<button class="comments-btn">Comments</button></div>'
+  const rollup = '<span class="creative-progress-incomplete">50%</span>'
+
+  const result = replaceProgressControl(html, rollup)
+
+  expect(result).toContain(rollup)
+  expect(result).not.toContain('progress-toggle-checkbox')
+  expect(result).toContain('comments-btn')
+})
+
+test('keeps a broadcast progress template instead of restoring stale DOM markup', () => {
+  const row = document.createElement('creative-tree-row')
+  row.progressHtml = '<span class="creative-progress-incomplete">0%</span>'
+  row.dataset.progressHtml = row.progressHtml
+  row.innerHTML = '<span class="creative-progress-area"><span class="creative-progress-incomplete">0%</span></span>'
+  row.requestUpdate = jest.fn()
+
+  applyRowProperties(row, {
+    templates: { progress_html: TOGGLE_HTML },
+  })
+
+  expect(row.progressHtml).toBe(TOGGLE_HTML)
+  expect(row.dataset.progressHtml).toBe(TOGGLE_HTML)
+  expect(row.requestUpdate).toHaveBeenCalledTimes(1)
 })

--- a/engines/collavre/app/javascript/creatives/__tests__/tree_renderer.test.js
+++ b/engines/collavre/app/javascript/creatives/__tests__/tree_renderer.test.js
@@ -1,0 +1,27 @@
+/**
+ * @jest-environment jsdom
+ */
+import { updateProgressHtml } from '../tree_renderer'
+
+const TOGGLE_HTML = '<span class="progress-toggle-wrap" data-progress-toggle="true" data-current-progress="0" data-new-progress="1" data-mark-complete="Mark complete" data-mark-incomplete="Mark incomplete" title="Mark complete"><input type="checkbox" class="progress-toggle-checkbox" aria-label="Mark complete"></span>'
+
+test('updates checkbox markup and the next action for binary progress broadcasts', () => {
+  const complete = updateProgressHtml(TOGGLE_HTML, 1, '100%')
+  expect(complete).toContain('checked="checked"')
+  expect(complete).toContain('data-current-progress="1"')
+  expect(complete).toContain('data-new-progress="0"')
+  expect(complete).toContain('title="Mark incomplete"')
+
+  const incomplete = updateProgressHtml(complete, 0, '0%')
+  expect(incomplete).not.toContain('checked="checked"')
+  expect(incomplete).toContain('data-current-progress="0"')
+  expect(incomplete).toContain('data-new-progress="1"')
+  expect(incomplete).toContain('title="Mark complete"')
+})
+
+test('keeps percentage markup working for non-interactive progress', () => {
+  const html = '<span class="creative-progress-incomplete">0%</span>'
+
+  expect(updateProgressHtml(html, 0.5, '50%')).toBe('<span class="creative-progress-incomplete">50%</span>')
+  expect(updateProgressHtml(html, 1, '✓')).toBe('<span class="creative-progress-complete">✓</span>')
+})

--- a/engines/collavre/app/javascript/creatives/__tests__/tree_renderer.test.js
+++ b/engines/collavre/app/javascript/creatives/__tests__/tree_renderer.test.js
@@ -13,12 +13,14 @@ test('updates checkbox markup and the next action for binary progress broadcasts
   expect(complete).toContain('data-current-progress="1"')
   expect(complete).toContain('data-new-progress="0"')
   expect(complete).toContain('title="Mark incomplete"')
+  expect(complete).toContain('aria-label="Mark incomplete"')
 
   const incomplete = updateProgressHtml(complete, 0, '0%')
   expect(incomplete).not.toContain('checked="checked"')
   expect(incomplete).toContain('data-current-progress="0"')
   expect(incomplete).toContain('data-new-progress="1"')
   expect(incomplete).toContain('title="Mark complete"')
+  expect(incomplete).toContain('aria-label="Mark complete"')
 })
 
 test('keeps percentage markup working for non-interactive progress', () => {
@@ -53,4 +55,26 @@ test('keeps a broadcast progress template instead of restoring stale DOM markup'
   expect(row.progressHtml).toBe(TOGGLE_HTML)
   expect(row.dataset.progressHtml).toBe(TOGGLE_HTML)
   expect(row.requestUpdate).toHaveBeenCalledTimes(1)
+})
+
+test('replaces the progress control when a remote update changes binary eligibility', () => {
+  const row = document.createElement('creative-tree-row')
+  row.progressHtml = TOGGLE_HTML
+  row.dataset.progressHtml = row.progressHtml
+  row.requestUpdate = jest.fn()
+  const partial = '<span class="creative-progress-incomplete">50%</span>'
+
+  applyRowProperties(row, {
+    inline_editor_payload: { progress: 0.5 },
+    progress_control_html: partial,
+  })
+
+  expect(row.progressHtml).toBe(partial)
+
+  applyRowProperties(row, {
+    inline_editor_payload: { progress: 0 },
+    progress_control_html: TOGGLE_HTML,
+  })
+
+  expect(row.progressHtml).toBe(TOGGLE_HTML)
 })

--- a/engines/collavre/app/javascript/creatives/tree_renderer.js
+++ b/engines/collavre/app/javascript/creatives/tree_renderer.js
@@ -43,7 +43,10 @@ export function updateProgressHtml(html, progress, displayText) {
       const label = complete ? toggle.dataset.markIncomplete : toggle.dataset.markComplete
       toggle.dataset.currentProgress = String(progress)
       toggle.dataset.newProgress = complete ? '0' : '1'
-      if (label) toggle.title = label
+      if (label) {
+        toggle.title = label
+        checkbox.setAttribute('aria-label', label)
+      }
     }
     return template.innerHTML
   }
@@ -187,7 +190,14 @@ function applyRowProperties(row, node) {
     setDatasetValue(row, 'progressValue', rawProgress)
     // Update progress percentage in existing progressHtml without replacing full HTML
     // (preserves chat badges, comment counts, etc.)
-    if (templates.progress_html == null) {
+    if (node.progress_control_html != null) {
+      const updated = replaceProgressControl(row.progressHtml || '', node.progress_control_html)
+      if (updated !== (row.progressHtml || '')) {
+        row.progressHtml = updated
+        setDatasetValue(row, 'progressHtml', updated)
+        dirty = true
+      }
+    } else if (templates.progress_html == null) {
       let updated = row.progressHtml || ''
       if (updated) {
         updated = updateProgressHtml(updated, rawProgress, displayText)

--- a/engines/collavre/app/javascript/creatives/tree_renderer.js
+++ b/engines/collavre/app/javascript/creatives/tree_renderer.js
@@ -30,34 +30,33 @@ function syncProgressHtmlFromDom(row) {
 
 export function updateProgressHtml(html, progress, displayText) {
   const complete = Number(progress) === 1
-  const checkboxRegex = /<input\b[^>]*class="progress-toggle-checkbox"[^>]*>/
+  const template = document.createElement('template')
+  template.innerHTML = html
 
-  if (checkboxRegex.test(html)) {
-    let updated = html.replace(checkboxRegex, input => {
-      const unchecked = input.replace(/\schecked(?:="checked")?/g, '')
-      return complete ? unchecked.replace(/>$/, ' checked="checked">') : unchecked
-    })
+  const checkbox = template.content.querySelector('input.progress-toggle-checkbox')
+  if (checkbox) {
+    checkbox.toggleAttribute('checked', complete)
+    if (complete) checkbox.setAttribute('checked', 'checked')
 
-    updated = updated.replace(/<span\b[^>]*data-progress-toggle="true"[^>]*>/, wrap => {
-      const labelName = complete ? 'markIncomplete' : 'markComplete'
-      const label = wrap.match(new RegExp(`data-${labelName.replace(/[A-Z]/g, letter => `-${letter.toLowerCase()}`)}="([^"]*)"`))?.[1]
-      let next = wrap
-        .replace(/data-current-progress="[^"]*"/, `data-current-progress="${progress}"`)
-        .replace(/data-new-progress="[^"]*"/, `data-new-progress="${complete ? 0 : 1}"`)
-      return label ? next.replace(/title="[^"]*"/, `title="${label}"`) : next
-    })
-    return updated
+    const toggle = template.content.querySelector('[data-progress-toggle="true"]')
+    if (toggle) {
+      const label = complete ? toggle.dataset.markIncomplete : toggle.dataset.markComplete
+      toggle.dataset.currentProgress = String(progress)
+      toggle.dataset.newProgress = complete ? '0' : '1'
+      if (label) toggle.title = label
+    }
+    return template.innerHTML
   }
 
-  const cssClass = complete ? 'creative-progress-complete' : 'creative-progress-incomplete'
-  const replaced = html.replace(
-    /(<span[^>]*class="creative-progress-(?:in)?complete"[^>]*>)[^<]*(<\/span>)/,
-    `$1${displayText}$2`
+  const progressElement = template.content.querySelector(
+    '.creative-progress-complete, .creative-progress-incomplete'
   )
-  return replaced === html ? html : replaced.replace(
-    /class="creative-progress-(?:in)?complete"/,
-    `class="${cssClass}"`
-  )
+  if (!progressElement) return html
+
+  progressElement.textContent = displayText
+  progressElement.classList.toggle('creative-progress-complete', complete)
+  progressElement.classList.toggle('creative-progress-incomplete', !complete)
+  return template.innerHTML
 }
 
 function applyRowProperties(row, node) {

--- a/engines/collavre/app/javascript/creatives/tree_renderer.js
+++ b/engines/collavre/app/javascript/creatives/tree_renderer.js
@@ -59,8 +59,30 @@ export function updateProgressHtml(html, progress, displayText) {
   return template.innerHTML
 }
 
+export function replaceProgressControl(html, controlHtml) {
+  const template = document.createElement('template')
+  template.innerHTML = html
+  const replacementTemplate = document.createElement('template')
+  replacementTemplate.innerHTML = controlHtml
+
+  const currentControl = template.content.querySelector(
+    '[data-progress-toggle="true"], .creative-progress-complete, .creative-progress-incomplete'
+  )
+  const replacementControl = replacementTemplate.content.querySelector(
+    '[data-progress-toggle="true"], .creative-progress-complete, .creative-progress-incomplete'
+  )
+  if (!currentControl || !replacementControl) return html
+
+  currentControl.replaceWith(replacementControl.cloneNode(true))
+  return template.innerHTML
+}
+
 function applyRowProperties(row, node) {
   if (!row || !node) return
+  // Preserve Turbo-mutated child markup before accepting server-side templates.
+  // This must run first: synchronizing after assignment would overwrite a new
+  // progress control with the stale DOM from the previous render.
+  syncProgressHtmlFromDom(row)
   let dirty = false
 
   if (node.id != null && row.creativeId !== node.id) {
@@ -191,12 +213,6 @@ function applyRowProperties(row, node) {
   }
 
   if (dirty && typeof row.requestUpdate === 'function') {
-    // Before Lit re-renders, sync progressHtml from current DOM.
-    // Turbo Streams may have replaced badge elements directly in the DOM
-    // (e.g. comment badge count), but the Lit progressHtml string still
-    // holds the stale initial HTML. On re-render, Lit would overwrite
-    // the Turbo-updated DOM with the stale string, losing badges.
-    syncProgressHtmlFromDom(row)
     row.requestUpdate()
   }
 }

--- a/engines/collavre/app/javascript/creatives/tree_renderer.js
+++ b/engines/collavre/app/javascript/creatives/tree_renderer.js
@@ -28,6 +28,38 @@ function syncProgressHtmlFromDom(row) {
   }
 }
 
+export function updateProgressHtml(html, progress, displayText) {
+  const complete = Number(progress) === 1
+  const checkboxRegex = /<input\b[^>]*class="progress-toggle-checkbox"[^>]*>/
+
+  if (checkboxRegex.test(html)) {
+    let updated = html.replace(checkboxRegex, input => {
+      const unchecked = input.replace(/\schecked(?:="checked")?/g, '')
+      return complete ? unchecked.replace(/>$/, ' checked="checked">') : unchecked
+    })
+
+    updated = updated.replace(/<span\b[^>]*data-progress-toggle="true"[^>]*>/, wrap => {
+      const labelName = complete ? 'markIncomplete' : 'markComplete'
+      const label = wrap.match(new RegExp(`data-${labelName.replace(/[A-Z]/g, letter => `-${letter.toLowerCase()}`)}="([^"]*)"`))?.[1]
+      let next = wrap
+        .replace(/data-current-progress="[^"]*"/, `data-current-progress="${progress}"`)
+        .replace(/data-new-progress="[^"]*"/, `data-new-progress="${complete ? 0 : 1}"`)
+      return label ? next.replace(/title="[^"]*"/, `title="${label}"`) : next
+    })
+    return updated
+  }
+
+  const cssClass = complete ? 'creative-progress-complete' : 'creative-progress-incomplete'
+  const replaced = html.replace(
+    /(<span[^>]*class="creative-progress-(?:in)?complete"[^>]*>)[^<]*(<\/span>)/,
+    `$1${displayText}$2`
+  )
+  return replaced === html ? html : replaced.replace(
+    /class="creative-progress-(?:in)?complete"/,
+    `class="${cssClass}"`
+  )
+}
+
 function applyRowProperties(row, node) {
   if (!row || !node) return
   let dirty = false
@@ -135,23 +167,9 @@ function applyRowProperties(row, node) {
     // Update progress percentage in existing progressHtml without replacing full HTML
     // (preserves chat badges, comment counts, etc.)
     if (templates.progress_html == null) {
-      const cssClass = pct >= 100 ? 'creative-progress-complete' : 'creative-progress-incomplete'
       let updated = row.progressHtml || ''
       if (updated) {
-        // Try regex replacement first (preserves chat buttons etc.)
-        const replaced = updated.replace(
-          /(<span[^>]*class="creative-progress-(?:in)?complete"[^>]*>)[^<]*(<\/span>)/,
-          `$1${displayText}$2`
-        )
-        if (replaced !== updated) {
-          // Also update ONLY the first progress class (not chat buttons etc.)
-          updated = replaced.replace(
-            /class="creative-progress-(?:in)?complete"/,
-            `class="${cssClass}"`
-          )
-        }
-        // If regex didn't match, do NOT create fresh HTML — preserve existing progressHtml
-        // (it contains chat buttons, comment badges, etc.)
+        updated = updateProgressHtml(updated, rawProgress, displayText)
       }
       if (updated !== (row.progressHtml || '')) {
         row.progressHtml = updated

--- a/engines/collavre/app/javascript/lib/__tests__/turbo_stream_actions.test.js
+++ b/engines/collavre/app/javascript/lib/__tests__/turbo_stream_actions.test.js
@@ -9,6 +9,7 @@ jest.unstable_mockModule('@hotwired/turbo-rails', () => ({ Turbo: fakeTurbo }))
 jest.unstable_mockModule('../../creatives/tree_renderer', () => ({
   createRow: jest.fn(),
   applyRowProperties: jest.fn(),
+  replaceProgressControl: jest.fn((_html, controlHtml) => controlHtml),
   updateProgressHtml: jest.fn((html, progress) => progress === 1
     ? html.replace('class="progress-toggle-checkbox"', 'class="progress-toggle-checkbox" checked="checked"')
       .replace('data-current-progress="0"', 'data-current-progress="1"')
@@ -139,4 +140,51 @@ test('remote progress updates keep checkbox controls actionable', () => {
   expect(row.progressHtml).toContain('data-current-progress="1"')
   expect(row.progressHtml).toContain('data-new-progress="0"')
   expect(row.progressHtml).toContain('title="Mark incomplete"')
+})
+
+test('remote child creation changes the parent checkbox into its rollup control', () => {
+  document.body.innerHTML = '<div id="creatives"><creative-tree-row creative-id="42"></creative-tree-row></div>'
+  const parent = document.querySelector('creative-tree-row[creative-id="42"]')
+  parent.progressHtml = '<span data-progress-toggle="true"><input class="progress-toggle-checkbox"></span>'
+  parent.dataset.progressHtml = parent.progressHtml
+
+  dispatchCreativeTreeStream({
+    action: 'created',
+    creative: {
+      id: 7,
+      parent_id: 42,
+      level: 2,
+      sequence: 0,
+      ancestors: [{ id: 42, progress: 0.5, progress_html: '<span class="creative-progress-incomplete">50%</span>' }],
+    },
+  })
+
+  expect(parent.hasChildren).toBe(true)
+  expect(parent.progressHtml).toBe('<span class="creative-progress-incomplete">50%</span>')
+})
+
+test('remote child deletion restores the parent leaf checkbox control', () => {
+  document.body.innerHTML = `
+    <div id="creatives">
+      <creative-tree-row creative-id="42" has-children></creative-tree-row>
+      <div id="creative-children-42"><creative-tree-row creative-id="7"></creative-tree-row></div>
+    </div>
+  `
+  const parent = document.querySelector('creative-tree-row[creative-id="42"]')
+  parent.hasChildren = true
+  parent.progressHtml = '<span class="creative-progress-incomplete">0%</span>'
+  parent.dataset.progressHtml = parent.progressHtml
+  const checkbox = '<span data-progress-toggle="true"><input class="progress-toggle-checkbox"></span>'
+
+  dispatchCreativeTreeStream({
+    action: 'destroyed',
+    creative: {
+      id: 7,
+      parent_id: 42,
+      ancestors: [{ id: 42, progress: 0, progress_html: checkbox }],
+    },
+  })
+
+  expect(parent.hasChildren).toBe(false)
+  expect(parent.progressHtml).toBe(checkbox)
 })

--- a/engines/collavre/app/javascript/lib/__tests__/turbo_stream_actions.test.js
+++ b/engines/collavre/app/javascript/lib/__tests__/turbo_stream_actions.test.js
@@ -9,6 +9,12 @@ jest.unstable_mockModule('@hotwired/turbo-rails', () => ({ Turbo: fakeTurbo }))
 jest.unstable_mockModule('../../creatives/tree_renderer', () => ({
   createRow: jest.fn(),
   applyRowProperties: jest.fn(),
+  updateProgressHtml: jest.fn((html, progress) => progress === 1
+    ? html.replace('class="progress-toggle-checkbox"', 'class="progress-toggle-checkbox" checked="checked"')
+      .replace('data-current-progress="0"', 'data-current-progress="1"')
+      .replace('data-new-progress="1"', 'data-new-progress="0"')
+      .replace('title="Mark complete"', 'title="Mark incomplete"')
+    : html),
 }))
 
 await import('../turbo_stream_actions')

--- a/engines/collavre/app/javascript/lib/__tests__/turbo_stream_actions.test.js
+++ b/engines/collavre/app/javascript/lib/__tests__/turbo_stream_actions.test.js
@@ -13,6 +13,7 @@ jest.unstable_mockModule('../../creatives/tree_renderer', () => ({
 
 await import('../turbo_stream_actions')
 const { createRow } = await import('../../creatives/tree_renderer')
+const { updateProgressForRow } = await import('../turbo_stream_actions')
 
 const EMPTY_HTML = '<div data-creatives-empty-state=""><p>No sub-creatives found.</p></div>'
 
@@ -118,4 +119,18 @@ test('remote destroyed streams keep the placeholder hidden while rows remain', (
 
   expect(container.querySelector('creative-tree-row[creative-id="8"]')).not.toBeNull()
   expect(container.querySelector('[data-creatives-empty-state]').hidden).toBe(true)
+})
+
+test('remote progress updates keep checkbox controls actionable', () => {
+  const row = {
+    dataset: {},
+    progressHtml: '<span class="progress-toggle-wrap" data-progress-toggle="true" data-current-progress="0" data-new-progress="1" data-mark-complete="Mark complete" data-mark-incomplete="Mark incomplete" title="Mark complete"><input type="checkbox" class="progress-toggle-checkbox"></span>',
+  }
+
+  updateProgressForRow(row, 1, '100%')
+
+  expect(row.progressHtml).toContain('checked="checked"')
+  expect(row.progressHtml).toContain('data-current-progress="1"')
+  expect(row.progressHtml).toContain('data-new-progress="0"')
+  expect(row.progressHtml).toContain('title="Mark incomplete"')
 })

--- a/engines/collavre/app/javascript/lib/turbo_stream_actions.js
+++ b/engines/collavre/app/javascript/lib/turbo_stream_actions.js
@@ -1,5 +1,5 @@
 import { Turbo } from "@hotwired/turbo-rails"
-import { createRow, applyRowProperties, updateProgressHtml } from "../creatives/tree_renderer"
+import { createRow, applyRowProperties, replaceProgressControl, updateProgressHtml } from "../creatives/tree_renderer"
 import { hideTreeEmptyState, restoreTreeEmptyState } from "../modules/creative_tree_empty_state"
 
 // Register custom actions on both the imported Turbo and the global window.Turbo
@@ -331,7 +331,7 @@ function handleDestroyed(creative) {
     restoreTreeEmptyState()
 }
 
-export function updateProgressForRow(row, progress, progressText) {
+export function updateProgressForRow(row, progress, progressText, progressHtml = null) {
     if (progress == null) return
     const pct = Math.round(progress * 100)
     // progressText from server: completion mark string, empty string (=complete but no mark), or null
@@ -340,7 +340,9 @@ export function updateProgressForRow(row, progress, progressText) {
     row.dataset.progressValue = String(progress)
 
     if (row.progressHtml) {
-	const updated = updateProgressHtml(row.progressHtml, progress, displayText)
+        const updated = progressHtml && !row.selectMode
+            ? replaceProgressControl(row.progressHtml, progressHtml)
+            : updateProgressHtml(row.progressHtml, progress, displayText)
 
         if (updated !== row.progressHtml) {
             row.progressHtml = updated
@@ -354,7 +356,7 @@ function updateAncestorProgress(ancestors) {
     ancestors.forEach(anc => {
         // findRowsForCreative already handles origin_id fallback for linked creatives
         const rows = findRowsForCreative(anc.id, anc.origin_id)
-        if (rows[0]) updateProgressForRow(rows[0], anc.progress, anc.progress_text)
+        if (rows[0]) updateProgressForRow(rows[0], anc.progress, anc.progress_text, anc.progress_html)
     })
 }
 

--- a/engines/collavre/app/javascript/lib/turbo_stream_actions.js
+++ b/engines/collavre/app/javascript/lib/turbo_stream_actions.js
@@ -1,5 +1,5 @@
 import { Turbo } from "@hotwired/turbo-rails"
-import { createRow, applyRowProperties } from "../creatives/tree_renderer"
+import { createRow, applyRowProperties, updateProgressHtml } from "../creatives/tree_renderer"
 import { hideTreeEmptyState, restoreTreeEmptyState } from "../modules/creative_tree_empty_state"
 
 // Register custom actions on both the imported Turbo and the global window.Turbo
@@ -340,33 +340,7 @@ export function updateProgressForRow(row, progress, progressText) {
     row.dataset.progressValue = String(progress)
 
     if (row.progressHtml) {
-        const complete = Number(progress) === 1
-        const checkboxRegex = /<input\b[^>]*class="progress-toggle-checkbox"[^>]*>/
-        let updated = row.progressHtml
-
-        if (checkboxRegex.test(updated)) {
-            updated = updated.replace(checkboxRegex, input => {
-                const unchecked = input.replace(/\schecked(?:="checked")?/g, '')
-                return complete ? unchecked.replace(/>$/, ' checked="checked">') : unchecked
-            }).replace(/<span\b[^>]*data-progress-toggle="true"[^>]*>/, wrap => {
-                const labelName = complete ? 'mark-incomplete' : 'mark-complete'
-                const label = wrap.match(new RegExp(`data-${labelName}="([^"]*)"`))?.[1]
-                let next = wrap
-                    .replace(/data-current-progress="[^"]*"/, `data-current-progress="${progress}"`)
-                    .replace(/data-new-progress="[^"]*"/, `data-new-progress="${complete ? 0 : 1}"`)
-                return label ? next.replace(/title="[^"]*"/, `title="${label}"`) : next
-            })
-        } else {
-            const cssClass = complete ? 'creative-progress-complete' : 'creative-progress-incomplete'
-            const replaced = updated.replace(
-                /(<span[^>]*class="creative-progress-(?:in)?complete"[^>]*>)[^<]*(<\/span>)/,
-                `$1${displayText}$2`
-            )
-            updated = replaced === updated ? updated : replaced.replace(
-                /class="creative-progress-(?:in)?complete"/,
-                `class="${cssClass}"`
-            )
-        }
+	const updated = updateProgressHtml(row.progressHtml, progress, displayText)
 
         if (updated !== row.progressHtml) {
             row.progressHtml = updated

--- a/engines/collavre/app/javascript/lib/turbo_stream_actions.js
+++ b/engines/collavre/app/javascript/lib/turbo_stream_actions.js
@@ -331,30 +331,47 @@ function handleDestroyed(creative) {
     restoreTreeEmptyState()
 }
 
-function updateProgressForRow(row, progress, progressText) {
+export function updateProgressForRow(row, progress, progressText) {
     if (progress == null) return
     const pct = Math.round(progress * 100)
-    const cssClass = pct >= 100 ? 'creative-progress-complete' : 'creative-progress-incomplete'
     // progressText from server: completion mark string, empty string (=complete but no mark), or null
     const displayText = progressText != null ? (progressText || '\u00a0\u00a0') : `${pct}%`
 
     row.dataset.progressValue = String(progress)
 
     if (row.progressHtml) {
-        // Try regex replacement on existing progress HTML (preserves chat buttons etc.)
-        const regex = /(<span[^>]*class="creative-progress-(?:in)?complete"[^>]*>)[^<]*(<\/span>)/
-        const updated = row.progressHtml.replace(regex, `$1${displayText}$2`)
-        if (updated !== row.progressHtml) {
-            // Also update ONLY the first progress class (not chat buttons etc.)
-            const classUpdated = updated.replace(
+        const complete = Number(progress) === 1
+        const checkboxRegex = /<input\b[^>]*class="progress-toggle-checkbox"[^>]*>/
+        let updated = row.progressHtml
+
+        if (checkboxRegex.test(updated)) {
+            updated = updated.replace(checkboxRegex, input => {
+                const unchecked = input.replace(/\schecked(?:="checked")?/g, '')
+                return complete ? unchecked.replace(/>$/, ' checked="checked">') : unchecked
+            }).replace(/<span\b[^>]*data-progress-toggle="true"[^>]*>/, wrap => {
+                const labelName = complete ? 'mark-incomplete' : 'mark-complete'
+                const label = wrap.match(new RegExp(`data-${labelName}="([^"]*)"`))?.[1]
+                let next = wrap
+                    .replace(/data-current-progress="[^"]*"/, `data-current-progress="${progress}"`)
+                    .replace(/data-new-progress="[^"]*"/, `data-new-progress="${complete ? 0 : 1}"`)
+                return label ? next.replace(/title="[^"]*"/, `title="${label}"`) : next
+            })
+        } else {
+            const cssClass = complete ? 'creative-progress-complete' : 'creative-progress-incomplete'
+            const replaced = updated.replace(
+                /(<span[^>]*class="creative-progress-(?:in)?complete"[^>]*>)[^<]*(<\/span>)/,
+                `$1${displayText}$2`
+            )
+            updated = replaced === updated ? updated : replaced.replace(
                 /class="creative-progress-(?:in)?complete"/,
                 `class="${cssClass}"`
             )
-            row.progressHtml = classUpdated
-            row.dataset.progressHtml = classUpdated
         }
-        // If regex didn't match, do NOT create fresh HTML — preserve existing progressHtml
-        // (it contains chat buttons, comment badges, etc.)
+
+        if (updated !== row.progressHtml) {
+            row.progressHtml = updated
+            row.dataset.progressHtml = updated
+        }
     }
 }
 

--- a/engines/collavre/app/jobs/collavre/creative_broadcast_job.rb
+++ b/engines/collavre/app/jobs/collavre/creative_broadcast_job.rb
@@ -245,7 +245,7 @@ module Collavre
       displayed_ids = linked_by_user.values.flat_map(&:values)
       creatives_by_id = Creative.where(id: (origin_ids + effective_ids + displayed_ids).uniq).index_by(&:id)
       effective_creatives = effective_ids.index_with { |id| creatives_by_id[id] }.compact
-      has_children_by_id = Creative.where(parent_id: effective_creatives.keys).distinct.pluck(:parent_id).to_set
+      has_visible_children_by_user = visible_children_by_user(effective_creatives, users)
       writable_by_user = batch_write_permissions(effective_creatives, users)
 
       users.each_with_object({}) do |user, controls_by_user|
@@ -264,10 +264,26 @@ module Collavre
               user,
               effective: effective,
               progress: progress,
-              has_children: has_children_by_id.include?(effective.id),
+              has_children: has_visible_children_by_user.fetch(user.id, Set.new).include?(effective.id),
               can_write: writable_by_user.dig(user.id, effective.id) && !effective.read_only_source?
             )
           }
+        end
+      end
+    end
+
+    # Match ChildrenIndex's default tree semantics: archived children and
+    # children the recipient cannot read do not make a visible row a rollup.
+    # Candidate children are loaded once, then visibility is resolved in a
+    # bounded batch per recipient rather than once per ancestor.
+    def visible_children_by_user(effective_creatives, users)
+      child_rows = Creative.where(parent_id: effective_creatives.keys, archived_at: nil).pluck(:id, :parent_id)
+      child_ids = child_rows.map(&:first)
+
+      users.each_with_object({}) do |user, result|
+        readable_ids = Creatives::PermissionFilter.new(user: user).readable_ids(child_ids).to_set
+        result[user.id] = child_rows.each_with_object(Set.new) do |(child_id, parent_id), parent_ids|
+          parent_ids << parent_id if readable_ids.include?(child_id)
         end
       end
     end

--- a/engines/collavre/app/jobs/collavre/creative_broadcast_job.rb
+++ b/engines/collavre/app/jobs/collavre/creative_broadcast_job.rb
@@ -169,17 +169,17 @@ module Collavre
     # Includes:
     # - turbo-cable-stream-source (per-user subscription for badge updates)
     # - comment button (hidden via no-comments class — 0 comments initially)
-    # - progress span
+    # - the same progress control used by normal server rendering
     def render_progress_html(creative, user, skip_permission_check: false)
       origin = creative.effective_origin
       progress = creative.progress || 0
-      pct = (progress * 100).round
-
-      # Progress span (comes first, matching helper output order)
-      css_class = pct >= 100 ? "creative-progress-complete" : "creative-progress-incomplete"
-      completion_mark = Collavre::SystemSetting.completion_mark
-      display_text = pct >= 100 && !completion_mark.nil? ? completion_mark : "#{pct}%"
-      progress_span = %(<span class="#{css_class}">#{display_text}</span>)
+      can_write = creative.has_permission?(user, :write)
+      progress_part = Collavre::ApplicationController.helpers.render_progress_control(
+        creative,
+        progress,
+        has_children: creative.children.exists?,
+        can_write: can_write
+      )
 
       # Comment part — only render if user has feedback permission (matching helper behavior)
       # When skip_permission_check is true, the user was already verified by find_broadcast_users
@@ -208,7 +208,7 @@ module Collavre
       end
 
       # Wrap in creative-row-end div — order: progress, then comment (matching helper)
-      %(<div class="creative-row-end">#{progress_span}#{comment_part}</div>)
+      %(<div class="creative-row-end">#{progress_part}#{comment_part}</div>)
     rescue StandardError => e
       Rails.logger.warn "[CreativeBroadcastJob] render_progress_html failed for creative##{creative.id} user##{user.id}: #{e.message}"
       nil

--- a/engines/collavre/app/jobs/collavre/creative_broadcast_job.rb
+++ b/engines/collavre/app/jobs/collavre/creative_broadcast_job.rb
@@ -293,7 +293,8 @@ module Collavre
         permissions_by_user[user.id] = effective_ids.index_with do |creative_id|
           effective = effective_creatives.fetch(creative_id)
           permission = user_permissions[user.id].fetch(creative_id, public_permissions[creative_id])
-          effective.user_id == user.id || permission.to_i >= CreativeShare.permissions[:write]
+          permission_rank = CreativeShare.permissions.fetch(permission.to_s, 0)
+          effective.user_id == user.id || permission_rank >= CreativeShare.permissions[:write]
         end
       end
     end

--- a/engines/collavre/app/jobs/collavre/creative_broadcast_job.rb
+++ b/engines/collavre/app/jobs/collavre/creative_broadcast_job.rb
@@ -96,6 +96,7 @@ module Collavre
 
         # Per-user progress text
         creative.send(:add_progress_text!, user_data, target_user)
+        add_ancestor_progress_controls!(user_data[:ancestors], target_user, user_map)
 
         # For created action, render per-user progress_html (includes chat button,
         # badge with turbo-cable-stream-source subscription, and progress span).
@@ -152,6 +153,7 @@ module Collavre
             mapped_id ? anc.merge(id: mapped_id, origin_id: anc[:id]) : anc
           end
         end
+        add_ancestor_progress_controls!(user_data[:ancestors], target_user, user_map)
 
         json_payload = { action: "destroyed", creative: user_data }.to_json
         Turbo::StreamsChannel.broadcast_action_to(
@@ -171,47 +173,65 @@ module Collavre
     # - comment button (hidden via no-comments class — 0 comments initially)
     # - the same progress control used by normal server rendering
     def render_progress_html(creative, user, skip_permission_check: false)
-      origin = creative.effective_origin
-      progress = creative.progress || 0
-      can_write = creative.has_permission?(user, :write)
-      progress_part = Collavre::ApplicationController.helpers.render_progress_control(
-        creative,
-        progress,
-        has_children: creative.children.exists?,
-        can_write: can_write
-      )
+      I18n.with_locale(user.locale.presence || I18n.default_locale) do
+        origin = creative.effective_origin
+        progress_part = render_progress_control_html(creative, user)
 
-      # Comment part — only render if user has feedback permission (matching helper behavior)
-      # When skip_permission_check is true, the user was already verified by find_broadcast_users
-      # (which checks :read permission on target + ancestors). Feedback permission is a subset
-      # of read permission in practice, so we can safely render the comment button.
-      comment_part = ""
-      has_feedback = skip_permission_check ||
-                     creative.has_permission?(user, :feedback) ||
-                     permission_via_ancestors(creative, user, :feedback)
-      if has_feedback
-        # Generate signed stream name for turbo-cable-stream-source
-        stream_name = Turbo::StreamsChannel.signed_stream_name([ user, origin, :comment_badge ])
-        stream_tag = %(<turbo-cable-stream-source channel="Turbo::StreamsChannel" signed-stream-name="#{stream_name}"></turbo-cable-stream-source>)
+        # Comment part — only render if user has feedback permission (matching helper behavior)
+        # When skip_permission_check is true, the user was already verified by find_broadcast_users
+        # (which checks :read permission on target + ancestors). Feedback permission is a subset
+        # of read permission in practice, so we can safely render the comment button.
+        comment_part = ""
+        has_feedback = skip_permission_check ||
+                       creative.has_permission?(user, :feedback) ||
+                       permission_via_ancestors(creative, user, :feedback)
+        if has_feedback
+          # Generate signed stream name for turbo-cable-stream-source
+          stream_name = Turbo::StreamsChannel.signed_stream_name([ user, origin, :comment_badge ])
+          stream_tag = %(<turbo-cable-stream-source channel="Turbo::StreamsChannel" signed-stream-name="#{stream_name}"></turbo-cable-stream-source>)
 
-        # Badge (no comments yet — hidden)
-        badge_id = "comment-badge-#{origin.id}"
-        badge = %(<span id="#{badge_id}" class="badge" style="display:none" data-count="0" data-controller="comment-badge" data-comment-badge-has-comments-value="false"></span>)
+          # Badge (no comments yet — hidden)
+          badge_id = "comment-badge-#{origin.id}"
+          badge = %(<span id="#{badge_id}" class="badge" style="display:none" data-count="0" data-controller="comment-badge" data-comment-badge-has-comments-value="false"></span>)
 
-        # Comment button — no-comments hides via visibility:hidden (0 comments initially)
-        comment_icon = read_svg("comment.svg", class: "comment-icon")
-        btn_classes = "comments-btn creative-action-btn no-comments"
-        comment_btn = %(<button name="show-comments-btn" class="#{btn_classes}" data-creative-id="#{creative.id}" data-can-comment="true" data-creative-snippet="#{ERB::Util.html_escape(creative.creative_snippet)}">)
-        comment_btn += %(#{comment_icon}#{badge}</button>)
+          # Comment button — no-comments hides via visibility:hidden (0 comments initially)
+          comment_icon = read_svg("comment.svg", class: "comment-icon")
+          btn_classes = "comments-btn creative-action-btn no-comments"
+          comment_btn = %(<button name="show-comments-btn" class="#{btn_classes}" data-creative-id="#{creative.id}" data-can-comment="true" data-creative-snippet="#{ERB::Util.html_escape(creative.creative_snippet)}">)
+          comment_btn += %(#{comment_icon}#{badge}</button>)
 
-        comment_part = "#{stream_tag}#{comment_btn}"
+          comment_part = "#{stream_tag}#{comment_btn}"
+        end
+
+        # Wrap in creative-row-end div — order: progress, then comment (matching helper)
+        %(<div class="creative-row-end">#{progress_part}#{comment_part}</div>)
       end
-
-      # Wrap in creative-row-end div — order: progress, then comment (matching helper)
-      %(<div class="creative-row-end">#{progress_part}#{comment_part}</div>)
     rescue StandardError => e
       Rails.logger.warn "[CreativeBroadcastJob] render_progress_html failed for creative##{creative.id} user##{user.id}: #{e.message}"
       nil
+    end
+
+    def add_ancestor_progress_controls!(ancestors, user, user_map)
+      ancestors&.each do |ancestor|
+        origin_id = ancestor[:origin_id] || ancestor[:id]
+        creative = Creative.find_by(id: user_map[origin_id] || origin_id)
+        next unless creative
+
+        ancestor[:progress] = creative.progress
+        ancestor[:progress_text] = creative.send(:format_progress_text, creative.progress, user)
+        ancestor[:progress_html] = render_progress_control_html(creative, user)
+      end
+    end
+
+    def render_progress_control_html(creative, user)
+      I18n.with_locale(user.locale.presence || I18n.default_locale) do
+        Collavre::ApplicationController.helpers.render_progress_control(
+          creative,
+          creative.progress || 0,
+          has_children: creative.children.exists?,
+          can_write: creative.has_permission?(user, :write)
+        )
+      end
     end
 
     # Check permission via ancestor chain (fallback when creative_shares_caches is not yet populated)

--- a/engines/collavre/app/jobs/collavre/creative_broadcast_job.rb
+++ b/engines/collavre/app/jobs/collavre/creative_broadcast_job.rb
@@ -57,7 +57,7 @@ module Collavre
 
       # Batch-load all linked creatives for remapping (avoids N+1)
       origin_ids_to_remap = [ data[:parent_id], data[:after_id], data[:previous_sibling_id] ].compact
-      ancestor_origin_ids = (data[:ancestors] || []).map { |a| a[:id] }.compact
+      ancestor_origin_ids = (data[:ancestors] || []).filter_map { |ancestor| ancestor[:origin_id] || ancestor[:id] }
       all_origin_ids = (origin_ids_to_remap + ancestor_origin_ids).uniq
 
       linked_by_user = {}
@@ -67,9 +67,12 @@ module Collavre
           linked_by_user[linked.user_id][linked.origin_id] = linked.id
         end
       end
+      ancestor_progress_controls = build_ancestor_progress_controls(
+        data[:ancestors], target_users, linked_by_user
+      )
 
       target_users.each do |target_user|
-        user_data = data.dup
+        user_data = data.deep_dup
         user_map = linked_by_user[target_user.id] || {}
 
         # Add linked_id
@@ -86,8 +89,9 @@ module Collavre
         # Remap ancestor IDs
         if user_data[:ancestors].present?
           user_data[:ancestors] = user_data[:ancestors].map do |anc|
-            mapped_id = user_map[anc[:id]]
-            mapped_id ? anc.merge(id: mapped_id, origin_id: anc[:id]) : anc
+            origin_id = anc[:origin_id] || anc[:id]
+            mapped_id = user_map[origin_id]
+            mapped_id ? anc.merge(id: mapped_id, origin_id: origin_id) : anc
           end
         end
 
@@ -96,7 +100,7 @@ module Collavre
 
         # Per-user progress text
         creative.send(:add_progress_text!, user_data, target_user)
-        add_ancestor_progress_controls!(user_data[:ancestors], target_user, user_map)
+        add_ancestor_progress_controls!(user_data[:ancestors], target_user, ancestor_progress_controls)
 
         # For created action, render per-user progress_html (includes chat button,
         # badge with turbo-cable-stream-source subscription, and progress span).
@@ -133,7 +137,7 @@ module Collavre
       linked_map = (options[:destroy_linked_map] || {}).transform_keys(&:to_i)
 
       # Batch-load linked creatives for ancestor remapping
-      ancestor_origin_ids = (payload[:ancestors] || []).map { |a| a[:id] }.compact
+      ancestor_origin_ids = (payload[:ancestors] || []).filter_map { |ancestor| ancestor[:origin_id] || ancestor[:id] }
       all_origin_ids = [ payload[:parent_id], *ancestor_origin_ids ].compact.uniq
 
       linked_by_user = {}
@@ -143,9 +147,12 @@ module Collavre
           linked_by_user[linked.user_id][linked.origin_id] = linked.id
         end
       end
+      ancestor_progress_controls = build_ancestor_progress_controls(
+        payload[:ancestors], users, linked_by_user
+      )
 
       users.each do |target_user|
-        user_data = payload.dup
+        user_data = payload.deep_dup
         user_map = linked_by_user[target_user.id] || {}
 
         user_data[:linked_id] = linked_map[target_user.id] if linked_map[target_user.id]
@@ -153,11 +160,12 @@ module Collavre
 
         if user_data[:ancestors].present?
           user_data[:ancestors] = user_data[:ancestors].map do |anc|
-            mapped_id = user_map[anc[:id]]
-            mapped_id ? anc.merge(id: mapped_id, origin_id: anc[:id]) : anc
+            origin_id = anc[:origin_id] || anc[:id]
+            mapped_id = user_map[origin_id]
+            mapped_id ? anc.merge(id: mapped_id, origin_id: origin_id) : anc
           end
         end
-        add_ancestor_progress_controls!(user_data[:ancestors], target_user, user_map)
+        add_ancestor_progress_controls!(user_data[:ancestors], target_user, ancestor_progress_controls)
 
         json_payload = { action: "destroyed", creative: user_data }.to_json
         Turbo::StreamsChannel.broadcast_action_to(
@@ -215,25 +223,89 @@ module Collavre
       nil
     end
 
-    def add_ancestor_progress_controls!(ancestors, user, user_map)
+    def add_ancestor_progress_controls!(ancestors, user, controls_by_user)
       ancestors&.each do |ancestor|
         origin_id = ancestor[:origin_id] || ancestor[:id]
-        creative = Creative.find_by(id: user_map[origin_id] || origin_id)
-        next unless creative
+        control = controls_by_user.dig(user.id, origin_id)
+        next unless control
 
-        ancestor[:progress] = creative.progress
-        ancestor[:progress_text] = creative.send(:format_progress_text, creative.progress, user)
-        ancestor[:progress_html] = render_progress_control_html(creative, user)
+        ancestor.merge!(control)
       end
     end
 
-    def render_progress_control_html(creative, user)
+    # Build every recipient's ancestor controls in a bounded number of queries.
+    # The row shown to a recipient may be a linked shell, while its child state
+    # and permission resolve through the effective origin.
+    def build_ancestor_progress_controls(ancestors, users, linked_by_user)
+      origin_ids = ancestors.to_a.filter_map { |ancestor| ancestor[:origin_id] || ancestor[:id] }.uniq
+      return {} if origin_ids.empty?
+
+      effective_ids_by_origin = Creatives::EffectiveCreativeResolution.effective_creative_ids(origin_ids)
+      effective_ids = effective_ids_by_origin.values.uniq
+      displayed_ids = linked_by_user.values.flat_map(&:values)
+      creatives_by_id = Creative.where(id: (origin_ids + effective_ids + displayed_ids).uniq).index_by(&:id)
+      effective_creatives = effective_ids.index_with { |id| creatives_by_id[id] }.compact
+      has_children_by_id = Creative.where(parent_id: effective_creatives.keys).distinct.pluck(:parent_id).to_set
+      writable_by_user = batch_write_permissions(effective_creatives, users)
+
+      users.each_with_object({}) do |user, controls_by_user|
+        user_map = linked_by_user[user.id] || {}
+        controls_by_user[user.id] = origin_ids.each_with_object({}) do |origin_id, controls|
+          effective = effective_creatives[effective_ids_by_origin[origin_id]]
+          displayed = creatives_by_id[user_map[origin_id] || origin_id]
+          next unless effective && displayed
+
+          progress = effective.progress || 0
+          controls[origin_id] = {
+            progress: progress,
+            progress_text: effective.send(:format_progress_text, progress, user),
+            progress_html: render_progress_control_html(
+              displayed,
+              user,
+              effective: effective,
+              progress: progress,
+              has_children: has_children_by_id.include?(effective.id),
+              can_write: writable_by_user.dig(user.id, effective.id)
+            )
+          }
+        end
+      end
+    end
+
+    def batch_write_permissions(effective_creatives, users)
+      effective_ids = effective_creatives.keys
+      return {} if effective_ids.empty?
+
+      user_ids = users.map(&:id)
+      permission_rows = CreativeSharesCache.where(creative_id: effective_ids, user_id: [ nil, *user_ids ])
+                                           .pluck(:creative_id, :user_id, :permission)
+      public_permissions = {}
+      user_permissions = Hash.new { |hash, key| hash[key] = {} }
+      permission_rows.each do |creative_id, user_id, permission|
+        if user_id.nil?
+          public_permissions[creative_id] = permission
+        else
+          user_permissions[user_id][creative_id] = permission
+        end
+      end
+
+      users.each_with_object({}) do |user, permissions_by_user|
+        permissions_by_user[user.id] = effective_ids.index_with do |creative_id|
+          effective = effective_creatives.fetch(creative_id)
+          permission = user_permissions[user.id].fetch(creative_id, public_permissions[creative_id])
+          effective.user_id == user.id || permission.to_i >= CreativeShare.permissions[:write]
+        end
+      end
+    end
+
+    def render_progress_control_html(creative, user, effective: nil, progress: nil, has_children: nil, can_write: nil)
       I18n.with_locale(user.locale.presence || I18n.default_locale) do
+        effective ||= creative.effective_origin
         Collavre::ApplicationController.helpers.render_progress_control(
           creative,
-          creative.progress || 0,
-          has_children: creative.children.exists?,
-          can_write: creative.has_permission?(user, :write)
+          progress || effective.progress || 0,
+          has_children: has_children.nil? ? effective.children.exists? : has_children,
+          can_write: can_write.nil? ? creative.has_permission?(user, :write) : can_write
         )
       end
     end

--- a/engines/collavre/app/jobs/collavre/creative_broadcast_job.rb
+++ b/engines/collavre/app/jobs/collavre/creative_broadcast_job.rb
@@ -106,6 +106,10 @@ module Collavre
           # target_user already passed find_broadcast_users permission check,
           # so we can skip the expensive permission_via_ancestors walk.
           user_data[:templates][:progress_html] = render_progress_html(creative, target_user, skip_permission_check: true)
+        elsif action == "updated"
+          # Keep unrelated row-end markup (such as comment badges) intact while
+          # replacing the progress control with the recipient-specific version.
+          user_data[:progress_control_html] = render_progress_control_html(creative, target_user)
         end
 
         json_payload = { action: action.to_s, creative: user_data }.to_json

--- a/engines/collavre/app/jobs/collavre/creative_broadcast_job.rb
+++ b/engines/collavre/app/jobs/collavre/creative_broadcast_job.rb
@@ -96,7 +96,7 @@ module Collavre
         end
 
         # Per-user can_write permission
-        user_data[:can_write] = creative.has_permission?(target_user, :write)
+        user_data[:can_write] = creative.has_permission?(target_user, :write) && !creative.effective_origin.read_only_source?
 
         # Per-user progress text
         creative.send(:add_progress_text!, user_data, target_user)
@@ -265,7 +265,7 @@ module Collavre
               effective: effective,
               progress: progress,
               has_children: has_children_by_id.include?(effective.id),
-              can_write: writable_by_user.dig(user.id, effective.id)
+              can_write: writable_by_user.dig(user.id, effective.id) && !effective.read_only_source?
             )
           }
         end
@@ -305,7 +305,7 @@ module Collavre
           creative,
           progress || effective.progress || 0,
           has_children: has_children.nil? ? effective.children.exists? : has_children,
-          can_write: can_write.nil? ? creative.has_permission?(user, :write) : can_write
+          can_write: (can_write.nil? ? creative.has_permission?(user, :write) : can_write) && !effective.read_only_source?
         )
       end
     end

--- a/engines/collavre/test/helpers/creatives_helper_test.rb
+++ b/engines/collavre/test/helpers/creatives_helper_test.rb
@@ -196,6 +196,48 @@ class CreativesHelperTest < ActionView::TestCase
     assert_equal 1, calls
   end
 
+  test "render_progress_control shows a checkbox for writable binary leaf progress" do
+    user = users(:one)
+    creative = Creative.create!(user: user, description: "Checkbox leaf", progress: 0)
+
+    Current.set(user: user) do
+      html = render_progress_control(creative, 0, has_children: false, can_write: true)
+
+      assert_includes html, 'data-progress-toggle="true"'
+      assert_includes html, 'type="checkbox"'
+      refute_includes html, "creative-progress-incomplete"
+    end
+  end
+
+  test "render_progress_control keeps percentages for non-binary leaves and parents" do
+    user = users(:one)
+    leaf = Creative.create!(user: user, description: "Partial leaf", progress: 0.5)
+    parent = Creative.create!(user: user, description: "Parent", progress: 0)
+
+    Current.set(user: user) do
+      partial_html = render_progress_control(leaf, 0.5, has_children: false, can_write: true)
+      parent_html = render_progress_control(parent, 0, has_children: true, can_write: true)
+
+      assert_includes partial_html, "50%"
+      refute_includes partial_html, "progress-toggle-checkbox"
+      assert_includes parent_html, "0%"
+      refute_includes parent_html, "progress-toggle-checkbox"
+    end
+  end
+
+  test "render_progress_control keeps percentages in select mode and for read-only users" do
+    user = users(:one)
+    creative = Creative.create!(user: user, description: "Non interactive leaf", progress: 1)
+
+    Current.set(user: user) do
+      select_mode_html = render_progress_control(creative, 1, has_children: false, can_write: true, select_mode: true)
+      read_only_html = render_progress_control(creative, 1, has_children: false, can_write: false)
+
+      refute_includes select_mode_html, "progress-toggle-checkbox"
+      refute_includes read_only_html, "progress-toggle-checkbox"
+    end
+  end
+
   test "render_creative_tree_markdown includes children of origin for linked creatives" do
     user = users(:one)
 

--- a/engines/collavre/test/jobs/collavre/creative_broadcast_job_test.rb
+++ b/engines/collavre/test/jobs/collavre/creative_broadcast_job_test.rb
@@ -99,6 +99,38 @@ module Collavre
       assert_includes payload.dig("creative", "progress_control_html"), "data-progress-toggle"
     end
 
+    test "broadcasts read-only-source leaf progress as a non-interactive percentage" do
+      Creative.register_read_only_source("test_read_only_source")
+      leaf = nil
+      perform_enqueued_jobs do
+        leaf = Creative.create!(
+          user: @owner,
+          parent: @root,
+          description: "Read-only progress leaf",
+          progress: 0,
+          data: { "source" => { "type" => "test_read_only_source" } }
+        )
+      end
+      broadcasts = []
+
+      Turbo::StreamsChannel.stub(:broadcast_action_to, ->(*, **kwargs) { broadcasts << kwargs }) do
+        CreativeBroadcastJob.perform_now(
+          leaf.id,
+          "updated",
+          current_user_id: @owner.id,
+          payload: leaf.broadcast_node_payload
+        )
+      end
+
+      payload = JSON.parse(broadcasts.fetch(0).fetch(:attributes).fetch(:data))
+      assert_equal false, payload.dig("creative", "can_write")
+      assert_includes payload.dig("creative", "progress_control_html"), "0%"
+      refute_includes payload.dig("creative", "progress_control_html"), "data-progress-toggle"
+
+      html = CreativeBroadcastJob.new.send(:render_progress_html, leaf, @shared_user, skip_permission_check: true)
+      refute_includes html, "data-progress-toggle"
+    end
+
     test "ancestor controls use the effective origin children for linked shells" do
       linked_root = nil
       perform_enqueued_jobs do

--- a/engines/collavre/test/jobs/collavre/creative_broadcast_job_test.rb
+++ b/engines/collavre/test/jobs/collavre/creative_broadcast_job_test.rb
@@ -144,6 +144,19 @@ module Collavre
       assert_includes html, "50%"
     end
 
+    test "render_progress_html uses the shared checkbox control for writable binary leaves" do
+      leaf = nil
+      perform_enqueued_jobs do
+        leaf = Creative.create!(user: @owner, parent: @root, description: "Checkbox leaf", progress: 0)
+      end
+
+      job = CreativeBroadcastJob.new
+      html = job.send(:render_progress_html, leaf, @shared_user, skip_permission_check: true)
+
+      assert_includes html, 'data-progress-toggle="true"'
+      assert_includes html, 'type="checkbox"'
+    end
+
     test "render_progress_html includes comment button when skip_permission_check" do
       job = CreativeBroadcastJob.new
       html = job.send(:render_progress_html, @child, @shared_user, skip_permission_check: true)

--- a/engines/collavre/test/jobs/collavre/creative_broadcast_job_test.rb
+++ b/engines/collavre/test/jobs/collavre/creative_broadcast_job_test.rb
@@ -99,6 +99,51 @@ module Collavre
       assert_includes payload.dig("creative", "progress_control_html"), "data-progress-toggle"
     end
 
+    test "ancestor controls use the effective origin children for linked shells" do
+      linked_root = nil
+      perform_enqueued_jobs do
+        linked_root = Creative.create!(
+          user: @shared_user,
+          origin_id: @root.id,
+          description: "Linked root shell"
+        )
+      end
+
+      controls = CreativeBroadcastJob.new.send(
+        :build_ancestor_progress_controls,
+        [ { id: @root.id, progress: @root.progress } ],
+        [ @shared_user ],
+        { @shared_user.id => { @root.id => linked_root.id } }
+      )
+
+      html = controls.dig(@shared_user.id, @root.id, :progress_html)
+      refute_includes html, "data-progress-toggle"
+      assert_includes html, "creative-progress-incomplete"
+    end
+
+    test "ancestor controls batch creative and permission lookups across recipients" do
+      another_user = users(:three)
+      perform_enqueued_jobs do
+        CreativeShare.create!(creative: @root, user: another_user, permission: :write)
+      end
+      queries = []
+      callback = lambda do |_name, _start, _finish, _id, payload|
+        queries << payload[:sql] unless payload[:cached] || payload[:name] == "SCHEMA"
+      end
+
+      ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
+        CreativeBroadcastJob.new.send(
+          :build_ancestor_progress_controls,
+          [ { id: @root.id, progress: @root.progress }, { id: @child.id, progress: @child.progress } ],
+          [ @shared_user, another_user ],
+          {}
+        )
+      end
+
+      per_ancestor_queries = queries.grep(/(?:FROM "creatives"|FROM "creative_shares_caches").*LIMIT 1/i)
+      assert_empty per_ancestor_queries, "expected batched ancestor-control reads, got:\n#{per_ancestor_queries.join("\n")}"
+    end
+
     # --- destroyed action ---
 
     test "destroyed action does not raise with valid options" do

--- a/engines/collavre/test/jobs/collavre/creative_broadcast_job_test.rb
+++ b/engines/collavre/test/jobs/collavre/creative_broadcast_job_test.rb
@@ -176,6 +176,19 @@ module Collavre
       assert_empty per_ancestor_queries, "expected batched ancestor-control reads, got:\n#{per_ancestor_queries.join("\n")}"
     end
 
+    test "batch write permissions recognizes enum write cache values" do
+      permission = CreativeSharesCache.where(creative: @child, user: @shared_user).pick(:permission)
+      assert_equal "write", permission
+
+      permissions = CreativeBroadcastJob.new.send(
+        :batch_write_permissions,
+        { @child.id => @child },
+        [ @shared_user ]
+      )
+
+      assert permissions.dig(@shared_user.id, @child.id)
+    end
+
     # --- destroyed action ---
 
     test "destroyed action does not raise with valid options" do

--- a/engines/collavre/test/jobs/collavre/creative_broadcast_job_test.rb
+++ b/engines/collavre/test/jobs/collavre/creative_broadcast_job_test.rb
@@ -64,6 +64,41 @@ module Collavre
       end
     end
 
+    test "updated action broadcasts the recipient-specific progress control" do
+      leaf = nil
+      perform_enqueued_jobs do
+        leaf = Creative.create!(user: @owner, parent: @root, description: "Progress control leaf", progress: 0.5)
+      end
+      broadcasts = []
+
+      Turbo::StreamsChannel.stub(:broadcast_action_to, ->(*, **kwargs) { broadcasts << kwargs }) do
+        CreativeBroadcastJob.perform_now(
+          leaf.id,
+          "updated",
+          current_user_id: @owner.id,
+          payload: leaf.broadcast_node_payload
+        )
+      end
+
+      payload = JSON.parse(broadcasts.fetch(0).fetch(:attributes).fetch(:data))
+      assert_includes payload.dig("creative", "progress_control_html"), "50%"
+      refute_includes payload.dig("creative", "progress_control_html"), "data-progress-toggle"
+
+      leaf.update_column(:progress, 0)
+      broadcasts.clear
+      Turbo::StreamsChannel.stub(:broadcast_action_to, ->(*, **kwargs) { broadcasts << kwargs }) do
+        CreativeBroadcastJob.perform_now(
+          leaf.id,
+          "updated",
+          current_user_id: @owner.id,
+          payload: leaf.broadcast_node_payload
+        )
+      end
+
+      payload = JSON.parse(broadcasts.fetch(0).fetch(:attributes).fetch(:data))
+      assert_includes payload.dig("creative", "progress_control_html"), "data-progress-toggle"
+    end
+
     # --- destroyed action ---
 
     test "destroyed action does not raise with valid options" do

--- a/engines/collavre/test/jobs/collavre/creative_broadcast_job_test.rb
+++ b/engines/collavre/test/jobs/collavre/creative_broadcast_job_test.rb
@@ -157,6 +157,20 @@ module Collavre
       assert_includes html, 'type="checkbox"'
     end
 
+    test "render_progress_html uses the recipient locale for checkbox labels" do
+      leaf = nil
+      perform_enqueued_jobs do
+        leaf = Creative.create!(user: @owner, parent: @root, description: "Localized checkbox leaf", progress: 0)
+      end
+      @shared_user.update!(locale: "ko")
+
+      html = I18n.with_locale(:en) do
+        CreativeBroadcastJob.new.send(:render_progress_html, leaf, @shared_user, skip_permission_check: true)
+      end
+
+      assert_includes html, "완료로 표시"
+    end
+
     test "render_progress_html includes comment button when skip_permission_check" do
       job = CreativeBroadcastJob.new
       html = job.send(:render_progress_html, @child, @shared_user, skip_permission_check: true)

--- a/engines/collavre/test/jobs/collavre/creative_broadcast_job_test.rb
+++ b/engines/collavre/test/jobs/collavre/creative_broadcast_job_test.rb
@@ -153,6 +153,36 @@ module Collavre
       assert_includes html, "creative-progress-incomplete"
     end
 
+    test "ancestor controls ignore archived children for each recipient" do
+      @child.update!(archived_at: Time.current)
+
+      controls = CreativeBroadcastJob.new.send(
+        :build_ancestor_progress_controls,
+        [ { id: @root.id, progress: @root.progress } ],
+        [ @shared_user ],
+        {}
+      )
+
+      html = controls.dig(@shared_user.id, @root.id, :progress_html)
+      assert_includes html, "data-progress-toggle"
+    end
+
+    test "ancestor controls ignore children the recipient cannot read" do
+      perform_enqueued_jobs do
+        CreativeShare.create!(creative: @child, user: @shared_user, permission: :no_access)
+      end
+
+      controls = CreativeBroadcastJob.new.send(
+        :build_ancestor_progress_controls,
+        [ { id: @root.id, progress: @root.progress } ],
+        [ @shared_user ],
+        {}
+      )
+
+      html = controls.dig(@shared_user.id, @root.id, :progress_html)
+      assert_includes html, "data-progress-toggle"
+    end
+
     test "ancestor controls batch creative and permission lookups across recipients" do
       another_user = users(:three)
       perform_enqueued_jobs do


### PR DESCRIPTION
## Summary
- Show persistent checkboxes for writable leaf creatives at 0% or 100%, while preserving percentage labels for rollups, partial values, read-only views, and selection mode.
- Keep checkbox state and the next action synchronized across initial rendering, broadcasts, and remote progress updates.
- Remove the hover-only progress control so it remains discoverable on touch devices.

## Validation
- `rbenv exec ruby ./bin/rubocop -a`
- `rbenv exec bundle exec bin/rails test engines/collavre/test/helpers/creatives_helper_test.rb engines/collavre/test/jobs/collavre/creative_broadcast_job_test.rb`
- `npm test -- engines/collavre/app/javascript/creatives/__tests__/tree_renderer.test.js engines/collavre/app/javascript/lib/__tests__/turbo_stream_actions.test.js`

The repository-wide CSS lint currently fails on existing violations outside this change.