### PR TITLE
fix: stabilize trigger status and workspace drawer tests

### DIFF
--- a/engines/collavre/test/system/trigger_task_status_test.rb
+++ b/engines/collavre/test/system/trigger_task_status_test.rb
@@ -42,25 +42,10 @@ class TriggerTaskStatusTest < ApplicationSystemTestCase
     # The trigger button should become visible
     trigger_btn = find("[data-comments--drop-trigger-target='triggerButton']", wait: 10)
 
-    # Wait for async _loadTriggerState to complete and update UI
-    # The button should not be hidden (display:none)
-    assert_eventually(timeout: 10) do
-      trigger_btn.evaluate_script("this.style.display") != "none"
-    end
-
-    # Verify tooltip
-    assert_match(/Idle/i, trigger_btn["title"])
-  end
-
-  private
-
-  def assert_eventually(timeout: 5, interval: 0.2)
-    deadline = Time.now + timeout
-    loop do
-      return if yield
-      raise "Assertion did not pass within #{timeout}s" if Time.now > deadline
-
-      sleep interval
-    end
+    # The popup initializes with the preceding creative's state while its
+    # trigger request is in flight. Wait for the task state instead of merely
+    # waiting for the shared button to become visible.
+    assert_selector "[data-comments--drop-trigger-target='triggerButton'][title*='Idle']", wait: 10
+    assert_equal "Idle — click to start", trigger_btn["title"]
   end
 end

--- a/engines/collavre/test/system/workspace_tree_drawer_test.rb
+++ b/engines/collavre/test/system/workspace_tree_drawer_test.rb
@@ -53,6 +53,7 @@ class WorkspaceTreeDrawerTest < ApplicationSystemTestCase
     test "the drawer keeps its expansion state across close and reopen at #{width}px" do
       visit_workspace(width)
       find(".creative-workspace-tree-toggle").click
+      assert_selector ".creative-workspace-tree-region.is-open"
       assert_selector ".creative-workspace-tree-link", text: "Root creative", wait: 10
 
       find(".creative-workspace-tree-branch-toggle").click
@@ -60,6 +61,7 @@ class WorkspaceTreeDrawerTest < ApplicationSystemTestCase
 
       find(".creative-workspace-tree-toggle").click
       assert_no_selector ".creative-workspace-tree-region.is-open"
+      assert_selector ".creative-workspace-tree-toggle[aria-expanded='false']"
       find(".creative-workspace-tree-toggle").click
 
       assert_selector ".creative-workspace-tree-region.is-open"


### PR DESCRIPTION
## Summary

- Wait for the loaded trigger task state before asserting its tooltip.
- Verify drawer open and closed state transitions before checking expansion persistence.

## Root cause

The system tests could observe shared UI controls before their asynchronous state updates completed.

## Validation

- `bin/rails test engines/collavre/test/system/trigger_task_status_test.rb:30`
- `bin/rails test engines/collavre/test/system/workspace_tree_drawer_test.rb:53`
- `./bin/rubocop -a engines/collavre/test/system/trigger_task_status_test.rb engines/collavre/test/system/workspace_tree_drawer_test.rb`
- `npm test -- --runInBand engines/collavre/app/javascript/controllers/__tests__/workspace_tree_controller.test.js`