### PR TITLE
feat: show the completion mark on completed leaf checkboxes

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/creatives.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/creatives.css
@@ -334,12 +334,21 @@ creative-tree-row.show-edit .creative-row {
     color: var(--text-muted);
 }
 
-/* Leaf creatives with binary progress are directly actionable. */
+/* Leaf creatives with binary progress are directly actionable. The checkbox and
+   the completion mark share one grid cell so the control keeps a single width
+   whichever state is showing. */
 .progress-toggle-wrap {
     cursor: pointer;
-    display: inline-flex;
+    display: inline-grid;
+    grid-template-areas: "progress-state";
     align-items: center;
+    justify-items: center;
+    min-width: 1.5em;
     padding-top: 4px;
+}
+
+.progress-toggle-wrap > * {
+    grid-area: progress-state;
 }
 
 .progress-toggle-checkbox {
@@ -348,6 +357,43 @@ creative-tree-row.show-edit .creative-row {
     margin: 0;
     cursor: pointer;
     accent-color: var(--color-brand);
+    transition: opacity 0.12s ease;
+}
+
+/* A completed leaf shows the admin completion mark (blank by default) instead of
+   a checked box, so finished rows read as quietly as completed parent rows. */
+.progress-toggle-mark {
+    color: var(--color-brand);
+    white-space: nowrap;
+    opacity: 0;
+    transition: opacity 0.12s ease;
+}
+
+.progress-toggle-wrap[data-current-progress="1"] .progress-toggle-checkbox {
+    opacity: 0;
+}
+
+.progress-toggle-wrap[data-current-progress="1"] .progress-toggle-mark {
+    opacity: 1;
+}
+
+/* Hover or keyboard focus brings the checked box back, so an accidental
+   completion is undone in place instead of through the inline editor. */
+.progress-toggle-wrap[data-current-progress="1"]:hover .progress-toggle-checkbox,
+.progress-toggle-wrap[data-current-progress="1"]:focus-within .progress-toggle-checkbox {
+    opacity: 1;
+}
+
+.progress-toggle-wrap[data-current-progress="1"]:hover .progress-toggle-mark,
+.progress-toggle-wrap[data-current-progress="1"]:focus-within .progress-toggle-mark {
+    opacity: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .progress-toggle-checkbox,
+    .progress-toggle-mark {
+        transition: none;
+    }
 }
 
 .progress-toggle-saving {

--- a/engines/collavre/app/helpers/collavre/creatives_helper.rb
+++ b/engines/collavre/app/helpers/collavre/creatives_helper.rb
@@ -111,6 +111,10 @@ module Collavre
       end
     end
 
+    # Rendered when the completion mark is blank, so the completed state keeps a
+    # stable baseline and a tappable hit area.
+    NBSP = "\u00A0"
+
     def render_progress_toggle(creative, value)
       complete = value == 1
       new_value = complete ? 0 : 1
@@ -132,11 +136,21 @@ module Collavre
           type: "checkbox",
           checked: complete || nil,
           class: "progress-toggle-checkbox",
-          tabindex: -1,
           "aria-label": tooltip
         )
-        checkbox
+        # A completed leaf reads as the admin completion mark (blank by default),
+        # the same way parent rows already render 100%. CSS swaps the mark back to
+        # the checked box on hover/focus so a mis-click is undone in place instead
+        # of through the inline editor. The checkbox stays the accessible control;
+        # the mark is decorative.
+        checkbox + tag.span(completion_mark_display, class: "progress-toggle-mark", aria: { hidden: true })
       end
+    end
+
+    # Blank (the default) collapses to a non-breaking space so the completed state
+    # keeps a stable baseline and a tappable hit area inside the toggle.
+    def completion_mark_display
+      completion_mark.to_s.presence || NBSP
     end
 
     def progress_toggleable?(value)

--- a/engines/collavre/app/helpers/collavre/creatives_helper.rb
+++ b/engines/collavre/app/helpers/collavre/creatives_helper.rb
@@ -125,7 +125,10 @@ module Collavre
         data: {
           progress_toggle: true,
           creative_id: creative.id,
-          current_progress: value,
+          # progress is a decimal, so the raw value serializes as "1.0" and the
+          # CSS/JS state checks against "1" would never match. Both sides of the
+          # toggle only ever mean 0 or 1, so emit it as an integer.
+          current_progress: complete ? 1 : 0,
           new_progress: new_value,
           mark_complete: t("collavre.creatives.index.mark_complete"),
           mark_incomplete: t("collavre.creatives.index.mark_incomplete")

--- a/engines/collavre/app/javascript/components/__tests__/creative_tree_row_progress_toggle.test.js
+++ b/engines/collavre/app/javascript/components/__tests__/creative_tree_row_progress_toggle.test.js
@@ -27,6 +27,12 @@ async function mountRow(progressHtml) {
 
 const INCOMPLETE_TOGGLE = '<span class="progress-toggle-wrap" data-progress-toggle="true" data-creative-id="7" data-current-progress="0" data-new-progress="1" data-mark-complete="Mark complete" data-mark-incomplete="Mark incomplete" title="Mark complete"><input type="checkbox" class="progress-toggle-checkbox" aria-label="Mark complete"><span class="progress-toggle-mark" aria-hidden="true"> </span></span>'
 
+const COMPLETE_TOGGLE = INCOMPLETE_TOGGLE
+  .replace('data-current-progress="0" data-new-progress="1"', 'data-current-progress="1" data-new-progress="0"')
+  .replace('title="Mark complete"', 'title="Mark incomplete"')
+  .replace('<input type="checkbox"', '<input type="checkbox" checked')
+  .replace('aria-label="Mark complete"', 'aria-label="Mark incomplete"')
+
 afterEach(() => {
   csrfFetch.mockReset()
   document.body.innerHTML = ''
@@ -78,6 +84,47 @@ test('flips the completion state optimistically so the mark shows before the req
   resolveFetch({ ok: true, json: async () => ({ progress: 1 }) })
   await Promise.resolve()
   await row.updateComplete
+})
+
+// Space (and a click landing on the box itself) runs the input's own activation:
+// the browser flips `checked` before the click reaches this handler. Reading the
+// checkbox instead of the dataset would invert the state back while the PATCH is
+// in flight, so a completed row would still read as checked. `checkbox.click()`
+// drives the same activation path Space does — jsdom has no Space-to-click
+// default action. Its canceled-activation restore inverts the current value
+// where browsers reassign the saved one, so the browser-faithful check lives in
+// test/system/creative_progress_toggle_keyboard_test.rb.
+test('unchecks the box when the completed checkbox itself is activated', async () => {
+  let resolveFetch
+  csrfFetch.mockReturnValue(new Promise((resolve) => { resolveFetch = resolve }))
+  const row = await mountRow(COMPLETE_TOGGLE)
+  const toggle = row.querySelector('[data-progress-toggle]')
+  const checkbox = toggle.querySelector('input')
+
+  checkbox.click()
+
+  expect(toggle.dataset.currentProgress).toBe('0')
+  expect(toggle.dataset.newProgress).toBe('1')
+  expect(checkbox.checked).toBe(false)
+
+  resolveFetch({ ok: true, json: async () => ({ progress: 0 }) })
+  await Promise.resolve()
+  await row.updateComplete
+})
+
+test('rolls the box back to unchecked when activating it directly fails', async () => {
+  jest.spyOn(console, 'error').mockImplementation(() => {})
+  csrfFetch.mockResolvedValue({ ok: false, status: 422 })
+  const row = await mountRow(INCOMPLETE_TOGGLE)
+  const toggle = row.querySelector('[data-progress-toggle]')
+  const checkbox = toggle.querySelector('input')
+
+  checkbox.click()
+  await Promise.resolve()
+  await row.updateComplete
+
+  expect(toggle.dataset.currentProgress).toBe('0')
+  expect(checkbox.checked).toBe(false)
 })
 
 test('restores checkbox metadata when a toggle request fails', async () => {

--- a/engines/collavre/app/javascript/components/__tests__/creative_tree_row_progress_toggle.test.js
+++ b/engines/collavre/app/javascript/components/__tests__/creative_tree_row_progress_toggle.test.js
@@ -127,6 +127,47 @@ test('rolls the box back to unchecked when activating it directly fails', async 
   expect(checkbox.checked).toBe(false)
 })
 
+// `pointer-events: none` on the saving row stops the mouse but not a checkbox
+// that already holds focus, so Space can re-enter the handler with the
+// optimistically inverted dataset and PATCH the opposite value. Two requests in
+// flight can settle out of order and leave the row on the losing one.
+test('ignores repeat activation while the PATCH is in flight', async () => {
+  csrfFetch.mockReturnValue(new Promise(() => {}))
+  const row = await mountRow(COMPLETE_TOGGLE)
+  const toggle = row.querySelector('[data-progress-toggle]')
+  const checkbox = toggle.querySelector('input')
+
+  checkbox.click()
+  checkbox.click()
+
+  expect(csrfFetch).toHaveBeenCalledTimes(1)
+  expect(toggle.dataset.currentProgress).toBe('0')
+  expect(toggle.dataset.newProgress).toBe('1')
+  expect(checkbox.checked).toBe(false)
+})
+
+// The server's progress_html replaces the toggle through unsafeHTML, which
+// discards the focused checkbox. Without restoring focus a keyboard user
+// toggles once and then Space scrolls the page instead of toggling back.
+test('keeps focus on the checkbox after the server re-renders the toggle', async () => {
+  csrfFetch.mockResolvedValue({
+    ok: true,
+    json: async () => ({ progress: 1, progress_html: COMPLETE_TOGGLE }),
+  })
+  const row = await mountRow(INCOMPLETE_TOGGLE)
+  const checkbox = row.querySelector('.progress-toggle-checkbox')
+  checkbox.focus()
+
+  checkbox.click()
+  await Promise.resolve()
+  await row.updateComplete
+  await row.updateComplete
+
+  const rendered = row.querySelector('.progress-toggle-checkbox')
+  expect(document.activeElement).toBe(rendered)
+  expect(rendered.checked).toBe(true)
+})
+
 test('restores checkbox metadata when a toggle request fails', async () => {
   jest.spyOn(console, 'error').mockImplementation(() => {})
   csrfFetch.mockResolvedValue({ ok: false, status: 422 })

--- a/engines/collavre/app/javascript/components/__tests__/creative_tree_row_progress_toggle.test.js
+++ b/engines/collavre/app/javascript/components/__tests__/creative_tree_row_progress_toggle.test.js
@@ -25,7 +25,7 @@ async function mountRow(progressHtml) {
   return row
 }
 
-const INCOMPLETE_TOGGLE = '<span class="progress-toggle-wrap" data-progress-toggle="true" data-creative-id="7" data-current-progress="0" data-new-progress="1" data-mark-complete="Mark complete" data-mark-incomplete="Mark incomplete" title="Mark complete"><input type="checkbox" class="progress-toggle-checkbox" aria-label="Mark complete"></span>'
+const INCOMPLETE_TOGGLE = '<span class="progress-toggle-wrap" data-progress-toggle="true" data-creative-id="7" data-current-progress="0" data-new-progress="1" data-mark-complete="Mark complete" data-mark-incomplete="Mark incomplete" title="Mark complete"><input type="checkbox" class="progress-toggle-checkbox" aria-label="Mark complete"><span class="progress-toggle-mark" aria-hidden="true"> </span></span>'
 
 afterEach(() => {
   csrfFetch.mockReset()
@@ -58,6 +58,26 @@ test('updates checkbox metadata and ancestor progress after a successful toggle'
   expect(csrfFetch).toHaveBeenCalledWith('/creatives/7', expect.objectContaining({ method: 'PATCH' }))
   expect(row.dataset.progressValue).toBe('1')
   expect(ancestor.progressHtml).toContain('50%')
+})
+
+test('flips the completion state optimistically so the mark shows before the request settles', async () => {
+  let resolveFetch
+  csrfFetch.mockReturnValue(new Promise((resolve) => { resolveFetch = resolve }))
+  const row = await mountRow(INCOMPLETE_TOGGLE)
+  const toggle = row.querySelector('[data-progress-toggle]')
+
+  toggle.click()
+
+  // CSS keys the mark/checkbox swap off data-current-progress, so the completed
+  // row reads as done immediately instead of waiting on the PATCH.
+  expect(toggle.dataset.currentProgress).toBe('1')
+  expect(toggle.dataset.newProgress).toBe('0')
+  expect(toggle.title).toBe('Mark incomplete')
+  expect(toggle.querySelector('.progress-toggle-mark')).not.toBeNull()
+
+  resolveFetch({ ok: true, json: async () => ({ progress: 1 }) })
+  await Promise.resolve()
+  await row.updateComplete
 })
 
 test('restores checkbox metadata when a toggle request fails', async () => {

--- a/engines/collavre/app/javascript/components/creative_tree_row.js
+++ b/engines/collavre/app/javascript/components/creative_tree_row.js
@@ -78,8 +78,24 @@ class CreativeTreeRow extends LitElement {
     this._extractTemplates();
   }
 
+  // `progressHtml` is committed through unsafeHTML, so every render that changes
+  // it discards the toggle — including the broadcast that lands after the PATCH
+  // this row already applied. A keyboard user would toggle once and then Space
+  // would scroll the page, so remember focus here and restore it in updated().
+  update(changedProperties) {
+    this._progressHadFocus = this._progressToggle != null &&
+      this._progressToggle.contains(document.activeElement);
+    super.update(changedProperties);
+  }
+
   updated(changedProperties) {
     this._attachHandlers();
+
+    if (this._progressHadFocus) {
+      this._progressHadFocus = false;
+      const checkbox = this.querySelector(".progress-toggle-checkbox");
+      if (checkbox && checkbox !== document.activeElement) checkbox.focus();
+    }
 
     // Re-tokenize the server-rendered description code blocks with hljs so they
     // match the editor's palette and follow light/dark theme. Idempotent: only
@@ -549,6 +565,15 @@ class CreativeTreeRow extends LitElement {
     const nativeActivation = checkbox != null && event.target === checkbox;
     if (!nativeActivation) event.preventDefault();
     event.stopPropagation();
+    // `pointer-events: none` on the saving row stops the mouse but not a
+    // checkbox that already holds focus, so Space can re-enter here while a
+    // PATCH is in flight. The dataset is already inverted at that point, so a
+    // second request would carry the opposite value and the two could settle
+    // out of order. Drop the activation and put the box back on the dataset.
+    if (wrap.classList.contains("progress-toggle-saving")) {
+      if (checkbox) checkbox.checked = wrap.dataset.currentProgress === "1";
+      return;
+    }
     const creativeId = wrap.dataset.creativeId;
     const newProgress = wrap.dataset.newProgress;
     // The dataset is the source of truth: `checked` may already be flipped.

--- a/engines/collavre/app/javascript/components/creative_tree_row.js
+++ b/engines/collavre/app/javascript/components/creative_tree_row.js
@@ -540,16 +540,25 @@ class CreativeTreeRow extends LitElement {
   }
 
   async _handleProgressToggle(event) {
-    event.preventDefault();
-    event.stopPropagation();
     const wrap = event.currentTarget;
+    const checkbox = wrap.querySelector(".progress-toggle-checkbox");
+    // Activating the input itself (Space, or a click landing on the box) flips
+    // `checked` before the click reaches this handler, and preventDefault would
+    // flip it back once dispatch finishes. Leave that activation alone and set
+    // the state explicitly below; cancel the default for every other target.
+    const nativeActivation = checkbox != null && event.target === checkbox;
+    if (!nativeActivation) event.preventDefault();
+    event.stopPropagation();
     const creativeId = wrap.dataset.creativeId;
     const newProgress = wrap.dataset.newProgress;
-    if (!creativeId || newProgress == null) return;
+    // The dataset is the source of truth: `checked` may already be flipped.
+    const wasComplete = wrap.dataset.currentProgress === "1";
+    if (!creativeId || newProgress == null) {
+      if (checkbox) checkbox.checked = wasComplete;
+      return;
+    }
 
     // Optimistic UI: toggle the always-visible checkbox immediately.
-    const checkbox = wrap.querySelector(".progress-toggle-checkbox");
-    const wasComplete = checkbox?.checked;
     const previousCurrentProgress = wrap.dataset.currentProgress;
     const previousNewProgress = wrap.dataset.newProgress;
     const previousTitle = wrap.title;

--- a/engines/collavre/test/helpers/creatives_helper_test.rb
+++ b/engines/collavre/test/helpers/creatives_helper_test.rb
@@ -238,6 +238,49 @@ class CreativesHelperTest < ActionView::TestCase
     end
   end
 
+  test "render_progress_toggle renders the completion mark alongside the checkbox" do
+    user = users(:one)
+    creative = Creative.create!(user: user, description: "Completed leaf", progress: 1)
+
+    Current.set(user: user) do
+      Collavre::SystemSetting.stub(:completion_mark, "✓") do
+        html = render_progress_control(creative, 1, has_children: false, can_write: true)
+
+        assert_includes html, 'data-current-progress="1"'
+        assert_includes html, "progress-toggle-mark"
+        assert_includes html, "✓"
+        # The checkbox stays the accessible control; CSS is what hides it behind
+        # the mark until the row is hovered or focused.
+        assert_includes html, "progress-toggle-checkbox"
+        assert_includes html, 'checked="checked"'
+      end
+    end
+  end
+
+  test "render_progress_toggle falls back to a non-breaking space for a blank completion mark" do
+    user = users(:one)
+    creative = Creative.create!(user: user, description: "Quietly completed leaf", progress: 1)
+
+    Current.set(user: user) do
+      Collavre::SystemSetting.stub(:completion_mark, "") do
+        html = render_progress_control(creative, 1, has_children: false, can_write: true)
+
+        assert_includes html, %(<span class="progress-toggle-mark" aria-hidden="true"> </span>)
+      end
+    end
+  end
+
+  test "render_progress_toggle keeps the checkbox reachable by keyboard" do
+    user = users(:one)
+    creative = Creative.create!(user: user, description: "Keyboard leaf", progress: 0)
+
+    Current.set(user: user) do
+      html = render_progress_control(creative, 0, has_children: false, can_write: true)
+
+      refute_includes html, 'tabindex="-1"'
+    end
+  end
+
   test "render_creative_tree_markdown includes children of origin for linked creatives" do
     user = users(:one)
 

--- a/engines/collavre/test/helpers/creatives_helper_test.rb
+++ b/engines/collavre/test/helpers/creatives_helper_test.rb
@@ -270,6 +270,23 @@ class CreativesHelperTest < ActionView::TestCase
     end
   end
 
+  # The view passes creative.progress, a decimal, so a raw value would serialize
+  # as "1.0"/"0.0" and the CSS and JS state checks against "1"/"0" would never
+  # match. Pass the value the way the view does, not a literal Integer.
+  test "render_progress_toggle emits the completion state as an integer" do
+    user = users(:one)
+    complete = Creative.create!(user: user, description: "Completed leaf", progress: 1)
+    incomplete = Creative.create!(user: user, description: "Open leaf", progress: 0)
+
+    Current.set(user: user) do
+      complete_html = render_progress_control(complete, complete.progress, has_children: false, can_write: true)
+      incomplete_html = render_progress_control(incomplete, incomplete.progress, has_children: false, can_write: true)
+
+      assert_includes complete_html, 'data-current-progress="1"'
+      assert_includes incomplete_html, 'data-current-progress="0"'
+    end
+  end
+
   test "render_progress_toggle keeps the checkbox reachable by keyboard" do
     user = users(:one)
     creative = Creative.create!(user: user, description: "Keyboard leaf", progress: 0)

--- a/engines/collavre/test/system/creative_progress_toggle_keyboard_test.rb
+++ b/engines/collavre/test/system/creative_progress_toggle_keyboard_test.rb
@@ -25,12 +25,35 @@ class CreativeProgressToggleKeyboardTest < ApplicationSystemTestCase
     "#creative-#{@leaf.id} .progress-toggle-wrap"
   end
 
-  def press_space_on_checkbox
+  def focus_checkbox
     checkbox = find("#{toggle_selector} .progress-toggle-checkbox", visible: :all)
     page.execute_script("arguments[0].focus()", checkbox)
-    assert page.evaluate_script("document.activeElement.classList.contains('progress-toggle-checkbox')"),
-           "expected the progress checkbox to hold focus"
+    assert checkbox_focused?, "expected the progress checkbox to hold focus"
+  end
+
+  def checkbox_focused?
+    page.evaluate_script(<<~JS)
+      !!document.activeElement &&
+        document.activeElement.classList.contains('progress-toggle-checkbox') &&
+        document.activeElement.closest('[data-creative-id="#{@leaf.id}"]') != null
+    JS
+  end
+
+  def assert_checkbox_keeps_focus(seconds: 3)
+    deadline = Time.current + seconds
+    while Time.current < deadline
+      assert checkbox_focused?, "expected focus to stay on the checkbox across every re-render"
+      sleep 0.2
+    end
+  end
+
+  def press_space
     page.driver.browser.action.send_keys(:space).perform
+  end
+
+  def press_space_on_checkbox
+    focus_checkbox
+    press_space
   end
 
   test "space toggles a leaf between complete and incomplete" do
@@ -63,5 +86,46 @@ class CreativeProgressToggleKeyboardTest < ApplicationSystemTestCase
 
     assert_selector "#{toggle_selector}[data-current-progress='0']", wait: 5
     assert_no_selector "#{toggle_selector} .progress-toggle-checkbox:checked", visible: :all
+  end
+
+  # The server's markup replaces the toggle through unsafeHTML, so the focused
+  # checkbox is discarded. Focus once and never again: the second press has to
+  # land on the replacement, not scroll the page.
+  test "focus survives the server re-render so space toggles back" do
+    focus_checkbox
+    press_space
+
+    assert_selector "#{toggle_selector}[data-current-progress='1']", wait: 5
+    wait_for_network_idle(timeout: 10)
+    assert_equal 1, @leaf.reload.progress
+    # The broadcast for this update re-renders the row a second time, after the
+    # PATCH response already did, so focus has to survive both. Hold the
+    # assertion open rather than sampling once: a single sample passes in the
+    # gap between the two renders.
+    assert_checkbox_keeps_focus
+
+    press_space
+
+    assert_selector "#{toggle_selector}[data-current-progress='0']", wait: 5
+    wait_for_network_idle(timeout: 10)
+    assert_equal 0, @leaf.reload.progress
+  end
+
+  # `pointer-events: none` on the saving row stops the mouse but not a checkbox
+  # that already holds focus, so a second press before the PATCH settles would
+  # send the opposite value and the two could settle out of order.
+  test "space is ignored while the request is in flight" do
+    page.execute_script(<<~JS)
+      window.__patchCount = 0;
+      window.fetch = () => { window.__patchCount += 1; return new Promise(() => {}); };
+    JS
+
+    press_space_on_checkbox
+    assert_selector "#{toggle_selector}[data-current-progress='1']", wait: 5
+    press_space
+
+    assert_no_selector "#{toggle_selector}[data-current-progress='0']", wait: 2
+    assert_selector "#{toggle_selector} .progress-toggle-checkbox:checked", visible: :all
+    assert_equal 1, page.evaluate_script("window.__patchCount")
   end
 end

--- a/engines/collavre/test/system/creative_progress_toggle_keyboard_test.rb
+++ b/engines/collavre/test/system/creative_progress_toggle_keyboard_test.rb
@@ -1,0 +1,67 @@
+require_relative "../application_system_test_case"
+
+# The leaf progress checkbox is keyboard reachable, so Space activates it. Space
+# runs the input's own activation behavior: the browser flips `checked` before
+# the click reaches the row handler, and cancelling that click would flip it back
+# once dispatch finishes. jsdom models the restore as an inversion rather than the
+# spec's reassignment, so the keyboard path is verified in a real browser here.
+class CreativeProgressToggleKeyboardTest < ApplicationSystemTestCase
+  setup do
+    @user = User.create!(
+      email: "user@example.com",
+      password: SystemHelpers::PASSWORD,
+      name: "User",
+      email_verified_at: Time.current,
+      notifications_enabled: false
+    )
+    @leaf = Creative.create!(description: "Leaf", user: @user, progress: 0)
+
+    resize_window_to
+    sign_in_via_ui(@user)
+    visit collavre.creatives_path
+  end
+
+  def toggle_selector
+    "#creative-#{@leaf.id} .progress-toggle-wrap"
+  end
+
+  def press_space_on_checkbox
+    checkbox = find("#{toggle_selector} .progress-toggle-checkbox", visible: :all)
+    page.execute_script("arguments[0].focus()", checkbox)
+    assert page.evaluate_script("document.activeElement.classList.contains('progress-toggle-checkbox')"),
+           "expected the progress checkbox to hold focus"
+    page.driver.browser.action.send_keys(:space).perform
+  end
+
+  test "space toggles a leaf between complete and incomplete" do
+    assert_selector "#{toggle_selector}[data-current-progress='0']"
+
+    press_space_on_checkbox
+
+    assert_selector "#{toggle_selector}[data-current-progress='1']", wait: 5
+    assert_selector "#{toggle_selector} .progress-toggle-checkbox:checked", visible: :all
+    wait_for_network_idle(timeout: 10)
+    assert_equal 1, @leaf.reload.progress
+
+    press_space_on_checkbox
+
+    assert_selector "#{toggle_selector}[data-current-progress='0']", wait: 5
+    assert_no_selector "#{toggle_selector} .progress-toggle-checkbox:checked", visible: :all
+    wait_for_network_idle(timeout: 10)
+    assert_equal 0, @leaf.reload.progress
+  end
+
+  test "space unchecks a completed leaf before the request settles" do
+    @leaf.update!(progress: 1)
+    visit collavre.creatives_path
+    assert_selector "#{toggle_selector}[data-current-progress='1']"
+
+    # Stall the PATCH so the optimistic state stays observable: the box has to
+    # read unchecked from the keystroke itself, not from the server's re-render.
+    page.execute_script("window.fetch = () => new Promise(() => {})")
+    press_space_on_checkbox
+
+    assert_selector "#{toggle_selector}[data-current-progress='0']", wait: 5
+    assert_no_selector "#{toggle_selector} .progress-toggle-checkbox:checked", visible: :all
+  end
+end


### PR DESCRIPTION
## Problem

After #1553 a writable binary leaf renders a checkbox, but the two completed
states are now inconsistent:

- a completed **parent** renders the admin completion mark, which is blank by
  default, so finished branches disappear from the scan
- a completed **leaf** renders a checked box, which keeps drawing the eye

Following that through to "leaves show the mark too" creates a second problem:
with a blank mark there is nothing left to click, so undoing a mis-click would
mean opening the inline editor.

## Change

- `render_progress_toggle` emits the completion mark next to the checkbox
  (blank collapses to a non-breaking space so the row keeps its baseline and a
  tappable hit area)
- CSS stacks both in one grid cell and keys the swap off `data-current-progress`,
  which the optimistic toggle already flips — so completing a row reads as done
  before the PATCH settles
- hover or keyboard focus on a completed toggle brings the checked box back, so
  the mis-click case is undone in place
- the checkbox stays the accessible control (it carries `checked` and the
  `aria-label`; the mark is `aria-hidden`) and its `tabindex="-1"` is dropped, so
  the toggle is now reachable and operable by keyboard — it previously was not

## Tradeoff

With the default blank mark, a completed leaf shows nothing until hovered. On
touch there is no hover, so the undo affordance is only discoverable by tapping
the reserved 1.5em area. Setting a completion mark (e.g. `✓`) in admin settings
makes the completed state visible everywhere. Flagging it rather than adding a
coarse-pointer special case that would put the visual noise back on mobile.

## Tests

- `creatives_helper_test.rb` — mark rendered with the checkbox, blank falls back
  to a non-breaking space, no `tabindex="-1"`
- `creative_tree_row_progress_toggle.test.js` — completion state flips
  optimistically before the request settles

```
23 runs, 93 assertions, 0 failures  (creatives_helper_test)
75 runs, 263 assertions, 0 failures  (broadcast job + realtime + completion mark)
16 passed  (jest: progress toggle, tree_renderer, turbo_stream_actions)
rubocop: 2 files inspected, no offenses
```