### PR TITLE
fix: keep topic list search box unfocused on mobile

### DIFF
--- a/engines/collavre/app/javascript/controllers/__tests__/topic_list_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/topic_list_controller.test.js
@@ -79,4 +79,43 @@ describe('TopicListController', () => {
         expect(cb).toHaveBeenCalledWith(item)
         expect(controller.popup.isOpen()).toBe(false)
     })
+
+    describe('search-box focus', () => {
+        const originalInnerWidth = window.innerWidth
+        const setViewportWidth = (value) =>
+            Object.defineProperty(window, 'innerWidth', { value, configurable: true })
+
+        afterEach(() => setViewportWidth(originalInnerWidth))
+
+        test('focuses the search box on desktop widths', () => {
+            setViewportWidth(1024)
+            controller.openForTopics(DATA, RECT, () => {})
+            expect(document.activeElement).toBe(controller.inputTarget)
+        })
+
+        test('does not focus the search box on mobile widths', () => {
+            setViewportWidth(390)
+            controller.openForTopics(DATA, RECT, () => {})
+            expect(document.activeElement).not.toBe(controller.inputTarget)
+        })
+
+        test('blurs the previously focused element on mobile so the keyboard closes', () => {
+            setViewportWidth(390)
+            const chatInput = document.createElement('textarea')
+            document.body.appendChild(chatInput)
+            chatInput.focus()
+            expect(document.activeElement).toBe(chatInput)
+
+            controller.openForTopics(DATA, RECT, () => {})
+
+            expect(document.activeElement).toBe(document.body)
+        })
+
+        test('tolerates a mobile open with nothing focused', () => {
+            setViewportWidth(390)
+            expect(document.activeElement).toBe(document.body)
+            expect(() => controller.openForTopics(DATA, RECT, () => {})).not.toThrow()
+            expect(document.activeElement).toBe(document.body)
+        })
+    })
 })

--- a/engines/collavre/app/javascript/controllers/topic_list_controller.js
+++ b/engines/collavre/app/javascript/controllers/topic_list_controller.js
@@ -29,7 +29,23 @@ export default class extends CommonPopupController {
         this.inputTarget.value = ''
         this.setItems(this._allItems)
         super.open(anchorRect, boundsElement)
+        if (this.isMobile()) {
+            // Autofocusing the search box raises the virtual keyboard, which covers
+            // the very list the user just asked to see. Drop focus instead — tapping
+            // the box still opens the keyboard when the user actually wants to search.
+            this._blurActiveElement()
+            return
+        }
         requestAnimationFrame(() => this.inputTarget.focus())
+    }
+
+    isMobile() {
+        return window.innerWidth <= 600
+    }
+
+    _blurActiveElement() {
+        const active = document.activeElement
+        if (active && active !== document.body && typeof active.blur === 'function') active.blur()
     }
 
     _buildItems({ topics, archivedTopics, mainTopicId, allMessagesLabel }) {

--- a/engines/collavre/test/system/topic_list_popup_test.rb
+++ b/engines/collavre/test/system/topic_list_popup_test.rb
@@ -72,4 +72,28 @@ class TopicListPopupTest < ApplicationSystemTestCase
     assert_no_selector "#topic-list-modal", visible: :visible
     assert_selector "#comment-topics .topic-tag.active[data-id='#{@active_topic.id}']", wait: 5
   end
+
+  test "search box takes focus on a desktop viewport" do
+    open_comments_popup
+    find("#comments-popup .topic-list-btn").click
+    assert_selector "#topic-list-modal", visible: :visible, wait: 5
+
+    assert_equal true, page.evaluate_script(
+      "document.activeElement === document.querySelector('#topic-list-modal input')"
+    )
+  end
+
+  test "search box stays unfocused on a mobile viewport so the keyboard stays down" do
+    # Resize before opening: the chat popup only picks up its mobile bottom-sheet
+    # layout at open time, so a mid-flight resize would slide it off screen.
+    resize_window_to(390, 844)
+    open_comments_popup
+
+    find("#comments-popup .topic-list-btn").click
+    assert_selector "#topic-list-modal", visible: :visible, wait: 5
+
+    assert_equal false, page.evaluate_script(
+      "document.activeElement === document.querySelector('#topic-list-modal input')"
+    )
+  end
 end


### PR DESCRIPTION
## Problem

Opening the topic list popup autofocused its search box. On mobile that raises the virtual keyboard, which covers the very list the user just asked to see.

## Change

`topic_list_controller` now skips the autofocus on viewports `<= 600px` (the same mobile breakpoint the comments popup and presence controller already use) and blurs whatever was focused — typically the chat composer — so an already-open keyboard drops. Tapping the search box still raises the keyboard when the user actually wants to search. Desktop behaviour is unchanged.

## Tests

- `topic_list_controller.test.js`: desktop focuses the input; mobile does not; mobile blurs a previously focused element; mobile open with nothing focused does not throw.
- `topic_list_popup_test.rb`: system tests asserting `document.activeElement` on a desktop (1200px) and a mobile (390px) viewport.

The mobile system test resizes before opening the chat popup — the popup only picks up its mobile bottom-sheet layout at open time, so a mid-flight resize slides it off screen.

Verified locally: `bin/rails test engines/collavre/test/system/topic_list_popup_test.rb` → 5 runs, 35 assertions, 0 failures; `npm test -- topic_list_controller` → 8 passed.