### PR TITLE
Reveal the leaf progress checkbox on row hover

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/creatives.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/creatives.css
@@ -389,6 +389,27 @@ creative-tree-row.show-edit .creative-row {
     opacity: 0;
 }
 
+/* Pointer devices keep a resting row quiet: the checkbox joins the row's other
+   hover-revealed actions (edit, comments) instead of standing in every row, and
+   keyboard focus reveals it for pointerless navigation. Touch devices have no
+   hover to reveal it, so there the checkbox stays visible. The wrap keeps its
+   width either way, so revealing the box never shifts the row. */
+@media (hover: hover) {
+    .creative-row .progress-toggle-checkbox {
+        opacity: 0;
+    }
+
+    .creative-row:hover .progress-toggle-checkbox,
+    .creative-row .progress-toggle-wrap:focus-within .progress-toggle-checkbox {
+        opacity: 1;
+    }
+
+    .creative-row:hover .progress-toggle-wrap[data-current-progress="1"] .progress-toggle-mark,
+    .creative-row .progress-toggle-wrap[data-current-progress="1"]:focus-within .progress-toggle-mark {
+        opacity: 0;
+    }
+}
+
 @media (prefers-reduced-motion: reduce) {
     .progress-toggle-checkbox,
     .progress-toggle-mark {

--- a/engines/collavre/test/application_system_test_case.rb
+++ b/engines/collavre/test/application_system_test_case.rb
@@ -47,13 +47,14 @@ end
 
 at_exit { SystemTestChromeLocator.cleanup_temp_dirs }
 
-Capybara.register_driver :custom_headless_chrome do |app|
+BUILD_CHROME_DRIVER = lambda do |app, extra_arguments|
   options = Selenium::WebDriver::Chrome::Options.new
   options.add_argument "--headless"
   options.add_argument "--disable-gpu"
   options.add_argument "--no-sandbox"
   options.add_argument "--disable-dev-shm-usage"
   options.add_argument "--window-size=1920,1080"
+  extra_arguments.each { |argument| options.add_argument argument }
   user_data_dir = File.join(Dir.tmpdir, "chrome-profile-#{SecureRandom.uuid}")
   FileUtils.mkdir_p(user_data_dir)
   options.add_argument "--user-data-dir=#{user_data_dir}"
@@ -66,6 +67,21 @@ Capybara.register_driver :custom_headless_chrome do |app|
   driver_options[:service] = driver_service if driver_service
 
   Capybara::Selenium::Driver.new(app, **driver_options)
+end
+
+Capybara.register_driver(:custom_headless_chrome) { |app| BUILD_CHROME_DRIVER.call(app, []) }
+
+# A headless run inherits whatever pointer the host reports, and CI runners
+# report none — `@media (hover: hover)` rules would silently never apply there.
+# Blink settings pin a fine, hovering pointer (hover types: 1 none, 2 hover;
+# pointer types: 1 none, 2 coarse, 4 fine) so tests covering hover-revealed UI
+# see what a desktop browser sees. DevTools touch emulation still overrides it
+# per test, which is how the touch branch is covered.
+Capybara.register_driver(:hovering_pointer_headless_chrome) do |app|
+  BUILD_CHROME_DRIVER.call(
+    app,
+    [ "--blink-settings=availableHoverTypes=2,primaryHoverType=2,availablePointerTypes=4,primaryPointerType=4" ]
+  )
 end
 
 DRIVER_ENV_KEY = "SYSTEM_TEST_DRIVER".freeze

--- a/engines/collavre/test/system/creative_progress_toggle_visibility_test.rb
+++ b/engines/collavre/test/system/creative_progress_toggle_visibility_test.rb
@@ -1,0 +1,130 @@
+require_relative "../application_system_test_case"
+
+# The leaf progress checkbox is a hover action on pointer devices: a resting row
+# stays quiet and the box appears with the row's other hover controls. Touch
+# devices have no hover to reveal it, so the box stays visible there. Both
+# branches are CSS-only, so they are verified in a real browser.
+class CreativeProgressToggleVisibilityTest < ApplicationSystemTestCase
+  setup do
+    @user = User.create!(
+      email: "user@example.com",
+      password: SystemHelpers::PASSWORD,
+      name: "User",
+      email_verified_at: Time.current,
+      notifications_enabled: false
+    )
+    @incomplete = Creative.create!(description: "Incomplete", user: @user, progress: 0)
+    @complete = Creative.create!(description: "Complete", user: @user, progress: 1)
+
+    resize_window_to
+    sign_in_via_ui(@user)
+    visit collavre.creatives_path
+    assert page.evaluate_script("matchMedia('(hover: hover)').matches"),
+      "expected the test browser to report a hovering pointer"
+    assert_selector "#{wrap_selector(@incomplete)}[data-current-progress='0']"
+    assert_selector "#{wrap_selector(@complete)}[data-current-progress='1']"
+  end
+
+  teardown do
+    reset_touch_emulation
+  end
+
+  def row_selector(creative)
+    "#creative-#{creative.id} .creative-row"
+  end
+
+  def wrap_selector(creative)
+    "#creative-#{creative.id} .progress-toggle-wrap"
+  end
+
+  def opacity(selector)
+    page.evaluate_script(<<~JS)
+      (function () {
+        const element = document.querySelector("#{selector}");
+        return element ? window.getComputedStyle(element).opacity : null;
+      })()
+    JS
+  end
+
+  # The reveal is a 0.12s fade, so sample until it settles rather than reading
+  # the value mid-transition.
+  def assert_opacity(selector, expected, message)
+    deadline = Time.current + Capybara.default_max_wait_time
+    actual = nil
+    while Time.current < deadline
+      actual = opacity(selector)
+      break if actual.to_f.round(2) == expected
+      sleep 0.05
+    end
+    assert_equal expected, actual.to_f.round(2), "#{message} (opacity was #{actual.inspect})"
+  end
+
+  def hover_row(creative)
+    find(row_selector(creative)).hover
+  end
+
+  # Park the pointer in the viewport's corner: hovering another element could
+  # land on a second creative row, which is the state under test.
+  def unhover
+    page.driver.browser.action.move_to_location(0, 0).perform
+  end
+
+  # `Emulation.setEmulatedMedia` does not cover `hover`/`pointer`; only device
+  # emulation flips them, so a touch device is emulated the way DevTools does it.
+  def emulate_touch_device
+    page.driver.browser.execute_cdp("Emulation.setTouchEmulationEnabled", enabled: true, maxTouchPoints: 5)
+    page.driver.browser.execute_cdp(
+      "Emulation.setDeviceMetricsOverride",
+      width: 390, height: 844, deviceScaleFactor: 3, mobile: true
+    )
+    assert page.evaluate_script("matchMedia('(hover: none)').matches"),
+      "expected the emulated device to report no hover capability"
+  end
+
+  def reset_touch_emulation
+    page.driver.browser.execute_cdp("Emulation.clearDeviceMetricsOverride")
+    page.driver.browser.execute_cdp("Emulation.setTouchEmulationEnabled", enabled: false)
+  rescue StandardError
+    # The browser is already gone when a test tears down after a failure.
+  end
+
+  test "a pointer device hides the checkbox until the row is hovered" do
+    checkbox = "#{wrap_selector(@incomplete)} .progress-toggle-checkbox"
+    assert_opacity checkbox, 0.0, "expected a resting row to hide the checkbox"
+
+    hover_row(@incomplete)
+    assert_opacity checkbox, 1.0, "expected row hover to reveal the checkbox"
+
+    unhover
+    assert_opacity checkbox, 0.0, "expected the checkbox to hide again once the pointer leaves"
+  end
+
+  test "a pointer device swaps a completed leaf's mark for the checkbox on row hover" do
+    checkbox = "#{wrap_selector(@complete)} .progress-toggle-checkbox"
+    mark = "#{wrap_selector(@complete)} .progress-toggle-mark"
+    assert_opacity mark, 1.0, "expected a resting completed row to show the completion mark"
+    assert_opacity checkbox, 0.0, "expected a resting completed row to hide the checkbox"
+
+    hover_row(@complete)
+    assert_opacity checkbox, 1.0, "expected row hover to reveal the checked box"
+    assert_opacity mark, 0.0, "expected row hover to hide the completion mark"
+  end
+
+  test "keyboard focus reveals the checkbox without a pointer" do
+    checkbox = "#{wrap_selector(@incomplete)} .progress-toggle-checkbox"
+    assert_opacity checkbox, 0.0, "expected a resting row to hide the checkbox"
+
+    page.execute_script("document.querySelector('#{checkbox}').focus()")
+
+    assert_opacity checkbox, 1.0, "expected keyboard focus to reveal the checkbox"
+  end
+
+  test "a touch device keeps the checkbox visible without hover" do
+    emulate_touch_device
+
+    assert_opacity "#{wrap_selector(@incomplete)} .progress-toggle-checkbox", 1.0,
+      "expected a touch device to keep the checkbox visible"
+    assert_opacity "#{wrap_selector(@complete)} .progress-toggle-mark", 1.0,
+      "expected a touch device to keep the completion mark visible"
+  end
+end

--- a/engines/collavre/test/system/creative_progress_toggle_visibility_test.rb
+++ b/engines/collavre/test/system/creative_progress_toggle_visibility_test.rb
@@ -5,6 +5,10 @@ require_relative "../application_system_test_case"
 # devices have no hover to reveal it, so the box stays visible there. Both
 # branches are CSS-only, so they are verified in a real browser.
 class CreativeProgressToggleVisibilityTest < ApplicationSystemTestCase
+  # Headless runners report no pointer at all, so the hover branch needs a
+  # browser pinned to a desktop pointer to be observable.
+  driven_by :hovering_pointer_headless_chrome
+
   setup do
     @user = User.create!(
       email: "user@example.com",


### PR DESCRIPTION
## Summary
- Restore the pre-#1553 desktop behavior for the leaf progress control: on hover-capable pointers the checkbox is hidden in a resting row and appears on row hover, next to the row's other hover actions (edit, comments).
- Touch devices are untouched: with no hover to reveal it, the checkbox stays visible there.
- Keyboard focus reveals the checkbox too, so the control stays reachable without a pointer.
- A completed leaf still rests as the completion mark and swaps to the checked box on row hover, so a mis-click is undone in place.

The control keeps its grid cell either way, so revealing the checkbox never shifts the row.

## Validation
- `rbenv exec bundle exec bin/rails test engines/collavre/test/system/creative_progress_toggle_visibility_test.rb` (new, 4 tests: resting/hover, completed swap, keyboard focus, emulated touch device)
- `rbenv exec bundle exec bin/rails test engines/collavre/test/system/creative_progress_toggle_keyboard_test.rb`
- `npm test -- engines/collavre/app/javascript/components/__tests__/creative_tree_row_progress_toggle.test.js`
- `rbenv exec ruby ./bin/rubocop engines/collavre/test/system/creative_progress_toggle_visibility_test.rb`
- `npx stylelint` on the changed file reports only pre-existing violations elsewhere in it.

## CI note
`scan_ruby` fails on this branch for an unrelated reason: `bin/brakeman` runs with `--ensure-latest` and the lockfile pins brakeman 8.0.5 while 8.0.6 was just published, so the job exits 5 before scanning. It reproduces on an unmodified checkout and needs a separate `bundle update brakeman` chore. Every other check passes, including the `test` job that runs the new system test.
