### PR TITLE
fix: keep a topic pick from being reverted by a landing load

### DIFF
--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_selection_race.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_selection_race.test.js
@@ -759,4 +759,67 @@ describe('TopicsController deep-link sources vs. a preference broadcast', () => 
 
     expect(controller.currentTopicId).toBe('1')
   })
+
+  // Every selection schedules a save, restores included, and the save is
+  // debounced by 500ms. Accepting a broadcast without following it leaves that
+  // timer holding the topic the link put us on, so it lands afterwards and
+  // writes the deep link back over the preference the other session just set.
+  describe('a pending save against an accepted broadcast', () => {
+    beforeEach(() => {
+      jest.useFakeTimers()
+    })
+
+    afterEach(() => {
+      jest.runOnlyPendingTimers()
+      jest.useRealTimers()
+    })
+
+    test('the deep link is not written back over the broadcast preference', () => {
+      window.history.replaceState({}, '', '/creatives/42?topic_id=3')
+      controller.restoreSelection()
+
+      controller.handleTopicMessage({ action: 'last_topic_changed', last_topic_id: 2 })
+      jest.advanceTimersByTime(500)
+
+      expect(saveLastTopic).not.toHaveBeenCalledWith('42', '3')
+    })
+
+    // The broadcast is the preference now; nothing this popup had queued
+    // beforehand describes it, so nothing queued beforehand may be sent.
+    test('no save at all follows an accepted broadcast', () => {
+      controller.setOverrideTopicId('3')
+      controller.restoreSelection()
+
+      controller.handleTopicMessage({ action: 'last_topic_changed', last_topic_id: 2 })
+      jest.advanceTimersByTime(500)
+
+      expect(saveLastTopic).not.toHaveBeenCalled()
+      expect(controller.serverLastTopicId).toBe('2')
+    })
+
+    // Cancelling is scoped to the accepted broadcast. A selection the user
+    // makes afterwards is theirs, and still has to reach the server.
+    test('a pick after the broadcast still saves', () => {
+      controller.setOverrideTopicId('3')
+      controller.restoreSelection()
+      controller.handleTopicMessage({ action: 'last_topic_changed', last_topic_id: 2 })
+
+      controller.selectTopic('1')
+      jest.advanceTimersByTime(500)
+
+      expect(saveLastTopic).toHaveBeenCalledWith('42', '1')
+    })
+
+    // With no link to hold the view, the broadcast is followed, and following
+    // it re-arms the debounce with the broadcast's own value — so the timer
+    // must not be left cancelled on that path.
+    test('a followed broadcast still persists its own value', () => {
+      controller.restoreSelection()
+
+      controller.handleTopicMessage({ action: 'last_topic_changed', last_topic_id: 2 })
+      jest.advanceTimersByTime(500)
+
+      expect(saveLastTopic).toHaveBeenCalledWith('42', '2')
+    })
+  })
 })

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_selection_race.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_selection_race.test.js
@@ -376,6 +376,148 @@ describe('TopicsController selection vs. in-flight loadTopics', () => {
     })
   })
 
+  // Not every write to the selection is a pick. loadTopics() empties the strip
+  // for the duration of its fetch, so any re-render landing in that window
+  // restores against an empty topic list and falls back to Main. That fallback
+  // is derived from state the load is about to replace — treating it as intent
+  // newer than the answer suppresses the very value it was derived from.
+  describe('a programmatic restore while the strip is loading', () => {
+    const NEW_TOPIC = { id: 4, name: 'Delta' }
+
+    const respond = (resolveFetch, topics = TOPICS) => resolveFetch({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        topics,
+        archived_topics: [],
+        can_manage: true,
+        main_topic_id: 1,
+        last_topic_id: 2,
+      }),
+    })
+
+    // Another member creates a topic mid-load. handleTopicMessage() renders it
+    // on its own — this.topics was emptied — and restoreSelection() cannot find
+    // the saved topic among the one topic on screen.
+    const broadcastCreate = (userId = '99') => controller.handleTopicMessage({
+      action: 'created', topic: NEW_TOPIC, user_id: userId,
+    })
+
+    afterEach(() => { delete document.body.dataset.currentUserId })
+
+    test('does not suppress the response it was derived from', async () => {
+      let resolveFetch
+      global.fetch = jest.fn(() => new Promise((resolve) => { resolveFetch = resolve }))
+
+      const loading = controller.loadTopics()
+      broadcastCreate()
+      expect(controller.currentTopicId).toBe('1') // fell back to Main
+
+      respond(resolveFetch)
+      await loading
+
+      expect(controller.currentTopicId).toBe('2')
+      expect(controller.listTarget.querySelector('.topic-tag[data-id="2"]').classList)
+        .toContain('active')
+    })
+
+    test('does not persist Main over the saved preference', async () => {
+      let resolveFetch
+      global.fetch = jest.fn(() => new Promise((resolve) => { resolveFetch = resolve }))
+
+      const loading = controller.loadTopics()
+      broadcastCreate()
+
+      respond(resolveFetch)
+      await loading
+      await controller.flushSaveLastTopic(controller.currentTopicId)
+
+      expect(saveLastTopic).toHaveBeenLastCalledWith('42', '2')
+    })
+
+    // The fallback is not the user moving off the link either, so it must not
+    // consume the sources that outrank the preference. They are one-shot: once
+    // released, not even a reload gets the linked conversation back.
+    test('does not consume a deep-link override', async () => {
+      let resolveFetch
+      global.fetch = jest.fn(() => new Promise((resolve) => { resolveFetch = resolve }))
+      controller.setOverrideTopicId('3')
+
+      const loading = controller.loadTopics()
+      broadcastCreate()
+
+      respond(resolveFetch)
+      await loading
+
+      expect(controller.overrideTopicId).toBe('3')
+      expect(controller.currentTopicId).toBe('3')
+    })
+
+    test('does not strip ?topic_id=', async () => {
+      let resolveFetch
+      global.fetch = jest.fn(() => new Promise((resolve) => { resolveFetch = resolve }))
+      window.history.replaceState({}, '', '/creatives/42?topic_id=3')
+
+      const loading = controller.loadTopics()
+      broadcastCreate()
+
+      respond(resolveFetch)
+      await loading
+
+      expect(new URLSearchParams(window.location.search).get('topic_id')).toBe('3')
+      expect(controller.currentTopicId).toBe('3')
+    })
+
+    // The fallback is not the only restore that can land mid-load. archivedTopics
+    // outlives the emptied strip, so a preference naming an archived topic is
+    // still found — and re-selecting it is no more a pick than falling back to
+    // Main is. Left as one, it discards a preference another session moved and
+    // writes the local value back over it.
+    test('re-selecting the topic already held does not suppress the response', async () => {
+      let resolveFetch
+      global.fetch = jest.fn(() => new Promise((resolve) => { resolveFetch = resolve }))
+      controller.archivedTopics = [{ id: 5, name: 'Archived' }]
+      controller.serverLastTopicId = '5'
+
+      const loading = controller.loadTopics()
+      broadcastCreate()
+      expect(controller.currentTopicId).toBe('5') // found among the archived
+
+      resolveFetch({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          topics: TOPICS,
+          archived_topics: [{ id: 5, name: 'Archived' }],
+          can_manage: true,
+          main_topic_id: 1,
+          last_topic_id: 2,
+        }),
+      })
+      await loading
+      await controller.flushSaveLastTopic(controller.currentTopicId)
+
+      expect(controller.currentTopicId).toBe('2')
+      expect(saveLastTopic).toHaveBeenLastCalledWith('42', '2')
+    })
+
+    // The same broadcast for a topic this user created elsewhere auto-selects
+    // it, and that is intent — it still has to outrank the landing answer.
+    test('the auto-select of the user\'s own new topic still outranks the response', async () => {
+      let resolveFetch
+      global.fetch = jest.fn(() => new Promise((resolve) => { resolveFetch = resolve }))
+      document.body.dataset.currentUserId = '7'
+
+      const loading = controller.loadTopics()
+      broadcastCreate('7')
+
+      respond(resolveFetch, [...TOPICS, NEW_TOPIC])
+      await loading
+
+      expect(controller.currentTopicId).toBe('4')
+    })
+  })
+
   // A load that starts *after* the pick is not racing it, so its answer wins
   // normally — otherwise a creative switch could never move the selection.
   test('a load started after the pick still restores the server selection', async () => {

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_selection_race.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_selection_race.test.js
@@ -455,6 +455,24 @@ describe('TopicsController selection vs. in-flight loadTopics', () => {
       expect(saveLastTopic).toHaveBeenLastCalledWith('42', '3')
     })
 
+    test('re-dispatches a picked All Messages after an interim restore', async () => {
+      let resolveFetch
+      global.fetch = jest.fn(() => new Promise((resolve) => { resolveFetch = resolve }))
+
+      const loading = controller.loadTopics()
+      controller.selectTopic('')
+      broadcastCreate()
+      expect(changeEvents.at(-1).topicId).toBe('1')
+
+      respond(resolveFetch)
+      await loading
+
+      expect(controller.currentTopicId).toBe('')
+      expect(changeEvents.at(-1).topicId).toBe('')
+      expect(controller.listTarget.querySelector('.topic-tag[data-id=""]').classList)
+        .toContain('active')
+    })
+
     // The fallback is not the user moving off the link either, so it must not
     // consume the sources that outrank the preference. They are one-shot: once
     // released, not even a reload gets the linked conversation back.

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_selection_race.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_selection_race.test.js
@@ -435,6 +435,26 @@ describe('TopicsController selection vs. in-flight loadTopics', () => {
       expect(saveLastTopic).toHaveBeenLastCalledWith('42', '2')
     })
 
+    // A real pick has already won this load. A later restore is derived from
+    // the interim one-topic strip, so it may fall back to Main, but it must not
+    // replace the id associated with that authoritative pick.
+    test('retains a picked topic across an interim restore', async () => {
+      let resolveFetch
+      global.fetch = jest.fn(() => new Promise((resolve) => { resolveFetch = resolve }))
+
+      const loading = controller.loadTopics()
+      controller.selectTopic('3')
+      broadcastCreate()
+      expect(controller.currentTopicId).toBe('1')
+
+      respond(resolveFetch)
+      await loading
+
+      expect(controller.currentTopicId).toBe('3')
+      await controller.flushSaveLastTopic(controller.currentTopicId)
+      expect(saveLastTopic).toHaveBeenLastCalledWith('42', '3')
+    })
+
     // The fallback is not the user moving off the link either, so it must not
     // consume the sources that outrank the preference. They are one-shot: once
     // released, not even a reload gets the linked conversation back.

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_selection_race.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_selection_race.test.js
@@ -503,3 +503,118 @@ describe('TopicsController selection vs. higher-priority selection sources', () 
     expect(controller.currentTopicId).toBe('')
   })
 })
+
+// last_topic_changed is another session of the same user moving the saved
+// preference. It is not a click in this popup, so it must not consume the
+// deep-link sources this popup was opened on — they outrank the preference by
+// design, and they are gone for good once released.
+describe('TopicsController deep-link sources vs. a preference broadcast', () => {
+  let application
+  let controller
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div id="topics" data-controller="comments--topics" data-topic-main-text="All Messages">
+        <div data-comments--topics-target="list"></div>
+      </div>
+    `
+    Element.prototype.scrollIntoView = jest.fn()
+
+    application = Application.start()
+    application.register('comments--topics', TopicsController)
+
+    return new Promise((resolve) => setTimeout(resolve, 0)).then(() => {
+      controller = application.getControllerForElementAndIdentifier(
+        document.getElementById('topics'), 'comments--topics'
+      )
+      controller.creativeIdValue = '42'
+      controller.topics = TOPICS
+      controller.archivedTopics = []
+      controller.mainTopicId = '1'
+      controller.canManageTopics = true
+      controller.showingArchived = false
+      controller.serverLastTopicId = ''
+      controller.renderTopics(TOPICS, true)
+    })
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+    application.stop()
+    jest.clearAllMocks()
+    window.history.replaceState({}, '', '/')
+  })
+
+  test('a broadcast does not consume a deep-link override', () => {
+    controller.setOverrideTopicId('3')
+
+    controller.handleTopicMessage({ action: 'last_topic_changed', last_topic_id: 2 })
+
+    expect(controller.overrideTopicId).toBe('3')
+    expect(controller.currentTopicId).toBe('3')
+  })
+
+  test('a broadcast does not strip ?topic_id=', () => {
+    window.history.replaceState({}, '', '/creatives/42?topic_id=3')
+
+    controller.handleTopicMessage({ action: 'last_topic_changed', last_topic_id: 2 })
+
+    expect(new URLSearchParams(window.location.search).get('topic_id')).toBe('3')
+    expect(controller.currentTopicId).toBe('3')
+  })
+
+  test('a broadcast leaves the linked topic selected in the strip', () => {
+    controller.setOverrideTopicId('3')
+
+    controller.handleTopicMessage({ action: 'last_topic_changed', last_topic_id: 2 })
+    controller.restoreSelection()
+
+    expect(controller.listTarget.querySelector('.topic-tag[data-id="3"]').classList)
+      .toContain('active')
+    expect(controller.listTarget.querySelector('.topic-tag[data-id="2"]').classList)
+      .not.toContain('active')
+  })
+
+  test('the broadcast preference is still recorded behind the deep link', () => {
+    controller.setOverrideTopicId('3')
+
+    controller.handleTopicMessage({ action: 'last_topic_changed', last_topic_id: 2 })
+
+    expect(controller.serverLastTopicId).toBe('2')
+    // Releasing the link hands the popup back to the preference the other
+    // session set, rather than to a value this popup never heard about.
+    controller.clearOverrideTopicId()
+    expect(controller.currentTopicId).toBe('2')
+  })
+
+  // comments_controller sends X-Topic-Id as effective_topic_id.to_s, so a
+  // comment that belongs to no topic resolves the deep link to All Messages and
+  // list_controller sets the override to "". It outranks the preference exactly
+  // like a named one — truthiness is the wrong test for "is a link set".
+  test('a broadcast does not consume a deep link that resolved to All Messages', () => {
+    controller.setOverrideTopicId('')
+
+    controller.handleTopicMessage({ action: 'last_topic_changed', last_topic_id: 2 })
+
+    expect(controller.overrideTopicId).toBe('')
+    expect(controller.currentTopicId).toBe('')
+  })
+
+  test('a broadcast still moves the selection when no deep link outranks it', () => {
+    controller.handleTopicMessage({ action: 'last_topic_changed', last_topic_id: 2 })
+
+    expect(controller.serverLastTopicId).toBe('2')
+    expect(controller.currentTopicId).toBe('2')
+    expect(controller.listTarget.querySelector('.topic-tag[data-id="2"]').classList)
+      .toContain('active')
+  })
+
+  test('a pick after a broadcast still supersedes the deep link', () => {
+    controller.setOverrideTopicId('3')
+    controller.handleTopicMessage({ action: 'last_topic_changed', last_topic_id: 2 })
+
+    controller.selectTopic('1')
+
+    expect(controller.currentTopicId).toBe('1')
+  })
+})

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_selection_race.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_selection_race.test.js
@@ -48,6 +48,10 @@ describe('TopicsController selection vs. in-flight loadTopics', () => {
       controller.canManageTopics = true
       controller.showingArchived = false
       controller.serverLastTopicId = '2'
+      // The strip is on screen before any of these races start — that is what
+      // makes a chip clickable, and it is what marks the pick as being about
+      // creative 42.
+      controller.renderTopics(TOPICS, true)
     })
   })
 
@@ -117,10 +121,102 @@ describe('TopicsController selection vs. in-flight loadTopics', () => {
     expect(controller.serverLastTopicId).toBe('3')
   })
 
-  // A pick can only outrank the response if it names a topic the response
-  // knows. Switching creatives leaves the previous creative's chips on screen
-  // until the new strip lands, so a click in that window picks a topic that
-  // does not belong to the creative being loaded — not intent about it.
+  // The strip can also be stale about its own creative: another member deletes
+  // a topic while the chip for it is still on screen. The pick is about this
+  // creative, but it names a topic that no longer exists, so keeping it would
+  // fail the lookup in restoreSelection() and persist Main over the preference
+  // the server actually holds.
+  test('a pick naming a topic the response no longer lists yields to the answer', async () => {
+    let resolveFetch
+    global.fetch = jest.fn(() => new Promise((resolve) => { resolveFetch = resolve }))
+
+    const loading = controller.loadTopics()
+    controller.selectTopic('3')
+
+    resolveFetch({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        topics: [{ id: 1, name: 'Main' }, { id: 2, name: 'Alpha' }],
+        archived_topics: [],
+        can_manage: true,
+        main_topic_id: 1,
+        last_topic_id: 2,
+      }),
+    })
+    await loading
+
+    expect(controller.currentTopicId).toBe('2')
+  })
+
+  // All Messages carries no topic id, so nothing about it can be read off the
+  // saved preference — but it is still a pick, and a landing load must not undo
+  // it any more than it may undo a chip click.
+  describe('an All Messages pick while the strip is loading', () => {
+    const respond = (resolveFetch) => resolveFetch({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        topics: TOPICS,
+        archived_topics: [],
+        can_manage: true,
+        main_topic_id: 1,
+        last_topic_id: 2,
+      }),
+    })
+
+    test('survives the response', async () => {
+      let resolveFetch
+      global.fetch = jest.fn(() => new Promise((resolve) => { resolveFetch = resolve }))
+
+      const loading = controller.loadTopics()
+      controller.selectTopic('')
+
+      respond(resolveFetch)
+      await loading
+
+      expect(controller.currentTopicId).toBe('')
+      expect(controller.listTarget.querySelector('.topic-all-messages').classList)
+        .toContain('active')
+    })
+
+    // The revert this PR is about is the message list snapping back, so the
+    // change event matters as much as the strip: nothing may re-announce the
+    // topic the user just left.
+    test('does not re-announce the topic the user left', async () => {
+      let resolveFetch
+      global.fetch = jest.fn(() => new Promise((resolve) => { resolveFetch = resolve }))
+
+      const loading = controller.loadTopics()
+      controller.selectTopic('')
+
+      respond(resolveFetch)
+      await loading
+
+      expect(changeEvents.at(-1).topicId).toBe('')
+    })
+
+    // ...and the debounced save must still record the pick, not the stale
+    // answer that overtook it.
+    test('persists All Messages, not the stale answer', async () => {
+      let resolveFetch
+      global.fetch = jest.fn(() => new Promise((resolve) => { resolveFetch = resolve }))
+
+      const loading = controller.loadTopics()
+      controller.selectTopic('')
+
+      respond(resolveFetch)
+      await loading
+      await controller.flushSaveLastTopic(controller.currentTopicId)
+
+      expect(saveLastTopic).toHaveBeenLastCalledWith('42', null)
+    })
+  })
+
+  // A pick can only outrank the response if it was made against the strip of
+  // the creative the response describes. Switching creatives leaves the
+  // previous creative's chips on screen until the new strip lands, so a click
+  // in that window is not intent about the creative being loaded.
   describe('a pick against the previous creative\'s strip', () => {
     const OTHER_TOPICS = [{ id: 10, name: 'Main' }, { id: 11, name: 'Gamma' }]
 
@@ -170,9 +266,9 @@ describe('TopicsController selection vs. in-flight loadTopics', () => {
       expect(saveLastTopic).toHaveBeenLastCalledWith('99', '11')
     })
 
-    // All Messages is not a persisted selection — saveLastTopic stores null for
-    // it and restoreSelection falls back to Main — so an empty pick cannot
-    // outrank the answer, and the creative being opened resolves normally.
+    // An empty pick is authoritative for the creative whose strip it was made
+    // against, and this one was made against the previous creative's — so the
+    // creative being opened still resolves to its own saved topic.
     test('an empty pick does not suppress the response either', async () => {
       let resolveFetch
       global.fetch = jest.fn(() => new Promise((resolve) => { resolveFetch = resolve }))

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_selection_race.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_selection_race.test.js
@@ -1,0 +1,246 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { jest } from '@jest/globals'
+
+const saveLastTopic = jest.fn().mockResolvedValue(undefined)
+
+jest.unstable_mockModule('../../../lib/api/topics', () => ({
+  fetchNextTopicName: jest.fn(),
+  createTopicWithComments: jest.fn(),
+  saveLastTopic,
+}))
+
+const { Application } = await import('@hotwired/stimulus')
+const TopicsController = (await import('../topics_controller')).default
+
+const TOPICS = [{ id: 1, name: 'Main' }, { id: 2, name: 'Alpha' }, { id: 3, name: 'Beta' }]
+
+describe('TopicsController selection vs. in-flight loadTopics', () => {
+  let application
+  let controller
+  let changeEvents
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div id="topics" data-controller="comments--topics" data-topic-main-text="All Messages">
+        <div data-comments--topics-target="list"></div>
+      </div>
+    `
+    Element.prototype.scrollIntoView = jest.fn()
+    document.head.innerHTML = '<meta name="csrf-token" content="test-csrf">'
+
+    application = Application.start()
+    application.register('comments--topics', TopicsController)
+
+    changeEvents = []
+    document.addEventListener('comments--topics:change', (e) => changeEvents.push(e.detail))
+
+    return new Promise((resolve) => setTimeout(resolve, 0)).then(() => {
+      controller = application.getControllerForElementAndIdentifier(
+        document.getElementById('topics'), 'comments--topics'
+      )
+      controller.creativeIdValue = '42'
+      controller.topics = TOPICS
+      controller.archivedTopics = []
+      controller.mainTopicId = '1'
+      controller.canManageTopics = true
+      controller.showingArchived = false
+      controller.serverLastTopicId = '2'
+    })
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+    document.head.innerHTML = ''
+    application.stop()
+    jest.clearAllMocks()
+    delete global.fetch
+    window.history.replaceState({}, '', '/')
+  })
+
+  // The user picked a topic while the strip was still fetching. The server's
+  // last_topic_id still names the topic they left, because the save for the new
+  // pick is debounced and has not landed. Honouring it throws the click away.
+  test('a topic picked while the strip is loading survives the response', async () => {
+    let resolveFetch
+    global.fetch = jest.fn(() => new Promise((resolve) => { resolveFetch = resolve }))
+
+    const loading = controller.loadTopics()
+
+    // The user clicks Beta while the fetch is in flight.
+    controller.selectTopic('3')
+    expect(controller.currentTopicId).toBe('3')
+
+    resolveFetch({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        topics: TOPICS,
+        archived_topics: [],
+        can_manage: true,
+        main_topic_id: 1,
+        last_topic_id: 2,
+      }),
+    })
+    await loading
+
+    expect(controller.currentTopicId).toBe('3')
+    expect(changeEvents.at(-1).topicId).toBe('3')
+    expect(controller.listTarget.querySelector('.topic-tag[data-id="3"]').classList)
+      .toContain('active')
+  })
+
+  // Same race, one step earlier: the pick has to survive the assignment of the
+  // server's answer to serverLastTopicId, not just restoreSelection().
+  test('the stale server last_topic_id does not overwrite the pick', async () => {
+    let resolveFetch
+    global.fetch = jest.fn(() => new Promise((resolve) => { resolveFetch = resolve }))
+
+    const loading = controller.loadTopics()
+    controller.selectTopic('3')
+
+    resolveFetch({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        topics: TOPICS,
+        archived_topics: [],
+        can_manage: true,
+        main_topic_id: 1,
+        last_topic_id: 2,
+      }),
+    })
+    await loading
+
+    expect(controller.serverLastTopicId).toBe('3')
+  })
+
+  // A load that starts *after* the pick is not racing it, so its answer wins
+  // normally — otherwise a creative switch could never move the selection.
+  test('a load started after the pick still restores the server selection', async () => {
+    controller.selectTopic('3')
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        topics: TOPICS,
+        archived_topics: [],
+        can_manage: true,
+        main_topic_id: 1,
+        last_topic_id: 2,
+      }),
+    })
+
+    await controller.loadTopics()
+
+    expect(controller.currentTopicId).toBe('2')
+  })
+})
+
+// The deep-link override and ?topic_id= both outrank the saved preference in
+// the getter, so a pick that only writes the preference never becomes the
+// answer — the next render lights the old chip and the next restore navigates
+// back to it.
+describe('TopicsController selection vs. higher-priority selection sources', () => {
+  let application
+  let controller
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div id="topics" data-controller="comments--topics" data-topic-main-text="All Messages">
+        <div data-comments--topics-target="list"></div>
+      </div>
+    `
+    Element.prototype.scrollIntoView = jest.fn()
+
+    application = Application.start()
+    application.register('comments--topics', TopicsController)
+
+    return new Promise((resolve) => setTimeout(resolve, 0)).then(() => {
+      controller = application.getControllerForElementAndIdentifier(
+        document.getElementById('topics'), 'comments--topics'
+      )
+      controller.creativeIdValue = '42'
+      controller.topics = TOPICS
+      controller.archivedTopics = []
+      controller.mainTopicId = '1'
+      controller.canManageTopics = true
+      controller.showingArchived = false
+      controller.serverLastTopicId = ''
+    })
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+    application.stop()
+    jest.clearAllMocks()
+    window.history.replaceState({}, '', '/')
+  })
+
+  test('a pick supersedes a deep-link override for a different topic', () => {
+    controller.setOverrideTopicId('2')
+
+    controller.selectTopic('3')
+
+    expect(controller.currentTopicId).toBe('3')
+  })
+
+  test('restoreSelection after such a pick stays on the picked topic', () => {
+    controller.setOverrideTopicId('2')
+    controller.selectTopic('3')
+
+    controller.restoreSelection()
+    controller.renderTopics(controller.topics, controller.canManageTopics)
+
+    expect(controller.currentTopicId).toBe('3')
+    expect(controller.listTarget.querySelector('.topic-tag[data-id="3"]').classList)
+      .toContain('active')
+  })
+
+  test('an override agreeing with the pick is kept so it can still outrank the server', () => {
+    controller.setOverrideTopicId('3')
+
+    controller.selectTopic('3')
+
+    expect(controller.overrideTopicId).toBe('3')
+    controller.serverLastTopicId = '2' // as a later loadTopics() would write it
+    expect(controller.currentTopicId).toBe('3')
+  })
+
+  test('a pick drops a ?topic_id= naming a different topic', () => {
+    window.history.replaceState({}, '', '/creatives/42?topic_id=2')
+
+    controller.selectTopic('3')
+
+    expect(controller.currentTopicId).toBe('3')
+    expect(new URLSearchParams(window.location.search).get('topic_id')).toBeNull()
+  })
+
+  test('a pick keeps a ?topic_id= naming the topic it selected', () => {
+    window.history.replaceState({}, '', '/creatives/42?topic_id=3')
+
+    controller.selectTopic('3')
+
+    expect(new URLSearchParams(window.location.search).get('topic_id')).toBe('3')
+  })
+
+  test('selecting All Messages drops a ?topic_id= too', () => {
+    window.history.replaceState({}, '', '/creatives/42?topic_id=2')
+
+    controller.selectTopic('')
+
+    expect(controller.currentTopicId).toBe('')
+    expect(new URLSearchParams(window.location.search).get('topic_id')).toBeNull()
+  })
+
+  test('selecting All Messages drops a deep-link override too', () => {
+    controller.setOverrideTopicId('2')
+
+    controller.selectTopic('')
+
+    expect(controller.currentTopicId).toBe('')
+  })
+})

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_selection_race.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_selection_race.test.js
@@ -117,6 +117,76 @@ describe('TopicsController selection vs. in-flight loadTopics', () => {
     expect(controller.serverLastTopicId).toBe('3')
   })
 
+  // A pick can only outrank the response if it names a topic the response
+  // knows. Switching creatives leaves the previous creative's chips on screen
+  // until the new strip lands, so a click in that window picks a topic that
+  // does not belong to the creative being loaded — not intent about it.
+  describe('a pick against the previous creative\'s strip', () => {
+    const OTHER_TOPICS = [{ id: 10, name: 'Main' }, { id: 11, name: 'Gamma' }]
+
+    const switchTo = (creativeId) => {
+      controller.subscribe = jest.fn()
+      return controller.onPopupOpened({ creativeId })
+    }
+
+    const otherCreativeResponse = {
+      ok: true,
+      status: 200,
+      json: async () => ({
+        topics: OTHER_TOPICS,
+        archived_topics: [],
+        can_manage: true,
+        main_topic_id: 10,
+        last_topic_id: 11,
+      }),
+    }
+
+    test('does not discard the new creative\'s last_topic_id', async () => {
+      let resolveFetch
+      global.fetch = jest.fn(() => new Promise((resolve) => { resolveFetch = resolve }))
+
+      const switching = switchTo('99')
+      // Beta belongs to creative 42; its chip is still rendered.
+      controller.selectTopic('3')
+
+      resolveFetch(otherCreativeResponse)
+      await switching
+
+      expect(controller.serverLastTopicId).toBe('11')
+      expect(controller.currentTopicId).toBe('11')
+    })
+
+    test('does not persist Main as the new creative\'s preference', async () => {
+      let resolveFetch
+      global.fetch = jest.fn(() => new Promise((resolve) => { resolveFetch = resolve }))
+
+      const switching = switchTo('99')
+      controller.selectTopic('3')
+
+      resolveFetch(otherCreativeResponse)
+      await switching
+      await controller.flushSaveLastTopic(controller.currentTopicId)
+
+      expect(saveLastTopic).toHaveBeenLastCalledWith('99', '11')
+    })
+
+    // All Messages is not a persisted selection — saveLastTopic stores null for
+    // it and restoreSelection falls back to Main — so an empty pick cannot
+    // outrank the answer, and the creative being opened resolves normally.
+    test('an empty pick does not suppress the response either', async () => {
+      let resolveFetch
+      global.fetch = jest.fn(() => new Promise((resolve) => { resolveFetch = resolve }))
+
+      const switching = switchTo('99')
+      controller.selectTopic('')
+
+      resolveFetch(otherCreativeResponse)
+      await switching
+
+      expect(controller.currentTopicId).toBe('11')
+    })
+  })
+
   // A load that starts *after* the pick is not racing it, so its answer wins
   // normally — otherwise a creative switch could never move the selection.
   test('a load started after the pick still restores the server selection', async () => {

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_selection_race.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_selection_race.test.js
@@ -213,6 +213,99 @@ describe('TopicsController selection vs. in-flight loadTopics', () => {
     })
   })
 
+  // The legacy per-browser preference is adopted on the first load that finds
+  // the server holding nothing. A winning empty pick leaves the server value
+  // empty on purpose, which reads exactly the same to the migration — so it
+  // would hand the user back the topic they just left, by another route.
+  describe('a winning empty pick against the localStorage migration', () => {
+    const LEGACY_KEY = 'collavre_creative_42_last_topic'
+
+    const respond = (resolveFetch, lastTopicId) => resolveFetch({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        topics: TOPICS,
+        archived_topics: [],
+        can_manage: true,
+        main_topic_id: 1,
+        last_topic_id: lastTopicId,
+      }),
+    })
+
+    afterEach(() => localStorage.clear())
+
+    test('the migration does not restore the legacy topic over the pick', async () => {
+      localStorage.setItem(LEGACY_KEY, '2')
+      let resolveFetch
+      global.fetch = jest.fn(() => new Promise((resolve) => { resolveFetch = resolve }))
+
+      const loading = controller.loadTopics()
+      controller.selectTopic('')
+
+      respond(resolveFetch, 2)
+      await loading
+
+      expect(controller.currentTopicId).toBe('')
+      expect(controller.listTarget.querySelector('.topic-all-messages').classList)
+        .toContain('active')
+    })
+
+    test('the legacy topic is not persisted as the preference either', async () => {
+      localStorage.setItem(LEGACY_KEY, '2')
+      let resolveFetch
+      global.fetch = jest.fn(() => new Promise((resolve) => { resolveFetch = resolve }))
+
+      const loading = controller.loadTopics()
+      controller.selectTopic('')
+
+      respond(resolveFetch, null)
+      await loading
+      await controller.flushSaveLastTopic(controller.currentTopicId)
+
+      expect(saveLastTopic).not.toHaveBeenCalledWith('42', '2')
+      expect(saveLastTopic).toHaveBeenLastCalledWith('42', null)
+    })
+
+    // The pick supersedes the legacy value, so the key has served its purpose
+    // and must not be left behind to re-apply on the next load.
+    test('the legacy key is still cleared', async () => {
+      localStorage.setItem(LEGACY_KEY, '2')
+      let resolveFetch
+      global.fetch = jest.fn(() => new Promise((resolve) => { resolveFetch = resolve }))
+
+      const loading = controller.loadTopics()
+      controller.selectTopic('')
+
+      respond(resolveFetch, null)
+      await loading
+
+      expect(localStorage.getItem(LEGACY_KEY)).toBeNull()
+    })
+
+    // ...and the migration itself is untouched when no pick is racing it.
+    test('an unraced load still migrates the legacy topic', async () => {
+      localStorage.setItem(LEGACY_KEY, '2')
+      controller.serverLastTopicId = ''
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          topics: TOPICS,
+          archived_topics: [],
+          can_manage: true,
+          main_topic_id: 1,
+          last_topic_id: null,
+        }),
+      })
+
+      await controller.loadTopics()
+
+      expect(controller.currentTopicId).toBe('2')
+      expect(saveLastTopic).toHaveBeenCalledWith('42', '2')
+      expect(localStorage.getItem(LEGACY_KEY)).toBeNull()
+    })
+  })
+
   // A pick can only outrank the response if it was made against the strip of
   // the creative the response describes. Switching creatives leaves the
   // previous creative's chips on screen until the new strip lands, so a click

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_selection_race.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_selection_race.test.js
@@ -573,9 +573,10 @@ describe('TopicsController selection vs. in-flight loadTopics', () => {
     })
   })
 
-  // A load that starts *after* the pick is not racing it, so its answer wins
-  // normally — otherwise a creative switch could never move the selection.
-  test('a load started after the pick still restores the server selection', async () => {
+  // A subsequent reload can begin before the debounce lands — archive state
+  // broadcasts do exactly that. Its answer still predates the unsaved pick,
+  // even though the pick happened before this particular request began.
+  test('an unsaved pick survives a load started after the pick', async () => {
     controller.selectTopic('3')
 
     global.fetch = jest.fn().mockResolvedValue({
@@ -592,7 +593,55 @@ describe('TopicsController selection vs. in-flight loadTopics', () => {
 
     await controller.loadTopics()
 
+    expect(controller.currentTopicId).toBe('3')
+    await controller.flushSaveLastTopic(controller.currentTopicId)
+    expect(saveLastTopic).toHaveBeenLastCalledWith('42', '3')
+  })
+
+  // Once that pick reaches the server, a later load is free to take the
+  // server's value again. The pending marker must not become a permanent
+  // preference override.
+  test('a saved pick yields to a later load', async () => {
+    controller.selectTopic('3')
+    await controller.flushSaveLastTopic('3')
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        topics: TOPICS,
+        archived_topics: [],
+        can_manage: true,
+        main_topic_id: 1,
+        last_topic_id: 2,
+      }),
+    })
+
+    await controller.loadTopics()
+
     expect(controller.currentTopicId).toBe('2')
+  })
+
+  test('a failed save keeps the pick authoritative for a later load', async () => {
+    controller.selectTopic('3')
+    saveLastTopic.mockResolvedValueOnce(false)
+    await controller.flushSaveLastTopic('3')
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        topics: TOPICS,
+        archived_topics: [],
+        can_manage: true,
+        main_topic_id: 1,
+        last_topic_id: 2,
+      }),
+    })
+
+    await controller.loadTopics()
+
+    expect(controller.currentTopicId).toBe('3')
   })
 })
 

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_selection_race.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_selection_race.test.js
@@ -374,6 +374,23 @@ describe('TopicsController selection vs. in-flight loadTopics', () => {
 
       expect(controller.currentTopicId).toBe('11')
     })
+
+    test('toggling stale archived topics does not make their strip look current', async () => {
+      controller.archivedTopics = [{ id: 4, name: 'Archived Alpha' }]
+      controller.renderTopics(TOPICS, true)
+      let resolveFetch
+      global.fetch = jest.fn(() => new Promise((resolve) => { resolveFetch = resolve }))
+
+      const switching = switchTo('99')
+      controller.toggleArchivedTopics({ stopPropagation: jest.fn() })
+      controller.selectTopic('')
+
+      resolveFetch(otherCreativeResponse)
+      await switching
+
+      expect(controller.serverLastTopicId).toBe('11')
+      expect(controller.currentTopicId).toBe('11')
+    })
   })
 
   // Not every write to the selection is a pick. loadTopics() empties the strip
@@ -858,6 +875,18 @@ describe('TopicsController deep-link sources vs. a preference broadcast', () => 
       jest.advanceTimersByTime(500)
 
       expect(saveLastTopic).toHaveBeenCalledWith('42', '2')
+    })
+
+    test('a later restore leaves the broadcast preference behind the deep link', () => {
+      controller.setOverrideTopicId('3')
+      controller.handleTopicMessage({ action: 'last_topic_changed', last_topic_id: 2 })
+
+      controller.handleTopicMessage({ action: 'updated', topic: { id: 1, name: 'Renamed Main' } })
+      jest.advanceTimersByTime(500)
+
+      expect(controller.currentTopicId).toBe('3')
+      expect(controller.serverLastTopicId).toBe('2')
+      expect(saveLastTopic).not.toHaveBeenCalledWith('42', '3')
     })
   })
 })

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_selection_race.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_selection_race.test.js
@@ -391,6 +391,32 @@ describe('TopicsController selection vs. in-flight loadTopics', () => {
       expect(controller.serverLastTopicId).toBe('11')
       expect(controller.currentTopicId).toBe('11')
     })
+
+    test('attributes a new-creative broadcast to the current creative', async () => {
+      const NEW_OTHER_TOPIC = { id: 12, name: 'Delta' }
+      let resolveFetch
+      global.fetch = jest.fn(() => new Promise((resolve) => { resolveFetch = resolve }))
+
+      const switching = switchTo('99')
+      controller.handleTopicMessage({ action: 'created', topic: NEW_OTHER_TOPIC, user_id: '88' })
+      controller.selectTopic('12')
+
+      resolveFetch({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          topics: [...OTHER_TOPICS, NEW_OTHER_TOPIC],
+          archived_topics: [],
+          can_manage: true,
+          main_topic_id: 10,
+          last_topic_id: 11,
+        }),
+      })
+      await switching
+
+      expect(controller._pickCreativeId).toBe('99')
+      expect(controller.currentTopicId).toBe('12')
+    })
   })
 
   // Not every write to the selection is a pick. loadTopics() empties the strip

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -839,7 +839,7 @@ export default class extends Controller {
             this.archivedAwayTopicId = null
         }
         if (reveal) this.revealArchivedTopic(id)
-        this.updateSelectionUI(id, { pick, persist })
+        this.updateSelectionUI(id, { pick, persist, pending: pick })
         if (id) {
             this.clearNewMessageBadge(id)
         }
@@ -929,8 +929,8 @@ export default class extends Controller {
         }
     }
 
-    updateSelectionUI(id, { pick = true, persist = true } = {}) {
-        this.applySelection(id, { pick, persist })
+    updateSelectionUI(id, { pick = true, persist = true, pending = false } = {}) {
+        this.applySelection(id, { pick, persist, pending })
         // Update UI
         let activeEl = null
         this.listTarget.querySelectorAll('.topic-tag').forEach(el => {
@@ -1097,7 +1097,7 @@ export default class extends Controller {
     // must leave the sources that outrank the preference alone. Recording the
     // preference and saving it happen either way; only the two consequences of
     // *intent* are gated.
-    applySelection(id, { pick = true, persist = true } = {}) {
+    applySelection(id, { pick = true, persist = true, pending = false } = {}) {
         if (persist) this.serverLastTopicId = id ? String(id) : ""
         if (pick) {
             // Writing only the preference leaves the two sources that outrank it
@@ -1112,6 +1112,12 @@ export default class extends Controller {
             this.selectionEpoch += 1
             this._pickCreativeId = this._renderedCreativeId
             this._pickTopicId = this.serverLastTopicId
+            if (pending) {
+                this._pendingPick = {
+                    creativeId: this._pickCreativeId,
+                    topicId: this._pickTopicId,
+                }
+            }
         }
         if (persist) this.debounceSaveLastTopic(id)
     }
@@ -1126,9 +1132,10 @@ export default class extends Controller {
         this._selectionEpoch = value
     }
 
-    // Did a pick land after the load at `epoch` started, and is it a pick about
-    // the creative that load describes? The first half says the pick is newer
-    // than the answer; the second is decided by the strip the click landed on,
+    // Did a pick land after the load at `epoch` started, or is there still an
+    // unsaved pick about the creative that load describes? A later load can
+    // begin before the pick's debounce lands, so request age alone cannot tell
+    // whether its answer predates the pick. The strip the click landed on,
     // not by this.creativeId — onPopupOpened assigns that synchronously before
     // the fetch, so a click on the outgoing creative's chips already carries the
     // incoming id. The rendered strip is what the user was actually looking at.
@@ -1140,7 +1147,10 @@ export default class extends Controller {
     // made against a strip that predates a delete, and keeping it would fail the
     // lookup in restoreSelection() and persist Main in its place.
     pickOutranks(epoch, creativeId, topics, archivedTopics) {
-        if (this.selectionEpoch === epoch) return false
+        const hasNewerPick = this.selectionEpoch !== epoch
+        const hasUnsavedPick = this._pendingPick &&
+            String(this._pendingPick.creativeId) === String(creativeId)
+        if (!hasNewerPick && !hasUnsavedPick) return false
         // creativeId is always truthy here — loadTopics() returns without it —
         // so a pick made before any strip was rendered fails this too.
         if (String(this._pickCreativeId) !== String(creativeId)) return false
@@ -1181,8 +1191,15 @@ export default class extends Controller {
 
     async flushSaveLastTopic(id) {
         this.cancelPendingSaveLastTopic()
-        if (this.creativeId) {
-            await saveLastTopic(this.creativeId, id || null)
+        const creativeId = this.creativeId
+        if (creativeId) {
+            const saved = await saveLastTopic(creativeId, id || null)
+            const topicId = id ? String(id) : ""
+            if (saved !== false && this._pendingPick &&
+                String(this._pendingPick.creativeId) === String(creativeId) &&
+                this._pendingPick.topicId === topicId) {
+                this._pendingPick = null
+            }
         }
     }
 

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -1319,7 +1319,16 @@ export default class extends Controller {
         if (existsByName) return
 
         this.topics = [...topics, data.topic]
-        this.renderTopics(this.topics, this.canManageTopics, this.canCreateTopic, this.canSetPrimaryAgent)
+        // This arrived on the subscription for the creative currently open.
+        // Unlike a local re-render of cached topics, it is not about the
+        // outgoing creative whose strip may still be on screen during a switch.
+        this.renderTopics(
+            this.topics,
+            this.canManageTopics,
+            this.canCreateTopic,
+            this.canSetPrimaryAgent,
+            this.creativeId
+        )
 
         // Auto-select the new topic if created by the current user
         const currentUserId = document.body.dataset.currentUserId

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -189,7 +189,17 @@ export default class extends Controller {
                 // strip and the message list back to the previous topic.
                 // _loadTopicsVersion does not cover this: it only discards a
                 // response outrun by another loadTopics(), not by a selection.
-                if (this.selectionEpoch === selectionEpoch) {
+                //
+                // Only a pick the response can account for, though. Switching
+                // creatives leaves the previous creative's chips on screen until
+                // this fetch lands, and a click on one of those names a topic
+                // this creative has never heard of — not intent about it. Its id
+                // would survive as the preference, fail the lookup in
+                // restoreSelection(), drop the user on Main and then persist Main
+                // as the new creative's saved topic. An empty pick (All Messages)
+                // is not a persisted selection either — saveLastTopic stores null
+                // for it — so it cannot outrank the answer.
+                if (!this.pickOutranks(selectionEpoch, topics, this.archivedTopics)) {
                     this.serverLastTopicId = data.last_topic_id ? String(data.last_topic_id) : ""
                 }
                 // The archive guard only has to outlive the sources that still
@@ -1054,6 +1064,18 @@ export default class extends Controller {
 
     set selectionEpoch(value) {
         this._selectionEpoch = value
+    }
+
+    // Did a pick land after the load at `epoch` started, and does the topic set
+    // the load returned actually contain it? Both halves are needed: the first
+    // says the pick is newer than the answer, the second that it is a pick about
+    // the creative the answer describes.
+    pickOutranks(epoch, topics, archivedTopics) {
+        if (this.selectionEpoch === epoch) return false
+        if (!this.serverLastTopicId) return false
+
+        return [ ...(topics || []), ...(archivedTopics || []) ]
+            .some(t => String(t.id) === String(this.serverLastTopicId))
     }
 
     releaseSelectionSourcesOtherThan(id) {

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -240,9 +240,12 @@ export default class extends Controller {
 
     // keepEmptyPick: the caller established that the user picked All Messages
     // after this render was set in motion. That pick names no topic, so it
-    // cannot be restored — it can only be left alone. Without this the Main
-    // fallback below would treat it as "nothing selected", navigate away from
-    // it and persist Main, which is the same revert a chip click suffers.
+    // cannot be restored from a topic list — it must be reapplied. Without
+    // this the Main fallback below would treat it as "nothing selected",
+    // navigate away from it and persist Main, which is the same revert a chip
+    // click suffers. A prior interim restore may also have dispatched Main, so
+    // reapplying sends the authoritative empty selection to downstream
+    // controllers again.
     restoreSelection({ keepEmptyPick = false } = {}) {
         const lastTopicId = this.currentTopicId
         // archiveTopic() switched away from this topic on purpose. The server
@@ -267,7 +270,10 @@ export default class extends Controller {
             }
         }
 
-        if (keepEmptyPick && !lastTopicId) return
+        if (keepEmptyPick && !lastTopicId) {
+            this.selectTopic("", { pick: false })
+            return
+        }
 
         // Not a pick: this fallback is what the current state resolves to, and
         // loadTopics() empties the strip for the length of its fetch, so any

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -221,7 +221,7 @@ export default class extends Controller {
                 }
 
                 // Migrate localStorage to server if server has no value
-                this.migrateLocalStorage()
+                this.migrateLocalStorage({ keepEmptyPick: pickWon })
 
                 this.renderTopics(this.topics, this.canManageTopics, this.canCreateTopic, this.canSetPrimaryAgent)
                 this.restoreSelection({ keepEmptyPick: pickWon })
@@ -1129,10 +1129,19 @@ export default class extends Controller {
         }
     }
 
-    migrateLocalStorage() {
+    // The legacy key is adopted only as a stand-in for a preference the server
+    // does not hold yet. A winning empty pick is a preference — it just names no
+    // topic, so it is indistinguishable here from "server holds nothing", and
+    // adopting the legacy value would hand the user back a topic they did not
+    // ask for and persist it. The caller knows which of the two it is.
+    //
+    // The key still goes, either way: the pick supersedes it, and its own save
+    // is already on the way, so leaving it behind would only re-apply a value
+    // the user has moved off on the next load.
+    migrateLocalStorage({ keepEmptyPick = false } = {}) {
         const key = `collavre_creative_${this.creativeId}_last_topic`
         const localValue = localStorage.getItem(key)
-        if (localValue && !this.serverLastTopicId) {
+        if (localValue && !this.serverLastTopicId && !keepEmptyPick) {
             this.serverLastTopicId = localValue
             saveLastTopic(this.creativeId, localValue)
         }

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -256,14 +256,19 @@ export default class extends Controller {
                 // restoreSelection is suppressed; every other selectTopic caller
                 // is the user going somewhere, and reveals normally.
                 const reveal = this.archivedCollapsedTopicId !== String(lastTopicId)
-                this.selectTopic(lastTopicId, { reveal })
+                this.selectTopic(lastTopicId, { reveal, pick: false })
                 return
             }
         }
 
         if (keepEmptyPick && !lastTopicId) return
 
-        this.selectTopic(this.mainTopicId || "")
+        // Not a pick: this fallback is what the current state resolves to, and
+        // loadTopics() empties the strip for the length of its fetch, so any
+        // re-render landing in that window resolves to Main whatever the user
+        // has selected. Counting it as intent would let it outrank the answer
+        // it was derived from — and drop the deep link on the way.
+        this.selectTopic(this.mainTopicId || "", { pick: false })
     }
 
     // An archived topic can be opened from the topic strip, the topic-list popup,
@@ -803,7 +808,7 @@ export default class extends Controller {
         this.selectTopic(id)
     }
 
-    selectTopic(id, { reveal = true } = {}) {
+    selectTopic(id, { reveal = true, pick = true } = {}) {
         // Only restoreSelection() is guarded, so reaching selectTopic with this
         // id means the user deliberately went back into the archived topic.
         // The transition is over.
@@ -811,7 +816,7 @@ export default class extends Controller {
             this.archivedAwayTopicId = null
         }
         if (reveal) this.revealArchivedTopic(id)
-        this.updateSelectionUI(id)
+        this.updateSelectionUI(id, { pick })
         if (id) {
             this.clearNewMessageBadge(id)
         }
@@ -901,8 +906,8 @@ export default class extends Controller {
         }
     }
 
-    updateSelectionUI(id) {
-        this.currentTopicId = id
+    updateSelectionUI(id, { pick = true } = {}) {
+        this.applySelection(id, { pick })
         // Update UI
         let activeEl = null
         this.listTarget.querySelectorAll('.topic-tag').forEach(el => {
@@ -1060,18 +1065,30 @@ export default class extends Controller {
     }
 
     set currentTopicId(id) {
+        this.applySelection(id)
+    }
+
+    // pick: this selection is new intent — the user picked it, or the server
+    // told us their preference moved. A restore is not: it re-derives the
+    // selection from state already held, so it is never newer than anything and
+    // must leave the sources that outrank the preference alone. Recording the
+    // preference and saving it happen either way; only the two consequences of
+    // *intent* are gated.
+    applySelection(id, { pick = true } = {}) {
         this.serverLastTopicId = id ? String(id) : ""
-        // Writing only the preference leaves the two sources that outrank it in
-        // the getter still naming the topic being left, so the getter keeps
-        // answering with it: the next renderTopics() lights the old chip and the
-        // next restoreSelection() navigates back to it. Both are one-shot
-        // pointers at a topic to open, and this selection has moved off it.
-        // Dropped only when they disagree — a deep link that resolved to the
-        // topic now being selected must keep outranking the stale server
-        // last_topic_id for the rest of the popup session.
-        this.releaseSelectionSourcesOtherThan(this.serverLastTopicId)
-        this.selectionEpoch += 1
-        this._pickCreativeId = this._renderedCreativeId
+        if (pick) {
+            // Writing only the preference leaves the two sources that outrank it
+            // in the getter still naming the topic being left, so the getter
+            // keeps answering with it: the next renderTopics() lights the old
+            // chip and the next restoreSelection() navigates back to it. Both
+            // are one-shot pointers at a topic to open, and this selection has
+            // moved off it. Dropped only when they disagree — a deep link that
+            // resolved to the topic now being selected must keep outranking the
+            // stale server last_topic_id for the rest of the popup session.
+            this.releaseSelectionSourcesOtherThan(this.serverLastTopicId)
+            this.selectionEpoch += 1
+            this._pickCreativeId = this._renderedCreativeId
+        }
         this.debounceSaveLastTopic(id)
     }
 

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -1020,6 +1020,15 @@ export default class extends Controller {
         return this.serverLastTopicId || ""
     }
 
+    // Is one of the two sources above the preference still set? Not the same
+    // question as "is the getter's answer nonempty" — an override of "" outranks
+    // the preference just as a named one does.
+    get hasDeepLinkSelection() {
+        if (this.overrideTopicId !== undefined && this.overrideTopicId !== null) return true
+
+        return Boolean(new URLSearchParams(window.location.search).get('topic_id'))
+    }
+
     // A topic leaving the strip — archived or deleted — has to leave both
     // sources that outrank serverLastTopicId in the currentTopicId getter.
     // Assigning "" only touches the preference, so on its own the getter goes
@@ -1183,7 +1192,15 @@ export default class extends Controller {
             const newTopicId = data.last_topic_id ? String(data.last_topic_id) : ""
             if (newTopicId !== this.serverLastTopicId) {
                 this.serverLastTopicId = newTopicId
-                this.selectTopic(newTopicId)
+                // Another session moved the preference; nobody clicked in this
+                // popup. A deep link outranks the preference in the getter, so
+                // following the broadcast would light a chip the getter does not
+                // name — and selectTopic() writes through the setter, which
+                // releases that link on the way. It is a one-shot pointer with
+                // nowhere to be recovered from: ?topic_id= is dropped from the
+                // URL, so not even a reload gets the linked conversation back.
+                // Record the preference, leave the view where the link put it.
+                if (!this.hasDeepLinkSelection) this.selectTopic(newTopicId)
             }
             return
         }

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -229,7 +229,7 @@ export default class extends Controller {
                 // Migrate localStorage to server if server has no value
                 this.migrateLocalStorage({ keepEmptyPick: pickWon })
 
-                this.renderTopics(this.topics, this.canManageTopics, this.canCreateTopic, this.canSetPrimaryAgent)
+                this.renderTopics(this.topics, this.canManageTopics, this.canCreateTopic, this.canSetPrimaryAgent, creativeId)
                 this.restoreSelection({ keepEmptyPick: pickWon })
             }
         } catch (e) {
@@ -248,6 +248,11 @@ export default class extends Controller {
     // controllers again.
     restoreSelection({ keepEmptyPick = false } = {}) {
         const lastTopicId = this.currentTopicId
+        // A deep link controls this popup's view, but it is not a replacement
+        // for the saved preference. Replaying the linked selection after a
+        // preference broadcast must therefore update the UI without writing the
+        // link back over that newer server value.
+        const preservePreference = this.hasDeepLinkSelection && !keepEmptyPick
         // archiveTopic() switched away from this topic on purpose. The server
         // preference still names it until the debounced save lands, so accept
         // the local intent over the stale server answer for that window.
@@ -265,7 +270,7 @@ export default class extends Controller {
                 // restoreSelection is suppressed; every other selectTopic caller
                 // is the user going somewhere, and reveals normally.
                 const reveal = this.archivedCollapsedTopicId !== String(lastTopicId)
-                this.selectTopic(lastTopicId, { reveal, pick: false })
+                this.selectTopic(lastTopicId, { reveal, pick: false, persist: !preservePreference })
                 return
             }
         }
@@ -275,12 +280,17 @@ export default class extends Controller {
             return
         }
 
+        if (preservePreference && !lastTopicId) {
+            this.selectTopic("", { pick: false, persist: false })
+            return
+        }
+
         // Not a pick: this fallback is what the current state resolves to, and
         // loadTopics() empties the strip for the length of its fetch, so any
         // re-render landing in that window resolves to Main whatever the user
         // has selected. Counting it as intent would let it outrank the answer
         // it was derived from — and drop the deep link on the way.
-        this.selectTopic(this.mainTopicId || "", { pick: false })
+        this.selectTopic(this.mainTopicId || "", { pick: false, persist: !preservePreference })
     }
 
     // An archived topic can be opened from the topic strip, the topic-list popup,
@@ -297,7 +307,7 @@ export default class extends Controller {
         this.renderTopics(this.topics, this.canManageTopics, this.canCreateTopic, this.canSetPrimaryAgent)
     }
 
-    renderTopics(topics, canManage = false, canCreateTopic = canManage, canSetPrimaryAgent = canManage) {
+    renderTopics(topics, canManage = false, canCreateTopic = canManage, canSetPrimaryAgent = canManage, sourceCreativeId = this._topicsCreativeId || this.creativeId) {
         const dragActions = canManage
             ? 'dragstart->comments--topics#handleTopicDragStart dragend->comments--topics#handleTopicDragEnd'
             : ''
@@ -375,7 +385,8 @@ export default class extends Controller {
         this.listTarget.innerHTML = html
         // Which creative the chips now on screen belong to. A click can only
         // ever be about this one, whatever this.creativeId has since become.
-        this._renderedCreativeId = this.creativeId
+        this._renderedCreativeId = sourceCreativeId
+        this._topicsCreativeId = sourceCreativeId
 
         // The create button lives outside the scrolling strip so it stays reachable
         // without horizontal scrolling, no matter how many topics there are.
@@ -820,7 +831,7 @@ export default class extends Controller {
         this.selectTopic(id)
     }
 
-    selectTopic(id, { reveal = true, pick = true } = {}) {
+    selectTopic(id, { reveal = true, pick = true, persist = true } = {}) {
         // Only restoreSelection() is guarded, so reaching selectTopic with this
         // id means the user deliberately went back into the archived topic.
         // The transition is over.
@@ -828,7 +839,7 @@ export default class extends Controller {
             this.archivedAwayTopicId = null
         }
         if (reveal) this.revealArchivedTopic(id)
-        this.updateSelectionUI(id, { pick })
+        this.updateSelectionUI(id, { pick, persist })
         if (id) {
             this.clearNewMessageBadge(id)
         }
@@ -918,8 +929,8 @@ export default class extends Controller {
         }
     }
 
-    updateSelectionUI(id, { pick = true } = {}) {
-        this.applySelection(id, { pick })
+    updateSelectionUI(id, { pick = true, persist = true } = {}) {
+        this.applySelection(id, { pick, persist })
         // Update UI
         let activeEl = null
         this.listTarget.querySelectorAll('.topic-tag').forEach(el => {
@@ -1086,8 +1097,8 @@ export default class extends Controller {
     // must leave the sources that outrank the preference alone. Recording the
     // preference and saving it happen either way; only the two consequences of
     // *intent* are gated.
-    applySelection(id, { pick = true } = {}) {
-        this.serverLastTopicId = id ? String(id) : ""
+    applySelection(id, { pick = true, persist = true } = {}) {
+        if (persist) this.serverLastTopicId = id ? String(id) : ""
         if (pick) {
             // Writing only the preference leaves the two sources that outrank it
             // in the getter still naming the topic being left, so the getter
@@ -1102,7 +1113,7 @@ export default class extends Controller {
             this._pickCreativeId = this._renderedCreativeId
             this._pickTopicId = this.serverLastTopicId
         }
-        this.debounceSaveLastTopic(id)
+        if (persist) this.debounceSaveLastTopic(id)
     }
 
     // Bumped on every selection so an in-flight loadTopics() can tell whether

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -151,6 +151,7 @@ export default class extends Controller {
         if (!this.creativeId) return
 
         const version = ++this._loadTopicsVersion
+        const selectionEpoch = this.selectionEpoch
         // Clear stale topics from previous creative to prevent name-based
         // dedupe in handleTopicMessage from blocking valid broadcasts
         this.topics = []
@@ -180,7 +181,17 @@ export default class extends Controller {
                 this.canSetPrimaryAgent = canSetPrimaryAgent
                 this.archivedTopics = data.archived_topics || []
                 this.pruneArchivedBadges()
-                this.serverLastTopicId = data.last_topic_id ? String(data.last_topic_id) : ""
+                // A topic picked while this fetch was in flight is newer intent
+                // than the answer coming back: last_topic_id still names the
+                // topic the user left, because the save for the pick is
+                // debounced and has not landed. Overwriting it here — and then
+                // restoring from it below — throws the click away, snapping the
+                // strip and the message list back to the previous topic.
+                // _loadTopicsVersion does not cover this: it only discards a
+                // response outrun by another loadTopics(), not by a selection.
+                if (this.selectionEpoch === selectionEpoch) {
+                    this.serverLastTopicId = data.last_topic_id ? String(data.last_topic_id) : ""
+                }
                 // The archive guard only has to outlive the sources that still
                 // name the topic. Test the effective selection, not just the
                 // preference: an unchanged ?topic_id= outranks it in the getter,
@@ -1022,7 +1033,39 @@ export default class extends Controller {
 
     set currentTopicId(id) {
         this.serverLastTopicId = id ? String(id) : ""
+        // Writing only the preference leaves the two sources that outrank it in
+        // the getter still naming the topic being left, so the getter keeps
+        // answering with it: the next renderTopics() lights the old chip and the
+        // next restoreSelection() navigates back to it. Both are one-shot
+        // pointers at a topic to open, and this selection has moved off it.
+        // Dropped only when they disagree — a deep link that resolved to the
+        // topic now being selected must keep outranking the stale server
+        // last_topic_id for the rest of the popup session.
+        this.releaseSelectionSourcesOtherThan(this.serverLastTopicId)
+        this.selectionEpoch += 1
         this.debounceSaveLastTopic(id)
+    }
+
+    // Bumped on every selection so an in-flight loadTopics() can tell whether
+    // its answer predates a pick the user has since made.
+    get selectionEpoch() {
+        return this._selectionEpoch || 0
+    }
+
+    set selectionEpoch(value) {
+        this._selectionEpoch = value
+    }
+
+    releaseSelectionSourcesOtherThan(id) {
+        if (this.overrideTopicId !== undefined && this.overrideTopicId !== null &&
+            String(this.overrideTopicId) !== String(id)) {
+            this.clearOverrideTopicId()
+        }
+
+        const urlTopicId = new URLSearchParams(window.location.search).get('topic_id')
+        if (urlTopicId && urlTopicId !== String(id)) {
+            this.clearUrlTopicId(urlTopicId)
+        }
     }
 
     debounceSaveLastTopic(id) {

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -152,12 +152,13 @@ export default class extends Controller {
 
         const version = ++this._loadTopicsVersion
         const selectionEpoch = this.selectionEpoch
+        const creativeId = this.creativeId
         // Clear stale topics from previous creative to prevent name-based
         // dedupe in handleTopicMessage from blocking valid broadcasts
         this.topics = []
 
         try {
-            const response = await fetch(`/creatives/${this.creativeId}/topics`)
+            const response = await fetch(`/creatives/${creativeId}/topics`)
             // Discard stale response if a newer loadTopics() call was made
             if (version !== this._loadTopicsVersion) return
 
@@ -190,16 +191,14 @@ export default class extends Controller {
                 // _loadTopicsVersion does not cover this: it only discards a
                 // response outrun by another loadTopics(), not by a selection.
                 //
-                // Only a pick the response can account for, though. Switching
-                // creatives leaves the previous creative's chips on screen until
-                // this fetch lands, and a click on one of those names a topic
-                // this creative has never heard of — not intent about it. Its id
-                // would survive as the preference, fail the lookup in
-                // restoreSelection(), drop the user on Main and then persist Main
-                // as the new creative's saved topic. An empty pick (All Messages)
-                // is not a persisted selection either — saveLastTopic stores null
-                // for it — so it cannot outrank the answer.
-                if (!this.pickOutranks(selectionEpoch, topics, this.archivedTopics)) {
+                // Only a pick about this creative, though. Switching creatives
+                // leaves the previous creative's chips on screen until this
+                // fetch lands, and a click on one of those is intent about the
+                // creative being left. Its id would survive as the preference,
+                // fail the lookup in restoreSelection(), drop the user on Main
+                // and then persist Main as the new creative's saved topic.
+                const pickWon = this.pickOutranks(selectionEpoch, creativeId, topics, this.archivedTopics)
+                if (!pickWon) {
                     this.serverLastTopicId = data.last_topic_id ? String(data.last_topic_id) : ""
                 }
                 // The archive guard only has to outlive the sources that still
@@ -225,7 +224,7 @@ export default class extends Controller {
                 this.migrateLocalStorage()
 
                 this.renderTopics(this.topics, this.canManageTopics, this.canCreateTopic, this.canSetPrimaryAgent)
-                this.restoreSelection()
+                this.restoreSelection({ keepEmptyPick: pickWon })
             }
         } catch (e) {
             console.error("Failed to load topics", e)
@@ -233,7 +232,12 @@ export default class extends Controller {
         }
     }
 
-    restoreSelection() {
+    // keepEmptyPick: the caller established that the user picked All Messages
+    // after this render was set in motion. That pick names no topic, so it
+    // cannot be restored — it can only be left alone. Without this the Main
+    // fallback below would treat it as "nothing selected", navigate away from
+    // it and persist Main, which is the same revert a chip click suffers.
+    restoreSelection({ keepEmptyPick = false } = {}) {
         const lastTopicId = this.currentTopicId
         // archiveTopic() switched away from this topic on purpose. The server
         // preference still names it until the debounced save lands, so accept
@@ -256,6 +260,8 @@ export default class extends Controller {
                 return
             }
         }
+
+        if (keepEmptyPick && !lastTopicId) return
 
         this.selectTopic(this.mainTopicId || "")
     }
@@ -350,6 +356,9 @@ export default class extends Controller {
         }
 
         this.listTarget.innerHTML = html
+        // Which creative the chips now on screen belong to. A click can only
+        // ever be about this one, whatever this.creativeId has since become.
+        this._renderedCreativeId = this.creativeId
 
         // The create button lives outside the scrolling strip so it stays reachable
         // without horizontal scrolling, no matter how many topics there are.
@@ -1053,6 +1062,7 @@ export default class extends Controller {
         // last_topic_id for the rest of the popup session.
         this.releaseSelectionSourcesOtherThan(this.serverLastTopicId)
         this.selectionEpoch += 1
+        this._pickCreativeId = this._renderedCreativeId
         this.debounceSaveLastTopic(id)
     }
 
@@ -1066,13 +1076,25 @@ export default class extends Controller {
         this._selectionEpoch = value
     }
 
-    // Did a pick land after the load at `epoch` started, and does the topic set
-    // the load returned actually contain it? Both halves are needed: the first
-    // says the pick is newer than the answer, the second that it is a pick about
-    // the creative the answer describes.
-    pickOutranks(epoch, topics, archivedTopics) {
+    // Did a pick land after the load at `epoch` started, and is it a pick about
+    // the creative that load describes? The first half says the pick is newer
+    // than the answer; the second is decided by the strip the click landed on,
+    // not by this.creativeId — onPopupOpened assigns that synchronously before
+    // the fetch, so a click on the outgoing creative's chips already carries the
+    // incoming id. The rendered strip is what the user was actually looking at.
+    //
+    // An empty pick (All Messages) names no topic to match against the response,
+    // and its provenance is the only thing that distinguishes it from a click on
+    // a stale strip — so it rests on that test alone. A named pick is checked
+    // against the topics too: one whose topic the response does not list was
+    // made against a strip that predates a delete, and keeping it would fail the
+    // lookup in restoreSelection() and persist Main in its place.
+    pickOutranks(epoch, creativeId, topics, archivedTopics) {
         if (this.selectionEpoch === epoch) return false
-        if (!this.serverLastTopicId) return false
+        // creativeId is always truthy here — loadTopics() returns without it —
+        // so a pick made before any strip was rendered fails this too.
+        if (String(this._pickCreativeId) !== String(creativeId)) return false
+        if (!this.serverLastTopicId) return true
 
         return [ ...(topics || []), ...(archivedTopics || []) ]
             .some(t => String(t.id) === String(this.serverLastTopicId))

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -1139,17 +1139,24 @@ export default class extends Controller {
     }
 
     debounceSaveLastTopic(id) {
-        if (this._saveLastTopicTimer) clearTimeout(this._saveLastTopicTimer)
+        this.cancelPendingSaveLastTopic()
         this._saveLastTopicTimer = setTimeout(() => {
             this.flushSaveLastTopic(id)
         }, 500)
     }
 
-    async flushSaveLastTopic(id) {
+    // Drop a queued save without sending it. The timer closes over the id it
+    // was scheduled with, so a save that is no longer wanted cannot be talked
+    // out of its value — only cancelled.
+    cancelPendingSaveLastTopic() {
         if (this._saveLastTopicTimer) {
             clearTimeout(this._saveLastTopicTimer)
             this._saveLastTopicTimer = null
         }
+    }
+
+    async flushSaveLastTopic(id) {
+        this.cancelPendingSaveLastTopic()
         if (this.creativeId) {
             await saveLastTopic(this.creativeId, id || null)
         }
@@ -1217,7 +1224,19 @@ export default class extends Controller {
                 // nowhere to be recovered from: ?topic_id= is dropped from the
                 // URL, so not even a reload gets the linked conversation back.
                 // Record the preference, leave the view where the link put it.
-                if (!this.hasDeepLinkSelection) this.selectTopic(newTopicId)
+                //
+                // Every selection queues a save, restores included, so landing
+                // on the link 500ms ago left one holding the linked topic. It
+                // describes a selection this popup has just conceded is not the
+                // preference; letting it land would write the link back over
+                // what the other session set. Following the broadcast re-arms
+                // the debounce with the broadcast's own value, so only the path
+                // that does not follow has anything to cancel.
+                if (this.hasDeepLinkSelection) {
+                    this.cancelPendingSaveLastTopic()
+                } else {
+                    this.selectTopic(newTopicId)
+                }
             }
             return
         }

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -198,7 +198,13 @@ export default class extends Controller {
                 // fail the lookup in restoreSelection(), drop the user on Main
                 // and then persist Main as the new creative's saved topic.
                 const pickWon = this.pickOutranks(selectionEpoch, creativeId, topics, this.archivedTopics)
-                if (!pickWon) {
+                if (pickWon) {
+                    // An interim restore can run while this fetch has the strip
+                    // empty and replace serverLastTopicId with Main. The epoch
+                    // belongs to the actual pick, so restore that picked value
+                    // rather than treating the derived fallback as its value.
+                    this.serverLastTopicId = this._pickTopicId
+                } else {
                     this.serverLastTopicId = data.last_topic_id ? String(data.last_topic_id) : ""
                 }
                 // The archive guard only has to outlive the sources that still
@@ -1088,6 +1094,7 @@ export default class extends Controller {
             this.releaseSelectionSourcesOtherThan(this.serverLastTopicId)
             this.selectionEpoch += 1
             this._pickCreativeId = this._renderedCreativeId
+            this._pickTopicId = this.serverLastTopicId
         }
         this.debounceSaveLastTopic(id)
     }
@@ -1120,10 +1127,10 @@ export default class extends Controller {
         // creativeId is always truthy here — loadTopics() returns without it —
         // so a pick made before any strip was rendered fails this too.
         if (String(this._pickCreativeId) !== String(creativeId)) return false
-        if (!this.serverLastTopicId) return true
+        if (!this._pickTopicId) return true
 
         return [ ...(topics || []), ...(archivedTopics || []) ]
-            .some(t => String(t.id) === String(this.serverLastTopicId))
+            .some(t => String(t.id) === String(this._pickTopicId))
     }
 
     releaseSelectionSourcesOtherThan(id) {


### PR DESCRIPTION
## Problem

Picking a topic while the strip was still loading — or after a deep link had resolved one — silently snapped the selection back to the topic the user had just left. The strip re-lit the old chip and the message list reloaded its conversation.

Reported as: 버그: 토픽 선택시 이전 토픽이 로딩되면 선택이 되돌려진다 (Collavre creative 18061).

## Root cause

Two independent paths, both the same shape: a selection source that outlives the pick.

**1. `loadTopics()` clobbers the pick with a stale server answer**

```js
this.serverLastTopicId = data.last_topic_id ? String(data.last_topic_id) : ""
...
this.restoreSelection()
```

The strip stays rendered and clickable while the fetch is in flight (popup open/switch, topic cable broadcast, archive/unarchive/create/delete all call `loadTopics()`). A pick made in that window writes `serverLastTopicId`, but persisting it is debounced by 500ms — so the response still names the previous topic, overwrites the pick, and `restoreSelection()` navigates back to it.

`_loadTopicsVersion` does not cover this: it only discards a response outrun by *another* `loadTopics()`, never one outrun by a selection.

**2. The `currentTopicId` setter is not authoritative**

```js
get currentTopicId() { return override ?? urlTopicId ?? serverLastTopicId }
set currentTopicId(id) { this.serverLastTopicId = ... }   // writes the lowest-priority source only
```

After `list_controller` resolves a deep link (`setOverrideTopicId`), or on any URL carrying `?topic_id=`, a later pick updated only the preference. The getter kept answering with the old topic, so the next `renderTopics()` lit the old chip and the next `restoreSelection()` navigated back to it — even though the message list had moved on.

## Fix

1. `loadTopics()` captures a selection epoch at request time and skips the `serverLastTopicId` assignment if a selection happened while its fetch was in flight. A load started *after* a pick still restores the server selection normally, so a creative switch is unaffected.
2. The setter releases the two higher-priority sources — but only when they disagree with the new selection. An override that resolved to the topic now being selected keeps outranking the stale server preference for the rest of the popup session, which is what it exists for.

## Tests

`topics_controller_selection_race.test.js`, 10 cases:

- a topic picked while the strip is loading survives the response (selection, change event, active chip)
- the stale `last_topic_id` does not overwrite the pick
- a load started *after* the pick still restores the server selection
- a pick supersedes a deep-link override for a different topic, and `restoreSelection()` stays put
- an override agreeing with the pick is kept and still outranks a later server value
- a pick drops a `?topic_id=` naming a different topic, keeps one naming the same topic
- selecting All Messages drops both sources

Verified each case fails on `main` before the fix (2 for path 1, 5 for path 2) and passes after.

Full JS suite: 110 suites / 1392 tests passing. Changed lines are at 100% coverage.