### PR TITLE
Fix topic list button toggle behavior

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -1781,6 +1781,10 @@ body.chat-fullscreen {
     background: var(--color-section-bg);
     color: var(--color-text);
 }
+.topic-list-btn[aria-expanded="true"] {
+    background: var(--color-section-bg);
+    color: var(--color-text);
+}
 
 /* Archived entries inside the topic list popup */
 .topic-list-item {

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_topic_list.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_topic_list.test.js
@@ -99,4 +99,12 @@ describe('TopicsController#openTopicListPopup', () => {
 
 		expect(event.stopPropagation).toHaveBeenCalled()
     })
+
+    test('removes the topic-list close listener when disconnecting', () => {
+		const removeEventListener = jest.spyOn(controller.element, 'removeEventListener')
+
+		controller.disconnect()
+
+		expect(removeEventListener).toHaveBeenCalledWith('topic-list:close', controller.handleTopicListClose)
+    })
 })

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_topic_list.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_topic_list.test.js
@@ -107,6 +107,21 @@ describe('TopicsController#openTopicListPopup', () => {
 		expect(popup.openForTopics).not.toHaveBeenCalled()
     })
 
+    test('keeps the toggle pending through a touch-generated mouse event', () => {
+		const btn = controller.topicListButtonTarget
+		const modal = document.createElement('div')
+		modal.id = 'topic-list-modal'
+		controller.element.appendChild(modal)
+		const popup = { popup: { isOpen: jest.fn().mockReturnValueOnce(true).mockReturnValue(false) }, close: jest.fn(), openForTopics: jest.fn() }
+		jest.spyOn(controller.application, 'getControllerForElementAndIdentifier').mockReturnValue(popup)
+
+		controller.prepareTopicListToggle() // touchstart while the popup is open
+		controller.prepareTopicListToggle() // generated mousedown after it closes
+		controller.openTopicListPopup({ currentTarget: btn })
+
+		expect(popup.openForTopics).not.toHaveBeenCalled()
+    })
+
     test('removes the topic-list close listener when disconnecting', () => {
 		const removeEventListener = jest.spyOn(controller.element, 'removeEventListener')
 

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_topic_list.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_topic_list.test.js
@@ -15,6 +15,7 @@ describe('TopicsController#openTopicListPopup', () => {
                data-topic-main-text="All Messages"
                data-topic-search-placeholder-text="Search topics...">
             <div data-comments--topics-target="list"></div>
+			<button data-comments--topics-target="topicListButton" aria-expanded="false"></button>
           </div>
         `
         application = Application.start()
@@ -57,5 +58,45 @@ describe('TopicsController#openTopicListPopup', () => {
         const modal = document.getElementById('topic-list-modal')
         // Bounded to the chat popup, not body-level.
         expect(modal.parentElement).toBe(document.getElementById('comments-popup'))
+    })
+
+    test('toggles an existing open popup closed and updates the button state', () => {
+		const btn = controller.topicListButtonTarget
+		const modal = document.createElement('div')
+		modal.id = 'topic-list-modal'
+		modal.style.display = 'block'
+		controller.element.appendChild(modal)
+		const popup = { popup: { isOpen: jest.fn(() => true) }, close: jest.fn() }
+		jest.spyOn(controller.application, 'getControllerForElementAndIdentifier').mockReturnValue(popup)
+
+		controller.openTopicListPopup({ currentTarget: btn })
+
+		expect(popup.close).toHaveBeenCalled()
+		expect(btn.getAttribute('aria-expanded')).toBe('false')
+    })
+
+    test('sets the button state while opening and clears it when the popup closes', () => {
+		const btn = controller.topicListButtonTarget
+		const modal = document.createElement('div')
+		modal.id = 'topic-list-modal'
+		controller.element.appendChild(modal)
+		const popup = { popup: { isOpen: jest.fn(() => false) }, openForTopics: jest.fn() }
+		jest.spyOn(controller.application, 'getControllerForElementAndIdentifier').mockReturnValue(popup)
+
+		controller.openTopicListPopup({ currentTarget: btn })
+
+		expect(popup.openForTopics).toHaveBeenCalled()
+		expect(btn.getAttribute('aria-expanded')).toBe('true')
+
+		modal.dispatchEvent(new CustomEvent('topic-list:close', { bubbles: true }))
+		expect(btn.getAttribute('aria-expanded')).toBe('false')
+    })
+
+    test('stops the opening pointer event from reaching the popup outside-click handler', () => {
+		const event = { stopPropagation: jest.fn() }
+
+		controller.stopTopicListTogglePropagation(event)
+
+		expect(event.stopPropagation).toHaveBeenCalled()
     })
 })

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_topic_list.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_topic_list.test.js
@@ -100,7 +100,7 @@ describe('TopicsController#openTopicListPopup', () => {
 		const popup = { popup: { isOpen: jest.fn(() => true) }, close: jest.fn(), openForTopics: jest.fn() }
 		jest.spyOn(controller.application, 'getControllerForElementAndIdentifier').mockReturnValue(popup)
 
-		controller.prepareTopicListToggle()
+		controller.prepareTopicListToggle({ isPrimary: true, button: 0, pointerId: 1, currentTarget: { setPointerCapture: jest.fn() } })
 		controller.openTopicListPopup({ currentTarget: btn })
 
 		expect(popup.close).not.toHaveBeenCalled()
@@ -115,12 +115,55 @@ describe('TopicsController#openTopicListPopup', () => {
 		const popup = { popup: { isOpen: jest.fn().mockReturnValueOnce(true).mockReturnValue(false) }, close: jest.fn(), openForTopics: jest.fn() }
 		jest.spyOn(controller.application, 'getControllerForElementAndIdentifier').mockReturnValue(popup)
 
-		controller.prepareTopicListToggle() // touchstart while the popup is open
-		controller.prepareTopicListToggle() // generated mousedown after it closes
+		controller.prepareTopicListToggle({ isPrimary: true, button: 0, pointerId: 1, currentTarget: { setPointerCapture: jest.fn() } }) // pointerdown while the popup is open
 		controller.openTopicListPopup({ currentTarget: btn })
 
 		expect(popup.openForTopics).not.toHaveBeenCalled()
     })
+
+    test('clears the pending toggle when a primary pointer is canceled or released outside the button', () => {
+		const btn = controller.topicListButtonTarget
+		const modal = document.createElement('div')
+		modal.id = 'topic-list-modal'
+		controller.element.appendChild(modal)
+		const popup = { popup: { isOpen: jest.fn(() => true) } }
+		jest.spyOn(controller.application, 'getControllerForElementAndIdentifier').mockReturnValue(popup)
+		jest.spyOn(btn, 'getBoundingClientRect').mockReturnValue({ left: 10, right: 20, top: 10, bottom: 20 })
+
+		controller.prepareTopicListToggle({ isPrimary: true, button: 0, pointerId: 1, currentTarget: { setPointerCapture: jest.fn() } })
+		controller.cancelTopicListToggle({ pointerId: 1 })
+		expect(controller.topicListTogglePointerDown).toBe(false)
+
+		controller.prepareTopicListToggle({ isPrimary: true, button: 0, pointerId: 2, currentTarget: { setPointerCapture: jest.fn() } })
+		controller.finishTopicListToggle({ currentTarget: btn, clientX: 25, clientY: 15, pointerId: 2 })
+		expect(controller.topicListTogglePointerDown).toBe(false)
+	})
+
+	test('clears a completed pointer gesture that does not dispatch click', () => {
+		jest.useFakeTimers()
+		const modal = document.createElement('div')
+		modal.id = 'topic-list-modal'
+		controller.element.appendChild(modal)
+		const popup = { popup: { isOpen: jest.fn(() => true) } }
+		jest.spyOn(controller.application, 'getControllerForElementAndIdentifier').mockReturnValue(popup)
+		const btn = controller.topicListButtonTarget
+		jest.spyOn(btn, 'getBoundingClientRect').mockReturnValue({ left: 10, right: 20, top: 10, bottom: 20 })
+
+		controller.prepareTopicListToggle({ isPrimary: true, button: 0, pointerId: 1, currentTarget: { setPointerCapture: jest.fn() } })
+		controller.finishTopicListToggle({ currentTarget: btn, clientX: 15, clientY: 15, pointerId: 1 })
+		jest.runOnlyPendingTimers()
+
+		expect(controller.topicListTogglePointerDown).toBe(false)
+		jest.useRealTimers()
+	})
+
+	test('ignores non-primary pointer events and stale pointer cleanup', () => {
+		controller.prepareTopicListToggle({ isPrimary: false, button: 0, pointerId: 1 })
+		controller.prepareTopicListToggle({ isPrimary: true, button: 2, pointerId: 2 })
+		controller.cancelTopicListToggle({ pointerId: 3 })
+
+		expect(controller.topicListTogglePointerDown).toBeUndefined()
+	})
 
     test('removes the topic-list close listener when disconnecting', () => {
 		const removeEventListener = jest.spyOn(controller.element, 'removeEventListener')

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_topic_list.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_topic_list.test.js
@@ -92,12 +92,19 @@ describe('TopicsController#openTopicListPopup', () => {
 		expect(btn.getAttribute('aria-expanded')).toBe('false')
     })
 
-    test('stops the opening pointer event from reaching the popup outside-click handler', () => {
-		const event = { stopPropagation: jest.fn() }
+    test('lets other popups process the pointer event and consumes the matching click when open', () => {
+		const btn = controller.topicListButtonTarget
+		const modal = document.createElement('div')
+		modal.id = 'topic-list-modal'
+		controller.element.appendChild(modal)
+		const popup = { popup: { isOpen: jest.fn(() => true) }, close: jest.fn(), openForTopics: jest.fn() }
+		jest.spyOn(controller.application, 'getControllerForElementAndIdentifier').mockReturnValue(popup)
 
-		controller.stopTopicListTogglePropagation(event)
+		controller.prepareTopicListToggle()
+		controller.openTopicListPopup({ currentTarget: btn })
 
-		expect(event.stopPropagation).toHaveBeenCalled()
+		expect(popup.close).not.toHaveBeenCalled()
+		expect(popup.openForTopics).not.toHaveBeenCalled()
     })
 
     test('removes the topic-list close listener when disconnecting', () => {

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -666,6 +666,11 @@ export default class extends Controller {
     }
 
     openTopicListPopup(event) {
+		if (this.topicListTogglePointerDown) {
+			this.topicListTogglePointerDown = false
+			return
+		}
+
         const btnRect = event.currentTarget.getBoundingClientRect()
 
         const openWith = (popup) => {
@@ -718,8 +723,13 @@ export default class extends Controller {
         })
     }
 
-	stopTopicListTogglePropagation(event) {
-		event.stopPropagation()
+	prepareTopicListToggle() {
+		const modal = document.getElementById('topic-list-modal')
+		const popup = modal && this.application.getControllerForElementAndIdentifier(modal, 'topic-list')
+		// Let every open popup receive this pointer event and perform its normal
+		// outside-click cleanup. If this popup was one of them, consume the
+		// following click so it does not immediately reopen.
+		this.topicListTogglePointerDown = Boolean(popup?.popup?.isOpen())
 	}
 
     handleTopicListClose() {

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -667,7 +667,7 @@ export default class extends Controller {
 
     openTopicListPopup(event) {
 		if (this.topicListTogglePointerDown) {
-			this.topicListTogglePointerDown = false
+			this.cancelTopicListToggle()
 			return
 		}
 
@@ -723,13 +723,43 @@ export default class extends Controller {
         })
     }
 
-	prepareTopicListToggle() {
+	prepareTopicListToggle(event) {
+		if (event.isPrimary === false || event.button !== 0) return
+
 		const modal = document.getElementById('topic-list-modal')
 		const popup = modal && this.application.getControllerForElementAndIdentifier(modal, 'topic-list')
 		// Let every open popup receive this pointer event and perform its normal
 		// outside-click cleanup. If this popup was one of them, consume the
 		// following click so it does not immediately reopen.
-		this.topicListTogglePointerDown ||= Boolean(popup?.popup?.isOpen())
+		if (popup?.popup?.isOpen()) {
+			this.topicListTogglePointerDown = true
+			this.topicListTogglePointerId = event.pointerId
+			event.currentTarget.setPointerCapture(event.pointerId)
+		}
+	}
+
+	finishTopicListToggle(event) {
+		if (event.pointerId !== this.topicListTogglePointerId) return
+
+		const rect = event.currentTarget.getBoundingClientRect()
+		const releasedOutsideButton = event.clientX < rect.left || event.clientX > rect.right ||
+			event.clientY < rect.top || event.clientY > rect.bottom
+		if (releasedOutsideButton) {
+			this.cancelTopicListToggle(event)
+		} else {
+			// A completed activation dispatches click before the next task. Clear a
+			// canceled in-button gesture afterwards so it cannot consume a later click.
+			this.topicListToggleClearTimeout = setTimeout(() => this.cancelTopicListToggle(event), 0)
+		}
+	}
+
+	cancelTopicListToggle(event = {}) {
+		if (event.pointerId != null && event.pointerId !== this.topicListTogglePointerId) return
+
+		clearTimeout(this.topicListToggleClearTimeout)
+		this.topicListToggleClearTimeout = undefined
+		this.topicListTogglePointerDown = false
+		this.topicListTogglePointerId = undefined
 	}
 
     handleTopicListClose() {

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -7,7 +7,7 @@ const ICON_ARCHIVE = `<svg width="12" height="12" viewBox="0 0 24 24" fill="none
 const ICON_RESTORE = `<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7v6h6"/><path d="M21 17a9 9 0 0 0-9-9 9 9 0 0 0-6.69 3L3 13"/></svg>`
 
 export default class extends Controller {
-    static targets = ["list", "creationContainer"]
+    static targets = ["list", "creationContainer", "topicListButton"]
 
     connect() {
         this.topics = []
@@ -24,13 +24,16 @@ export default class extends Controller {
         }
         this.handleNewMessage = this.handleNewMessage.bind(this)
         this.handleTopicMoved = this.handleTopicMoved.bind(this)
+		this.handleTopicListClose = this.handleTopicListClose.bind(this)
         window.addEventListener('comments--topics:new-message', this.handleNewMessage)
         window.addEventListener('collavre:topic-moved', this.handleTopicMoved)
+		this.element.addEventListener('topic-list:close', this.handleTopicListClose)
     }
 
     disconnect() {
         window.removeEventListener('comments--topics:new-message', this.handleNewMessage)
         window.removeEventListener('collavre:topic-moved', this.handleTopicMoved)
+		this.element.removeEventListener('topic-list:close', this.handleTopicListClose)
         this.unsubscribe()
     }
 
@@ -677,12 +680,18 @@ export default class extends Controller {
                 (item) => this.selectTopic(item.id),
                 this.element
             )
+			this.setTopicListButtonExpanded(true)
         }
 
-        let modal = document.getElementById('topic-list-modal')
-        if (modal) {
-            const popup = this.application.getControllerForElementAndIdentifier(modal, 'topic-list')
-            if (popup) openWith(popup)
+		let modal = document.getElementById('topic-list-modal')
+		if (modal) {
+			const popup = this.application.getControllerForElementAndIdentifier(modal, 'topic-list')
+			if (popup?.popup?.isOpen()) {
+				popup?.close()
+				this.setTopicListButtonExpanded(false)
+			} else if (popup) {
+				openWith(popup)
+			}
             return
         }
 
@@ -707,6 +716,20 @@ export default class extends Controller {
             if (popup) openWith(popup)
             else console.error('topic-list controller not found after creation')
         })
+    }
+
+	stopTopicListTogglePropagation(event) {
+		event.stopPropagation()
+	}
+
+    handleTopicListClose() {
+		this.setTopicListButtonExpanded(false)
+    }
+
+    setTopicListButtonExpanded(expanded) {
+		if (this.hasTopicListButtonTarget) {
+			this.topicListButtonTarget.setAttribute('aria-expanded', String(expanded))
+		}
     }
 
     showInput(event) {

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -729,7 +729,7 @@ export default class extends Controller {
 		// Let every open popup receive this pointer event and perform its normal
 		// outside-click cleanup. If this popup was one of them, consume the
 		// following click so it does not immediately reopen.
-		this.topicListTogglePointerDown = Boolean(popup?.popup?.isOpen())
+		this.topicListTogglePointerDown ||= Boolean(popup?.popup?.isOpen())
 	}
 
     handleTopicListClose() {

--- a/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
@@ -137,7 +137,7 @@
           data-action="dragover->comments--topics#handleAddButtonDragOver dragleave->comments--topics#handleDragLeave drop->comments--topics#handleAddButtonDrop"></span>
     <button type="button" class="topic-list-btn"
 			data-comments--topics-target="topicListButton"
-			data-action="mousedown->comments--topics#stopTopicListTogglePropagation touchstart->comments--topics#stopTopicListTogglePropagation click->comments--topics#openTopicListPopup"
+			data-action="mousedown->comments--topics#prepareTopicListToggle touchstart->comments--topics#prepareTopicListToggle click->comments--topics#openTopicListPopup"
             title="<%= t('collavre.comments.topic_list') %>"
 			aria-label="<%= t('collavre.comments.topic_list') %>"
 			aria-expanded="false">

--- a/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
@@ -137,7 +137,7 @@
           data-action="dragover->comments--topics#handleAddButtonDragOver dragleave->comments--topics#handleDragLeave drop->comments--topics#handleAddButtonDrop"></span>
     <button type="button" class="topic-list-btn"
 			data-comments--topics-target="topicListButton"
-			data-action="mousedown->comments--topics#prepareTopicListToggle touchstart->comments--topics#prepareTopicListToggle click->comments--topics#openTopicListPopup"
+			data-action="pointerdown->comments--topics#prepareTopicListToggle pointerup->comments--topics#finishTopicListToggle pointercancel->comments--topics#cancelTopicListToggle click->comments--topics#openTopicListPopup"
             title="<%= t('collavre.comments.topic_list') %>"
 			aria-label="<%= t('collavre.comments.topic_list') %>"
 			aria-expanded="false">

--- a/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
@@ -136,9 +136,11 @@
     <span class="topic-creation-container" data-comments--topics-target="creationContainer" hidden
           data-action="dragover->comments--topics#handleAddButtonDragOver dragleave->comments--topics#handleDragLeave drop->comments--topics#handleAddButtonDrop"></span>
     <button type="button" class="topic-list-btn"
-            data-action="click->comments--topics#openTopicListPopup"
+			data-comments--topics-target="topicListButton"
+			data-action="mousedown->comments--topics#stopTopicListTogglePropagation touchstart->comments--topics#stopTopicListTogglePropagation click->comments--topics#openTopicListPopup"
             title="<%= t('collavre.comments.topic_list') %>"
-            aria-label="<%= t('collavre.comments.topic_list') %>">
+			aria-label="<%= t('collavre.comments.topic_list') %>"
+			aria-expanded="false">
       <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><line x1="3" y1="6" x2="3.01" y2="6"/><line x1="3" y1="12" x2="3.01" y2="12"/><line x1="3" y1="18" x2="3.01" y2="18"/></svg>
     </button>
   </div>

--- a/engines/collavre/test/system/topic_list_popup_test.rb
+++ b/engines/collavre/test/system/topic_list_popup_test.rb
@@ -47,6 +47,19 @@ class TopicListPopupTest < ApplicationSystemTestCase
     end
   end
 
+  test "list button toggles an open popup closed" do
+    open_comments_popup
+
+    button = find("#comments-popup .topic-list-btn")
+    button.click
+    assert_selector "#topic-list-modal", visible: :visible, wait: 5
+    assert_equal "true", button["aria-expanded"]
+
+    button.click
+    assert_no_selector "#topic-list-modal", visible: :visible
+    assert_equal "false", button["aria-expanded"]
+  end
+
   test "search filters the list" do
     open_comments_popup
     find("#comments-popup .topic-list-btn").click


### PR DESCRIPTION
## Summary

- make the topic list button close an already open list
- keep the button's expanded state in sync when the list closes
- prevent the outside-click handler from reopening the list on a second click

## Root cause

The popup's outside-click `mousedown` handler ran before the button's `click` handler. It closed the popup, then the click handler opened it again.

## Validation

- `npm test -- engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_topic_list.test.js`
- `mise exec ruby@3.4.4 -- bundle _2.6.2_ exec rails test engines/collavre/test/system/topic_list_popup_test.rb`