### PR TITLE
feat: introduce system event envelope and vocabulary

### DIFF
--- a/engines/collavre/app/controllers/collavre/api/v1/agents_controller.rb
+++ b/engines/collavre/app/controllers/collavre/api/v1/agents_controller.rb
@@ -544,8 +544,10 @@ module Collavre
             reply_comment: comment,
             context: {
               "creative" => { "id" => comment.creative_id },
-              "topic" => { "id" => comment.topic_id }
-            },
+              "topic" => { "id" => comment.topic_id },
+              SystemEvents::Envelope::KEY =>
+                task&.trigger_event_payload&.dig(SystemEvents::Envelope::KEY)
+            }.compact,
             workspace_user: workspace_user_for(task)
           ).dispatch
         end

--- a/engines/collavre/app/controllers/collavre/api/v1/agents_controller.rb
+++ b/engines/collavre/app/controllers/collavre/api/v1/agents_controller.rb
@@ -542,11 +542,9 @@ module Collavre
           AiAgent::A2aDispatcher.new(
             agent: agent,
             reply_comment: comment,
-            context: {
-              "creative" => { "id" => comment.creative_id },
+            context: { "creative" => { "id" => comment.creative_id },
               "topic" => { "id" => comment.topic_id },
-              SystemEvents::Envelope::KEY =>
-                task&.trigger_event_payload&.dig(SystemEvents::Envelope::KEY)
+              SystemEvents::Envelope::KEY => task&.trigger_event_payload&.dig(SystemEvents::Envelope::KEY)
             }.compact,
             workspace_user: workspace_user_for(task)
           ).dispatch

--- a/engines/collavre/app/controllers/collavre/creatives_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creatives_controller.rb
@@ -810,9 +810,7 @@ module Collavre
           skip_dispatch: true
         )
 
-        scheduled = SystemEvents::Dispatcher.dispatch(
-          "comment_created", comment.dispatch_payload, source: "trigger_restart"
-        )
+        scheduled = SystemEvents::Dispatcher.dispatch("comment_created", comment.dispatch_payload, source: "trigger_restart")
         Rails.logger.info("[TriggerAction] restart: posted trigger comment #{comment.id}, dispatched to #{scheduled&.size || 0} agents")
       end
 

--- a/engines/collavre/app/controllers/collavre/creatives_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creatives_controller.rb
@@ -810,7 +810,9 @@ module Collavre
           skip_dispatch: true
         )
 
-        scheduled = SystemEvents::Dispatcher.dispatch("comment_created", comment.dispatch_payload)
+        scheduled = SystemEvents::Dispatcher.dispatch(
+          "comment_created", comment.dispatch_payload, source: "trigger_restart"
+        )
         Rails.logger.info("[TriggerAction] restart: posted trigger comment #{comment.id}, dispatched to #{scheduled&.size || 0} agents")
       end
 

--- a/engines/collavre/app/jobs/collavre/cron_action_job.rb
+++ b/engines/collavre/app/jobs/collavre/cron_action_job.rb
@@ -66,7 +66,7 @@ module Collavre
         chat: {
           content: comment.content
         }
-      })
+      }, source: "cron")
 
       Rails.logger.info(
         "[CronActionJob] Posted cron message to creative #{creative_id}, topic #{topic_id || 'main'}"

--- a/engines/collavre/app/jobs/collavre/drop_trigger_job.rb
+++ b/engines/collavre/app/jobs/collavre/drop_trigger_job.rb
@@ -190,7 +190,7 @@ module Collavre
       # Use Comment#dispatch_payload — single source of truth shared with
       # the after_create_commit callback, preventing payload drift.
       scheduled_agents = SystemEvents::Dispatcher.dispatch(
-        "comment_created", comment.dispatch_payload
+        "comment_created", comment.dispatch_payload, source: "drop_trigger"
       )
 
       if scheduled_agents.blank?

--- a/engines/collavre/app/models/collavre/comment.rb
+++ b/engines/collavre/app/models/collavre/comment.rb
@@ -565,7 +565,9 @@ module Collavre
       # when the local Claude TUI answered the prompt, leaving pending_tool_call
       # set on the server for the rest of a locally-approved tool run.
 
-      SystemEvents::Dispatcher.dispatch("comment_created", dispatch_payload)
+      SystemEvents::Dispatcher.dispatch(
+        "comment_created", dispatch_payload, source: "comment_callback"
+      )
     rescue StandardError => e
       Rails.logger.error(
         "[Comment#dispatch_to_orchestration] Failed for comment #{id}: " \

--- a/engines/collavre/app/models/collavre/comment.rb
+++ b/engines/collavre/app/models/collavre/comment.rb
@@ -565,9 +565,7 @@ module Collavre
       # when the local Claude TUI answered the prompt, leaving pending_tool_call
       # set on the server for the rest of a locally-approved tool run.
 
-      SystemEvents::Dispatcher.dispatch(
-        "comment_created", dispatch_payload, source: "comment_callback"
-      )
+      SystemEvents::Dispatcher.dispatch("comment_created", dispatch_payload, source: "comment_callback")
     rescue StandardError => e
       Rails.logger.error(
         "[Comment#dispatch_to_orchestration] Failed for comment #{id}: " \

--- a/engines/collavre/app/services/collavre/ai_agent/a2a_dispatcher.rb
+++ b/engines/collavre/app/services/collavre/ai_agent/a2a_dispatcher.rb
@@ -73,7 +73,12 @@ module Collavre
         # creator and execute with that person's workspace credentials.
         payload[:workspace_user_id] = @workspace_user&.id
 
-        SystemEvents::Dispatcher.dispatch("comment_created", payload)
+        SystemEvents::Dispatcher.dispatch(
+          "comment_created",
+          payload,
+          source: "a2a",
+          parent: SystemEvents::Envelope.in(@context)
+        )
       end
     end
   end

--- a/engines/collavre/app/services/collavre/ai_agent/message_builder.rb
+++ b/engines/collavre/app/services/collavre/ai_agent/message_builder.rb
@@ -236,7 +236,8 @@ module Collavre
       end
 
       def append_trigger_message(messages)
-        payload_text = @context.dig("comment", "content") || @context.to_json
+        payload_text = @context.dig("comment", "content") ||
+          @context.except(SystemEvents::Envelope::KEY).to_json
 
         if review_eligible?
           quoted_body = @original_comment.quoted_comment&.content

--- a/engines/collavre/app/services/collavre/ai_agent/message_builder.rb
+++ b/engines/collavre/app/services/collavre/ai_agent/message_builder.rb
@@ -236,8 +236,7 @@ module Collavre
       end
 
       def append_trigger_message(messages)
-        payload_text = @context.dig("comment", "content") ||
-          @context.except(SystemEvents::Envelope::KEY).to_json
+        payload_text = trigger_payload_text
 
         if review_eligible?
           quoted_body = @original_comment.quoted_comment&.content
@@ -271,6 +270,10 @@ module Collavre
         end
 
         messages << { role: "user", kind: :trigger, parts: trigger_parts }
+      end
+
+      def trigger_payload_text
+        @context.dig("comment", "content") || @context.except(SystemEvents::Envelope::KEY).to_json
       end
 
       def merged_trigger

--- a/engines/collavre/app/services/collavre/system_events/dispatcher.rb
+++ b/engines/collavre/app/services/collavre/system_events/dispatcher.rb
@@ -1,22 +1,59 @@
+# frozen_string_literal: true
+
 module Collavre
   module SystemEvents
+    # The only entry point to orchestration. It validates the event type and
+    # stamps its envelope before the payload is persisted or scheduled.
     class Dispatcher
-      def self.dispatch(event_name, context)
-        new.dispatch(event_name, context)
+      def self.dispatch(event_name, context, source: nil, parent: nil)
+        new.dispatch(event_name, context, source: source, parent: parent)
       end
 
-      def dispatch(event_name, context)
-        comment_id = context.dig("comment", "id")
-        comment_user_id = context.dig("comment", "user_id")
-        creative_id = context.dig("creative", "id")
-        Rails.logger.info(
-          "[SystemEvents::Dispatcher] event=#{event_name} " \
-          "comment_id=#{comment_id} comment_user_id=#{comment_user_id} " \
-          "creative_id=#{creative_id} " \
-          "caller=#{caller_locations(1, 5)&.map { |l| "#{File.basename(l.path)}:#{l.lineno}" }&.join(' <- ')}"
+      def dispatch(event_name, context, source: nil, parent: nil)
+        definition = Vocabulary.fetch(event_name)
+        ctx = (context || {}).deep_stringify_keys
+        envelope = resolve_envelope(definition.name, ctx, source, parent)
+        ctx[Envelope::KEY] = envelope.to_h
+
+        warn_missing_keys(definition, ctx, envelope)
+        log_dispatch(definition, ctx, envelope)
+
+        Orchestration::AgentOrchestrator.dispatch(definition.name, ctx)
+      end
+
+      private
+
+      def resolve_envelope(event_name, context, source, parent)
+        return Envelope.child(event_name, parent: parent, source: source) if parent
+
+        existing = Envelope.in(context)
+        return Envelope.root(event_name, source: source) if existing.nil?
+        return existing if existing.name == event_name
+
+        Envelope.child(event_name, parent: existing, source: source)
+      end
+
+      def warn_missing_keys(definition, context, envelope)
+        missing = Vocabulary.missing_keys(definition.name, context)
+        return if missing.empty?
+
+        Rails.logger.warn(
+          "[SystemEvents::Dispatcher] event=#{definition.name} " \
+          "event_id=#{envelope.id} missing_keys=#{missing.join(',')}"
         )
-        # Delegate to AgentOrchestrator for unified routing/scheduling
-        Orchestration::AgentOrchestrator.dispatch(event_name, context)
+      end
+
+      def log_dispatch(definition, context, envelope)
+        Rails.logger.info(
+          "[SystemEvents::Dispatcher] event=#{definition.name} " \
+          "event_id=#{envelope.id} correlation_id=#{envelope.correlation_id} " \
+          "causation_id=#{envelope.causation_id || '-'} depth=#{envelope.depth} " \
+          "source=#{envelope.source} " \
+          "comment_id=#{context.dig('comment', 'id')} " \
+          "comment_user_id=#{context.dig('comment', 'user_id')} " \
+          "creative_id=#{context.dig('creative', 'id')} " \
+          "caller=#{caller_locations(1, 5)&.map { |location| "#{File.basename(location.path)}:#{location.lineno}" }&.join(' <- ')}"
+        )
       end
     end
   end

--- a/engines/collavre/app/services/collavre/system_events/envelope.rb
+++ b/engines/collavre/app/services/collavre/system_events/envelope.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+module Collavre
+  module SystemEvents
+    # JSON-safe metadata that identifies an orchestration dispatch and its
+    # causal chain. It travels inside tasks.trigger_event_payload under KEY.
+    class Envelope < Data.define(
+      :id, :name, :correlation_id, :causation_id, :depth, :source, :occurred_at
+    )
+      KEY = "event"
+      UNKNOWN_SOURCE = "unknown"
+
+      def self.root(name, source: nil)
+        id = SecureRandom.uuid
+        new(
+          id: id,
+          name: name.to_s,
+          correlation_id: id,
+          causation_id: nil,
+          depth: 0,
+          source: (source.presence || UNKNOWN_SOURCE).to_s,
+          occurred_at: Time.current.utc.iso8601
+        )
+      end
+
+      def self.child(name, parent:, source: nil)
+        parent = from(parent) unless parent.is_a?(Envelope)
+        return root(name, source: source) if parent.nil?
+
+        root(name, source: source).with(
+          correlation_id: parent.correlation_id,
+          causation_id: parent.id,
+          depth: parent.depth.to_i + 1
+        )
+      end
+
+      def self.from(hash)
+        return hash if hash.is_a?(Envelope)
+        return nil unless hash.respond_to?(:to_h)
+
+        hash = hash.to_h.deep_stringify_keys
+        id = hash["id"]
+        return nil if id.blank?
+
+        new(
+          id: id,
+          name: hash["name"].to_s,
+          correlation_id: hash["correlation_id"].presence || id,
+          causation_id: hash["causation_id"].presence,
+          depth: hash["depth"].to_i,
+          source: hash["source"].presence || UNKNOWN_SOURCE,
+          occurred_at: hash["occurred_at"].presence
+        )
+      rescue TypeError
+        nil
+      end
+
+      def self.in(context)
+        return nil unless context.is_a?(Hash)
+
+        from(context[KEY] || context[KEY.to_sym])
+      end
+
+      def root?
+        causation_id.nil?
+      end
+
+      def to_h
+        super.deep_stringify_keys
+      end
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/system_events/vocabulary.rb
+++ b/engines/collavre/app/services/collavre/system_events/vocabulary.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Collavre
+  module SystemEvents
+    # The registry of event names orchestration can dispatch.
+    module Vocabulary
+      UnknownEvent = Class.new(ArgumentError)
+      Definition = Data.define(:name, :required_keys, :sources)
+
+      EVENTS = {
+        "comment_created" => Definition.new(
+          name: "comment_created",
+          required_keys: %w[comment creative],
+          sources: %w[comment_callback cron a2a drop_trigger trigger_restart]
+        )
+      }.freeze
+
+      def self.names
+        EVENTS.keys
+      end
+
+      def self.known?(name)
+        EVENTS.key?(name.to_s)
+      end
+
+      def self.fetch(name)
+        EVENTS.fetch(name.to_s) do
+          raise UnknownEvent,
+            "Unknown system event #{name.inspect}. Known events: #{names.join(', ')}"
+        end
+      end
+
+      # Required keys are advisory. The dispatcher warns rather than refusing
+      # a malformed payload, preserving the behavior of existing callers.
+      def self.missing_keys(name, payload)
+        return [] unless known?(name)
+
+        payload ||= {}
+        fetch(name).required_keys.reject do |key|
+          !payload[key].nil? || !payload[key.to_sym].nil?
+        end
+      end
+    end
+  end
+end

--- a/engines/collavre/test/controllers/creatives_controller_event_source_test.rb
+++ b/engines/collavre/test/controllers/creatives_controller_event_source_test.rb
@@ -1,0 +1,31 @@
+require "test_helper"
+
+module Collavre
+  class CreativesControllerEventSourceTest < ActiveSupport::TestCase
+    setup do
+      @user = users(:one)
+      Current.session = OpenStruct.new(user: @user)
+      @agent = users(:ai_bot)
+      @parent = Creative.create!(user: @user, description: "Trigger parent")
+      @child = Creative.create!(user: @user, parent: @parent, description: "Trigger child")
+      CreativeShare.create!(creative: @parent, user: @agent, permission: :write)
+      @child.topics.create!(name: "Drop Trigger", user: @user)
+    end
+
+    teardown do
+      Current.reset
+    end
+
+    test "a trigger restart declares its dispatch source" do
+      dispatch_options = nil
+      SystemEvents::Dispatcher.stub(:dispatch, lambda { |_event, _payload, **options|
+        dispatch_options = options
+        []
+      }) do
+        CreativesController.new.send(:post_restart_trigger, @child)
+      end
+
+      assert_equal "trigger_restart", dispatch_options[:source]
+    end
+  end
+end

--- a/engines/collavre/test/jobs/collavre/ai_agent_job_topic_slot_test.rb
+++ b/engines/collavre/test/jobs/collavre/ai_agent_job_topic_slot_test.rb
@@ -1084,7 +1084,7 @@ module Collavre
       )
 
       payload = nil
-      SystemEvents::Dispatcher.stub(:dispatch, ->(_event, sent) { payload = sent; [] }) do
+      SystemEvents::Dispatcher.stub(:dispatch, ->(_event, sent, **_options) { payload = sent; [] }) do
         CronActionJob.perform_now(
           creative_id: @creative.id, topic_id: nil,
           agent_id: @user.id, message: "@#{@agent.name}: scheduled check-in"

--- a/engines/collavre/test/jobs/collavre/cron_action_job_test.rb
+++ b/engines/collavre/test/jobs/collavre/cron_action_job_test.rb
@@ -76,7 +76,11 @@ module Collavre
     # (admission, the topic slot, the promotion refresh) believes the payload.
     test "a Main-topic cron names the topic its comment was filed under" do
       payload = nil
-      SystemEvents::Dispatcher.stub(:dispatch, ->(_event, sent) { payload = sent; [] }) do
+      SystemEvents::Dispatcher.stub(:dispatch, ->(_event, sent, **options) {
+        payload = sent
+        @dispatch_options = options
+        []
+      }) do
         CronActionJob.perform_now(
           creative_id: @creative.id,
           topic_id: nil,
@@ -90,13 +94,18 @@ module Collavre
                      "assign_main_topic files a topic-less comment under Main"
       assert_equal comment.topic_id, payload.dig(:topic, :id),
                    "the dispatch payload must name the topic the comment lives in"
+      assert_equal "cron", @dispatch_options[:source]
     end
 
     # Control: an explicit topic still round-trips. "Always resolve Main" would
     # pass the test above on its own while sending every cron to the wrong topic.
     test "an explicit cron topic is dispatched unchanged" do
       payload = nil
-      SystemEvents::Dispatcher.stub(:dispatch, ->(_event, sent) { payload = sent; [] }) do
+      SystemEvents::Dispatcher.stub(:dispatch, ->(_event, sent, **options) {
+        payload = sent
+        @dispatch_options = options
+        []
+      }) do
         CronActionJob.perform_now(
           creative_id: @creative.id,
           topic_id: @topic.id,
@@ -106,6 +115,7 @@ module Collavre
       end
 
       assert_equal @topic.id, payload.dig(:topic, :id)
+      assert_equal "cron", @dispatch_options[:source]
     end
   end
 end

--- a/engines/collavre/test/jobs/collavre/drop_trigger_job_test.rb
+++ b/engines/collavre/test/jobs/collavre/drop_trigger_job_test.rb
@@ -41,7 +41,7 @@ module Collavre
 
     test "dispatches exactly once via explicit call, not callback" do
       dispatch_calls = []
-      dispatcher = ->(*args) { dispatch_calls << args; [ @ai_bot ] }
+      dispatcher = ->(*args, **options) { dispatch_calls << [ args, options ]; [ @ai_bot ] }
 
       SystemEvents::Dispatcher.stub(:dispatch, dispatcher) do
         DropTriggerJob.perform_now(@parent.id, @child.id)
@@ -51,6 +51,7 @@ module Collavre
       # - after_create_commit callback is suppressed (skip_dispatch: true)
       # - Job dispatches explicitly in Step 3
       assert_equal 1, dispatch_calls.size, "Should dispatch exactly once (job only, not callback)"
+      assert_equal "drop_trigger", dispatch_calls.first.last[:source]
     end
 
     test "reuses existing Drop Trigger topic" do

--- a/engines/collavre/test/models/collavre/comment_dispatch_test.rb
+++ b/engines/collavre/test/models/collavre/comment_dispatch_test.rb
@@ -18,9 +18,10 @@ module Collavre
       dispatched_event = nil
       dispatched_context = nil
 
-      SystemEvents::Dispatcher.stub(:dispatch, ->(event, context) {
+      SystemEvents::Dispatcher.stub(:dispatch, ->(event, context, **options) {
         dispatched_event = event
         dispatched_context = context
+        @dispatch_options = options
         []
       }) do
         @creative.comments.create!(content: "test dispatch", user: @user)
@@ -29,6 +30,7 @@ module Collavre
       assert_equal "comment_created", dispatched_event
       assert_equal "test dispatch", dispatched_context.dig(:comment, :content)
       assert_equal @creative.id, dispatched_context.dig(:creative, :id)
+      assert_equal "comment_callback", @dispatch_options[:source]
     end
 
     test "does not dispatch for private comments" do

--- a/engines/collavre/test/services/ai_agent_service_test.rb
+++ b/engines/collavre/test/services/ai_agent_service_test.rb
@@ -157,13 +157,12 @@ class AiAgentServiceTest < ActiveSupport::TestCase
     def mock_client.handed_off? = true
 
     dispatched = false
-    original_dispatch = Collavre::SystemEvents::Dispatcher.method(:dispatch)
-
-    Collavre::SystemEvents::Dispatcher.stub :dispatch, ->(event_name, context) {
+    Collavre::SystemEvents::Dispatcher.stub :dispatch, ->(event_name, context, **options) {
       dispatched = true
       assert_equal "comment_created", event_name
       assert_equal "@AgentB: 이 주제에 대해 어떻게 생각해?", context[:comment][:content]
       assert_equal @user.id, context[:workspace_user_id]
+      assert_equal "a2a", options[:source]
     } do
       AiClient.stub :new, mock_client do
         AiAgentService.new(@task).call
@@ -268,7 +267,7 @@ class AiAgentServiceTest < ActiveSupport::TestCase
     mock_client.define_singleton_method(:handed_off?) { true }
     dispatched = nil
 
-    SystemEvents::Dispatcher.stub(:dispatch, ->(_event_name, payload) { dispatched = payload }) do
+    SystemEvents::Dispatcher.stub(:dispatch, ->(_event_name, payload, **_options) { dispatched = payload }) do
       AiClient.stub(:new, mock_client) { AiAgentService.new(@task).call }
     end
 

--- a/engines/collavre/test/services/collavre/ai_agent/a2a_dispatcher_envelope_test.rb
+++ b/engines/collavre/test/services/collavre/ai_agent/a2a_dispatcher_envelope_test.rb
@@ -1,0 +1,120 @@
+require "test_helper"
+
+module Collavre
+  module AiAgent
+    class A2aDispatcherEnvelopeTest < ActiveSupport::TestCase
+      include ActiveJob::TestHelper
+
+      Envelope = Collavre::SystemEvents::Envelope
+
+      setup do
+        @original_adapter = ActiveJob::Base.queue_adapter
+        ActiveJob::Base.queue_adapter = :test
+        @creative = creatives(:tshirt)
+        @speaker = build_agent("a2a_speaker@example.com", "A2A Speaker")
+        @listener = build_agent("a2a_listener@example.com", "A2A Listener")
+        @reply = Comment.create!(
+          creative: @creative,
+          user: @speaker,
+          content: "@A2A Listener: your turn",
+          skip_dispatch: true
+        )
+      end
+
+      teardown do
+        ActiveJob::Base.queue_adapter = @original_adapter
+      end
+
+      test "an A2A dispatch is a child of the turn that produced it" do
+        parent = Envelope.root("comment_created", source: "comment_callback")
+
+        dispatch_with(parent)
+
+        envelope = dispatched_envelope
+        assert_equal "a2a", envelope.source
+        assert_equal parent.id, envelope.causation_id
+        assert_equal parent.correlation_id, envelope.correlation_id
+        assert_equal 1, envelope.depth
+      end
+
+      test "A2A chains retain their original correlation and keep increasing depth" do
+        root = Envelope.root("comment_created", source: "comment_callback")
+        parent = Envelope.child("comment_created", parent: root, source: "a2a")
+
+        dispatch_with(parent)
+
+        envelope = dispatched_envelope
+        assert_equal root.correlation_id, envelope.correlation_id
+        assert_equal parent.id, envelope.causation_id
+        assert_equal 2, envelope.depth
+      end
+
+      test "a missing parent envelope still dispatches as an A2A root" do
+        dispatch_with(nil)
+
+        envelope = dispatched_envelope
+        assert_equal "a2a", envelope.source
+        assert envelope.root?
+        assert_equal 0, envelope.depth
+      end
+
+      test "the Claude Channel reply path carries the task envelope into A2A context" do
+        parent = Envelope.root("comment_created", source: "comment_callback")
+        task = Task.create!(
+          name: "Response to comment_created",
+          status: "running",
+          trigger_event_name: "comment_created",
+          trigger_event_payload: { Envelope::KEY => parent.to_h },
+          agent: @speaker,
+          topic_id: @reply.topic_id,
+          creative_id: @creative.id
+        )
+        captured_context = nil
+        dispatcher = Object.new
+        dispatcher.define_singleton_method(:dispatch) { }
+
+        A2aDispatcher.stub(:new, lambda { |**options|
+          captured_context = options.fetch(:context)
+          dispatcher
+        }) do
+          Api::V1::AgentsController.new.send(:dispatch_a2a, @speaker, @reply, task: task)
+        end
+
+        assert_equal parent.to_h, captured_context[Envelope::KEY]
+      end
+
+      private
+
+      def build_agent(email, name)
+        agent = User.create!(
+          email: email,
+          name: name,
+          password: "password123",
+          llm_vendor: "google",
+          llm_model: "gemini-1.5-flash",
+          searchable: true
+        )
+        share = CreativeShare.find_or_create_by!(creative: @creative, user: agent)
+        share.update!(permission: "feedback")
+        CreativeSharesCache.find_or_create_by!(
+          creative_id: @creative.id, user_id: agent.id, permission: :feedback
+        )
+        agent
+      end
+
+      def dispatch_with(parent)
+        context = {
+          "creative" => { "id" => @creative.id },
+          "topic" => { "id" => @reply.topic_id }
+        }
+        context[Envelope::KEY] = parent.to_h if parent
+
+        A2aDispatcher.new(agent: @speaker, reply_comment: @reply, context: context).dispatch
+      end
+
+      def dispatched_envelope
+        Envelope.in(ActiveJob::Base.queue_adapter.enqueued_jobs.last[:args][2])
+      end
+    end
+  end
+end

--- a/engines/collavre/test/services/collavre/ai_agent/message_builder_test.rb
+++ b/engines/collavre/test/services/collavre/ai_agent/message_builder_test.rb
@@ -203,6 +203,21 @@ module Collavre
         assert_instance_of Array, result[:messages]
       end
 
+      test "does not expose event envelope metadata in the JSON trigger fallback" do
+        envelope = SystemEvents::Envelope.root("comment_created", source: "cron")
+        context = {
+          "creative" => { "id" => @creative.id },
+          SystemEvents::Envelope::KEY => envelope.to_h
+        }
+
+        result = MessageBuilder.new(agent: @agent, context: context).build
+        trigger_text = result[:messages].find { |message| message[:kind] == :trigger }
+                       .dig(:parts, 0, :text)
+
+        assert_not_includes trigger_text, envelope.id
+        assert_not_includes trigger_text, "correlation_id"
+      end
+
       test "first_message is true when no chat history exists" do
         context = {
           "comment" => { "id" => @comment.id, "content" => "Hello" },

--- a/engines/collavre/test/services/collavre/orchestration/envelope_propagation_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/envelope_propagation_test.rb
@@ -1,0 +1,93 @@
+require "test_helper"
+
+module Collavre
+  module Orchestration
+    class EnvelopePropagationTest < ActiveSupport::TestCase
+      include ActiveJob::TestHelper
+
+      Envelope = Collavre::SystemEvents::Envelope
+
+      setup do
+        @original_adapter = ActiveJob::Base.queue_adapter
+        ActiveJob::Base.queue_adapter = :test
+        @human = users(:one)
+        @creative = creatives(:tshirt)
+        @agent = User.create!(
+          email: "envelope_propagation_agent@example.com",
+          name: "Envelope Propagation Agent",
+          password: "password123",
+          llm_vendor: "google",
+          llm_model: "gemini-1.5-flash",
+          routing_expression: "true",
+          searchable: true
+        )
+        share = CreativeShare.find_or_create_by!(creative: @creative, user: @agent)
+        share.update!(permission: "feedback")
+        CreativeSharesCache.find_or_create_by!(
+          creative_id: @creative.id, user_id: @agent.id, permission: :feedback
+        )
+        @envelope = Envelope.child(
+          "comment_created",
+          parent: Envelope.root("comment_created", source: "comment_callback"),
+          source: "a2a"
+        )
+      end
+
+      teardown do
+        ActiveJob::Base.queue_adapter = @original_adapter
+      end
+
+      test "the envelope survives task persistence, re-anchoring, and coalescing" do
+        anchor = comment!("first")
+        later = comment!("second")
+        task = Task.create!(
+          name: "Response to comment_created",
+          status: "queued",
+          trigger_event_name: "comment_created",
+          trigger_event_payload: payload(anchor),
+          agent: @agent,
+          topic_id: anchor.topic_id,
+          creative_id: @creative.id
+        )
+
+        assert_equal @envelope, Envelope.in(task.reload.trigger_event_payload)
+
+        moved = TaskCoalescer.reanchor_payload(payload(anchor), later)
+        assert_equal later.id, moved.dig("comment", "id")
+        assert_equal @envelope, Envelope.in(moved)
+
+        merged = TaskCoalescer.absorb_into_payload(payload(anchor), [ later.id ])
+        assert_includes merged[TaskCoalescer::PAYLOAD_KEY], later.id
+        assert_equal @envelope, Envelope.in(merged)
+      end
+
+      test "a promoted waiter preserves its event envelope" do
+        anchor = comment!("first")
+        waiter = Task.create!(
+          name: "Response to comment_created",
+          status: "queued",
+          trigger_event_name: "comment_created",
+          trigger_event_payload: payload(anchor),
+          agent: @agent,
+          topic_id: anchor.topic_id,
+          creative_id: @creative.id
+        )
+
+        AgentOrchestrator.dequeue_next_for_topic(waiter.topic_id, waiter.creative_id)
+
+        assert_equal "pending", waiter.reload.status
+        assert_equal @envelope, Envelope.in(waiter.trigger_event_payload)
+      end
+
+      private
+
+      def comment!(content)
+        Comment.create!(creative: @creative, user: @human, content: content, skip_dispatch: true)
+      end
+
+      def payload(comment)
+        comment.dispatch_payload.deep_stringify_keys.merge(Envelope::KEY => @envelope.to_h)
+      end
+    end
+  end
+end

--- a/engines/collavre/test/services/collavre/system_events/envelope_test.rb
+++ b/engines/collavre/test/services/collavre/system_events/envelope_test.rb
@@ -1,0 +1,67 @@
+require "test_helper"
+
+module Collavre
+  module SystemEvents
+    class EnvelopeTest < ActiveSupport::TestCase
+      test "a root is its own correlation at depth zero" do
+        envelope = Envelope.root("comment_created", source: "comment_callback")
+
+        assert_equal envelope.id, envelope.correlation_id
+        assert_nil envelope.causation_id
+        assert_equal 0, envelope.depth
+        assert_equal "comment_callback", envelope.source
+        assert envelope.root?
+        assert_match(/\A\d{4}-\d{2}-\d{2}T/, envelope.occurred_at)
+      end
+
+      test "a child advances depth and retains its causal chain" do
+        parent = Envelope.root("comment_created", source: "comment_callback")
+        child = Envelope.child("comment_created", parent: parent.to_h, source: "a2a")
+
+        assert_not_equal parent.id, child.id
+        assert_equal parent.correlation_id, child.correlation_id
+        assert_equal parent.id, child.causation_id
+        assert_equal 1, child.depth
+        assert_equal "a2a", child.source
+        assert_not child.root?
+      end
+
+      test "an absent or invalid parent falls back to a root" do
+        [ nil, "not a hash", {} ].each do |parent|
+          envelope = Envelope.child("comment_created", parent: parent, source: nil)
+
+          assert envelope.root?
+          assert_equal envelope.id, envelope.correlation_id
+          assert_equal Envelope::UNKNOWN_SOURCE, envelope.source
+        end
+      end
+
+      test "it round trips through JSON with string keys" do
+        envelope = Envelope.root("comment_created", source: "cron")
+        restored = Envelope.from(JSON.parse(envelope.to_h.to_json))
+
+        assert_equal envelope, restored
+        assert_equal %w[causation_id correlation_id depth id name occurred_at source], envelope.to_h.keys.sort
+        assert envelope.to_h.keys.all? { |key| key.is_a?(String) }
+      end
+
+      test "from tolerates incomplete data and in reads either key form" do
+        envelope = Envelope.root("comment_created", source: "cron")
+
+        assert_nil Envelope.from(nil)
+        assert_nil Envelope.from({ "name" => "comment_created" })
+        restored = Envelope.from({ "id" => "evt-1", "name" => "comment_created" })
+        assert_equal "evt-1", restored.correlation_id
+        assert_equal 0, restored.depth
+        assert_equal envelope, Envelope.in({ "event" => envelope.to_h })
+        assert_equal envelope, Envelope.in({ event: envelope.to_h })
+        assert_nil Envelope.in(nil)
+      end
+
+      test "constants belong to Envelope rather than SystemEvents" do
+        assert_equal "event", Envelope::KEY
+        assert_not Collavre::SystemEvents.const_defined?(:KEY, false)
+      end
+    end
+  end
+end

--- a/engines/collavre/test/services/collavre/system_events/vocabulary_test.rb
+++ b/engines/collavre/test/services/collavre/system_events/vocabulary_test.rb
@@ -1,0 +1,39 @@
+require "test_helper"
+
+module Collavre
+  module SystemEvents
+    class VocabularyTest < ActiveSupport::TestCase
+      test "comment_created is registered with its payload shape and sources" do
+        definition = Vocabulary.fetch(:comment_created)
+
+        assert Vocabulary.known?("comment_created")
+        assert_includes Vocabulary.names, "comment_created"
+        assert_equal %w[comment creative], definition.required_keys
+        assert_includes definition.sources, "comment_callback"
+        assert_includes definition.sources, "a2a"
+      end
+
+      test "an unregistered event raises and is not known" do
+        error = assert_raises(Vocabulary::UnknownEvent) { Vocabulary.fetch("deploy_requested") }
+
+        assert_match(/deploy_requested/, error.message)
+        assert_match(/comment_created/, error.message)
+        assert_not Vocabulary.known?("deploy_requested")
+        assert_not Vocabulary.known?(nil)
+      end
+
+      test "missing keys accepts symbol or string payload keys and treats nil as absent" do
+        assert_equal %w[creative], Vocabulary.missing_keys("comment_created", { "comment" => {} })
+        assert_empty Vocabulary.missing_keys("comment_created", { comment: {}, creative: {} })
+        assert_equal %w[creative], Vocabulary.missing_keys(
+          "comment_created", { "comment" => {}, "creative" => nil }
+        )
+      end
+
+      test "an unknown event has no declared missing payload keys" do
+        assert_empty Vocabulary.missing_keys("deploy_requested", {})
+        assert Vocabulary::EVENTS.frozen?
+      end
+    end
+  end
+end

--- a/engines/collavre/test/services/system_events/dispatcher_test.rb
+++ b/engines/collavre/test/services/system_events/dispatcher_test.rb
@@ -4,14 +4,13 @@ module SystemEvents
   class DispatcherTest < ActiveSupport::TestCase
     include ActiveJob::TestHelper
 
+    Envelope = Collavre::SystemEvents::Envelope
+    Vocabulary = Collavre::SystemEvents::Vocabulary
+
     setup do
-      # Use test adapter for this file to test job enqueueing behavior
       @original_adapter = ActiveJob::Base.queue_adapter
       ActiveJob::Base.queue_adapter = :test
-
-      @user = users(:one)
       @creative = creatives(:tshirt)
-
       @agent = User.create!(
         email: "dispatcher_test_agent@example.com",
         name: "Dispatcher Agent",
@@ -21,17 +20,11 @@ module SystemEvents
         routing_expression: "true",
         searchable: true
       )
-
-      # Grant feedback permission on the creative for AI agent
       share = Collavre::CreativeShare.find_or_create_by!(creative: @creative, user: @agent)
       share.update!(permission: "feedback")
-      # Manually create cache entry (after_commit doesn't run in test transaction)
       Collavre::CreativeSharesCache.find_or_create_by!(
-        creative_id: @creative.id,
-        user_id: @agent.id,
-        permission: :feedback
+        creative_id: @creative.id, user_id: @agent.id, permission: :feedback
       )
-
       @context = { "creative" => { "id" => @creative.id }, "some" => "context" }
     end
 
@@ -39,26 +32,81 @@ module SystemEvents
       ActiveJob::Base.queue_adapter = @original_adapter
     end
 
-    test "dispatches event and enqueues job for matched agent" do
-      assert_enqueued_with(job: AiAgentJob) do
-        SystemEvents::Dispatcher.dispatch("test_event", @context)
-      end
-
-      # Verify the enqueued job has the correct agent and event
-      job = ActiveJob::Base.queue_adapter.enqueued_jobs.last
-      assert_equal @agent.id, job[:args][0]
-      assert_equal "test_event", job[:args][1]
-
-      # Context should include event_name (added by Orchestrator)
-      enqueued_context = job[:args][2]
-      assert_equal "test_event", enqueued_context["event_name"]
+    def enqueued_context
+      ActiveJob::Base.queue_adapter.enqueued_jobs.last[:args][2]
     end
 
-    test "does not enqueue job if no agent matches" do
+    test "dispatches the registered event and stamps a root envelope" do
+      assert_enqueued_with(job: AiAgentJob) do
+        SystemEvents::Dispatcher.dispatch("comment_created", @context, source: "cron")
+      end
+
+      job = ActiveJob::Base.queue_adapter.enqueued_jobs.last
+      assert_equal @agent.id, job[:args][0]
+      assert_equal "comment_created", job[:args][1]
+      assert_equal "comment_created", enqueued_context["event_name"]
+
+      envelope = Envelope.in(enqueued_context)
+      assert_equal "cron", envelope.source
+      assert_equal 0, envelope.depth
+      assert_equal envelope.id, envelope.correlation_id
+      assert_nil envelope.causation_id
+    end
+
+    test "preserves a same-name envelope already in the payload" do
+      existing = Envelope.root("comment_created", source: "drop_trigger")
+
+      SystemEvents::Dispatcher.dispatch(
+        "comment_created", @context.merge(Envelope::KEY => existing.to_h)
+      )
+
+      assert_equal existing, Envelope.in(enqueued_context)
+    end
+
+    test "an explicit parent makes a child and outranks the payload envelope" do
+      existing = Envelope.root("comment_created", source: "drop_trigger")
+      parent = Envelope.root("comment_created", source: "comment_callback")
+
+      SystemEvents::Dispatcher.dispatch(
+        "comment_created",
+        @context.merge(Envelope::KEY => existing.to_h),
+        source: "a2a",
+        parent: parent
+      )
+
+      envelope = Envelope.in(enqueued_context)
+      assert_equal parent.correlation_id, envelope.correlation_id
+      assert_equal parent.id, envelope.causation_id
+      assert_equal 1, envelope.depth
+      assert_equal "a2a", envelope.source
+    end
+
+    test "an envelope for a different event becomes the parent" do
+      existing = Envelope.root("other_event", source: "cron")
+
+      SystemEvents::Dispatcher.dispatch(
+        "comment_created", @context.merge(Envelope::KEY => existing.to_h), source: "a2a"
+      )
+
+      envelope = Envelope.in(enqueued_context)
+      assert_equal existing.id, envelope.causation_id
+      assert_equal existing.correlation_id, envelope.correlation_id
+    end
+
+    test "normalizes a symbol-keyed context without mutating the caller" do
+      context = { creative: { id: @creative.id } }
+
+      SystemEvents::Dispatcher.dispatch("comment_created", context, source: "cron")
+
+      assert_equal [ :creative ], context.keys
+      assert_equal "cron", Envelope.in(enqueued_context).source
+    end
+
+    test "does not enqueue work when no agent matches" do
       @agent.update!(routing_expression: "false")
 
       assert_no_enqueued_jobs do
-        SystemEvents::Dispatcher.dispatch("test_event", @context)
+        SystemEvents::Dispatcher.dispatch("comment_created", @context)
       end
     end
 
@@ -68,15 +116,27 @@ module SystemEvents
         "chat" => { "content" => "@Dispatcher Agent: Hello" }
       }
 
-      assert_enqueued_with(job: AiAgentJob) do
-        SystemEvents::Dispatcher.dispatch("test_event", chat_context)
+      SystemEvents::Dispatcher.dispatch("comment_created", chat_context)
+
+      assert_equal @agent.id, enqueued_context.dig("chat", "mentioned_user", "id")
+    end
+
+    test "unknown event names fail before scheduling" do
+      assert_no_enqueued_jobs do
+        assert_raises(Vocabulary::UnknownEvent) do
+          SystemEvents::Dispatcher.dispatch("deploy_requested", @context)
+        end
+      end
+    end
+
+    test "missing required payload keys warn but still dispatch" do
+      warnings = []
+      Rails.logger.stub(:warn, ->(message) { warnings << message }) do
+        SystemEvents::Dispatcher.dispatch("comment_created", @context, source: "cron")
       end
 
-      job = ActiveJob::Base.queue_adapter.enqueued_jobs.last
-      enqueued_context = job[:args][2]
-
-      assert enqueued_context["chat"].key?("mentioned_user")
-      assert_equal @agent.id, enqueued_context["chat"]["mentioned_user"]["id"]
+      assert warnings.any? { |message| message.include?("missing_keys=comment") }
+      assert_enqueued_jobs 1, only: AiAgentJob
     end
   end
 end

--- a/engines/collavre_github/test/integration/pr_channel_end_to_end_test.rb
+++ b/engines/collavre_github/test/integration/pr_channel_end_to_end_test.rb
@@ -39,7 +39,7 @@ module CollavreGithub
       sig = "sha256=" + OpenSSL::HMAC.hexdigest("SHA256", @link.webhook_secret, payload)
 
       dispatched_events = []
-      Collavre::SystemEvents::Dispatcher.stub(:dispatch, ->(event, _ctx) { dispatched_events << event; [] }) do
+      Collavre::SystemEvents::Dispatcher.stub(:dispatch, ->(event, _ctx, **) { dispatched_events << event; [] }) do
         assert_difference -> { Collavre::Comment.where(topic_id: @topic.id).count }, 1 do
           post "/github/webhooks",
             params: payload,
@@ -70,7 +70,7 @@ module CollavreGithub
         "X-Hub-Signature-256" => sig
       }
 
-      Collavre::SystemEvents::Dispatcher.stub(:dispatch, ->(_event, _ctx) { [] }) do
+      Collavre::SystemEvents::Dispatcher.stub(:dispatch, ->(_event, _ctx, **) { [] }) do
         # GitHub redelivers a webhook when the receiver 5xx's. The second
         # delivery must short-circuit (row lock + state re-check) instead of
         # injecting another "PR #321 was merged" comment into the topic.


### PR DESCRIPTION
## Summary

Introduces the event vocabulary and causal envelope for orchestration dispatches.

- Registers `comment_created` with required payload keys and declared ingress sources.
- Adds JSON-safe envelopes to `context["event"]` with event, correlation, causation, depth, source, and timestamp metadata.
- Stamps and logs envelopes at the single dispatcher entry point without changing routing decisions.
- Tags every current ingress path, preserves envelopes across task lifecycle operations, and links A2A replies (including Claude Channel replies) to their parent event.

## Validation

- `./bin/rubocop -a` on all changed Ruby files
- `bin/complexity_check`
- Changed-area Rails suite: 1,010 runs, 0 failures
- `rake test:system`

`bin/rails test` was also run. It has 11 pre-existing GitHub webhook/reprovisioning errors because Active Record encryption credentials are not configured in this environment; the changed-area suite passes.