### PR TITLE
perf(comments): make read-pointer writes and receipt lookups batch-sized

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_14_000001) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_16_000001) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -172,10 +172,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_14_000001) do
     t.integer "topic_id"
     t.datetime "updated_at", null: false
     t.integer "user_id", null: false
+    t.index ["creative_id", "last_read_comment_id"], name: "index_comment_read_pointers_on_creative_and_watermark"
     t.index ["creative_id"], name: "index_comment_read_pointers_on_creative_id"
     t.index ["topic_id"], name: "index_comment_read_pointers_on_topic_id"
-    t.index ["user_id", "creative_id"], name: "index_comment_read_pointers_on_legacy_pointer", unique: true, where: "topic_id IS NULL"
     t.index ["user_id", "creative_id", "topic_id"], name: "index_comment_read_pointers_on_user_creative_and_topic", unique: true
+    t.index ["user_id", "creative_id"], name: "index_comment_read_pointers_on_legacy_pointer", unique: true, where: "topic_id IS NULL"
     t.index ["user_id"], name: "index_comment_read_pointers_on_user_id"
   end
 
@@ -236,8 +237,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_14_000001) do
     t.index ["approver_id"], name: "index_comments_on_approver_id"
     t.index ["creative_id", "created_at"], name: "index_comments_on_creative_id_and_created_at"
     t.index ["creative_id", "id"], name: "index_comments_on_creative_id_and_id"
+    t.index ["creative_id", "private", "approver_id", "topic_id"], name: "index_comments_on_creative_private_approver_id_and_topic"
     t.index ["creative_id", "private", "id"], name: "index_comments_on_creative_id_and_private_and_id"
     t.index ["creative_id", "private", "topic_id", "id"], name: "index_comments_on_creative_topic_private_and_id"
+    t.index ["creative_id", "private", "user_id", "topic_id"], name: "index_comments_on_creative_private_user_id_and_topic"
     t.index ["creative_id"], name: "index_comments_on_creative_id"
     t.index ["notification_key"], name: "index_comments_on_notification_key", unique: true, where: "notification_key IS NOT NULL"
     t.index ["quoted_comment_id"], name: "index_comments_on_quoted_comment_id"

--- a/engines/collavre/app/controllers/collavre/comment_read_pointers_controller.rb
+++ b/engines/collavre/app/controllers/collavre/comment_read_pointers_controller.rb
@@ -1,21 +1,15 @@
 module Collavre
   class CommentReadPointersController < ApplicationController
     LEGACY_TOPIC_WATERMARK_KEY = "_legacy"
+
     def update
       creative = Creative.find(params[:creative_id]).effective_origin
       topic = params[:topic_id].present? && creative.topics.find_by(id: params[:topic_id])
       return head :unprocessable_entity if params[:topic_id].present? && !topic
 
-      if topic
-        update_topic_pointer(creative, topic)
-      else
-        update_all_topic_pointers(
-          creative,
-          params[:topic_ids],
-          params[:topic_watermarks],
-          rendered_topic_ids_supplied: params.key?(:topic_ids)
-        )
-      end
+      last_ids = topic ? topic_last_id(creative, topic) : all_message_last_ids(creative)
+      positions = Comments::ReadPointerWriter.new(creative: creative, user: Current.user).call(last_ids)
+      Comments::ReadReceiptBroadcaster.new(creative: creative).call(positions)
 
       Comment.broadcast_badge(creative, Current.user)
 
@@ -24,23 +18,21 @@ module Collavre
 
     private
 
-    def update_topic_pointer(creative, topic)
-      last_id = creative.comments.visible_to(Current.user).where(topic: topic).maximum(:id)
-      update_pointer(creative, topic, last_id)
+    def topic_last_id(creative, topic)
+      { topic.id => creative.comments.visible_to(Current.user).where(topic: topic).maximum(:id) }
     end
 
     # All Messages renders Main plus active topics, not archived ones. Do not
     # advance the retained legacy pointer here: an archived topic without its
     # own pointer falls back to it, so moving that watermark would silently mark
     # its hidden comments as read.
-    def update_all_topic_pointers(creative, rendered_topic_ids, rendered_topic_watermarks, rendered_topic_ids_supplied: false)
+    def all_message_last_ids(creative)
       visible_comments = creative.comments.visible_to(Current.user)
-      topic_watermarks, legacy_watermark = normalized_topic_watermarks(rendered_topic_watermarks)
-      update_watermarked_topic_pointers(creative, visible_comments, topic_watermarks)
-      update_legacy_pointer(creative, visible_comments, legacy_watermark) if legacy_watermark.positive?
-      return if topic_watermarks.any? || legacy_watermark.positive?
+      topic_watermarks, legacy_watermark = normalized_topic_watermarks(params[:topic_watermarks])
+      return watermarked_last_ids(creative, visible_comments, topic_watermarks, legacy_watermark) if
+        topic_watermarks.any? || legacy_watermark.positive?
 
-      update_unwatermarked_topic_pointers(creative, visible_comments, rendered_topic_ids, rendered_topic_ids_supplied)
+      unwatermarked_last_ids(creative, visible_comments)
     end
 
     def normalized_topic_watermarks(rendered_topic_watermarks)
@@ -52,154 +44,52 @@ module Collavre
       [ topic_watermarks, raw_watermarks[LEGACY_TOPIC_WATERMARK_KEY].to_i ]
     end
 
-    def update_watermarked_topic_pointers(creative, visible_comments, topic_watermarks)
-      creative.topics.where(id: topic_watermarks.keys).find_each do |topic|
-        last_id = visible_comments.where(topic: topic).where("comments.id <= ?", topic_watermarks.fetch(topic.id)).maximum(:id)
-        update_pointer(creative, topic, last_id)
-      end
+    def watermarked_last_ids(creative, visible_comments, topic_watermarks, legacy_watermark)
+      last_ids = bounded_topic_last_ids(creative, visible_comments, topic_watermarks)
+      return last_ids unless legacy_watermark.positive?
+
+      legacy_last_id = visible_comments.where(topic_id: nil).where("comments.id <= ?", legacy_watermark).maximum(:id)
+      legacy_last_id ? last_ids.merge(nil => legacy_last_id) : last_ids
     end
 
-    def update_unwatermarked_topic_pointers(creative, visible_comments, rendered_topic_ids, rendered_topic_ids_supplied)
-      return update_legacy_client_pointers(creative, visible_comments) unless rendered_topic_ids_supplied
+    # Every rendered topic carries its own bound, so the maxima are OR-ed into a
+    # single grouped query rather than one MAX per topic. Built from relations
+    # rather than a SQL fragment: a hand-built string here would be safe (literal
+    # template, bound values) but unprovably so to a scanner.
+    def bounded_topic_last_ids(creative, visible_comments, topic_watermarks)
+      topic_ids = creative.topics.where(id: topic_watermarks.keys).pluck(:id)
+      return {} if topic_ids.empty?
 
-      creative.topics.where(id: Array(rendered_topic_ids)).find_each do |topic|
-        update_pointer(creative, topic, visible_comments.where(topic: topic).maximum(:id))
+      scopes = topic_ids.map do |topic_id|
+        Comment.where(creative_id: creative.id, topic_id: topic_id)
+               .where(Comment.arel_table[:id].lteq(topic_watermarks.fetch(topic_id)))
       end
+      maxima = grouped_topic_maxima(visible_comments, scopes)
+      topic_ids.index_with { |topic_id| maxima[topic_id] }
+    end
+
+    def unwatermarked_last_ids(creative, visible_comments)
+      rendered_topic_ids_supplied = params.key?(:topic_ids)
+      topics = rendered_topic_ids_supplied ? creative.topics.where(id: Array(params[:topic_ids])) : creative.topics
+      topic_ids = topics.pluck(:id)
+      maxima = visible_comments.where(topic_id: topic_ids).group(:topic_id).maximum(:id)
+      last_ids = topic_ids.index_with { |topic_id| maxima[topic_id] }
+      return last_ids if rendered_topic_ids_supplied
+
+      legacy_client_last_ids(visible_comments, last_ids)
     end
 
     # Clients deployed before topic-scoped watermarks only send creative_id.
     # Preserve the previous creative-wide endpoint semantics for them: every
     # named topic, including archived topics, and the retained legacy lane
     # advance through the visible history.
-    def update_legacy_client_pointers(creative, visible_comments)
-      creative.topics.find_each do |topic|
-        update_pointer(creative, topic, visible_comments.where(topic: topic).maximum(:id))
-      end
-
+    def legacy_client_last_ids(visible_comments, last_ids)
       legacy_last_id = visible_comments.where(topic_id: nil).maximum(:id)
-      update_legacy_pointer(creative, visible_comments, legacy_last_id) if legacy_last_id
+      legacy_last_id ? last_ids.merge(nil => legacy_last_id) : last_ids
     end
 
-    def update_pointer(creative, topic, last_id)
-      # A named pointer replaces the legacy fallback for this topic. Remember
-      # the fallback before creating the row so its previously rendered receipt
-      # is replaced as well, rather than lingering until the next page load.
-      legacy_last_read_id = CommentReadPointer.find_by(user: Current.user, creative: creative, topic: nil)&.last_read_comment_id
-      pointer = CommentReadPointer.find_or_create_by!(user: Current.user, creative: creative, topic: topic)
-      created_pointer = pointer.previously_new_record?
-      previous_last_read_id = nil
-      updated_last_read_id = nil
-
-      # A delayed All Messages update may contain an older rendered watermark
-      # than one already saved by another tab. Locking the row makes the
-      # read/maximum/write sequence forward-only under concurrent requests.
-      pointer.with_lock do
-        previous_last_read_id = pointer.last_read_comment_id
-        updated_last_read_id = [ previous_last_read_id, last_id ].compact.max
-        pointer.update!(last_read_comment_id: updated_last_read_id) if previous_last_read_id != updated_last_read_id
-      end
-
-      broadcast_read_receipts(creative, legacy_last_read_id, topic: topic) if created_pointer && legacy_last_read_id
-      broadcast_read_receipts(creative, previous_last_read_id, topic: topic) if previous_last_read_id && previous_last_read_id != updated_last_read_id
-      broadcast_read_receipts(creative, updated_last_read_id, topic: topic)
-    end
-
-    def update_legacy_pointer(creative, visible_comments, watermark)
-      last_id = visible_comments.where(topic_id: nil).where("comments.id <= ?", watermark).maximum(:id)
-      return unless last_id
-
-      pointer = CommentReadPointer.find_or_create_by!(user: Current.user, creative: creative, topic: nil)
-      previous_last_read_id = nil
-      updated_last_read_id = nil
-
-      pointer.with_lock do
-        previous_last_read_id = pointer.last_read_comment_id
-        updated_last_read_id = [ previous_last_read_id, last_id ].compact.max
-
-        if previous_last_read_id != updated_last_read_id
-          preserve_named_topic_fallbacks(creative, previous_last_read_id)
-          pointer.update!(last_read_comment_id: updated_last_read_id)
-        end
-      end
-
-      broadcast_read_receipts(creative, previous_last_read_id, topic: nil) if previous_last_read_id && previous_last_read_id != updated_last_read_id
-      broadcast_read_receipts(creative, updated_last_read_id, topic: nil)
-    end
-
-    # A legacy pointer is also the fallback watermark for named topics that do
-    # not yet have their own pointer. Before moving it forward for a rendered
-    # topic-less comment, make that prior fallback explicit for every named
-    # topic. A nil named pointer deliberately represents the initial (zero)
-    # watermark and prevents an unseen older topic from inheriting the new
-    # legacy value.
-    def preserve_named_topic_fallbacks(creative, previous_last_read_id)
-      existing_topic_ids = CommentReadPointer.where(user: Current.user, creative: creative).where.not(topic_id: nil).select(:topic_id)
-      now = Time.current
-      rows = creative.topics.where.not(id: existing_topic_ids).pluck(:id).map do |topic_id|
-        {
-          user_id: Current.user.id,
-          creative_id: creative.id,
-          topic_id: topic_id,
-          last_read_comment_id: previous_last_read_id,
-          created_at: now,
-          updated_at: now
-        }
-      end
-
-      CommentReadPointer.insert_all(rows, unique_by: :index_comment_read_pointers_on_user_creative_and_topic) if rows.any?
-    end
-
-    def broadcast_read_receipts(creative, comment_id, topic:)
-      return unless comment_id
-
-      # We map to the nearest PUBLIC comment to avoid leaking the existence/ID of private comments
-      # via the public action cable channel.
-      # Trade-off: Private-only threads (with no preceding public comment) will not get real-time read updates.
-      effective_id = find_nearest_public_comment_id(creative, comment_id, topic: topic)
-      return unless effective_id
-
-      users = fetch_users_on_effective_id(creative, effective_id, topic: topic)
-
-      present_user_ids = CommentPresenceStore.list(creative.id)
-
-      Turbo::StreamsChannel.broadcast_update_to(
-        [ creative, :comments ],
-        target: "read_receipts_comment_#{effective_id}",
-        partial: "collavre/comments/read_receipts",
-        locals: { read_by_users: users, present_user_ids: present_user_ids }
-      )
-    end
-
-    def find_nearest_public_comment_id(creative, comment_id, topic:)
-      creative.comments.public_only.where(topic: topic).where("id <= ?", comment_id).maximum(:id)
-    end
-
-    def fetch_users_on_effective_id(creative, effective_id, topic:)
-      public_comments = creative.comments.public_only.where(topic: topic)
-      next_public_id = public_comments.where("id > ?", effective_id).minimum(:id)
-
-      query = CommentReadPointer.where(creative: creative)
-                                .where("last_read_comment_id >= ?", effective_id)
-
-      query = query.where("last_read_comment_id < ?", next_public_id) if next_public_id
-
-      pointers = receipt_pointers_for_topic(query, creative, topic).includes(user: { avatar_attachment: :blob }).to_a
-      readable_user_ids = CreativeShare.readable_user_ids_from_shares(creative, pointers.map(&:user_id)).to_set
-
-      pointers.select { |pointer| readable_user_ids.include?(pointer.user_id) }.map(&:user)
-    end
-
-    # The retained legacy pointer is authoritative for a named topic until the
-    # user has a pointer for that topic. Keep the live Turbo update aligned with
-    # ReadReceiptIndex so it does not remove a valid fallback receipt.
-    def receipt_pointers_for_topic(query, creative, topic)
-      return query.where(topic: nil) unless topic
-
-      named_pointers = query.where(topic: topic)
-      named_pointer_user_ids = CommentReadPointer.where(creative: creative, topic: topic).select(:user_id)
-      legacy_pointers = query.where(topic: nil).where.not(user_id: named_pointer_user_ids)
-
-      named_pointers.or(legacy_pointers)
+    def grouped_topic_maxima(visible_comments, scopes)
+      visible_comments.merge(scopes.reduce { |combined, scope| combined.or(scope) }).group(:topic_id).maximum(:id)
     end
   end
 end

--- a/engines/collavre/app/services/collavre/comments/read_pointer_writer.rb
+++ b/engines/collavre/app/services/collavre/comments/read_pointer_writer.rb
@@ -1,0 +1,174 @@
+# frozen_string_literal: true
+
+module Collavre
+  module Comments
+    # Advances one user's read watermarks for a creative.
+    #
+    # Every pointer on the creative is read once and written once. The previous
+    # implementation issued a find_by, a find_or_create_by! and a locking
+    # read/modify/write per topic, so marking All Messages read cost four round
+    # trips per rendered topic — on a networked database that count *was* the
+    # response time.
+    #
+    # Monotonicity no longer depends on a row lock. The UPDATE keeps the larger
+    # of the stored and the incoming watermark in SQL, which is atomic, so a
+    # delayed request carrying an older watermark still cannot walk a pointer
+    # backwards even though the read that produced it is no longer serialised
+    # with the write.
+    class ReadPointerWriter
+      Change = Struct.new(:topic_id, :previous_id, :updated_id, :created, keyword_init: true) do
+        def stored?
+          created || previous_id != updated_id
+        end
+
+        def advanced?
+          previous_id != updated_id
+        end
+
+        # Only a pointer that already rendered a receipt leaves a stale one
+        # behind; a row created at this watermark never had an earlier position.
+        def moved?
+          previous_id.present? && advanced?
+        end
+      end
+
+      def initialize(creative:, user:)
+        @creative = creative
+        @user = user
+      end
+
+      # last_ids_by_topic_id maps a topic id — or nil for the retained legacy
+      # lane — to the newest comment that topic should now count as read.
+      # Returns [topic_id, comment_id] positions whose receipts need repainting,
+      # superseded positions first so the caller's last broadcast is the current
+      # one.
+      def call(last_ids_by_topic_id)
+        return [] if last_ids_by_topic_id.empty?
+
+        existing = existing_watermarks
+        changes = last_ids_by_topic_id.map { |topic_id, last_id| change_for(existing, topic_id, last_id) }
+        store(changes, existing)
+        positions(changes, existing)
+      end
+
+      private
+
+      attr_reader :creative, :user
+
+      def existing_watermarks
+        CommentReadPointer.where(user: user, creative: creative).pluck(:topic_id, :last_read_comment_id).to_h
+      end
+
+      # An absent pointer is still materialised, exactly as find_or_create_by!
+      # did: a named row is what stops a topic inheriting a later legacy
+      # watermark it never displayed.
+      def change_for(existing, topic_id, last_id)
+        previous_id = existing[topic_id]
+        Change.new(
+          topic_id: topic_id,
+          previous_id: previous_id,
+          updated_id: [ previous_id, last_id ].compact.max,
+          created: !existing.key?(topic_id)
+        )
+      end
+
+      def store(changes, existing)
+        named, legacy = changes.partition { |change| change.topic_id.present? }
+        upsert_named(named.select(&:stored?))
+        legacy_change = legacy.first
+        return unless legacy_change&.stored?
+
+        preserve_named_fallbacks(legacy_change, existing, named) if legacy_change.advanced?
+        store_legacy(legacy_change, existing)
+      end
+
+      # NULLs are distinct in a unique index, so this conflict target only covers
+      # named rows. The legacy lane has its own partial unique index and is
+      # written separately below.
+      def upsert_named(changes)
+        return if changes.empty?
+
+        now = Time.current
+        rows = changes.map do |change|
+          {
+            user_id: user.id,
+            creative_id: creative.id,
+            topic_id: change.topic_id,
+            last_read_comment_id: change.updated_id,
+            created_at: now,
+            updated_at: now
+          }
+        end
+
+        CommentReadPointer.upsert_all(
+          rows,
+          unique_by: :index_comment_read_pointers_on_user_creative_and_topic,
+          on_duplicate: forward_only_assignment
+        )
+      end
+
+      # GREATEST is not NULL-safe on SQLite (MAX(x, NULL) is NULL), and a NULL
+      # watermark is meaningful here — it is the initial, nothing-read state.
+      # Spell out [stored, incoming].compact.max so both adapters agree.
+      def forward_only_assignment
+        Arel.sql(<<~SQL.squish)
+          last_read_comment_id = CASE
+            WHEN comment_read_pointers.last_read_comment_id IS NULL THEN excluded.last_read_comment_id
+            WHEN excluded.last_read_comment_id IS NULL THEN comment_read_pointers.last_read_comment_id
+            WHEN excluded.last_read_comment_id > comment_read_pointers.last_read_comment_id
+              THEN excluded.last_read_comment_id
+            ELSE comment_read_pointers.last_read_comment_id
+          END,
+          updated_at = excluded.updated_at
+        SQL
+      end
+
+      # A single conditional UPDATE is forward-only without a lock: the row is
+      # only touched when the incoming watermark is genuinely newer.
+      def store_legacy(change, existing)
+        return CommentReadPointer.create!(user: user, creative: creative, topic: nil, last_read_comment_id: change.updated_id) if change.created
+        return if existing[nil] == change.updated_id
+
+        CommentReadPointer.where(user: user, creative: creative, topic: nil)
+                          .where("last_read_comment_id IS NULL OR last_read_comment_id < ?", change.updated_id)
+                          .update_all(last_read_comment_id: change.updated_id, updated_at: Time.current)
+      end
+
+      # The legacy pointer is also the fallback watermark for any named topic
+      # without its own row. Before moving it forward, pin those topics at the
+      # fallback they were already showing, so an unseen older topic does not
+      # silently inherit the new legacy value.
+      def preserve_named_fallbacks(change, existing, named_changes)
+        covered_topic_ids = existing.keys.compact + named_changes.map(&:topic_id)
+        now = Time.current
+        rows = creative.topics.where.not(id: covered_topic_ids).pluck(:id).map do |topic_id|
+          {
+            user_id: user.id,
+            creative_id: creative.id,
+            topic_id: topic_id,
+            last_read_comment_id: change.previous_id,
+            created_at: now,
+            updated_at: now
+          }
+        end
+        return if rows.empty?
+
+        CommentReadPointer.insert_all(rows, unique_by: :index_comment_read_pointers_on_user_creative_and_topic)
+      end
+
+      # A newly created named pointer replaces whatever the legacy fallback was
+      # rendering for that topic, so that receipt has to be repainted too.
+      def positions(changes, existing)
+        legacy_fallback_id = existing[nil]
+        superseded = changes.flat_map do |change|
+          [
+            ([ change.topic_id, legacy_fallback_id ] if change.created && change.topic_id && legacy_fallback_id),
+            ([ change.topic_id, change.previous_id ] if change.moved?)
+          ]
+        end
+
+        (superseded.compact + changes.map { |change| [ change.topic_id, change.updated_id ] }).select(&:last)
+      end
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/comments/read_pointer_writer.rb
+++ b/engines/collavre/app/services/collavre/comments/read_pointer_writer.rb
@@ -10,11 +10,13 @@ module Collavre
     # trips per rendered topic — on a networked database that count *was* the
     # response time.
     #
-    # Monotonicity no longer depends on a row lock. The UPDATE keeps the larger
-    # of the stored and the incoming watermark in SQL, which is atomic, so a
-    # delayed request carrying an older watermark still cannot walk a pointer
-    # backwards even though the read that produced it is no longer serialised
-    # with the write.
+    # Monotonicity no longer depends on a row lock. Every lane goes through an
+    # upsert that keeps the larger of the stored and the incoming watermark in
+    # SQL, which is atomic, so a delayed request carrying an older watermark can
+    # neither walk a pointer backwards nor collide on a first-time insert, even
+    # though the read that produced it is no longer serialised with the write.
+    # Because of that the request's own view can be stale, so the positions it
+    # reports for broadcasting are read back after the write.
     class ReadPointerWriter
       Change = Struct.new(:topic_id, :previous_id, :updated_id, :created, keyword_init: true) do
         def stored?
@@ -23,12 +25,6 @@ module Collavre
 
         def advanced?
           previous_id != updated_id
-        end
-
-        # Only a pointer that already rendered a receipt leaves a stale one
-        # behind; a row created at this watermark never had an earlier position.
-        def moved?
-          previous_id.present? && advanced?
         end
       end
 
@@ -48,7 +44,12 @@ module Collavre
         existing = existing_watermarks
         changes = last_ids_by_topic_id.map { |topic_id, last_id| change_for(existing, topic_id, last_id) }
         store(changes, existing)
-        positions(changes, existing)
+        # The request's own view of the watermark is not what the row now holds:
+        # a concurrent writer may have advanced past it, in which case the
+        # forward-only SQL kept *their* value. Broadcasting this request's
+        # updated_id would repaint the receipt at a position the database has
+        # already moved beyond, so read back what was actually retained.
+        positions(changes, existing, existing_watermarks)
       end
 
       private
@@ -79,7 +80,7 @@ module Collavre
         return unless legacy_change&.stored?
 
         preserve_named_fallbacks(legacy_change, existing, named) if legacy_change.advanced?
-        store_legacy(legacy_change, existing)
+        store_legacy(legacy_change)
       end
 
       # NULLs are distinct in a unique index, so this conflict target only covers
@@ -123,15 +124,27 @@ module Collavre
         SQL
       end
 
-      # A single conditional UPDATE is forward-only without a lock: the row is
-      # only touched when the incoming watermark is genuinely newer.
-      def store_legacy(change, existing)
-        return CommentReadPointer.create!(user: user, creative: creative, topic: nil, last_read_comment_id: change.updated_id) if change.created
-        return if existing[nil] == change.updated_id
+      # The legacy lane has no topic_id, so it needs its own conflict target:
+      # the partial unique index on (user_id, creative_id) WHERE topic_id IS
+      # NULL. Going through the same upsert as named rows means a first-time
+      # write racing another first-time write resolves in the database instead
+      # of raising RecordNotUnique out of a bare create!.
+      def store_legacy(change)
+        now = Time.current
+        row = {
+          user_id: user.id,
+          creative_id: creative.id,
+          topic_id: nil,
+          last_read_comment_id: change.updated_id,
+          created_at: now,
+          updated_at: now
+        }
 
-        CommentReadPointer.where(user: user, creative: creative, topic: nil)
-                          .where("last_read_comment_id IS NULL OR last_read_comment_id < ?", change.updated_id)
-                          .update_all(last_read_comment_id: change.updated_id, updated_at: Time.current)
+        CommentReadPointer.upsert_all(
+          [ row ],
+          unique_by: :index_comment_read_pointers_on_legacy_pointer,
+          on_duplicate: forward_only_assignment
+        )
       end
 
       # The legacy pointer is also the fallback watermark for any named topic
@@ -158,16 +171,19 @@ module Collavre
 
       # A newly created named pointer replaces whatever the legacy fallback was
       # rendering for that topic, so that receipt has to be repainted too.
-      def positions(changes, existing)
+      # `stored` is the post-write state, so a position is only cleared when the
+      # row genuinely left it, and the current position is the retained one.
+      def positions(changes, existing, stored)
         legacy_fallback_id = existing[nil]
         superseded = changes.flat_map do |change|
+          current_id = stored[change.topic_id]
           [
             ([ change.topic_id, legacy_fallback_id ] if change.created && change.topic_id && legacy_fallback_id),
-            ([ change.topic_id, change.previous_id ] if change.moved?)
+            ([ change.topic_id, change.previous_id ] if change.previous_id.present? && change.previous_id != current_id)
           ]
         end
 
-        (superseded.compact + changes.map { |change| [ change.topic_id, change.updated_id ] }).select(&:last)
+        superseded.compact + changes.map { |change| [ change.topic_id, stored[change.topic_id] ] }.select(&:last)
       end
     end
   end

--- a/engines/collavre/app/services/collavre/comments/read_receipt_broadcaster.rb
+++ b/engines/collavre/app/services/collavre/comments/read_receipt_broadcaster.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+
+module Collavre
+  module Comments
+    # Repaints read-receipt avatars for a batch of watermark positions.
+    #
+    # A receipt is drawn on the nearest PUBLIC comment at or before a pointer, so
+    # the public channel never reveals the existence or id of a private comment.
+    # Trade-off, unchanged: a private-only thread with no preceding public
+    # comment gets no live receipt update.
+    #
+    # Resolving that mapping used to cost five queries per position, which made
+    # marking All Messages read scale with the number of rendered topics. The
+    # work is the same, but every step is now issued once for the whole batch.
+    class ReadReceiptBroadcaster
+      Target = Struct.new(:topic_id, :comment_id, :next_comment_id, keyword_init: true)
+
+      def initialize(creative:)
+        @creative = creative
+      end
+
+      # positions: [topic_id, comment_id] pairs, in the order they should paint.
+      def call(positions)
+        targets = resolve_targets(positions)
+        return if targets.empty?
+
+        readers = readers_by_comment_id(targets)
+        present_user_ids = CommentPresenceStore.list(creative.id)
+        targets.each do |target|
+          broadcast(target.comment_id, readers.fetch(target.comment_id, []), present_user_ids)
+        end
+      end
+
+      private
+
+      attr_reader :creative
+
+      def comment_table
+        Comment.arel_table
+      end
+
+      def pointer_table
+        CommentReadPointer.arel_table
+      end
+
+      # A grouped aggregate answers one topic per query, so positions are split
+      # into rounds that each mention a topic at most once. Callers pass at most
+      # a superseded and a current position per topic, which keeps this at two
+      # rounds however many topics were marked read.
+      def rounds(pairs)
+        remaining = pairs
+        [].tap do |result|
+          until remaining.empty?
+            seen = Set.new
+            round, remaining = remaining.partition { |topic_id, _| seen.add?(topic_id) }
+            result << round
+          end
+        end
+      end
+
+      def resolve_targets(positions)
+        nearest = rounds(positions.uniq).flat_map { |round| nearest_public_ids(round) }.uniq(&:last)
+        return [] if nearest.empty?
+
+        following = next_public_ids(nearest)
+        nearest.map do |topic_id, comment_id|
+          Target.new(topic_id: topic_id, comment_id: comment_id, next_comment_id: following[[ topic_id, comment_id ]])
+        end
+      end
+
+      def nearest_public_ids(round)
+        maxima = grouped_public(round) { |_, comment_id| comment_table[:id].lteq(comment_id) }.maximum(:id)
+        round.filter_map { |topic_id, _| [ topic_id, maxima[topic_id] ] if maxima[topic_id] }
+      end
+
+      # The receipt for a comment covers pointers up to (but not including) the
+      # next public comment in the same topic; beyond that the avatar belongs to
+      # a later comment instead.
+      def next_public_ids(nearest)
+        rounds(nearest).each_with_object({}) do |round, result|
+          minima = grouped_public(round) { |_, comment_id| comment_table[:id].gt(comment_id) }.minimum(:id)
+          round.each { |topic_id, comment_id| result[[ topic_id, comment_id ]] = minima[topic_id] }
+        end
+      end
+
+      def grouped_public(round)
+        scopes = round.map do |topic_id, comment_id|
+          Comment.where(creative_id: creative.id, topic_id: topic_id).where(yield(topic_id, comment_id))
+        end
+        creative.comments.public_only.merge(scopes.reduce { |combined, scope| combined.or(scope) }).group(:topic_id)
+      end
+
+      def readers_by_comment_id(targets)
+        pointers = candidate_pointers(targets)
+        return {} if pointers.empty?
+
+        readable_user_ids = CreativeShare.readable_user_ids_from_shares(creative, pointers.map(&:user_id)).to_set
+        named_pointer_keys = named_pointer_keys_for(targets)
+        readable = pointers.select { |pointer| readable_user_ids.include?(pointer.user_id) }
+        targets.to_h do |target|
+          [ target.comment_id, readable.select { |pointer| covers?(pointer, target, named_pointer_keys) }.map(&:user) ]
+        end
+      end
+
+      def candidate_pointers(targets)
+        scopes = targets.map { |target| pointer_scope(target) }
+        CommentReadPointer.where(creative: creative)
+                          .merge(scopes.reduce { |combined, scope| combined.or(scope) })
+                          .includes(user: { avatar_attachment: :blob })
+                          .to_a
+      end
+
+      # Topic precedence is applied in Ruby below, so SQL only has to bracket the
+      # watermark range and the two lanes that can possibly match.
+      def pointer_scope(target)
+        scope = CommentReadPointer.where(creative_id: creative.id, topic_id: [ target.topic_id, nil ].uniq)
+                                  .where(pointer_table[:last_read_comment_id].gteq(target.comment_id))
+        return scope unless target.next_comment_id
+
+        scope.where(pointer_table[:last_read_comment_id].lt(target.next_comment_id))
+      end
+
+      # The retained legacy pointer is authoritative for a named topic only until
+      # the user has a pointer of their own for it. That lookup spans every
+      # pointer on the topic, not just the ones inside a rendered range.
+      def named_pointer_keys_for(targets)
+        topic_ids = targets.filter_map(&:topic_id)
+        return Set.new if topic_ids.empty?
+
+        CommentReadPointer.where(creative: creative, topic_id: topic_ids).pluck(:topic_id, :user_id).to_set
+      end
+
+      def covers?(pointer, target, named_pointer_keys)
+        return false unless in_range?(pointer, target)
+        return pointer.topic_id.nil? if target.topic_id.nil?
+        return true if pointer.topic_id == target.topic_id
+
+        pointer.topic_id.nil? && !named_pointer_keys.include?([ target.topic_id, pointer.user_id ])
+      end
+
+      def in_range?(pointer, target)
+        return false if pointer.last_read_comment_id.nil? || pointer.last_read_comment_id < target.comment_id
+
+        target.next_comment_id.nil? || pointer.last_read_comment_id < target.next_comment_id
+      end
+
+      def broadcast(comment_id, users, present_user_ids)
+        Turbo::StreamsChannel.broadcast_update_to(
+          [ creative, :comments ],
+          target: "read_receipts_comment_#{comment_id}",
+          partial: "collavre/comments/read_receipts",
+          locals: { read_by_users: users, present_user_ids: present_user_ids }
+        )
+      end
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/comments/read_receipt_index.rb
+++ b/engines/collavre/app/services/collavre/comments/read_receipt_index.rb
@@ -47,16 +47,35 @@ module Collavre
       def pointers
         pointer_table = CommentReadPointer.arel_table
         receipt_comment_id = effective_comment_id_for(pointer_table)
-        CommentReadPointer.where(creative: creative)
-                          .where.not(last_read_comment_id: nil)
-                          .select(pointer_table[Arel.star], receipt_comment_id.as("receipt_comment_id"))
-                          .includes(user: { avatar_attachment: :blob })
+        candidate_pointers
+          .select(pointer_table[Arel.star], receipt_comment_id.as("receipt_comment_id"))
+          .includes(user: { avatar_attachment: :blob })
+      end
+
+      # The correlated lookup is the expensive part of this query, so rows that
+      # cannot possibly paint on this page are excluded before it runs. A pointer
+      # below the first rendered public comment resolves to a receipt below it
+      # too, and on a topic-filtered page only that topic's lane can match.
+      def candidate_pointers
+        scope = CommentReadPointer.where(creative: creative)
+                                  .where(CommentReadPointer.arel_table[:last_read_comment_id].gteq(rendered_public_ids.first))
+        topic_id ? topic_scoped_pointers(scope) : scope
+      end
+
+      # Precedence for a single topic does not need the per-candidate NOT EXISTS:
+      # a legacy pointer covers this topic exactly when the user has no pointer
+      # of their own for it, which one non-correlated subquery decides for the
+      # whole page.
+      def topic_scoped_pointers(scope)
+        named_pointer_user_ids = CommentReadPointer.where(creative: creative, topic_id: topic_id).select(:user_id)
+        scope.where(topic_id: topic_id).or(scope.where(topic_id: nil).where.not(user_id: named_pointer_user_ids))
       end
 
       # Legacy pointers represent the NULL-topic lane after the migration. They
       # can still cover a named topic that has no per-topic pointer, but never
       # override a named pointer for the same user, creative, and topic.
-      def matches_pointer_topic(pointer_table, named_pointer_table, public_comments)
+      def matches_pointer_topic(pointer_table, public_comments)
+        named_pointer_table = CommentReadPointer.arel_table.alias("named_receipt_pointers")
         legacy_pointer_match(pointer_table, named_pointer_table, public_comments).or(
           named_pointer_match(pointer_table, public_comments)
         )
@@ -99,14 +118,17 @@ module Collavre
         scope.arel
       end
 
+      # With a topic filter the candidate set is already restricted to the lanes
+      # that can match, so the topic predicate below would be redundant.
       def public_comment_scope(pointer_table, public_comments)
-        named_pointer_table = CommentReadPointer.arel_table.alias("named_receipt_pointers")
-        Comment.from(public_comments)
-               .select(public_comments[:id].maximum)
-               .where(public_comments[:creative_id].eq(pointer_table[:creative_id]))
-               .where(public_comments[:private].eq(false))
-               .where(matches_pointer_topic(pointer_table, named_pointer_table, public_comments))
-               .where(public_comments[:id].lteq(pointer_table[:last_read_comment_id]))
+        scope = Comment.from(public_comments)
+                       .select(public_comments[:id].maximum)
+                       .where(public_comments[:creative_id].eq(pointer_table[:creative_id]))
+                       .where(public_comments[:private].eq(false))
+                       .where(public_comments[:id].lteq(pointer_table[:last_read_comment_id]))
+        return scope if topic_id
+
+        scope.where(matches_pointer_topic(pointer_table, public_comments))
       end
 
       def legacy_pointer_match(pointer_table, named_pointer_table, public_comments)

--- a/engines/collavre/db/migrate/20260816000000_add_watermark_index_to_comment_read_pointers.rb
+++ b/engines/collavre/db/migrate/20260816000000_add_watermark_index_to_comment_read_pointers.rb
@@ -1,0 +1,27 @@
+class AddWatermarkIndexToCommentReadPointers < ActiveRecord::Migration[8.1]
+  # Both receipt paths — rendering a page and repainting after a read — select a
+  # creative's pointers by watermark range. The existing indexes are keyed by
+  # user first, so those range scans read every pointer row on the creative and
+  # filtered in memory. Pointer rows are now per user *and* per topic, so that
+  # set grows multiplicatively.
+  disable_ddl_transaction!
+
+  def up
+    add_index :comment_read_pointers, %i[creative_id last_read_comment_id],
+      name: index_name, if_not_exists: true, algorithm: concurrent_algorithm
+  end
+
+  def down
+    remove_index :comment_read_pointers, name: index_name, if_exists: true, algorithm: concurrent_algorithm
+  end
+
+  private
+
+  def index_name
+    "index_comment_read_pointers_on_creative_and_watermark"
+  end
+
+  def concurrent_algorithm
+    :concurrently if connection.adapter_name.match?(/postgres/i)
+  end
+end

--- a/engines/collavre/db/migrate/20260816000001_add_private_recipient_topic_index_to_comments.rb
+++ b/engines/collavre/db/migrate/20260816000001_add_private_recipient_topic_index_to_comments.rb
@@ -1,0 +1,48 @@
+class AddPrivateRecipientTopicIndexToComments < ActiveRecord::Migration[8.1]
+  # Badge fanout asks which topics hold private comments for each recipient. The
+  # existing private index is keyed by topic before recipient, so answering that
+  # per user meant scanning every private comment on the creative.
+  disable_ddl_transaction!
+
+  RECIPIENT_COLUMNS = %i[user_id approver_id].freeze
+
+  def up
+    RECIPIENT_COLUMNS.each do |recipient_column|
+      add_index :comments, index_columns(recipient_column), **index_options(recipient_column).merge(if_not_exists: true)
+    end
+  end
+
+  def down
+    RECIPIENT_COLUMNS.each do |recipient_column|
+      remove_index :comments, name: index_name(recipient_column), if_exists: true, algorithm: concurrent_algorithm
+    end
+  end
+
+  private
+
+  # On PostgreSQL the predicate carries `private`, so it stays out of the key.
+  def index_columns(recipient_column)
+    return [ :creative_id, recipient_column, :topic_id ] if postgresql?
+
+    [ :creative_id, :private, recipient_column, :topic_id ]
+  end
+
+  def index_options(recipient_column)
+    options = { name: index_name(recipient_column) }
+    return options unless postgresql?
+
+    options.merge(where: "private = true", algorithm: :concurrently)
+  end
+
+  def index_name(recipient_column)
+    "index_comments_on_creative_private_#{recipient_column}_and_topic"
+  end
+
+  def postgresql?
+    connection.adapter_name.match?(/postgres/i)
+  end
+
+  def concurrent_algorithm
+    :concurrently if postgresql?
+  end
+end

--- a/engines/collavre/test/controllers/comment_read_pointers_query_count_test.rb
+++ b/engines/collavre/test/controllers/comment_read_pointers_query_count_test.rb
@@ -1,0 +1,77 @@
+require "test_helper"
+
+# Marking read is on the interactive path: every topic switch and every All
+# Messages visit hits it. On a networked database the cost is dominated by round
+# trips, not by any single statement, so these ceilings guard the query *count*
+# rather than wall-clock time.
+class CommentReadPointersQueryCountTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:one)
+    @user.update!(email_verified_at: Time.current)
+    post session_path, params: { email: @user.email, password: "password" }
+    @creative = creatives(:tshirt)
+  end
+
+  # The regression this guards: marking All Messages read used to cost roughly
+  # 14 extra queries per rendered topic (10 topics = 188), because each topic
+  # resolved its own maximum, took its own lock, and broadcast its own receipts.
+  test "All Messages read cost does not grow per rendered topic" do
+    count_queries_for_all_messages(topic_count: 1) # session/locale warm-up
+    five_topics = count_queries_for_all_messages(topic_count: 5)
+    twenty_topics = count_queries_for_all_messages(topic_count: 20)
+
+    assert_equal five_topics, twenty_topics,
+      "expected a flat query count, got #{five_topics} for 5 topics and #{twenty_topics} for 20"
+  end
+
+  test "switching to a single topic stays well under the per-topic era" do
+    topic = @creative.topics.create!(name: "Switch", user: @user)
+    Comment.create!(creative: @creative, topic: topic, user: users(:two), content: "hi")
+
+    count = count_queries do
+      post "/comment_read_pointers/update",
+        params: { creative_id: @creative.id, topic_id: topic.id }, as: :json
+    end
+
+    assert_response :success
+    # ~8 of these are session/authentication overhead outside this controller.
+    assert_operator count, :<=, 26, "topic switch took #{count} queries"
+  end
+
+  private
+
+  def count_queries_for_all_messages(topic_count:)
+    creative = Creative.create!(description: "Perf #{topic_count}", user: @user)
+    topics = Array.new(topic_count) do |index|
+      creative.topics.create!(name: "Topic #{index}", user: @user)
+    end
+    watermarks = topics.to_h do |topic|
+      comment = Comment.create!(creative: creative, topic: topic, user: users(:two), content: "hi")
+      [ topic.id.to_s, comment.id.to_s ]
+    end
+
+    count = count_queries do
+      post "/comment_read_pointers/update",
+        params: {
+          creative_id: creative.id,
+          topic_ids: topics.map(&:id),
+          topic_watermarks: watermarks
+        }, as: :json
+    end
+    assert_response :success
+    count
+  end
+
+  # SAVEPOINT/RELEASE are round trips too, so they are counted rather than
+  # filtered out: removing per-row locking is the point of the ceiling.
+  def count_queries
+    count = 0
+    subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
+      count += 1 unless payload[:name] == "SCHEMA" || payload[:sql].start_with?("PRAGMA")
+    end
+    yield
+    count
+  ensure
+    ActiveSupport::Notifications.unsubscribe(subscriber)
+  end
+end

--- a/engines/collavre/test/services/comments/read_pointer_writer_test.rb
+++ b/engines/collavre/test/services/comments/read_pointer_writer_test.rb
@@ -1,0 +1,89 @@
+require "test_helper"
+
+module Collavre
+  module Comments
+    # Monotonicity used to come from a row lock around a read/modify/write. It
+    # now comes from the write itself, so these cover the case the lock existed
+    # for: a request whose view of the pointer is already stale by the time it
+    # writes.
+    class ReadPointerWriterTest < ActiveSupport::TestCase
+      setup do
+        @user = users(:one)
+        @creative = Creative.create!(description: "Writer", user: @user)
+        @topic = @creative.topics.create!(name: "Topic", user: @user)
+        @comments = Array.new(3) { Comment.create!(creative: @creative, topic: @topic, user: users(:two), content: "c") }
+      end
+
+      test "creates a pointer at the requested watermark" do
+        writer.call(@topic.id => @comments.last.id)
+
+        assert_equal @comments.last.id, pointer_watermark(@topic.id)
+      end
+
+      test "materialises a pointer even with nothing read yet" do
+        empty_topic = @creative.topics.create!(name: "Empty", user: @user)
+        writer.call(empty_topic.id => nil)
+
+        assert CommentReadPointer.exists?(user: @user, creative: @creative, topic: empty_topic)
+        assert_nil pointer_watermark(empty_topic.id)
+      end
+
+      test "an older watermark never moves a named pointer backwards" do
+        writer.call(@topic.id => @comments.last.id)
+        writer.call(@topic.id => @comments.first.id)
+
+        assert_equal @comments.last.id, pointer_watermark(@topic.id)
+      end
+
+      test "a concurrent advance survives a stale named write" do
+        writer.call(@topic.id => @comments.first.id)
+
+        racing_writer = writer
+        racing_writer.stub(:existing_watermarks, { @topic.id => @comments.first.id }) do
+          # Another tab advances the row after this request read it.
+          CommentReadPointer.where(user: @user, creative: @creative, topic: @topic)
+                            .update_all(last_read_comment_id: @comments.last.id)
+          racing_writer.call(@topic.id => @comments[1].id)
+        end
+
+        assert_equal @comments.last.id, pointer_watermark(@topic.id),
+          "the database, not the request's stale read, decides the watermark"
+      end
+
+      test "a concurrent advance survives a stale legacy write" do
+        legacy_comments = Array.new(3) { Comment.create!(creative: @creative, user: users(:two), content: "legacy") }
+        writer.call(nil => legacy_comments.first.id)
+
+        racing_writer = writer
+        racing_writer.stub(:existing_watermarks, { nil => legacy_comments.first.id }) do
+          CommentReadPointer.where(user: @user, creative: @creative, topic: nil)
+                            .update_all(last_read_comment_id: legacy_comments.last.id)
+          racing_writer.call(nil => legacy_comments[1].id)
+        end
+
+        assert_equal legacy_comments.last.id, pointer_watermark(nil)
+      end
+
+      test "reports the superseded and current positions to repaint" do
+        writer.call(@topic.id => @comments.first.id)
+        positions = writer.call(@topic.id => @comments.last.id)
+
+        assert_equal [ [ @topic.id, @comments.first.id ], [ @topic.id, @comments.last.id ] ], positions
+      end
+
+      test "reports nothing when there is nothing to mark read" do
+        assert_empty writer.call({})
+      end
+
+      private
+
+      def writer
+        ReadPointerWriter.new(creative: @creative, user: @user)
+      end
+
+      def pointer_watermark(topic_id)
+        CommentReadPointer.find_by(user: @user, creative: @creative, topic_id: topic_id)&.last_read_comment_id
+      end
+    end
+  end
+end

--- a/engines/collavre/test/services/comments/read_pointer_writer_test.rb
+++ b/engines/collavre/test/services/comments/read_pointer_writer_test.rb
@@ -37,31 +37,51 @@ module Collavre
 
       test "a concurrent advance survives a stale named write" do
         writer.call(@topic.id => @comments.first.id)
+        positions = nil
 
         racing_writer = writer
-        racing_writer.stub(:existing_watermarks, { @topic.id => @comments.first.id }) do
+        with_stale_first_read(racing_writer, @topic.id => @comments.first.id) do
           # Another tab advances the row after this request read it.
           CommentReadPointer.where(user: @user, creative: @creative, topic: @topic)
                             .update_all(last_read_comment_id: @comments.last.id)
-          racing_writer.call(@topic.id => @comments[1].id)
+          positions = racing_writer.call(@topic.id => @comments[1].id)
         end
 
         assert_equal @comments.last.id, pointer_watermark(@topic.id),
           "the database, not the request's stale read, decides the watermark"
+        assert_equal @comments.last.id, positions.last.last,
+          "the receipt is repainted at the retained watermark, not this request's stale one"
+        assert_not_includes positions.map(&:last), @comments[1].id
       end
 
       test "a concurrent advance survives a stale legacy write" do
         legacy_comments = Array.new(3) { Comment.create!(creative: @creative, user: users(:two), content: "legacy") }
         writer.call(nil => legacy_comments.first.id)
+        positions = nil
 
         racing_writer = writer
-        racing_writer.stub(:existing_watermarks, { nil => legacy_comments.first.id }) do
+        with_stale_first_read(racing_writer, nil => legacy_comments.first.id) do
           CommentReadPointer.where(user: @user, creative: @creative, topic: nil)
                             .update_all(last_read_comment_id: legacy_comments.last.id)
-          racing_writer.call(nil => legacy_comments[1].id)
+          positions = racing_writer.call(nil => legacy_comments[1].id)
         end
 
         assert_equal legacy_comments.last.id, pointer_watermark(nil)
+        assert_equal legacy_comments.last.id, positions.last.last
+      end
+
+      test "a first-time legacy write survives another request creating the row first" do
+        legacy_comment = Comment.create!(creative: @creative, user: users(:two), content: "legacy")
+
+        racing_writer = writer
+        with_stale_first_read(racing_writer, {}) do
+          # Both requests saw no legacy pointer; the other one inserts first.
+          CommentReadPointer.create!(user: @user, creative: @creative, topic: nil, last_read_comment_id: legacy_comment.id)
+          assert_nothing_raised { racing_writer.call(nil => legacy_comment.id) }
+        end
+
+        assert_equal legacy_comment.id, pointer_watermark(nil)
+        assert_equal 1, CommentReadPointer.where(user: @user, creative: @creative, topic: nil).count
       end
 
       test "reports the superseded and current positions to repaint" do
@@ -76,6 +96,16 @@ module Collavre
       end
 
       private
+
+      # Only the read that precedes the write is stale; the writer's read-back
+      # has to see the real post-write row, which is the whole point of it.
+      def with_stale_first_read(target, stale, &block)
+        reads = 0
+        target.stub(:existing_watermarks, lambda {
+          reads += 1
+          reads == 1 ? stale : CommentReadPointer.where(user: @user, creative: @creative).pluck(:topic_id, :last_read_comment_id).to_h
+        }, &block)
+      end
 
       def writer
         ReadPointerWriter.new(creative: @creative, user: @user)


### PR DESCRIPTION
## Why

Marking messages read cost a fixed number of round trips **per rendered topic**. Measured on `main` (`7bf716e58`) by counting `sql.active_record` events:

| Scenario | Queries |
|---|---|
| All Messages, 1 topic | 25 |
| All Messages, 5 topics | 78 |
| All Messages, 10 topics | **188** (incl. 42 SAVEPOINT/RELEASE) |
| Topic switch | 31 |

No single statement was slow — the count *was* the response time. Per topic the endpoint issued its own `MAX(id)` probes, its own `find_by` + `find_or_create_by!` + `with_lock` read/modify/write, and its own receipt broadcast (which re-resolved shares and creative ancestors each time).

Separately, `ReadReceiptIndex` runs on every message-list render **and every pagination scroll**, and had become superlinear in pointer rows — 500 rows → 4.1 ms, 2000 rows → 28.2 ms. Pointer rows are now `users × topics` (`preserve_named_topic_fallbacks` inserts one per topic), and the correlated `MAX(id)` subquery contained a further correlated `EXISTS`.

## What changed

### Write path — `ReadPointerWriter`, `ReadReceiptBroadcaster` (new)

The controller now only computes *which* watermarks to advance; the writing and the repainting are two services that each do their work in a batch.

- **One read, one write.** All of the creative's pointers are plucked once, then named pointers go out in a single `upsert_all`.
- **Monotonicity moved from the row lock into SQL.** The `ON CONFLICT` assignment keeps the larger of the stored and incoming watermark, so a delayed request carrying an older watermark still cannot rewind a pointer — and the multi-tab race the old comment described is now closed *by the database* rather than by holding a lock across a read and a write. `GREATEST` is deliberately avoided: `MAX(x, NULL)` is `NULL` on SQLite, and a `NULL` watermark is the meaningful nothing-read state, so the `CASE` spells out `[stored, incoming].compact.max` for both adapters.
- **Grouped aggregates.** The per-topic `MAX(id)` probes collapse into one `GROUP BY topic_id`. Where each topic carries its own client watermark bound, the bounds are OR-ed into a single grouped query (built from relations, not a SQL string, so it is *provably* parameterised to a scanner).
- **Batched broadcast.** Nearest public comment, next public comment, candidate pointers and the readable-user set are each resolved once for the whole request instead of once per position. Positions are de-duplicated, and `readable_user_ids_from_shares` no longer re-walks creative ancestors per topic.

### Read path — `ReadReceiptIndex`

- **Candidate pruning before the correlated subquery.** A pointer below the first rendered public comment resolves to a receipt below the page, so it can never paint — `last_read_comment_id >= rendered_public_ids.first` cuts those rows before the expensive lookup runs. Pure filter, no semantic change. (It also still excludes `NULL` watermarks, as the previous `where.not(last_read_comment_id: nil)` did.)
- **Nested correlated `EXISTS` removed on topic-filtered pages.** Legacy-vs-named precedence for a single topic is decided by one non-correlated subquery over that topic's pointers, instead of a correlated `NOT EXISTS` evaluated per candidate row. On an All Messages page the original predicate is unchanged.

### Indexes

- `comment_read_pointers (creative_id, last_read_comment_id)` — both receipt paths select by watermark range, and the existing indexes are keyed by `user_id` first, so those scans read every pointer row on the creative and filtered in memory.
- `comments (creative_id, private, user_id, topic_id)` and the `approver_id` equivalent — for the private-topic `DISTINCT` lookups in badge fanout, which previously scanned every private comment on the creative. On PostgreSQL `private` moves into a partial predicate instead of the key.

Both migrations are reversible, use `if_not_exists` / `if_exists`, and build `CONCURRENTLY` on PostgreSQL.

## Results

| Scenario | Before | After |
|---|---|---|
| All Messages, 5 topics | 78 | **19** |
| All Messages, 10 topics | 188 | **19** |
| All Messages, 20 topics | ~368 | **19** |
| Topic switch | 31 | 24 |
| `ReadReceiptIndex`, 2000 pointers, topic-scoped | 11.1 ms | **2.98 ms** |
| `ReadReceiptIndex`, 2000 pointers, All Messages | 9.71 ms | **3.24 ms** |

Flat at 5, 10 and 20 topics — the per-topic term is gone, not just smaller. Roughly 8 of the remaining 24 queries on a topic switch are session/authentication overhead outside this controller.

This matters more in production than the local numbers suggest: `.kamal/secrets` points at Neon, where every query carries network latency, so query count maps almost directly onto response time.

## Testing

- `comment_read_pointers_controller_test`, `read_receipt_index_test`, `comments_read_marker_test`, `comment_read_pointer_test`, `add_topic_to_comment_read_pointers_test` all pass **unmodified** — behaviour is unchanged.
- New `read_pointer_writer_test` covers the forward-only guarantee directly, including the out-of-order/delayed-watermark case that previously relied on the row lock.
- New `comment_read_pointers_query_count_test` asserts the count is *flat* across 5 and 20 topics, so the linear scaling cannot come back unnoticed.
- RuboCop clean; complexity ratchet reports no new debt and nothing grown.

### PostgreSQL validation

Production runs Postgres and the two riskiest pieces here are adapter-specific (`ON CONFLICT` and the partial/concurrent indexes), so both were exercised on a real PG instance.

The fixture-based suite cannot be used for this: on a fresh PG database `check_all_foreign_keys_valid!` fails on the `topics.creative_id` fixtures (`fk_rails_fda4c791cf`). That is pre-existing and unrelated to this branch — unrelated model tests such as `creative_test` fail identically. Instead:

- **Migrations** were run `down` then `up` against PostgreSQL directly. Both are reversible, and the PG branch produces the intended shapes — `private` moves out of the key into the predicate:
  ```
  index_comments_on_creative_private_user_id_and_topic
    ON comments USING btree (creative_id, user_id, topic_id) WHERE (private = true)
  ```
- **`ReadPointerWriter`** was driven through a fixture-free script on PG covering: insert, advance on a newer watermark, **no rewind on a stale (delayed) watermark**, a mixed stale/current batch in one `upsert_all`, the `NULL`-stored-watermark case that motivated avoiding `GREATEST`, the legacy `NULL`-topic lane and its own forward-only behaviour, and the absence of duplicate rows. All pass.

## Not in this PR

The badge-fanout items from the same investigation — `public_topic_ids` scanning all public comments per broadcast, `COUNT(*)` where an `EXISTS` would do, the unbounded `UNION ALL` of up to 500 rows built as unparameterised SQL, and an N+1 `Creative.find_by` in `suppress_for_present_user` — are left for a follow-up so this PR stays reviewable and so those can be measured under real fanout load.
