### PR TITLE
fix: align chat close action icon

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -194,6 +194,9 @@ body.chat-fullscreen {
     color: var(--color-text);
     cursor: pointer;
     padding: 0;
+    width: var(--space-px-5);
+    height: var(--space-px-5);
+    flex: 0 0 var(--space-px-5);
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -201,9 +204,16 @@ body.chat-fullscreen {
     line-height: 1;
 }
 
+.comments-popup-action > span {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
 .comments-popup-action-icon {
-    width: 16px;
-    height: 16px;
+    display: block;
+    width: var(--space-px-3);
+    height: var(--space-px-3);
     fill: currentColor;
 }
 

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/popup_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/popup_controller.test.js
@@ -22,7 +22,10 @@ describe('CommentsPopupController', () => {
         <h3 data-comments--popup-target="title">Title</h3>
         <div data-comments--popup-target="list">List</div>
         <a data-comments--popup-target="fullscreenLink" href="#"></a>
-        <button data-comments--popup-target="closeButton">Close</button>
+        <button data-comments--popup-target="closeButton">
+          <span data-comments--popup-target="closeIcon" aria-hidden="true"><svg data-icon="close"></svg></span>
+          <span data-comments--popup-target="expandDockedIcon" aria-hidden="true" style="display:none;"><svg data-icon="expand"></svg></span>
+        </button>
         <div data-comments--popup-target="leftHandle"></div>
         <div data-comments--popup-target="rightHandle"></div>
       </div>
@@ -132,7 +135,7 @@ describe('CommentsPopupController', () => {
         expect(controller.closeButtonTarget.getAttribute('aria-label')).toBe('Expand chat')
     })
 
-    test('docked close button keeps the close icon while expanded and shows a chevron when collapsed', () => {
+    test('docked close button shows the close asset while expanded and a chevron when collapsed', () => {
         const popup = document.getElementById('comments-popup')
         popup.dataset.docked = 'true'
         popup.dataset.collapseDockedLabel = 'Collapse chat'
@@ -140,26 +143,28 @@ describe('CommentsPopupController', () => {
 
         controller.enterDockedMode()
         controller.syncDockedUI()
-        expect(controller.closeButtonTarget.textContent).toBe('×')
-        expect(controller.closeButtonTarget.querySelector('svg')).toBeNull()
+        expect(controller.closeIconTarget.style.display).toBe('')
+        expect(controller.expandDockedIconTarget.style.display).toBe('none')
+        expect(controller.closeIconTarget.getAttribute('aria-hidden')).toBe('true')
+        expect(controller.closeIconTarget.querySelector('[data-icon="close"]')).not.toBeNull()
         expect(controller.closeButtonTarget.getAttribute('aria-label')).toBe('Collapse chat')
 
         controller.toggleDocked()
         expect(popup.classList.contains('docked-collapsed')).toBe(true)
-        const icon = controller.closeButtonTarget.querySelector('svg')
-        expect(icon).not.toBeNull()
-        expect(icon.getAttribute('aria-hidden')).toBe('true')
-        expect(controller.closeButtonTarget.textContent.trim()).toBe('')
+        expect(controller.closeIconTarget.style.display).toBe('none')
+        expect(controller.expandDockedIconTarget.style.display).toBe('')
+        expect(controller.expandDockedIconTarget.getAttribute('aria-hidden')).toBe('true')
+        expect(controller.expandDockedIconTarget.querySelector('[data-icon="expand"]')).not.toBeNull()
         expect(controller.closeButtonTarget.getAttribute('aria-label')).toBe('Expand chat')
 
         controller.toggleDocked()
         expect(popup.classList.contains('docked-collapsed')).toBe(false)
-        expect(controller.closeButtonTarget.querySelector('svg')).toBeNull()
-        expect(controller.closeButtonTarget.textContent).toBe('×')
+        expect(controller.closeIconTarget.style.display).toBe('')
+        expect(controller.expandDockedIconTarget.style.display).toBe('none')
         expect(controller.closeButtonTarget.getAttribute('aria-label')).toBe('Collapse chat')
     })
 
-    test('leaving docked mode while collapsed restores the close glyph', () => {
+    test('leaving docked mode while collapsed restores the close asset', () => {
         const popup = document.getElementById('comments-popup')
         popup.dataset.docked = 'true'
         popup.dataset.closeLabel = 'Close chat'
@@ -167,13 +172,13 @@ describe('CommentsPopupController', () => {
 
         controller.enterDockedMode()
         controller.toggleDocked()
-        expect(controller.closeButtonTarget.querySelector('svg')).not.toBeNull()
+        expect(controller.expandDockedIconTarget.style.display).toBe('')
 
         controller.dockedMediaQuery.matches = false
         controller.syncDockedUI()
 
-        expect(controller.closeButtonTarget.querySelector('svg')).toBeNull()
-        expect(controller.closeButtonTarget.textContent).toBe('×')
+        expect(controller.closeIconTarget.style.display).toBe('')
+        expect(controller.expandDockedIconTarget.style.display).toBe('none')
     })
 
     test('restores the floating close button label after leaving docked mode', () => {
@@ -185,7 +190,8 @@ describe('CommentsPopupController', () => {
 
         controller.syncDockedUI()
 
-        expect(controller.closeButtonTarget.textContent).toBe('×')
+        expect(controller.closeIconTarget.style.display).toBe('')
+        expect(controller.expandDockedIconTarget.style.display).toBe('none')
         expect(controller.closeButtonTarget.getAttribute('aria-label')).toBe('Close chat')
         expect(controller.closeButtonTarget.title).toBe('Close chat')
     })

--- a/engines/collavre/app/javascript/controllers/comments/popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_controller.js
@@ -7,19 +7,14 @@ const CREATIVE_CLICK_EVENT = 'creative-comments-click'
 const CREATIVE_DESTROYED_EVENT = 'creative-destroyed'
 const LONG_PRESS_MS = 500
 
-// A collapsed docked chat shrinks to a 3rem rail where the close button is the
-// only visible control, so it acts as the expand affordance and shows a chevron
-// instead of the close glyph. Matched to the tree chevrons
-// (link_creative_controller.js) so the affordance reads the same everywhere.
-const EXPAND_CHEVRON =
-  '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M15 6L9 12L15 18"/></svg>'
-
 export default class extends Controller {
   static targets = [
     'title',
     'list',
     'form',
     'closeButton',
+    'closeIcon',
+    'expandDockedIcon',
     'leftHandle',
     'rightHandle',
     'fullscreenButton',
@@ -668,7 +663,8 @@ export default class extends Controller {
 
     if (!this.isDocked()) {
       const label = this.element.dataset.closeLabel || ''
-      this.closeButtonTarget.textContent = '×'
+      this.closeIconTarget.style.display = ''
+      this.expandDockedIconTarget.style.display = 'none'
       this.closeButtonTarget.setAttribute('aria-label', label)
       this.closeButtonTarget.title = label
       return
@@ -678,11 +674,8 @@ export default class extends Controller {
     const label = collapsed
       ? (this.element.dataset.expandDockedLabel || '')
       : (this.element.dataset.collapseDockedLabel || '')
-    if (collapsed) {
-      this.closeButtonTarget.innerHTML = EXPAND_CHEVRON
-    } else {
-      this.closeButtonTarget.textContent = '×'
-    }
+    this.closeIconTarget.style.display = collapsed ? 'none' : ''
+    this.expandDockedIconTarget.style.display = collapsed ? '' : 'none'
     this.closeButtonTarget.setAttribute('aria-label', label)
     this.closeButtonTarget.title = label
   }

--- a/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
@@ -119,7 +119,14 @@
           <%= svg_tag "exit-fullscreen.svg", class: "comments-popup-action-icon" %>
         </span>
       </button>
-      <button id="close-comments-btn" data-comments--popup-target="closeButton" class="popup-close-btn" type="button" aria-label="<%= t('collavre.comments.close') %>" title="<%= t('collavre.comments.close') %>">&times;</button>
+      <button id="close-comments-btn" data-comments--popup-target="closeButton" class="comments-popup-action popup-close-btn" type="button" aria-label="<%= t('collavre.comments.close') %>" title="<%= t('collavre.comments.close') %>">
+        <span data-comments--popup-target="closeIcon" aria-hidden="true">
+          <%= svg_tag "close.svg", class: "comments-popup-action-icon" %>
+        </span>
+        <span data-comments--popup-target="expandDockedIcon" aria-hidden="true" style="display:none;">
+          <%= svg_tag "chevron-left.svg", class: "comments-popup-action-icon" %>
+        </span>
+      </button>
     </div>
   </div>
   <div id="comment-contexts" data-comments--contexts-target="list" class="comment-contexts-list" style="display:none;"

--- a/engines/collavre/test/controllers/creatives_controller_test.rb
+++ b/engines/collavre/test/controllers/creatives_controller_test.rb
@@ -316,6 +316,20 @@ class CreativesControllerTest < ActionDispatch::IntegrationTest
     assert_select "turbo-frame#creative-workspace-content #{creative_tree_stream_selector}", count: 0
   end
 
+  test "comments popup close control uses shared SVG action icons" do
+    get creatives_path(id: creatives(:root_parent))
+
+    assert_response :success
+    assert_select "#close-comments-btn.comments-popup-action.popup-close-btn" do
+      assert_select "[data-comments--popup-target='closeIcon'][aria-hidden='true'] svg.comments-popup-action-icon" do
+        assert_select "path[d='M6 6l12 12M6 18L18 6']"
+      end
+      assert_select "[data-comments--popup-target='expandDockedIcon'][aria-hidden='true'] svg.comments-popup-action-icon" do
+        assert_select "path[d='M15 6L9 12L15 18']"
+      end
+    end
+  end
+
   test "workspace breadcrumb root and ancestor links advance browser history" do
     ancestor = creatives(:unconvert_target)
     child = creatives(:unconvert_child_two)

--- a/engines/collavre/test/system/comments_popup_action_alignment_test.rb
+++ b/engines/collavre/test/system/comments_popup_action_alignment_test.rb
@@ -1,0 +1,58 @@
+require_relative "../application_system_test_case"
+
+class CommentsPopupActionAlignmentTest < ApplicationSystemTestCase
+  setup do
+    @user = User.create!(
+      email: "comments-action-alignment@example.com",
+      password: SystemHelpers::PASSWORD,
+      name: "CommentsActionAlignmentUser",
+      email_verified_at: Time.current,
+      notifications_enabled: false
+    )
+    @creative = Creative.create!(description: "Root", user: @user)
+
+    resize_window_to
+    sign_in_via_ui(@user)
+  end
+
+  test "close and fullscreen actions share centered dimensions" do
+    visit root_path
+    assert_selector "#creative-#{@creative.id}", wait: 5
+    find("#creative-#{@creative.id}").hover
+    within("#creative-#{@creative.id}") { find(".comments-btn").click }
+    assert_selector "#comments-popup", visible: :visible, wait: 5
+
+    dimensions = page.evaluate_script(<<~JS)
+      (() => {
+        const box = (selector) => {
+          const rect = document.querySelector(selector).getBoundingClientRect()
+          return {
+            width: rect.width,
+            height: rect.height,
+            centerX: rect.left + rect.width / 2,
+            centerY: rect.top + rect.height / 2
+          }
+        }
+
+        return {
+          fullscreenButton: box('.comments-popup-fullscreen'),
+          closeButton: box('#close-comments-btn'),
+          fullscreenIcon: box('[data-comments--popup-target="fullscreenIcon"] svg'),
+          closeIcon: box('[data-comments--popup-target="closeIcon"] svg')
+        }
+      })()
+    JS
+
+    assert_equal 24, dimensions.dig("fullscreenButton", "width")
+    assert_equal 24, dimensions.dig("fullscreenButton", "height")
+    assert_equal 24, dimensions.dig("closeButton", "width")
+    assert_equal 24, dimensions.dig("closeButton", "height")
+    assert_equal 16, dimensions.dig("fullscreenIcon", "width")
+    assert_equal 16, dimensions.dig("fullscreenIcon", "height")
+    assert_equal 16, dimensions.dig("closeIcon", "width")
+    assert_equal 16, dimensions.dig("closeIcon", "height")
+    assert_in_delta dimensions.dig("fullscreenButton", "centerY"), dimensions.dig("closeButton", "centerY"), 0.01
+    assert_in_delta dimensions.dig("closeButton", "centerX"), dimensions.dig("closeIcon", "centerX"), 0.01
+    assert_in_delta dimensions.dig("closeButton", "centerY"), dimensions.dig("closeIcon", "centerY"), 0.01
+  end
+end


### PR DESCRIPTION
## Summary

- Replace the chat close text glyph with the shared `close.svg` asset.
- Keep the docked expand state on the shared `chevron-left.svg` asset instead of rebuilding inline SVG in JavaScript.
- Normalize popup action hit areas to 24×24 with centered 16×16 icons so the close action aligns with the fullscreen action.
- Add render, controller-state, and browser geometry regression coverage.

## Root cause

The close action used a font-rendered `×` while the fullscreen action used an SVG. Their different font baseline and rendered bounds caused a visible vertical mismatch.

## Impact

The chat header actions now use consistent sizing and alignment across floating and docked states, while preserving accessible labels and the collapsed docked-chat chevron.

## Validation

- `npm test -- --runInBand engines/collavre/app/javascript/controllers/comments/__tests__/popup_controller.test.js` (32 tests)
- `bin/rails test engines/collavre/test/controllers/creatives_controller_test.rb -n /shared_SVG_action_icons/` (1 test, 12 assertions)
- `bin/rails test engines/collavre/test/system/comments_popup_action_alignment_test.rb` (1 test, 14 assertions)
- `./bin/rubocop -a` (1,211 files, no offenses)
- `bin/complexity_check` (passed)
- `bundle exec rake test` (4,118 tests, 13,971 assertions)

Local full-system execution reached 14 unrelated existing workspace/session-navigation failures. The new alignment system test passes independently; rerunning the failed files serially left two existing `InlineScriptsTest` failures.