### PR TITLE
feat: show unread badges in topic list

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -1798,13 +1798,21 @@ body.chat-fullscreen {
 
 /* Archived entries inside the topic list popup */
 .topic-list-item {
-    display: inline-flex;
+    display: flex;
     align-items: center;
     gap: 0.3em;
+    width: 100%;
 }
 .topic-list-item--archived {
-    opacity: 0.5;
     font-style: italic;
+}
+.topic-list-item--archived > svg,
+.topic-list-item--archived > .topic-list-item-label {
+    opacity: 0.5;
+}
+.topic-list-item .topic-unread-badge {
+    flex-shrink: 0;
+    margin-left: auto;
 }
 .topic-branch-icon {
     font-size: 0.75em;

--- a/engines/collavre/app/javascript/controllers/__tests__/topic_list_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/topic_list_controller.test.js
@@ -59,6 +59,22 @@ describe('TopicListController', () => {
         expect(archived[0].textContent).toContain('#Zeta')
     })
 
+    test('renders unread badges for active and archived topics, but not zero counts', () => {
+        controller.openForTopics({
+            ...DATA,
+            topics: [
+                { id: 1, name: 'Main', unread_count: 2 },
+                { id: 2, name: 'Alpha', unread_count: 0 }
+            ],
+            archivedTopics: [{ id: 3, name: 'Zeta', unread_count: 4 }]
+        }, RECT, () => {})
+
+        expect(items()[0].querySelector('.topic-unread-badge').textContent).toBe('2')
+        expect(items()[1].querySelector('.topic-unread-badge')).toBeNull()
+        expect(items()[2].querySelector('.topic-unread-badge')).toBeNull()
+        expect(items()[3].querySelector('.topic-unread-badge').textContent).toBe('4')
+    })
+
     test('filters by label substring and adds NO create option', () => {
         controller.openForTopics(DATA, RECT, () => {})
         controller.inputTarget.value = 'alpha'
@@ -69,6 +85,30 @@ describe('TopicListController', () => {
         controller.inputTarget.value = 'brandnew'
         controller._onInput()
         expect(items()).toHaveLength(0) // no "create and move" pseudo-item
+    })
+
+    test('does not include unread counts in topic search', () => {
+        controller.openForTopics({
+            ...DATA,
+            topics: [{ id: 1, name: 'Main', unread_count: 42 }],
+            archivedTopics: []
+        }, RECT, () => {})
+        controller.inputTarget.value = '42'
+        controller._onInput()
+
+        expect(items()).toHaveLength(0)
+    })
+
+    test('escapes topic labels and rejects non-numeric unread counts', () => {
+        controller.openForTopics({
+            ...DATA,
+            topics: [{ id: 1, name: '<img src=x onerror=alert(1)>', unread_count: '<img src=x>' }],
+            archivedTopics: []
+        }, RECT, () => {})
+
+        expect(controller.listTarget.querySelector('img')).toBeNull()
+        expect(controller.listTarget.textContent).toContain('#<img src=x onerror=alert(1)>')
+        expect(controller.listTarget.querySelector('.topic-unread-badge')).toBeNull()
     })
 
     test('select invokes the callback with the item and closes', () => {

--- a/engines/collavre/app/javascript/controllers/__tests__/topic_list_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/topic_list_controller.test.js
@@ -114,6 +114,23 @@ describe('TopicListController', () => {
         expect(items()[0].querySelector('.topic-unread-badge').textContent).toBe('3')
     })
 
+    test('preserves the active topic across unread count refreshes', () => {
+        const onSelect = jest.fn()
+        controller.openForTopics(DATA, RECT, onSelect)
+        controller.popup.setActiveIndex(1)
+
+        controller.updateTopics({
+            ...DATA,
+            topics: [{ id: 1, name: 'Main' }, { id: 2, name: 'Alpha', unread_count: 3 }]
+        })
+
+        expect(controller.popup.activeIndex).toBe(1)
+        expect(items()[1].classList).toContain('active')
+        controller.handleInputKeydown({ key: 'Enter', preventDefault: jest.fn() })
+
+        expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ id: 2 }))
+    })
+
     test('escapes topic labels and rejects non-numeric unread counts', () => {
         controller.openForTopics({
             ...DATA,

--- a/engines/collavre/app/javascript/controllers/__tests__/topic_list_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/topic_list_controller.test.js
@@ -99,6 +99,21 @@ describe('TopicListController', () => {
         expect(items()).toHaveLength(0)
     })
 
+    test('refreshes unread counts without clearing the current search', () => {
+        controller.openForTopics(DATA, RECT, () => {})
+        controller.inputTarget.value = 'alpha'
+        controller._onInput()
+
+        controller.updateTopics({
+            ...DATA,
+            topics: [{ id: 1, name: 'Main' }, { id: 2, name: 'Alpha', unread_count: 3 }]
+        })
+
+        expect(controller.inputTarget.value).toBe('alpha')
+        expect(items()).toHaveLength(1)
+        expect(items()[0].querySelector('.topic-unread-badge').textContent).toBe('3')
+    })
+
     test('escapes topic labels and rejects non-numeric unread counts', () => {
         controller.openForTopics({
             ...DATA,

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_topic_list.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_topic_list.test.js
@@ -31,6 +31,7 @@ describe('TopicsController#openTopicListPopup', () => {
     })
 
     afterEach(() => {
+		jest.useRealTimers()
         document.body.innerHTML = ''
         application.stop()
         jest.clearAllMocks()
@@ -115,36 +116,43 @@ describe('TopicsController#openTopicListPopup', () => {
 		)
     })
 
-    test('increments cached unread counts and refreshes an open topic-list popup', () => {
+    test('reloads authoritative unread counts without incrementing the cached snapshot', async () => {
+		jest.useFakeTimers()
 		controller.topics = [{ id: 2, name: 'Alpha', unread_count: 2 }]
 		controller.archivedTopics = [{ id: 3, name: 'Zeta', unread_count: 4 }]
-		const modal = document.createElement('div')
-		modal.id = 'topic-list-modal'
-		controller.element.appendChild(modal)
-		const popup = { popup: { isOpen: jest.fn(() => true) }, updateTopics: jest.fn() }
-		jest.spyOn(controller.application, 'getControllerForElementAndIdentifier').mockReturnValue(popup)
+		controller.loadTopics = jest.fn().mockResolvedValue(undefined)
 
 		controller.handleNewMessage({ detail: { topicId: '2' } })
+		controller.handleNewMessage({ detail: { topicId: '2' } })
 
-		expect(controller.topics[0].unread_count).toBe(3)
-		expect(popup.updateTopics).toHaveBeenCalledWith(expect.objectContaining({
-			topics: controller.topics,
-			archivedTopics: controller.archivedTopics
-		}))
+		expect(controller.topics[0].unread_count).toBe(2)
+		expect(controller.loadTopics).not.toHaveBeenCalled()
+		await jest.advanceTimersByTimeAsync(250)
+		expect(controller.loadTopics).toHaveBeenCalledTimes(1)
     })
 
-    test('updates archived cached counts but does not refresh a closed popup', () => {
+    test('leaves archived cached counts unchanged while scheduling a reload', async () => {
+		jest.useFakeTimers()
 		controller.archivedTopics = [{ id: 3, name: 'Zeta' }]
-		const modal = document.createElement('div')
-		modal.id = 'topic-list-modal'
-		controller.element.appendChild(modal)
-		const popup = { popup: { isOpen: jest.fn(() => false) }, updateTopics: jest.fn() }
-		jest.spyOn(controller.application, 'getControllerForElementAndIdentifier').mockReturnValue(popup)
+		controller.loadTopics = jest.fn().mockResolvedValue(undefined)
 
 		controller.handleNewMessage({ detail: { topicId: 3 } })
 
-		expect(controller.archivedTopics[0].unread_count).toBe(1)
-		expect(popup.updateTopics).not.toHaveBeenCalled()
+		expect(controller.archivedTopics[0].unread_count).toBeUndefined()
+		await jest.advanceTimersByTimeAsync(250)
+		expect(controller.loadTopics).toHaveBeenCalledTimes(1)
+    })
+
+    test('cancels a scheduled unread reload when the popup closes', async () => {
+		jest.useFakeTimers()
+		controller.creativeIdValue = '42'
+		controller.loadTopics = jest.fn().mockResolvedValue(undefined)
+		controller.handleNewMessage({ detail: { topicId: '2' } })
+
+		controller.onPopupClosed()
+		await jest.advanceTimersByTimeAsync(250)
+
+		expect(controller.loadTopics).not.toHaveBeenCalled()
     })
 
     test('lets other popups process the pointer event and consumes the matching click when open', () => {

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_topic_list.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_topic_list.test.js
@@ -7,6 +7,7 @@ import TopicsController from '../topics_controller'
 
 describe('TopicsController#openTopicListPopup', () => {
     let application, controller
+    const originalFetch = global.fetch
 
     beforeEach(() => {
         global.requestAnimationFrame = (fn) => { fn(); return 0 }
@@ -32,6 +33,7 @@ describe('TopicsController#openTopicListPopup', () => {
 
     afterEach(() => {
 		jest.useRealTimers()
+        global.fetch = originalFetch
         document.body.innerHTML = ''
         application.stop()
         jest.clearAllMocks()
@@ -120,34 +122,34 @@ describe('TopicsController#openTopicListPopup', () => {
 		jest.useFakeTimers()
 		controller.topics = [{ id: 2, name: 'Alpha', unread_count: 2 }]
 		controller.archivedTopics = [{ id: 3, name: 'Zeta', unread_count: 4 }]
-		controller.loadTopics = jest.fn().mockResolvedValue(undefined)
+		controller.refreshUnreadCounts = jest.fn().mockResolvedValue(undefined)
 
 		controller.handleNewMessage({ detail: { topicId: '2' } })
 		controller.handleNewMessage({ detail: { topicId: '2' } })
 
 		expect(controller.topics[0].unread_count).toBe(2)
-		expect(controller.loadTopics).not.toHaveBeenCalled()
+		expect(controller.refreshUnreadCounts).not.toHaveBeenCalled()
 		await jest.advanceTimersByTimeAsync(250)
-		expect(controller.loadTopics).toHaveBeenCalledTimes(1)
+		expect(controller.refreshUnreadCounts).toHaveBeenCalledTimes(1)
     })
 
     test('leaves archived cached counts unchanged while scheduling a reload', async () => {
 		jest.useFakeTimers()
 		controller.archivedTopics = [{ id: 3, name: 'Zeta' }]
-		controller.loadTopics = jest.fn().mockResolvedValue(undefined)
+		controller.refreshUnreadCounts = jest.fn().mockResolvedValue(undefined)
 
 		controller.handleNewMessage({ detail: { topicId: 3 } })
 
 		expect(controller.archivedTopics[0].unread_count).toBeUndefined()
 		await jest.advanceTimersByTimeAsync(250)
-		expect(controller.loadTopics).toHaveBeenCalledTimes(1)
+		expect(controller.refreshUnreadCounts).toHaveBeenCalledTimes(1)
     })
 
     test('queues one trailing reload while an unread reload is in flight', async () => {
 		jest.useFakeTimers()
 		let finishFirstLoad
 		const firstLoad = new Promise(resolve => { finishFirstLoad = resolve })
-		controller.loadTopics = jest.fn()
+		controller.refreshUnreadCounts = jest.fn()
 			.mockReturnValueOnce(firstLoad)
 			.mockResolvedValueOnce(undefined)
 
@@ -156,11 +158,48 @@ describe('TopicsController#openTopicListPopup', () => {
 		controller.handleNewMessage({ detail: { topicId: '2' } })
 		controller.handleNewMessage({ detail: { topicId: '2' } })
 
-		expect(controller.loadTopics).toHaveBeenCalledTimes(1)
+		expect(controller.refreshUnreadCounts).toHaveBeenCalledTimes(1)
 		finishFirstLoad()
 		await Promise.resolve()
 		await jest.advanceTimersByTimeAsync(250)
-		expect(controller.loadTopics).toHaveBeenCalledTimes(2)
+		expect(controller.refreshUnreadCounts).toHaveBeenCalledTimes(2)
+	})
+
+    test('reports an unread refresh failure without leaving it in flight', async () => {
+		jest.useFakeTimers()
+		const error = new Error('network failed')
+		controller.refreshUnreadCounts = jest.fn().mockRejectedValue(error)
+		const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+		controller.handleNewMessage({ detail: { topicId: '2' } })
+		await jest.advanceTimersByTimeAsync(250)
+
+		expect(consoleError).toHaveBeenCalledWith('Failed to refresh topic unread counts', error)
+		expect(controller._unreadCountRefreshInFlight).toBe(false)
+	})
+
+    test('retains topic snapshots while refreshing only authoritative unread counts', async () => {
+		let finishRequest
+		global.fetch = jest.fn(() => new Promise(resolve => { finishRequest = resolve }))
+		controller.creativeIdValue = '42'
+		controller.topics = [{ id: 2, name: 'Alpha', unread_count: 2 }]
+		controller.archivedTopics = [{ id: 3, name: 'Zeta', unread_count: 1 }]
+		controller.debounceSaveLastTopic = jest.fn()
+
+		const refreshing = controller.refreshUnreadCounts()
+		expect(controller.topics).toEqual([{ id: 2, name: 'Alpha', unread_count: 2 }])
+		finishRequest({
+			ok: true,
+			json: jest.fn().mockResolvedValue({
+				topics: [{ id: 2, name: 'Changed on server', unread_count: 4 }],
+				archived_topics: [{ id: 3, name: 'Also changed', unread_count: 5 }]
+			})
+		})
+		await refreshing
+
+		expect(controller.topics).toEqual([{ id: 2, name: 'Alpha', unread_count: 4 }])
+		expect(controller.archivedTopics).toEqual([{ id: 3, name: 'Zeta', unread_count: 5 }])
+		expect(controller.debounceSaveLastTopic).not.toHaveBeenCalled()
 	})
 
     test('clears cached and rendered unread counts when a topic is opened', () => {
@@ -176,13 +215,13 @@ describe('TopicsController#openTopicListPopup', () => {
     test('cancels a scheduled unread reload when the popup closes', async () => {
 		jest.useFakeTimers()
 		controller.creativeIdValue = '42'
-		controller.loadTopics = jest.fn().mockResolvedValue(undefined)
+		controller.refreshUnreadCounts = jest.fn().mockResolvedValue(undefined)
 		controller.handleNewMessage({ detail: { topicId: '2' } })
 
 		controller.onPopupClosed()
 		await jest.advanceTimersByTimeAsync(250)
 
-		expect(controller.loadTopics).not.toHaveBeenCalled()
+		expect(controller.refreshUnreadCounts).not.toHaveBeenCalled()
     })
 
     test('lets other popups process the pointer event and consumes the matching click when open', () => {

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_topic_list.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_topic_list.test.js
@@ -182,24 +182,88 @@ describe('TopicsController#openTopicListPopup', () => {
 		let finishRequest
 		global.fetch = jest.fn(() => new Promise(resolve => { finishRequest = resolve }))
 		controller.creativeIdValue = '42'
-		controller.topics = [{ id: 2, name: 'Alpha', unread_count: 2 }]
+		controller.topics = [
+			{ id: 2, name: 'Alpha', unread_count: 0 },
+			{ id: 4, name: 'Beta', unread_count: 3 }
+		]
 		controller.archivedTopics = [{ id: 3, name: 'Zeta', unread_count: 1 }]
 		controller.debounceSaveLastTopic = jest.fn()
+		controller.renderTopics(controller.topics)
+		const renderTopics = jest.spyOn(controller, 'renderTopics')
 
 		const refreshing = controller.refreshUnreadCounts()
-		expect(controller.topics).toEqual([{ id: 2, name: 'Alpha', unread_count: 2 }])
+		expect(controller.topics).toEqual([
+			{ id: 2, name: 'Alpha', unread_count: 0 },
+			{ id: 4, name: 'Beta', unread_count: 3 }
+		])
 		finishRequest({
 			ok: true,
 			json: jest.fn().mockResolvedValue({
-				topics: [{ id: 2, name: 'Changed on server', unread_count: 4 }],
+				topics: [
+					{ id: 2, name: 'Changed on server', unread_count: 4 },
+					{ id: 4, name: 'Also changed', unread_count: 0 }
+				],
 				archived_topics: [{ id: 3, name: 'Also changed', unread_count: 5 }]
 			})
 		})
 		await refreshing
 
-		expect(controller.topics).toEqual([{ id: 2, name: 'Alpha', unread_count: 4 }])
+		expect(controller.topics).toEqual([
+			{ id: 2, name: 'Alpha', unread_count: 4 },
+			{ id: 4, name: 'Beta', unread_count: 0 }
+		])
 		expect(controller.archivedTopics).toEqual([{ id: 3, name: 'Zeta', unread_count: 5 }])
+		expect(controller.listTarget.querySelector('[data-id="2"] .topic-unread-badge').textContent).toBe('4')
+		expect(controller.listTarget.querySelector('[data-id="4"] .topic-unread-badge')).toBeNull()
+		expect(renderTopics).not.toHaveBeenCalled()
 		expect(controller.debounceSaveLastTopic).not.toHaveBeenCalled()
+	})
+
+	test('preserves an in-progress topic edit while refreshing unread counts', async () => {
+		global.fetch = jest.fn().mockResolvedValue({
+			ok: true,
+			json: jest.fn().mockResolvedValue({
+				topics: [{ id: 2, name: 'Alpha', unread_count: 4 }],
+				archived_topics: []
+			})
+		})
+		controller.creativeIdValue = '42'
+		controller.topics = [{ id: 2, name: 'Alpha', unread_count: 1 }]
+		controller.canManageTopics = true
+		controller.renderTopics(controller.topics, true)
+		const topicEl = controller.listTarget.querySelector('[data-id="2"]')
+		controller.showEditInput(topicEl, '2')
+		const input = topicEl.querySelector('.topic-edit-input')
+		input.value = 'Draft topic name'
+
+		await controller.refreshUnreadCounts()
+
+		expect(topicEl.querySelector('.topic-edit-input')).toBe(input)
+		expect(input.value).toBe('Draft topic name')
+		controller.cancelEdit({ target: input })
+		expect(topicEl.querySelector('.topic-unread-badge').textContent).toBe('4')
+	})
+
+	test('discards an in-flight unread response after disconnect', async () => {
+		let finishRequest
+		global.fetch = jest.fn(() => new Promise(resolve => { finishRequest = resolve }))
+		controller.creativeIdValue = '42'
+		controller.topics = [{ id: 2, name: 'Alpha', unread_count: 1 }]
+		const refreshPopup = jest.spyOn(controller, 'refreshOpenTopicListPopup')
+		const refreshing = controller.refreshUnreadCounts()
+
+		controller.disconnect()
+		finishRequest({
+			ok: true,
+			json: jest.fn().mockResolvedValue({
+				topics: [{ id: 2, name: 'Alpha', unread_count: 5 }],
+				archived_topics: []
+			})
+		})
+		await refreshing
+
+		expect(controller.topics[0].unread_count).toBe(1)
+		expect(refreshPopup).not.toHaveBeenCalled()
 	})
 
     test('clears cached and rendered unread counts when a topic is opened', () => {

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_topic_list.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_topic_list.test.js
@@ -115,6 +115,38 @@ describe('TopicsController#openTopicListPopup', () => {
 		)
     })
 
+    test('increments cached unread counts and refreshes an open topic-list popup', () => {
+		controller.topics = [{ id: 2, name: 'Alpha', unread_count: 2 }]
+		controller.archivedTopics = [{ id: 3, name: 'Zeta', unread_count: 4 }]
+		const modal = document.createElement('div')
+		modal.id = 'topic-list-modal'
+		controller.element.appendChild(modal)
+		const popup = { popup: { isOpen: jest.fn(() => true) }, updateTopics: jest.fn() }
+		jest.spyOn(controller.application, 'getControllerForElementAndIdentifier').mockReturnValue(popup)
+
+		controller.handleNewMessage({ detail: { topicId: '2' } })
+
+		expect(controller.topics[0].unread_count).toBe(3)
+		expect(popup.updateTopics).toHaveBeenCalledWith(expect.objectContaining({
+			topics: controller.topics,
+			archivedTopics: controller.archivedTopics
+		}))
+    })
+
+    test('updates archived cached counts but does not refresh a closed popup', () => {
+		controller.archivedTopics = [{ id: 3, name: 'Zeta' }]
+		const modal = document.createElement('div')
+		modal.id = 'topic-list-modal'
+		controller.element.appendChild(modal)
+		const popup = { popup: { isOpen: jest.fn(() => false) }, updateTopics: jest.fn() }
+		jest.spyOn(controller.application, 'getControllerForElementAndIdentifier').mockReturnValue(popup)
+
+		controller.handleNewMessage({ detail: { topicId: 3 } })
+
+		expect(controller.archivedTopics[0].unread_count).toBe(1)
+		expect(popup.updateTopics).not.toHaveBeenCalled()
+    })
+
     test('lets other popups process the pointer event and consumes the matching click when open', () => {
 		const btn = controller.topicListButtonTarget
 		const modal = document.createElement('div')

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_topic_list.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_topic_list.test.js
@@ -143,6 +143,36 @@ describe('TopicsController#openTopicListPopup', () => {
 		expect(controller.loadTopics).toHaveBeenCalledTimes(1)
     })
 
+    test('queues one trailing reload while an unread reload is in flight', async () => {
+		jest.useFakeTimers()
+		let finishFirstLoad
+		const firstLoad = new Promise(resolve => { finishFirstLoad = resolve })
+		controller.loadTopics = jest.fn()
+			.mockReturnValueOnce(firstLoad)
+			.mockResolvedValueOnce(undefined)
+
+		controller.handleNewMessage({ detail: { topicId: '2' } })
+		await jest.advanceTimersByTimeAsync(250)
+		controller.handleNewMessage({ detail: { topicId: '2' } })
+		controller.handleNewMessage({ detail: { topicId: '2' } })
+
+		expect(controller.loadTopics).toHaveBeenCalledTimes(1)
+		finishFirstLoad()
+		await Promise.resolve()
+		await jest.advanceTimersByTimeAsync(250)
+		expect(controller.loadTopics).toHaveBeenCalledTimes(2)
+	})
+
+    test('clears cached and rendered unread counts when a topic is opened', () => {
+		controller.topics = [{ id: 2, name: 'Alpha', unread_count: 3 }]
+		controller.renderTopics(controller.topics)
+
+		controller.clearNewMessageBadge('2')
+
+		expect(controller.topics[0].unread_count).toBe(0)
+		expect(controller.listTarget.querySelector('[data-id="2"] .topic-unread-badge')).toBeNull()
+    })
+
     test('cancels a scheduled unread reload when the popup closes', async () => {
 		jest.useFakeTimers()
 		controller.creativeIdValue = '42'

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_topic_list.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_topic_list.test.js
@@ -92,6 +92,29 @@ describe('TopicsController#openTopicListPopup', () => {
 		expect(btn.getAttribute('aria-expanded')).toBe('false')
     })
 
+    test('passes unread counts through to the topic-list popup', () => {
+		controller.topics = [{ id: 2, name: 'Alpha', unread_count: 3 }]
+		controller.archivedTopics = [{ id: 3, name: 'Zeta', unread_count: 5 }]
+		const btn = controller.topicListButtonTarget
+		const modal = document.createElement('div')
+		modal.id = 'topic-list-modal'
+		controller.element.appendChild(modal)
+		const popup = { popup: { isOpen: jest.fn(() => false) }, openForTopics: jest.fn() }
+		jest.spyOn(controller.application, 'getControllerForElementAndIdentifier').mockReturnValue(popup)
+
+		controller.openTopicListPopup({ currentTarget: btn })
+
+		expect(popup.openForTopics).toHaveBeenCalledWith(
+			expect.objectContaining({
+				topics: controller.topics,
+				archivedTopics: controller.archivedTopics
+			}),
+			expect.any(Object),
+			expect.any(Function),
+			controller.element
+		)
+    })
+
     test('lets other popups process the pointer event and consumes the matching click when open', () => {
 		const btn = controller.topicListButtonTarget
 		const modal = document.createElement('div')

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -855,12 +855,7 @@ export default class extends Controller {
 
         const openWith = (popup) => {
             popup.openForTopics(
-                {
-                    topics: this.topics || [],
-                    archivedTopics: this.archivedTopics || [],
-                    mainTopicId: this.mainTopicId,
-                    allMessagesLabel: this.element.dataset.topicMainText || 'All Messages'
-                },
+                this.topicListData(),
                 btnRect,
                 (item) => this.selectTopic(item.id),
                 this.element
@@ -901,6 +896,21 @@ export default class extends Controller {
             if (popup) openWith(popup)
             else console.error('topic-list controller not found after creation')
         })
+    }
+
+    topicListData() {
+        return {
+            topics: this.topics || [],
+            archivedTopics: this.archivedTopics || [],
+            mainTopicId: this.mainTopicId,
+            allMessagesLabel: this.element.dataset.topicMainText || 'All Messages'
+        }
+    }
+
+    refreshOpenTopicListPopup() {
+        const modal = document.getElementById('topic-list-modal')
+        const popup = modal && this.application.getControllerForElementAndIdentifier(modal, 'topic-list')
+        if (popup?.popup?.isOpen()) popup.updateTopics(this.topicListData())
     }
 
     prepareTopicListToggle(event) {
@@ -1162,8 +1172,17 @@ export default class extends Controller {
         const isArchived = this.isArchivedTopic(topicId)
         if (isArchived) this.archivedWithNewMessages.add(String(topicId))
 
+        const topic = [...(this.topics || []), ...(this.archivedTopics || [])]
+            .find(candidate => String(candidate.id) === String(topicId))
+        if (topic) {
+            const unreadCount = Number(topic.unread_count)
+            topic.unread_count = (Number.isFinite(unreadCount) && unreadCount > 0 ? unreadCount : 0) + 1
+        }
+
         const topicEl = this.listTarget.querySelector(`.topic-tag[data-id="${topicId}"]`)
         if (topicEl) topicEl.classList.add('has-new-messages')
+
+        this.refreshOpenTopicListPopup()
 
         // A collapsed archived section has no chip to badge, so the toggle carries
         // the notice — otherwise a message in an archived topic is invisible.

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -39,6 +39,7 @@ export default class extends Controller {
         this.subscribedCreativeId = null
         this.topicsSubscription = null
         this._loadTopicsVersion = 0
+        this._unreadCountsOverlay = null
         // Initial load if creativeId is available (e.g. from dataset if set server-side)
         if (this.creativeId && this.element.dataset.docked !== 'true') {
             this.loadTopics()
@@ -210,6 +211,7 @@ export default class extends Controller {
         if (!this.creativeId) return
 
         const version = ++this._loadTopicsVersion
+        this._unreadCountsOverlay = null
         const selectionEpoch = this.selectionEpoch
         // A response can carry a snapshot produced before a save, while that
         // save's HTTP response reaches us before the snapshot is processed.
@@ -232,7 +234,10 @@ export default class extends Controller {
             }
             if (response.ok) {
                 const data = await response.json()
-                const topics = Array.isArray(data) ? data : data.topics
+                const unreadCounts = this._unreadCountsOverlay?.loadVersion === version
+                    ? this._unreadCountsOverlay.counts
+                    : null
+                const topics = this.applyUnreadCounts(Array.isArray(data) ? data : data.topics, unreadCounts)
                 const canManage = Array.isArray(data) ? false : data.can_manage
                 const canCreateTopic = Array.isArray(data) ? false : (data.can_create_topic ?? canManage)
                 // Assigning an agent is authorized at :write, not :admin, so the
@@ -245,7 +250,7 @@ export default class extends Controller {
                 this.canManageTopics = canManage
                 this.canCreateTopic = canCreateTopic
                 this.canSetPrimaryAgent = canSetPrimaryAgent
-                this.archivedTopics = data.archived_topics || []
+                this.archivedTopics = this.applyUnreadCounts(data.archived_topics || [], unreadCounts)
                 this.pruneArchivedBadges()
                 const effectiveCreativeId = data.effective_creative_id
                     ? String(data.effective_creative_id)
@@ -928,8 +933,8 @@ export default class extends Controller {
         this._unreadCountRefreshTimer = setTimeout(() => {
             this._unreadCountRefreshTimer = null
             this._unreadCountRefreshInFlight = true
-            this.loadTopics()
-                .catch(() => { /* loadTopics already reports the failure */ })
+            this.refreshUnreadCounts()
+                .catch(error => console.error("Failed to refresh topic unread counts", error))
                 .finally(() => {
                     this._unreadCountRefreshInFlight = false
                     if (!this._unreadCountRefreshQueued) return
@@ -944,6 +949,38 @@ export default class extends Controller {
         clearTimeout(this._unreadCountRefreshTimer)
         this._unreadCountRefreshTimer = null
         this._unreadCountRefreshQueued = false
+    }
+
+    async refreshUnreadCounts() {
+        if (!this.creativeId) return
+
+        const creativeId = String(this.creativeId)
+        const loadVersion = this._loadTopicsVersion
+        const response = await fetch(`/creatives/${creativeId}/topics`)
+        if (!response.ok) return
+
+        const data = await response.json()
+        if (String(this.creativeId) !== creativeId || this._loadTopicsVersion !== loadVersion) return
+
+        const activeTopics = Array.isArray(data) ? data : data.topics
+        const counts = new Map(
+            [...(activeTopics || []), ...(data.archived_topics || [])]
+                .map(topic => [String(topic.id), Number(topic.unread_count) || 0])
+        )
+        this._unreadCountsOverlay = { loadVersion, counts }
+        this.topics = this.applyUnreadCounts(this.topics, counts)
+        this.archivedTopics = this.applyUnreadCounts(this.archivedTopics, counts)
+        this.renderTopics(this.topics, this.canManageTopics, this.canCreateTopic, this.canSetPrimaryAgent)
+        if (this.currentTopicId) this.clearNewMessageBadge(this.currentTopicId)
+        this.refreshOpenTopicListPopup()
+    }
+
+    applyUnreadCounts(topics = [], counts = null) {
+        if (!counts) return topics
+
+        return topics.map(topic => counts.has(String(topic.id))
+            ? { ...topic, unread_count: counts.get(String(topic.id)) }
+            : topic)
     }
 
     prepareTopicListToggle(event) {

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -56,8 +56,7 @@ export default class extends Controller {
         window.removeEventListener('comments--topics:new-message', this.handleNewMessage)
         window.removeEventListener('collavre:topic-moved', this.handleTopicMoved)
         this.element.removeEventListener('topic-list:close', this.handleTopicListClose)
-        clearTimeout(this._unreadCountRefreshTimer)
-        this._unreadCountRefreshTimer = null
+        this.cancelUnreadCountRefresh()
         this.unsubscribe()
     }
 
@@ -104,8 +103,7 @@ export default class extends Controller {
         this.releaseAcknowledgedPendingSelfEchoes()
         this.markPendingSelfEchoesAsPossiblyMissed()
         this._loadTopicsVersion += 1
-        clearTimeout(this._unreadCountRefreshTimer)
-        this._unreadCountRefreshTimer = null
+        this.cancelUnreadCountRefresh()
         // The same creative can reopen before an in-flight save broadcasts.
         // Keep that save's claim so its delayed echo remains recognisable on
         // the replacement subscription; a different creative clears it when
@@ -355,10 +353,11 @@ export default class extends Controller {
                 }
 
                 this.renderTopics(this.topics, this.canManageTopics, this.canCreateTopic, this.canSetPrimaryAgent, creativeId)
-                this.refreshOpenTopicListPopup()
+                if (this.currentTopicId) this.clearNewMessageBadge(this.currentTopicId)
                 if (!skipLastTopicReconciliation) {
                     this.restoreSelection({ keepEmptyPick: pickWon })
                 }
+                this.refreshOpenTopicListPopup()
             }
         } catch (e) {
             console.error("Failed to load topics", e)
@@ -920,12 +919,31 @@ export default class extends Controller {
     }
 
     scheduleUnreadCountRefresh() {
+        if (this._unreadCountRefreshInFlight) {
+            this._unreadCountRefreshQueued = true
+            return
+        }
         if (this._unreadCountRefreshTimer) return
 
         this._unreadCountRefreshTimer = setTimeout(() => {
             this._unreadCountRefreshTimer = null
-            this.loadTopics().catch(() => { /* loadTopics already reports the failure */ })
+            this._unreadCountRefreshInFlight = true
+            this.loadTopics()
+                .catch(() => { /* loadTopics already reports the failure */ })
+                .finally(() => {
+                    this._unreadCountRefreshInFlight = false
+                    if (!this._unreadCountRefreshQueued) return
+
+                    this._unreadCountRefreshQueued = false
+                    this.scheduleUnreadCountRefresh()
+                })
         }, UNREAD_COUNT_REFRESH_DELAY)
+    }
+
+    cancelUnreadCountRefresh() {
+        clearTimeout(this._unreadCountRefreshTimer)
+        this._unreadCountRefreshTimer = null
+        this._unreadCountRefreshQueued = false
     }
 
     prepareTopicListToggle(event) {
@@ -1203,7 +1221,12 @@ export default class extends Controller {
         const topicEl = this.listTarget.querySelector(`.topic-tag[data-id="${topicId}"]`)
         if (topicEl) {
             topicEl.classList.remove('has-new-messages')
+            topicEl.querySelector('.topic-unread-badge')?.remove()
         }
+
+        const topic = [...(this.topics || []), ...(this.archivedTopics || [])]
+            .find(candidate => String(candidate.id) === String(topicId))
+        if (topic) topic.unread_count = 0
 
         // The toggle aggregates every archived topic, so it only clears once none
         // of them is left unread.

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -38,7 +38,7 @@ export default class extends Controller {
         this.canSetPrimaryAgent = false
         this.subscribedCreativeId = null
         this.topicsSubscription = null
-        this._loadTopicsVersion = 0
+        this._loadTopicsVersion ||= 0
         this._unreadCountsOverlay = null
         // Initial load if creativeId is available (e.g. from dataset if set server-side)
         if (this.creativeId && this.element.dataset.docked !== 'true') {
@@ -57,6 +57,7 @@ export default class extends Controller {
         window.removeEventListener('comments--topics:new-message', this.handleNewMessage)
         window.removeEventListener('collavre:topic-moved', this.handleTopicMoved)
         this.element.removeEventListener('topic-list:close', this.handleTopicListClose)
+        this._loadTopicsVersion += 1
         this.cancelUnreadCountRefresh()
         this.unsubscribe()
     }
@@ -918,7 +919,7 @@ export default class extends Controller {
     }
 
     refreshOpenTopicListPopup() {
-        const modal = document.getElementById('topic-list-modal')
+        const modal = this.element.querySelector('#topic-list-modal')
         const popup = modal && this.application.getControllerForElementAndIdentifier(modal, 'topic-list')
         if (popup?.popup?.isOpen()) popup.updateTopics(this.topicListData())
     }
@@ -970,8 +971,8 @@ export default class extends Controller {
         this._unreadCountsOverlay = { loadVersion, counts }
         this.topics = this.applyUnreadCounts(this.topics, counts)
         this.archivedTopics = this.applyUnreadCounts(this.archivedTopics, counts)
-        this.renderTopics(this.topics, this.canManageTopics, this.canCreateTopic, this.canSetPrimaryAgent)
         if (this.currentTopicId) this.clearNewMessageBadge(this.currentTopicId)
+        this.refreshRenderedUnreadCounts()
         this.refreshOpenTopicListPopup()
     }
 
@@ -981,6 +982,34 @@ export default class extends Controller {
         return topics.map(topic => counts.has(String(topic.id))
             ? { ...topic, unread_count: counts.get(String(topic.id)) }
             : topic)
+    }
+
+    refreshRenderedUnreadCounts() {
+        const topicsById = new Map(
+            [...(this.topics || []), ...(this.archivedTopics || [])]
+                .map(topic => [String(topic.id), topic])
+        )
+
+        this.listTarget.querySelectorAll('.topic-tag[data-id]').forEach(topicEl => {
+            const topic = topicsById.get(String(topicEl.dataset.id))
+            if (!topic || topicEl.querySelector('.topic-edit-input')) return
+
+            const count = Number(topic.unread_count) || 0
+            const badge = topicEl.querySelector('.topic-unread-badge')
+            if (count <= 0) {
+                badge?.remove()
+                return
+            }
+            if (badge) {
+                badge.textContent = String(count)
+                return
+            }
+
+            const newBadge = document.createElement('span')
+            newBadge.className = 'topic-unread-badge'
+            newBadge.textContent = String(count)
+            topicEl.insertBefore(newBadge, topicEl.querySelector('button'))
+        })
     }
 
     prepareTopicListToggle(event) {
@@ -1158,6 +1187,7 @@ export default class extends Controller {
         if (topicEl && topicEl.dataset.originalHtml) {
             topicEl.innerHTML = topicEl.dataset.originalHtml
             delete topicEl.dataset.originalHtml
+            this.refreshRenderedUnreadCounts()
         }
 
         setTimeout(() => { this.editCancelling = false }, 100)

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -7,6 +7,7 @@ const ICON_ARCHIVE = `<svg width="12" height="12" viewBox="0 0 24 24" fill="none
 const ICON_RESTORE = `<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7v6h6"/><path d="M21 17a9 9 0 0 0-9-9 9 9 0 0 0-6.69 3L3 13"/></svg>`
 const AMBIGUOUS_SAVE_CLAIM_TIMEOUT = 5_000
 const SAVE_REQUEST_TIMEOUT = 5_000
+const UNREAD_COUNT_REFRESH_DELAY = 250
 const LAST_TOPIC_SAVE_SESSION_STORAGE_KEY = "collavre:last-topic-save-session-id"
 const LAST_TOPIC_SAVE_SEQUENCE_STORAGE_KEY = "collavre:last-topic-save-sequence"
 const LAST_TOPIC_SAVE_WINDOW_NAME_PREFIX = "collavre:last-topic-save-session:"
@@ -55,6 +56,8 @@ export default class extends Controller {
         window.removeEventListener('comments--topics:new-message', this.handleNewMessage)
         window.removeEventListener('collavre:topic-moved', this.handleTopicMoved)
         this.element.removeEventListener('topic-list:close', this.handleTopicListClose)
+        clearTimeout(this._unreadCountRefreshTimer)
+        this._unreadCountRefreshTimer = null
         this.unsubscribe()
     }
 
@@ -101,6 +104,8 @@ export default class extends Controller {
         this.releaseAcknowledgedPendingSelfEchoes()
         this.markPendingSelfEchoesAsPossiblyMissed()
         this._loadTopicsVersion += 1
+        clearTimeout(this._unreadCountRefreshTimer)
+        this._unreadCountRefreshTimer = null
         // The same creative can reopen before an in-flight save broadcasts.
         // Keep that save's claim so its delayed echo remains recognisable on
         // the replacement subscription; a different creative clears it when
@@ -350,6 +355,7 @@ export default class extends Controller {
                 }
 
                 this.renderTopics(this.topics, this.canManageTopics, this.canCreateTopic, this.canSetPrimaryAgent, creativeId)
+                this.refreshOpenTopicListPopup()
                 if (!skipLastTopicReconciliation) {
                     this.restoreSelection({ keepEmptyPick: pickWon })
                 }
@@ -913,6 +919,15 @@ export default class extends Controller {
         if (popup?.popup?.isOpen()) popup.updateTopics(this.topicListData())
     }
 
+    scheduleUnreadCountRefresh() {
+        if (this._unreadCountRefreshTimer) return
+
+        this._unreadCountRefreshTimer = setTimeout(() => {
+            this._unreadCountRefreshTimer = null
+            this.loadTopics().catch(() => { /* loadTopics already reports the failure */ })
+        }, UNREAD_COUNT_REFRESH_DELAY)
+    }
+
     prepareTopicListToggle(event) {
         if (event.isPrimary === false || event.button !== 0) return
 
@@ -1172,17 +1187,10 @@ export default class extends Controller {
         const isArchived = this.isArchivedTopic(topicId)
         if (isArchived) this.archivedWithNewMessages.add(String(topicId))
 
-        const topic = [...(this.topics || []), ...(this.archivedTopics || [])]
-            .find(candidate => String(candidate.id) === String(topicId))
-        if (topic) {
-            const unreadCount = Number(topic.unread_count)
-            topic.unread_count = (Number.isFinite(unreadCount) && unreadCount > 0 ? unreadCount : 0) + 1
-        }
-
         const topicEl = this.listTarget.querySelector(`.topic-tag[data-id="${topicId}"]`)
         if (topicEl) topicEl.classList.add('has-new-messages')
 
-        this.refreshOpenTopicListPopup()
+        this.scheduleUnreadCountRefresh()
 
         // A collapsed archived section has no chip to badge, so the toggle carries
         // the notice — otherwise a message in an archived topic is invisible.

--- a/engines/collavre/app/javascript/controllers/topic_list_controller.js
+++ b/engines/collavre/app/javascript/controllers/topic_list_controller.js
@@ -51,11 +51,20 @@ export default class extends CommonPopupController {
     _buildItems({ topics, archivedTopics, mainTopicId, allMessagesLabel }) {
         const main = mainTopicId ? topics.find(t => String(t.id) === String(mainTopicId)) : null
         const others = topics.filter(t => !main || String(t.id) !== String(mainTopicId))
+        const topicItem = (topic, archived) => {
+            const unreadCount = Number(topic.unread_count)
+            return {
+                id: topic.id,
+                label: `#${topic.name}`,
+                archived,
+                unreadCount: Number.isFinite(unreadCount) ? unreadCount : 0
+            }
+        }
         const items = []
-        if (main) items.push({ id: main.id, label: `#${main.name}`, archived: false })
-        others.forEach(t => items.push({ id: t.id, label: `#${t.name}`, archived: false }))
+        if (main) items.push(topicItem(main, false))
+        others.forEach(t => items.push(topicItem(t, false)))
         items.push({ id: '', label: `📋 ${allMessagesLabel}`, archived: false })
-        archivedTopics.forEach(t => items.push({ id: t.id, label: `#${t.name}`, archived: true }))
+        archivedTopics.forEach(t => items.push(topicItem(t, true)))
         return items
     }
 
@@ -81,10 +90,13 @@ export default class extends CommonPopupController {
             .replace(/&/g, '&amp;')
             .replace(/</g, '&lt;')
             .replace(/>/g, '&gt;')
+        const unreadBadge = item.unreadCount > 0
+            ? `<span class="topic-unread-badge">${item.unreadCount}</span>`
+            : ''
         if (item.archived) {
-            return `<span class="topic-list-item topic-list-item--archived">${ICON_ARCHIVE} ${escaped}</span>`
+            return `<span class="topic-list-item topic-list-item--archived">${ICON_ARCHIVE}<span class="topic-list-item-label">${escaped}</span>${unreadBadge}</span>`
         }
-        return `<span class="topic-list-item">${escaped}</span>`
+        return `<span class="topic-list-item"><span class="topic-list-item-label">${escaped}</span>${unreadBadge}</span>`
     }
 
     dispatchClose(reason) {

--- a/engines/collavre/app/javascript/controllers/topic_list_controller.js
+++ b/engines/collavre/app/javascript/controllers/topic_list_controller.js
@@ -25,9 +25,8 @@ export default class extends CommonPopupController {
 
     openForTopics({ topics = [], archivedTopics = [], mainTopicId = null, allMessagesLabel = 'All Messages' }, anchorRect, onSelectCallback, boundsElement = null) {
         this.onSelectCallback = onSelectCallback
-        this._allItems = this._buildItems({ topics, archivedTopics, mainTopicId, allMessagesLabel })
         this.inputTarget.value = ''
-        this.setItems(this._allItems)
+        this.updateTopics({ topics, archivedTopics, mainTopicId, allMessagesLabel })
         super.open(anchorRect, boundsElement)
         if (this.isMobile()) {
             // Autofocusing the search box raises the virtual keyboard, which covers
@@ -37,6 +36,11 @@ export default class extends CommonPopupController {
             return
         }
         requestAnimationFrame(() => this.inputTarget.focus())
+    }
+
+    updateTopics({ topics = [], archivedTopics = [], mainTopicId = null, allMessagesLabel = 'All Messages' }) {
+        this._allItems = this._buildItems({ topics, archivedTopics, mainTopicId, allMessagesLabel })
+        this._onInput()
     }
 
     isMobile() {

--- a/engines/collavre/app/javascript/controllers/topic_list_controller.js
+++ b/engines/collavre/app/javascript/controllers/topic_list_controller.js
@@ -39,8 +39,13 @@ export default class extends CommonPopupController {
     }
 
     updateTopics({ topics = [], archivedTopics = [], mainTopicId = null, allMessagesLabel = 'All Messages' }) {
+        const activeItem = this.popup.items[this.popup.activeIndex]
         this._allItems = this._buildItems({ topics, archivedTopics, mainTopicId, allMessagesLabel })
         this._onInput()
+        if (!activeItem) return
+
+        const activeIndex = this.popup.items.findIndex(item => String(item.id) === String(activeItem.id))
+        if (activeIndex >= 0) this.popup.setActiveIndex(activeIndex)
     }
 
     isMobile() {


### PR DESCRIPTION
## Summary
- preserve each topic unread count when building popup items
- show right-aligned badges for active and archived topics
- keep All Messages unbadged and searches scoped to topic labels
- normalize unread counts before rendering to prevent markup injection

## Performance
- frontend-only rendering change
- no API, query, or database changes
- O(n) item mapping, matching the existing topic-list render cost

## Tests
- npm test -- --runInBand engines/collavre/app/javascript/controllers/__tests__/topic_list_controller.test.js engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_topic_list.test.js
- npm run build
- bin/complexity_check

## Notes
- targeted tests: 22 passed
- changed executable JavaScript lines are fully covered
- full CSS lint remains blocked by pre-existing repository-wide violations; the edited section adds no new violation