### PR TITLE
feat: add topic and topic-message MCP tools

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_16_000001) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_20_000000) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -227,6 +227,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_16_000001) do
     t.integer "review_type", limit: 1
     t.integer "selected_version_id"
     t.integer "task_id"
+    t.datetime "topic_assigned_at", null: false
     t.boolean "topic_concurrency_defer", default: false, null: false
     t.integer "topic_id"
     t.datetime "updated_at", null: false
@@ -246,6 +247,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_16_000001) do
     t.index ["quoted_comment_id"], name: "index_comments_on_quoted_comment_id"
     t.index ["selected_version_id"], name: "index_comments_on_selected_version_id"
     t.index ["task_id"], name: "index_comments_on_task_id"
+    t.index ["topic_id", "topic_assigned_at"], name: "index_comments_on_topic_and_assigned_at"
     t.index ["topic_id"], name: "index_comments_on_topic_id"
     t.index ["user_id"], name: "index_comments_on_user_id"
   end

--- a/engines/collavre/app/controllers/collavre/topics_controller.rb
+++ b/engines/collavre/app/controllers/collavre/topics_controller.rb
@@ -1,5 +1,7 @@
 module Collavre
   class TopicsController < ApplicationController
+    rescue_from Topics::TopicMove::SourceChangedError, with: :render_source_changed
+
     include Collavre::CreativePermissionGuard
 
     before_action :set_creative
@@ -269,6 +271,10 @@ module Collavre
     end
 
     private
+
+    def render_source_changed(error)
+      render json: { error: error.message }, status: :forbidden
+    end
 
     def set_creative
       @creative = Creative.find(params[:creative_id]).effective_origin

--- a/engines/collavre/app/controllers/collavre/topics_controller.rb
+++ b/engines/collavre/app/controllers/collavre/topics_controller.rb
@@ -344,38 +344,21 @@ module Collavre
     end
 
     def generate_next_topic_name
-      prefix = I18n.t("collavre.topics.default_name_prefix")
-      existing_numbers = @creative.topics.active
-        .where("name LIKE ?", "#{Topic.sanitize_sql_like(prefix)}%")
-        .pluck(:name)
-        .filter_map { |n|
-          suffix = n.delete_prefix(prefix)
-          suffix.match?(/\A\d+\z/) ? suffix.to_i : nil
-        }
-
-      next_number = (existing_numbers.max || 0) + 1
-      "#{prefix}#{next_number}"
+      Topics::NextName.for(@creative)
     end
 
+    # Delegated to Topics::Serializer so the topic MCP tools, which broadcast the
+    # same events from outside a request, cannot describe a topic differently
+    # from this controller.
     def topic_json(topic, unread_count: nil)
-      data = topic.slice(:id, :name, :source_topic_id)
-      if topic.primary_agent
-        data[:primary_agent] = agent_json(topic.primary_agent)
-      end
-      data[:agent_locked] = topic.session_id.present?
-      data[:archived_at] = topic.archived_at if topic.archived_at
-      data[:unread_count] = unread_count unless unread_count.nil?
-      data
+      Topics::Serializer.call(topic, unread_count: unread_count)
     end
 
     # Always carries a :primary_agent key, explicitly nil when cleared. The client
     # merges this payload into its cached topic, so an omitted key would leave a
     # stale avatar on screen instead of removing it.
     def topic_json_with_agent(topic, agent)
-      data = topic.slice(:id, :name, :source_topic_id)
-      data[:primary_agent] = agent ? agent_json(agent) : nil
-      data[:agent_locked] = topic.session_id.present?
-      data
+      Topics::Serializer.with_agent(topic, agent)
     end
 
     def agent_json(agent)

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/list_controller_docked.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/list_controller_docked.test.js
@@ -90,4 +90,26 @@ describe('CommentsListController docked startup', () => {
 
     expect(controller.listTarget.innerHTML).toBe('')
   })
+
+  test('flushes a pending read safely when the CSRF meta tag is absent', () => {
+    const controller = Object.create(CommentsListController.prototype)
+    const element = document.createElement('div')
+    document.body.appendChild(element)
+    controller.creativeId = '12'
+    controller.currentTopicId = ''
+    controller.pendingRead = { creativeId: '12', topicId: null, topicIds: null, topicWatermarks: null }
+    Object.defineProperty(controller, 'element', { value: element })
+    const originalFetch = global.fetch
+    global.fetch = jest.fn().mockResolvedValue({ ok: true, headers: new Headers() })
+    document.querySelector('meta[name="csrf-token"]')?.remove()
+
+    expect(() => controller.flushPendingRead()).not.toThrow()
+    expect(global.fetch).toHaveBeenCalledWith(
+      '/comment_read_pointers/update',
+      expect.objectContaining({ method: 'POST' })
+    )
+
+    global.fetch = originalFetch
+    element.remove()
+  })
 })

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/list_controller_read_pointer.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/list_controller_read_pointer.test.js
@@ -8,6 +8,7 @@ import CommentsListController from '../list_controller'
 describe('CommentsListController read pointer updates', () => {
   let controller
   let topicsController
+  const successfulResponse = () => ({ ok: true, headers: { get: () => null } })
 
   beforeEach(() => {
     jest.useFakeTimers()
@@ -28,7 +29,7 @@ describe('CommentsListController read pointer updates', () => {
   })
 
   test('reloads topic unread counts after a successful read pointer update', async () => {
-    global.fetch = jest.fn().mockResolvedValue({ ok: true })
+    global.fetch = jest.fn().mockResolvedValue(successfulResponse())
 
     controller.markCommentsRead()
     await jest.advanceTimersByTimeAsync(2000)
@@ -40,7 +41,7 @@ describe('CommentsListController read pointer updates', () => {
 
   test('sends the selected topic to the read pointer endpoint', async () => {
     controller.currentTopicId = '9'
-    global.fetch = jest.fn().mockResolvedValue({ ok: true })
+    global.fetch = jest.fn().mockResolvedValue(successfulResponse())
 
     controller.markCommentsRead()
     await jest.advanceTimersByTimeAsync(2000)
@@ -51,7 +52,7 @@ describe('CommentsListController read pointer updates', () => {
   test('keeps the rendered All Messages topic snapshot in a read update', async () => {
     controller.renderedAllTopicIds = ['1', '2']
     controller.renderedAllTopicWatermarks = { 1: 20, 2: 21 }
-    global.fetch = jest.fn().mockResolvedValue({ ok: true })
+    global.fetch = jest.fn().mockResolvedValue(successfulResponse())
 
     controller.markCommentsRead()
     await jest.advanceTimersByTimeAsync(2000)
@@ -131,7 +132,7 @@ describe('CommentsListController read pointer updates', () => {
     controller.renderedAllTopicWatermarks = { 1: 20 }
     controller.listTarget = document.createElement('div')
     controller.listTarget.innerHTML = '<div class="comment-item" data-comment-id="21" data-topic-id="1"></div>'
-    global.fetch = jest.fn().mockResolvedValue({ ok: true })
+    global.fetch = jest.fn().mockResolvedValue(successfulResponse())
 
     controller.recordRenderedAllTopicWatermarks(controller.listTarget.firstElementChild)
     controller.markCommentsRead()
@@ -148,7 +149,7 @@ describe('CommentsListController read pointer updates', () => {
     controller.renderedAllTopicWatermarks = { 1: 20 }
     controller.listTarget = document.createElement('div')
     controller.listTarget.innerHTML = '<div class="comment-item" data-comment-id="21" data-topic-id="2"></div>'
-    global.fetch = jest.fn().mockResolvedValue({ ok: true })
+    global.fetch = jest.fn().mockResolvedValue(successfulResponse())
 
     const addedTopic = controller.recordRenderedAllTopicWatermarks(
       controller.listTarget.firstElementChild,
@@ -206,7 +207,7 @@ describe('CommentsListController read pointer updates', () => {
   })
 
   test('flushes a pending read pointer update before closing the popup', () => {
-    global.fetch = jest.fn().mockResolvedValue({ ok: true })
+    global.fetch = jest.fn().mockResolvedValue(successfulResponse())
     controller.resetState = jest.fn()
     controller.listTarget = document.createElement('div')
     controller.markCommentsRead()
@@ -218,7 +219,7 @@ describe('CommentsListController read pointer updates', () => {
   })
 
   test('uses an unload-safe request when disconnecting with a pending read', () => {
-    global.fetch = jest.fn().mockResolvedValue({ ok: true })
+    global.fetch = jest.fn().mockResolvedValue(successfulResponse())
     controller.listTarget = document.createElement('div')
     document.body.appendChild(controller.listTarget)
     controller.markCommentsRead()
@@ -231,7 +232,7 @@ describe('CommentsListController read pointer updates', () => {
   })
 
   test('flushes a pending read pointer update before switching topics', () => {
-    global.fetch = jest.fn().mockResolvedValue({ ok: true })
+    global.fetch = jest.fn().mockResolvedValue(successfulResponse())
     controller.resetToLatest = jest.fn()
     controller.markCommentsRead()
 
@@ -242,7 +243,7 @@ describe('CommentsListController read pointer updates', () => {
   })
 
   test('flushes a pending read pointer update before opening another creative', () => {
-    global.fetch = jest.fn().mockResolvedValue({ ok: true })
+    global.fetch = jest.fn().mockResolvedValue(successfulResponse())
     controller.resetState = jest.fn()
     controller.loadInitialComments = jest.fn()
     controller.listTarget = document.createElement('div')
@@ -256,7 +257,7 @@ describe('CommentsListController read pointer updates', () => {
   })
 
   test('flushes a pending All Messages snapshot before applying a search', () => {
-    global.fetch = jest.fn().mockResolvedValue({ ok: true })
+    global.fetch = jest.fn().mockResolvedValue(successfulResponse())
     controller.renderedAllTopicIds = ['1', '2']
     controller.renderedAllTopicWatermarks = { 1: 20, 2: 21 }
     controller.resetState = jest.fn()

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/popup_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/popup_controller.test.js
@@ -330,6 +330,51 @@ describe('CommentsPopupController', () => {
         })
     })
 
+    test('same-creative deep links clear suppression from a canceled pending open', async () => {
+        const popup = document.getElementById('comments-popup')
+        const triggerBtn = document.getElementById('trigger-btn')
+        popup.dataset.docked = 'true'
+        let finishTopicsLoad
+        const listController = {
+            creativeId: null,
+            suppressTopicChangeLoad: false,
+            onPopupOpened: jest.fn(),
+            onPopupClosed: jest.fn(),
+        }
+        const topicsController = {
+            clearOverrideTopicId: jest.fn(),
+            currentTopicId: '7',
+            onPopupOpened: jest.fn(() => new Promise(resolve => { finishTopicsLoad = resolve })),
+            onPopupClosed: jest.fn(),
+        }
+        Object.defineProperty(controller, 'listController', { configurable: true, value: listController })
+        Object.defineProperty(controller, 'topicsController', { configurable: true, value: topicsController })
+
+        const pendingOpen = controller.open(triggerBtn)
+        await Promise.resolve()
+        expect(listController.suppressTopicChangeLoad).toBe(true)
+
+        document.dispatchEvent(new CustomEvent('creative-comments-click', {
+            detail: {
+                button: triggerBtn,
+                creativeId: '123',
+                workspaceSync: true,
+                highlightId: '456',
+            },
+        }))
+
+        const suppressionAfterReload = listController.suppressTopicChangeLoad
+        expect(listController.onPopupOpened).toHaveBeenCalledWith({
+            creativeId: '123',
+            highlightId: '456',
+            topicId: '7',
+        })
+
+        finishTopicsLoad()
+        await pendingOpen
+        expect(suppressionAfterReload).toBe(false)
+    })
+
     test('same-creative workspace deep links highlight an already loaded comment without reloading', () => {
         const popup = document.getElementById('comments-popup')
         const triggerBtn = document.getElementById('trigger-btn')

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/popup_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/popup_controller.test.js
@@ -290,13 +290,28 @@ describe('CommentsPopupController', () => {
         expect(openFromUrl).not.toHaveBeenCalled()
     })
 
-    test('same-creative workspace deep links refresh the docked chat highlight', () => {
+    test('same-creative workspace deep links reload only the highlighted comment window', () => {
         const popup = document.getElementById('comments-popup')
         const triggerBtn = document.getElementById('trigger-btn')
         popup.dataset.docked = 'true'
         popup.dataset.creativeId = '123'
         popup.style.display = 'flex'
         const open = jest.spyOn(controller, 'open').mockResolvedValue()
+        const listController = {
+            onPopupOpened: jest.fn(),
+            onPopupClosed: jest.fn(),
+        }
+        Object.defineProperty(controller, 'listController', {
+            configurable: true,
+            value: listController,
+        })
+        Object.defineProperty(controller, 'topicsController', {
+            configurable: true,
+            value: {
+                currentTopicId: '7',
+                onPopupClosed: jest.fn(),
+            },
+        })
 
         document.dispatchEvent(new CustomEvent('creative-comments-click', {
             detail: {
@@ -307,10 +322,47 @@ describe('CommentsPopupController', () => {
             },
         }))
 
-        expect(open).toHaveBeenCalledWith(triggerBtn, {
+        expect(open).not.toHaveBeenCalled()
+        expect(listController.onPopupOpened).toHaveBeenCalledWith({
             creativeId: '123',
             highlightId: '456',
+            topicId: '7',
         })
+    })
+
+    test('same-creative workspace deep links highlight an already loaded comment without reloading', () => {
+        const popup = document.getElementById('comments-popup')
+        const triggerBtn = document.getElementById('trigger-btn')
+        const listTarget = document.createElement('div')
+        const comment = document.createElement('div')
+        comment.id = 'comment_456'
+        listTarget.appendChild(comment)
+        popup.appendChild(listTarget)
+        popup.dataset.docked = 'true'
+        popup.dataset.creativeId = '123'
+        popup.style.display = 'flex'
+        const listController = {
+            listTarget,
+            highlightComment: jest.fn(),
+            onPopupOpened: jest.fn(),
+            onPopupClosed: jest.fn(),
+        }
+        Object.defineProperty(controller, 'listController', {
+            configurable: true,
+            value: listController,
+        })
+
+        document.dispatchEvent(new CustomEvent('creative-comments-click', {
+            detail: {
+                button: triggerBtn,
+                creativeId: '123',
+                workspaceSync: true,
+                highlightId: '456',
+            },
+        }))
+
+        expect(listController.highlightComment).toHaveBeenCalledWith('456')
+        expect(listController.onPopupOpened).not.toHaveBeenCalled()
     })
 
     test('same-creative workspace sync without a deep link keeps the docked chat', () => {

--- a/engines/collavre/app/javascript/controllers/comments/list_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/list_controller.js
@@ -4,7 +4,7 @@ import { attachBundleDragImage } from '../../utils/drag_bundle_image'
 import { renderMarkdownInContainer } from '../../lib/utils/markdown'
 import creativesApi from '../../lib/api/creatives'
 import { renderCreativeTree, dispatchCreativeTreeUpdated } from '../../creatives/tree_renderer'
-import { updateCsrfTokenFromResponse } from '../../lib/api/csrf_fetch'
+import csrfFetch, { updateCsrfTokenFromResponse } from '../../lib/api/csrf_fetch'
 import { alertDialog, confirmDialog } from '../../lib/utils/dialog'
 import PrevMessageNavigator from './prev_message_navigator'
 // CommonPopup is now used via TopicSearchController (Stimulus)
@@ -529,10 +529,9 @@ export default class extends Controller {
   updateReadPointer(creativeId, topicId, topicIds = null, topicWatermarks = null, { keepalive = false } = {}) {
     if (!creativeId) return
 
-    fetch('/comment_read_pointers/update', {
+    csrfFetch('/comment_read_pointers/update', {
       method: 'POST',
       headers: {
-        'X-CSRF-Token': document.querySelector('meta[name=csrf-token]').content,
         'Content-Type': 'application/json',
       },
       keepalive,

--- a/engines/collavre/app/javascript/controllers/comments/popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_controller.js
@@ -243,7 +243,7 @@ export default class extends Controller {
           // subscriptions survive.
           this.expandDocked()
         } else if (highlightId) {
-          this.open(button, { creativeId, highlightId })
+          this.reloadDockedHighlight(creativeId, highlightId)
         }
         return
       }
@@ -254,6 +254,22 @@ export default class extends Controller {
     const openOptions = { creativeId }
     if (highlightId) openOptions.highlightId = highlightId
     this.open(button, openOptions)
+  }
+
+  reloadDockedHighlight(creativeId, highlightId) {
+    this.openGeneration += 1
+    const listController = this.listController
+    const existingComment = document.getElementById(`comment_${highlightId}`)
+    if (existingComment && listController?.listTarget?.contains(existingComment)) {
+      listController.highlightComment(highlightId)
+      return
+    }
+
+    listController?.onPopupOpened({
+      creativeId,
+      highlightId,
+      topicId: this.topicsController?.currentTopicId,
+    })
   }
 
   resetDockedToEmpty() {

--- a/engines/collavre/app/javascript/controllers/comments/popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_controller.js
@@ -259,6 +259,10 @@ export default class extends Controller {
   reloadDockedHighlight(creativeId, highlightId) {
     this.openGeneration += 1
     const listController = this.listController
+    // This direct reload supersedes any full open that is still waiting for
+    // topics. That open will stop at its generation check, so release the
+    // suppression it installed before starting the replacement highlight load.
+    if (listController) listController.suppressTopicChangeLoad = false
     const existingComment = document.getElementById(`comment_${highlightId}`)
     if (existingComment && listController?.listTarget?.contains(existingComment)) {
       listController.highlightComment(highlightId)

--- a/engines/collavre/app/jobs/collavre/drop_trigger_job.rb
+++ b/engines/collavre/app/jobs/collavre/drop_trigger_job.rb
@@ -102,6 +102,7 @@ module Collavre
       # selection cap so full Main history transfers regardless of length.
       main_comment_ids = main.comments
                              .visible_to(creative.user)
+                             .without_approval_action
                              .order(:created_at)
                              .pluck(:id)
 

--- a/engines/collavre/app/jobs/collavre/drop_trigger_job.rb
+++ b/engines/collavre/app/jobs/collavre/drop_trigger_job.rb
@@ -114,7 +114,12 @@ module Collavre
           user: creative.user,
           source_topic: main,
           name: DROP_TRIGGER_TOPIC_NAME
-        ).call(comment_ids: main_comment_ids, enforce_limit: false, auto_select: false)
+        ).call(
+          comment_ids: main_comment_ids,
+          enforce_limit: false,
+          auto_select: false,
+          skip_approval_actions: true
+        )
       else
         creative.topics.create!(
           name: DROP_TRIGGER_TOPIC_NAME,

--- a/engines/collavre/app/models/collavre/comment.rb
+++ b/engines/collavre/app/models/collavre/comment.rb
@@ -171,7 +171,6 @@ module Collavre
     include Notifiable
     include Approvable
     include ClaudeChannelPermission
-    include TopicMembership
 
     attribute :skip_default_user, :boolean, default: false
     attribute :skip_dispatch, :boolean, default: false
@@ -184,6 +183,7 @@ module Collavre
 
     before_validation :use_origin_creative
     before_validation :assign_default_user, on: :create
+    include TopicMembership
     after_commit :enqueue_link_preview, on: [ :create, :update ], if: :link_preview_enqueue_required?
     after_create_commit :dispatch_to_orchestration
     after_create_commit :resume_trigger_loop_if_awaiting

--- a/engines/collavre/app/models/collavre/comment.rb
+++ b/engines/collavre/app/models/collavre/comment.rb
@@ -171,6 +171,7 @@ module Collavre
     include Notifiable
     include Approvable
     include ClaudeChannelPermission
+    include TopicMembership
 
     attribute :skip_default_user, :boolean, default: false
     attribute :skip_dispatch, :boolean, default: false
@@ -183,7 +184,6 @@ module Collavre
 
     before_validation :use_origin_creative
     before_validation :assign_default_user, on: :create
-    before_validation :assign_main_topic, on: :create
     after_commit :enqueue_link_preview, on: [ :create, :update ], if: :link_preview_enqueue_required?
     after_create_commit :dispatch_to_orchestration
     after_create_commit :resume_trigger_loop_if_awaiting
@@ -643,14 +643,6 @@ module Collavre
         "[Comment#resume_trigger_loop_if_awaiting] Failed for comment #{id}: " \
         "#{e.class} #{e.message}"
       )
-    end
-
-    def assign_main_topic
-      return if topic_id.present?
-      return unless creative
-
-      fallback = user || Collavre.current_user || creative.user
-      self.topic = creative.main_topic(fallback_user: fallback)
     end
 
     def use_origin_creative

--- a/engines/collavre/app/models/collavre/comment/topic_membership.rb
+++ b/engines/collavre/app/models/collavre/comment/topic_membership.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Collavre
+  class Comment
+    module TopicMembership
+      extend ActiveSupport::Concern
+
+      included do
+        before_validation :assign_main_topic, on: :create
+        before_validation :stamp_topic_assignment
+      end
+
+      private
+
+      def assign_main_topic
+        return if topic_id.present?
+        return unless creative
+
+        fallback = user || Collavre.current_user || creative.user
+        self.topic = creative.main_topic(fallback_user: fallback)
+      end
+
+      # Paging snapshots topic membership separately from comment ids. Content
+      # edits leave this timestamp alone; topic changes advance it.
+      def stamp_topic_assignment
+        return unless will_save_change_to_topic_id? || topic_assigned_at.nil?
+
+        self.topic_assigned_at = Time.current
+      end
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/comment_move_service.rb
+++ b/engines/collavre/app/services/collavre/comment_move_service.rb
@@ -63,6 +63,11 @@ module Collavre
     def perform_move(comments, target_origin, new_topic_id)
       moved_count = 0
       ActiveRecord::Base.transaction do
+        # MessagePage holds the destination topic lock while fixing its
+        # membership anchor. Serialize move-ins on the same row so a comment
+        # cannot be stamped before the snapshot but committed after its reads.
+        Topic.lock.find(new_topic_id)
+
         comments.each do |comment|
           same_creative = comment.creative_id == target_origin.id
           same_topic = comment.topic_id.to_s == new_topic_id.to_s

--- a/engines/collavre/app/services/collavre/tools/id_list.rb
+++ b/engines/collavre/app/services/collavre/tools/id_list.rb
@@ -9,15 +9,29 @@ module Collavre
     # writes when it means the same thing. Rejecting four fifths of those is a
     # tool that fails for a reason the caller cannot see in its own request, so
     # every shape is accepted here instead of at four separate call sites.
+    #
+    # Lenient about shape, strict about content. A token that is not entirely
+    # digits raises rather than coercing: to_i turns "12.5" into 12 and
+    # "123oops" into 123, and topic_create/topic_branch would then move a
+    # different message than the one named and report success. A tool that
+    # silently acts on a neighbouring id is worse than one that fails.
     module IdList
       module_function
+
+      DIGITS = /\A\d+\z/
 
       def parse(value)
         Array(value)
           .flat_map { |entry| entry.to_s.split(",") }
           .filter_map { |token| token.strip.presence }
-          .map(&:to_i)
+          .map { |token| cast(token) }
           .uniq
+      end
+
+      def cast(token)
+        raise ArgumentError, "#{token.inspect} is not a valid id — ids must be whole numbers" unless token.match?(DIGITS)
+
+        token.to_i
       end
     end
   end

--- a/engines/collavre/app/services/collavre/tools/id_list.rb
+++ b/engines/collavre/app/services/collavre/tools/id_list.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Collavre
+  module Tools
+    # Parses the "list of ids" parameters the topic tools take.
+    #
+    # MCP schemas describe a list, but what actually arrives depends on the
+    # calling model: "12,45", ["12", 45], 12 and "12" are all things an agent
+    # writes when it means the same thing. Rejecting four fifths of those is a
+    # tool that fails for a reason the caller cannot see in its own request, so
+    # every shape is accepted here instead of at four separate call sites.
+    module IdList
+      module_function
+
+      def parse(value)
+        Array(value)
+          .flat_map { |entry| entry.to_s.split(",") }
+          .filter_map { |token| token.strip.presence }
+          .map(&:to_i)
+          .uniq
+      end
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/tools/topic_authorizer.rb
+++ b/engines/collavre/app/services/collavre/tools/topic_authorizer.rb
@@ -2,22 +2,70 @@
 
 module Collavre
   module Tools
-    # Topic write authorization for MCP tool services. Mirrors
-    # CreativePermissionGuard#require_creative_write! but is callable outside a
-    # controller request. Attaching a channel injects external messages into a
-    # topic, so it is a write-equivalent mutation — restrict to users with
-    # write permission on the topic's effective_origin creative.
+    # Topic authorization for MCP tool services. Mirrors
+    # CreativePermissionGuard's require_creative_{read,write,admin}! but is
+    # callable outside a controller request. Every check resolves the topic's
+    # effective_origin creative first, because that is where shares live — a
+    # linked creative carries none of its own.
+    #
+    # The owner short-circuit matches CreativePermissionGuard: an owner can hold
+    # no explicit share on their own creative, so has_permission? alone would
+    # lock them out of their own topics.
     module TopicAuthorizer
       module_function
 
+      # Reading a topic's messages exposes every participant's words, so it is
+      # gated at :read — the same level the creative's own body needs.
+      def authorize_read!(topic, user: Collavre::Current.user)
+        authorize!(topic, :read, user: user)
+      end
+
+      # Attaching a channel injects external messages into a topic, and creating
+      # or archiving one restructures where conversation lands, so both are
+      # write-equivalent mutations.
       def authorize_write!(topic, user: Collavre::Current.user)
+        authorize!(topic, :write, user: user)
+      end
+
+      # Renaming a topic rewrites a name other members' links and habits point
+      # at, so TopicsController gates it at :admin. Tools must not be the softer
+      # door onto the same mutation.
+      def authorize_admin!(topic, user: Collavre::Current.user)
+        authorize!(topic, :admin, user: user)
+      end
+
+      # Topic creation has no topic to authorize against yet, so the creative is
+      # the subject. Kept here so every topic-shaped permission decision reads
+      # from one place.
+      def authorize_creative!(creative, level, user: Collavre::Current.user)
+        origin = creative&.effective_origin
+        raise ArgumentError, "Creative is required" unless origin
+        return if origin.user == user
+        return if user && origin.has_permission?(user, level)
+
+        raise Collavre::Tools::PermissionDeniedError,
+          "No #{level} permission on creative #{origin.id}"
+      end
+
+      def authorize!(topic, level, user: Collavre::Current.user)
         creative = topic.creative&.effective_origin
         raise ArgumentError, "Topic has no creative" unless creative
         return if creative.user == user
-        return if user && creative.has_permission?(user, :write)
+        return if user && creative.has_permission?(user, level)
 
         raise Collavre::Tools::PermissionDeniedError,
-          "No write permission on topic #{topic.id}"
+          "No #{level} permission on topic #{topic.id}"
+      end
+
+      # True when the user may read the topic. Used by the multi-topic read
+      # tools, which report an inaccessible topic as a per-topic error entry
+      # rather than failing the whole call — one unreadable id in a batch of
+      # three should not discard the two that worked.
+      def readable?(topic, user: Collavre::Current.user)
+        authorize_read!(topic, user: user)
+        true
+      rescue Collavre::Tools::PermissionDeniedError, ArgumentError
+        false
       end
     end
   end

--- a/engines/collavre/app/services/collavre/tools/topic_branch_service.rb
+++ b/engines/collavre/app/services/collavre/tools/topic_branch_service.rb
@@ -30,6 +30,8 @@ module Tools
 
       The new topic is created on the same creative and records the source in
       source_topic_id. Requires feedback permission or better on the creative.
+      Main and an inbox's System name are reserved and cannot be assigned to
+      the branch.
 
       Approval prompts cannot be branched — a copy would lose the approval
       action and read as ordinary history. Passing one is an error.

--- a/engines/collavre/app/services/collavre/tools/topic_branch_service.rb
+++ b/engines/collavre/app/services/collavre/tools/topic_branch_service.rb
@@ -53,7 +53,7 @@ module Tools
 
       ids = IdList.parse(comment_ids)
       validate_ids!(ids)
-      reject_approval_actions!(source, ids)
+      reject_approval_actions!(source, ids, user)
 
       # Fully qualified: inside Collavre::Tools, a bare TopicBranchService is
       # this tool, not the branching service it wraps.
@@ -91,8 +91,18 @@ module Tools
     # without_approval_action: the predicate is the documented single source of
     # truth, and a second copy of the condition could drift out of step with it.
     # validate_ids! has already capped the selection, so the load is bounded.
-    def reject_approval_actions!(source, ids)
-      blocked = source.comments.where(id: ids).select(&:approval_action?).map(&:id)
+    #
+    # Scoped to visible_to because this error names an id. Over the whole topic
+    # it answers "is comment 4312 an approval prompt?" for a comment the caller
+    # cannot read — a specific error where any other hidden id gets the generic
+    # not-found — and it runs before the wrapped service checks feedback
+    # permission, so read-only access is enough to ask. Restricted to what the
+    # caller can already see, a hidden id falls through to the same not-found
+    # every other unreadable id gets, and nothing distinguishes them. Approval
+    # prompts stay unbranchable either way: the wrapped service's fetch is
+    # visible_to as well, so an invisible one is refused there instead.
+    def reject_approval_actions!(source, ids, user)
+      blocked = source.comments.visible_to(user).where(id: ids).select(&:approval_action?).map(&:id)
       return if blocked.empty?
 
       raise ArgumentError,

--- a/engines/collavre/app/services/collavre/tools/topic_branch_service.rb
+++ b/engines/collavre/app/services/collavre/tools/topic_branch_service.rb
@@ -1,0 +1,80 @@
+module Collavre
+require "sorbet-runtime"
+require "rails_mcp_engine"
+module Tools
+  # Branches selected messages of a topic into a new topic, copying them.
+  #
+  # The context-length escape hatch. A topic that has run long is expensive for
+  # every agent that reads it and hard for a person to re-enter, but the history
+  # is not disposable. Branching carries the few messages the next stretch of
+  # work actually depends on into a fresh topic and leaves the original intact
+  # as the record.
+  class TopicBranchService
+    extend T::Sig
+    extend ToolMeta
+
+    tool_name "topic_branch"
+    tool_description <<~DESC.strip
+      Branch a topic: create a new topic containing COPIES of selected messages
+      from an existing one. The originals stay where they are.
+
+      Use this to reset a conversation that has grown too long to carry, or to
+      split one thread that has drifted into two subjects, while keeping the
+      source topic as the record. To move messages instead of copying them, use
+      topic_create with comment_ids.
+
+      Get the message ids from topic_messages. At most
+      #{::Collavre::TopicBranchService::MAX_BRANCH_COMMENTS} messages per branch
+      — pick the ones the next stretch of work depends on rather than the whole
+      history. Asking for more is an error, not a silent trim.
+
+      The new topic is created on the same creative and records the source in
+      source_topic_id. Requires feedback permission or better on the creative.
+    DESC
+
+    tool_param :source_topic_id, description: "The topic to branch from."
+    tool_param :comment_ids, description: "Comma-separated ids of the messages to copy, e.g. \"991,994,1002\". They must all belong to the source topic and be visible to you. Get ids from topic_messages."
+    tool_param :name, description: "Name for the new topic. Defaults to a generated \"branch:<source name>\" name.", required: false
+
+    sig do
+      params(
+        source_topic_id: Integer,
+        comment_ids: T.any(String, Integer, T::Array[T.untyped]),
+        name: T.nilable(String)
+      ).returns(T::Hash[Symbol, T.untyped])
+    end
+    def call(source_topic_id:, comment_ids:, name: nil)
+      user = Current.user || raise("Current.user is required")
+      source = Topic.find(source_topic_id)
+      TopicAuthorizer.authorize_read!(source, user: user)
+
+      ids = IdList.parse(comment_ids)
+      validate_ids!(ids)
+
+      # Fully qualified: inside Collavre::Tools, a bare TopicBranchService is
+      # this tool, not the branching service it wraps.
+      topic = ::Collavre::TopicBranchService.new(
+        creative: source.creative, user: user, source_topic: source, name: name
+      ).call(comment_ids: ids)
+
+      Topics::Serializer.for_tool(topic).merge(source_topic_id: source.id, copied_count: ids.size)
+    end
+
+    private
+
+    # TopicBranchService trims an oversized selection to its cap and reports
+    # success for the shortened list, which is right for a UI that already
+    # capped the selection but wrong here: a caller that pasted 150 ids would be
+    # told it branched them and be missing 50 with nothing to read that says so.
+    def validate_ids!(ids)
+      cap = ::Collavre::TopicBranchService::MAX_BRANCH_COMMENTS
+      raise ArgumentError, "comment_ids is required" if ids.empty?
+      return if ids.size <= cap
+
+      raise ArgumentError,
+        "#{ids.size} messages requested but a branch copies at most #{cap}. " \
+        "Select fewer messages, or branch more than once."
+    end
+  end
+end
+end

--- a/engines/collavre/app/services/collavre/tools/topic_branch_service.rb
+++ b/engines/collavre/app/services/collavre/tools/topic_branch_service.rb
@@ -30,6 +30,9 @@ module Tools
 
       The new topic is created on the same creative and records the source in
       source_topic_id. Requires feedback permission or better on the creative.
+
+      Approval prompts cannot be branched — a copy would lose the approval
+      action and read as ordinary history. Passing one is an error.
     DESC
 
     tool_param :source_topic_id, description: "The topic to branch from."
@@ -50,6 +53,7 @@ module Tools
 
       ids = IdList.parse(comment_ids)
       validate_ids!(ids)
+      reject_approval_actions!(source, ids)
 
       # Fully qualified: inside Collavre::Tools, a bare TopicBranchService is
       # this tool, not the branching service it wraps.
@@ -74,6 +78,27 @@ module Tools
       raise ArgumentError,
         "#{ids.size} messages requested but a branch copies at most #{cap}. " \
         "Select fewer messages, or branch more than once."
+    end
+
+    # Copying an approval prompt launders it. The branch copies content but not
+    # `action`, so the copy no longer matches Comment.without_approval_action
+    # and lands in exactly the agent-context queries the column exists to keep
+    # it out of — the invariant survives a move, which keeps the column, but
+    # not a copy. Refused here rather than silently dropped: a caller that
+    # asked for 40 messages and got 39 has no way to learn which one is missing.
+    #
+    # Filtered through Comment#approval_action? rather than a SQL complement of
+    # without_approval_action: the predicate is the documented single source of
+    # truth, and a second copy of the condition could drift out of step with it.
+    # validate_ids! has already capped the selection, so the load is bounded.
+    def reject_approval_actions!(source, ids)
+      blocked = source.comments.where(id: ids).select(&:approval_action?).map(&:id)
+      return if blocked.empty?
+
+      raise ArgumentError,
+        "#{blocked.join(', ')} #{blocked.one? ? 'is an approval prompt' : 'are approval prompts'} " \
+        "and cannot be branched: a copy loses the approval action and becomes ordinary chat " \
+        "history that agents read. Remove #{blocked.one? ? 'it' : 'them'} from comment_ids."
     end
   end
 end

--- a/engines/collavre/app/services/collavre/tools/topic_branch_service.rb
+++ b/engines/collavre/app/services/collavre/tools/topic_branch_service.rb
@@ -55,7 +55,6 @@ module Tools
 
       ids = IdList.parse(comment_ids)
       validate_ids!(ids)
-      reject_approval_actions!(source, ids, user)
 
       # Fully qualified: inside Collavre::Tools, a bare TopicBranchService is
       # this tool, not the branching service it wraps.
@@ -80,37 +79,6 @@ module Tools
       raise ArgumentError,
         "#{ids.size} messages requested but a branch copies at most #{cap}. " \
         "Select fewer messages, or branch more than once."
-    end
-
-    # Copying an approval prompt launders it. The branch copies content but not
-    # `action`, so the copy no longer matches Comment.without_approval_action
-    # and lands in exactly the agent-context queries the column exists to keep
-    # it out of — the invariant survives a move, which keeps the column, but
-    # not a copy. Refused here rather than silently dropped: a caller that
-    # asked for 40 messages and got 39 has no way to learn which one is missing.
-    #
-    # Filtered through Comment#approval_action? rather than a SQL complement of
-    # without_approval_action: the predicate is the documented single source of
-    # truth, and a second copy of the condition could drift out of step with it.
-    # validate_ids! has already capped the selection, so the load is bounded.
-    #
-    # Scoped to visible_to because this error names an id. Over the whole topic
-    # it answers "is comment 4312 an approval prompt?" for a comment the caller
-    # cannot read — a specific error where any other hidden id gets the generic
-    # not-found — and it runs before the wrapped service checks feedback
-    # permission, so read-only access is enough to ask. Restricted to what the
-    # caller can already see, a hidden id falls through to the same not-found
-    # every other unreadable id gets, and nothing distinguishes them. Approval
-    # prompts stay unbranchable either way: the wrapped service's fetch is
-    # visible_to as well, so an invisible one is refused there instead.
-    def reject_approval_actions!(source, ids, user)
-      blocked = source.comments.visible_to(user).where(id: ids).select(&:approval_action?).map(&:id)
-      return if blocked.empty?
-
-      raise ArgumentError,
-        "#{blocked.join(', ')} #{blocked.one? ? 'is an approval prompt' : 'are approval prompts'} " \
-        "and cannot be branched: a copy loses the approval action and becomes ordinary chat " \
-        "history that agents read. Remove #{blocked.one? ? 'it' : 'them'} from comment_ids."
     end
   end
 end

--- a/engines/collavre/app/services/collavre/tools/topic_create_service.rb
+++ b/engines/collavre/app/services/collavre/tools/topic_create_service.rb
@@ -34,7 +34,8 @@ module Tools
       Accepts an agent id, email, or exact name for primary_agent. Searchable
       agents, agents created by the caller, and private agents already shared
       on this creative can be resolved. Omit `name` to get the next default
-      name ("Topic 3").
+      name ("Topic 3"). Main and an inbox's System name are reserved and
+      cannot be assigned to a new topic.
 
       comment_ids moves existing messages out of their current topic into the
       new one. To copy messages and leave the originals in place, use
@@ -91,7 +92,9 @@ module Tools
     end
 
     def build_topic(creative, name, user)
-      creative.topics.build(name: name.presence || Topics::NextName.for(creative), user: user)
+      topic_name = name.presence || Topics::NextName.for(creative)
+      Topics::ReservedName.reject!(creative, topic_name)
+      creative.topics.build(name: topic_name, user: user)
     end
 
     def move_comments(creative, user, topic, comment_ids)

--- a/engines/collavre/app/services/collavre/tools/topic_create_service.rb
+++ b/engines/collavre/app/services/collavre/tools/topic_create_service.rb
@@ -31,8 +31,10 @@ module Tools
       permission or better on the creative, otherwise the pin is refused (a
       pinned agent that cannot answer would silence the topic for everyone).
 
-      Accepts an agent id, email, or exact name for primary_agent. Omit `name`
-      to get the next default name ("Topic 3").
+      Accepts an agent id, email, or exact name for primary_agent. Searchable
+      agents, agents created by the caller, and private agents already shared
+      on this creative can be resolved. Omit `name` to get the next default
+      name ("Topic 3").
 
       comment_ids moves existing messages out of their current topic into the
       new one. To copy messages and leave the originals in place, use
@@ -79,7 +81,7 @@ module Tools
     # session agent can never be routed on it and pinning one would produce a
     # dead topic rather than an error.
     def resolve_agent(primary_agent, creative)
-      resolved = Topics::AgentResolver.call(primary_agent)
+      resolved = Topics::AgentResolver.call(primary_agent, creative: creative)
       return nil if resolved.nil? || resolved == Topics::AgentResolver::CLEAR
 
       rejection = Topic.primary_agent_rejection(creative, resolved)

--- a/engines/collavre/app/services/collavre/tools/topic_create_service.rb
+++ b/engines/collavre/app/services/collavre/tools/topic_create_service.rb
@@ -1,0 +1,112 @@
+module Collavre
+require "sorbet-runtime"
+require "rails_mcp_engine"
+module Tools
+  # Creates a topic on a creative, optionally pinning a primary agent and
+  # optionally moving existing messages into it.
+  #
+  # This is the fan-out primitive. Topics are the concurrency unit — tasks in
+  # one topic queue behind each other, tasks in different topics run in parallel
+  # — so an agent that can only create creatives can split work up on paper but
+  # cannot actually run it in parallel. Creating a topic per unit of work, with
+  # the agent that owns it pinned, is what turns a plan into concurrent work.
+  class TopicCreateService
+    extend T::Sig
+    extend ToolMeta
+
+    tool_name "topic_create"
+    tool_description <<~DESC.strip
+      Create a topic (conversation thread) on a creative.
+
+      Topics are how work runs in parallel in Collavre: tasks dispatched in the
+      same topic are serialized — one holds the topic's slot while the rest
+      queue — while tasks in different topics run concurrently. Split work into
+      one topic per independently-runnable unit; do not pile parallel work into
+      one topic expecting it to overlap.
+
+      primary_agent pins one agent to the topic. A pin is EXCLUSIVE: the pinned
+      agent alone answers ambient messages there and no other agent responds, so
+      use it for a dedicated 1:1 working channel and leave it unset for a thread
+      several participants should hear. The agent must already have feedback
+      permission or better on the creative, otherwise the pin is refused (a
+      pinned agent that cannot answer would silence the topic for everyone).
+
+      Accepts an agent id, email, or exact name for primary_agent. Omit `name`
+      to get the next default name ("Topic 3").
+
+      comment_ids moves existing messages out of their current topic into the
+      new one. To copy messages and leave the originals in place, use
+      topic_branch instead.
+
+      Requires write permission on the creative.
+    DESC
+
+    tool_param :creative_id, description: "The creative to create the topic on."
+    tool_param :name, description: "Topic name. Must be unique on the creative. Defaults to the next generated name, e.g. \"Topic 3\".", required: false
+    tool_param :primary_agent, description: "Agent to pin to this topic — id, email, or exact name. The pin is exclusive: only this agent answers here. The agent needs feedback permission or better on the creative.", required: false
+    tool_param :comment_ids, description: "Comma-separated ids of existing messages to MOVE into the new topic. Use topic_branch to copy instead of move.", required: false
+
+    sig do
+      params(
+        creative_id: Integer,
+        name: T.nilable(String),
+        primary_agent: T.nilable(String),
+        comment_ids: T.nilable(T.any(String, Integer, T::Array[T.untyped]))
+      ).returns(T::Hash[Symbol, T.untyped])
+    end
+    def call(creative_id:, name: nil, primary_agent: nil, comment_ids: nil)
+      user = Current.user || raise("Current.user is required")
+      creative = Creative.find(creative_id).effective_origin
+      TopicAuthorizer.authorize_creative!(creative, :write, user: user)
+
+      agent = resolve_agent(primary_agent, creative)
+      topic = build_topic(creative, name, user)
+
+      Topic.transaction do
+        topic.save!
+        topic.set_primary_agent!(agent) if agent
+        move_comments(creative, user, topic, comment_ids)
+      end
+
+      broadcast(creative, topic, agent, user)
+      Topics::Serializer.for_tool(topic)
+    end
+
+    private
+
+    # Checked before the topic exists, exactly as TopicsController#create does:
+    # a topic created here never carries a session_id, so a Claude Channel
+    # session agent can never be routed on it and pinning one would produce a
+    # dead topic rather than an error.
+    def resolve_agent(primary_agent, creative)
+      resolved = Topics::AgentResolver.call(primary_agent)
+      return nil if resolved.nil? || resolved == Topics::AgentResolver::CLEAR
+
+      rejection = Topic.primary_agent_rejection(creative, resolved)
+      raise ArgumentError, Topics::PinRejection.message(resolved, rejection) if rejection
+
+      resolved
+    end
+
+    def build_topic(creative, name, user)
+      creative.topics.build(name: name.presence || Topics::NextName.for(creative), user: user)
+    end
+
+    def move_comments(creative, user, topic, comment_ids)
+      ids = IdList.parse(comment_ids)
+      return if ids.empty?
+
+      CommentMoveService.new(creative: creative, user: user).call(comment_ids: ids, target_topic_id: topic.id)
+    end
+
+    # user_id in the payload is what makes the creating user's own client select
+    # the new topic. Included for parity with TopicsController#create: a user
+    # asking an agent to open a topic expects to land in it, the same as if they
+    # had made it themselves.
+    def broadcast(creative, topic, agent, user)
+      payload = agent ? Topics::Serializer.with_agent(topic, agent) : topic.slice(:id, :name)
+      TopicsChannel.broadcast_to(creative, { action: "created", topic: payload, user_id: user.id })
+    end
+  end
+end
+end

--- a/engines/collavre/app/services/collavre/tools/topic_list_service.rb
+++ b/engines/collavre/app/services/collavre/tools/topic_list_service.rb
@@ -42,7 +42,7 @@ module Tools
     tool_param :topic_ids, description: "Describe these specific topics. Comma-separated ids, e.g. \"12,45,78\". Either this or creative_id is required.", required: false
     tool_param :include_archived, description: "Include archived topics when listing by creative_id (default: false). Archived topics keep their messages and stay readable by id.", required: false
     tool_param :include_stats, description: "Include message_count / message_chars / last_message_at (default: true). Pass false to skip the totals query on a creative with very many topics.", required: false
-    tool_param :include_system, description: "Count authorless system messages and approval prompts in the totals (default: false). Matches the topic_messages default so the counts describe the same set of messages you would read back.", required: false
+    tool_param :include_system, description: "Count authorless system messages in the totals (default: false). Approval prompts are never counted. Matches the topic_messages default so the counts describe the same set of messages you would read back.", required: false
 
     sig do
       params(

--- a/engines/collavre/app/services/collavre/tools/topic_list_service.rb
+++ b/engines/collavre/app/services/collavre/tools/topic_list_service.rb
@@ -30,9 +30,9 @@ module Tools
       when the topic was branched off another), primary_agent, agent_locked, and
       the message totals.
 
-      message_chars is the length of the stored message HTML — an upper bound on
-      the text topic_messages will return, useful for relative sizing rather
-      than exact budgeting.
+      message_chars combines stored message HTML length with a conservative
+      estimate for image attachment markers. It is useful for relative sizing,
+      not exact budgeting.
 
       Requires read permission on each topic's creative. Unknown or unreadable
       ids come back in "errors" instead of failing the call.

--- a/engines/collavre/app/services/collavre/tools/topic_list_service.rb
+++ b/engines/collavre/app/services/collavre/tools/topic_list_service.rb
@@ -1,0 +1,101 @@
+module Collavre
+require "sorbet-runtime"
+require "rails_mcp_engine"
+module Tools
+  # Lists a creative's topics, or describes specific topics by id.
+  #
+  # This is the planning call. A topic is a Collavre conversation's concurrency
+  # unit — work in separate topics runs in parallel, work piled into one topic
+  # queues — so an agent deciding how to split a job needs to see what topics
+  # already exist, who is pinned to them, and how much conversation each one
+  # holds, before it reads a single message.
+  class TopicListService
+    extend T::Sig
+    extend ToolMeta
+
+    tool_name "topic_list"
+    tool_description <<~DESC.strip
+      List the topics of a creative, or describe specific topics by id.
+
+      A topic is a conversation thread on a creative, and it is also the unit of
+      agent concurrency: tasks in different topics run in parallel, tasks in the
+      same topic queue behind each other. Use this before splitting work up, and
+      before calling topic_messages — the per-topic message_count and
+      message_chars tell you how much conversation you would be pulling in, so
+      you can pick an offset/limit that fits your context.
+
+      Pass creative_id to list a creative's topics, or topic_ids to describe
+      known topics (which may live on different creatives). Returns, per topic:
+      id, name, creative_id, archived, main/system flags, source_topic_id (set
+      when the topic was branched off another), primary_agent, agent_locked, and
+      the message totals.
+
+      message_chars is the length of the stored message HTML — an upper bound on
+      the text topic_messages will return, useful for relative sizing rather
+      than exact budgeting.
+
+      Requires read permission on each topic's creative. Unknown or unreadable
+      ids come back in "errors" instead of failing the call.
+    DESC
+
+    tool_param :creative_id, description: "List every topic on this creative. Either this or topic_ids is required.", required: false
+    tool_param :topic_ids, description: "Describe these specific topics. Comma-separated ids, e.g. \"12,45,78\". Either this or creative_id is required.", required: false
+    tool_param :include_archived, description: "Include archived topics when listing by creative_id (default: false). Archived topics keep their messages and stay readable by id.", required: false
+    tool_param :include_stats, description: "Include message_count / message_chars / last_message_at (default: true). Pass false to skip the totals query on a creative with very many topics.", required: false
+    tool_param :include_system, description: "Count authorless system messages and approval prompts in the totals (default: false). Matches the topic_messages default so the counts describe the same set of messages you would read back.", required: false
+
+    sig do
+      params(
+        creative_id: T.nilable(Integer),
+        topic_ids: T.nilable(T.any(String, Integer, T::Array[T.untyped])),
+        include_archived: T.nilable(T::Boolean),
+        include_stats: T.nilable(T::Boolean),
+        include_system: T.nilable(T::Boolean)
+      ).returns(T::Hash[Symbol, T.untyped])
+    end
+    def call(creative_id: nil, topic_ids: nil, include_archived: false, include_stats: true, include_system: false)
+      user = require_user!
+      include_stats = true if include_stats.nil?
+
+      topics, errors = select_topics(creative_id, topic_ids, user, include_archived)
+      stats = include_stats ? Topics::MessageStats.for(topics, user: user, include_system: include_system) : {}
+
+      { topics: topics.map { |topic| describe(topic, stats[topic.id]) }, errors: errors }
+    end
+
+    private
+
+    def require_user!
+      Current.user || raise("Current.user is required")
+    end
+
+    def select_topics(creative_id, topic_ids, user, include_archived)
+      ids = IdList.parse(topic_ids)
+      return TopicSelection.resolve(ids.first(TopicSelection::MAX_TOPICS), user: user) if ids.any?
+      raise ArgumentError, "Either creative_id or topic_ids is required" if creative_id.blank?
+
+      [ topics_of(creative_id, user, include_archived), [] ]
+    end
+
+    # effective_origin because topics hang off the origin creative, not off a
+    # link to it — passing a linked creative's id would otherwise list nothing.
+    def topics_of(creative_id, user, include_archived)
+      creative = Creative.find(creative_id).effective_origin
+      TopicAuthorizer.authorize_creative!(creative, :read, user: user)
+
+      scope = creative.topics
+      scope = scope.active unless include_archived
+      scope.includes(:primary_agent).to_a
+    end
+
+    def describe(topic, stat)
+      Topics::Serializer.for_tool(
+        topic,
+        message_count: stat&.count,
+        message_chars: stat&.chars,
+        last_message_at: stat&.last_at
+      )
+    end
+  end
+end
+end

--- a/engines/collavre/app/services/collavre/tools/topic_list_service.rb
+++ b/engines/collavre/app/services/collavre/tools/topic_list_service.rb
@@ -39,7 +39,7 @@ module Tools
     DESC
 
     tool_param :creative_id, description: "List every topic on this creative. Either this or topic_ids is required.", required: false
-    tool_param :topic_ids, description: "Describe these specific topics. Comma-separated ids, e.g. \"12,45,78\". Either this or creative_id is required.", required: false
+    tool_param :topic_ids, description: "Describe these specific topics. Comma-separated ids, e.g. \"12,45,78\" (max #{TopicSelection::MAX_TOPICS} per call — asking for more is an error, not a silent trim). Either this or creative_id is required.", required: false
     tool_param :include_archived, description: "Include archived topics when listing by creative_id (default: false). Archived topics keep their messages and stay readable by id.", required: false
     tool_param :include_stats, description: "Include message_count / message_chars / last_message_at (default: true). Pass false to skip the totals query on a creative with very many topics.", required: false
     tool_param :include_system, description: "Count authorless system messages in the totals (default: false). Approval prompts are never counted. Matches the topic_messages default so the counts describe the same set of messages you would read back.", required: false
@@ -71,7 +71,7 @@ module Tools
 
     def select_topics(creative_id, topic_ids, user, include_archived)
       ids = IdList.parse(topic_ids)
-      return TopicSelection.resolve(ids.first(TopicSelection::MAX_TOPICS), user: user) if ids.any?
+      return TopicSelection.resolve(ids, user: user) if ids.any?
       raise ArgumentError, "Either creative_id or topic_ids is required" if creative_id.blank?
 
       [ topics_of(creative_id, user, include_archived), [] ]

--- a/engines/collavre/app/services/collavre/tools/topic_messages_service.rb
+++ b/engines/collavre/app/services/collavre/tools/topic_messages_service.rb
@@ -39,7 +39,7 @@ module Tools
     # plus their delimiters — around 285 characters measured, against the two
     # lines markdown prints — so the reserve is per format rather than one
     # constant that is right for one of them and wrong for the other.
-    TOPIC_HEADER_CHARS = { "markdown" => 250, "json" => 425 }.freeze
+    TOPIC_HEADER_CHARS = { "markdown" => 300, "json" => 475 }.freeze
 
     # The trailing "output hit max_chars" notice, which only exists when the
     # budget ran out and so cannot be paid for out of what is left of it.
@@ -60,19 +60,21 @@ module Tools
       topic_messages(topic_ids: "12,45,78", limit: 100).
 
       Every topic reports total_count and total_chars for the whole topic, so
-      you can tell how much you have not read yet, plus has_more and next_offset
-      for the next call. Pass the returned newest_message_id back as
-      max_message_id on follow-up pages: it pins paging to a snapshot, so
-      messages arriving mid-read cannot shift rows between pages.
+      you can tell how much you have not read yet, plus has_more, next_offset,
+      and next_cursor for the next call. Pass next_cursor and the returned
+      newest_message_id back on follow-up pages. The snapshot id excludes later
+      arrivals; the cursor keeps paging stable when earlier rows are moved or
+      deleted.
 
       If one message is too large for the response cap, its row remains at the
       same next_offset and next_content_offset identifies the next character to
-      read. Repeat both values with the snapshot id until next_content_offset is
-      absent; only then has that message row been consumed.
+      read. Repeat those values with next_cursor and the snapshot id until
+      next_content_offset is absent; only then has that message row been
+      consumed.
 
       Markdown "More:" calls repeat the resolved limit and max_chars as well
-      as the snapshot, order, scope, and content offset, so following one keeps
-      the same context budget and paging semantics.
+      as the cursor, snapshot, order, scope, and content offset, so following
+      one keeps the same context budget and paging semantics.
 
       Image attachments are appended to message content as explicit markers
       with filename, content type, byte size, and a readable public-asset URL.
@@ -91,7 +93,7 @@ module Tools
       error instead of exceeding max_chars or silently omitting a topic.
 
       Long topics: call topic_list first to see message_count, then page. To
-      summarize a whole large topic, page from offset 0 upward, keeping
+      summarize a whole large topic, follow next_cursor while keeping
       max_message_id fixed, until has_more is false.
 
       Requires read permission on each topic's creative. Private messages you
@@ -102,10 +104,11 @@ module Tools
 
     tool_param :topic_ids, description: "Topic ids to read. Comma-separated for several, e.g. \"12,45,78\" (max #{TopicSelection::MAX_TOPICS} per call — asking for more is an error, not a silent trim). A single id also works."
     tool_param :offset, description: "How many messages back from the newest to start, applied per topic (default: 0).", required: false
+    tool_param :cursor, description: "Opaque per-topic keyset cursor returned as next_cursor. Pass it on follow-up pages so moved or deleted earlier messages cannot shift and skip unread rows.", required: false
     tool_param :limit, description: "Messages per topic (default: #{Topics::MessagePage::DEFAULT_LIMIT}, max #{Topics::MessagePage::MAX_LIMIT}).", required: false
     tool_param :order, description: "Rendering order within the returned window: 'asc' (default, oldest-to-newest — reads as a transcript) or 'desc' (newest first). Does not change which messages the window selects.", required: false, enum: Topics::MessagePage::ORDERS
     tool_param :max_message_id, description: "Only consider messages with id <= this. Pass the newest_message_id from your first page on every follow-up page so paging stays on one snapshot of a live topic.", required: false
-    tool_param :content_offset, description: "Character offset within the first message selected by offset (default: 0). For a clipped message, repeat next_offset and pass next_content_offset here with the same max_message_id until the whole row has been returned.", required: false
+    tool_param :content_offset, description: "Character offset within the first selected message (default: 0). For a clipped message, repeat next_offset and next_cursor, and pass next_content_offset here with the same max_message_id until the whole row has been returned.", required: false
     tool_param :include_system, description: "Include authorless system notices such as concurrency and channel announcements (default: false). Approval prompts are never returned.", required: false
     tool_param :max_chars, description: "Character cap for the whole response across all topics, measured in the format you requested (default: #{DEFAULT_MAX_CHARS}, min #{MIN_MAX_CHARS}, max #{MAX_MAX_CHARS}). Values below the minimum are raised to it.", required: false
     tool_param :format, description: "'markdown' (default, compact transcript) or 'json' (same data, structured; costs noticeably more of max_chars for the same messages, since field names and string escaping are charged too).", required: false, enum: Topics::CharBudget::FORMATS
@@ -118,7 +121,7 @@ module Tools
     end
     def call(topic_ids:, **options)
       options.assert_valid_keys(
-        :offset, :limit, :order, :max_message_id, :content_offset, :include_system, :max_chars, :format
+        :offset, :limit, :order, :cursor, :max_message_id, :content_offset, :include_system, :max_chars, :format
       )
       user = Current.user || raise("Current.user is required")
       ids = IdList.parse(topic_ids)
@@ -144,6 +147,7 @@ module Tools
     def page_options(options, budget)
       {
         offset: options.fetch(:offset, 0).to_i,
+        cursor: options[:cursor],
         limit: options[:limit],
         order: options[:order],
         max_message_id: options[:max_message_id],
@@ -184,7 +188,7 @@ module Tools
       served = false
 
       topics.map do |topic|
-        next not_fetched(topic, options[:offset], options[:content_offset], served) if remaining <= 0
+        next not_fetched(topic, options[:offset], options[:content_offset], options[:cursor], served) if remaining <= 0
 
         entry = page_entry(topic, user, options, remaining)
         remaining -= entry[:billed_chars].to_i
@@ -210,7 +214,7 @@ module Tools
         topic: topic, user: user,
         offset: options[:offset], limit: options[:limit], order: options[:order] || Topics::MessagePage::DEFAULT_ORDER,
         include_system: options[:include_system], max_message_id: options[:max_message_id],
-        content_offset: options[:content_offset],
+        content_offset: options[:content_offset], cursor: options[:cursor],
         budget: options[:budget].with(chars: remaining)
       ).call
 
@@ -235,6 +239,7 @@ module Tools
         billed_chars: page.billed_chars,
         has_more: page.has_more?,
         next_offset: page.next_offset,
+        next_cursor: page.next_cursor,
         next_content_offset: page.next_content_offset,
         newest_message_id: page.newest_message_id,
         # Echoed so the rendered "More:" line can repeat it. A continuation
@@ -259,7 +264,7 @@ module Tools
     # The reason distinguishes the two ways to run out of room, because the
     # fixes differ: drop topics from the call, or raise the cap. Blaming
     # "earlier topics" when this was the first one sends the caller the wrong way.
-    def not_fetched(topic, offset, content_offset, served)
+    def not_fetched(topic, offset, content_offset, cursor, served)
       reason = if served
         "max_chars budget spent on earlier topics"
       else
@@ -277,6 +282,7 @@ module Tools
         billed_chars: 0,
         has_more: true,
         next_offset: offset,
+        next_cursor: cursor.presence,
         skipped_reason: reason,
         messages: []
       }

--- a/engines/collavre/app/services/collavre/tools/topic_messages_service.rb
+++ b/engines/collavre/app/services/collavre/tools/topic_messages_service.rb
@@ -39,7 +39,7 @@ module Tools
     # plus their delimiters — around 285 characters measured, against the two
     # lines markdown prints — so the reserve is per format rather than one
     # constant that is right for one of them and wrong for the other.
-    TOPIC_HEADER_CHARS = { "markdown" => 200, "json" => 400 }.freeze
+    TOPIC_HEADER_CHARS = { "markdown" => 250, "json" => 425 }.freeze
 
     # The trailing "output hit max_chars" notice, which only exists when the
     # budget ran out and so cannot be paid for out of what is left of it.
@@ -69,6 +69,10 @@ module Tools
       same next_offset and next_content_offset identifies the next character to
       read. Repeat both values with the snapshot id until next_content_offset is
       absent; only then has that message row been consumed.
+
+      Markdown "More:" calls repeat the resolved limit and max_chars as well
+      as the snapshot, order, scope, and content offset, so following one keeps
+      the same context budget and paging semantics.
 
       Image attachments are appended to message content as explicit markers
       with filename, content type, byte size, and a readable public-asset URL.
@@ -203,10 +207,10 @@ module Tools
         budget: options[:budget].with(chars: remaining)
       ).call
 
-      serialize(page, include_system: options[:include_system])
+      serialize(page, include_system: options[:include_system], max_chars: options[:budget].chars)
     end
 
-    def serialize(page, include_system:)
+    def serialize(page, include_system:, max_chars:)
       {
         topic_id: page.topic.id,
         topic_name: page.topic.name,
@@ -215,6 +219,7 @@ module Tools
         total_chars: page.total_chars,
         offset: page.offset,
         limit: page.limit,
+        max_chars: max_chars,
         order: page.order,
         returned_count: page.returned_count,
         returned_chars: page.returned_chars,

--- a/engines/collavre/app/services/collavre/tools/topic_messages_service.rb
+++ b/engines/collavre/app/services/collavre/tools/topic_messages_service.rb
@@ -56,7 +56,9 @@ module Tools
 
       The response is capped at max_chars in total. A topic that does not fit is
       returned partially or marked not-fetched rather than silently trimmed —
-      check "truncated" and each topic's next_offset.
+      check "truncated" and each topic's next_offset. A single message wider
+      than the whole cap is clipped rather than dropped, marked in its text and
+      counted in the topic's clipped_count.
 
       Long topics: call topic_list first to see message_count, then page. To
       summarize a whole large topic, page from offset 0 upward, keeping
@@ -112,7 +114,7 @@ module Tools
 
       {
         topics: entries + errors,
-        truncated: entries.any? { |entry| entry[:skipped_reason] || entry[:budget_limited] },
+        truncated: entries.any? { |entry| entry[:skipped_reason] || entry[:budget_limited] || entry[:clipped_count] },
         max_chars: options[:budget]
       }
     end
@@ -185,6 +187,9 @@ module Tools
         # is what ended this topic's window — the caller's fix differs: raise
         # max_chars or ask for fewer topics, not just page again.
         budget_limited: page.budget_exhausted.presence,
+        # Present only when max_chars cut a message short rather than cutting
+        # the window short. has_more can be false while this is set.
+        clipped_count: page.clipped_count.nonzero?,
         messages: page.messages
       }.compact
     end

--- a/engines/collavre/app/services/collavre/tools/topic_messages_service.rb
+++ b/engines/collavre/app/services/collavre/tools/topic_messages_service.rb
@@ -44,6 +44,7 @@ module Tools
     # The trailing "output hit max_chars" notice, which only exists when the
     # budget ran out and so cannot be paid for out of what is left of it.
     TRUNCATION_CHARS = 120
+    NOTHING_FITS_REASON = "max_chars is too small to return anything for this topic"
 
     tool_name "topic_messages"
     tool_description <<~DESC.strip
@@ -269,8 +270,13 @@ module Tools
         # Present only when max_chars cut a message short rather than cutting
         # the window between rows. next_content_offset resumes the same row.
         clipped_count: page.clipped_count.nonzero?,
+        skipped_reason: nothing_fits_reason(page),
         messages: page.messages
       }.compact
+    end
+
+    def nothing_fits_reason(page)
+      NOTHING_FITS_REASON if page.returned_count.zero? && page.budget_exhausted
     end
 
     # Carries has_more/next_offset so the caller can resume this topic without
@@ -284,7 +290,7 @@ module Tools
       reason = if served
         "max_chars budget spent on earlier topics"
       else
-        "max_chars is too small to return anything for this topic"
+        NOTHING_FITS_REASON
       end
 
       {

--- a/engines/collavre/app/services/collavre/tools/topic_messages_service.rb
+++ b/engines/collavre/app/services/collavre/tools/topic_messages_service.rb
@@ -39,7 +39,7 @@ module Tools
     # plus their delimiters — around 285 characters measured, against the two
     # lines markdown prints — so the reserve is per format rather than one
     # constant that is right for one of them and wrong for the other.
-    TOPIC_HEADER_CHARS = { "markdown" => 325, "json" => 500 }.freeze
+    TOPIC_HEADER_CHARS = { "markdown" => 350, "json" => 525 }.freeze
 
     # The trailing "output hit max_chars" notice, which only exists when the
     # budget ran out and so cannot be paid for out of what is left of it.
@@ -66,11 +66,11 @@ module Tools
       Every topic reports total_count and total_chars for the whole topic, so
       you can tell how much you have not read yet, plus has_more, next_offset,
       and next_cursor for the next call. Pass next_cursor and the returned
-      newest_message_id back on follow-up pages. The snapshot id excludes later
-      arrivals; the cursor keeps paging stable when earlier rows are moved or
-      deleted. It also binds a clipped continuation to that row's content
-      version, so an edit restarts the changed message at character zero rather
-      than applying a stale offset.
+      newest_message_id back on follow-up pages. The snapshot id excludes newly
+      created messages; the cursor also excludes older messages moved into the
+      topic later and keeps paging stable when earlier rows leave. It binds a
+      clipped continuation to that row's content version, so an edit restarts
+      the changed message at character zero rather than applying a stale offset.
 
       If one message is too large for the response cap, its row remains at the
       same next_offset and next_content_offset identifies the next character to
@@ -110,7 +110,7 @@ module Tools
 
     tool_param :topic_ids, description: "Topic ids to read. Comma-separated for several, e.g. \"12,45,78\" (max #{TopicSelection::MAX_TOPICS} per call — asking for more is an error, not a silent trim). A single id also works."
     tool_param :offset, description: "How many messages back from the newest to start, applied per topic (default: 0).", required: false
-    tool_param :cursor, description: "Opaque per-topic keyset cursor returned as next_cursor. Pass it on a single-topic follow-up page so moved or deleted earlier messages cannot shift and skip unread rows.", required: false
+    tool_param :cursor, description: "Opaque per-topic snapshot/keyset cursor returned as next_cursor. Pass it on a single-topic follow-up page so later move-ins stay excluded and moved or deleted earlier messages cannot shift and skip unread rows.", required: false
     tool_param :limit, description: "Messages per topic (default: #{Topics::MessagePage::DEFAULT_LIMIT}, max #{Topics::MessagePage::MAX_LIMIT}).", required: false
     tool_param :order, description: "Rendering order within the returned window: 'asc' (default, oldest-to-newest — reads as a transcript) or 'desc' (newest first). Does not change which messages the window selects.", required: false, enum: Topics::MessagePage::ORDERS
     tool_param :max_message_id, description: "Only consider messages with id <= this. Pass the newest_message_id from your first page on every single-topic follow-up page so paging stays on one snapshot of a live topic.", required: false

--- a/engines/collavre/app/services/collavre/tools/topic_messages_service.rb
+++ b/engines/collavre/app/services/collavre/tools/topic_messages_service.rb
@@ -24,6 +24,12 @@ module Tools
     DEFAULT_MAX_CHARS = 40_000
     MAX_MAX_CHARS = 200_000
 
+    # A successful bounded fallback needs enough room to explain why the
+    # requested response was omitted. Values below this are raised to the
+    # minimum instead of returning a response wider than the cap just to spell
+    # out that the cap was too small.
+    MIN_MAX_CHARS = 160
+
     # Each topic also pays for its own heading, totals line and "More:" call —
     # or, if it does not fit, its not-fetched notice, which is about the same
     # size. Charged separately from the messages so that a call for many topics
@@ -65,7 +71,9 @@ module Tools
       that does not fit is returned partially or marked not-fetched rather than
       silently trimmed — check "truncated" and each topic's next_offset. A
       single message wider than the whole cap is clipped rather than dropped,
-      marked in its text and counted in the topic's clipped_count.
+      marked in its text and counted in the topic's clipped_count. If fixed
+      metadata such as a topic name cannot fit, the tool returns a bounded
+      error instead of exceeding max_chars or silently omitting a topic.
 
       Long topics: call topic_list first to see message_count, then page. To
       summarize a whole large topic, page from offset 0 upward, keeping
@@ -83,7 +91,7 @@ module Tools
     tool_param :order, description: "Rendering order within the returned window: 'asc' (default, oldest-to-newest — reads as a transcript) or 'desc' (newest first). Does not change which messages the window selects.", required: false, enum: Topics::MessagePage::ORDERS
     tool_param :max_message_id, description: "Only consider messages with id <= this. Pass the newest_message_id from your first page on every follow-up page so paging stays on one snapshot of a live topic.", required: false
     tool_param :include_system, description: "Include authorless system notices such as concurrency and channel announcements (default: false). Approval prompts are never returned.", required: false
-    tool_param :max_chars, description: "Character cap for the whole response across all topics, measured in the format you requested (default: #{DEFAULT_MAX_CHARS}, max #{MAX_MAX_CHARS}).", required: false
+    tool_param :max_chars, description: "Character cap for the whole response across all topics, measured in the format you requested (default: #{DEFAULT_MAX_CHARS}, min #{MIN_MAX_CHARS}, max #{MAX_MAX_CHARS}). Values below the minimum are raised to it.", required: false
     tool_param :format, description: "'markdown' (default, compact transcript) or 'json' (same data, structured; costs noticeably more of max_chars for the same messages, since field names and string escaping are charged too).", required: false, enum: Topics::CharBudget::FORMATS
 
     sig do
@@ -116,7 +124,8 @@ module Tools
                    include_system: include_system, budget: budget }
       )
 
-      budget.json? ? payload : Topics::MessagePageMarkdown.call(payload)
+      response = budget.json? ? payload : Topics::MessagePageMarkdown.call(payload)
+      enforce_cap(response, budget)
     end
 
     private
@@ -242,7 +251,32 @@ module Tools
       value = max_chars.to_i
       return DEFAULT_MAX_CHARS if value <= 0
 
-      [ value, MAX_MAX_CHARS ].min
+      value.clamp(MIN_MAX_CHARS, MAX_MAX_CHARS)
+    end
+
+    # Message budgeting normally keeps the rendered response below max_chars,
+    # but fixed metadata can be wider than its budget by itself: a tiny cap, a
+    # batch of skipped topics, or one unrestricted topic name is enough. The
+    # final emitted form is the only authoritative measurement, so replace an
+    # oversized result with a bounded error instead of silently chopping a
+    # topic name or returning malformed JSON/Markdown.
+    def enforce_cap(response, budget)
+      emitted_chars = budget.json? ? response.to_json.length : response.length
+      return response if emitted_chars <= budget.chars
+
+      bounded_error(budget, required_chars: emitted_chars)
+    end
+
+    def bounded_error(budget, required_chars:)
+      return {
+        error: "topic_messages metadata exceeds max_chars",
+        required_chars: required_chars,
+        max_chars: budget.chars,
+        truncated: true
+      } if budget.json?
+
+      "> topic_messages metadata needs #{required_chars} chars; max_chars is #{budget.chars}. " \
+        "Request fewer topics or raise max_chars.\n"
     end
   end
 end

--- a/engines/collavre/app/services/collavre/tools/topic_messages_service.rb
+++ b/engines/collavre/app/services/collavre/tools/topic_messages_service.rb
@@ -70,6 +70,11 @@ module Tools
       read. Repeat both values with the snapshot id until next_content_offset is
       absent; only then has that message row been consumed.
 
+      Image attachments are appended to message content as explicit markers
+      with filename, content type, byte size, and a readable public-asset URL.
+      Image-only comments therefore remain visible, and attachment metadata is
+      covered by the same max_chars/content_offset continuation as prose.
+
       The response is capped at max_chars in total, measured against the format
       you asked for — json is charged for its field names and string escaping,
       so the same call returns fewer messages as json than as markdown. A topic

--- a/engines/collavre/app/services/collavre/tools/topic_messages_service.rb
+++ b/engines/collavre/app/services/collavre/tools/topic_messages_service.rb
@@ -155,7 +155,7 @@ module Tools
 
     def build_payload(ids:, user:, options:)
       topics, errors = TopicSelection.resolve(ids, user: user)
-      entries = collect(topics, user, options)
+      entries = collect(topics, errors, user, options)
 
       {
         topics: entries + errors,
@@ -178,9 +178,9 @@ module Tools
     # one at a time would charge only the topics that succeed, and the
     # not-fetched notices — which exist precisely because the budget ran out —
     # would push the response over the cap that skipping them was enforcing.
-    def collect(topics, user, options)
+    def collect(topics, errors, user, options)
       budget = options[:budget]
-      remaining = budget.chars - reserved_chars(topics, budget.format)
+      remaining = budget.chars - reserved_chars(topics, errors, budget.format)
       served = false
 
       topics.map do |topic|
@@ -193,9 +193,16 @@ module Tools
       end
     end
 
-    def reserved_chars(topics, format)
+    def reserved_chars(topics, errors, format)
       per_topic = TOPIC_HEADER_CHARS.fetch(format)
-      TRUNCATION_CHARS + topics.sum { |topic| per_topic + topic.name.to_s.length }
+      TRUNCATION_CHARS + topics.sum { |topic| per_topic + topic.name.to_s.length } +
+        error_chars(errors, format)
+    end
+
+    def error_chars(errors, format)
+      return errors.sum { |error| error.to_json.length + 1 } if format == "json"
+
+      errors.sum { |error| Topics::MessagePageMarkdown.render_error(error).length + 1 }
     end
 
     def page_entry(topic, user, options, remaining)

--- a/engines/collavre/app/services/collavre/tools/topic_messages_service.rb
+++ b/engines/collavre/app/services/collavre/tools/topic_messages_service.rb
@@ -65,13 +65,19 @@ module Tools
       max_message_id on follow-up pages: it pins paging to a snapshot, so
       messages arriving mid-read cannot shift rows between pages.
 
+      If one message is too large for the response cap, its row remains at the
+      same next_offset and next_content_offset identifies the next character to
+      read. Repeat both values with the snapshot id until next_content_offset is
+      absent; only then has that message row been consumed.
+
       The response is capped at max_chars in total, measured against the format
       you asked for — json is charged for its field names and string escaping,
       so the same call returns fewer messages as json than as markdown. A topic
       that does not fit is returned partially or marked not-fetched rather than
       silently trimmed — check "truncated" and each topic's next_offset. A
       single message wider than the whole cap is clipped rather than dropped,
-      marked in its text and counted in the topic's clipped_count. If fixed
+      given a content continuation and counted in the topic's clipped_count. If
+      fixed
       metadata such as a topic name cannot fit, the tool returns a bounded
       error instead of exceeding max_chars or silently omitting a topic.
 
@@ -90,6 +96,7 @@ module Tools
     tool_param :limit, description: "Messages per topic (default: #{Topics::MessagePage::DEFAULT_LIMIT}, max #{Topics::MessagePage::MAX_LIMIT}).", required: false
     tool_param :order, description: "Rendering order within the returned window: 'asc' (default, oldest-to-newest — reads as a transcript) or 'desc' (newest first). Does not change which messages the window selects.", required: false, enum: Topics::MessagePage::ORDERS
     tool_param :max_message_id, description: "Only consider messages with id <= this. Pass the newest_message_id from your first page on every follow-up page so paging stays on one snapshot of a live topic.", required: false
+    tool_param :content_offset, description: "Character offset within the first message selected by offset (default: 0). For a clipped message, repeat next_offset and pass next_content_offset here with the same max_message_id until the whole row has been returned.", required: false
     tool_param :include_system, description: "Include authorless system notices such as concurrency and channel announcements (default: false). Approval prompts are never returned.", required: false
     tool_param :max_chars, description: "Character cap for the whole response across all topics, measured in the format you requested (default: #{DEFAULT_MAX_CHARS}, min #{MIN_MAX_CHARS}, max #{MAX_MAX_CHARS}). Values below the minimum are raised to it.", required: false
     tool_param :format, description: "'markdown' (default, compact transcript) or 'json' (same data, structured; costs noticeably more of max_chars for the same messages, since field names and string escaping are charged too).", required: false, enum: Topics::CharBudget::FORMATS
@@ -97,17 +104,13 @@ module Tools
     sig do
       params(
         topic_ids: T.any(String, Integer, T::Array[T.untyped]),
-        offset: T.nilable(Integer),
-        limit: T.nilable(Integer),
-        order: T.nilable(String),
-        max_message_id: T.nilable(Integer),
-        include_system: T.nilable(T::Boolean),
-        max_chars: T.nilable(Integer),
-        format: T.nilable(String)
+        options: T.untyped
       ).returns(T.any(String, T::Hash[Symbol, T.untyped]))
     end
-    def call(topic_ids:, offset: 0, limit: nil, order: nil, max_message_id: nil,
-             include_system: false, max_chars: nil, format: "markdown")
+    def call(topic_ids:, **options)
+      options.assert_valid_keys(
+        :offset, :limit, :order, :max_message_id, :content_offset, :include_system, :max_chars, :format
+      )
       user = Current.user || raise("Current.user is required")
       ids = IdList.parse(topic_ids)
       raise ArgumentError, "topic_ids is required" if ids.empty?
@@ -116,12 +119,11 @@ module Tools
       # through as one object, because what a message costs is what emitting it
       # in this format costs. Budgeting in markdown's units and then returning
       # json is how a 40k cap emits 60k.
-      budget = Topics::CharBudget.new(chars: clamp_chars(max_chars), format: format)
+      budget = Topics::CharBudget.new(chars: clamp_chars(options[:max_chars]), format: options[:format])
 
       payload = build_payload(
         ids: ids, user: user,
-        options: { offset: offset.to_i, limit: limit, order: order, max_message_id: max_message_id,
-                   include_system: include_system, budget: budget }
+        options: page_options(options, budget)
       )
 
       response = budget.json? ? payload : Topics::MessagePageMarkdown.call(payload)
@@ -129,6 +131,18 @@ module Tools
     end
 
     private
+
+    def page_options(options, budget)
+      {
+        offset: options.fetch(:offset, 0).to_i,
+        limit: options[:limit],
+        order: options[:order],
+        max_message_id: options[:max_message_id],
+        content_offset: options.fetch(:content_offset, 0).to_i,
+        include_system: options.fetch(:include_system, false),
+        budget: budget
+      }
+    end
 
     def build_payload(ids:, user:, options:)
       topics, errors = TopicSelection.resolve(ids, user: user)
@@ -161,7 +175,7 @@ module Tools
       served = false
 
       topics.map do |topic|
-        next not_fetched(topic, options[:offset], served) if remaining <= 0
+        next not_fetched(topic, options[:offset], options[:content_offset], served) if remaining <= 0
 
         entry = page_entry(topic, user, options, remaining)
         remaining -= entry[:billed_chars].to_i
@@ -180,6 +194,7 @@ module Tools
         topic: topic, user: user,
         offset: options[:offset], limit: options[:limit], order: options[:order] || Topics::MessagePage::DEFAULT_ORDER,
         include_system: options[:include_system], max_message_id: options[:max_message_id],
+        content_offset: options[:content_offset],
         budget: options[:budget].with(chars: remaining)
       ).call
 
@@ -202,6 +217,7 @@ module Tools
         billed_chars: page.billed_chars,
         has_more: page.has_more?,
         next_offset: page.next_offset,
+        next_content_offset: page.next_content_offset,
         newest_message_id: page.newest_message_id,
         # Echoed so the rendered "More:" line can repeat it. A continuation
         # that drops it pages a narrower set at the same offset and skips
@@ -212,7 +228,7 @@ module Tools
         # max_chars or ask for fewer topics, not just page again.
         budget_limited: page.budget_exhausted.presence,
         # Present only when max_chars cut a message short rather than cutting
-        # the window short. has_more can be false while this is set.
+        # the window between rows. next_content_offset resumes the same row.
         clipped_count: page.clipped_count.nonzero?,
         messages: page.messages
       }.compact
@@ -225,7 +241,7 @@ module Tools
     # The reason distinguishes the two ways to run out of room, because the
     # fixes differ: drop topics from the call, or raise the cap. Blaming
     # "earlier topics" when this was the first one sends the caller the wrong way.
-    def not_fetched(topic, offset, served)
+    def not_fetched(topic, offset, content_offset, served)
       reason = if served
         "max_chars budget spent on earlier topics"
       else
@@ -237,6 +253,7 @@ module Tools
         topic_name: topic.name,
         creative_id: topic.creative_id,
         offset: offset,
+        next_content_offset: content_offset.presence,
         returned_count: 0,
         returned_chars: 0,
         billed_chars: 0,

--- a/engines/collavre/app/services/collavre/tools/topic_messages_service.rb
+++ b/engines/collavre/app/services/collavre/tools/topic_messages_service.rb
@@ -77,7 +77,7 @@ module Tools
       unreadable ids are reported per topic instead of failing the call.
     DESC
 
-    tool_param :topic_ids, description: "Topic ids to read. Comma-separated for several, e.g. \"12,45,78\" (max #{TopicSelection::MAX_TOPICS} per call). A single id also works."
+    tool_param :topic_ids, description: "Topic ids to read. Comma-separated for several, e.g. \"12,45,78\" (max #{TopicSelection::MAX_TOPICS} per call — asking for more is an error, not a silent trim). A single id also works."
     tool_param :offset, description: "How many messages back from the newest to start, applied per topic (default: 0).", required: false
     tool_param :limit, description: "Messages per topic (default: #{Topics::MessagePage::DEFAULT_LIMIT}, max #{Topics::MessagePage::MAX_LIMIT}).", required: false
     tool_param :order, description: "Rendering order within the returned window: 'asc' (default, oldest-to-newest — reads as a transcript) or 'desc' (newest first). Does not change which messages the window selects.", required: false, enum: Topics::MessagePage::ORDERS
@@ -122,7 +122,7 @@ module Tools
     private
 
     def build_payload(ids:, user:, options:)
-      topics, errors = TopicSelection.resolve(ids.first(TopicSelection::MAX_TOPICS), user: user)
+      topics, errors = TopicSelection.resolve(ids, user: user)
       entries = collect(topics, user, options)
 
       {

--- a/engines/collavre/app/services/collavre/tools/topic_messages_service.rb
+++ b/engines/collavre/app/services/collavre/tools/topic_messages_service.rb
@@ -210,6 +210,7 @@ module Tools
         total_chars: page.total_chars,
         offset: page.offset,
         limit: page.limit,
+        order: page.order,
         returned_count: page.returned_count,
         returned_chars: page.returned_chars,
         # What this topic charged against max_chars: what emitting these

--- a/engines/collavre/app/services/collavre/tools/topic_messages_service.rb
+++ b/engines/collavre/app/services/collavre/tools/topic_messages_service.rb
@@ -28,7 +28,12 @@ module Tools
     # or, if it does not fit, its not-fetched notice, which is about the same
     # size. Charged separately from the messages so that a call for many topics
     # cannot overrun the cap on section furniture alone.
-    TOPIC_HEADER_CHARS = 200
+    #
+    # json restates the same section as the seventeen keys of the entry hash
+    # plus their delimiters — around 285 characters measured, against the two
+    # lines markdown prints — so the reserve is per format rather than one
+    # constant that is right for one of them and wrong for the other.
+    TOPIC_HEADER_CHARS = { "markdown" => 200, "json" => 400 }.freeze
 
     # The trailing "output hit max_chars" notice, which only exists when the
     # budget ran out and so cannot be paid for out of what is left of it.
@@ -54,11 +59,13 @@ module Tools
       max_message_id on follow-up pages: it pins paging to a snapshot, so
       messages arriving mid-read cannot shift rows between pages.
 
-      The response is capped at max_chars in total. A topic that does not fit is
-      returned partially or marked not-fetched rather than silently trimmed —
-      check "truncated" and each topic's next_offset. A single message wider
-      than the whole cap is clipped rather than dropped, marked in its text and
-      counted in the topic's clipped_count.
+      The response is capped at max_chars in total, measured against the format
+      you asked for — json is charged for its field names and string escaping,
+      so the same call returns fewer messages as json than as markdown. A topic
+      that does not fit is returned partially or marked not-fetched rather than
+      silently trimmed — check "truncated" and each topic's next_offset. A
+      single message wider than the whole cap is clipped rather than dropped,
+      marked in its text and counted in the topic's clipped_count.
 
       Long topics: call topic_list first to see message_count, then page. To
       summarize a whole large topic, page from offset 0 upward, keeping
@@ -76,8 +83,8 @@ module Tools
     tool_param :order, description: "Rendering order within the returned window: 'asc' (default, oldest-to-newest — reads as a transcript) or 'desc' (newest first). Does not change which messages the window selects.", required: false, enum: Topics::MessagePage::ORDERS
     tool_param :max_message_id, description: "Only consider messages with id <= this. Pass the newest_message_id from your first page on every follow-up page so paging stays on one snapshot of a live topic.", required: false
     tool_param :include_system, description: "Include authorless system notices such as concurrency and channel announcements (default: false). Approval prompts are never returned.", required: false
-    tool_param :max_chars, description: "Character cap for the whole response across all topics (default: #{DEFAULT_MAX_CHARS}, max #{MAX_MAX_CHARS}).", required: false
-    tool_param :format, description: "'markdown' (default, compact transcript) or 'json' (same data, structured).", required: false, enum: %w[markdown json]
+    tool_param :max_chars, description: "Character cap for the whole response across all topics, measured in the format you requested (default: #{DEFAULT_MAX_CHARS}, max #{MAX_MAX_CHARS}).", required: false
+    tool_param :format, description: "'markdown' (default, compact transcript) or 'json' (same data, structured; costs noticeably more of max_chars for the same messages, since field names and string escaping are charged too).", required: false, enum: Topics::CharBudget::FORMATS
 
     sig do
       params(
@@ -97,13 +104,19 @@ module Tools
       ids = IdList.parse(topic_ids)
       raise ArgumentError, "topic_ids is required" if ids.empty?
 
+      # The cap and the format it counts in are resolved together and carried
+      # through as one object, because what a message costs is what emitting it
+      # in this format costs. Budgeting in markdown's units and then returning
+      # json is how a 40k cap emits 60k.
+      budget = Topics::CharBudget.new(chars: clamp_chars(max_chars), format: format)
+
       payload = build_payload(
         ids: ids, user: user,
         options: { offset: offset.to_i, limit: limit, order: order, max_message_id: max_message_id,
-                   include_system: include_system, budget: clamp_chars(max_chars) }
+                   include_system: include_system, budget: budget }
       )
 
-      format.to_s == "json" ? payload : Topics::MessagePageMarkdown.call(payload)
+      budget.json? ? payload : Topics::MessagePageMarkdown.call(payload)
     end
 
     private
@@ -115,7 +128,7 @@ module Tools
       {
         topics: entries + errors,
         truncated: entries.any? { |entry| entry[:skipped_reason] || entry[:budget_limited] || entry[:clipped_count] },
-        max_chars: options[:budget]
+        max_chars: options[:budget].chars
       }
     end
 
@@ -134,7 +147,8 @@ module Tools
     # not-fetched notices — which exist precisely because the budget ran out —
     # would push the response over the cap that skipping them was enforcing.
     def collect(topics, user, options)
-      remaining = options[:budget] - reserved_chars(topics)
+      budget = options[:budget]
+      remaining = budget.chars - reserved_chars(topics, budget.format)
       served = false
 
       topics.map do |topic|
@@ -147,8 +161,9 @@ module Tools
       end
     end
 
-    def reserved_chars(topics)
-      TRUNCATION_CHARS + topics.sum { |topic| TOPIC_HEADER_CHARS + topic.name.to_s.length }
+    def reserved_chars(topics, format)
+      per_topic = TOPIC_HEADER_CHARS.fetch(format)
+      TRUNCATION_CHARS + topics.sum { |topic| per_topic + topic.name.to_s.length }
     end
 
     def page_entry(topic, user, options, remaining)
@@ -156,7 +171,7 @@ module Tools
         topic: topic, user: user,
         offset: options[:offset], limit: options[:limit], order: options[:order] || Topics::MessagePage::DEFAULT_ORDER,
         include_system: options[:include_system], max_message_id: options[:max_message_id],
-        char_budget: remaining
+        budget: options[:budget].with(chars: remaining)
       ).call
 
       serialize(page, include_system: options[:include_system])
@@ -173,8 +188,8 @@ module Tools
         limit: page.limit,
         returned_count: page.returned_count,
         returned_chars: page.returned_chars,
-        # What this topic charged against max_chars: prose plus the rendered
-        # envelope around each message.
+        # What this topic charged against max_chars: what emitting these
+        # messages in the requested format costs, not what their prose measures.
         billed_chars: page.billed_chars,
         has_more: page.has_more?,
         next_offset: page.next_offset,

--- a/engines/collavre/app/services/collavre/tools/topic_messages_service.rb
+++ b/engines/collavre/app/services/collavre/tools/topic_messages_service.rb
@@ -39,7 +39,7 @@ module Tools
     # plus their delimiters — around 285 characters measured, against the two
     # lines markdown prints — so the reserve is per format rather than one
     # constant that is right for one of them and wrong for the other.
-    TOPIC_HEADER_CHARS = { "markdown" => 300, "json" => 475 }.freeze
+    TOPIC_HEADER_CHARS = { "markdown" => 325, "json" => 500 }.freeze
 
     # The trailing "output hit max_chars" notice, which only exists when the
     # budget ran out and so cannot be paid for out of what is left of it.
@@ -64,7 +64,9 @@ module Tools
       and next_cursor for the next call. Pass next_cursor and the returned
       newest_message_id back on follow-up pages. The snapshot id excludes later
       arrivals; the cursor keeps paging stable when earlier rows are moved or
-      deleted.
+      deleted. It also binds a clipped continuation to that row's content
+      version, so an edit restarts the changed message at character zero rather
+      than applying a stale offset.
 
       If one message is too large for the response cap, its row remains at the
       same next_offset and next_content_offset identifies the next character to

--- a/engines/collavre/app/services/collavre/tools/topic_messages_service.rb
+++ b/engines/collavre/app/services/collavre/tools/topic_messages_service.rb
@@ -58,6 +58,9 @@ module Tools
       by topic — offset/limit apply to EACH topic, never to a merged timeline.
       Use this to summarize several topics at once, e.g.
       topic_messages(topic_ids: "12,45,78", limit: 100).
+      Multi-topic calls are first-page reads: each topic returns its own cursor
+      and snapshot, so continue each topic in a separate call rather than
+      applying one topic's continuation state to the whole batch.
 
       Every topic reports total_count and total_chars for the whole topic, so
       you can tell how much you have not read yet, plus has_more, next_offset,
@@ -106,11 +109,11 @@ module Tools
 
     tool_param :topic_ids, description: "Topic ids to read. Comma-separated for several, e.g. \"12,45,78\" (max #{TopicSelection::MAX_TOPICS} per call — asking for more is an error, not a silent trim). A single id also works."
     tool_param :offset, description: "How many messages back from the newest to start, applied per topic (default: 0).", required: false
-    tool_param :cursor, description: "Opaque per-topic keyset cursor returned as next_cursor. Pass it on follow-up pages so moved or deleted earlier messages cannot shift and skip unread rows.", required: false
+    tool_param :cursor, description: "Opaque per-topic keyset cursor returned as next_cursor. Pass it on a single-topic follow-up page so moved or deleted earlier messages cannot shift and skip unread rows.", required: false
     tool_param :limit, description: "Messages per topic (default: #{Topics::MessagePage::DEFAULT_LIMIT}, max #{Topics::MessagePage::MAX_LIMIT}).", required: false
     tool_param :order, description: "Rendering order within the returned window: 'asc' (default, oldest-to-newest — reads as a transcript) or 'desc' (newest first). Does not change which messages the window selects.", required: false, enum: Topics::MessagePage::ORDERS
-    tool_param :max_message_id, description: "Only consider messages with id <= this. Pass the newest_message_id from your first page on every follow-up page so paging stays on one snapshot of a live topic.", required: false
-    tool_param :content_offset, description: "Character offset within the first selected message (default: 0). For a clipped message, repeat next_offset and next_cursor, and pass next_content_offset here with the same max_message_id until the whole row has been returned.", required: false
+    tool_param :max_message_id, description: "Only consider messages with id <= this. Pass the newest_message_id from your first page on every single-topic follow-up page so paging stays on one snapshot of a live topic.", required: false
+    tool_param :content_offset, description: "Character offset within the first selected message (default: 0). For a clipped message, make a single-topic follow-up that repeats next_offset and next_cursor, and pass next_content_offset here with the same max_message_id until the whole row has been returned.", required: false
     tool_param :include_system, description: "Include authorless system notices such as concurrency and channel announcements (default: false). Approval prompts are never returned.", required: false
     tool_param :max_chars, description: "Character cap for the whole response across all topics, measured in the format you requested (default: #{DEFAULT_MAX_CHARS}, min #{MIN_MAX_CHARS}, max #{MAX_MAX_CHARS}). Values below the minimum are raised to it.", required: false
     tool_param :format, description: "'markdown' (default, compact transcript) or 'json' (same data, structured; costs noticeably more of max_chars for the same messages, since field names and string escaping are charged too).", required: false, enum: Topics::CharBudget::FORMATS
@@ -128,6 +131,7 @@ module Tools
       user = Current.user || raise("Current.user is required")
       ids = IdList.parse(topic_ids)
       raise ArgumentError, "topic_ids is required" if ids.empty?
+      reject_batch_continuation!(ids, options)
 
       # The cap and the format it counts in are resolved together and carried
       # through as one object, because what a message costs is what emitting it
@@ -145,6 +149,16 @@ module Tools
     end
 
     private
+
+    def reject_batch_continuation!(ids, options)
+      return if ids.one?
+      return unless options[:cursor].present? || options[:max_message_id].present? ||
+        options[:content_offset].to_i.positive?
+
+      raise ArgumentError,
+        "cursor, max_message_id, and content_offset continuation values belong to one topic; " \
+        "continue each topic in a separate topic_messages call."
+    end
 
     def page_options(options, budget)
       {

--- a/engines/collavre/app/services/collavre/tools/topic_messages_service.rb
+++ b/engines/collavre/app/services/collavre/tools/topic_messages_service.rb
@@ -24,6 +24,16 @@ module Tools
     DEFAULT_MAX_CHARS = 40_000
     MAX_MAX_CHARS = 200_000
 
+    # Each topic also pays for its own heading, totals line and "More:" call —
+    # or, if it does not fit, its not-fetched notice, which is about the same
+    # size. Charged separately from the messages so that a call for many topics
+    # cannot overrun the cap on section furniture alone.
+    TOPIC_HEADER_CHARS = 200
+
+    # The trailing "output hit max_chars" notice, which only exists when the
+    # budget ran out and so cannot be paid for out of what is left of it.
+    TRUNCATION_CHARS = 120
+
     tool_name "topic_messages"
     tool_description <<~DESC.strip
       Read messages from one or more Collavre topics, newest first, with paging.
@@ -53,9 +63,9 @@ module Tools
       max_message_id fixed, until has_more is false.
 
       Requires read permission on each topic's creative. Private messages you
-      cannot see, authorless system notices and approval prompts are excluded
-      (see include_system). Unknown or unreadable ids are reported per topic
-      instead of failing the call.
+      cannot see and approval prompts are always excluded; authorless system
+      notices are excluded by default (see include_system). Unknown or
+      unreadable ids are reported per topic instead of failing the call.
     DESC
 
     tool_param :topic_ids, description: "Topic ids to read. Comma-separated for several, e.g. \"12,45,78\" (max #{TopicSelection::MAX_TOPICS} per call). A single id also works."
@@ -63,7 +73,7 @@ module Tools
     tool_param :limit, description: "Messages per topic (default: #{Topics::MessagePage::DEFAULT_LIMIT}, max #{Topics::MessagePage::MAX_LIMIT}).", required: false
     tool_param :order, description: "Rendering order within the returned window: 'asc' (default, oldest-to-newest — reads as a transcript) or 'desc' (newest first). Does not change which messages the window selects.", required: false, enum: Topics::MessagePage::ORDERS
     tool_param :max_message_id, description: "Only consider messages with id <= this. Pass the newest_message_id from your first page on every follow-up page so paging stays on one snapshot of a live topic.", required: false
-    tool_param :include_system, description: "Include authorless system notices and approval prompts (default: false).", required: false
+    tool_param :include_system, description: "Include authorless system notices such as concurrency and channel announcements (default: false). Approval prompts are never returned.", required: false
     tool_param :max_chars, description: "Character cap for the whole response across all topics (default: #{DEFAULT_MAX_CHARS}, max #{MAX_MAX_CHARS}).", required: false
     tool_param :format, description: "'markdown' (default, compact transcript) or 'json' (same data, structured).", required: false, enum: %w[markdown json]
 
@@ -111,16 +121,32 @@ module Tools
     # an early huge topic can leave later ones unfetched. That is reported per
     # topic rather than smoothed over: the caller asked for a specific order and
     # needs to know which of its topics it is still missing.
+    #
+    # What is charged is what is emitted — message envelopes as well as prose.
+    # Counting content alone let a few hundred one-word messages print their
+    # ids, timestamps and authors for free and sail past the cap.
+    #
+    # Every requested topic prints a section whether or not it fits, so all the
+    # headers are reserved before any topic spends on messages. Reserving them
+    # one at a time would charge only the topics that succeed, and the
+    # not-fetched notices — which exist precisely because the budget ran out —
+    # would push the response over the cap that skipping them was enforcing.
     def collect(topics, user, options)
-      remaining = options[:budget]
+      remaining = options[:budget] - reserved_chars(topics)
+      served = false
 
       topics.map do |topic|
-        next not_fetched(topic, options[:offset]) if remaining <= 0
+        next not_fetched(topic, options[:offset], served) if remaining <= 0
 
         entry = page_entry(topic, user, options, remaining)
-        remaining -= entry[:returned_chars]
+        remaining -= entry[:billed_chars].to_i
+        served = true
         entry
       end
+    end
+
+    def reserved_chars(topics)
+      TRUNCATION_CHARS + topics.sum { |topic| TOPIC_HEADER_CHARS + topic.name.to_s.length }
     end
 
     def page_entry(topic, user, options, remaining)
@@ -131,10 +157,10 @@ module Tools
         char_budget: remaining
       ).call
 
-      serialize(page)
+      serialize(page, include_system: options[:include_system])
     end
 
-    def serialize(page)
+    def serialize(page, include_system:)
       {
         topic_id: page.topic.id,
         topic_name: page.topic.name,
@@ -145,9 +171,16 @@ module Tools
         limit: page.limit,
         returned_count: page.returned_count,
         returned_chars: page.returned_chars,
+        # What this topic charged against max_chars: prose plus the rendered
+        # envelope around each message.
+        billed_chars: page.billed_chars,
         has_more: page.has_more?,
         next_offset: page.next_offset,
         newest_message_id: page.newest_message_id,
+        # Echoed so the rendered "More:" line can repeat it. A continuation
+        # that drops it pages a narrower set at the same offset and skips
+        # whatever the wider first page had already counted.
+        include_system: (true if include_system),
         # Only present when the shared max_chars budget, rather than `limit`,
         # is what ended this topic's window — the caller's fix differs: raise
         # max_chars or ask for fewer topics, not just page again.
@@ -159,7 +192,17 @@ module Tools
     # Carries has_more/next_offset so the caller can resume this topic without
     # having to work out that "no messages" here means "not read yet" rather
     # than "empty topic".
-    def not_fetched(topic, offset)
+    #
+    # The reason distinguishes the two ways to run out of room, because the
+    # fixes differ: drop topics from the call, or raise the cap. Blaming
+    # "earlier topics" when this was the first one sends the caller the wrong way.
+    def not_fetched(topic, offset, served)
+      reason = if served
+        "max_chars budget spent on earlier topics"
+      else
+        "max_chars is too small to return anything for this topic"
+      end
+
       {
         topic_id: topic.id,
         topic_name: topic.name,
@@ -167,9 +210,10 @@ module Tools
         offset: offset,
         returned_count: 0,
         returned_chars: 0,
+        billed_chars: 0,
         has_more: true,
         next_offset: offset,
-        skipped_reason: "max_chars budget spent on earlier topics",
+        skipped_reason: reason,
         messages: []
       }
     end

--- a/engines/collavre/app/services/collavre/tools/topic_messages_service.rb
+++ b/engines/collavre/app/services/collavre/tools/topic_messages_service.rb
@@ -1,0 +1,185 @@
+module Collavre
+require "sorbet-runtime"
+require "rails_mcp_engine"
+module Tools
+  # Reads a page of messages from one or more topics.
+  #
+  # Multi-topic in one call, but never interleaved: each topic is windowed and
+  # reported on its own. A merged cross-topic timeline would be the wrong answer
+  # to the question people actually ask ("summarize #a, #b and #c") — three
+  # conversations shuffled by timestamp read as none of them — and it would make
+  # offset meaningless, since a merged offset moves when any of the topics grows.
+  #
+  # Per-topic windows keep offset reproducible, and max_chars keeps the total
+  # bounded so asking for three topics cannot return three times the context you
+  # planned for.
+  class TopicMessagesService
+    extend T::Sig
+    extend ToolMeta
+
+    # Roughly a mid-sized page of prose per call. The cap is on the whole
+    # response rather than per topic because the caller's context is the shared
+    # resource: five topics at a comfortable per-topic size is not a comfortable
+    # call.
+    DEFAULT_MAX_CHARS = 40_000
+    MAX_MAX_CHARS = 200_000
+
+    tool_name "topic_messages"
+    tool_description <<~DESC.strip
+      Read messages from one or more Collavre topics, newest first, with paging.
+
+      Messages are selected from the newest end: offset 0 is the latest message,
+      offset 100 starts 100 messages back. Within the returned window they are
+      rendered oldest-to-newest by default so the transcript reads forwards
+      (pass order: "desc" for newest-first rendering).
+
+      Multiple topics per call are windowed independently and returned grouped
+      by topic — offset/limit apply to EACH topic, never to a merged timeline.
+      Use this to summarize several topics at once, e.g.
+      topic_messages(topic_ids: "12,45,78", limit: 100).
+
+      Every topic reports total_count and total_chars for the whole topic, so
+      you can tell how much you have not read yet, plus has_more and next_offset
+      for the next call. Pass the returned newest_message_id back as
+      max_message_id on follow-up pages: it pins paging to a snapshot, so
+      messages arriving mid-read cannot shift rows between pages.
+
+      The response is capped at max_chars in total. A topic that does not fit is
+      returned partially or marked not-fetched rather than silently trimmed —
+      check "truncated" and each topic's next_offset.
+
+      Long topics: call topic_list first to see message_count, then page. To
+      summarize a whole large topic, page from offset 0 upward, keeping
+      max_message_id fixed, until has_more is false.
+
+      Requires read permission on each topic's creative. Private messages you
+      cannot see, authorless system notices and approval prompts are excluded
+      (see include_system). Unknown or unreadable ids are reported per topic
+      instead of failing the call.
+    DESC
+
+    tool_param :topic_ids, description: "Topic ids to read. Comma-separated for several, e.g. \"12,45,78\" (max #{TopicSelection::MAX_TOPICS} per call). A single id also works."
+    tool_param :offset, description: "How many messages back from the newest to start, applied per topic (default: 0).", required: false
+    tool_param :limit, description: "Messages per topic (default: #{Topics::MessagePage::DEFAULT_LIMIT}, max #{Topics::MessagePage::MAX_LIMIT}).", required: false
+    tool_param :order, description: "Rendering order within the returned window: 'asc' (default, oldest-to-newest — reads as a transcript) or 'desc' (newest first). Does not change which messages the window selects.", required: false, enum: Topics::MessagePage::ORDERS
+    tool_param :max_message_id, description: "Only consider messages with id <= this. Pass the newest_message_id from your first page on every follow-up page so paging stays on one snapshot of a live topic.", required: false
+    tool_param :include_system, description: "Include authorless system notices and approval prompts (default: false).", required: false
+    tool_param :max_chars, description: "Character cap for the whole response across all topics (default: #{DEFAULT_MAX_CHARS}, max #{MAX_MAX_CHARS}).", required: false
+    tool_param :format, description: "'markdown' (default, compact transcript) or 'json' (same data, structured).", required: false, enum: %w[markdown json]
+
+    sig do
+      params(
+        topic_ids: T.any(String, Integer, T::Array[T.untyped]),
+        offset: T.nilable(Integer),
+        limit: T.nilable(Integer),
+        order: T.nilable(String),
+        max_message_id: T.nilable(Integer),
+        include_system: T.nilable(T::Boolean),
+        max_chars: T.nilable(Integer),
+        format: T.nilable(String)
+      ).returns(T.any(String, T::Hash[Symbol, T.untyped]))
+    end
+    def call(topic_ids:, offset: 0, limit: nil, order: nil, max_message_id: nil,
+             include_system: false, max_chars: nil, format: "markdown")
+      user = Current.user || raise("Current.user is required")
+      ids = IdList.parse(topic_ids)
+      raise ArgumentError, "topic_ids is required" if ids.empty?
+
+      payload = build_payload(
+        ids: ids, user: user,
+        options: { offset: offset.to_i, limit: limit, order: order, max_message_id: max_message_id,
+                   include_system: include_system, budget: clamp_chars(max_chars) }
+      )
+
+      format.to_s == "json" ? payload : Topics::MessagePageMarkdown.call(payload)
+    end
+
+    private
+
+    def build_payload(ids:, user:, options:)
+      topics, errors = TopicSelection.resolve(ids.first(TopicSelection::MAX_TOPICS), user: user)
+      entries = collect(topics, user, options)
+
+      {
+        topics: entries + errors,
+        truncated: entries.any? { |entry| entry[:skipped_reason] || entry[:budget_limited] },
+        max_chars: options[:budget]
+      }
+    end
+
+    # Topics are served in request order and the budget is spent as it goes, so
+    # an early huge topic can leave later ones unfetched. That is reported per
+    # topic rather than smoothed over: the caller asked for a specific order and
+    # needs to know which of its topics it is still missing.
+    def collect(topics, user, options)
+      remaining = options[:budget]
+
+      topics.map do |topic|
+        next not_fetched(topic, options[:offset]) if remaining <= 0
+
+        entry = page_entry(topic, user, options, remaining)
+        remaining -= entry[:returned_chars]
+        entry
+      end
+    end
+
+    def page_entry(topic, user, options, remaining)
+      page = Topics::MessagePage.new(
+        topic: topic, user: user,
+        offset: options[:offset], limit: options[:limit], order: options[:order] || Topics::MessagePage::DEFAULT_ORDER,
+        include_system: options[:include_system], max_message_id: options[:max_message_id],
+        char_budget: remaining
+      ).call
+
+      serialize(page)
+    end
+
+    def serialize(page)
+      {
+        topic_id: page.topic.id,
+        topic_name: page.topic.name,
+        creative_id: page.topic.creative_id,
+        total_count: page.total_count,
+        total_chars: page.total_chars,
+        offset: page.offset,
+        limit: page.limit,
+        returned_count: page.returned_count,
+        returned_chars: page.returned_chars,
+        has_more: page.has_more?,
+        next_offset: page.next_offset,
+        newest_message_id: page.newest_message_id,
+        # Only present when the shared max_chars budget, rather than `limit`,
+        # is what ended this topic's window — the caller's fix differs: raise
+        # max_chars or ask for fewer topics, not just page again.
+        budget_limited: page.budget_exhausted.presence,
+        messages: page.messages
+      }.compact
+    end
+
+    # Carries has_more/next_offset so the caller can resume this topic without
+    # having to work out that "no messages" here means "not read yet" rather
+    # than "empty topic".
+    def not_fetched(topic, offset)
+      {
+        topic_id: topic.id,
+        topic_name: topic.name,
+        creative_id: topic.creative_id,
+        offset: offset,
+        returned_count: 0,
+        returned_chars: 0,
+        has_more: true,
+        next_offset: offset,
+        skipped_reason: "max_chars budget spent on earlier topics",
+        messages: []
+      }
+    end
+
+    def clamp_chars(max_chars)
+      value = max_chars.to_i
+      return DEFAULT_MAX_CHARS if value <= 0
+
+      [ value, MAX_MAX_CHARS ].min
+    end
+  end
+end
+end

--- a/engines/collavre/app/services/collavre/tools/topic_selection.rb
+++ b/engines/collavre/app/services/collavre/tools/topic_selection.rb
@@ -21,12 +21,28 @@ module Collavre
       # Returns [topics, errors], preserving the caller's id order so a numbered
       # request reads back in the order it was asked.
       def resolve(ids, user: Collavre::Current.user)
+        enforce_cap!(ids)
         by_id = Topic.where(id: ids).index_by(&:id)
 
         ids.each_with_object([ [], [] ]) do |id, (topics, errors)|
           error = rejection_for(by_id[id], user)
           error ? errors << { topic_id: id, error: error } : topics << by_id[id]
         end
+      end
+
+      # An oversized batch is an error, not a trim. Silently keeping the first
+      # twenty returns a response that looks complete — every topic asked for
+      # that appears, appears in full — while whole conversations are missing
+      # with nothing in the payload that says so, and a caller summarizing
+      # "all of these" would report on a subset believing it had them all.
+      # Unreadable ids are still reported per topic rather than raised: those
+      # the caller can see and act on, one entry each.
+      def enforce_cap!(ids)
+        return if ids.size <= MAX_TOPICS
+
+        raise ArgumentError,
+          "#{ids.size} topics requested but at most #{MAX_TOPICS} can be read per call. " \
+          "Split the ids across several calls."
       end
 
       # Deliberately the same message for missing and unreadable. Distinguishing

--- a/engines/collavre/app/services/collavre/tools/topic_selection.rb
+++ b/engines/collavre/app/services/collavre/tools/topic_selection.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Collavre
+  module Tools
+    # Turns the `topic_ids` parameter of the read tools into topics, and reports
+    # the ones it could not turn into topics instead of raising.
+    #
+    # A caller asking about three topics has usually copied the ids out of a
+    # conversation, so one of them being stale or unshared is ordinary. Failing
+    # the whole call there would throw away the two that worked and give no way
+    # to tell which id was the bad one.
+    module TopicSelection
+      # A ceiling on topics per call, not on messages — that is max_chars' job.
+      # This one exists because each topic costs a header, a totals query and a
+      # window query, and a caller that pastes forty ids has stopped planning
+      # and started dumping.
+      MAX_TOPICS = 20
+
+      module_function
+
+      # Returns [topics, errors], preserving the caller's id order so a numbered
+      # request reads back in the order it was asked.
+      def resolve(ids, user: Collavre::Current.user)
+        by_id = Topic.where(id: ids).index_by(&:id)
+
+        ids.each_with_object([ [], [] ]) do |id, (topics, errors)|
+          error = rejection_for(by_id[id], user)
+          error ? errors << { topic_id: id, error: error } : topics << by_id[id]
+        end
+      end
+
+      # Deliberately the same message for missing and unreadable. Distinguishing
+      # them would let a caller probe which topic ids exist on creatives they
+      # cannot see.
+      def rejection_for(topic, user)
+        return "Topic not found or not readable" if topic.nil?
+        return nil if TopicAuthorizer.readable?(topic, user: user)
+
+        "Topic not found or not readable"
+      end
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/tools/topic_update_service.rb
+++ b/engines/collavre/app/services/collavre/tools/topic_update_service.rb
@@ -115,19 +115,14 @@ module Tools
 
     def reject_reserved_mutation!(topic, name, archived)
       return unless name.present? || !archived.nil?
-      return unless reserved_topic?(topic) || reserved_name?(topic.creative, name)
+      return unless reserved_topic?(topic) || Topics::ReservedName.reserved?(topic.creative, name)
 
       raise ArgumentError,
         "Reserved topic names cannot be assigned or changed, and reserved topics cannot be archived."
     end
 
     def reserved_topic?(topic)
-      reserved_name?(topic.creative, topic.name)
-    end
-
-    def reserved_name?(creative, name)
-      name == Creative::MAIN_TOPIC_NAME ||
-        (creative.inbox? && name == Creative::SYSTEM_TOPIC_NAME)
+      Topics::ReservedName.reserved?(topic.creative, topic.name)
     end
 
     def set_archived(topic, archived)

--- a/engines/collavre/app/services/collavre/tools/topic_update_service.rb
+++ b/engines/collavre/app/services/collavre/tools/topic_update_service.rb
@@ -34,8 +34,9 @@ module Tools
       Permissions: renaming needs admin on the creative (a rename changes what
       everyone else's links and habits point at); archiving and pin changes need
       write. Main and an inbox's System topic are reserved: their names and
-      archive state cannot change, but their pin can. A Claude Channel session
-      topic's pin is part of its session identity and cannot be changed here.
+      archive state cannot change, and those names cannot be assigned to another
+      topic, but their pin can. A Claude Channel session topic's pin is part of
+      its session identity and cannot be changed here.
     DESC
 
     tool_param :topic_id, description: "The topic to update."
@@ -114,15 +115,19 @@ module Tools
 
     def reject_reserved_mutation!(topic, name, archived)
       return unless name.present? || !archived.nil?
-      return unless reserved_topic?(topic)
+      return unless reserved_topic?(topic) || reserved_name?(topic.creative, name)
 
       raise ArgumentError,
-        "#{topic.name} is a reserved topic; its name and archive state cannot be changed."
+        "Reserved topic names cannot be assigned or changed, and reserved topics cannot be archived."
     end
 
     def reserved_topic?(topic)
-      topic.name == Creative::MAIN_TOPIC_NAME ||
-        (topic.creative.inbox? && topic.name == Creative::SYSTEM_TOPIC_NAME)
+      reserved_name?(topic.creative, topic.name)
+    end
+
+    def reserved_name?(creative, name)
+      name == Creative::MAIN_TOPIC_NAME ||
+        (creative.inbox? && name == Creative::SYSTEM_TOPIC_NAME)
     end
 
     def set_archived(topic, archived)

--- a/engines/collavre/app/services/collavre/tools/topic_update_service.rb
+++ b/engines/collavre/app/services/collavre/tools/topic_update_service.rb
@@ -58,10 +58,14 @@ module Tools
       # matches an accessible agent, and a caller with no rights on the topic
       # should not be able to ask.
       authorize!(topic, name)
-      changed = apply(topic, name, archived, Topics::AgentResolver.call(primary_agent))
+      agent_change = Topics::AgentResolver.call(primary_agent)
+      changed = requested(name, archived, agent_change)
       raise ArgumentError, "Nothing to update: pass name, archived, or primary_agent" if changed.empty?
 
-      Topics::Serializer.for_tool(topic.reload).merge(changed: changed)
+      agent = apply(topic, name, archived, agent_change)
+      broadcast_all(topic.reload, changed, archived, agent)
+
+      Topics::Serializer.for_tool(topic).merge(changed: changed)
     end
 
     private
@@ -74,24 +78,34 @@ module Tools
       name.present? ? TopicAuthorizer.authorize_admin!(topic) : TopicAuthorizer.authorize_write!(topic)
     end
 
-    def apply(topic, name, archived, agent_change)
+    def requested(name, archived, agent_change)
       changed = []
-      changed << rename(topic, name) if name.present?
-      changed << set_archived(topic, archived) unless archived.nil?
-      changed << set_agent(topic, agent_change) if agent_change
+      changed << "name" if name.present?
+      changed << "archived" unless archived.nil?
+      changed << "primary_agent" if agent_change
       changed
     end
 
-    def rename(topic, name)
-      topic.update!(name: name)
-      broadcast(topic, "updated", topic: Topics::Serializer.call(topic))
-      "name"
+    # Every requested field is checked before any of them is written, and the
+    # writes share one transaction. A call that renames, archives, and pins an
+    # agent the creative has not shared with must report failure over a topic
+    # that is still named what it was — not one that was quietly renamed and
+    # archived on the way to the error. Nothing broadcasts until the whole set
+    # has committed, for the same reason.
+    def apply(topic, name, archived, agent_change)
+      agent = agent_change ? validated_agent(topic, agent_change) : nil
+
+      Topic.transaction do
+        topic.update!(name: name) if name.present?
+        set_archived(topic, archived) unless archived.nil?
+        topic.set_primary_agent!(agent) if agent_change
+      end
+
+      agent
     end
 
     def set_archived(topic, archived)
       archived ? topic.archive! : topic.unarchive!
-      broadcast(topic, archived ? "archived" : "unarchived", topic: topic.slice(:id, :name, :archived_at))
-      "archived"
     end
 
     # Mirrors TopicsController#set_primary_agent, including the session lock:
@@ -99,15 +113,18 @@ module Tools
     # not a routing preference — Matcher needs it to route the agent at all and
     # SessionProvisioner reuses the topic by it, so rewriting it would leave a
     # live session unroutable and fork the next registration into a second topic.
-    def set_agent(topic, agent_change)
+    def validated_agent(topic, agent_change)
       raise ArgumentError, "This is a session topic; its agent assignment is locked." if topic.session_id.present?
 
       agent = agent_change == Topics::AgentResolver::CLEAR ? nil : agent_change
       reject_unassignable!(topic, agent)
+      agent
+    end
 
-      topic.set_primary_agent!(agent)
-      broadcast(topic, "updated", topic: Topics::Serializer.with_agent(topic, agent))
-      "primary_agent"
+    def broadcast_all(topic, changed, archived, agent)
+      broadcast(topic, "updated", topic: Topics::Serializer.call(topic)) if changed.include?("name")
+      broadcast(topic, archived ? "archived" : "unarchived", topic: topic.slice(:id, :name, :archived_at)) if changed.include?("archived")
+      broadcast(topic, "updated", topic: Topics::Serializer.with_agent(topic, agent)) if changed.include?("primary_agent")
     end
 
     def reject_unassignable!(topic, agent)

--- a/engines/collavre/app/services/collavre/tools/topic_update_service.rb
+++ b/engines/collavre/app/services/collavre/tools/topic_update_service.rb
@@ -29,7 +29,7 @@ module Tools
       alone answers ambient messages and no other agent responds. The agent must
       already have feedback permission or better on the creative. Pass "none" to
       clear the pin and let normal routing resume. Accepts an agent id, email,
-      or exact name.
+      or exact name; private agents already shared on this creative resolve too.
 
       Permissions: renaming needs admin on the creative (a rename changes what
       everyone else's links and habits point at); archiving and pin changes need
@@ -58,7 +58,7 @@ module Tools
       # matches an accessible agent, and a caller with no rights on the topic
       # should not be able to ask.
       authorize!(topic, name)
-      agent_change = Topics::AgentResolver.call(primary_agent)
+      agent_change = Topics::AgentResolver.call(primary_agent, creative: topic.creative)
       changed = requested(name, archived, agent_change)
       raise ArgumentError, "Nothing to update: pass name, archived, or primary_agent" if changed.empty?
 

--- a/engines/collavre/app/services/collavre/tools/topic_update_service.rb
+++ b/engines/collavre/app/services/collavre/tools/topic_update_service.rb
@@ -59,11 +59,10 @@ module Tools
       # matches an accessible agent, and a caller with no rights on the topic
       # should not be able to ask.
       authorize!(topic, name)
-      agent_change = Topics::AgentResolver.call(primary_agent, creative: topic.creative)
-      changed = requested(name, archived, agent_change)
+      changed = requested(name, archived, primary_agent)
       raise ArgumentError, "Nothing to update: pass name, archived, or primary_agent" if changed.empty?
 
-      agent = apply(topic, name, archived, agent_change)
+      agent = apply(topic, name, archived, primary_agent)
       broadcast_all(topic.reload, changed, archived, agent)
 
       Topics::Serializer.for_tool(topic).merge(changed: changed)
@@ -79,11 +78,11 @@ module Tools
       name.present? ? TopicAuthorizer.authorize_admin!(topic) : TopicAuthorizer.authorize_write!(topic)
     end
 
-    def requested(name, archived, agent_change)
+    def requested(name, archived, primary_agent)
       changed = []
       changed << "name" if name.present?
       changed << "archived" unless archived.nil?
-      changed << "primary_agent" if agent_change
+      changed << "primary_agent" unless primary_agent.nil?
       changed
     end
 
@@ -93,18 +92,24 @@ module Tools
     # that is still named what it was — not one that was quietly renamed and
     # archived on the way to the error. Nothing broadcasts until the whole set
     # has committed, for the same reason.
-    def apply(topic, name, archived, agent_change)
-      agent = agent_change ? validated_agent(topic, agent_change) : nil
-
+    def apply(topic, name, archived, primary_agent)
+      agent = nil
       Topic.transaction do
         topic.lock!
+        authorize!(topic, name)
         reject_reserved_mutation!(topic, name, archived)
+        agent = resolve_agent(topic, primary_agent)
         topic.update!(name: name) if name.present?
         set_archived(topic, archived) unless archived.nil?
-        topic.set_primary_agent!(agent) if agent_change
+        topic.set_primary_agent!(agent) unless primary_agent.nil?
       end
 
       agent
+    end
+
+    def resolve_agent(topic, primary_agent)
+      change = Topics::AgentResolver.call(primary_agent, creative: topic.creative)
+      change ? validated_agent(topic, change) : nil
     end
 
     def reject_reserved_mutation!(topic, name, archived)

--- a/engines/collavre/app/services/collavre/tools/topic_update_service.rb
+++ b/engines/collavre/app/services/collavre/tools/topic_update_service.rb
@@ -1,0 +1,127 @@
+module Collavre
+require "sorbet-runtime"
+require "rails_mcp_engine"
+module Tools
+  # Renames a topic, archives/unarchives it, or changes its primary agent.
+  #
+  # One tool rather than three because these are the three ways a topic changes
+  # after it exists, and they are routinely done together — an agent finishing a
+  # unit of work archives the topic and releases the pin in the same breath.
+  # They do not share a permission level, so each field is authorized for what
+  # it actually does.
+  class TopicUpdateService
+    extend T::Sig
+    extend ToolMeta
+
+    tool_name "topic_update"
+    tool_description <<~DESC.strip
+      Rename a topic, archive or unarchive it, or set/clear its primary agent.
+      Pass only the fields you want to change.
+
+      Archiving is how a finished thread is put away: the topic leaves the
+      active sidebar but keeps every message, and topic_messages can still read
+      it by id. Archive a topic when its conversation has reached its
+      conclusion, rather than reusing it for the next subject — a topic is one
+      thread of one conclusion, and it is also the concurrency unit, so reusing
+      one serializes unrelated work behind it.
+
+      primary_agent pins one agent to the topic, EXCLUSIVELY: the pinned agent
+      alone answers ambient messages and no other agent responds. The agent must
+      already have feedback permission or better on the creative. Pass "none" to
+      clear the pin and let normal routing resume. Accepts an agent id, email,
+      or exact name.
+
+      Permissions: renaming needs admin on the creative (a rename changes what
+      everyone else's links and habits point at); archiving and pin changes need
+      write. A Claude Channel session topic's pin is part of its session
+      identity and cannot be changed here.
+    DESC
+
+    tool_param :topic_id, description: "The topic to update."
+    tool_param :name, description: "New name. Must be unique on the creative. Requires admin permission.", required: false
+    tool_param :archived, description: "true archives the topic (hides it from the active list, keeps all messages); false unarchives it.", required: false
+    tool_param :primary_agent, description: "Agent to pin — id, email, or exact name. Pass \"none\" to clear the pin. The pin is exclusive: only this agent answers in the topic.", required: false
+
+    sig do
+      params(
+        topic_id: Integer,
+        name: T.nilable(String),
+        archived: T.nilable(T::Boolean),
+        primary_agent: T.nilable(String)
+      ).returns(T::Hash[Symbol, T.untyped])
+    end
+    def call(topic_id:, name: nil, archived: nil, primary_agent: nil)
+      Current.user || raise("Current.user is required")
+      topic = Topic.find(topic_id)
+
+      # Authorize before resolving the agent: resolution reports whether a name
+      # matches an accessible agent, and a caller with no rights on the topic
+      # should not be able to ask.
+      authorize!(topic, name)
+      changed = apply(topic, name, archived, Topics::AgentResolver.call(primary_agent))
+      raise ArgumentError, "Nothing to update: pass name, archived, or primary_agent" if changed.empty?
+
+      Topics::Serializer.for_tool(topic.reload).merge(changed: changed)
+    end
+
+    private
+
+    # A rename is gated at :admin to match TopicsController#update. Everything
+    # else here is a :write action, so the stricter gate is only applied when a
+    # rename is actually requested — otherwise archiving would silently need
+    # admin through this door and not through the UI.
+    def authorize!(topic, name)
+      name.present? ? TopicAuthorizer.authorize_admin!(topic) : TopicAuthorizer.authorize_write!(topic)
+    end
+
+    def apply(topic, name, archived, agent_change)
+      changed = []
+      changed << rename(topic, name) if name.present?
+      changed << set_archived(topic, archived) unless archived.nil?
+      changed << set_agent(topic, agent_change) if agent_change
+      changed
+    end
+
+    def rename(topic, name)
+      topic.update!(name: name)
+      broadcast(topic, "updated", topic: Topics::Serializer.call(topic))
+      "name"
+    end
+
+    def set_archived(topic, archived)
+      archived ? topic.archive! : topic.unarchive!
+      broadcast(topic, archived ? "archived" : "unarchived", topic: topic.slice(:id, :name, :archived_at))
+      "archived"
+    end
+
+    # Mirrors TopicsController#set_primary_agent, including the session lock:
+    # on a Claude Channel session topic primary_agent_id is session identity,
+    # not a routing preference — Matcher needs it to route the agent at all and
+    # SessionProvisioner reuses the topic by it, so rewriting it would leave a
+    # live session unroutable and fork the next registration into a second topic.
+    def set_agent(topic, agent_change)
+      raise ArgumentError, "This is a session topic; its agent assignment is locked." if topic.session_id.present?
+
+      agent = agent_change == Topics::AgentResolver::CLEAR ? nil : agent_change
+      reject_unassignable!(topic, agent)
+
+      topic.set_primary_agent!(agent)
+      broadcast(topic, "updated", topic: Topics::Serializer.with_agent(topic, agent))
+      "primary_agent"
+    end
+
+    def reject_unassignable!(topic, agent)
+      return if agent.nil?
+
+      rejection = Topic.primary_agent_rejection(topic.creative, agent, topic: topic)
+      return unless rejection
+
+      raise ArgumentError, Topics::PinRejection.message(agent, rejection)
+    end
+
+    def broadcast(topic, action, payload)
+      TopicsChannel.broadcast_to(topic.creative, { action: action, **payload })
+    end
+  end
+end
+end

--- a/engines/collavre/app/services/collavre/tools/topic_update_service.rb
+++ b/engines/collavre/app/services/collavre/tools/topic_update_service.rb
@@ -33,8 +33,9 @@ module Tools
 
       Permissions: renaming needs admin on the creative (a rename changes what
       everyone else's links and habits point at); archiving and pin changes need
-      write. A Claude Channel session topic's pin is part of its session
-      identity and cannot be changed here.
+      write. Main and an inbox's System topic are reserved: their names and
+      archive state cannot change, but their pin can. A Claude Channel session
+      topic's pin is part of its session identity and cannot be changed here.
     DESC
 
     tool_param :topic_id, description: "The topic to update."
@@ -96,12 +97,27 @@ module Tools
       agent = agent_change ? validated_agent(topic, agent_change) : nil
 
       Topic.transaction do
+        topic.lock!
+        reject_reserved_mutation!(topic, name, archived)
         topic.update!(name: name) if name.present?
         set_archived(topic, archived) unless archived.nil?
         topic.set_primary_agent!(agent) if agent_change
       end
 
       agent
+    end
+
+    def reject_reserved_mutation!(topic, name, archived)
+      return unless name.present? || !archived.nil?
+      return unless reserved_topic?(topic)
+
+      raise ArgumentError,
+        "#{topic.name} is a reserved topic; its name and archive state cannot be changed."
+    end
+
+    def reserved_topic?(topic)
+      topic.name == Creative::MAIN_TOPIC_NAME ||
+        (topic.creative.inbox? && topic.name == Creative::SYSTEM_TOPIC_NAME)
     end
 
     def set_archived(topic, archived)

--- a/engines/collavre/app/services/collavre/topic_branch_service.rb
+++ b/engines/collavre/app/services/collavre/topic_branch_service.rb
@@ -23,8 +23,9 @@ module Collavre
       comment_ids = comment_ids.first(MAX_BRANCH_COMMENTS) if enforce_limit
       raise BranchError, I18n.t("collavre.comments.branch.no_selection") if comment_ids.empty?
 
-      validate_permissions!
       Topic.transaction do
+        lock_source!
+        validate_permissions!
         originals = fetch_comments(comment_ids)
         reject_approval_actions!(originals)
         @new_topic = create_branch_topic
@@ -39,6 +40,16 @@ module Collavre
     private
 
     attr_reader :creative, :user, :source_topic, :name
+
+    def lock_source!
+      return unless source_topic
+
+      # The topic can move after a caller's preflight authorization. Pin its
+      # current creative under the same lock that protects the comment fetch so
+      # permissions and the branch destination cannot refer to stale state.
+      source_topic.lock!
+      @creative = source_topic.creative
+    end
 
     def validate_permissions!
       unless creative.has_permission?(user, :feedback)

--- a/engines/collavre/app/services/collavre/topic_branch_service.rb
+++ b/engines/collavre/app/services/collavre/topic_branch_service.rb
@@ -18,7 +18,11 @@ module Collavre
     # does not apply.
     # auto_select: false omits user_id from the topic-created broadcast so
     # background/system branches do not hijack the owner's current selection.
-    def call(comment_ids:, enforce_limit: true, auto_select: true)
+    # skip_approval_actions is reserved for system history copies that already
+    # selected an approval-free set but must tolerate a row becoming an approval
+    # prompt before the locked fetch. Interactive branches keep the default
+    # all-or-nothing rejection.
+    def call(comment_ids:, enforce_limit: true, auto_select: true, skip_approval_actions: false)
       comment_ids = Array(comment_ids).map(&:presence).compact.map(&:to_i)
       comment_ids = comment_ids.first(MAX_BRANCH_COMMENTS) if enforce_limit
       raise BranchError, I18n.t("collavre.comments.branch.no_selection") if comment_ids.empty?
@@ -27,6 +31,7 @@ module Collavre
         lock_source!
         validate_permissions!
         originals = fetch_comments(comment_ids)
+        originals = originals.reject(&:approval_action?) if skip_approval_actions
         reject_approval_actions!(originals)
         @new_topic = create_branch_topic
         copy_comments(originals)

--- a/engines/collavre/app/services/collavre/topic_branch_service.rb
+++ b/engines/collavre/app/services/collavre/topic_branch_service.rb
@@ -24,9 +24,9 @@ module Collavre
       raise BranchError, I18n.t("collavre.comments.branch.no_selection") if comment_ids.empty?
 
       validate_permissions!
-      originals = fetch_comments(comment_ids)
-
       Topic.transaction do
+        originals = fetch_comments(comment_ids)
+        reject_approval_actions!(originals)
         @new_topic = create_branch_topic
         copy_comments(originals)
       end
@@ -48,11 +48,17 @@ module Collavre
 
     def fetch_comments(comment_ids)
       scope = source_topic ? source_topic.comments.visible_to(user) : creative.comments.visible_to(user)
-      comments = scope.where(id: comment_ids).order(:created_at).to_a
+      comments = scope.where(id: comment_ids).order(:created_at).lock.to_a
       if comments.length != comment_ids.length
         raise BranchError, I18n.t("collavre.comments.branch.comments_not_found")
       end
       comments
+    end
+
+    def reject_approval_actions!(comments)
+      return unless comments.any?(&:approval_action?)
+
+      raise BranchError, I18n.t("collavre.comments.branch.approval_action_not_branchable")
     end
 
     def create_branch_topic

--- a/engines/collavre/app/services/collavre/topic_branch_service.rb
+++ b/engines/collavre/app/services/collavre/topic_branch_service.rb
@@ -110,13 +110,13 @@ module Collavre
           new_comment.quoted_comment_id = id_mapping[original.quoted_comment_id]
         end
 
+        # Attach before validation so an image-only comment still satisfies the
+        # Comment content-or-images invariant. Reuse the blobs without copying
+        # file data, as the post-save loop did previously.
+        new_comment.images.attach(original.images.map(&:blob)) if original.images.attached?
+
         new_comment.save!
         id_mapping[original.id] = new_comment.id
-
-        # Share image blobs (no duplication of file data)
-        original.images.each do |image|
-          new_comment.images.attach(image.blob)
-        end
       end
     end
 

--- a/engines/collavre/app/services/collavre/topic_branch_service.rb
+++ b/engines/collavre/app/services/collavre/topic_branch_service.rb
@@ -74,6 +74,7 @@ module Collavre
 
     def create_branch_topic
       topic_name = name.presence || default_branch_name
+      Topics::ReservedName.reject!(creative, topic_name, error_class: BranchError)
 
       creative.topics.create!(
         name: topic_name,

--- a/engines/collavre/app/services/collavre/topic_branch_service.rb
+++ b/engines/collavre/app/services/collavre/topic_branch_service.rb
@@ -88,6 +88,12 @@ module Collavre
           user_id: original.user_id,
           content: original.content,
           private: original.private,
+          # Carried with `private`, not separately from it: visible_to reads a
+          # private comment for its author *and* its approver, so copying the
+          # flag without the approver narrows who can see the copy. The user who
+          # selected the message can be the approver rather than the author, and
+          # would then get a branch reporting a message it cannot show them.
+          approver_id: original.approver_id,
           review_type: original.review_type,
           skip_default_user: true,
           skip_dispatch: true

--- a/engines/collavre/app/services/collavre/topics/agent_resolver.rb
+++ b/engines/collavre/app/services/collavre/topics/agent_resolver.rb
@@ -9,9 +9,9 @@ module Collavre
     # Accepting id / email / display name is what makes topic_create and
     # topic_update usable without a preceding lookup round-trip.
     #
-    # Candidates come from User.accessible_ai_agents_for, the same
-    # owned-or-searchable set CreativeSharesController enforces when sharing to
-    # an AI agent. Resolving over every agent row would let a caller confirm a
+    # Candidates are the owned-or-searchable set plus agents already shared on
+    # the target Creative. The latter matches User.mentionable_for and the UI's
+    # agent palette. Resolving over every agent row would let a caller confirm a
     # private agent's existence by name, and would let them pin one they are not
     # allowed to see.
     module AgentResolver
@@ -30,16 +30,27 @@ module Collavre
       module_function
 
       # Returns nil (no change), CLEAR (unassign), or a User.
-      def call(value, actor: Collavre::Current.user)
+      def call(value, actor: Collavre::Current.user, creative: nil)
         token = value.to_s.strip
         return nil if value.nil?
         return CLEAR if token.empty? || CLEAR_TOKENS.include?(token.downcase)
 
-        candidates = User.accessible_ai_agents_for(actor)
+        candidates = candidates_for(actor, creative)
         find_by_id(candidates, token) ||
           find_by_email(candidates, token) ||
           find_by_name(candidates, token) ||
           raise(UnknownAgentError, unknown_message(token))
+      end
+
+      def candidates_for(actor, creative)
+        accessible = User.accessible_ai_agents_for(actor)
+        return accessible unless creative
+
+        shared = User.mentionable_for(creative).ai_agents
+        base = User.ai_agents
+        base.where(id: accessible.reorder(nil).select(:id))
+            .or(base.where(id: shared.reorder(nil).select(:id)))
+            .distinct.order(:name)
       end
 
       def find_by_id(candidates, token)
@@ -68,7 +79,8 @@ module Collavre
 
       def unknown_message(token)
         "No accessible AI agent matches #{token.inspect}. " \
-          "Pass an agent id, email, or exact name; the agent must be searchable or created by you."
+          "Pass an agent id, email, or exact name; the agent must be searchable, created by you, " \
+          "or already shared on this creative."
       end
     end
   end

--- a/engines/collavre/app/services/collavre/topics/agent_resolver.rb
+++ b/engines/collavre/app/services/collavre/topics/agent_resolver.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+module Collavre
+  module Topics
+    # Resolves the `primary_agent` string an MCP caller passes into a User.
+    #
+    # The UI picks an agent from a palette and sends an id; an agent calling a
+    # tool has read a name out of a conversation and has no palette to click.
+    # Accepting id / email / display name is what makes topic_create and
+    # topic_update usable without a preceding lookup round-trip.
+    #
+    # Candidates come from User.accessible_ai_agents_for, the same
+    # owned-or-searchable set CreativeSharesController enforces when sharing to
+    # an AI agent. Resolving over every agent row would let a caller confirm a
+    # private agent's existence by name, and would let them pin one they are not
+    # allowed to see.
+    module AgentResolver
+      # Sentinel distinguishing "clear the pin" from "no change". A blank string
+      # cannot carry that difference on its own: topic_update omitting the
+      # parameter and topic_update asking to unassign both arrive as falsy.
+      CLEAR = :clear
+
+      # What a caller writes to mean "unassign". Spelled out because an agent
+      # that guesses will guess one of these.
+      CLEAR_TOKENS = %w[none clear null nil unassign].freeze
+
+      class AmbiguousAgentError < ArgumentError; end
+      class UnknownAgentError < ArgumentError; end
+
+      module_function
+
+      # Returns nil (no change), CLEAR (unassign), or a User.
+      def call(value, actor: Collavre::Current.user)
+        token = value.to_s.strip
+        return nil if value.nil?
+        return CLEAR if token.empty? || CLEAR_TOKENS.include?(token.downcase)
+
+        candidates = User.accessible_ai_agents_for(actor)
+        find_by_id(candidates, token) ||
+          find_by_email(candidates, token) ||
+          find_by_name(candidates, token) ||
+          raise(UnknownAgentError, unknown_message(token))
+      end
+
+      def find_by_id(candidates, token)
+        return nil unless token.match?(/\A\d+\z/)
+
+        candidates.find_by(id: token.to_i)
+      end
+
+      def find_by_email(candidates, token)
+        return nil unless token.include?("@")
+
+        candidates.find_by(email: token.downcase)
+      end
+
+      # Names are not unique, so an exact-match tie is reported with the ids
+      # rather than silently resolved to the first row — picking one would
+      # quietly dedicate a topic to the wrong agent.
+      def find_by_name(candidates, token)
+        matches = candidates.where(name: token).to_a
+        return matches.first if matches.one?
+        return nil if matches.empty?
+
+        raise AmbiguousAgentError,
+          "Multiple agents named #{token.inspect}: ids #{matches.map(&:id).join(', ')}. Pass the id instead."
+      end
+
+      def unknown_message(token)
+        "No accessible AI agent matches #{token.inspect}. " \
+          "Pass an agent id, email, or exact name; the agent must be searchable or created by you."
+      end
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/topics/char_budget.rb
+++ b/engines/collavre/app/services/collavre/topics/char_budget.rb
@@ -53,7 +53,8 @@ module Collavre
       def cost(message)
         return message.to_json.length + 1 if json?
 
-        ENVELOPE_CHARS + message[:content].to_s.length + message[:author].to_s.length +
+        ENVELOPE_CHARS + message[:content].to_s.length + message[:clip_notice].to_s.length +
+          message[:author].to_s.length +
           (message[:agent] ? AGENT_SUFFIX_CHARS : 0)
       end
 

--- a/engines/collavre/app/services/collavre/topics/char_budget.rb
+++ b/engines/collavre/app/services/collavre/topics/char_budget.rb
@@ -20,6 +20,12 @@ module Collavre
       # messages is then an entire budget spent off the books.
       ENVELOPE_CHARS = 36
 
+      # Markdown tags an AI author with a " (agent)" suffix on its byline. Eight
+      # characters is nothing on one message and a page's worth on a stretch of
+      # short agent turns, which is exactly the shape a busy topic has — and it
+      # is more than the margin the per-topic reserve leaves to absorb it.
+      AGENT_SUFFIX_CHARS = " (agent)".length
+
       attr_reader :chars, :format
 
       def self.normalize_format(value)
@@ -47,7 +53,8 @@ module Collavre
       def cost(message)
         return message.to_json.length + 1 if json?
 
-        ENVELOPE_CHARS + message[:content].to_s.length + message[:author].to_s.length
+        ENVELOPE_CHARS + message[:content].to_s.length + message[:author].to_s.length +
+          (message[:agent] ? AGENT_SUFFIX_CHARS : 0)
       end
 
       # Whether a message of this cost still fits alongside what has been spent.

--- a/engines/collavre/app/services/collavre/topics/char_budget.rb
+++ b/engines/collavre/app/services/collavre/topics/char_budget.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module Collavre
+  module Topics
+    # A character cap and the unit it is measured in.
+    #
+    # The two travel together because neither is meaningful alone. A cap of
+    # 40,000 buys a different amount of conversation depending on whether the
+    # response is a markdown transcript or a JSON object, and budgeting in one
+    # unit while emitting the other is exactly how a cap gets exceeded by half
+    # again. Keeping them in one object means a caller cannot supply a cap and
+    # forget to say what it counts.
+    class CharBudget
+      FORMATS = %w[markdown json].freeze
+      DEFAULT_FORMAT = "markdown"
+
+      # Markdown's per-message overhead: the id, the ISO-8601 timestamp, the
+      # author separator and two newlines. Measured rather than guessed —
+      # content-only accounting hands this out for free, and a few hundred short
+      # messages is then an entire budget spent off the books.
+      ENVELOPE_CHARS = 36
+
+      attr_reader :chars, :format
+
+      def self.normalize_format(value)
+        FORMATS.include?(value.to_s) ? value.to_s : DEFAULT_FORMAT
+      end
+
+      def initialize(chars: nil, format: DEFAULT_FORMAT)
+        @chars = chars
+        @format = self.class.normalize_format(format)
+      end
+
+      def unlimited? = @chars.nil?
+
+      def json? = @format == "json"
+
+      def with(chars:) = self.class.new(chars: chars, format: @format)
+
+      # What emitting this message costs, which is a property of the format
+      # rather than of the record.
+      #
+      # json is measured against the serialized form instead of estimated from
+      # it: the field names are a fixed ~120 characters the prose never sees,
+      # and the escaping ratio varies with the message, so no constant tracks
+      # both. The trailing character is the comma that joins it to the next one.
+      def cost(message)
+        return message.to_json.length + 1 if json?
+
+        ENVELOPE_CHARS + message[:content].to_s.length + message[:author].to_s.length
+      end
+
+      # Whether a message of this cost still fits alongside what has been spent.
+      # Takes the cost rather than the message so the caller can charge what it
+      # measured instead of serializing the same message twice.
+      #
+      # Deciding before keeping is the point: appending first and checking
+      # afterwards let a message wider than the entire cap through untouched.
+      def fits?(cost, spent: 0) = unlimited? || (spent + cost) <= @chars
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/topics/message_page.rb
+++ b/engines/collavre/app/services/collavre/topics/message_page.rb
@@ -20,6 +20,18 @@ module Collavre
       ORDERS = %w[asc desc].freeze
       DEFAULT_ORDER = "asc"
 
+      # What a message costs the caller, as opposed to what it says. The
+      # rendered line carries an id, an ISO-8601 timestamp, the author name and
+      # two newlines on top of the prose — roughly forty characters that
+      # content-only accounting hands out for free. A few hundred short or
+      # empty messages is then an entire budget spent off the books, which is
+      # the one thing max_chars exists to prevent.
+      ENVELOPE_CHARS = 36
+
+      def self.cost(message)
+        ENVELOPE_CHARS + message[:content].to_s.length + message[:author].to_s.length
+      end
+
       Page = Struct.new(
         :topic, :total_count, :total_chars, :offset, :limit,
         :messages, :newest_message_id, :budget_exhausted,
@@ -27,7 +39,11 @@ module Collavre
       ) do
         def returned_count = messages.size
 
+        # What the caller reads.
         def returned_chars = messages.sum { |m| m[:content].to_s.length }
+
+        # What the caller is charged: prose plus the envelope around it.
+        def billed_chars = messages.sum { |m| MessagePage.cost(m) }
 
         def has_more? = (offset + returned_count) < total_count
 
@@ -111,7 +127,7 @@ module Collavre
           break if spent >= @char_budget
 
           kept << message
-          spent += message[:content].to_s.length
+          spent += self.class.cost(message)
         end
         kept
       end

--- a/engines/collavre/app/services/collavre/topics/message_page.rb
+++ b/engines/collavre/app/services/collavre/topics/message_page.rb
@@ -20,21 +20,9 @@ module Collavre
       ORDERS = %w[asc desc].freeze
       DEFAULT_ORDER = "asc"
 
-      # What a message costs the caller, as opposed to what it says. The
-      # rendered line carries an id, an ISO-8601 timestamp, the author name and
-      # two newlines on top of the prose — roughly forty characters that
-      # content-only accounting hands out for free. A few hundred short or
-      # empty messages is then an entire budget spent off the books, which is
-      # the one thing max_chars exists to prevent.
-      ENVELOPE_CHARS = 36
-
-      def self.cost(message)
-        ENVELOPE_CHARS + message[:content].to_s.length + message[:author].to_s.length
-      end
-
       Page = Struct.new(
         :topic, :total_count, :total_chars, :offset, :limit,
-        :messages, :newest_message_id, :budget_exhausted,
+        :messages, :newest_message_id, :budget_exhausted, :budget,
         keyword_init: true
       ) do
         def returned_count = messages.size
@@ -42,8 +30,9 @@ module Collavre
         # What the caller reads.
         def returned_chars = messages.sum { |m| m[:content].to_s.length }
 
-        # What the caller is charged: prose plus the envelope around it.
-        def billed_chars = messages.sum { |m| MessagePage.cost(m) }
+        # What the caller is charged: what emitting these messages in the
+        # requested format costs, which is not what their prose measures.
+        def billed_chars = messages.sum { |m| budget.cost(m) }
 
         # A clipped message is a partial answer that has_more cannot express:
         # the window did reach the end of the topic, it just could not print
@@ -55,8 +44,10 @@ module Collavre
         def next_offset = has_more? ? offset + returned_count : nil
       end
 
+      # budget carries both the cap and the format it is counted in — see
+      # CharBudget for why those cannot be separate arguments.
       def initialize(topic:, user:, offset: 0, limit: DEFAULT_LIMIT, order: DEFAULT_ORDER,
-                     include_system: false, max_message_id: nil, char_budget: nil)
+                     include_system: false, max_message_id: nil, budget: CharBudget.new)
         @topic = topic
         @user = user
         @offset = [ offset.to_i, 0 ].max
@@ -64,7 +55,7 @@ module Collavre
         @order = ORDERS.include?(order.to_s) ? order.to_s : DEFAULT_ORDER
         @include_system = include_system
         @max_message_id = max_message_id
-        @char_budget = char_budget
+        @budget = budget
       end
 
       def call
@@ -82,7 +73,8 @@ module Collavre
           limit: @limit,
           messages: @order == "asc" ? messages.reverse : messages,
           newest_message_id: @max_message_id,
-          budget_exhausted: @char_budget && messages.size < @limit && (@offset + messages.size) < stat.count
+          budget_exhausted: !@budget.unlimited? && messages.size < @limit && (@offset + messages.size) < stat.count,
+          budget: @budget
         )
       end
 
@@ -125,19 +117,19 @@ module Collavre
       # That one is clipped to what the budget can pay for, with the clip
       # announced in its own text, so the cap holds and the offset still moves.
       def within_budget(messages)
-        return messages if @char_budget.nil?
+        return messages if @budget.unlimited?
 
         spent = 0
         kept = []
         messages.each do |message|
-          cost = self.class.cost(message)
-          if spent + cost <= @char_budget
+          cost = @budget.cost(message)
+          if @budget.fits?(cost, spent: spent)
             kept << message
             spent += cost
             next
           end
 
-          clipped = kept.empty? ? clip(message, @char_budget) : nil
+          clipped = kept.empty? ? clip(message) : nil
           kept << clipped if clipped
           break
         end
@@ -147,13 +139,38 @@ module Collavre
       # Returns nil when the budget cannot pay even for the envelope and the
       # notice — there is no honest way to emit a fragment that small, and the
       # empty page carries budget_limited to say so.
-      def clip(message, budget)
+      def clip(message)
         content = message[:content].to_s
         notice = clip_notice(content.length)
-        room = budget - ENVELOPE_CHARS - message[:author].to_s.length - notice.length
+        room = widest_prefix(message, content, notice)
         return nil if room <= 0
 
-        message.merge(content: content[0, room] + notice, clipped: true)
+        clipped(message, content, notice, room)
+      end
+
+      # The longest prefix of the prose whose rendered cost still fits.
+      # Subtraction would do for markdown, where a character of content costs a
+      # character of output, but json escapes the prose while serializing it, so
+      # a slice can emit wider than it reads and arithmetic only gives an upper
+      # bound. Cost rises monotonically with the prefix, so the exact answer is
+      # a bisection — eighteen serializations at the largest cap, and only on
+      # the clip path, which is one message per call at most.
+      def widest_prefix(message, content, notice)
+        low = 0
+        high = content.length
+        while low < high
+          mid = (low + high + 1) / 2
+          if @budget.fits?(@budget.cost(clipped(message, content, notice, mid)))
+            low = mid
+          else
+            high = mid - 1
+          end
+        end
+        low
+      end
+
+      def clipped(message, content, notice, take)
+        message.merge(content: content[0, take] + notice, clipped: true)
       end
 
       # Counted against the budget like any other content, and phrased for the

--- a/engines/collavre/app/services/collavre/topics/message_page.rb
+++ b/engines/collavre/app/services/collavre/topics/message_page.rb
@@ -70,13 +70,28 @@ module Collavre
         @max_message_id = options[:max_message_id]
         @content_offset = [ options.fetch(:content_offset, 0).to_i, 0 ].max
         @cursor = decode_cursor(options[:cursor])
+        @topic_assigned_before = @cursor&.fetch(:topic_assigned_before)
         @budget = options.fetch(:budget, CharBudget.new)
       end
 
       def call
+        # CommentMoveService takes the destination topic lock before changing a
+        # comment's membership. Holding the same lock through the anchor and
+        # reads makes the assignment timestamp a commit-order boundary: a move
+        # is either wholly before this snapshot or wholly after it.
+        Topic.transaction do
+          lock_authorized_topic
+          build_page
+        end
+      end
+
+      private
+
+      def build_page
         anchor!
         stat = MessageStats.for(
-          [ @topic ], user: @user, include_system: @include_system, max_message_id: @max_message_id
+          [ @topic ], user: @user, include_system: @include_system,
+          max_message_id: @max_message_id, topic_assigned_before: @topic_assigned_before
         ).fetch(@topic.id)
         window = fetch_window
         content_offset = content_offset_for(window.first)
@@ -99,7 +114,12 @@ module Collavre
         )
       end
 
-      private
+      # Do not reload @topic here: TopicSelection already authorized its
+      # creative. If a concurrent TopicMove changed that creative, the exact
+      # authorized pair no longer locks or reads anything and fails closed.
+      def lock_authorized_topic
+        Topic.where(id: @topic.id, creative_id: @topic.creative_id).lock.pick(:id)
+      end
 
       # An unanchored call picks its own anchor before it reads anything else,
       # so the totals, the window and the advertised newest_message_id all
@@ -116,14 +136,17 @@ module Collavre
       # id, so it names the empty snapshot exactly, and Ruby's 0 is truthy —
       # a caller passing it back gets the same bound rather than a fresh anchor.
       def anchor!
+        @topic_assigned_before ||= Time.current
         @max_message_id ||= MessageScope.for(
-          @topic, user: @user, include_system: @include_system
+          @topic, user: @user, include_system: @include_system,
+          topic_assigned_before: @topic_assigned_before
         ).maximum(:id) || 0
       end
 
       def scope
         @scope ||= MessageScope.for(
-          @topic, user: @user, include_system: @include_system, max_message_id: @max_message_id
+          @topic, user: @user, include_system: @include_system,
+          max_message_id: @max_message_id, topic_assigned_before: @topic_assigned_before
         )
       end
 
@@ -180,24 +203,35 @@ module Collavre
       def encode_cursor(comment)
         return unless comment
 
-        "#{timestamp_micros(comment.created_at)}:#{comment.id}:#{timestamp_micros(comment.updated_at)}"
+        [
+          timestamp_micros(comment.created_at), comment.id,
+          timestamp_micros(comment.updated_at), timestamp_micros(@topic_assigned_before)
+        ].join(":")
       end
 
       def decode_cursor(value)
         return if value.blank?
 
-        match = /\A(\d{1,20}):(\d{1,20}):(\d{1,20})\z/.match(value.to_s)
+        match = /\A(\d{1,20}):(\d{1,20}):(\d{1,20}):(\d{1,20})\z/.match(value.to_s)
         raise ArgumentError, "cursor is invalid" unless match
 
         micros = Integer(match[1], 10)
         id = Integer(match[2], 10)
         updated_at_micros = Integer(match[3], 10)
-        raise ArgumentError, "cursor is invalid" unless micros.positive? && id.positive? && updated_at_micros.positive?
+        topic_assigned_before_micros = Integer(match[4], 10)
+        unless [ micros, id, updated_at_micros, topic_assigned_before_micros ].all?(&:positive?)
+          raise ArgumentError, "cursor is invalid"
+        end
 
         {
           created_at: Time.at(micros / 1_000_000, micros % 1_000_000, :microsecond).utc,
           id: id,
-          updated_at_micros: updated_at_micros
+          updated_at_micros: updated_at_micros,
+          topic_assigned_before: Time.at(
+            topic_assigned_before_micros / 1_000_000,
+            topic_assigned_before_micros % 1_000_000,
+            :microsecond
+          ).utc
         }
       rescue RangeError
         raise ArgumentError, "cursor is invalid"

--- a/engines/collavre/app/services/collavre/topics/message_page.rb
+++ b/engines/collavre/app/services/collavre/topics/message_page.rb
@@ -47,6 +47,7 @@ module Collavre
       end
 
       def call
+        anchor!
         stat = MessageStats.for(
           [ @topic ], user: @user, include_system: @include_system, max_message_id: @max_message_id
         ).fetch(@topic.id)
@@ -59,12 +60,25 @@ module Collavre
           offset: @offset,
           limit: @limit,
           messages: @order == "asc" ? messages.reverse : messages,
-          newest_message_id: @max_message_id || scope.maximum(:id),
+          newest_message_id: @max_message_id,
           budget_exhausted: @char_budget && messages.size < @limit && (@offset + messages.size) < stat.count
         )
       end
 
       private
+
+      # An unanchored call picks its own anchor before it reads anything else,
+      # so the totals, the window and the advertised newest_message_id all
+      # describe one snapshot. Reading the anchor last instead lets a message
+      # that arrives mid-call land in the totals but not the window, or be
+      # named as newest without having been returned — and the caller then
+      # pages with an anchor that shifts every offset under it, repeating one
+      # message and skipping another.
+      def anchor!
+        @max_message_id ||= MessageScope.for(
+          @topic, user: @user, include_system: @include_system
+        ).maximum(:id)
+      end
 
       def scope
         @scope ||= MessageScope.for(

--- a/engines/collavre/app/services/collavre/topics/message_page.rb
+++ b/engines/collavre/app/services/collavre/topics/message_page.rb
@@ -25,7 +25,7 @@ module Collavre
       Page = Struct.new(
         :topic, :total_count, :total_chars, :offset, :limit,
         :messages, :newest_message_id, :budget_exhausted, :budget,
-        :content_offset, :order,
+        :content_offset, :order, :next_cursor,
         keyword_init: true
       ) do
         def returned_count = messages.size
@@ -41,15 +41,15 @@ module Collavre
 
         def next_content_offset
           messages.filter_map { |message| message[:next_content_offset] }.first ||
-            (content_offset if messages.empty? && offset < total_count)
+            (content_offset if messages.empty? && next_cursor.present?)
         end
 
         # A clipped row is not consumed. The next call stays on the same row
         # and advances inside its content; only a complete row advances offset.
-        def has_more? = next_content_offset.present? || (offset + returned_count) < total_count
+        def has_more? = next_cursor.present?
 
         def next_offset
-          return offset if next_content_offset.present?
+          return offset if next_content_offset.present? || (messages.empty? && has_more?)
 
           has_more? ? offset + returned_count : nil
         end
@@ -59,7 +59,7 @@ module Collavre
       # CharBudget for why those cannot be separate arguments.
       def initialize(topic:, user:, **options)
         options.assert_valid_keys(
-          :offset, :limit, :order, :include_system, :max_message_id, :content_offset, :budget
+          :offset, :limit, :order, :include_system, :max_message_id, :content_offset, :cursor, :budget
         )
         @topic = topic
         @user = user
@@ -69,6 +69,7 @@ module Collavre
         @include_system = options.fetch(:include_system, false)
         @max_message_id = options[:max_message_id]
         @content_offset = [ options.fetch(:content_offset, 0).to_i, 0 ].max
+        @cursor = decode_cursor(options[:cursor])
         @budget = options.fetch(:budget, CharBudget.new)
       end
 
@@ -77,7 +78,9 @@ module Collavre
         stat = MessageStats.for(
           [ @topic ], user: @user, include_system: @include_system, max_message_id: @max_message_id
         ).fetch(@topic.id)
-        messages = within_budget(fetch_window)
+        window = fetch_window
+        messages = within_budget(serialize_window(window.first(@limit)))
+        next_cursor = encode_cursor(next_candidate(window, messages))
 
         Page.new(
           topic: @topic,
@@ -87,9 +90,10 @@ module Collavre
           limit: @limit,
           messages: @order == "asc" ? messages.reverse : messages,
           newest_message_id: @max_message_id,
-          budget_exhausted: budget_exhausted?(messages, stat),
+          budget_exhausted: budget_exhausted?(messages, next_cursor),
           content_offset: @content_offset,
           order: @order,
+          next_cursor: next_cursor,
           budget: @budget
         )
       end
@@ -126,11 +130,60 @@ module Collavre
       # clock tick would otherwise order arbitrarily, and an unstable sort makes
       # offset pagination drop and repeat rows across pages.
       def fetch_window
-        scope.includes(:user, images_attachments: :blob)
-             .order(created_at: :desc, id: :desc)
-             .offset(@offset)
-             .limit(@limit)
-             .map.with_index { |comment, index| serialize(comment, content_offset: index.zero? ? @content_offset : 0) }
+        relation = scope.includes(:user, images_attachments: :blob)
+                        .order(created_at: :desc, id: :desc)
+        relation = after_cursor(relation) if @cursor
+        relation = relation.offset(@offset) unless @cursor
+        relation.limit(@limit + 1).to_a
+      end
+
+      def serialize_window(comments)
+        comments.map.with_index do |comment, index|
+          serialize(comment, content_offset: index.zero? ? @content_offset : 0)
+        end
+      end
+
+      # The cursor names the first row not yet consumed, inclusively. This is
+      # what makes it survive that row itself being deleted or moved: the same
+      # ordered boundary still selects every older surviving row. During a
+      # clipped-row continuation it names the current row instead.
+      def next_candidate(window, messages)
+        return window.first if messages.empty? || messages.first[:clipped]
+
+        window[messages.length]
+      end
+
+      def after_cursor(relation)
+        relation.where(
+          "comments.created_at < :created_at OR " \
+            "(comments.created_at = :created_at AND comments.id <= :id)",
+          created_at: @cursor.fetch(:created_at), id: @cursor.fetch(:id)
+        )
+      end
+
+      def encode_cursor(comment)
+        return unless comment
+
+        micros = (comment.created_at.to_r * 1_000_000).to_i
+        "#{micros}:#{comment.id}"
+      end
+
+      def decode_cursor(value)
+        return if value.blank?
+
+        match = /\A(\d{1,20}):(\d{1,20})\z/.match(value.to_s)
+        raise ArgumentError, "cursor is invalid" unless match
+
+        micros = Integer(match[1], 10)
+        id = Integer(match[2], 10)
+        raise ArgumentError, "cursor is invalid" unless micros.positive? && id.positive?
+
+        {
+          created_at: Time.at(micros / 1_000_000, micros % 1_000_000, :microsecond).utc,
+          id: id
+        }
+      rescue RangeError
+        raise ArgumentError, "cursor is invalid"
       end
 
       # Trims the newest-first window to the character budget. A message that
@@ -250,11 +303,11 @@ module Collavre
         end.join("\n")
       end
 
-      def budget_exhausted?(messages, stat)
+      def budget_exhausted?(messages, next_cursor)
         return false if @budget.unlimited?
 
         messages.any? { |message| message[:clipped] } ||
-          (messages.size < @limit && (@offset + messages.size) < stat.count)
+          (messages.size < @limit && next_cursor.present?)
       end
 
       def clamp_limit(limit)

--- a/engines/collavre/app/services/collavre/topics/message_page.rb
+++ b/engines/collavre/app/services/collavre/topics/message_page.rb
@@ -23,7 +23,7 @@ module Collavre
       Page = Struct.new(
         :topic, :total_count, :total_chars, :offset, :limit,
         :messages, :newest_message_id, :budget_exhausted, :budget,
-        :content_offset,
+        :content_offset, :order,
         keyword_init: true
       ) do
         def returned_count = messages.size
@@ -87,6 +87,7 @@ module Collavre
           newest_message_id: @max_message_id,
           budget_exhausted: budget_exhausted?(messages, stat),
           content_offset: @content_offset,
+          order: @order,
           budget: @budget
         )
       end

--- a/engines/collavre/app/services/collavre/topics/message_page.rb
+++ b/engines/collavre/app/services/collavre/topics/message_page.rb
@@ -87,10 +87,17 @@ module Collavre
       # named as newest without having been returned — and the caller then
       # pages with an anchor that shifts every offset under it, repeating one
       # message and skipping another.
+      #
+      # An empty topic anchors at 0 rather than nil, because nil is how this
+      # scope spells "unbounded": leaving it there would let a message arriving
+      # between the anchor and the totals query into both, and then advertise
+      # no anchor for the caller to pin the next page with. Zero is below every
+      # id, so it names the empty snapshot exactly, and Ruby's 0 is truthy —
+      # a caller passing it back gets the same bound rather than a fresh anchor.
       def anchor!
         @max_message_id ||= MessageScope.for(
           @topic, user: @user, include_system: @include_system
-        ).maximum(:id)
+        ).maximum(:id) || 0
       end
 
       def scope

--- a/engines/collavre/app/services/collavre/topics/message_page.rb
+++ b/engines/collavre/app/services/collavre/topics/message_page.rb
@@ -10,6 +10,8 @@ module Collavre
     # change as the topic grows — an oldest-first offset would point somewhere
     # different every time a message arrived.
     class MessagePage
+      include Collavre::PublicAssetsHelper
+
       DEFAULT_LIMIT = 50
       MAX_LIMIT = 200
 
@@ -124,7 +126,7 @@ module Collavre
       # clock tick would otherwise order arbitrarily, and an unstable sort makes
       # offset pagination drop and repeat rows across pages.
       def fetch_window
-        scope.includes(:user)
+        scope.includes(:user, images_attachments: :blob)
              .order(created_at: :desc, id: :desc)
              .offset(@offset)
              .limit(@limit)
@@ -213,7 +215,7 @@ module Collavre
       end
 
       def serialize(comment, content_offset:)
-        content = Collavre::HtmlText.plain(comment.content).strip
+        content = serialized_content(comment)
         start = [ content_offset, content.length ].min
         message = {
           id: comment.id,
@@ -230,6 +232,22 @@ module Collavre
           content_end_offset: content.length,
           content_total_chars: content.length
         )
+      end
+
+      # Image metadata lives inside the pageable content rather than beside it.
+      # That keeps image-only comments meaningful while letting max_chars and
+      # content_offset bound and continue an arbitrarily large attachment list
+      # through the same contract as the message prose.
+      def serialized_content(comment)
+        text = Collavre::HtmlText.plain(comment.content).strip
+        [ text.presence, image_markers(comment).presence ].compact.join("\n\n")
+      end
+
+      def image_markers(comment)
+        comment.images.map.with_index(1) do |image, index|
+          "[Image attachment #{index}: #{image.filename.sanitized} " \
+            "(#{image.content_type}, #{image.byte_size} bytes) — #{public_asset_url(image.blob)}]"
+        end.join("\n")
       end
 
       def budget_exhausted?(messages, stat)

--- a/engines/collavre/app/services/collavre/topics/message_page.rb
+++ b/engines/collavre/app/services/collavre/topics/message_page.rb
@@ -79,7 +79,8 @@ module Collavre
           [ @topic ], user: @user, include_system: @include_system, max_message_id: @max_message_id
         ).fetch(@topic.id)
         window = fetch_window
-        messages = within_budget(serialize_window(window.first(@limit)))
+        content_offset = content_offset_for(window.first)
+        messages = within_budget(serialize_window(window.first(@limit), content_offset: content_offset))
         next_cursor = encode_cursor(next_candidate(window, messages))
 
         Page.new(
@@ -91,7 +92,7 @@ module Collavre
           messages: @order == "asc" ? messages.reverse : messages,
           newest_message_id: @max_message_id,
           budget_exhausted: budget_exhausted?(messages, next_cursor),
-          content_offset: @content_offset,
+          content_offset: content_offset,
           order: @order,
           next_cursor: next_cursor,
           budget: @budget
@@ -137,10 +138,20 @@ module Collavre
         relation.limit(@limit + 1).to_a
       end
 
-      def serialize_window(comments)
+      def serialize_window(comments, content_offset:)
         comments.map.with_index do |comment, index|
-          serialize(comment, content_offset: index.zero? ? @content_offset : 0)
+          serialize(comment, content_offset: index.zero? ? content_offset : 0)
         end
+      end
+
+      # A content offset belongs to the row named by the cursor. If that row
+      # leaves the topic, the inclusive keyset boundary correctly selects the
+      # next surviving row, but its content must start at zero.
+      def content_offset_for(first_comment)
+        return @content_offset unless @cursor
+        return @content_offset if first_comment&.id == @cursor.fetch(:id)
+
+        0
       end
 
       # The cursor names the first row not yet consumed, inclusively. This is

--- a/engines/collavre/app/services/collavre/topics/message_page.rb
+++ b/engines/collavre/app/services/collavre/topics/message_page.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+module Collavre
+  module Topics
+    # One newest-first window of a topic's messages.
+    #
+    # Newest-first is the ordering the window is *selected* in: offset 0 is the
+    # latest message. A conversation's recent end is the part worth reading when
+    # you can only afford part of it, and it is the part whose position does not
+    # change as the topic grows — an oldest-first offset would point somewhere
+    # different every time a message arrived.
+    class MessagePage
+      DEFAULT_LIMIT = 50
+      MAX_LIMIT = 200
+
+      # Rendered oldest-first inside the window by default. The window is chosen
+      # from the newest end; how it reads once chosen is a separate question,
+      # and a summary written from a backwards transcript inverts cause and
+      # effect. Callers wanting the raw newest-first order pass order: "desc".
+      ORDERS = %w[asc desc].freeze
+      DEFAULT_ORDER = "asc"
+
+      Page = Struct.new(
+        :topic, :total_count, :total_chars, :offset, :limit,
+        :messages, :newest_message_id, :budget_exhausted,
+        keyword_init: true
+      ) do
+        def returned_count = messages.size
+
+        def returned_chars = messages.sum { |m| m[:content].to_s.length }
+
+        def has_more? = (offset + returned_count) < total_count
+
+        def next_offset = has_more? ? offset + returned_count : nil
+      end
+
+      def initialize(topic:, user:, offset: 0, limit: DEFAULT_LIMIT, order: DEFAULT_ORDER,
+                     include_system: false, max_message_id: nil, char_budget: nil)
+        @topic = topic
+        @user = user
+        @offset = [ offset.to_i, 0 ].max
+        @limit = clamp_limit(limit)
+        @order = ORDERS.include?(order.to_s) ? order.to_s : DEFAULT_ORDER
+        @include_system = include_system
+        @max_message_id = max_message_id
+        @char_budget = char_budget
+      end
+
+      def call
+        stat = MessageStats.for(
+          [ @topic ], user: @user, include_system: @include_system, max_message_id: @max_message_id
+        ).fetch(@topic.id)
+        messages = within_budget(fetch_window)
+
+        Page.new(
+          topic: @topic,
+          total_count: stat.count,
+          total_chars: stat.chars,
+          offset: @offset,
+          limit: @limit,
+          messages: @order == "asc" ? messages.reverse : messages,
+          newest_message_id: @max_message_id || scope.maximum(:id),
+          budget_exhausted: @char_budget && messages.size < @limit && (@offset + messages.size) < stat.count
+        )
+      end
+
+      private
+
+      def scope
+        @scope ||= MessageScope.for(
+          @topic, user: @user, include_system: @include_system, max_message_id: @max_message_id
+        )
+      end
+
+      # id is the tiebreak, not decoration: comments posted inside the same
+      # clock tick would otherwise order arbitrarily, and an unstable sort makes
+      # offset pagination drop and repeat rows across pages.
+      def fetch_window
+        scope.includes(:user)
+             .order(created_at: :desc, id: :desc)
+             .offset(@offset)
+             .limit(@limit)
+             .map { |comment| serialize(comment) }
+      end
+
+      # Trims the newest-first window to the character budget. A message that
+      # crosses the budget is kept whole rather than cut — a half message is
+      # worse than one message too many, and stopping *before* it could return
+      # zero rows and leave the caller paginating forever against an offset that
+      # never advances.
+      def within_budget(messages)
+        return messages if @char_budget.nil?
+
+        spent = 0
+        kept = []
+        messages.each do |message|
+          break if spent >= @char_budget
+
+          kept << message
+          spent += message[:content].to_s.length
+        end
+        kept
+      end
+
+      def serialize(comment)
+        {
+          id: comment.id,
+          author: comment.user&.display_name || "system",
+          author_id: comment.user_id,
+          agent: comment.user&.ai_user? || false,
+          created_at: comment.created_at&.iso8601,
+          content: Collavre::HtmlText.plain(comment.content).strip
+        }
+      end
+
+      def clamp_limit(limit)
+        limit = limit.to_i
+        return DEFAULT_LIMIT if limit <= 0
+
+        [ limit, MAX_LIMIT ].min
+      end
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/topics/message_page.rb
+++ b/engines/collavre/app/services/collavre/topics/message_page.rb
@@ -45,6 +45,11 @@ module Collavre
         # What the caller is charged: prose plus the envelope around it.
         def billed_chars = messages.sum { |m| MessagePage.cost(m) }
 
+        # A clipped message is a partial answer that has_more cannot express:
+        # the window did reach the end of the topic, it just could not print
+        # all of the last thing it found.
+        def clipped_count = messages.count { |m| m[:clipped] }
+
         def has_more? = (offset + returned_count) < total_count
 
         def next_offset = has_more? ? offset + returned_count : nil
@@ -114,22 +119,48 @@ module Collavre
       end
 
       # Trims the newest-first window to the character budget. A message that
-      # crosses the budget is kept whole rather than cut — a half message is
-      # worse than one message too many, and stopping *before* it could return
-      # zero rows and leave the caller paginating forever against an offset that
-      # never advances.
+      # does not fit ends the window rather than being cut in half — except for
+      # the first one, where stopping short would return zero rows at an offset
+      # that does have rows and leave the caller paging against it forever.
+      # That one is clipped to what the budget can pay for, with the clip
+      # announced in its own text, so the cap holds and the offset still moves.
       def within_budget(messages)
         return messages if @char_budget.nil?
 
         spent = 0
         kept = []
         messages.each do |message|
-          break if spent >= @char_budget
+          cost = self.class.cost(message)
+          if spent + cost <= @char_budget
+            kept << message
+            spent += cost
+            next
+          end
 
-          kept << message
-          spent += self.class.cost(message)
+          clipped = kept.empty? ? clip(message, @char_budget) : nil
+          kept << clipped if clipped
+          break
         end
         kept
+      end
+
+      # Returns nil when the budget cannot pay even for the envelope and the
+      # notice — there is no honest way to emit a fragment that small, and the
+      # empty page carries budget_limited to say so.
+      def clip(message, budget)
+        content = message[:content].to_s
+        notice = clip_notice(content.length)
+        room = budget - ENVELOPE_CHARS - message[:author].to_s.length - notice.length
+        return nil if room <= 0
+
+        message.merge(content: content[0, room] + notice, clipped: true)
+      end
+
+      # Counted against the budget like any other content, and phrased for the
+      # reader of the transcript: the caller sees the clip where the words stop,
+      # not only in a flag on the payload it may have rendered away.
+      def clip_notice(total)
+        "…[clipped from #{total} chars — raise max_chars for the rest]"
       end
 
       def serialize(comment)

--- a/engines/collavre/app/services/collavre/topics/message_page.rb
+++ b/engines/collavre/app/services/collavre/topics/message_page.rb
@@ -149,9 +149,14 @@ module Collavre
       # next surviving row, but its content must start at zero.
       def content_offset_for(first_comment)
         return @content_offset unless @cursor
-        return @content_offset if first_comment&.id == @cursor.fetch(:id)
+        return @content_offset if cursor_row_unchanged?(first_comment)
 
         0
+      end
+
+      def cursor_row_unchanged?(comment)
+        comment&.id == @cursor.fetch(:id) &&
+          timestamp_micros(comment.updated_at) == @cursor.fetch(:updated_at_micros)
       end
 
       # The cursor names the first row not yet consumed, inclusively. This is
@@ -175,26 +180,31 @@ module Collavre
       def encode_cursor(comment)
         return unless comment
 
-        micros = (comment.created_at.to_r * 1_000_000).to_i
-        "#{micros}:#{comment.id}"
+        "#{timestamp_micros(comment.created_at)}:#{comment.id}:#{timestamp_micros(comment.updated_at)}"
       end
 
       def decode_cursor(value)
         return if value.blank?
 
-        match = /\A(\d{1,20}):(\d{1,20})\z/.match(value.to_s)
+        match = /\A(\d{1,20}):(\d{1,20}):(\d{1,20})\z/.match(value.to_s)
         raise ArgumentError, "cursor is invalid" unless match
 
         micros = Integer(match[1], 10)
         id = Integer(match[2], 10)
-        raise ArgumentError, "cursor is invalid" unless micros.positive? && id.positive?
+        updated_at_micros = Integer(match[3], 10)
+        raise ArgumentError, "cursor is invalid" unless micros.positive? && id.positive? && updated_at_micros.positive?
 
         {
           created_at: Time.at(micros / 1_000_000, micros % 1_000_000, :microsecond).utc,
-          id: id
+          id: id,
+          updated_at_micros: updated_at_micros
         }
       rescue RangeError
         raise ArgumentError, "cursor is invalid"
+      end
+
+      def timestamp_micros(time)
+        (time.to_r * 1_000_000).to_i
       end
 
       # Trims the newest-first window to the character budget. A message that

--- a/engines/collavre/app/services/collavre/topics/message_page.rb
+++ b/engines/collavre/app/services/collavre/topics/message_page.rb
@@ -23,6 +23,7 @@ module Collavre
       Page = Struct.new(
         :topic, :total_count, :total_chars, :offset, :limit,
         :messages, :newest_message_id, :budget_exhausted, :budget,
+        :content_offset,
         keyword_init: true
       ) do
         def returned_count = messages.size
@@ -34,28 +35,39 @@ module Collavre
         # requested format costs, which is not what their prose measures.
         def billed_chars = messages.sum { |m| budget.cost(m) }
 
-        # A clipped message is a partial answer that has_more cannot express:
-        # the window did reach the end of the topic, it just could not print
-        # all of the last thing it found.
         def clipped_count = messages.count { |m| m[:clipped] }
 
-        def has_more? = (offset + returned_count) < total_count
+        def next_content_offset
+          messages.filter_map { |message| message[:next_content_offset] }.first ||
+            (content_offset if messages.empty? && offset < total_count)
+        end
 
-        def next_offset = has_more? ? offset + returned_count : nil
+        # A clipped row is not consumed. The next call stays on the same row
+        # and advances inside its content; only a complete row advances offset.
+        def has_more? = next_content_offset.present? || (offset + returned_count) < total_count
+
+        def next_offset
+          return offset if next_content_offset.present?
+
+          has_more? ? offset + returned_count : nil
+        end
       end
 
       # budget carries both the cap and the format it is counted in — see
       # CharBudget for why those cannot be separate arguments.
-      def initialize(topic:, user:, offset: 0, limit: DEFAULT_LIMIT, order: DEFAULT_ORDER,
-                     include_system: false, max_message_id: nil, budget: CharBudget.new)
+      def initialize(topic:, user:, **options)
+        options.assert_valid_keys(
+          :offset, :limit, :order, :include_system, :max_message_id, :content_offset, :budget
+        )
         @topic = topic
         @user = user
-        @offset = [ offset.to_i, 0 ].max
-        @limit = clamp_limit(limit)
-        @order = ORDERS.include?(order.to_s) ? order.to_s : DEFAULT_ORDER
-        @include_system = include_system
-        @max_message_id = max_message_id
-        @budget = budget
+        @offset = [ options.fetch(:offset, 0).to_i, 0 ].max
+        @limit = clamp_limit(options.fetch(:limit, DEFAULT_LIMIT))
+        @order = normalized_order(options.fetch(:order, DEFAULT_ORDER))
+        @include_system = options.fetch(:include_system, false)
+        @max_message_id = options[:max_message_id]
+        @content_offset = [ options.fetch(:content_offset, 0).to_i, 0 ].max
+        @budget = options.fetch(:budget, CharBudget.new)
       end
 
       def call
@@ -73,7 +85,8 @@ module Collavre
           limit: @limit,
           messages: @order == "asc" ? messages.reverse : messages,
           newest_message_id: @max_message_id,
-          budget_exhausted: !@budget.unlimited? && messages.size < @limit && (@offset + messages.size) < stat.count,
+          budget_exhausted: budget_exhausted?(messages, stat),
+          content_offset: @content_offset,
           budget: @budget
         )
       end
@@ -114,15 +127,15 @@ module Collavre
              .order(created_at: :desc, id: :desc)
              .offset(@offset)
              .limit(@limit)
-             .map { |comment| serialize(comment) }
+             .map.with_index { |comment, index| serialize(comment, content_offset: index.zero? ? @content_offset : 0) }
       end
 
       # Trims the newest-first window to the character budget. A message that
       # does not fit ends the window rather than being cut in half — except for
       # the first one, where stopping short would return zero rows at an offset
       # that does have rows and leave the caller paging against it forever.
-      # That one is clipped to what the budget can pay for, with the clip
-      # announced in its own text, so the cap holds and the offset still moves.
+      # That one is clipped to what the budget can pay for and exposes a content
+      # continuation. The row offset stays put until all of its prose is read.
       def within_budget(messages)
         return messages if @budget.unlimited?
 
@@ -148,11 +161,10 @@ module Collavre
       # empty page carries budget_limited to say so.
       def clip(message)
         content = message[:content].to_s
-        notice = clip_notice(content.length)
-        room = widest_prefix(message, content, notice)
+        room = widest_prefix(message, content)
         return nil if room <= 0
 
-        clipped(message, content, notice, room)
+        clipped(message, content, room)
       end
 
       # The longest prefix of the prose whose rendered cost still fits.
@@ -162,12 +174,12 @@ module Collavre
       # bound. Cost rises monotonically with the prefix, so the exact answer is
       # a bisection — eighteen serializations at the largest cap, and only on
       # the clip path, which is one message per call at most.
-      def widest_prefix(message, content, notice)
+      def widest_prefix(message, content)
         low = 0
         high = content.length
         while low < high
           mid = (low + high + 1) / 2
-          if @budget.fits?(@budget.cost(clipped(message, content, notice, mid)))
+          if @budget.fits?(@budget.cost(clipped(message, content, mid)))
             low = mid
           else
             high = mid - 1
@@ -176,26 +188,54 @@ module Collavre
         low
       end
 
-      def clipped(message, content, notice, take)
-        message.merge(content: content[0, take] + notice, clipped: true)
+      def clipped(message, content, take)
+        start = message[:content_offset].to_i
+        finish = start + take
+        total = message[:content_total_chars] || content.length
+
+        message.merge(
+          content: content[0, take],
+          content_offset: start,
+          content_end_offset: finish,
+          content_total_chars: total,
+          next_content_offset: finish,
+          clip_notice: clip_notice(finish, total),
+          clipped: true
+        )
       end
 
       # Counted against the budget like any other content, and phrased for the
       # reader of the transcript: the caller sees the clip where the words stop,
       # not only in a flag on the payload it may have rendered away.
-      def clip_notice(total)
-        "…[clipped from #{total} chars — raise max_chars for the rest]"
+      def clip_notice(next_offset, total)
+        "…[clipped at #{next_offset} of #{total} chars — continue with content_offset: #{next_offset}]"
       end
 
-      def serialize(comment)
-        {
+      def serialize(comment, content_offset:)
+        content = Collavre::HtmlText.plain(comment.content).strip
+        start = [ content_offset, content.length ].min
+        message = {
           id: comment.id,
           author: comment.user&.display_name || "system",
           author_id: comment.user_id,
           agent: comment.user&.ai_user? || false,
           created_at: comment.created_at&.iso8601,
-          content: Collavre::HtmlText.plain(comment.content).strip
+          content: content[start..] || ""
         }
+        return message if start.zero?
+
+        message.merge(
+          content_offset: start,
+          content_end_offset: content.length,
+          content_total_chars: content.length
+        )
+      end
+
+      def budget_exhausted?(messages, stat)
+        return false if @budget.unlimited?
+
+        messages.any? { |message| message[:clipped] } ||
+          (messages.size < @limit && (@offset + messages.size) < stat.count)
       end
 
       def clamp_limit(limit)
@@ -203,6 +243,10 @@ module Collavre
         return DEFAULT_LIMIT if limit <= 0
 
         [ limit, MAX_LIMIT ].min
+      end
+
+      def normalized_order(order)
+        ORDERS.include?(order.to_s) ? order.to_s : DEFAULT_ORDER
       end
     end
   end

--- a/engines/collavre/app/services/collavre/topics/message_page_markdown.rb
+++ b/engines/collavre/app/services/collavre/topics/message_page_markdown.rb
@@ -52,11 +52,20 @@ module Collavre
       # decode. max_message_id is repeated into it because that is the whole
       # point of the anchor — a caller that drops it silently re-reads messages
       # as the topic grows underneath the pagination.
+      #
+      # include_system is repeated for the same reason, and it matters more:
+      # the anchor shifts rows, but a narrower scope renumbers them. Paging
+      # into a set that no longer contains the system rows the first page
+      # counted lands the offset past messages that were never returned.
       def continuation(entry)
         return [] unless entry[:has_more]
 
         [ "More: topic_messages(topic_ids: #{entry[:topic_id]}, offset: #{entry[:next_offset]}, " \
-          "max_message_id: #{entry[:newest_message_id]})" ]
+          "max_message_id: #{entry[:newest_message_id]}#{scope_option(entry)})" ]
+      end
+
+      def scope_option(entry)
+        entry[:include_system] ? ", include_system: true" : ""
       end
 
       def skipped_notice(entry)

--- a/engines/collavre/app/services/collavre/topics/message_page_markdown.rb
+++ b/engines/collavre/app/services/collavre/topics/message_page_markdown.rb
@@ -61,6 +61,7 @@ module Collavre
         return [] unless entry[:has_more]
 
         [ "More: topic_messages(topic_ids: #{entry[:topic_id]}, offset: #{entry[:next_offset]}, " \
+          "cursor: \"#{entry[:next_cursor]}\", " \
           "max_message_id: #{entry[:newest_message_id]}, limit: #{entry[:limit]}, " \
           "max_chars: #{entry[:max_chars]}#{content_option(entry)}" \
           "#{order_option(entry)}#{scope_option(entry)})" ]

--- a/engines/collavre/app/services/collavre/topics/message_page_markdown.rb
+++ b/engines/collavre/app/services/collavre/topics/message_page_markdown.rb
@@ -61,7 +61,11 @@ module Collavre
         return [] unless entry[:has_more]
 
         [ "More: topic_messages(topic_ids: #{entry[:topic_id]}, offset: #{entry[:next_offset]}, " \
-          "max_message_id: #{entry[:newest_message_id]}#{scope_option(entry)})" ]
+          "max_message_id: #{entry[:newest_message_id]}#{content_option(entry)}#{scope_option(entry)})" ]
+      end
+
+      def content_option(entry)
+        entry[:next_content_offset] ? ", content_offset: #{entry[:next_content_offset]}" : ""
       end
 
       def scope_option(entry)
@@ -76,8 +80,9 @@ module Collavre
       # forwards even though the window was chosen from the newest end.
       def body(entry)
         entry[:messages].map do |message|
-          "[#{message[:id]}] #{message[:created_at]} #{message[:author]}" \
+          rendered = "[#{message[:id]}] #{message[:created_at]} #{message[:author]}" \
             "#{message[:agent] ? ' (agent)' : ''}\n#{message[:content]}\n"
+          message[:clip_notice] ? "#{rendered}#{message[:clip_notice]}\n" : rendered
         end
       end
 

--- a/engines/collavre/app/services/collavre/topics/message_page_markdown.rb
+++ b/engines/collavre/app/services/collavre/topics/message_page_markdown.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+module Collavre
+  module Topics
+    # Renders the topic_messages payload as markdown.
+    #
+    # Renders the *payload*, not the records, so the markdown and json formats
+    # of the same call cannot disagree about what was returned — the json branch
+    # returns the identical hash this reads.
+    #
+    # Markdown is the default format because the content is prose. Wrapping
+    # conversation in JSON escaping costs a large fraction of the character
+    # budget the paging exists to protect, and buys nothing: the caller is going
+    # to read the words, not index into them.
+    module MessagePageMarkdown
+      module_function
+
+      def call(payload)
+        sections = payload[:topics].map { |topic| render_topic(topic) }
+        sections << truncation_notice if payload[:truncated]
+        sections.join("\n")
+      end
+
+      def render_topic(entry)
+        return render_error(entry) if entry[:error]
+        return "#{title(entry)}\n#{skipped_notice(entry)}\n" if entry[:skipped_reason]
+
+        [ header(entry), *continuation(entry), "", *body(entry) ].join("\n")
+      end
+
+      def render_error(entry)
+        "## [topic #{entry[:topic_id]}] unavailable\n#{entry[:error]}\n"
+      end
+
+      def title(entry)
+        "## [topic #{entry[:topic_id]}] #{entry[:topic_name]} (creative #{entry[:creative_id]})"
+      end
+
+      def header(entry)
+        "#{title(entry)}\n" \
+          "#{entry[:total_count]} messages, ~#{entry[:total_chars]} raw chars — " \
+          "showing #{shown_range(entry)} of #{entry[:total_count]}, newest-first window"
+      end
+
+      def shown_range(entry)
+        return "none" if entry[:returned_count].to_i.zero?
+
+        "#{entry[:offset]}-#{entry[:offset] + entry[:returned_count] - 1}"
+      end
+
+      # The next call is spelled out rather than left as a next_offset field to
+      # decode. max_message_id is repeated into it because that is the whole
+      # point of the anchor — a caller that drops it silently re-reads messages
+      # as the topic grows underneath the pagination.
+      def continuation(entry)
+        return [] unless entry[:has_more]
+
+        [ "More: topic_messages(topic_ids: #{entry[:topic_id]}, offset: #{entry[:next_offset]}, " \
+          "max_message_id: #{entry[:newest_message_id]})" ]
+      end
+
+      def skipped_notice(entry)
+        "Not fetched: #{entry[:skipped_reason]}. Re-request this topic alone, or raise max_chars."
+      end
+
+      # Oldest-to-newest within the window by default, so the transcript reads
+      # forwards even though the window was chosen from the newest end.
+      def body(entry)
+        entry[:messages].map do |message|
+          "[#{message[:id]}] #{message[:created_at]} #{message[:author]}" \
+            "#{message[:agent] ? ' (agent)' : ''}\n#{message[:content]}\n"
+        end
+      end
+
+      def truncation_notice
+        "> Output hit max_chars. Topics above may be partial — see each topic's " \
+          "\"More:\" line, or request fewer topics per call.\n"
+      end
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/topics/message_page_markdown.rb
+++ b/engines/collavre/app/services/collavre/topics/message_page_markdown.rb
@@ -61,7 +61,8 @@ module Collavre
         return [] unless entry[:has_more]
 
         [ "More: topic_messages(topic_ids: #{entry[:topic_id]}, offset: #{entry[:next_offset]}, " \
-          "max_message_id: #{entry[:newest_message_id]}#{content_option(entry)}" \
+          "max_message_id: #{entry[:newest_message_id]}, limit: #{entry[:limit]}, " \
+          "max_chars: #{entry[:max_chars]}#{content_option(entry)}" \
           "#{order_option(entry)}#{scope_option(entry)})" ]
       end
 

--- a/engines/collavre/app/services/collavre/topics/message_page_markdown.rb
+++ b/engines/collavre/app/services/collavre/topics/message_page_markdown.rb
@@ -61,11 +61,16 @@ module Collavre
         return [] unless entry[:has_more]
 
         [ "More: topic_messages(topic_ids: #{entry[:topic_id]}, offset: #{entry[:next_offset]}, " \
-          "max_message_id: #{entry[:newest_message_id]}#{content_option(entry)}#{scope_option(entry)})" ]
+          "max_message_id: #{entry[:newest_message_id]}#{content_option(entry)}" \
+          "#{order_option(entry)}#{scope_option(entry)})" ]
       end
 
       def content_option(entry)
         entry[:next_content_offset] ? ", content_offset: #{entry[:next_content_offset]}" : ""
+      end
+
+      def order_option(entry)
+        entry[:order] == "desc" ? ', order: "desc"' : ""
       end
 
       def scope_option(entry)

--- a/engines/collavre/app/services/collavre/topics/message_scope.rb
+++ b/engines/collavre/app/services/collavre/topics/message_scope.rb
@@ -24,11 +24,10 @@ module Collavre
       # comment belongs to its author and approver, and a tool must not be the
       # way around that.
       #
-      # max_message_id freezes the window. Newest-first offset pagination drifts
-      # when the topic is live — a message posted between page 1 and page 2
-      # shifts every later row down one, so the caller re-reads one message and
-      # never sees another. Passing back the newest_message_id from the first
-      # page pins every subsequent page to the same snapshot.
+      # max_message_id excludes rows created after the first page. MessagePage's
+      # keyset cursor separately protects the other direction of drift: rows
+      # already returned can leave the topic without shifting unread survivors
+      # ahead of a numeric offset.
       def for(topic, user:, include_system: false, max_message_id: nil)
         for_ids([ topic.id ], user: user, include_system: include_system, max_message_id: max_message_id)
       end

--- a/engines/collavre/app/services/collavre/topics/message_scope.rb
+++ b/engines/collavre/app/services/collavre/topics/message_scope.rb
@@ -9,15 +9,20 @@ module Collavre
       module_function
 
       # include_system: false is the default because the caller is almost always
-      # summarizing a conversation. Authorless rows are the timeline's
-      # furniture — "⏳" concurrency notices, channel announcements — and
-      # approval-action rows are the approval surface, which
-      # Comment.without_approval_action already keeps away from agents
-      # everywhere else. Leaving them in would spend the caller's character
-      # budget on text nobody wrote.
+      # summarizing a conversation, and authorless rows are the timeline's
+      # furniture — "⏳" concurrency notices, channel announcements. Leaving
+      # them in would spend the caller's character budget on text nobody wrote.
       #
-      # visible_to is applied unconditionally: a private comment belongs to its
-      # author and approver, and a tool must not be the way around that.
+      # without_approval_action is NOT part of that switch. Approval-surface
+      # rows are excluded unconditionally, because Comment.without_approval_action
+      # carries an invariant these tools do not get to opt out of: an approval
+      # prompt must never reach an agent as history or trigger context. Every
+      # other agent-context query in the engine applies it the same way, and a
+      # read tool is exactly the back door that invariant exists to close.
+      #
+      # visible_to is applied unconditionally for the same reason: a private
+      # comment belongs to its author and approver, and a tool must not be the
+      # way around that.
       #
       # max_message_id freezes the window. Newest-first offset pagination drifts
       # when the topic is live — a message posted between page 1 and page 2
@@ -30,8 +35,8 @@ module Collavre
 
       # Same rules across many topics at once, for the grouped totals query.
       def for_ids(topic_ids, user:, include_system: false, max_message_id: nil)
-        scope = Comment.where(topic_id: topic_ids).visible_to(user)
-        scope = scope.without_approval_action.where.not(user_id: nil) unless include_system
+        scope = Comment.where(topic_id: topic_ids).visible_to(user).without_approval_action
+        scope = scope.where.not(user_id: nil) unless include_system
         scope = scope.where("comments.id <= ?", max_message_id) if max_message_id
         scope
       end

--- a/engines/collavre/app/services/collavre/topics/message_scope.rb
+++ b/engines/collavre/app/services/collavre/topics/message_scope.rb
@@ -29,15 +29,28 @@ module Collavre
       # already returned can leave the topic without shifting unread survivors
       # ahead of a numeric offset.
       def for(topic, user:, include_system: false, max_message_id: nil)
-        for_ids([ topic.id ], user: user, include_system: include_system, max_message_id: max_message_id)
+        for_topics([ topic ], user: user, include_system: include_system, max_message_id: max_message_id)
       end
 
-      # Same rules across many topics at once, for the grouped totals query.
-      def for_ids(topic_ids, user:, include_system: false, max_message_id: nil)
-        scope = Comment.where(topic_id: topic_ids).visible_to(user).without_approval_action
+      # Pair every topic id with the creative that was authorized. TopicMove
+      # preserves the topic id while relocating all of its comments, so an
+      # id-only query could read the destination creative after the permission
+      # check. The exact pair also avoids cross-topic matches in batch totals.
+      def for_topics(topics, user:, include_system: false, max_message_id: nil)
+        membership = topic_membership(topics)
+        return Comment.none unless membership
+
+        scope = Comment.where(membership).visible_to(user).without_approval_action
         scope = scope.where.not(user_id: nil) unless include_system
         scope = scope.where("comments.id <= ?", max_message_id) if max_message_id
         scope
+      end
+
+      def topic_membership(topics)
+        table = Comment.arel_table
+        Array(topics).map do |topic|
+          table[:topic_id].eq(topic.id).and(table[:creative_id].eq(topic.creative_id))
+        end.reduce { |combined, pair| combined.or(pair) }
       end
     end
   end

--- a/engines/collavre/app/services/collavre/topics/message_scope.rb
+++ b/engines/collavre/app/services/collavre/topics/message_scope.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Collavre
+  module Topics
+    # The one definition of "the messages of a topic" that the read tools share,
+    # so a count reported by topic_list and a page returned by topic_messages
+    # can never describe different sets.
+    module MessageScope
+      module_function
+
+      # include_system: false is the default because the caller is almost always
+      # summarizing a conversation. Authorless rows are the timeline's
+      # furniture — "⏳" concurrency notices, channel announcements — and
+      # approval-action rows are the approval surface, which
+      # Comment.without_approval_action already keeps away from agents
+      # everywhere else. Leaving them in would spend the caller's character
+      # budget on text nobody wrote.
+      #
+      # visible_to is applied unconditionally: a private comment belongs to its
+      # author and approver, and a tool must not be the way around that.
+      #
+      # max_message_id freezes the window. Newest-first offset pagination drifts
+      # when the topic is live — a message posted between page 1 and page 2
+      # shifts every later row down one, so the caller re-reads one message and
+      # never sees another. Passing back the newest_message_id from the first
+      # page pins every subsequent page to the same snapshot.
+      def for(topic, user:, include_system: false, max_message_id: nil)
+        for_ids([ topic.id ], user: user, include_system: include_system, max_message_id: max_message_id)
+      end
+
+      # Same rules across many topics at once, for the grouped totals query.
+      def for_ids(topic_ids, user:, include_system: false, max_message_id: nil)
+        scope = Comment.where(topic_id: topic_ids).visible_to(user)
+        scope = scope.without_approval_action.where.not(user_id: nil) unless include_system
+        scope = scope.where("comments.id <= ?", max_message_id) if max_message_id
+        scope
+      end
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/topics/message_scope.rb
+++ b/engines/collavre/app/services/collavre/topics/message_scope.rb
@@ -24,25 +24,29 @@ module Collavre
       # comment belongs to its author and approver, and a tool must not be the
       # way around that.
       #
-      # max_message_id excludes rows created after the first page. MessagePage's
-      # keyset cursor separately protects the other direction of drift: rows
-      # already returned can leave the topic without shifting unread survivors
-      # ahead of a numeric offset.
-      def for(topic, user:, include_system: false, max_message_id: nil)
-        for_topics([ topic ], user: user, include_system: include_system, max_message_id: max_message_id)
+      # max_message_id excludes rows created after the first page. The topic
+      # assignment anchor excludes older rows moved in after that page, while
+      # MessagePage's keyset cursor lets rows leave without shifting unread
+      # survivors ahead of a numeric offset.
+      def for(topic, user:, include_system: false, max_message_id: nil, topic_assigned_before: nil)
+        for_topics(
+          [ topic ], user: user, include_system: include_system,
+          max_message_id: max_message_id, topic_assigned_before: topic_assigned_before
+        )
       end
 
       # Pair every topic id with the creative that was authorized. TopicMove
       # preserves the topic id while relocating all of its comments, so an
       # id-only query could read the destination creative after the permission
       # check. The exact pair also avoids cross-topic matches in batch totals.
-      def for_topics(topics, user:, include_system: false, max_message_id: nil)
+      def for_topics(topics, user:, include_system: false, max_message_id: nil, topic_assigned_before: nil)
         membership = topic_membership(topics)
         return Comment.none unless membership
 
         scope = Comment.where(membership).visible_to(user).without_approval_action
         scope = scope.where.not(user_id: nil) unless include_system
         scope = scope.where("comments.id <= ?", max_message_id) if max_message_id
+        scope = scope.where("comments.topic_assigned_at <= ?", topic_assigned_before) if topic_assigned_before
         scope
       end
 

--- a/engines/collavre/app/services/collavre/topics/message_stats.rb
+++ b/engines/collavre/app/services/collavre/topics/message_stats.rb
@@ -2,7 +2,7 @@
 
 module Collavre
   module Topics
-    # Per-topic message totals for a set of topics, in one grouped query.
+    # Per-topic message totals for a set of topics, in grouped aggregate queries.
     #
     # This is the call that makes fan-out planning possible: before an agent
     # spends its context on message bodies it asks how much there is, and
@@ -11,6 +11,12 @@ module Collavre
     module MessageStats
       Stat = Struct.new(:count, :chars, :last_at, keyword_init: true)
 
+      # Marker prose, attachment index, byte-size digits, separators and the
+      # signed-id path are bounded conservatively here. Filename is charged
+      # twice because it appears in both the label and URL; content type and a
+      # configured public-assets host are charged at their actual lengths.
+      ATTACHMENT_MARKER_OVERHEAD_CHARS = 300
+
       EMPTY = Stat.new(count: 0, chars: 0, last_at: nil).freeze
 
       module_function
@@ -18,11 +24,10 @@ module Collavre
       # Returns { topic_id => Stat }, with EMPTY for topics that have no
       # visible messages (a grouped query returns no row for them at all).
       #
-      # `chars` is LENGTH over the stored content, which is HTML — an upper
-      # bound on the plain text a page will actually return, not the exact
-      # figure. Getting the exact figure means stripping every body, which is
-      # the load this query exists to avoid. Callers that need a true rate can
-      # divide a returned page's own plain-text length by its message count.
+      # `chars` combines LENGTH over the stored HTML with a conservative image
+      # marker estimate. It remains a planning estimate rather than an exact
+      # rendered size: exact text requires stripping every body, which is the
+      # load this query exists to avoid.
       # max_message_id must reach the totals as well as the window. has_more? is
       # (offset + returned) < total, so a total counting past the anchor would
       # keep claiming there is another page after the snapshot has been fully
@@ -31,10 +36,14 @@ module Collavre
         topics = Array(topics)
         return {} if topics.empty?
 
-        rows = grouped_rows(topics.map(&:id), user: user, include_system: include_system,
-                            max_message_id: max_message_id)
+        scope = MessageScope.for_ids(
+          topics.map(&:id), user: user, include_system: include_system, max_message_id: max_message_id
+        )
+        rows = grouped_rows(scope)
+        attachment_chars = attachment_chars_by_topic(scope)
         totals = rows.to_h do |topic_id, count, chars, last_at|
-          [ topic_id, Stat.new(count: count.to_i, chars: chars.to_i, last_at: as_time(last_at)) ]
+          total_chars = chars.to_i + attachment_chars.fetch(topic_id, 0)
+          [ topic_id, Stat.new(count: count.to_i, chars: total_chars, last_at: as_time(last_at)) ]
         end
 
         topics.to_h { |topic| [ topic.id, totals[topic.id] || EMPTY ] }
@@ -50,14 +59,31 @@ module Collavre
         Time.zone.parse(value.to_s)
       end
 
-      def grouped_rows(topic_ids, user:, include_system:, max_message_id: nil)
-        MessageScope.for_ids(
-          topic_ids, user: user, include_system: include_system, max_message_id: max_message_id
-        ).group(:topic_id).pluck(
+      def grouped_rows(scope)
+        scope.group(:topic_id).pluck(
           :topic_id,
           Arel.sql("COUNT(*)"),
           Arel.sql("COALESCE(SUM(LENGTH(comments.content)), 0)"),
           Arel.sql("MAX(comments.created_at)")
+        )
+      end
+
+      def attachment_chars_by_topic(scope)
+        host_chars = Collavre::IntegrationSettings.fetch(:public_assets_host).to_s.length
+
+        attachment_rows(scope).to_h do |topic_id, count, filename_chars, content_type_chars|
+          estimate = count.to_i * (ATTACHMENT_MARKER_OVERHEAD_CHARS + host_chars) +
+            filename_chars.to_i * 2 + content_type_chars.to_i
+          [ topic_id, estimate ]
+        end
+      end
+
+      def attachment_rows(scope)
+        scope.joins(images_attachments: :blob).group(:topic_id).pluck(
+          :topic_id,
+          Arel.sql("COUNT(active_storage_attachments.id)"),
+          Arel.sql("COALESCE(SUM(LENGTH(active_storage_blobs.filename)), 0)"),
+          Arel.sql("COALESCE(SUM(LENGTH(active_storage_blobs.content_type)), 0)")
         )
       end
     end

--- a/engines/collavre/app/services/collavre/topics/message_stats.rb
+++ b/engines/collavre/app/services/collavre/topics/message_stats.rb
@@ -36,8 +36,8 @@ module Collavre
         topics = Array(topics)
         return {} if topics.empty?
 
-        scope = MessageScope.for_ids(
-          topics.map(&:id), user: user, include_system: include_system, max_message_id: max_message_id
+        scope = MessageScope.for_topics(
+          topics, user: user, include_system: include_system, max_message_id: max_message_id
         )
         rows = grouped_rows(scope)
         attachment_chars = attachment_chars_by_topic(scope)

--- a/engines/collavre/app/services/collavre/topics/message_stats.rb
+++ b/engines/collavre/app/services/collavre/topics/message_stats.rb
@@ -32,12 +32,13 @@ module Collavre
       # (offset + returned) < total, so a total counting past the anchor would
       # keep claiming there is another page after the snapshot has been fully
       # read — the caller pages forever against rows its anchor excludes.
-      def for(topics, user:, include_system: false, max_message_id: nil)
+      def for(topics, user:, include_system: false, max_message_id: nil, topic_assigned_before: nil)
         topics = Array(topics)
         return {} if topics.empty?
 
         scope = MessageScope.for_topics(
-          topics, user: user, include_system: include_system, max_message_id: max_message_id
+          topics, user: user, include_system: include_system,
+          max_message_id: max_message_id, topic_assigned_before: topic_assigned_before
         )
         rows = grouped_rows(scope)
         attachment_chars = attachment_chars_by_topic(scope)

--- a/engines/collavre/app/services/collavre/topics/message_stats.rb
+++ b/engines/collavre/app/services/collavre/topics/message_stats.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module Collavre
+  module Topics
+    # Per-topic message totals for a set of topics, in one grouped query.
+    #
+    # This is the call that makes fan-out planning possible: before an agent
+    # spends its context on message bodies it asks how much there is, and
+    # decides how to chunk. Counting by loading is exactly what that is meant to
+    # avoid, so nothing here instantiates a Comment.
+    module MessageStats
+      Stat = Struct.new(:count, :chars, :last_at, keyword_init: true)
+
+      EMPTY = Stat.new(count: 0, chars: 0, last_at: nil).freeze
+
+      module_function
+
+      # Returns { topic_id => Stat }, with EMPTY for topics that have no
+      # visible messages (a grouped query returns no row for them at all).
+      #
+      # `chars` is LENGTH over the stored content, which is HTML — an upper
+      # bound on the plain text a page will actually return, not the exact
+      # figure. Getting the exact figure means stripping every body, which is
+      # the load this query exists to avoid. Callers that need a true rate can
+      # divide a returned page's own plain-text length by its message count.
+      # max_message_id must reach the totals as well as the window. has_more? is
+      # (offset + returned) < total, so a total counting past the anchor would
+      # keep claiming there is another page after the snapshot has been fully
+      # read — the caller pages forever against rows its anchor excludes.
+      def for(topics, user:, include_system: false, max_message_id: nil)
+        topics = Array(topics)
+        return {} if topics.empty?
+
+        rows = grouped_rows(topics.map(&:id), user: user, include_system: include_system,
+                            max_message_id: max_message_id)
+        totals = rows.to_h do |topic_id, count, chars, last_at|
+          [ topic_id, Stat.new(count: count.to_i, chars: chars.to_i, last_at: as_time(last_at)) ]
+        end
+
+        topics.to_h { |topic| [ topic.id, totals[topic.id] || EMPTY ] }
+      end
+
+      # An aggregate selected through Arel.sql carries no column type, so the
+      # adapter hands MAX(created_at) back as the raw driver value — a String on
+      # Postgres. Callers expect a Time they can format, so normalize here
+      # rather than at each of them.
+      def as_time(value)
+        return value if value.nil? || value.is_a?(Time)
+
+        Time.zone.parse(value.to_s)
+      end
+
+      def grouped_rows(topic_ids, user:, include_system:, max_message_id: nil)
+        MessageScope.for_ids(
+          topic_ids, user: user, include_system: include_system, max_message_id: max_message_id
+        ).group(:topic_id).pluck(
+          :topic_id,
+          Arel.sql("COUNT(*)"),
+          Arel.sql("COALESCE(SUM(LENGTH(comments.content)), 0)"),
+          Arel.sql("MAX(comments.created_at)")
+        )
+      end
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/topics/next_name.rb
+++ b/engines/collavre/app/services/collavre/topics/next_name.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Collavre
+  module Topics
+    # The default name for a newly created topic: the localized prefix followed
+    # by the next unused number ("Topic 3").
+    #
+    # Extracted from TopicsController so the topic_create MCP tool produces the
+    # same names as the UI. An agent fanning work out across topics names them
+    # far more often than a human does, and two generators would have drifted
+    # into two numbering series in the same sidebar.
+    module NextName
+      module_function
+
+      # Archived topics count towards the next number. Topic names are unique
+      # per creative whether or not the topic is archived, so the previous
+      # active-only scan could propose a name that cannot be saved: archive
+      # "Topic 1" on an otherwise unnumbered creative and the next create
+      # proposes "Topic 1" again and fails validation. Reachable by hand before,
+      # routine once an agent creates topics in a loop.
+      def for(creative)
+        prefix = I18n.t("collavre.topics.default_name_prefix")
+        existing_numbers = creative.topics
+          .where("name LIKE ?", "#{Topic.sanitize_sql_like(prefix)}%")
+          .pluck(:name)
+          .filter_map { |n|
+            suffix = n.delete_prefix(prefix)
+            suffix.match?(/\A\d+\z/) ? suffix.to_i : nil
+          }
+
+        "#{prefix}#{(existing_numbers.max || 0) + 1}"
+      end
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/topics/pin_rejection.rb
+++ b/engines/collavre/app/services/collavre/topics/pin_rejection.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Collavre
+  module Topics
+    # Explains a Topic.primary_agent_rejection symbol to an MCP caller.
+    #
+    # The two reasons need different advice and the difference matters: sharing
+    # the creative fixes a missing-permission rejection, while a Claude Channel
+    # session agent stays confined to its own session topic no matter what is
+    # shared. Telling a caller to share in that second case sends it after a fix
+    # that cannot work — the same distinction TopicsController draws for humans.
+    module PinRejection
+      module_function
+
+      def message(agent, rejection)
+        if rejection == :session_agent_outside_session_topic
+          "#{agent.display_name} is a session agent and can only be pinned to its own session topic."
+        else
+          "#{agent.display_name} has no feedback permission on this creative, so it cannot be pinned. " \
+            "Share the creative with the agent at feedback or higher first."
+        end
+      end
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/topics/reserved_name.rb
+++ b/engines/collavre/app/services/collavre/topics/reserved_name.rb
@@ -1,0 +1,18 @@
+module Collavre
+  module Topics
+    module ReservedName
+      module_function
+
+      def reserved?(creative, name)
+        name == Creative::MAIN_TOPIC_NAME ||
+          (creative.inbox? && name == Creative::SYSTEM_TOPIC_NAME)
+      end
+
+      def reject!(creative, name, error_class: ArgumentError)
+        return unless reserved?(creative, name)
+
+        raise error_class, I18n.t("collavre.topics.reserved_name")
+      end
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/topics/serializer.rb
+++ b/engines/collavre/app/services/collavre/topics/serializer.rb
@@ -28,11 +28,34 @@ module Collavre
         data
       end
 
-      # Avatar URLs are built by a view helper, so reach it through the
-      # controller's helper proxy rather than duplicating the variant/asset
-      # fallback logic here.
+      # Matches ApplicationHelper#user_json's shape, but resolves the avatar
+      # itself. user_json reaches main_app.url_for, which needs the request that
+      # only the controller path has — the MCP tools broadcast this same event
+      # from outside one, and calling it there raises NameError. An attached
+      # avatar therefore resolves to a path, the way CreativesChannel already
+      # does for its out-of-request broadcasts; the client is same-origin, so a
+      # path merges into the sidebar the same as an absolute URL did.
+      AVATAR_SIZE = 20
+
       def agent_json(agent)
-        ::ApplicationController.helpers.user_json(agent)
+        {
+          id: agent.id,
+          name: agent.display_name,
+          avatar_url: avatar_url_for(agent),
+          default_avatar: !agent.avatar.attached? && agent.avatar_url.blank?,
+          initial: agent.display_name&.at(0)&.upcase || "?"
+        }
+      end
+
+      def avatar_url_for(agent)
+        if agent.avatar.attached?
+          variant = agent.avatar.variant(resize_to_fill: [ AVATAR_SIZE, AVATAR_SIZE ])
+          ::Rails.application.routes.url_helpers.rails_representation_path(variant, only_path: true)
+        elsif agent.avatar_url.present?
+          agent.avatar_url
+        else
+          ::ApplicationController.helpers.asset_path("default_avatar.svg")
+        end
       end
 
       # The compact shape the MCP tools return. Deliberately not the broadcast

--- a/engines/collavre/app/services/collavre/topics/serializer.rb
+++ b/engines/collavre/app/services/collavre/topics/serializer.rb
@@ -68,7 +68,7 @@ module Collavre
           creative_id: topic.creative_id,
           archived: topic.archived?,
           main: topic.name == Creative::MAIN_TOPIC_NAME,
-          system: topic.name == Creative::SYSTEM_TOPIC_NAME,
+          system: topic.creative.inbox? && topic.name == Creative::SYSTEM_TOPIC_NAME,
           source_topic_id: topic.source_topic_id,
           primary_agent: primary_agent_for_tool(topic),
           # A session topic's pin is session identity, not a routing choice, and

--- a/engines/collavre/app/services/collavre/topics/serializer.rb
+++ b/engines/collavre/app/services/collavre/topics/serializer.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module Collavre
+  module Topics
+    # The topic payload the client merges into its cached sidebar entry, built
+    # outside a controller so TopicsController and the topic MCP tools cannot
+    # describe the same topic two different ways.
+    #
+    # The client merges rather than replaces, so a key that is sometimes omitted
+    # leaves stale state on screen. That is why #with_agent always carries
+    # :primary_agent, explicitly nil when the pin was cleared.
+    module Serializer
+      module_function
+
+      def call(topic, unread_count: nil)
+        data = topic.slice(:id, :name, :source_topic_id)
+        data[:primary_agent] = agent_json(topic.primary_agent) if topic.primary_agent
+        data[:agent_locked] = topic.session_id.present?
+        data[:archived_at] = topic.archived_at if topic.archived_at
+        data[:unread_count] = unread_count unless unread_count.nil?
+        data
+      end
+
+      def with_agent(topic, agent)
+        data = topic.slice(:id, :name, :source_topic_id)
+        data[:primary_agent] = agent ? agent_json(agent) : nil
+        data[:agent_locked] = topic.session_id.present?
+        data
+      end
+
+      # Avatar URLs are built by a view helper, so reach it through the
+      # controller's helper proxy rather than duplicating the variant/asset
+      # fallback logic here.
+      def agent_json(agent)
+        ::ApplicationController.helpers.user_json(agent)
+      end
+
+      # The compact shape the MCP tools return. Deliberately not the broadcast
+      # payload: an agent wants names and counts it can reason about, not the
+      # avatar URLs and merge-semantics keys the sidebar needs.
+      def for_tool(topic, message_count: nil, message_chars: nil, last_message_at: nil)
+        {
+          id: topic.id,
+          name: topic.name,
+          creative_id: topic.creative_id,
+          archived: topic.archived?,
+          main: topic.name == Creative::MAIN_TOPIC_NAME,
+          system: topic.name == Creative::SYSTEM_TOPIC_NAME,
+          source_topic_id: topic.source_topic_id,
+          primary_agent: primary_agent_for_tool(topic),
+          # A session topic's pin is session identity, not a routing choice, and
+          # topic_update refuses to rewrite it. Say so here so an agent does not
+          # plan a reassignment that is going to be rejected.
+          agent_locked: topic.session_id.present?,
+          message_count: message_count,
+          message_chars: message_chars,
+          last_message_at: last_message_at&.iso8601
+        }.compact
+      end
+
+      def primary_agent_for_tool(topic)
+        agent = topic.primary_agent
+        return nil unless agent
+
+        { id: agent.id, name: agent.display_name }
+      end
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/topics/topic_move.rb
+++ b/engines/collavre/app/services/collavre/topics/topic_move.rb
@@ -3,9 +3,12 @@
 module Collavre
   module Topics
     class TopicMove
+      class SourceChangedError < StandardError; end
+
       def initialize(topic:, target_creative:)
         @topic = topic
         @target_creative = target_creative
+        @source_creative_id = topic.creative_id
       end
 
       def call
@@ -15,6 +18,7 @@ module Collavre
           # authorize the old creative while this transaction has already
           # relocated the topic's comment rows to the new one.
           topic.lock!
+          reject_changed_source!
           topic.comments.update_all(creative_id: target_creative.id)
           ReadPointerRelocator.new(topic: topic, target_creative: target_creative).call
           topic.update!(creative: target_creative)
@@ -24,7 +28,13 @@ module Collavre
 
       private
 
-      attr_reader :topic, :target_creative
+      attr_reader :topic, :target_creative, :source_creative_id
+
+      def reject_changed_source!
+        return if topic.creative_id == source_creative_id
+
+        raise SourceChangedError, I18n.t("collavre.topics.move.source_changed")
+      end
 
       def release_unroutable_primary_agent
         agent = topic.primary_agent

--- a/engines/collavre/app/services/collavre/topics/topic_move.rb
+++ b/engines/collavre/app/services/collavre/topics/topic_move.rb
@@ -10,6 +10,11 @@ module Collavre
 
       def call
         Topic.transaction do
+          # TopicBranchService locks the source before reading its comments.
+          # Take the same parent-first lock order here so a branch cannot
+          # authorize the old creative while this transaction has already
+          # relocated the topic's comment rows to the new one.
+          topic.lock!
           topic.comments.update_all(creative_id: target_creative.id)
           ReadPointerRelocator.new(topic: topic, target_creative: target_creative).call
           topic.update!(creative: target_creative)

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -21,6 +21,7 @@ en:
       create_and_move: 'Create "%{name}" and move'
       move:
         no_target_permission: You don't have write permission on the target creative.
+        source_changed: The topic moved to another creative while this request was waiting. Reload it and try again from its current creative.
         duplicate_name: A topic named '%{name}' already exists in the target creative.
         session_topic_locked: This topic belongs to a live agent session and cannot be moved.
         primary_agent_released: '@%{agent} was released as primary agent because it has no feedback access in "%{creative}". Share that creative with the agent and assign it again to keep it on this topic.'

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -151,6 +151,7 @@ en:
         no_selection: "Select at least one message to branch."
         not_authorized: "You don't have permission to branch messages."
         comments_not_found: "Some selected messages could not be found."
+        approval_action_not_branchable: "Approval prompts cannot be branched."
       batch_delete_confirm: Are you sure you want to delete the selected messages?
       batch_delete_no_selection: Select at least one message to delete.
       batch_delete_not_found: Some selected messages could not be found.

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -16,6 +16,7 @@ en:
       branch_prefix: "Branch"
       main_name: "Main"
       cannot_delete_main: "Cannot delete the Main topic."
+      reserved_name: "This topic name is reserved and cannot be assigned."
       orphaned_cron_notice: "[System] The topic '%{topic_name}' was deleted, but a recurring cron job (%{cron_key}) still targets it and will silently do nothing on each run. Original message: \"%{message}\". Re-point it to another topic or cancel it with cron_cancel."
       create_and_move: 'Create "%{name}" and move'
       move:

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -21,6 +21,7 @@ ko:
       create_and_move: '"%{name}" 생성후 이동'
       move:
         no_target_permission: 대상 크리에이티브에 대한 쓰기 권한이 없습니다.
+        source_changed: 요청이 대기하는 동안 토픽이 다른 크리에이티브로 이동했습니다. 현재 크리에이티브에서 다시 불러온 뒤 재시도하세요.
         duplicate_name: "'%{name}' 토픽이 대상 크리에이티브에 이미 존재합니다."
         session_topic_locked: 이 토픽은 실행 중인 에이전트 세션에 속해 있어 이동할 수 없습니다.
         primary_agent_released: '@%{agent}은(는) "%{creative}"에 피드백 권한이 없어 Primary Agent 지정이 해제되었습니다. 계속 담당하게 하려면 해당 크리에이티브를 에이전트와 공유한 뒤 다시 지정하세요.'

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -16,6 +16,7 @@ ko:
       branch_prefix: "분기"
       main_name: "메인"
       cannot_delete_main: "메인 토픽은 삭제할 수 없습니다."
+      reserved_name: "예약된 토픽 이름은 지정할 수 없습니다."
       orphaned_cron_notice: "[시스템] '%{topic_name}' 토픽이 삭제되었지만, 이 토픽을 대상으로 하는 반복 크론 작업(%{cron_key})이 아직 남아 있어 실행될 때마다 아무 동작도 하지 않고 조용히 종료됩니다. 원래 메시지: \"%{message}\". 다른 토픽으로 다시 지정하거나 cron_cancel로 취소하세요."
       create_and_move: '"%{name}" 생성후 이동'
       move:

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -148,6 +148,7 @@ ko:
         no_selection: "분기할 메시지를 선택하세요."
         not_authorized: "메시지를 분기할 권한이 없습니다."
         comments_not_found: "일부 선택한 메시지를 찾을 수 없습니다."
+        approval_action_not_branchable: "승인 요청 메시지는 분기할 수 없습니다."
       batch_delete_confirm: 선택한 메시지를 삭제하시겠습니까?
       batch_delete_no_selection: 삭제할 메시지를 선택해주세요.
       batch_delete_not_found: 일부 선택한 메시지를 찾을 수 없습니다.

--- a/engines/collavre/db/migrate/20260820000000_add_topic_assigned_at_to_comments.rb
+++ b/engines/collavre/db/migrate/20260820000000_add_topic_assigned_at_to_comments.rb
@@ -1,0 +1,13 @@
+class AddTopicAssignedAtToComments < ActiveRecord::Migration[8.1]
+  def up
+    add_column :comments, :topic_assigned_at, :datetime, precision: 6
+    execute "UPDATE comments SET topic_assigned_at = created_at"
+    change_column_null :comments, :topic_assigned_at, false
+    add_index :comments, %i[topic_id topic_assigned_at], name: "index_comments_on_topic_and_assigned_at"
+  end
+
+  def down
+    remove_index :comments, name: "index_comments_on_topic_and_assigned_at"
+    remove_column :comments, :topic_assigned_at
+  end
+end

--- a/engines/collavre/skills/collavre/SKILL.md
+++ b/engines/collavre/skills/collavre/SKILL.md
@@ -99,10 +99,10 @@ collavre tool run topic_list --json '{"creative_id": 8849}'
 collavre tool run topic_messages --json '{"topic_ids": "12,45,78", "limit": 100}'
 
 # Page a long topic with the returned next_offset, next_cursor, and snapshot id
-collavre tool run topic_messages --json '{"topic_ids": 12, "offset": 100, "cursor": "1770000000000000:989", "max_message_id": 9931}'
+collavre tool run topic_messages --json '{"topic_ids": 12, "offset": 100, "cursor": "1770000000000000:989:1770000001000000", "max_message_id": 9931}'
 
 # Continue inside one clipped message, preserving its row cursor
-collavre tool run topic_messages --json '{"topic_ids": 12, "offset": 100, "cursor": "1770000000000000:989", "content_offset": 28400, "max_message_id": 9931}'
+collavre tool run topic_messages --json '{"topic_ids": 12, "offset": 100, "cursor": "1770000000000000:989:1770000001000000", "content_offset": 28400, "max_message_id": 9931}'
 
 # Fan work out: one topic per unit of work, with an agent pinned to each
 collavre tool run topic_create --json '{"creative_id": 8849, "name": "Research", "primary_agent": "Dev1Claude"}'

--- a/engines/collavre/skills/collavre/SKILL.md
+++ b/engines/collavre/skills/collavre/SKILL.md
@@ -84,6 +84,33 @@ ops.json format:
 ]
 ```
 
+### Topics and messages
+
+Topics are conversation threads on a Creative — and the unit of agent
+concurrency. Tasks in the same topic are serialized (one runs, the rest queue);
+tasks in different topics run in parallel. There is no dedicated CLI verb yet;
+drive them through `collavre tool run`:
+
+```bash
+# See what topics exist and how much conversation each holds
+collavre tool run topic_list --json '{"creative_id": 8849}'
+
+# Summarize three topics at once — offset/limit apply per topic, newest first
+collavre tool run topic_messages --json '{"topic_ids": "12,45,78", "limit": 100}'
+
+# Page a long topic, pinned to one snapshot
+collavre tool run topic_messages --json '{"topic_ids": 12, "offset": 100, "max_message_id": 9931}'
+
+# Fan work out: one topic per unit of work, with an agent pinned to each
+collavre tool run topic_create --json '{"creative_id": 8849, "name": "Research", "primary_agent": "Dev1Claude"}'
+
+# Put a finished thread away (messages are kept and stay readable by id)
+collavre tool run topic_update --json '{"topic_id": 12, "archived": true}'
+
+# Carry the messages that still matter into a fresh topic
+collavre tool run topic_branch --json '{"source_topic_id": 12, "comment_ids": "991,994"}'
+```
+
 ### Discover & run tools (meta)
 ```bash
 collavre tool list                                # list available tools
@@ -97,6 +124,12 @@ collavre tool run <tool_name> --key value         # run with flag args
 ## Key Concepts
 
 - **Tree structure**: Creatives nest via `parent_id`. Use `--level` to control depth.
+- **Topics**: conversation threads on a Creative, and the concurrency unit — same
+  topic serializes, different topics run in parallel. One topic = one thread
+  reaching one conclusion; archive it when it gets there rather than reusing it.
+- **Primary agent**: pinning an agent to a topic is exclusive — that agent alone
+  answers there. Use it for a dedicated 1:1 channel; leave it unset for a thread
+  several participants should hear.
 - **Progress**: Leaf = manual (0.0 or 1.0). Parent = auto-calculated from children.
 - **Import**: Markdown headings/bullets become nested Creatives.
 - **Batch**: All-or-nothing transaction. Requires approval.

--- a/engines/collavre/skills/collavre/SKILL.md
+++ b/engines/collavre/skills/collavre/SKILL.md
@@ -98,11 +98,11 @@ collavre tool run topic_list --json '{"creative_id": 8849}'
 # Summarize three topics at once — offset/limit apply per topic, newest first
 collavre tool run topic_messages --json '{"topic_ids": "12,45,78", "limit": 100}'
 
-# Page a long topic, pinned to one snapshot
-collavre tool run topic_messages --json '{"topic_ids": 12, "offset": 100, "max_message_id": 9931}'
+# Page a long topic with the returned next_offset, next_cursor, and snapshot id
+collavre tool run topic_messages --json '{"topic_ids": 12, "offset": 100, "cursor": "1770000000000000:989", "max_message_id": 9931}'
 
-# Continue inside one clipped message without consuming its row
-collavre tool run topic_messages --json '{"topic_ids": 12, "offset": 100, "content_offset": 28400, "max_message_id": 9931}'
+# Continue inside one clipped message, preserving its row cursor
+collavre tool run topic_messages --json '{"topic_ids": 12, "offset": 100, "cursor": "1770000000000000:989", "content_offset": 28400, "max_message_id": 9931}'
 
 # Fan work out: one topic per unit of work, with an agent pinned to each
 collavre tool run topic_create --json '{"creative_id": 8849, "name": "Research", "primary_agent": "Dev1Claude"}'

--- a/engines/collavre/skills/collavre/SKILL.md
+++ b/engines/collavre/skills/collavre/SKILL.md
@@ -101,6 +101,9 @@ collavre tool run topic_messages --json '{"topic_ids": "12,45,78", "limit": 100}
 # Page a long topic, pinned to one snapshot
 collavre tool run topic_messages --json '{"topic_ids": 12, "offset": 100, "max_message_id": 9931}'
 
+# Continue inside one clipped message without consuming its row
+collavre tool run topic_messages --json '{"topic_ids": 12, "offset": 100, "content_offset": 28400, "max_message_id": 9931}'
+
 # Fan work out: one topic per unit of work, with an agent pinned to each
 collavre tool run topic_create --json '{"creative_id": 8849, "name": "Research", "primary_agent": "Dev1Claude"}'
 

--- a/engines/collavre/skills/collavre/SKILL.md
+++ b/engines/collavre/skills/collavre/SKILL.md
@@ -114,6 +114,10 @@ collavre tool run topic_update --json '{"topic_id": 12, "archived": true}'
 collavre tool run topic_branch --json '{"source_topic_id": 12, "comment_ids": "991,994"}'
 ```
 
+`topic_messages` includes each comment image as a URL-bearing marker in the
+message content. Image-only comments are not blank, and a long attachment list
+uses the same `content_offset` continuation as long prose.
+
 ### Discover & run tools (meta)
 ```bash
 collavre tool list                                # list available tools

--- a/engines/collavre/skills/collavre/SKILL.md
+++ b/engines/collavre/skills/collavre/SKILL.md
@@ -95,10 +95,10 @@ drive them through `collavre tool run`:
 # See what topics exist and how much conversation each holds
 collavre tool run topic_list --json '{"creative_id": 8849}'
 
-# Summarize three topics at once — offset/limit apply per topic, newest first
+# Summarize three topics at once — first page only; offset/limit apply per topic
 collavre tool run topic_messages --json '{"topic_ids": "12,45,78", "limit": 100}'
 
-# Page a long topic with the returned next_offset, next_cursor, and snapshot id
+# Continue each topic separately with its own cursor and snapshot id
 collavre tool run topic_messages --json '{"topic_ids": 12, "offset": 100, "cursor": "1770000000000000:989:1770000001000000", "max_message_id": 9931}'
 
 # Continue inside one clipped message, preserving its row cursor

--- a/engines/collavre/skills/collavre/SKILL.md
+++ b/engines/collavre/skills/collavre/SKILL.md
@@ -99,10 +99,10 @@ collavre tool run topic_list --json '{"creative_id": 8849}'
 collavre tool run topic_messages --json '{"topic_ids": "12,45,78", "limit": 100}'
 
 # Continue each topic separately with its own cursor and snapshot id
-collavre tool run topic_messages --json '{"topic_ids": 12, "offset": 100, "cursor": "1770000000000000:989:1770000001000000", "max_message_id": 9931}'
+collavre tool run topic_messages --json '{"topic_ids": 12, "offset": 100, "cursor": "1770000000000000:989:1770000001000000:1770000002000000", "max_message_id": 9931}'
 
 # Continue inside one clipped message, preserving its row cursor
-collavre tool run topic_messages --json '{"topic_ids": 12, "offset": 100, "cursor": "1770000000000000:989:1770000001000000", "content_offset": 28400, "max_message_id": 9931}'
+collavre tool run topic_messages --json '{"topic_ids": 12, "offset": 100, "cursor": "1770000000000000:989:1770000001000000:1770000002000000", "content_offset": 28400, "max_message_id": 9931}'
 
 # Fan work out: one topic per unit of work, with an agent pinned to each
 collavre tool run topic_create --json '{"creative_id": 8849, "name": "Research", "primary_agent": "Dev1Claude"}'

--- a/engines/collavre/skills/collavre/references/tool-reference.md
+++ b/engines/collavre/skills/collavre/references/tool-reference.md
@@ -232,6 +232,10 @@ Archiving hides the topic from the active list but keeps every message, and
 `topic_messages` can still read it by id. Archive a topic when its thread has
 reached a conclusion rather than reusing it for the next subject.
 
+Main and an inbox Creative's System topic are reserved. Their names and archive
+state cannot change because message routing looks them up by name; their primary
+agent pin can still change.
+
 A Claude Channel session topic's pin is part of its session identity and cannot
 be changed here.
 
@@ -254,7 +258,8 @@ a silent trim. Requires **feedback** or better on the Creative.
 Approval prompts cannot be branched. The copy carries the content but not the
 approval action, so it would stop being excluded from agent history and read as
 an ordinary message. Passing one is an error — `topic_messages` never returns
-their ids in the first place.
+their ids in the first place. Image attachments, including image-only messages,
+remain attached to the copies.
 
 ## meta_tool
 

--- a/engines/collavre/skills/collavre/references/tool-reference.md
+++ b/engines/collavre/skills/collavre/references/tool-reference.md
@@ -110,7 +110,7 @@ use it before `topic_messages` to see how much conversation each topic holds.
 | Param | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `creative_id` | Integer | One of | — | List every topic on this Creative |
-| `topic_ids` | String | One of | — | Describe these topics, e.g. `"12,45,78"` |
+| `topic_ids` | String | One of | — | Describe these topics, e.g. `"12,45,78"` (max 20 per call) |
 | `include_archived` | Boolean | No | false | Include archived topics (listing by `creative_id`) |
 | `include_stats` | Boolean | No | true | Include `message_count` / `message_chars` / `last_message_at` |
 | `include_system` | Boolean | No | false | Count authorless notices. Approval prompts are never counted |
@@ -169,6 +169,12 @@ dropped — dropping it would return an empty page at an offset that has rows an
 the caller would page against it forever. The clip is announced in the message
 text and counted in the topic's `clipped_count`, which can be set even when
 `has_more` is false.
+
+Asking for more than 20 topics in one call is an error, not a silent trim — the
+ids past the cap were never read, so there would be no per-topic entry to say
+they were missing. Split them across calls. (Unknown or unreadable ids are
+different: those are reported per topic and the call continues.) `topic_list`
+applies the same cap to `topic_ids`.
 
 Requires **read** on each topic's Creative. Private messages you are not party
 to are always excluded.

--- a/engines/collavre/skills/collavre/references/tool-reference.md
+++ b/engines/collavre/skills/collavre/references/tool-reference.md
@@ -161,8 +161,14 @@ topic_messages(topic_ids: 12, offset: 100, content_offset: 28400, max_message_id
 `limit`, `returned_count`, `returned_chars`, `has_more`, `next_offset`,
 `next_content_offset`, `newest_message_id`, `messages[]`, and `budget_limited`
 when `max_chars` (rather than `limit`) ended the window. Each message: `id`,
-`author`, `author_id`, `agent`, `created_at`, `content` (plain text), plus content
-range fields when the row is continued.
+`author`, `author_id`, `agent`, `created_at`, `content` (plain text plus one
+URL-bearing metadata marker per image attachment), plus content range fields
+when the row is continued.
+
+Attachment markers include filename, content type, byte size, and a readable
+public-asset URL. Because they are part of `content`, image-only comments remain
+visible and long attachment lists page through `content_offset` without evading
+`max_chars`.
 
 A topic the budget could not reach at all comes back with `skipped_reason` and
 `returned_count: 0` rather than looking like an empty conversation.

--- a/engines/collavre/skills/collavre/references/tool-reference.md
+++ b/engines/collavre/skills/collavre/references/tool-reference.md
@@ -95,6 +95,131 @@ Import a markdown document as a Creative tree. Uses the built-in MarkdownImporte
 
 **Returns:** `{ success, parent_id, created_count, tree[] }`
 
+## Topic tools
+
+A **topic** is a conversation thread on a Creative, and it is also the unit of
+agent concurrency: tasks dispatched in the same topic are serialized (one holds
+the topic's slot, the rest queue), while tasks in different topics run in
+parallel. Splitting work across topics is what makes it run concurrently.
+
+### topic_list
+
+List a Creative's topics, or describe specific topics by id. The planning call —
+use it before `topic_messages` to see how much conversation each topic holds.
+
+| Param | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `creative_id` | Integer | One of | — | List every topic on this Creative |
+| `topic_ids` | String | One of | — | Describe these topics, e.g. `"12,45,78"` |
+| `include_archived` | Boolean | No | false | Include archived topics (listing by `creative_id`) |
+| `include_stats` | Boolean | No | true | Include `message_count` / `message_chars` / `last_message_at` |
+| `include_system` | Boolean | No | false | Count authorless notices and approval prompts |
+
+**Returns:** `{ topics[], errors[] }`. Each topic: `id`, `name`, `creative_id`,
+`archived`, `main`, `system`, `source_topic_id`, `primary_agent`,
+`agent_locked`, `message_count`, `message_chars`, `last_message_at`.
+
+`message_chars` is the length of the stored message HTML — an upper bound on the
+text `topic_messages` returns, good for relative sizing rather than exact
+budgeting. Requires **read** on each topic's Creative; unknown or unreadable ids
+come back in `errors`.
+
+### topic_messages
+
+Read messages from one or more topics, newest first, with paging.
+
+| Param | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `topic_ids` | String | **Yes** | — | `"12,45,78"` (max 20 per call); a single id also works |
+| `offset` | Integer | No | 0 | Messages back from the newest, **per topic** |
+| `limit` | Integer | No | 50 | Messages **per topic** (max 200) |
+| `order` | String | No | `"asc"` | Rendering order in the window: `asc` (transcript) or `desc` |
+| `max_message_id` | Integer | No | — | Snapshot anchor: only messages with `id <=` this |
+| `include_system` | Boolean | No | false | Include authorless notices and approval prompts |
+| `max_chars` | Integer | No | 40000 | Cap for the **whole response** (max 200000) |
+| `format` | String | No | `"markdown"` | `markdown` or `json` |
+
+**Windowing.** Selection is always from the newest end: `offset: 0` is the latest
+message. `order` only changes how the selected window is rendered, not which
+messages it contains. With several topics, `offset`/`limit` apply to **each topic
+independently** and results are grouped per topic — never merged into one
+timeline, so an offset stays reproducible.
+
+**Paging a long topic.** Take `newest_message_id` from the first page and pass it
+as `max_message_id` on every later page. Without it, messages arriving mid-read
+shift rows down and you re-read one message while never seeing another.
+
+```
+topic_messages(topic_ids: "12,45,78", limit: 100)          # summarize three topics
+topic_messages(topic_ids: 12, offset: 100, max_message_id: 9931)  # next page
+```
+
+**Returns (json):** `{ topics[], truncated, max_chars }`. Each topic entry:
+`topic_id`, `topic_name`, `creative_id`, `total_count`, `total_chars`, `offset`,
+`limit`, `returned_count`, `returned_chars`, `has_more`, `next_offset`,
+`newest_message_id`, `messages[]`, and `budget_limited` when `max_chars` (rather
+than `limit`) ended the window. Each message: `id`, `author`, `author_id`,
+`agent`, `created_at`, `content` (plain text).
+
+A topic the budget could not reach at all comes back with `skipped_reason` and
+`returned_count: 0` rather than looking like an empty conversation.
+
+Requires **read** on each topic's Creative. Private messages you are not party
+to are always excluded.
+
+### topic_create
+
+Create a topic on a Creative. The fan-out primitive.
+
+| Param | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `creative_id` | Integer | **Yes** | — | Creative to create the topic on |
+| `name` | String | No | `"Topic N"` | Must be unique on the Creative |
+| `primary_agent` | String | No | — | Agent to pin — id, email, or exact name |
+| `comment_ids` | String | No | — | Existing messages to **move** into the new topic |
+
+Pinning a `primary_agent` is **exclusive**: the pinned agent alone answers
+ambient messages in the topic and every other agent is silent. The agent must
+already hold **feedback** or better on the Creative, otherwise the pin is
+refused — a pinned agent that cannot answer would silence the topic entirely.
+
+Requires **write** on the Creative. Use `topic_branch` to copy messages instead
+of moving them.
+
+### topic_update
+
+Rename, archive/unarchive, or re-pin a topic. Pass only what changes.
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `topic_id` | Integer | **Yes** | Topic to update |
+| `name` | String | No | New name (requires **admin**) |
+| `archived` | Boolean | No | `true` archives, `false` unarchives (requires **write**) |
+| `primary_agent` | String | No | Agent id/email/name, or `"none"` to clear (requires **write**) |
+
+Archiving hides the topic from the active list but keeps every message, and
+`topic_messages` can still read it by id. Archive a topic when its thread has
+reached a conclusion rather than reusing it for the next subject.
+
+A Claude Channel session topic's pin is part of its session identity and cannot
+be changed here.
+
+**Returns:** the topic payload plus `changed[]` naming the fields that moved.
+
+### topic_branch
+
+Create a new topic containing **copies** of selected messages. The originals stay
+in place — the context-length escape hatch.
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `source_topic_id` | Integer | **Yes** | Topic to branch from |
+| `comment_ids` | String | **Yes** | Messages to copy, e.g. `"991,994,1002"` (max 100) |
+| `name` | String | No | Defaults to `"branch:<source name>"` |
+
+Get the ids from `topic_messages`. Asking for more than the cap is an error, not
+a silent trim. Requires **feedback** or better on the Creative.
+
 ## meta_tool
 
 Introspect and dynamically run any registered MCP tool. Enables tool discovery without CLI updates.

--- a/engines/collavre/skills/collavre/references/tool-reference.md
+++ b/engines/collavre/skills/collavre/references/tool-reference.md
@@ -136,7 +136,7 @@ Read messages from one or more topics, newest first, with paging.
 | `order` | String | No | `"asc"` | Rendering order in the window: `asc` (transcript) or `desc` |
 | `max_message_id` | Integer | No | — | Snapshot anchor: only messages with `id <=` this |
 | `include_system` | Boolean | No | false | Include authorless notices. Approval prompts are never returned |
-| `max_chars` | Integer | No | 40000 | Cap for the **whole response** (max 200000) |
+| `max_chars` | Integer | No | 40000 | Cap for the **whole response** (min 160, max 200000; smaller positive values are raised to 160) |
 | `format` | String | No | `"markdown"` | `markdown` or `json` |
 
 **Windowing.** Selection is always from the newest end: `offset: 0` is the latest
@@ -163,6 +163,10 @@ than `limit`) ended the window. Each message: `id`, `author`, `author_id`,
 
 A topic the budget could not reach at all comes back with `skipped_reason` and
 `returned_count: 0` rather than looking like an empty conversation.
+
+If the fixed topic metadata alone cannot fit — for example, because a topic
+name is unusually long — the tool returns a bounded error instead of emitting
+a response wider than `max_chars` or silently omitting a topic.
 
 A single message wider than the whole `max_chars` cap is clipped rather than
 dropped — dropping it would return an empty page at an offset that has rows and

--- a/engines/collavre/skills/collavre/references/tool-reference.md
+++ b/engines/collavre/skills/collavre/references/tool-reference.md
@@ -119,10 +119,10 @@ use it before `topic_messages` to see how much conversation each topic holds.
 `archived`, `main`, `system`, `source_topic_id`, `primary_agent`,
 `agent_locked`, `message_count`, `message_chars`, `last_message_at`.
 
-`message_chars` is the length of the stored message HTML — an upper bound on the
-text `topic_messages` returns, good for relative sizing rather than exact
-budgeting. Requires **read** on each topic's Creative; unknown or unreadable ids
-come back in `errors`.
+`message_chars` combines stored message HTML length with a conservative estimate
+for the image attachment markers emitted by `topic_messages`. It is good for
+relative sizing rather than exact budgeting. Requires **read** on each topic's
+Creative; unknown or unreadable ids come back in `errors`.
 
 ### topic_messages
 

--- a/engines/collavre/skills/collavre/references/tool-reference.md
+++ b/engines/collavre/skills/collavre/references/tool-reference.md
@@ -135,6 +135,7 @@ Read messages from one or more topics, newest first, with paging.
 | `limit` | Integer | No | 50 | Messages **per topic** (max 200) |
 | `order` | String | No | `"asc"` | Rendering order in the window: `asc` (transcript) or `desc` |
 | `max_message_id` | Integer | No | — | Snapshot anchor: only messages with `id <=` this |
+| `content_offset` | Integer | No | 0 | Character offset within the first message selected by `offset`; use the returned `next_content_offset` |
 | `include_system` | Boolean | No | false | Include authorless notices. Approval prompts are never returned |
 | `max_chars` | Integer | No | 40000 | Cap for the **whole response** (min 160, max 200000; smaller positive values are raised to 160) |
 | `format` | String | No | `"markdown"` | `markdown` or `json` |
@@ -152,14 +153,16 @@ shift rows down and you re-read one message while never seeing another.
 ```
 topic_messages(topic_ids: "12,45,78", limit: 100)          # summarize three topics
 topic_messages(topic_ids: 12, offset: 100, max_message_id: 9931)  # next page
+topic_messages(topic_ids: 12, offset: 100, content_offset: 28400, max_message_id: 9931)  # clipped tail
 ```
 
 **Returns (json):** `{ topics[], truncated, max_chars }`. Each topic entry:
 `topic_id`, `topic_name`, `creative_id`, `total_count`, `total_chars`, `offset`,
 `limit`, `returned_count`, `returned_chars`, `has_more`, `next_offset`,
-`newest_message_id`, `messages[]`, and `budget_limited` when `max_chars` (rather
-than `limit`) ended the window. Each message: `id`, `author`, `author_id`,
-`agent`, `created_at`, `content` (plain text).
+`next_content_offset`, `newest_message_id`, `messages[]`, and `budget_limited`
+when `max_chars` (rather than `limit`) ended the window. Each message: `id`,
+`author`, `author_id`, `agent`, `created_at`, `content` (plain text), plus content
+range fields when the row is continued.
 
 A topic the budget could not reach at all comes back with `skipped_reason` and
 `returned_count: 0` rather than looking like an empty conversation.
@@ -170,9 +173,11 @@ a response wider than `max_chars` or silently omitting a topic.
 
 A single message wider than the whole `max_chars` cap is clipped rather than
 dropped — dropping it would return an empty page at an offset that has rows and
-the caller would page against it forever. The clip is announced in the message
-text and counted in the topic's `clipped_count`, which can be set even when
-`has_more` is false.
+the caller would page against it forever. A clipped row keeps `next_offset` on
+the same message and returns `next_content_offset`; pass both values with the
+same `max_message_id` until `next_content_offset` disappears. Only then is the
+message row consumed. The clip notice is separate from `content`, so JSON
+callers can concatenate fragments without stripping tool text.
 
 Asking for more than 20 topics in one call is an error, not a silent trim — the
 ids past the cap were never read, so there would be no per-topic entry to say

--- a/engines/collavre/skills/collavre/references/tool-reference.md
+++ b/engines/collavre/skills/collavre/references/tool-reference.md
@@ -132,7 +132,7 @@ Read messages from one or more topics, newest first, with paging.
 |-------|------|----------|---------|-------------|
 | `topic_ids` | String | **Yes** | — | `"12,45,78"` (max 20 per call); a single id also works |
 | `offset` | Integer | No | 0 | Messages back from the newest, **per topic** |
-| `cursor` | String | No | — | Opaque per-topic keyset cursor returned as `next_cursor` |
+| `cursor` | String | No | — | Opaque per-topic snapshot/keyset cursor returned as `next_cursor` |
 | `limit` | Integer | No | 50 | Messages **per topic** (max 200) |
 | `order` | String | No | `"asc"` | Rendering order in the window: `asc` (transcript) or `desc` |
 | `max_message_id` | Integer | No | — | Snapshot anchor: only messages with `id <=` this |
@@ -149,15 +149,16 @@ timeline, so an offset stays reproducible.
 
 **Paging a long topic.** Take `newest_message_id` and `next_cursor` from the
 first page and pass them as `max_message_id` and `cursor` on every later page.
-The snapshot excludes later arrivals; the keyset cursor prevents already-read
-messages that are moved or deleted from shifting unread rows past the offset.
-It also binds a clipped continuation to the row's content version, so an edit
-restarts that changed message at character zero instead of skipping text.
+The snapshot excludes newly-created messages and older messages moved into the
+topic after page one. The keyset cursor also prevents messages that leave from
+shifting unread rows past the offset. It binds a clipped continuation to the
+row's content version, so an edit restarts that changed message at character
+zero instead of skipping text.
 
 ```
 topic_messages(topic_ids: "12,45,78", limit: 100)          # summarize three topics
-topic_messages(topic_ids: 12, offset: 100, cursor: "1770000000000000:9820:1770000001000000", max_message_id: 9931)  # next page
-topic_messages(topic_ids: 12, offset: 100, cursor: "1770000000000000:9820:1770000001000000", content_offset: 28400, max_message_id: 9931)  # clipped tail
+topic_messages(topic_ids: 12, offset: 100, cursor: "1770000000000000:9820:1770000001000000:1770000002000000", max_message_id: 9931)  # next page
+topic_messages(topic_ids: 12, offset: 100, cursor: "1770000000000000:9820:1770000001000000:1770000002000000", content_offset: 28400, max_message_id: 9931)  # clipped tail
 ```
 
 **Returns (json):** `{ topics[], truncated, max_chars }`. Each topic entry:

--- a/engines/collavre/skills/collavre/references/tool-reference.md
+++ b/engines/collavre/skills/collavre/references/tool-reference.md
@@ -113,7 +113,7 @@ use it before `topic_messages` to see how much conversation each topic holds.
 | `topic_ids` | String | One of | — | Describe these topics, e.g. `"12,45,78"` |
 | `include_archived` | Boolean | No | false | Include archived topics (listing by `creative_id`) |
 | `include_stats` | Boolean | No | true | Include `message_count` / `message_chars` / `last_message_at` |
-| `include_system` | Boolean | No | false | Count authorless notices and approval prompts |
+| `include_system` | Boolean | No | false | Count authorless notices. Approval prompts are never counted |
 
 **Returns:** `{ topics[], errors[] }`. Each topic: `id`, `name`, `creative_id`,
 `archived`, `main`, `system`, `source_topic_id`, `primary_agent`,
@@ -135,7 +135,7 @@ Read messages from one or more topics, newest first, with paging.
 | `limit` | Integer | No | 50 | Messages **per topic** (max 200) |
 | `order` | String | No | `"asc"` | Rendering order in the window: `asc` (transcript) or `desc` |
 | `max_message_id` | Integer | No | — | Snapshot anchor: only messages with `id <=` this |
-| `include_system` | Boolean | No | false | Include authorless notices and approval prompts |
+| `include_system` | Boolean | No | false | Include authorless notices. Approval prompts are never returned |
 | `max_chars` | Integer | No | 40000 | Cap for the **whole response** (max 200000) |
 | `format` | String | No | `"markdown"` | `markdown` or `json` |
 

--- a/engines/collavre/skills/collavre/references/tool-reference.md
+++ b/engines/collavre/skills/collavre/references/tool-reference.md
@@ -164,6 +164,12 @@ than `limit`) ended the window. Each message: `id`, `author`, `author_id`,
 A topic the budget could not reach at all comes back with `skipped_reason` and
 `returned_count: 0` rather than looking like an empty conversation.
 
+A single message wider than the whole `max_chars` cap is clipped rather than
+dropped — dropping it would return an empty page at an offset that has rows and
+the caller would page against it forever. The clip is announced in the message
+text and counted in the topic's `clipped_count`, which can be set even when
+`has_more` is false.
+
 Requires **read** on each topic's Creative. Private messages you are not party
 to are always excluded.
 
@@ -219,6 +225,11 @@ in place — the context-length escape hatch.
 
 Get the ids from `topic_messages`. Asking for more than the cap is an error, not
 a silent trim. Requires **feedback** or better on the Creative.
+
+Approval prompts cannot be branched. The copy carries the content but not the
+approval action, so it would stop being excluded from agent history and read as
+an ordinary message. Passing one is an error — `topic_messages` never returns
+their ids in the first place.
 
 ## meta_tool
 

--- a/engines/collavre/skills/collavre/references/tool-reference.md
+++ b/engines/collavre/skills/collavre/references/tool-reference.md
@@ -132,6 +132,7 @@ Read messages from one or more topics, newest first, with paging.
 |-------|------|----------|---------|-------------|
 | `topic_ids` | String | **Yes** | — | `"12,45,78"` (max 20 per call); a single id also works |
 | `offset` | Integer | No | 0 | Messages back from the newest, **per topic** |
+| `cursor` | String | No | — | Opaque per-topic keyset cursor returned as `next_cursor` |
 | `limit` | Integer | No | 50 | Messages **per topic** (max 200) |
 | `order` | String | No | `"asc"` | Rendering order in the window: `asc` (transcript) or `desc` |
 | `max_message_id` | Integer | No | — | Snapshot anchor: only messages with `id <=` this |
@@ -146,20 +147,21 @@ messages it contains. With several topics, `offset`/`limit` apply to **each topi
 independently** and results are grouped per topic — never merged into one
 timeline, so an offset stays reproducible.
 
-**Paging a long topic.** Take `newest_message_id` from the first page and pass it
-as `max_message_id` on every later page. Without it, messages arriving mid-read
-shift rows down and you re-read one message while never seeing another.
+**Paging a long topic.** Take `newest_message_id` and `next_cursor` from the
+first page and pass them as `max_message_id` and `cursor` on every later page.
+The snapshot excludes later arrivals; the keyset cursor prevents already-read
+messages that are moved or deleted from shifting unread rows past the offset.
 
 ```
 topic_messages(topic_ids: "12,45,78", limit: 100)          # summarize three topics
-topic_messages(topic_ids: 12, offset: 100, max_message_id: 9931)  # next page
-topic_messages(topic_ids: 12, offset: 100, content_offset: 28400, max_message_id: 9931)  # clipped tail
+topic_messages(topic_ids: 12, offset: 100, cursor: "1770000000000000:9820", max_message_id: 9931)  # next page
+topic_messages(topic_ids: 12, offset: 100, cursor: "1770000000000000:9820", content_offset: 28400, max_message_id: 9931)  # clipped tail
 ```
 
 **Returns (json):** `{ topics[], truncated, max_chars }`. Each topic entry:
 `topic_id`, `topic_name`, `creative_id`, `total_count`, `total_chars`, `offset`,
 `limit`, `returned_count`, `returned_chars`, `has_more`, `next_offset`,
-`next_content_offset`, `newest_message_id`, `messages[]`, and `budget_limited`
+`next_cursor`, `next_content_offset`, `newest_message_id`, `messages[]`, and `budget_limited`
 when `max_chars` (rather than `limit`) ended the window. Each message: `id`,
 `author`, `author_id`, `agent`, `created_at`, `content` (plain text plus one
 URL-bearing metadata marker per image attachment), plus content range fields
@@ -181,13 +183,14 @@ A single message wider than the whole `max_chars` cap is clipped rather than
 dropped — dropping it would return an empty page at an offset that has rows and
 the caller would page against it forever. A clipped row keeps `next_offset` on
 the same message and returns `next_content_offset`; pass both values with the
-same `max_message_id` until `next_content_offset` disappears. Only then is the
-message row consumed. The clip notice is separate from `content`, so JSON
-callers can concatenate fragments without stripping tool text.
+same `next_cursor` and `max_message_id` until `next_content_offset` disappears.
+Only then is the message row consumed. The clip notice is separate from
+`content`, so JSON callers can concatenate fragments without stripping tool
+text.
 
 Markdown `More:` calls repeat the resolved `limit` and `max_chars` alongside
-the snapshot, content offset, order, and system-message scope. Following the
-generated call therefore keeps the same page size and context budget.
+the cursor, snapshot, content offset, order, and system-message scope. Following
+the generated call therefore keeps the same page size and context budget.
 
 Asking for more than 20 topics in one call is an error, not a silent trim — the
 ids past the cap were never read, so there would be no per-topic entry to say

--- a/engines/collavre/skills/collavre/references/tool-reference.md
+++ b/engines/collavre/skills/collavre/references/tool-reference.md
@@ -151,11 +151,13 @@ timeline, so an offset stays reproducible.
 first page and pass them as `max_message_id` and `cursor` on every later page.
 The snapshot excludes later arrivals; the keyset cursor prevents already-read
 messages that are moved or deleted from shifting unread rows past the offset.
+It also binds a clipped continuation to the row's content version, so an edit
+restarts that changed message at character zero instead of skipping text.
 
 ```
 topic_messages(topic_ids: "12,45,78", limit: 100)          # summarize three topics
-topic_messages(topic_ids: 12, offset: 100, cursor: "1770000000000000:9820", max_message_id: 9931)  # next page
-topic_messages(topic_ids: 12, offset: 100, cursor: "1770000000000000:9820", content_offset: 28400, max_message_id: 9931)  # clipped tail
+topic_messages(topic_ids: 12, offset: 100, cursor: "1770000000000000:9820:1770000001000000", max_message_id: 9931)  # next page
+topic_messages(topic_ids: 12, offset: 100, cursor: "1770000000000000:9820:1770000001000000", content_offset: 28400, max_message_id: 9931)  # clipped tail
 ```
 
 **Returns (json):** `{ topics[], truncated, max_chars }`. Each topic entry:

--- a/engines/collavre/skills/collavre/references/tool-reference.md
+++ b/engines/collavre/skills/collavre/references/tool-reference.md
@@ -185,6 +185,10 @@ same `max_message_id` until `next_content_offset` disappears. Only then is the
 message row consumed. The clip notice is separate from `content`, so JSON
 callers can concatenate fragments without stripping tool text.
 
+Markdown `More:` calls repeat the resolved `limit` and `max_chars` alongside
+the snapshot, content offset, order, and system-message scope. Following the
+generated call therefore keeps the same page size and context budget.
+
 Asking for more than 20 topics in one call is an error, not a silent trim — the
 ids past the cap were never read, so there would be no per-topic entry to say
 they were missing. Split them across calls. (Unknown or unreadable ids are
@@ -202,7 +206,7 @@ Create a topic on a Creative. The fan-out primitive.
 |-------|------|----------|---------|-------------|
 | `creative_id` | Integer | **Yes** | — | Creative to create the topic on |
 | `name` | String | No | `"Topic N"` | Must be unique on the Creative |
-| `primary_agent` | String | No | — | Agent to pin — id, email, or exact name |
+| `primary_agent` | String | No | — | Agent to pin — id, email, or exact name; private agents already shared here resolve too |
 | `comment_ids` | String | No | — | Existing messages to **move** into the new topic |
 
 Pinning a `primary_agent` is **exclusive**: the pinned agent alone answers
@@ -222,7 +226,7 @@ Rename, archive/unarchive, or re-pin a topic. Pass only what changes.
 | `topic_id` | Integer | **Yes** | Topic to update |
 | `name` | String | No | New name (requires **admin**) |
 | `archived` | Boolean | No | `true` archives, `false` unarchives (requires **write**) |
-| `primary_agent` | String | No | Agent id/email/name, or `"none"` to clear (requires **write**) |
+| `primary_agent` | String | No | Agent id/email/name, or `"none"` to clear (requires **write**; private agents already shared here resolve too) |
 
 Archiving hides the topic from the active list but keeps every message, and
 `topic_messages` can still read it by id. Archive a topic when its thread has

--- a/engines/collavre/test/controllers/topics_controller_test.rb
+++ b/engines/collavre/test/controllers/topics_controller_test.rb
@@ -277,6 +277,24 @@ class TopicsControllerTest < ActionDispatch::IntegrationTest
     assert_equal target_creative.id, comment.creative_id, "Comment should move with topic"
   end
 
+  test "a source changed while waiting for the move lock is forbidden" do
+    target_creative = creatives(:root_parent)
+    failed_move = Object.new
+    failed_move.define_singleton_method(:call) do
+      raise Collavre::Topics::TopicMove::SourceChangedError,
+        I18n.t("collavre.topics.move.source_changed")
+    end
+
+    Collavre::Topics::TopicMove.stub(:new, ->(**) { failed_move }) do
+      patch move_creative_topic_url(@creative, @topic),
+        params: { target_creative_id: target_creative.id }, as: :json
+    end
+
+    assert_response :forbidden
+    assert_includes JSON.parse(response.body).fetch("error"), "moved"
+    assert_equal @creative.id, @topic.reload.creative_id
+  end
+
   test "moving a topic moves its read pointers with it" do
     target_creative = creatives(:root_parent)
     comment = Collavre::Comment.create!(creative: @creative, topic: @topic, user: @user, content: "read comment")

--- a/engines/collavre/test/jobs/collavre/drop_trigger_job_test.rb
+++ b/engines/collavre/test/jobs/collavre/drop_trigger_job_test.rb
@@ -299,6 +299,36 @@ module Collavre
         "Other users' private Main comments must not leak into the branched topic")
     end
 
+    test "skips approval prompts in Main when branching" do
+      main = @child.main_topic(fallback_user: @owner)
+      visible = @child.comments.create!(
+        content: "ordinary history",
+        topic_id: main.id,
+        user: @owner,
+        skip_default_user: true,
+        skip_dispatch: true
+      )
+      approval = @child.comments.create!(
+        content: "approve this tool",
+        topic_id: main.id,
+        user: @ai_bot,
+        approver: @owner,
+        action: JSON.generate(action: "approve_tool"),
+        skip_default_user: true,
+        skip_dispatch: true
+      )
+
+      SystemEvents::Dispatcher.stub(:dispatch, ->(*_args) { [ @ai_bot ] }) do
+        DropTriggerJob.perform_now(@parent.id, @child.id)
+      end
+
+      topic = @child.topics.find_by(name: "Drop Trigger")
+      assert topic, "Drop Trigger should be created when Main contains an approval prompt"
+      copied_contents = topic.comments.pluck(:content)
+      assert_includes copied_contents, visible.content
+      refute_includes copied_contents, approval.content
+    end
+
     test "branches more than MAX_BRANCH_COMMENTS Main messages without truncation" do
       main = @child.main_topic(fallback_user: @owner)
       total = TopicBranchService::MAX_BRANCH_COMMENTS + 5

--- a/engines/collavre/test/jobs/collavre/drop_trigger_job_test.rb
+++ b/engines/collavre/test/jobs/collavre/drop_trigger_job_test.rb
@@ -329,6 +329,46 @@ module Collavre
       refute_includes copied_contents, approval.content
     end
 
+    test "skips a Main message that becomes an approval prompt after selection" do
+      main = @child.main_topic(fallback_user: @owner)
+      visible = @child.comments.create!(
+        content: "ordinary history",
+        topic_id: main.id,
+        user: @owner,
+        skip_default_user: true,
+        skip_dispatch: true
+      )
+      raced = @child.comments.create!(
+        content: "changes after selection",
+        topic_id: main.id,
+        user: @ai_bot,
+        approver: @owner,
+        skip_default_user: true,
+        skip_dispatch: true
+      )
+      constructor = TopicBranchService.method(:new)
+      mutate_after_selection = lambda do |**arguments|
+        service = constructor.call(**arguments)
+        branch = service.method(:call)
+        service.define_singleton_method(:call) do |**options|
+          raced.update!(action: JSON.generate(action: "approve_tool"))
+          branch.call(**options)
+        end
+        service
+      end
+
+      TopicBranchService.stub(:new, mutate_after_selection) do
+        SystemEvents::Dispatcher.stub(:dispatch, ->(*_args) { [ @ai_bot ] }) do
+          DropTriggerJob.perform_now(@parent.id, @child.id)
+        end
+      end
+
+      topic = @child.topics.find_by!(name: "Drop Trigger")
+      copied_contents = topic.comments.pluck(:content)
+      assert_includes copied_contents, visible.content
+      refute_includes copied_contents, raced.content
+    end
+
     test "branches more than MAX_BRANCH_COMMENTS Main messages without truncation" do
       main = @child.main_topic(fallback_user: @owner)
       total = TopicBranchService::MAX_BRANCH_COMMENTS + 5

--- a/engines/collavre/test/services/collavre/tools/id_list_test.rb
+++ b/engines/collavre/test/services/collavre/tools/id_list_test.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  module Tools
+    class IdListTest < ActiveSupport::TestCase
+      test "accepts the shapes a model actually writes" do
+        assert_equal [ 12, 45, 78 ], IdList.parse("12,45,78")
+        assert_equal [ 12, 45 ], IdList.parse([ "12", 45 ])
+        assert_equal [ 12 ], IdList.parse(12)
+        assert_equal [ 12 ], IdList.parse("12")
+        assert_equal [ 12, 45 ], IdList.parse(" 12 , 45 ")
+        assert_equal [ 12 ], IdList.parse("12,12")
+        assert_empty IdList.parse(nil)
+        assert_empty IdList.parse(" , ")
+      end
+
+      # to_i reads "12.5" as 12 and "123oops" as 123. topic_create and
+      # topic_branch move messages, so coercion moves a different message than
+      # the one named and reports success — the failure the caller never sees.
+      test "rejects tokens that are not whole numbers instead of coercing them" do
+        [ "123oops", "12.5", "-4", "1e3", "abc", "#12" ].each do |token|
+          error = assert_raises(ArgumentError, "expected #{token.inspect} to be rejected") do
+            IdList.parse(token)
+          end
+          assert_match(/not a valid id/, error.message)
+        end
+      end
+
+      test "rejects a malformed token even when the rest of the list is valid" do
+        assert_raises(ArgumentError) { IdList.parse("12,oops,45") }
+      end
+    end
+  end
+end

--- a/engines/collavre/test/services/collavre/tools/topic_authorizer_test.rb
+++ b/engines/collavre/test/services/collavre/tools/topic_authorizer_test.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  module Tools
+    class TopicAuthorizerTest < ActiveSupport::TestCase
+      setup do
+        @owner = users(:one)
+        @member = users(:two)
+        @creative = Collavre::Creative.create!(description: "Auth Host", user: @owner)
+        @topic = @creative.topics.create!(name: "Gated", user: @owner)
+      end
+
+      def share!(permission)
+        Collavre::CreativeShare.create!(creative: @creative, user: @member, permission: permission,
+                                        shared_by: @owner)
+      end
+
+      test "the owner passes every level without holding an explicit share" do
+        assert_nil TopicAuthorizer.authorize_read!(@topic, user: @owner)
+        assert_nil TopicAuthorizer.authorize_write!(@topic, user: @owner)
+        assert_nil TopicAuthorizer.authorize_admin!(@topic, user: @owner)
+      end
+
+      test "each level admits only what it should" do
+        share!(:write)
+
+        assert_nil TopicAuthorizer.authorize_read!(@topic, user: @member)
+        assert_nil TopicAuthorizer.authorize_write!(@topic, user: @member)
+        assert_raises(Collavre::Tools::PermissionDeniedError) do
+          TopicAuthorizer.authorize_admin!(@topic, user: @member)
+        end
+      end
+
+      test "a user with no share is refused" do
+        assert_raises(Collavre::Tools::PermissionDeniedError) do
+          TopicAuthorizer.authorize_read!(@topic, user: @member)
+        end
+      end
+
+      test "a nil user is refused rather than treated as anonymous read" do
+        assert_raises(Collavre::Tools::PermissionDeniedError) do
+          TopicAuthorizer.authorize_read!(@topic, user: nil)
+        end
+      end
+
+      test "permission is resolved on the origin creative, where shares live" do
+        share!(:read)
+        link = Collavre::Creative.create!(description: "Link", user: @member, origin: @creative)
+        linked_topic = Topic.new(creative: link, user: @member, name: "Linked")
+
+        assert_nil TopicAuthorizer.authorize_read!(linked_topic, user: @member)
+      end
+
+      test "a topic with no creative is a caller error, not a permission failure" do
+        assert_raises(ArgumentError) { TopicAuthorizer.authorize_read!(Topic.new, user: @owner) }
+        assert_raises(ArgumentError) { TopicAuthorizer.authorize_creative!(nil, :read, user: @owner) }
+      end
+
+      test "readable? answers without raising, including for a broken topic" do
+        share!(:read)
+
+        assert TopicAuthorizer.readable?(@topic, user: @member)
+        assert_not TopicAuthorizer.readable?(@topic, user: users(:three))
+        assert_not TopicAuthorizer.readable?(Topic.new, user: @owner)
+      end
+
+      test "authorize_creative! gates topic creation on the creative itself" do
+        share!(:read)
+
+        assert_nil TopicAuthorizer.authorize_creative!(@creative, :read, user: @member)
+        assert_raises(Collavre::Tools::PermissionDeniedError) do
+          TopicAuthorizer.authorize_creative!(@creative, :write, user: @member)
+        end
+      end
+    end
+  end
+end

--- a/engines/collavre/test/services/collavre/tools/topic_branch_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/topic_branch_service_test.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  module Tools
+    class TopicBranchServiceTest < ActiveSupport::TestCase
+      setup do
+        @user = users(:one)
+        @stranger = users(:two)
+        @creative = Collavre::Creative.create!(description: "Branch Host", user: @user)
+        @source = @creative.topics.create!(name: "Long thread", user: @user)
+        @comments = 3.times.map { |i| post("m#{i}") }
+        Collavre::Current.user = @user
+      end
+
+      teardown { Collavre::Current.user = nil }
+
+      def post(content)
+        Comment.create!(creative: @creative, topic: @source, user: @user, content: content,
+                        skip_default_user: true, skip_dispatch: true)
+      end
+
+      test "copies the selected messages into a new topic and leaves the originals" do
+        ids = @comments.first(2).map(&:id)
+        result = TopicBranchService.new.call(source_topic_id: @source.id, comment_ids: ids.join(","),
+                                             name: "Focused")
+
+        assert_equal "Focused", result[:name]
+        assert_equal @source.id, result[:source_topic_id]
+        assert_equal 2, result[:copied_count]
+        assert_equal 2, Topic.find(result[:id]).comments.count
+        assert_equal 3, @source.comments.count
+      end
+
+      test "records the source so the branch can be traced back" do
+        result = TopicBranchService.new.call(source_topic_id: @source.id, comment_ids: @comments.first.id)
+
+        assert_equal @source.id, Topic.find(result[:id]).source_topic_id
+      end
+
+      test "defaults to a generated branch name" do
+        result = TopicBranchService.new.call(source_topic_id: @source.id, comment_ids: @comments.first.id)
+
+        assert_includes result[:name], I18n.t("collavre.topics.branch_prefix")
+      end
+
+      test "requires at least one message id" do
+        assert_raises(ArgumentError) { TopicBranchService.new.call(source_topic_id: @source.id, comment_ids: "") }
+      end
+
+      # The wrapped service trims an oversized selection and reports success for
+      # the shortened list; through a tool that would silently lose messages.
+      test "an oversized selection is an error rather than a silent trim" do
+        ids = (1..::Collavre::TopicBranchService::MAX_BRANCH_COMMENTS + 1).to_a
+        error = assert_raises(ArgumentError) do
+          TopicBranchService.new.call(source_topic_id: @source.id, comment_ids: ids.join(","))
+        end
+
+        assert_includes error.message, "at most #{::Collavre::TopicBranchService::MAX_BRANCH_COMMENTS}"
+      end
+
+      test "a message id from another topic is refused" do
+        other = @creative.topics.create!(name: "Elsewhere", user: @user)
+        stray = Comment.create!(creative: @creative, topic: other, user: @user, content: "stray",
+                                skip_default_user: true, skip_dispatch: true)
+
+        assert_raises(::Collavre::TopicBranchService::BranchError) do
+          TopicBranchService.new.call(source_topic_id: @source.id, comment_ids: stray.id)
+        end
+      end
+
+      test "requires read access to the source topic" do
+        Collavre::Current.user = @stranger
+
+        assert_raises(Collavre::Tools::PermissionDeniedError) do
+          TopicBranchService.new.call(source_topic_id: @source.id, comment_ids: @comments.first.id)
+        end
+      end
+
+      test "read alone is not enough to branch — the copy needs feedback" do
+        Collavre::CreativeShare.create!(creative: @creative, user: @stranger, permission: :read, shared_by: @user)
+        Collavre::Current.user = @stranger
+
+        assert_raises(::Collavre::TopicBranchService::BranchError) do
+          TopicBranchService.new.call(source_topic_id: @source.id, comment_ids: @comments.first.id)
+        end
+      end
+
+      test "requires a current user" do
+        Collavre::Current.user = nil
+
+        assert_raises(RuntimeError) do
+          TopicBranchService.new.call(source_topic_id: @source.id, comment_ids: @comments.first.id)
+        end
+      end
+
+      test "the branch is readable through topic_messages" do
+        result = TopicBranchService.new.call(source_topic_id: @source.id,
+                                             comment_ids: @comments.map(&:id).join(","))
+        payload = TopicMessagesService.new.call(topic_ids: result[:id], format: "json")
+
+        assert_equal %w[m0 m1 m2], payload[:topics].first[:messages].map { |m| m[:content] }
+      end
+    end
+  end
+end

--- a/engines/collavre/test/services/collavre/tools/topic_branch_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/topic_branch_service_test.rb
@@ -16,9 +16,40 @@ module Collavre
 
       teardown { Collavre::Current.user = nil }
 
-      def post(content)
+      def post(content, action: nil)
         Comment.create!(creative: @creative, topic: @source, user: @user, content: content,
-                        skip_default_user: true, skip_dispatch: true)
+                        action: action, skip_default_user: true, skip_dispatch: true)
+      end
+
+      # The branch copies content but not `action`, so a copied approval prompt
+      # stops matching Comment.without_approval_action and lands in the agent
+      # history queries the column exists to keep it out of.
+      test "an approval prompt cannot be branched" do
+        prompt = post("Approve the deploy?", action: "approve")
+
+        error = assert_raises(ArgumentError) do
+          TopicBranchService.new.call(source_topic_id: @source.id, comment_ids: prompt.id)
+        end
+
+        assert_includes error.message, "approval prompt"
+        assert_equal 0, @creative.topics.where(source_topic_id: @source.id).count
+      end
+
+      test "an approval prompt mixed into an otherwise valid selection fails the whole branch" do
+        prompt = post("Approve the deploy?", action: "approve")
+        ids = [ @comments.first.id, prompt.id ]
+
+        assert_raises(ArgumentError) do
+          TopicBranchService.new.call(source_topic_id: @source.id, comment_ids: ids.join(","))
+        end
+
+        assert_equal 0, @creative.topics.where(source_topic_id: @source.id).count
+      end
+
+      test "the copy of an ordinary message stays outside the approval surface" do
+        result = TopicBranchService.new.call(source_topic_id: @source.id, comment_ids: @comments.first.id)
+
+        assert_equal 1, Topic.find(result[:id]).comments.without_approval_action.count
       end
 
       test "copies the selected messages into a new topic and leaves the originals" do

--- a/engines/collavre/test/services/collavre/tools/topic_branch_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/topic_branch_service_test.rb
@@ -208,6 +208,25 @@ module Collavre
         end
       end
 
+      test "reauthorizes a source moved to an inaccessible creative after locking it" do
+        restricted = Collavre::Creative.create!(description: "Restricted", user: @stranger)
+        lock_after_move = lambda do
+          @source.update_column(:creative_id, restricted.id)
+          @source.reload
+        end
+
+        Collavre::Topic.stub(:find, @source) do
+          @source.stub(:lock!, lock_after_move) do
+            assert_raises(::Collavre::TopicBranchService::BranchError) do
+              TopicBranchService.new.call(source_topic_id: @source.id, comment_ids: @comments.first.id)
+            end
+          end
+        end
+
+        assert_equal 0, @creative.topics.where(source_topic_id: @source.id).count
+        assert_equal 0, restricted.topics.where(source_topic_id: @source.id).count
+      end
+
       test "requires a current user" do
         Collavre::Current.user = nil
 

--- a/engines/collavre/test/services/collavre/tools/topic_branch_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/topic_branch_service_test.rb
@@ -16,9 +16,14 @@ module Collavre
 
       teardown { Collavre::Current.user = nil }
 
-      def post(content, action: nil)
+      def post(content, action: nil, private_flag: false, approver: nil)
         Comment.create!(creative: @creative, topic: @source, user: @user, content: content,
-                        action: action, skip_default_user: true, skip_dispatch: true)
+                        action: action, private: private_flag, approver: approver,
+                        skip_default_user: true, skip_dispatch: true)
+      end
+
+      def share!(user, permission)
+        Collavre::CreativeShare.create!(creative: @creative, user: user, permission: permission, shared_by: @user)
       end
 
       # The branch copies content but not `action`, so a copied approval prompt
@@ -44,6 +49,58 @@ module Collavre
         end
 
         assert_equal 0, @creative.topics.where(source_topic_id: @source.id).count
+      end
+
+      # The refusal names the id, so running it over the whole topic answered
+      # "is comment N an approval prompt?" for a comment the caller cannot read
+      # — a distinct error where every other hidden id gets the generic
+      # not-found. Feedback is granted here so the probe reaches the furthest
+      # point it can: the check ran before the wrapped service's permission
+      # gate, so read alone was enough to ask.
+      test "a hidden approval prompt is not distinguishable from any other unreadable id" do
+        hidden = post("Approve the deploy?", action: "approve", private_flag: true)
+        share!(@stranger, :feedback)
+        Collavre::Current.user = @stranger
+
+        hidden_error = assert_raises(::Collavre::TopicBranchService::BranchError) do
+          TopicBranchService.new.call(source_topic_id: @source.id, comment_ids: hidden.id)
+        end
+        absent_error = assert_raises(::Collavre::TopicBranchService::BranchError) do
+          TopicBranchService.new.call(source_topic_id: @source.id, comment_ids: 999_999)
+        end
+
+        assert_equal absent_error.message, hidden_error.message
+        assert_equal 0, @creative.topics.where(source_topic_id: @source.id).count
+      end
+
+      # Narrowing the lookup must not open the hole it closed: a prompt the
+      # caller *can* see is still refused, by name.
+      test "a visible approval prompt is still refused by name" do
+        prompt = post("Approve the deploy?", action: "approve")
+
+        error = assert_raises(ArgumentError) do
+          TopicBranchService.new.call(source_topic_id: @source.id, comment_ids: prompt.id)
+        end
+
+        assert_includes error.message, prompt.id.to_s
+      end
+
+      # visible_to reads a private comment for its author and its approver, so
+      # copying `private` without `approver_id` narrows who can see the copy.
+      # The caller selecting the message can be the approver rather than the
+      # author, and would get a branch whose copied_count counts a message the
+      # branch will never show them.
+      test "branching a private message carries its approver onto the copy" do
+        share!(@stranger, :feedback)
+        secret = post("between us", private_flag: true, approver: @stranger)
+        Collavre::Current.user = @stranger
+
+        result = TopicBranchService.new.call(source_topic_id: @source.id, comment_ids: secret.id)
+        copies = Topic.find(result[:id]).comments
+
+        assert_equal 1, result[:copied_count]
+        assert_equal 1, copies.visible_to(@stranger).count
+        assert_equal @stranger.id, copies.sole.approver_id
       end
 
       test "the copy of an ordinary message stays outside the approval surface" do

--- a/engines/collavre/test/services/collavre/tools/topic_branch_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/topic_branch_service_test.rb
@@ -166,6 +166,22 @@ module Collavre
         assert_includes result[:name], I18n.t("collavre.topics.branch_prefix")
       end
 
+      test "an inbox branch cannot take the reserved System name" do
+        inbox = Collavre::Creative.create!(description: "Inbox", user: @user, data: { "kind" => "inbox" })
+        source = inbox.topics.create!(name: "Conversation", user: @user)
+        comment = Comment.create!(creative: inbox, topic: source, user: @user, content: "carry me",
+                                  skip_default_user: true, skip_dispatch: true)
+        assert_nil inbox.topics.find_by(name: Collavre::Creative::SYSTEM_TOPIC_NAME)
+
+        error = assert_raises(::Collavre::TopicBranchService::BranchError) do
+          TopicBranchService.new.call(source_topic_id: source.id, comment_ids: comment.id,
+                                      name: Collavre::Creative::SYSTEM_TOPIC_NAME)
+        end
+
+        assert_includes error.message, "reserved"
+        assert_nil inbox.topics.find_by(name: Collavre::Creative::SYSTEM_TOPIC_NAME)
+      end
+
       test "requires at least one message id" do
         assert_raises(ArgumentError) { TopicBranchService.new.call(source_topic_id: @source.id, comment_ids: "") }
       end

--- a/engines/collavre/test/services/collavre/tools/topic_branch_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/topic_branch_service_test.rb
@@ -32,11 +32,11 @@ module Collavre
       test "an approval prompt cannot be branched" do
         prompt = post("Approve the deploy?", action: "approve")
 
-        error = assert_raises(ArgumentError) do
+        error = assert_raises(::Collavre::TopicBranchService::BranchError) do
           TopicBranchService.new.call(source_topic_id: @source.id, comment_ids: prompt.id)
         end
 
-        assert_includes error.message, "approval prompt"
+        assert_equal I18n.t("collavre.comments.branch.approval_action_not_branchable"), error.message
         assert_equal 0, @creative.topics.where(source_topic_id: @source.id).count
       end
 
@@ -44,7 +44,7 @@ module Collavre
         prompt = post("Approve the deploy?", action: "approve")
         ids = [ @comments.first.id, prompt.id ]
 
-        assert_raises(ArgumentError) do
+        assert_raises(::Collavre::TopicBranchService::BranchError) do
           TopicBranchService.new.call(source_topic_id: @source.id, comment_ids: ids.join(","))
         end
 
@@ -90,16 +90,14 @@ module Collavre
         assert_equal 0, @creative.topics.where(source_topic_id: @source.id).count
       end
 
-      # Narrowing the lookup must not open the hole it closed: a prompt the
-      # caller *can* see is still refused, by name.
-      test "a visible approval prompt is still refused by name" do
+      test "a visible approval prompt is still refused" do
         prompt = post("Approve the deploy?", action: "approve")
 
-        error = assert_raises(ArgumentError) do
+        error = assert_raises(::Collavre::TopicBranchService::BranchError) do
           TopicBranchService.new.call(source_topic_id: @source.id, comment_ids: prompt.id)
         end
 
-        assert_includes error.message, prompt.id.to_s
+        assert_equal I18n.t("collavre.comments.branch.approval_action_not_branchable"), error.message
       end
 
       # visible_to reads a private comment for its author and its approver, so
@@ -241,6 +239,26 @@ module Collavre
 
         assert_equal 0, @creative.topics.where(source_topic_id: @source.id).count
         assert_equal 0, restricted.topics.where(source_topic_id: @source.id).count
+      end
+
+      test "does not reveal approval state after the source moves to an inaccessible creative" do
+        prompt = post("Approve the deploy?", action: "approve")
+        restricted = Collavre::Creative.create!(description: "Restricted", user: @stranger)
+        parse = IdList.method(:parse)
+        move_after_authorization = lambda do |value|
+          @source.comments.update_all(creative_id: restricted.id)
+          @source.update_column(:creative_id, restricted.id)
+          parse.call(value)
+        end
+
+        error = assert_raises(::Collavre::TopicBranchService::BranchError) do
+          IdList.stub(:parse, move_after_authorization) do
+            TopicBranchService.new.call(source_topic_id: @source.id, comment_ids: prompt.id)
+          end
+        end
+
+        assert_equal I18n.t("collavre.comments.branch.not_authorized"), error.message
+        assert_not_includes error.message, "approval"
       end
 
       test "requires a current user" do

--- a/engines/collavre/test/services/collavre/tools/topic_branch_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/topic_branch_service_test.rb
@@ -126,6 +126,22 @@ module Collavre
         assert_equal 1, Topic.find(result[:id]).comments.without_approval_action.count
       end
 
+      test "copies an image-only message with its attachments" do
+        original = Comment.new(creative: @creative, topic: @source, user: @user, content: "",
+                               skip_default_user: true, skip_dispatch: true)
+        original.images.attach(
+          io: StringIO.new("image bytes"), filename: "diagram.png", content_type: "image/png"
+        )
+        original.save!
+
+        result = TopicBranchService.new.call(source_topic_id: @source.id, comment_ids: original.id)
+        copy = Topic.find(result[:id]).comments.sole
+
+        assert_equal "", copy.content
+        assert_equal [ original.images.sole.blob_id ], copy.images.map(&:blob_id)
+        assert_equal "diagram.png", copy.images.sole.filename.to_s
+      end
+
       test "copies the selected messages into a new topic and leaves the originals" do
         ids = @comments.first(2).map(&:id)
         result = TopicBranchService.new.call(source_topic_id: @source.id, comment_ids: ids.join(","),

--- a/engines/collavre/test/services/collavre/tools/topic_branch_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/topic_branch_service_test.rb
@@ -51,6 +51,23 @@ module Collavre
         assert_equal 0, @creative.topics.where(source_topic_id: @source.id).count
       end
 
+      test "an ordinary message changed into an approval prompt after preflight is not copied" do
+        comment = @comments.first
+        constructor = ::Collavre::TopicBranchService.method(:new)
+        mutate_after_preflight = lambda do |**arguments|
+          comment.update!(action: "approve")
+          constructor.call(**arguments)
+        end
+
+        assert_raises(::Collavre::TopicBranchService::BranchError) do
+          ::Collavre::TopicBranchService.stub(:new, mutate_after_preflight) do
+            TopicBranchService.new.call(source_topic_id: @source.id, comment_ids: comment.id)
+          end
+        end
+
+        assert_equal 0, @creative.topics.where(source_topic_id: @source.id).count
+      end
+
       # The refusal names the id, so running it over the whole topic answered
       # "is comment N an approval prompt?" for a comment the caller cannot read
       # — a distinct error where every other hidden id gets the generic

--- a/engines/collavre/test/services/collavre/tools/topic_create_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/topic_create_service_test.rb
@@ -44,6 +44,17 @@ module Collavre
         assert_equal({ id: @agent.id, name: "Worker" }, result[:primary_agent])
       end
 
+      test "pins a private agent already shared on the creative" do
+        @agent.update!(searchable: false)
+        share!(:feedback)
+
+        result = TopicCreateService.new.call(
+          creative_id: @creative.id, name: "Shared Pin", primary_agent: "Worker"
+        )
+
+        assert_equal @agent.id, result.dig(:primary_agent, :id)
+      end
+
       test "refuses to pin an agent with no access, and creates no topic" do
         error = assert_raises(ArgumentError) do
           TopicCreateService.new.call(creative_id: @creative.id, name: "Pinned", primary_agent: @agent.id.to_s)

--- a/engines/collavre/test/services/collavre/tools/topic_create_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/topic_create_service_test.rb
@@ -91,6 +91,26 @@ module Collavre
         end
       end
 
+      test "an inbox topic cannot take the reserved System name" do
+        inbox = Collavre::Creative.create!(description: "Inbox", user: @user, data: { "kind" => "inbox" })
+        assert_nil inbox.topics.find_by(name: Collavre::Creative::SYSTEM_TOPIC_NAME)
+
+        error = assert_raises(ArgumentError) do
+          TopicCreateService.new.call(creative_id: inbox.id, name: Collavre::Creative::SYSTEM_TOPIC_NAME)
+        end
+
+        assert_includes error.message, "reserved"
+        assert_nil inbox.topics.find_by(name: Collavre::Creative::SYSTEM_TOPIC_NAME)
+      end
+
+      test "System remains an ordinary topic name outside an inbox" do
+        result = TopicCreateService.new.call(
+          creative_id: @creative.id, name: Collavre::Creative::SYSTEM_TOPIC_NAME
+        )
+
+        assert_equal Collavre::Creative::SYSTEM_TOPIC_NAME, result[:name]
+      end
+
       test "requires write permission on the creative" do
         Collavre::Current.user = @stranger
 

--- a/engines/collavre/test/services/collavre/tools/topic_create_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/topic_create_service_test.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  module Tools
+    class TopicCreateServiceTest < ActiveSupport::TestCase
+      setup do
+        @user = users(:one)
+        @stranger = users(:two)
+        @creative = Collavre::Creative.create!(description: "Create Host", user: @user)
+        @agent = Collavre::User.create!(name: "Worker", email: "worker-#{SecureRandom.hex(4)}@test.test",
+                                        password: "password123", llm_vendor: "google",
+                                        llm_model: "gemini-1.5-flash", searchable: true)
+        Collavre::Current.user = @user
+      end
+
+      teardown { Collavre::Current.user = nil }
+
+      def share!(permission)
+        Collavre::CreativeShare.create!(creative: @creative, user: @agent, permission: permission,
+                                        shared_by: @user)
+      end
+
+      test "creates a named topic on the creative" do
+        result = TopicCreateService.new.call(creative_id: @creative.id, name: "Research")
+
+        assert_equal "Research", result[:name]
+        assert_equal @creative.id, result[:creative_id]
+        assert @creative.topics.exists?(name: "Research")
+      end
+
+      test "falls back to the same generated name the UI would use" do
+        result = TopicCreateService.new.call(creative_id: @creative.id)
+
+        assert_equal Topics::NextName.for(@creative), "#{I18n.t('collavre.topics.default_name_prefix')}2"
+        assert_equal "#{I18n.t('collavre.topics.default_name_prefix')}1", result[:name]
+      end
+
+      test "pins an agent that has feedback on the creative" do
+        share!(:feedback)
+        result = TopicCreateService.new.call(creative_id: @creative.id, name: "Pinned", primary_agent: "Worker")
+
+        assert_equal({ id: @agent.id, name: "Worker" }, result[:primary_agent])
+      end
+
+      test "refuses to pin an agent with no access, and creates no topic" do
+        error = assert_raises(ArgumentError) do
+          TopicCreateService.new.call(creative_id: @creative.id, name: "Pinned", primary_agent: @agent.id.to_s)
+        end
+
+        assert_includes error.message, "no feedback permission"
+        assert_not @creative.topics.exists?(name: "Pinned")
+      end
+
+      test "an unresolvable agent name is rejected before anything is created" do
+        assert_raises(Topics::AgentResolver::UnknownAgentError) do
+          TopicCreateService.new.call(creative_id: @creative.id, name: "Pinned", primary_agent: "Ghost")
+        end
+
+        assert_not @creative.topics.exists?(name: "Pinned")
+      end
+
+      test "moves existing messages into the new topic" do
+        main = @creative.main_topic(fallback_user: @user)
+        comment = Comment.create!(creative: @creative, topic: main, user: @user, content: "carry me",
+                                  skip_default_user: true, skip_dispatch: true)
+
+        result = TopicCreateService.new.call(creative_id: @creative.id, name: "Moved",
+                                             comment_ids: comment.id.to_s)
+
+        assert_equal result[:id], comment.reload.topic_id
+      end
+
+      test "a duplicate name is refused" do
+        @creative.topics.create!(name: "Taken", user: @user)
+
+        assert_raises(ActiveRecord::RecordInvalid) do
+          TopicCreateService.new.call(creative_id: @creative.id, name: "Taken")
+        end
+      end
+
+      test "requires write permission on the creative" do
+        Collavre::Current.user = @stranger
+
+        assert_raises(Collavre::Tools::PermissionDeniedError) do
+          TopicCreateService.new.call(creative_id: @creative.id, name: "Nope")
+        end
+      end
+
+      test "read permission alone is not enough" do
+        Collavre::CreativeShare.create!(creative: @creative, user: @stranger, permission: :read, shared_by: @user)
+        Collavre::Current.user = @stranger
+
+        assert_raises(Collavre::Tools::PermissionDeniedError) do
+          TopicCreateService.new.call(creative_id: @creative.id, name: "Nope")
+        end
+      end
+
+      test "requires a current user" do
+        Collavre::Current.user = nil
+
+        assert_raises(RuntimeError) { TopicCreateService.new.call(creative_id: @creative.id) }
+      end
+
+      test "a linked creative creates the topic on the origin" do
+        link = Collavre::Creative.create!(description: "Link", user: @user, origin: @creative)
+        result = TopicCreateService.new.call(creative_id: link.id, name: "Via link")
+
+        assert_equal @creative.id, result[:creative_id]
+      end
+
+      test "announces the new topic so open clients see it, and selects it for the caller" do
+        payload = nil
+        Collavre::TopicsChannel.stub(:broadcast_to, ->(_creative, data) { payload = data }) do
+          TopicCreateService.new.call(creative_id: @creative.id, name: "Announced")
+        end
+
+        assert_equal "created", payload[:action]
+        assert_equal "Announced", payload[:topic][:name]
+        assert_equal @user.id, payload[:user_id]
+      end
+
+      test "the announcement carries the pin so the sidebar shows the avatar immediately" do
+        share!(:feedback)
+        payload = nil
+        Collavre::TopicsChannel.stub(:broadcast_to, ->(_creative, data) { payload = data }) do
+          TopicCreateService.new.call(creative_id: @creative.id, name: "Announced", primary_agent: "Worker")
+        end
+
+        assert_equal @agent.id, payload[:topic][:primary_agent][:id]
+      end
+    end
+  end
+end

--- a/engines/collavre/test/services/collavre/tools/topic_list_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/topic_list_service_test.rb
@@ -23,6 +23,18 @@ module Collavre
 
       def names(result) = result[:topics].map { |t| t[:name] }
 
+      # Same rule as topic_messages, and for the same reason: a caller sizing up
+      # thirty topics before splitting work would have been handed twenty and
+      # nothing to say the other ten existed. Listing a whole creative is
+      # unaffected — the cap is on explicit id batches, not on what a creative
+      # happens to hold.
+      test "more topic_ids than the per-call cap is an error, not a silent trim" do
+        ids = (1..TopicSelection::MAX_TOPICS + 1).to_a
+
+        error = assert_raises(ArgumentError) { TopicListService.new.call(topic_ids: ids.join(",")) }
+        assert_match(/at most #{TopicSelection::MAX_TOPICS}/, error.message)
+      end
+
       test "lists a creative's active topics with message totals" do
         post(@work, "hello")
         result = TopicListService.new.call(creative_id: @creative.id)

--- a/engines/collavre/test/services/collavre/tools/topic_list_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/topic_list_service_test.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  module Tools
+    class TopicListServiceTest < ActiveSupport::TestCase
+      setup do
+        @user = users(:one)
+        @stranger = users(:two)
+        @creative = Collavre::Creative.create!(description: "List Host", user: @user)
+        @main = @creative.main_topic(fallback_user: @user)
+        @work = @creative.topics.create!(name: "Work", user: @user)
+        Collavre::Current.user = @user
+      end
+
+      teardown { Collavre::Current.user = nil }
+
+      def post(topic, content)
+        Comment.create!(creative: @creative, topic: topic, user: @user, content: content,
+                        skip_default_user: true, skip_dispatch: true)
+      end
+
+      def names(result) = result[:topics].map { |t| t[:name] }
+
+      test "lists a creative's active topics with message totals" do
+        post(@work, "hello")
+        result = TopicListService.new.call(creative_id: @creative.id)
+
+        work = result[:topics].find { |t| t[:name] == "Work" }
+        assert_includes names(result), "Main"
+        assert_equal 1, work[:message_count]
+        assert_equal 5, work[:message_chars]
+        assert_not_nil work[:last_message_at]
+      end
+
+      test "archived topics are hidden unless asked for" do
+        @work.archive!
+
+        assert_not_includes names(TopicListService.new.call(creative_id: @creative.id)), "Work"
+        assert_includes names(TopicListService.new.call(creative_id: @creative.id, include_archived: true)), "Work"
+      end
+
+      test "include_stats false omits the totals" do
+        post(@work, "hello")
+        result = TopicListService.new.call(creative_id: @creative.id, include_stats: false)
+
+        assert_not result[:topics].first.key?(:message_count)
+      end
+
+      test "a nil include_stats still counts, so an explicit null does not silently disable totals" do
+        post(@work, "hello")
+        result = TopicListService.new.call(creative_id: @creative.id, include_stats: nil)
+
+        assert_equal 1, result[:topics].find { |t| t[:name] == "Work" }[:message_count]
+      end
+
+      test "include_system matches what topic_messages would return" do
+        Comment.create!(creative: @creative, topic: @work, user: nil, content: "⏳",
+                        skip_default_user: true, skip_dispatch: true)
+
+        plain = TopicListService.new.call(creative_id: @creative.id)
+        with_system = TopicListService.new.call(creative_id: @creative.id, include_system: true)
+
+        assert_equal 0, plain[:topics].find { |t| t[:name] == "Work" }[:message_count]
+        assert_equal 1, with_system[:topics].find { |t| t[:name] == "Work" }[:message_count]
+      end
+
+      test "topic_ids describes specific topics and reports the ones it cannot reach" do
+        result = TopicListService.new.call(topic_ids: "#{@work.id},999999")
+
+        assert_equal [ "Work" ], names(result)
+        assert_equal [ { topic_id: 999_999, error: "Topic not found or not readable" } ], result[:errors]
+      end
+
+      test "topic_ids wins over creative_id when both are given" do
+        result = TopicListService.new.call(creative_id: @creative.id, topic_ids: @work.id)
+
+        assert_equal [ "Work" ], names(result)
+      end
+
+      test "reports a topic pinned to an agent" do
+        agent = Collavre::User.create!(name: "Pinned", email: "pin-#{SecureRandom.hex(4)}@test.test",
+                                       password: "password123", llm_vendor: "google")
+        @work.set_primary_agent!(agent)
+
+        work = TopicListService.new.call(topic_ids: @work.id)[:topics].first
+        assert_equal "Pinned", work[:primary_agent][:name]
+      end
+
+      test "requires read permission on the creative" do
+        Collavre::Current.user = @stranger
+
+        assert_raises(Collavre::Tools::PermissionDeniedError) do
+          TopicListService.new.call(creative_id: @creative.id)
+        end
+      end
+
+      test "a topic on an unreadable creative is an error entry, not a leak" do
+        Collavre::Current.user = @stranger
+        result = TopicListService.new.call(topic_ids: @work.id)
+
+        assert_empty result[:topics]
+        assert_equal "Topic not found or not readable", result[:errors].first[:error]
+      end
+
+      test "requires either creative_id or topic_ids" do
+        assert_raises(ArgumentError) { TopicListService.new.call }
+      end
+
+      test "requires a current user" do
+        Collavre::Current.user = nil
+
+        assert_raises(RuntimeError) { TopicListService.new.call(creative_id: @creative.id) }
+      end
+
+      test "a linked creative lists the origin's topics" do
+        link = Collavre::Creative.create!(description: "Link", user: @user, origin: @creative)
+
+        assert_includes names(TopicListService.new.call(creative_id: link.id)), "Work"
+      end
+    end
+  end
+end

--- a/engines/collavre/test/services/collavre/tools/topic_messages_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/topic_messages_service_test.rb
@@ -95,12 +95,42 @@ module Collavre
 
       # "Nothing fit" and "the topics before you ate it" need different fixes,
       # so the first topic must not be told it lost a race it never ran.
-      test "a first topic too large for the cap says so rather than blaming earlier topics" do
+      test "a first topic with no message budget says so rather than blaming earlier topics" do
         post(@a, "x" * 500)
-        payload = json(topic_ids: @a.id, max_chars: 50)
+        payload = json(topic_ids: @a.id, max_chars: reserved_for(@a))
 
         assert_equal "max_chars is too small to return anything for this topic",
                      entry_for(payload, @a)[:skipped_reason]
+      end
+
+      test "tiny max_chars is clamped and fixed markdown metadata stays bounded" do
+        markdown = TopicMessagesService.new.call(topic_ids: @a.id, max_chars: 50)
+
+        assert_operator markdown.length, :<=, TopicMessagesService::MIN_MAX_CHARS
+        assert_includes markdown, "metadata needs"
+        assert_includes markdown, "max_chars is #{TopicMessagesService::MIN_MAX_CHARS}"
+      end
+
+      test "tiny max_chars returns a bounded json error instead of oversized topic metadata" do
+        payload = json(topic_ids: @a.id, max_chars: 50)
+
+        assert_equal "topic_messages metadata exceeds max_chars", payload[:error]
+        assert_equal TopicMessagesService::MIN_MAX_CHARS, payload[:max_chars]
+        assert payload[:truncated]
+        assert_operator payload.to_json.length, :<=, payload[:max_chars]
+      end
+
+      test "an unrestricted long topic name cannot exceed the response cap" do
+        @a.update!(name: "a\n\"\\" * 20_000)
+        cap = 1_000
+
+        markdown = TopicMessagesService.new.call(topic_ids: @a.id, max_chars: cap)
+        payload = json(topic_ids: @a.id, max_chars: cap)
+
+        assert_operator markdown.length, :<=, cap
+        assert_includes markdown, "metadata needs"
+        assert_operator payload.to_json.length, :<=, cap
+        assert_equal "topic_messages metadata exceeds max_chars", payload[:error]
       end
 
       test "budget_limited marks a topic the shared cap cut short" do
@@ -231,6 +261,8 @@ module Collavre
 
         assert_equal TopicMessagesService::DEFAULT_MAX_CHARS, json(topic_ids: @a.id)[:max_chars]
         assert_equal TopicMessagesService::DEFAULT_MAX_CHARS, json(topic_ids: @a.id, max_chars: 0)[:max_chars]
+        assert_equal TopicMessagesService::MIN_MAX_CHARS,
+                     json(topic_ids: @a.id, max_chars: 1)[:max_chars]
         assert_equal TopicMessagesService::MAX_MAX_CHARS, json(topic_ids: @a.id, max_chars: 10_000_000)[:max_chars]
       end
 

--- a/engines/collavre/test/services/collavre/tools/topic_messages_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/topic_messages_service_test.rb
@@ -175,7 +175,7 @@ module Collavre
         markdown = TopicMessagesService.new.call(topic_ids: @a.id, max_chars: cap)
 
         assert_operator markdown.length, :<=, cap
-        assert_includes markdown, "clipped from 50000 chars"
+        assert_includes markdown, "continue with content_offset"
       end
 
       # max_chars has to bound the response the caller actually receives, and
@@ -238,14 +238,68 @@ module Collavre
                         as_markdown.scan(/^\[\d+\] /).length
       end
 
-      # has_more is false here — the window did reach the end of the topic — so
-      # clipped_count is the only thing that can say the answer is partial.
-      test "a clipped message marks the response truncated even with nothing left to page" do
+      test "a clipped message remains pageable even when it is the topic's only row" do
         post(@a, "y" * 50_000)
         payload = json(topic_ids: @a.id, max_chars: 1_200)
+        entry = entry_for(payload, @a)
 
-        assert_equal 1, entry_for(payload, @a)[:clipped_count]
+        assert_equal 1, entry[:clipped_count]
+        assert entry[:has_more]
+        assert_equal 0, entry[:next_offset]
+        assert_operator entry[:next_content_offset], :>, 0
         assert payload[:truncated]
+      end
+
+
+      test "content continuation returns every character of an oversized message" do
+        content = (%Q(He said "yes".\n) * 600).freeze
+        comment = post(@a, content)
+        chunks = []
+        offset = 0
+        content_offset = 0
+        anchor = nil
+
+        100.times do
+          payload = json(
+            topic_ids: @a.id, limit: 1, max_chars: 1_200,
+            offset: offset, content_offset: content_offset, max_message_id: anchor
+          )
+          entry = entry_for(payload, @a)
+          message = entry[:messages].first
+          anchor ||= entry[:newest_message_id]
+          chunks << message[:content]
+
+          assert_equal comment.id, message[:id]
+          assert_operator payload.to_json.length, :<=, 1_200
+
+          content_offset = entry[:next_content_offset]
+          break unless content_offset
+
+          offset = entry[:next_offset]
+          assert_equal 0, offset
+        end
+
+        assert_nil content_offset
+        assert_equal content.strip, chunks.join
+      end
+
+      test "content beyond the maximum response cap remains retrievable" do
+        content = "z" * (TopicMessagesService::MAX_MAX_CHARS + 1_000)
+        post(@a, content)
+
+        first = json(topic_ids: @a.id, limit: 1, max_chars: TopicMessagesService::MAX_MAX_CHARS)
+        first_entry = entry_for(first, @a)
+        second = json(
+          topic_ids: @a.id, limit: 1, max_chars: TopicMessagesService::MAX_MAX_CHARS,
+          offset: first_entry[:next_offset], content_offset: first_entry[:next_content_offset],
+          max_message_id: first_entry[:newest_message_id]
+        )
+        second_entry = entry_for(second, @a)
+
+        assert_equal 0, first_entry[:next_offset]
+        assert_operator first_entry[:next_content_offset], :>, 0
+        assert_nil second_entry[:next_content_offset]
+        assert_equal content, first_entry[:messages].first[:content] + second_entry[:messages].first[:content]
       end
 
       test "a fully returned topic is not marked truncated" do

--- a/engines/collavre/test/services/collavre/tools/topic_messages_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/topic_messages_service_test.rb
@@ -74,6 +74,16 @@ module Collavre
         payload = json(topic_ids: @a.id, limit: 2, order: "desc")
 
         assert_equal %w[m2 m1], entry_for(payload, @a)[:messages].map { |m| m[:content] }
+        assert_equal "desc", entry_for(payload, @a)[:order]
+      end
+
+
+      test "markdown continuation preserves newest-first rendering order" do
+        3.times { |i| post(@a, "m#{i}") }
+
+        markdown = TopicMessagesService.new.call(topic_ids: @a.id, limit: 1, order: "desc")
+
+        assert_includes markdown, 'order: "desc"'
       end
 
       test "max_chars is a whole-response cap, and a topic it cannot reach is reported unfetched" do

--- a/engines/collavre/test/services/collavre/tools/topic_messages_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/topic_messages_service_test.rb
@@ -432,6 +432,25 @@ module Collavre
         assert_equal [ { topic_id: @a.id, error: "Topic not found or not readable" } ], payload[:topics]
       end
 
+      test "a topic moved after authorization cannot expose its destination messages" do
+        post(@a, "secret after move")
+        restricted = Creative.create!(description: "Restricted", user: @stranger)
+        service = TopicMessagesService.new
+        collect = service.method(:collect)
+        move_before_collect = lambda do |topics, errors, user, options|
+          Topics::TopicMove.new(topic: @a, target_creative: restricted).call
+          collect.call(topics, errors, user, options)
+        end
+
+        payload = service.stub(:collect, move_before_collect) do
+          service.call(topic_ids: @a.id, format: "json")
+        end
+
+        assert_equal 0, entry_for(payload, @a)[:returned_count]
+        assert_empty entry_for(payload, @a)[:messages]
+        assert_equal restricted.id, @a.reload.creative_id
+      end
+
       # Trimming to the cap returned a response that looked complete — every
       # topic present, each one in full — while whole conversations were absent
       # with nothing in the payload to say so. A caller told to summarize all of

--- a/engines/collavre/test/services/collavre/tools/topic_messages_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/topic_messages_service_test.rb
@@ -74,13 +74,30 @@ module Collavre
       test "paging with the returned anchor stays on one snapshot while the topic grows" do
         4.times { |i| post(@a, "m#{i}") }
         first = json(topic_ids: @a.id, limit: 2)
-        anchor = entry_for(first, @a)[:newest_message_id]
+        first_entry = entry_for(first, @a)
 
         post(@a, "arrived mid-read")
-        second = json(topic_ids: @a.id, limit: 2, offset: 2, max_message_id: anchor)
+        second = json(
+          topic_ids: @a.id, limit: 2, offset: first_entry[:next_offset],
+          cursor: first_entry[:next_cursor], max_message_id: first_entry[:newest_message_id]
+        )
 
         assert_equal %w[m0 m1], entry_for(second, @a)[:messages].map { |m| m[:content] }
         assert_not entry_for(second, @a)[:has_more]
+      end
+
+      test "paging cursor survives a returned message moving to another topic" do
+        comments = 5.times.map { |i| post(@a, "m#{i}") }
+        first = json(topic_ids: @a.id, limit: 2, order: "desc")
+        first_entry = entry_for(first, @a)
+
+        comments.last.update!(topic: @b)
+        second = json(
+          topic_ids: @a.id, limit: 2, order: "desc", offset: first_entry[:next_offset],
+          cursor: first_entry[:next_cursor], max_message_id: first_entry[:newest_message_id]
+        )
+
+        assert_equal %w[m2 m1], entry_for(second, @a)[:messages].map { |message| message[:content] }
       end
 
       test "order desc renders the window newest-first without changing which messages it selects" do

--- a/engines/collavre/test/services/collavre/tools/topic_messages_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/topic_messages_service_test.rb
@@ -168,8 +168,18 @@ module Collavre
         post(@a, "x" * 500)
         payload = json(topic_ids: @a.id, max_chars: reserved_for(@a))
 
-        assert_equal "max_chars is too small to return anything for this topic",
+        assert_equal TopicMessagesService::NOTHING_FITS_REASON,
                      entry_for(payload, @a)[:skipped_reason]
+      end
+
+      test "a positive message budget too small for one fragment is marked unfetched" do
+        post(@a, "x" * 5_000)
+        payload = json(topic_ids: @a.id, max_chars: reserved_for(@a) + 1)
+        entry = entry_for(payload, @a)
+
+        assert_equal TopicMessagesService::NOTHING_FITS_REASON, entry[:skipped_reason]
+        assert_empty entry[:messages]
+        assert payload[:truncated]
       end
 
       test "tiny max_chars is clamped and fixed markdown metadata stays bounded" do

--- a/engines/collavre/test/services/collavre/tools/topic_messages_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/topic_messages_service_test.rb
@@ -108,11 +108,34 @@ module Collavre
         assert_operator markdown.length, :<=, cap
       end
 
+      # The other way to blow the cap: one message bigger than the whole budget.
+      # Envelope accounting alone did not stop it, because the loop appended
+      # before it charged.
+      test "the rendered response stays within max_chars against one oversized message" do
+        post(@a, "y" * 50_000)
+        cap = 1_200
+        markdown = TopicMessagesService.new.call(topic_ids: @a.id, max_chars: cap)
+
+        assert_operator markdown.length, :<=, cap
+        assert_includes markdown, "clipped from 50000 chars"
+      end
+
+      # has_more is false here — the window did reach the end of the topic — so
+      # clipped_count is the only thing that can say the answer is partial.
+      test "a clipped message marks the response truncated even with nothing left to page" do
+        post(@a, "y" * 50_000)
+        payload = json(topic_ids: @a.id, max_chars: 1_200)
+
+        assert_equal 1, entry_for(payload, @a)[:clipped_count]
+        assert payload[:truncated]
+      end
+
       test "a fully returned topic is not marked truncated" do
         post(@a, "short")
 
         assert_not json(topic_ids: @a.id)[:truncated]
         assert_not entry_for(json(topic_ids: @a.id), @a).key?(:budget_limited)
+        assert_not entry_for(json(topic_ids: @a.id), @a).key?(:clipped_count)
       end
 
       test "max_chars is clamped and defaults when non-positive" do

--- a/engines/collavre/test/services/collavre/tools/topic_messages_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/topic_messages_service_test.rb
@@ -69,7 +69,7 @@ module Collavre
       test "max_chars is a whole-response cap, and a topic it cannot reach is reported unfetched" do
         post(@a, "x" * 500)
         post(@b, "y" * 500)
-        payload = json(topic_ids: "#{@a.id},#{@b.id}", max_chars: 100)
+        payload = json(topic_ids: "#{@a.id},#{@b.id}", max_chars: 800)
 
         assert payload[:truncated]
         assert_equal 1, entry_for(payload, @a)[:returned_count]
@@ -78,12 +78,34 @@ module Collavre
         assert entry_for(payload, @b)[:has_more]
       end
 
+      # "Nothing fit" and "the topics before you ate it" need different fixes,
+      # so the first topic must not be told it lost a race it never ran.
+      test "a first topic too large for the cap says so rather than blaming earlier topics" do
+        post(@a, "x" * 500)
+        payload = json(topic_ids: @a.id, max_chars: 50)
+
+        assert_equal "max_chars is too small to return anything for this topic",
+                     entry_for(payload, @a)[:skipped_reason]
+      end
+
       test "budget_limited marks a topic the shared cap cut short" do
-        3.times { post(@a, "x" * 100) }
-        payload = json(topic_ids: @a.id, max_chars: 150)
+        3.times { post(@a, "x" * 1000) }
+        payload = json(topic_ids: @a.id, max_chars: 2000)
 
         assert entry_for(payload, @a)[:budget_limited]
         assert payload[:truncated]
+      end
+
+      # max_chars is advertised as a cap on the response, so it has to bound
+      # the response — headers and per-message envelopes included, not just the
+      # prose. Hundreds of one-word messages used to cost almost nothing.
+      test "the rendered response stays within max_chars when messages are tiny" do
+        60.times { |i| post(@a, "m#{i}") }
+        60.times { |i| post(@b, "n#{i}") }
+        cap = 1_500
+        markdown = TopicMessagesService.new.call(topic_ids: "#{@a.id},#{@b.id}", limit: 200, max_chars: cap)
+
+        assert_operator markdown.length, :<=, cap
       end
 
       test "a fully returned topic is not marked truncated" do

--- a/engines/collavre/test/services/collavre/tools/topic_messages_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/topic_messages_service_test.rb
@@ -16,8 +16,8 @@ module Collavre
 
       teardown { Collavre::Current.user = nil }
 
-      def post(topic, content)
-        Comment.create!(creative: @creative, topic: topic, user: @user, content: content,
+      def post(topic, content, user: @user)
+        Comment.create!(creative: @creative, topic: topic, user: user, content: content,
                         skip_default_user: true, skip_dispatch: true)
       end
 
@@ -120,6 +120,19 @@ module Collavre
         cap = 1_500
         markdown = TopicMessagesService.new.call(topic_ids: "#{@a.id},#{@b.id}", limit: 200, max_chars: cap)
 
+        assert_operator markdown.length, :<=, cap
+      end
+
+      # An agent byline renders " (agent)" that content-plus-envelope did not
+      # charge. Eight characters is invisible on one message and larger than the
+      # per-topic reserve across a page of short agent turns — the shape a busy
+      # topic has, since the agent is the one that answers every message.
+      test "the rendered response stays within max_chars when the authors are agents" do
+        60.times { |i| post(@a, "m#{i}", user: users(:ai_bot)) }
+        cap = 1_500
+        markdown = TopicMessagesService.new.call(topic_ids: @a.id, limit: 200, max_chars: cap)
+
+        assert_includes markdown, "(agent)"
         assert_operator markdown.length, :<=, cap
       end
 
@@ -248,11 +261,22 @@ module Collavre
         assert_equal [ { topic_id: @a.id, error: "Topic not found or not readable" } ], payload[:topics]
       end
 
-      test "more topics than the per-call cap are dropped from the tail, not silently merged" do
+      # Trimming to the cap returned a response that looked complete — every
+      # topic present, each one in full — while whole conversations were absent
+      # with nothing in the payload to say so. A caller told to summarize all of
+      # them would have reported on a subset believing it had them all.
+      test "more topics than the per-call cap is an error, not a silent trim" do
         ids = (1..TopicSelection::MAX_TOPICS + 2).map { |i| @creative.topics.create!(name: "T#{i}", user: @user).id }
-        payload = json(topic_ids: ids.join(","))
 
-        assert_equal TopicSelection::MAX_TOPICS, payload[:topics].size
+        error = assert_raises(ArgumentError) { json(topic_ids: ids.join(",")) }
+        assert_match(/#{ids.size} topics requested/, error.message)
+        assert_match(/at most #{TopicSelection::MAX_TOPICS}/, error.message)
+      end
+
+      test "a batch exactly at the cap is still served" do
+        ids = (1..TopicSelection::MAX_TOPICS).map { |i| @creative.topics.create!(name: "T#{i}", user: @user).id }
+
+        assert_equal TopicSelection::MAX_TOPICS, json(topic_ids: ids.join(","))[:topics].size
       end
 
       test "requires at least one topic id" do

--- a/engines/collavre/test/services/collavre/tools/topic_messages_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/topic_messages_service_test.rb
@@ -100,6 +100,14 @@ module Collavre
         assert_includes markdown, 'order: "desc"'
       end
 
+      test "markdown continuation preserves the resolved limit and max_chars" do
+        3.times { |i| post(@a, "m#{i}") }
+
+        markdown = TopicMessagesService.new.call(topic_ids: @a.id, limit: 1, max_chars: 1_000)
+
+        assert_includes markdown, "limit: 1, max_chars: 1000"
+      end
+
       test "max_chars is a whole-response cap, and a topic it cannot reach is reported unfetched" do
         post(@a, "x" * 500)
         post(@b, "y" * 500)

--- a/engines/collavre/test/services/collavre/tools/topic_messages_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/topic_messages_service_test.rb
@@ -381,6 +381,32 @@ module Collavre
                      payload[:topics].last)
       end
 
+      test "unreadable topic errors do not replace readable messages at the response cap" do
+        post(@a, "visible " * 200)
+        missing_ids = (999_990..999_999).to_a
+        cap = 2_000
+
+        payload = json(topic_ids: [ @a.id, *missing_ids ], max_chars: cap)
+
+        assert_nil payload[:error]
+        assert_operator entry_for(payload, @a)[:returned_count], :>, 0
+        assert_equal missing_ids, payload[:topics].filter_map { |entry| entry[:topic_id] if entry[:error] }
+        assert_operator payload.to_json.length, :<=, cap
+      end
+
+      test "markdown reserves unreadable topic errors without discarding readable messages" do
+        post(@a, "visible " * 200)
+        missing_ids = (999_990..999_999).to_a
+        cap = 2_000
+
+        markdown = TopicMessagesService.new.call(topic_ids: [ @a.id, *missing_ids ], max_chars: cap)
+
+        assert_includes markdown, "visible"
+        assert_equal missing_ids.size, markdown.scan(/^## \[topic \d+\] unavailable$/).size
+        assert_not_includes markdown, "topic_messages metadata needs"
+        assert_operator markdown.length, :<=, cap
+      end
+
       test "a topic on a creative the caller cannot read is refused, not returned" do
         post(@a, "secret")
         Collavre::Current.user = @stranger

--- a/engines/collavre/test/services/collavre/tools/topic_messages_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/topic_messages_service_test.rb
@@ -27,6 +27,16 @@ module Collavre
 
       def entry_for(payload, topic) = payload[:topics].find { |t| t[:topic_id] == topic.id }
 
+      # The furniture every requested topic pays for whether or not it fits,
+      # reserved up front so the not-fetched notices cannot themselves overrun
+      # the cap that skipping produced them.
+      def reserved_for(*topics)
+        TopicMessagesService::TRUNCATION_CHARS +
+          topics.sum { |t| TopicMessagesService::TOPIC_HEADER_CHARS.fetch("json") + t.name.length }
+      end
+
+      def billed_chars_of(topic) = entry_for(json(topic_ids: topic.id), topic)[:billed_chars]
+
       test "reads one topic newest-first and renders the window as a forward transcript" do
         3.times { |i| post(@a, "m#{i}") }
         payload = json(topic_ids: @a.id, limit: 2)
@@ -69,7 +79,12 @@ module Collavre
       test "max_chars is a whole-response cap, and a topic it cannot reach is reported unfetched" do
         post(@a, "x" * 500)
         post(@b, "y" * 500)
-        payload = json(topic_ids: "#{@a.id},#{@b.id}", max_chars: 800)
+        # Sized from what Alpha actually bills rather than from a round number,
+        # so this stays a test of the skip semantics and not of anyone's
+        # arithmetic: room for both sections' furniture plus all of Alpha, and
+        # nothing left for Beta.
+        payload = json(topic_ids: "#{@a.id},#{@b.id}",
+                       max_chars: reserved_for(@a, @b) + billed_chars_of(@a))
 
         assert payload[:truncated]
         assert_equal 1, entry_for(payload, @a)[:returned_count]
@@ -118,6 +133,66 @@ module Collavre
 
         assert_operator markdown.length, :<=, cap
         assert_includes markdown, "clipped from 50000 chars"
+      end
+
+      # max_chars has to bound the response the caller actually receives, and
+      # for format: "json" that is the serialized hash — every field name and
+      # delimiter included. Charging markdown's 36-character envelope for a json
+      # message undercounted it by roughly 120, so a few dozen short messages
+      # sailed past the cap. Measured on to_json here for the same reason the
+      # markdown tests measure the rendered string: the emitted form is the only
+      # honest unit. (The MCP layer's own wrapper around this is out of scope —
+      # this tool can only be accountable for what it returns.)
+      test "the json response stays within max_chars when messages are tiny" do
+        60.times { |i| post(@a, "m#{i}") }
+        60.times { |i| post(@b, "n#{i}") }
+        cap = 3_000
+
+        payload = json(topic_ids: "#{@a.id},#{@b.id}", limit: 200, max_chars: cap)
+
+        assert_operator payload.to_json.length, :<=, cap
+        assert_operator entry_for(payload, @a)[:returned_count], :>, 0
+      end
+
+      # The other half of the undercount: json escapes the prose while it
+      # serializes it, so a quote- and newline-heavy message emits far wider
+      # than String#length reads. No fixed envelope constant can track that
+      # ratio, which is why the cost is measured on the serialized form.
+      test "the json response stays within max_chars when the prose is escape-heavy" do
+        20.times { post(@a, %Q(He said "yes",\nthen "no",\tthen \\ nothing.\n) * 20) }
+        cap = 6_000
+
+        payload = json(topic_ids: @a.id, limit: 200, max_chars: cap)
+
+        assert_operator payload.to_json.length, :<=, cap
+        assert_operator entry_for(payload, @a)[:returned_count], :>, 0
+      end
+
+      # Clipping has to respect the format too. The raw subtraction that sized
+      # the fragment is only an upper bound once escaping is in play, so the
+      # clip is bisected against the serialized cost instead of assumed.
+      test "the json response stays within max_chars against one oversized escape-heavy message" do
+        post(@a, %Q("y"\n) * 12_500)
+        cap = 1_500
+
+        payload = json(topic_ids: @a.id, max_chars: cap)
+
+        assert_operator payload.to_json.length, :<=, cap
+        assert_equal 1, entry_for(payload, @a)[:clipped_count]
+      end
+
+      # json pays for its own structure, so the same cap buys strictly fewer
+      # messages there. Pinning the direction guards against a later refactor
+      # collapsing the two cost models back into one.
+      test "json costs more of the budget than markdown for the same messages" do
+        40.times { |i| post(@a, "m#{i}") }
+        cap = 2_000
+
+        as_json = json(topic_ids: @a.id, limit: 200, max_chars: cap)
+        as_markdown = TopicMessagesService.new.call(topic_ids: @a.id, limit: 200, max_chars: cap)
+
+        assert_operator entry_for(as_json, @a)[:returned_count], :<,
+                        as_markdown.scan(/^\[\d+\] /).length
       end
 
       # has_more is false here — the window did reach the end of the topic — so

--- a/engines/collavre/test/services/collavre/tools/topic_messages_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/topic_messages_service_test.rb
@@ -1,0 +1,166 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  module Tools
+    class TopicMessagesServiceTest < ActiveSupport::TestCase
+      setup do
+        @user = users(:one)
+        @stranger = users(:two)
+        @creative = Collavre::Creative.create!(description: "Messages Host", user: @user)
+        @a = @creative.topics.create!(name: "Alpha", user: @user)
+        @b = @creative.topics.create!(name: "Beta", user: @user)
+        Collavre::Current.user = @user
+      end
+
+      teardown { Collavre::Current.user = nil }
+
+      def post(topic, content)
+        Comment.create!(creative: @creative, topic: topic, user: @user, content: content,
+                        skip_default_user: true, skip_dispatch: true)
+      end
+
+      def json(**args)
+        TopicMessagesService.new.call(format: "json", **args)
+      end
+
+      def entry_for(payload, topic) = payload[:topics].find { |t| t[:topic_id] == topic.id }
+
+      test "reads one topic newest-first and renders the window as a forward transcript" do
+        3.times { |i| post(@a, "m#{i}") }
+        payload = json(topic_ids: @a.id, limit: 2)
+
+        assert_equal %w[m1 m2], entry_for(payload, @a)[:messages].map { |m| m[:content] }
+        assert_equal 3, entry_for(payload, @a)[:total_count]
+        assert_equal 2, entry_for(payload, @a)[:next_offset]
+      end
+
+      test "offset and limit apply per topic, and topics are never interleaved" do
+        3.times { |i| post(@a, "a#{i}") }
+        3.times { |i| post(@b, "b#{i}") }
+        payload = json(topic_ids: "#{@a.id},#{@b.id}", limit: 2)
+
+        assert_equal %w[a1 a2], entry_for(payload, @a)[:messages].map { |m| m[:content] }
+        assert_equal %w[b1 b2], entry_for(payload, @b)[:messages].map { |m| m[:content] }
+        assert_equal 2, entry_for(payload, @a)[:next_offset]
+        assert_equal 2, entry_for(payload, @b)[:next_offset]
+      end
+
+      test "paging with the returned anchor stays on one snapshot while the topic grows" do
+        4.times { |i| post(@a, "m#{i}") }
+        first = json(topic_ids: @a.id, limit: 2)
+        anchor = entry_for(first, @a)[:newest_message_id]
+
+        post(@a, "arrived mid-read")
+        second = json(topic_ids: @a.id, limit: 2, offset: 2, max_message_id: anchor)
+
+        assert_equal %w[m0 m1], entry_for(second, @a)[:messages].map { |m| m[:content] }
+        assert_not entry_for(second, @a)[:has_more]
+      end
+
+      test "order desc renders the window newest-first without changing which messages it selects" do
+        3.times { |i| post(@a, "m#{i}") }
+        payload = json(topic_ids: @a.id, limit: 2, order: "desc")
+
+        assert_equal %w[m2 m1], entry_for(payload, @a)[:messages].map { |m| m[:content] }
+      end
+
+      test "max_chars is a whole-response cap, and a topic it cannot reach is reported unfetched" do
+        post(@a, "x" * 500)
+        post(@b, "y" * 500)
+        payload = json(topic_ids: "#{@a.id},#{@b.id}", max_chars: 100)
+
+        assert payload[:truncated]
+        assert_equal 1, entry_for(payload, @a)[:returned_count]
+        assert_equal 0, entry_for(payload, @b)[:returned_count]
+        assert_equal "max_chars budget spent on earlier topics", entry_for(payload, @b)[:skipped_reason]
+        assert entry_for(payload, @b)[:has_more]
+      end
+
+      test "budget_limited marks a topic the shared cap cut short" do
+        3.times { post(@a, "x" * 100) }
+        payload = json(topic_ids: @a.id, max_chars: 150)
+
+        assert entry_for(payload, @a)[:budget_limited]
+        assert payload[:truncated]
+      end
+
+      test "a fully returned topic is not marked truncated" do
+        post(@a, "short")
+
+        assert_not json(topic_ids: @a.id)[:truncated]
+        assert_not entry_for(json(topic_ids: @a.id), @a).key?(:budget_limited)
+      end
+
+      test "max_chars is clamped and defaults when non-positive" do
+        post(@a, "hi")
+
+        assert_equal TopicMessagesService::DEFAULT_MAX_CHARS, json(topic_ids: @a.id)[:max_chars]
+        assert_equal TopicMessagesService::DEFAULT_MAX_CHARS, json(topic_ids: @a.id, max_chars: 0)[:max_chars]
+        assert_equal TopicMessagesService::MAX_MAX_CHARS, json(topic_ids: @a.id, max_chars: 10_000_000)[:max_chars]
+      end
+
+      test "markdown is the default format and carries the same numbers as json" do
+        2.times { |i| post(@a, "m#{i}") }
+        output = TopicMessagesService.new.call(topic_ids: @a.id, limit: 1)
+
+        assert_kind_of String, output
+        assert_includes output, "## [topic #{@a.id}] Alpha"
+        assert_includes output, "2 messages"
+        assert_includes output, "offset: 1"
+      end
+
+      test "an unreadable or unknown topic is reported beside the ones that worked" do
+        post(@a, "visible")
+        payload = json(topic_ids: "#{@a.id},999999")
+
+        assert_equal 1, entry_for(payload, @a)[:returned_count]
+        assert_equal({ topic_id: 999_999, error: "Topic not found or not readable" },
+                     payload[:topics].last)
+      end
+
+      test "a topic on a creative the caller cannot read is refused, not returned" do
+        post(@a, "secret")
+        Collavre::Current.user = @stranger
+        payload = json(topic_ids: @a.id)
+
+        assert_equal [ { topic_id: @a.id, error: "Topic not found or not readable" } ], payload[:topics]
+      end
+
+      test "more topics than the per-call cap are dropped from the tail, not silently merged" do
+        ids = (1..TopicSelection::MAX_TOPICS + 2).map { |i| @creative.topics.create!(name: "T#{i}", user: @user).id }
+        payload = json(topic_ids: ids.join(","))
+
+        assert_equal TopicSelection::MAX_TOPICS, payload[:topics].size
+      end
+
+      test "requires at least one topic id" do
+        assert_raises(ArgumentError) { json(topic_ids: "") }
+        assert_raises(ArgumentError) { json(topic_ids: []) }
+      end
+
+      test "requires a current user" do
+        Collavre::Current.user = nil
+
+        assert_raises(RuntimeError) { json(topic_ids: @a.id) }
+      end
+
+      test "accepts an integer, a string and an array of ids alike" do
+        post(@a, "hi")
+
+        [ @a.id, @a.id.to_s, [ @a.id ], [ @a.id.to_s ] ].each do |ids|
+          assert_equal 1, entry_for(json(topic_ids: ids), @a)[:returned_count]
+        end
+      end
+
+      test "include_system pulls in authorless notices that are hidden by default" do
+        Comment.create!(creative: @creative, topic: @a, user: nil, content: "⏳ waiting",
+                        skip_default_user: true, skip_dispatch: true)
+
+        assert_equal 0, entry_for(json(topic_ids: @a.id), @a)[:returned_count]
+        assert_equal 1, entry_for(json(topic_ids: @a.id, include_system: true), @a)[:returned_count]
+      end
+    end
+  end
+end

--- a/engines/collavre/test/services/collavre/tools/topic_messages_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/topic_messages_service_test.rb
@@ -71,6 +71,26 @@ module Collavre
         assert_equal 2, entry_for(payload, @b)[:next_offset]
       end
 
+      test "continuation state cannot be shared across multiple topics" do
+        2.times { |i| post(@a, "a#{i}") }
+        2.times { |i| post(@b, "b#{i}") }
+        first = json(topic_ids: [ @a.id, @b.id ], limit: 1)
+        a_page = entry_for(first, @a)
+
+        continuation_options = [
+          { cursor: a_page[:next_cursor] },
+          { max_message_id: a_page[:newest_message_id] },
+          { content_offset: 1 }
+        ]
+
+        continuation_options.each do |options|
+          error = assert_raises(ArgumentError) do
+            json(topic_ids: [ @a.id, @b.id ], limit: 1, **options)
+          end
+          assert_includes error.message, "one topic"
+        end
+      end
+
       test "paging with the returned anchor stays on one snapshot while the topic grows" do
         4.times { |i| post(@a, "m#{i}") }
         first = json(topic_ids: @a.id, limit: 2)

--- a/engines/collavre/test/services/collavre/tools/topic_messages_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/topic_messages_service_test.rb
@@ -21,6 +21,20 @@ module Collavre
                         skip_default_user: true, skip_dispatch: true)
       end
 
+      def post_with_image(topic, content: "")
+        comment = Comment.new(
+          creative: @creative, topic: topic, user: @user, content: content,
+          skip_default_user: true, skip_dispatch: true
+        )
+        comment.images.attach(
+          io: StringIO.new(file_fixture("small.png").binread),
+          filename: "small.png",
+          content_type: "image/png"
+        )
+        comment.save!
+        comment
+      end
+
       def json(**args)
         TopicMessagesService.new.call(format: "json", **args)
       end
@@ -338,6 +352,16 @@ module Collavre
         assert_includes output, "## [topic #{@a.id}] Alpha"
         assert_includes output, "2 messages"
         assert_includes output, "offset: 1"
+      end
+
+      test "image attachment markers are returned in both json and markdown" do
+        post_with_image(@a)
+
+        payload = json(topic_ids: @a.id)
+        markdown = TopicMessagesService.new.call(topic_ids: @a.id)
+
+        assert_includes entry_for(payload, @a)[:messages].first[:content], "Image attachment 1: small.png"
+        assert_match %r{/public-assets/blobs/[^/]+/small\.png}, markdown
       end
 
       test "an unreadable or unknown topic is reported beside the ones that worked" do

--- a/engines/collavre/test/services/collavre/tools/topic_selection_test.rb
+++ b/engines/collavre/test/services/collavre/tools/topic_selection_test.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  module Tools
+    class TopicSelectionTest < ActiveSupport::TestCase
+      setup do
+        @user = users(:one)
+        @stranger = users(:two)
+        @creative = Collavre::Creative.create!(description: "Selection Host", user: @user)
+        @a = @creative.topics.create!(name: "A", user: @user)
+        @b = @creative.topics.create!(name: "B", user: @user)
+      end
+
+      test "accepts every id shape an agent is likely to write" do
+        assert_equal [ 1, 2, 3 ], IdList.parse("1,2,3")
+        assert_equal [ 1, 2 ], IdList.parse([ "1", 2 ])
+        assert_equal [ 5 ], IdList.parse(5)
+        assert_equal [ 5 ], IdList.parse("5")
+        assert_equal [ 1, 2 ], IdList.parse(" 1 , 2 , ")
+      end
+
+      test "deduplicates and returns nothing for blank input" do
+        assert_equal [ 7 ], IdList.parse("7,7")
+        assert_empty IdList.parse(nil)
+        assert_empty IdList.parse("")
+        assert_empty IdList.parse([ "", "  " ])
+      end
+
+      test "resolves readable topics in the order they were asked for" do
+        topics, errors = TopicSelection.resolve([ @b.id, @a.id ], user: @user)
+
+        assert_equal [ @b.id, @a.id ], topics.map(&:id)
+        assert_empty errors
+      end
+
+      test "reports missing and unreadable ids identically so existence cannot be probed" do
+        _, errors = TopicSelection.resolve([ 999_999 ], user: @user)
+        _, denied = TopicSelection.resolve([ @a.id ], user: @stranger)
+
+        assert_equal "Topic not found or not readable", errors.first[:error]
+        assert_equal errors.first[:error], denied.first[:error]
+      end
+
+      test "one bad id does not discard the good ones" do
+        topics, errors = TopicSelection.resolve([ @a.id, 999_999 ], user: @user)
+
+        assert_equal [ @a.id ], topics.map(&:id)
+        assert_equal 1, errors.size
+      end
+    end
+  end
+end

--- a/engines/collavre/test/services/collavre/tools/topic_selection_test.rb
+++ b/engines/collavre/test/services/collavre/tools/topic_selection_test.rb
@@ -49,6 +49,22 @@ module Collavre
         assert_equal [ @a.id ], topics.map(&:id)
         assert_equal 1, errors.size
       end
+
+      # An unreadable id is reported and the call continues, because the caller
+      # can see that entry and act on it. An over-cap batch cannot be reported
+      # the same way: the ids past the cap were never looked at, so there is no
+      # entry to carry them, and trimming hands back a response that reads as
+      # complete while whole topics are missing from it.
+      test "a batch over the cap is refused rather than trimmed" do
+        ids = (1..TopicSelection::MAX_TOPICS + 1).to_a
+
+        error = assert_raises(ArgumentError) { TopicSelection.resolve(ids, user: @user) }
+        assert_match(/at most #{TopicSelection::MAX_TOPICS}/, error.message)
+      end
+
+      test "a batch exactly at the cap is accepted" do
+        assert_nothing_raised { TopicSelection.resolve((1..TopicSelection::MAX_TOPICS).to_a, user: @user) }
+      end
     end
   end
 end

--- a/engines/collavre/test/services/collavre/tools/topic_update_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/topic_update_service_test.rb
@@ -163,6 +163,41 @@ module Collavre
         assert_equal [ "archived" ], TopicUpdateService.new.call(topic_id: @topic.id, archived: true)[:changed]
       end
 
+      test "reauthorizes after locking a topic moved to an inaccessible creative" do
+        restricted = Collavre::Creative.create!(description: "Restricted", user: @writer)
+        lock_after_move = lambda do
+          @topic.update_column(:creative_id, restricted.id)
+          @topic.reload
+        end
+
+        Collavre::Topic.stub(:find, @topic) do
+          @topic.stub(:lock!, lock_after_move) do
+            assert_raises(Collavre::Tools::PermissionDeniedError) do
+              TopicUpdateService.new.call(topic_id: @topic.id, name: "Unauthorized")
+            end
+          end
+        end
+      end
+
+      test "resolves a requested agent against the locked topic creative" do
+        target = Collavre::Creative.create!(description: "Target", user: @writer)
+        Collavre::CreativeShare.create!(creative: target, user: @user, permission: :write, shared_by: @writer)
+        @agent.update!(searchable: false)
+        share!(@agent, :feedback)
+        lock_after_move = lambda do
+          @topic.update_column(:creative_id, target.id)
+          @topic.reload
+        end
+
+        Collavre::Topic.stub(:find, @topic) do
+          @topic.stub(:lock!, lock_after_move) do
+            assert_raises(Collavre::Topics::AgentResolver::UnknownAgentError) do
+              TopicUpdateService.new.call(topic_id: @topic.id, primary_agent: @agent.id.to_s)
+            end
+          end
+        end
+      end
+
       test "a reader can do nothing" do
         share!(@writer, :read)
         Collavre::Current.user = @writer

--- a/engines/collavre/test/services/collavre/tools/topic_update_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/topic_update_service_test.rb
@@ -131,6 +131,28 @@ module Collavre
         assert_equal %w[updated archived], actions
       end
 
+      test "a rejected pin rolls back the fields that came before it" do
+        assert_raises(ArgumentError) do
+          TopicUpdateService.new.call(topic_id: @topic.id, name: "Renamed", archived: true,
+                                      primary_agent: "Worker")
+        end
+
+        @topic.reload
+        assert_equal "Work", @topic.name
+        assert_not @topic.archived?
+      end
+
+      test "a failed call broadcasts nothing" do
+        actions = []
+        Collavre::TopicsChannel.stub(:broadcast_to, ->(_creative, data) { actions << data[:action] }) do
+          assert_raises(ArgumentError) do
+            TopicUpdateService.new.call(topic_id: @topic.id, name: "Renamed", primary_agent: "Worker")
+          end
+        end
+
+        assert_empty actions
+      end
+
       test "clearing the pin broadcasts an explicit nil so the avatar is removed" do
         share!(@agent, :feedback)
         @topic.set_primary_agent!(@agent)

--- a/engines/collavre/test/services/collavre/tools/topic_update_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/topic_update_service_test.rb
@@ -37,6 +37,59 @@ module Collavre
         assert_not @topic.reload.archived?
       end
 
+      test "the Main topic cannot be renamed or archived" do
+        main_topic = @creative.main_topic
+
+        rename_error = assert_raises(ArgumentError) do
+          TopicUpdateService.new.call(topic_id: main_topic.id, name: "Replacement")
+        end
+        archive_error = assert_raises(ArgumentError) do
+          TopicUpdateService.new.call(topic_id: main_topic.id, archived: true)
+        end
+
+        assert_includes rename_error.message, "reserved"
+        assert_includes archive_error.message, "reserved"
+        assert_equal Collavre::Creative::MAIN_TOPIC_NAME, main_topic.reload.name
+        assert_not main_topic.archived?
+        assert_equal main_topic.id, @creative.main_topic.id
+      end
+
+      test "an inbox System topic cannot be renamed or archived" do
+        inbox = Collavre::Creative.create!(description: "Inbox", user: @user, data: { "kind" => "inbox" })
+        system_topic = inbox.system_topic
+
+        assert_raises(ArgumentError) do
+          TopicUpdateService.new.call(topic_id: system_topic.id, name: "Notices")
+        end
+        assert_raises(ArgumentError) do
+          TopicUpdateService.new.call(topic_id: system_topic.id, archived: true)
+        end
+
+        assert_equal Collavre::Creative::SYSTEM_TOPIC_NAME, system_topic.reload.name
+        assert_not system_topic.archived?
+        assert_equal system_topic.id, inbox.system_topic.id
+      end
+
+      test "reserved topics still allow primary agent changes" do
+        main_topic = @creative.main_topic
+        share!(@agent, :feedback)
+
+        result = TopicUpdateService.new.call(topic_id: main_topic.id, primary_agent: @agent.id.to_s)
+
+        assert_equal [ "primary_agent" ], result[:changed]
+        assert_equal @agent.id, main_topic.reload.primary_agent_id
+      end
+
+      test "System is an ordinary mutable name outside an inbox" do
+        system_named = @creative.topics.create!(name: Collavre::Creative::SYSTEM_TOPIC_NAME, user: @user)
+
+        result = TopicUpdateService.new.call(topic_id: system_named.id, name: "Alerts", archived: true)
+
+        assert_equal %w[name archived], result[:changed]
+        assert_equal "Alerts", system_named.reload.name
+        assert system_named.archived?
+      end
+
       test "an archived topic keeps its messages and stays readable" do
         Comment.create!(creative: @creative, topic: @topic, user: @user, content: "kept",
                         skip_default_user: true, skip_dispatch: true)

--- a/engines/collavre/test/services/collavre/tools/topic_update_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/topic_update_service_test.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  module Tools
+    class TopicUpdateServiceTest < ActiveSupport::TestCase
+      setup do
+        @user = users(:one)
+        @writer = users(:two)
+        @creative = Collavre::Creative.create!(description: "Update Host", user: @user)
+        @topic = @creative.topics.create!(name: "Work", user: @user)
+        @agent = Collavre::User.create!(name: "Worker", email: "worker-#{SecureRandom.hex(4)}@test.test",
+                                        password: "password123", llm_vendor: "google",
+                                        llm_model: "gemini-1.5-flash", searchable: true)
+        Collavre::Current.user = @user
+      end
+
+      teardown { Collavre::Current.user = nil }
+
+      def share!(user, permission)
+        Collavre::CreativeShare.create!(creative: @creative, user: user, permission: permission, shared_by: @user)
+      end
+
+      test "renames a topic and reports what changed" do
+        result = TopicUpdateService.new.call(topic_id: @topic.id, name: "Renamed")
+
+        assert_equal "Renamed", result[:name]
+        assert_equal [ "name" ], result[:changed]
+      end
+
+      test "archives and unarchives" do
+        assert_equal [ "archived" ], TopicUpdateService.new.call(topic_id: @topic.id, archived: true)[:changed]
+        assert @topic.reload.archived?
+
+        TopicUpdateService.new.call(topic_id: @topic.id, archived: false)
+        assert_not @topic.reload.archived?
+      end
+
+      test "an archived topic keeps its messages and stays readable" do
+        Comment.create!(creative: @creative, topic: @topic, user: @user, content: "kept",
+                        skip_default_user: true, skip_dispatch: true)
+        TopicUpdateService.new.call(topic_id: @topic.id, archived: true)
+
+        payload = TopicMessagesService.new.call(topic_ids: @topic.id, format: "json")
+        assert_equal 1, payload[:topics].first[:returned_count]
+      end
+
+      test "pins and clears the primary agent" do
+        share!(@agent, :feedback)
+
+        assert_equal [ "primary_agent" ],
+                     TopicUpdateService.new.call(topic_id: @topic.id, primary_agent: "Worker")[:changed]
+        assert_equal @agent.id, @topic.reload.primary_agent_id
+
+        TopicUpdateService.new.call(topic_id: @topic.id, primary_agent: "none")
+        assert_nil @topic.reload.primary_agent_id
+      end
+
+      test "several fields change in one call" do
+        share!(@agent, :feedback)
+        result = TopicUpdateService.new.call(topic_id: @topic.id, name: "Done", archived: true,
+                                             primary_agent: "none")
+
+        assert_equal %w[name archived primary_agent], result[:changed]
+      end
+
+      test "refuses to pin an agent without feedback on the creative" do
+        error = assert_raises(ArgumentError) do
+          TopicUpdateService.new.call(topic_id: @topic.id, primary_agent: @agent.id.to_s)
+        end
+
+        assert_includes error.message, "no feedback permission"
+        assert_nil @topic.reload.primary_agent_id
+      end
+
+      test "a session topic's agent assignment is locked" do
+        @topic.update!(session_id: "sess-1")
+        share!(@agent, :feedback)
+
+        error = assert_raises(ArgumentError) do
+          TopicUpdateService.new.call(topic_id: @topic.id, primary_agent: "Worker")
+        end
+
+        assert_includes error.message, "session topic"
+      end
+
+      test "renaming needs admin, so a writer cannot rename" do
+        share!(@writer, :write)
+        Collavre::Current.user = @writer
+
+        assert_raises(Collavre::Tools::PermissionDeniedError) do
+          TopicUpdateService.new.call(topic_id: @topic.id, name: "Nope")
+        end
+      end
+
+      test "a writer can still archive and pin" do
+        share!(@writer, :write)
+        Collavre::Current.user = @writer
+
+        assert_equal [ "archived" ], TopicUpdateService.new.call(topic_id: @topic.id, archived: true)[:changed]
+      end
+
+      test "a reader can do nothing" do
+        share!(@writer, :read)
+        Collavre::Current.user = @writer
+
+        assert_raises(Collavre::Tools::PermissionDeniedError) do
+          TopicUpdateService.new.call(topic_id: @topic.id, archived: true)
+        end
+      end
+
+      test "a call that changes nothing is an error rather than a silent no-op" do
+        error = assert_raises(ArgumentError) { TopicUpdateService.new.call(topic_id: @topic.id) }
+
+        assert_includes error.message, "Nothing to update"
+      end
+
+      test "requires a current user" do
+        Collavre::Current.user = nil
+
+        assert_raises(RuntimeError) { TopicUpdateService.new.call(topic_id: @topic.id, archived: true) }
+      end
+
+      test "broadcasts each change so open clients stay in step" do
+        actions = []
+        Collavre::TopicsChannel.stub(:broadcast_to, ->(_creative, data) { actions << data[:action] }) do
+          TopicUpdateService.new.call(topic_id: @topic.id, name: "Renamed", archived: true)
+        end
+
+        assert_equal %w[updated archived], actions
+      end
+
+      test "clearing the pin broadcasts an explicit nil so the avatar is removed" do
+        share!(@agent, :feedback)
+        @topic.set_primary_agent!(@agent)
+
+        payload = nil
+        Collavre::TopicsChannel.stub(:broadcast_to, ->(_creative, data) { payload = data }) do
+          TopicUpdateService.new.call(topic_id: @topic.id, primary_agent: "none")
+        end
+
+        assert payload[:topic].key?(:primary_agent)
+        assert_nil payload[:topic][:primary_agent]
+      end
+    end
+  end
+end

--- a/engines/collavre/test/services/collavre/tools/topic_update_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/topic_update_service_test.rb
@@ -70,6 +70,22 @@ module Collavre
         assert_equal system_topic.id, inbox.system_topic.id
       end
 
+      test "an ordinary inbox topic cannot take the reserved System name" do
+        inbox = Collavre::Creative.create!(description: "Inbox", user: @user, data: { "kind" => "inbox" })
+        ordinary = inbox.topics.create!(name: "Notices", user: @user)
+        assert_nil inbox.topics.find_by(name: Collavre::Creative::SYSTEM_TOPIC_NAME)
+
+        error = assert_raises(ArgumentError) do
+          TopicUpdateService.new.call(topic_id: ordinary.id,
+                                      name: Collavre::Creative::SYSTEM_TOPIC_NAME, archived: true)
+        end
+
+        assert_includes error.message, "reserved"
+        assert_equal "Notices", ordinary.reload.name
+        assert_not ordinary.archived?
+        assert_not_equal ordinary.id, inbox.system_topic.id
+      end
+
       test "reserved topics still allow primary agent changes" do
         main_topic = @creative.main_topic
         share!(@agent, :feedback)

--- a/engines/collavre/test/services/collavre/tools/topic_update_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/topic_update_service_test.rb
@@ -57,6 +57,15 @@ module Collavre
         assert_nil @topic.reload.primary_agent_id
       end
 
+      test "pins a private agent already shared on the creative" do
+        @agent.update!(searchable: false)
+        share!(@agent, :feedback)
+
+        TopicUpdateService.new.call(topic_id: @topic.id, primary_agent: "Worker")
+
+        assert_equal @agent.id, @topic.reload.primary_agent_id
+      end
+
       test "several fields change in one call" do
         share!(@agent, :feedback)
         result = TopicUpdateService.new.call(topic_id: @topic.id, name: "Done", archived: true,

--- a/engines/collavre/test/services/collavre/topics/agent_resolver_test.rb
+++ b/engines/collavre/test/services/collavre/topics/agent_resolver_test.rb
@@ -7,6 +7,7 @@ module Collavre
     class AgentResolverTest < ActiveSupport::TestCase
       setup do
         @user = users(:one)
+        @creative = Collavre::Creative.create!(description: "Agent Host", user: @user)
         @agent = create_agent(name: "Reviewer", searchable: true)
       end
 
@@ -44,6 +45,18 @@ module Collavre
         mine = create_agent(name: "Mine", created_by: @user)
 
         assert_equal mine, AgentResolver.call("Mine", actor: @user)
+      end
+
+      test "a private agent shared on the creative resolves only in that creative" do
+        shared = create_agent(name: "Shared Private")
+        Collavre::CreativeShare.create!(
+          creative: @creative, user: shared, shared_by: @user, permission: :feedback
+        )
+
+        assert_equal shared, AgentResolver.call("Shared Private", actor: @user, creative: @creative)
+        assert_raises(AgentResolver::UnknownAgentError) do
+          AgentResolver.call("Shared Private", actor: @user)
+        end
       end
 
       test "a duplicate name is reported with the candidate ids rather than guessed" do

--- a/engines/collavre/test/services/collavre/topics/agent_resolver_test.rb
+++ b/engines/collavre/test/services/collavre/topics/agent_resolver_test.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  module Topics
+    class AgentResolverTest < ActiveSupport::TestCase
+      setup do
+        @user = users(:one)
+        @agent = create_agent(name: "Reviewer", searchable: true)
+      end
+
+      def create_agent(name:, searchable: false, created_by: nil)
+        Collavre::User.create!(
+          name: name, email: "agent-#{SecureRandom.hex(4)}@test.test", password: "password123",
+          llm_vendor: "google", llm_model: "gemini-1.5-flash",
+          searchable: searchable, created_by_id: created_by&.id
+        )
+      end
+
+      test "resolves by id, email and exact name" do
+        assert_equal @agent, AgentResolver.call(@agent.id.to_s, actor: @user)
+        assert_equal @agent, AgentResolver.call(@agent.email, actor: @user)
+        assert_equal @agent, AgentResolver.call("Reviewer", actor: @user)
+      end
+
+      test "nil means no change, blank and clear tokens mean unassign" do
+        assert_nil AgentResolver.call(nil, actor: @user)
+        assert_equal AgentResolver::CLEAR, AgentResolver.call("", actor: @user)
+        assert_equal AgentResolver::CLEAR, AgentResolver.call("  ", actor: @user)
+        AgentResolver::CLEAR_TOKENS.each do |token|
+          assert_equal AgentResolver::CLEAR, AgentResolver.call(token.upcase, actor: @user)
+        end
+      end
+
+      test "an agent the actor cannot see does not resolve, by id or by name" do
+        hidden = create_agent(name: "Hidden")
+
+        assert_raises(AgentResolver::UnknownAgentError) { AgentResolver.call(hidden.id.to_s, actor: @user) }
+        assert_raises(AgentResolver::UnknownAgentError) { AgentResolver.call("Hidden", actor: @user) }
+      end
+
+      test "an agent created by the actor resolves even when it is not searchable" do
+        mine = create_agent(name: "Mine", created_by: @user)
+
+        assert_equal mine, AgentResolver.call("Mine", actor: @user)
+      end
+
+      test "a duplicate name is reported with the candidate ids rather than guessed" do
+        twin = create_agent(name: "Reviewer", searchable: true)
+
+        error = assert_raises(AgentResolver::AmbiguousAgentError) { AgentResolver.call("Reviewer", actor: @user) }
+        assert_includes error.message, @agent.id.to_s
+        assert_includes error.message, twin.id.to_s
+      end
+
+      test "a human user is never resolved as an agent" do
+        assert_raises(AgentResolver::UnknownAgentError) { AgentResolver.call(users(:two).email, actor: @user) }
+      end
+
+      test "an unmatched token explains what is accepted" do
+        error = assert_raises(AgentResolver::UnknownAgentError) { AgentResolver.call("nobody", actor: @user) }
+
+        assert_includes error.message, "id, email, or exact name"
+      end
+    end
+  end
+end

--- a/engines/collavre/test/services/collavre/topics/char_budget_test.rb
+++ b/engines/collavre/test/services/collavre/topics/char_budget_test.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  module Topics
+    class CharBudgetTest < ActiveSupport::TestCase
+      def sample(content: "hello", author: "Ann")
+        { id: 12, author: author, author_id: 3, agent: false,
+          created_at: "2026-08-19T10:23:45+09:00", content: content }
+      end
+
+      test "markdown charges the rendered envelope on top of the prose" do
+        budget = CharBudget.new(format: "markdown")
+
+        assert_equal CharBudget::ENVELOPE_CHARS + 5 + 3, budget.cost(sample)
+      end
+
+      # The undercount this class exists to fix: json restates every field name
+      # and delimiter, so a message with no prose at all already costs well over
+      # a hundred characters that markdown's envelope constant does not
+      # describe. Charging markdown's number for a json response is what let a
+      # few dozen short messages sail past max_chars.
+      test "json charges the serialized form, so an empty message is already expensive" do
+        empty = sample(content: "")
+        overhead = CharBudget.new(format: "json").cost(empty) - CharBudget.new(format: "markdown").cost(empty)
+
+        assert_operator overhead, :>=, 60
+      end
+
+      # The other half: escaping. No fixed constant tracks this, because the
+      # ratio depends on the message rather than on the schema.
+      test "json charges escaping, so quote-heavy prose costs more than its length" do
+        budget = CharBudget.new(format: "json")
+        plain = "a" * 100
+        quoted = '"' * 100
+
+        assert_operator budget.cost(sample(content: quoted)), :>, budget.cost(sample(content: plain))
+      end
+
+      test "an unknown or missing format falls back to markdown rather than raising" do
+        assert_equal "markdown", CharBudget.new(format: "yaml").format
+        assert_equal "markdown", CharBudget.new.format
+        assert_equal "json", CharBudget.new(format: :json).format
+      end
+
+      # fits? decides before keeping. Asking "have I already overspent?"
+      # afterwards let a message wider than the entire cap through untouched.
+      test "fits? refuses a message that would cross the cap, not one that already has" do
+        budget = CharBudget.new(chars: 50, format: "markdown")
+
+        assert_not budget.fits?(budget.cost(sample(content: "x" * 100)))
+        assert budget.fits?(budget.cost(sample(content: "x")))
+      end
+
+      test "fits? counts what has already been spent" do
+        budget = CharBudget.new(chars: 100, format: "markdown")
+        cost = budget.cost(sample(content: "x" * 10))
+
+        assert budget.fits?(cost, spent: 0)
+        assert_not budget.fits?(cost, spent: 60)
+      end
+
+      test "an unlimited budget fits everything" do
+        budget = CharBudget.new(chars: nil, format: "json")
+
+        assert budget.unlimited?
+        assert budget.fits?(1_000_000, spent: 1_000_000)
+      end
+
+      test "with carries the format onto a new cap" do
+        derived = CharBudget.new(chars: 100, format: "json").with(chars: 20)
+
+        assert_equal 20, derived.chars
+        assert_equal "json", derived.format
+      end
+    end
+  end
+end

--- a/engines/collavre/test/services/collavre/topics/char_budget_test.rb
+++ b/engines/collavre/test/services/collavre/topics/char_budget_test.rb
@@ -38,6 +38,17 @@ module Collavre
         assert_operator budget.cost(sample(content: quoted)), :>, budget.cost(sample(content: plain))
       end
 
+      # Markdown tags an AI byline with " (agent)". Charging content, author and
+      # a fixed envelope left those eight characters off the books on every
+      # agent turn — nothing on one message, a page's worth across a stretch of
+      # short ones, which is the shape an agent-heavy topic actually has.
+      test "markdown charges the agent byline suffix" do
+        budget = CharBudget.new(format: "markdown")
+        human = sample.merge(agent: false)
+
+        assert_equal budget.cost(human) + CharBudget::AGENT_SUFFIX_CHARS, budget.cost(sample.merge(agent: true))
+      end
+
       test "an unknown or missing format falls back to markdown rather than raising" do
         assert_equal "markdown", CharBudget.new(format: "yaml").format
         assert_equal "markdown", CharBudget.new.format

--- a/engines/collavre/test/services/collavre/topics/message_page_markdown_test.rb
+++ b/engines/collavre/test/services/collavre/topics/message_page_markdown_test.rb
@@ -32,6 +32,21 @@ module Collavre
         assert_includes output, "topic_messages(topic_ids: 12, offset: 2, max_message_id: 991)"
       end
 
+      # Dropping include_system from the follow-up call pages a narrower set at
+      # an offset counted against the wider one, which walks straight past
+      # messages the caller has not seen.
+      test "repeats include_system in the next call so the follow-up pages the same set" do
+        output = MessagePageMarkdown.call({ topics: [ entry(include_system: true) ], truncated: false })
+
+        assert_includes output, "max_message_id: 991, include_system: true)"
+      end
+
+      test "leaves include_system out of the next call when it was not requested" do
+        output = MessagePageMarkdown.call({ topics: [ entry ], truncated: false })
+
+        assert_not_includes output, "include_system"
+      end
+
       test "omits the continuation line when the topic is fully read" do
         output = MessagePageMarkdown.call({ topics: [ entry(has_more: false, next_offset: nil) ], truncated: false })
 

--- a/engines/collavre/test/services/collavre/topics/message_page_markdown_test.rb
+++ b/engines/collavre/test/services/collavre/topics/message_page_markdown_test.rb
@@ -40,6 +40,22 @@ module Collavre
         assert_includes output, "offset: 0, max_message_id: 991, content_offset: 320"
       end
 
+      test "repeats newest-first rendering order in the continuation" do
+        output = MessagePageMarkdown.call(
+          { topics: [ entry(order: "desc") ], truncated: false }
+        )
+
+        assert_includes output, 'max_message_id: 991, order: "desc")'
+      end
+
+      test "leaves the default rendering order out of the continuation" do
+        output = MessagePageMarkdown.call(
+          { topics: [ entry(order: "asc") ], truncated: false }
+        )
+
+        assert_not_includes output, "order:"
+      end
+
       # Dropping include_system from the follow-up call pages a narrower set at
       # an offset counted against the wider one, which walks straight past
       # messages the caller has not seen.

--- a/engines/collavre/test/services/collavre/topics/message_page_markdown_test.rb
+++ b/engines/collavre/test/services/collavre/topics/message_page_markdown_test.rb
@@ -114,6 +114,7 @@ module Collavre
         assert_includes output, "## [topic 45] Later (creative 7)"
         assert_includes output, "Not fetched: max_chars budget spent on earlier topics"
         assert_includes output, "Output hit max_chars"
+        assert_empty output.lines.grep(/\AMore:/)
       end
 
       test "an unreadable topic is reported in place, not dropped" do

--- a/engines/collavre/test/services/collavre/topics/message_page_markdown_test.rb
+++ b/engines/collavre/test/services/collavre/topics/message_page_markdown_test.rb
@@ -32,6 +32,14 @@ module Collavre
         assert_includes output, "topic_messages(topic_ids: 12, offset: 2, max_message_id: 991)"
       end
 
+      test "spells out the content continuation without consuming the clipped row" do
+        output = MessagePageMarkdown.call(
+          { topics: [ entry(next_offset: 0, next_content_offset: 320) ], truncated: true }
+        )
+
+        assert_includes output, "offset: 0, max_message_id: 991, content_offset: 320"
+      end
+
       # Dropping include_system from the follow-up call pages a narrower set at
       # an offset counted against the wider one, which walks straight past
       # messages the caller has not seen.
@@ -58,6 +66,13 @@ module Collavre
 
         assert_includes output, "[990] 2026-08-19T10:00:00Z One\nfirst"
         assert_includes output, "[991] 2026-08-19T10:01:00Z Bot (agent)\nsecond"
+      end
+
+      test "renders a clipped message notice outside its retrievable content fragment" do
+        clipped = entry(messages: [ entry[:messages].first.merge(content: "fragment", clip_notice: "continue") ])
+        output = MessagePageMarkdown.call({ topics: [ clipped ], truncated: true })
+
+        assert_includes output, "\nfragment\ncontinue\n"
       end
 
       test "shows 'none' rather than a nonsense range when the window is empty" do

--- a/engines/collavre/test/services/collavre/topics/message_page_markdown_test.rb
+++ b/engines/collavre/test/services/collavre/topics/message_page_markdown_test.rb
@@ -11,7 +11,7 @@ module Collavre
           total_count: 130, total_chars: 4200,
           offset: 0, limit: 2, max_chars: 1_000, returned_count: 2, returned_chars: 20,
           has_more: true, next_offset: 2,
-          next_cursor: "1770000000000000:989:1770000001000000", newest_message_id: 991,
+          next_cursor: "1770000000000000:989:1770000001000000:1770000002000000", newest_message_id: 991,
           messages: [
             { id: 990, created_at: "2026-08-19T10:00:00Z", author: "One", agent: false, content: "first" },
             { id: 991, created_at: "2026-08-19T10:01:00Z", author: "Bot", agent: true, content: "second" }
@@ -32,7 +32,7 @@ module Collavre
 
         assert_includes output,
                         "topic_messages(topic_ids: 12, offset: 2, " \
-                          "cursor: \"1770000000000000:989:1770000001000000\", " \
+                          "cursor: \"1770000000000000:989:1770000001000000:1770000002000000\", " \
                           "max_message_id: 991, limit: 2, max_chars: 1000)"
       end
 
@@ -42,7 +42,7 @@ module Collavre
         )
 
         assert_includes output,
-                        "offset: 0, cursor: \"1770000000000000:989:1770000001000000\", " \
+                        "offset: 0, cursor: \"1770000000000000:989:1770000001000000:1770000002000000\", " \
                           "max_message_id: 991, " \
                           "limit: 2, max_chars: 1000, content_offset: 320"
       end

--- a/engines/collavre/test/services/collavre/topics/message_page_markdown_test.rb
+++ b/engines/collavre/test/services/collavre/topics/message_page_markdown_test.rb
@@ -9,7 +9,7 @@ module Collavre
         {
           topic_id: 12, topic_name: "Planning", creative_id: 7,
           total_count: 130, total_chars: 4200,
-          offset: 0, limit: 2, returned_count: 2, returned_chars: 20,
+          offset: 0, limit: 2, max_chars: 1_000, returned_count: 2, returned_chars: 20,
           has_more: true, next_offset: 2, newest_message_id: 991,
           messages: [
             { id: 990, created_at: "2026-08-19T10:00:00Z", author: "One", agent: false, content: "first" },
@@ -29,7 +29,8 @@ module Collavre
       test "spells out the next call including the snapshot anchor" do
         output = MessagePageMarkdown.call({ topics: [ entry ], truncated: false })
 
-        assert_includes output, "topic_messages(topic_ids: 12, offset: 2, max_message_id: 991)"
+        assert_includes output,
+                        "topic_messages(topic_ids: 12, offset: 2, max_message_id: 991, limit: 2, max_chars: 1000)"
       end
 
       test "spells out the content continuation without consuming the clipped row" do
@@ -37,7 +38,7 @@ module Collavre
           { topics: [ entry(next_offset: 0, next_content_offset: 320) ], truncated: true }
         )
 
-        assert_includes output, "offset: 0, max_message_id: 991, content_offset: 320"
+        assert_includes output, "offset: 0, max_message_id: 991, limit: 2, max_chars: 1000, content_offset: 320"
       end
 
       test "repeats newest-first rendering order in the continuation" do
@@ -45,7 +46,7 @@ module Collavre
           { topics: [ entry(order: "desc") ], truncated: false }
         )
 
-        assert_includes output, 'max_message_id: 991, order: "desc")'
+        assert_includes output, 'max_chars: 1000, order: "desc")'
       end
 
       test "leaves the default rendering order out of the continuation" do
@@ -62,7 +63,7 @@ module Collavre
       test "repeats include_system in the next call so the follow-up pages the same set" do
         output = MessagePageMarkdown.call({ topics: [ entry(include_system: true) ], truncated: false })
 
-        assert_includes output, "max_message_id: 991, include_system: true)"
+        assert_includes output, "max_chars: 1000, include_system: true)"
       end
 
       test "leaves include_system out of the next call when it was not requested" do

--- a/engines/collavre/test/services/collavre/topics/message_page_markdown_test.rb
+++ b/engines/collavre/test/services/collavre/topics/message_page_markdown_test.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  module Topics
+    class MessagePageMarkdownTest < ActiveSupport::TestCase
+      def entry(**overrides)
+        {
+          topic_id: 12, topic_name: "Planning", creative_id: 7,
+          total_count: 130, total_chars: 4200,
+          offset: 0, limit: 2, returned_count: 2, returned_chars: 20,
+          has_more: true, next_offset: 2, newest_message_id: 991,
+          messages: [
+            { id: 990, created_at: "2026-08-19T10:00:00Z", author: "One", agent: false, content: "first" },
+            { id: 991, created_at: "2026-08-19T10:01:00Z", author: "Bot", agent: true, content: "second" }
+          ]
+        }.merge(overrides)
+      end
+
+      test "renders a header with totals and the window that was returned" do
+        output = MessagePageMarkdown.call({ topics: [ entry ], truncated: false })
+
+        assert_includes output, "## [topic 12] Planning (creative 7)"
+        assert_includes output, "130 messages, ~4200 raw chars"
+        assert_includes output, "showing 0-1 of 130"
+      end
+
+      test "spells out the next call including the snapshot anchor" do
+        output = MessagePageMarkdown.call({ topics: [ entry ], truncated: false })
+
+        assert_includes output, "topic_messages(topic_ids: 12, offset: 2, max_message_id: 991)"
+      end
+
+      test "omits the continuation line when the topic is fully read" do
+        output = MessagePageMarkdown.call({ topics: [ entry(has_more: false, next_offset: nil) ], truncated: false })
+
+        assert_not_includes output, "More:"
+      end
+
+      test "marks agent authors and renders each message with its id and time" do
+        output = MessagePageMarkdown.call({ topics: [ entry ], truncated: false })
+
+        assert_includes output, "[990] 2026-08-19T10:00:00Z One\nfirst"
+        assert_includes output, "[991] 2026-08-19T10:01:00Z Bot (agent)\nsecond"
+      end
+
+      test "shows 'none' rather than a nonsense range when the window is empty" do
+        output = MessagePageMarkdown.call(
+          { topics: [ entry(returned_count: 0, messages: [], has_more: false) ], truncated: false }
+        )
+
+        assert_includes output, "showing none of 130"
+      end
+
+      test "an unfetched topic says so instead of reading as an empty conversation" do
+        skipped = { topic_id: 45, topic_name: "Later", creative_id: 7,
+                    skipped_reason: "max_chars budget spent on earlier topics", messages: [] }
+        output = MessagePageMarkdown.call({ topics: [ skipped ], truncated: true })
+
+        assert_includes output, "## [topic 45] Later (creative 7)"
+        assert_includes output, "Not fetched: max_chars budget spent on earlier topics"
+        assert_includes output, "Output hit max_chars"
+      end
+
+      test "an unreadable topic is reported in place, not dropped" do
+        output = MessagePageMarkdown.call(
+          { topics: [ entry, { topic_id: 99, error: "Topic not found or not readable" } ], truncated: false }
+        )
+
+        assert_includes output, "## [topic 99] unavailable"
+        assert_includes output, "Topic not found or not readable"
+        assert_includes output, "## [topic 12] Planning"
+      end
+    end
+  end
+end

--- a/engines/collavre/test/services/collavre/topics/message_page_markdown_test.rb
+++ b/engines/collavre/test/services/collavre/topics/message_page_markdown_test.rb
@@ -10,7 +10,7 @@ module Collavre
           topic_id: 12, topic_name: "Planning", creative_id: 7,
           total_count: 130, total_chars: 4200,
           offset: 0, limit: 2, max_chars: 1_000, returned_count: 2, returned_chars: 20,
-          has_more: true, next_offset: 2, newest_message_id: 991,
+          has_more: true, next_offset: 2, next_cursor: "1770000000000000:989", newest_message_id: 991,
           messages: [
             { id: 990, created_at: "2026-08-19T10:00:00Z", author: "One", agent: false, content: "first" },
             { id: 991, created_at: "2026-08-19T10:01:00Z", author: "Bot", agent: true, content: "second" }
@@ -30,7 +30,8 @@ module Collavre
         output = MessagePageMarkdown.call({ topics: [ entry ], truncated: false })
 
         assert_includes output,
-                        "topic_messages(topic_ids: 12, offset: 2, max_message_id: 991, limit: 2, max_chars: 1000)"
+                        "topic_messages(topic_ids: 12, offset: 2, cursor: \"1770000000000000:989\", " \
+                          "max_message_id: 991, limit: 2, max_chars: 1000)"
       end
 
       test "spells out the content continuation without consuming the clipped row" do
@@ -38,7 +39,9 @@ module Collavre
           { topics: [ entry(next_offset: 0, next_content_offset: 320) ], truncated: true }
         )
 
-        assert_includes output, "offset: 0, max_message_id: 991, limit: 2, max_chars: 1000, content_offset: 320"
+        assert_includes output,
+                        "offset: 0, cursor: \"1770000000000000:989\", max_message_id: 991, " \
+                          "limit: 2, max_chars: 1000, content_offset: 320"
       end
 
       test "repeats newest-first rendering order in the continuation" do

--- a/engines/collavre/test/services/collavre/topics/message_page_markdown_test.rb
+++ b/engines/collavre/test/services/collavre/topics/message_page_markdown_test.rb
@@ -10,7 +10,8 @@ module Collavre
           topic_id: 12, topic_name: "Planning", creative_id: 7,
           total_count: 130, total_chars: 4200,
           offset: 0, limit: 2, max_chars: 1_000, returned_count: 2, returned_chars: 20,
-          has_more: true, next_offset: 2, next_cursor: "1770000000000000:989", newest_message_id: 991,
+          has_more: true, next_offset: 2,
+          next_cursor: "1770000000000000:989:1770000001000000", newest_message_id: 991,
           messages: [
             { id: 990, created_at: "2026-08-19T10:00:00Z", author: "One", agent: false, content: "first" },
             { id: 991, created_at: "2026-08-19T10:01:00Z", author: "Bot", agent: true, content: "second" }
@@ -30,7 +31,8 @@ module Collavre
         output = MessagePageMarkdown.call({ topics: [ entry ], truncated: false })
 
         assert_includes output,
-                        "topic_messages(topic_ids: 12, offset: 2, cursor: \"1770000000000000:989\", " \
+                        "topic_messages(topic_ids: 12, offset: 2, " \
+                          "cursor: \"1770000000000000:989:1770000001000000\", " \
                           "max_message_id: 991, limit: 2, max_chars: 1000)"
       end
 
@@ -40,7 +42,8 @@ module Collavre
         )
 
         assert_includes output,
-                        "offset: 0, cursor: \"1770000000000000:989\", max_message_id: 991, " \
+                        "offset: 0, cursor: \"1770000000000000:989:1770000001000000\", " \
+                          "max_message_id: 991, " \
                           "limit: 2, max_chars: 1000, content_offset: 320"
       end
 

--- a/engines/collavre/test/services/collavre/topics/message_page_test.rb
+++ b/engines/collavre/test/services/collavre/topics/message_page_test.rb
@@ -71,6 +71,7 @@ module Collavre
 
         assert_not result.has_more?
         assert_nil result.next_offset
+        assert_nil result.next_cursor
       end
 
       test "excludes private comments the reader is not party to" do
@@ -110,6 +111,55 @@ module Collavre
         assert_equal %w[m2 m1], result.messages.map { |m| m[:content] }
         assert_equal 3, result.total_count
         assert_equal anchor, result.newest_message_id
+      end
+
+      test "cursor does not skip remaining rows when an earlier row leaves the topic" do
+        comments = 5.times.map { |i| post("m#{i}") }
+        first = page(limit: 2, order: "desc")
+
+        comments.last.update!(topic: @creative.topics.create!(name: "Moved", user: @user))
+        second = page(
+          limit: 2, order: "desc", offset: first.next_offset,
+          max_message_id: first.newest_message_id, cursor: first.next_cursor
+        )
+
+        assert_equal %w[m4 m3], first.messages.map { |message| message[:content] }
+        assert_equal %w[m2 m1], second.messages.map { |message| message[:content] }
+      end
+
+      test "cursor follows created_at and id ordering rather than id alone" do
+        oldest = post("oldest")
+        newest = post("newest")
+        middle = post("middle")
+        base = Time.current.change(usec: 0)
+        oldest.update_column(:created_at, base)
+        newest.update_column(:created_at, base + 2.seconds)
+        middle.update_column(:created_at, base + 1.second)
+
+        first = page(limit: 1, order: "desc")
+        second = page(
+          limit: 1, order: "desc", offset: first.next_offset,
+          max_message_id: first.newest_message_id, cursor: first.next_cursor
+        )
+
+        assert_operator middle.id, :>, newest.id
+        assert_equal "newest", first.messages.first[:content]
+        assert_equal "middle", second.messages.first[:content]
+      end
+
+      test "content continuation keeps its cursor on the clipped row" do
+        post("older")
+        post("x" * 5_000)
+
+        first = page(limit: 1, char_budget: 300, order: "desc")
+        second = page(
+          limit: 1, char_budget: 300, order: "desc",
+          offset: first.next_offset, max_message_id: first.newest_message_id,
+          cursor: first.next_cursor, content_offset: first.next_content_offset
+        )
+
+        assert_equal first.messages.first[:id], second.messages.first[:id]
+        assert_equal first.next_cursor, second.next_cursor
       end
 
       test "newest_message_id reports the topic's newest id when unpinned" do
@@ -293,6 +343,12 @@ module Collavre
 
         assert_equal 0, result.offset
         assert_equal %w[m0 m1], result.messages.map { |m| m[:content] }
+      end
+
+      test "rejects a malformed cursor" do
+        error = assert_raises(ArgumentError) { page(cursor: "not-a-cursor") }
+
+        assert_equal "cursor is invalid", error.message
       end
 
       # The anchor is what makes an unanchored first page safe to paginate from.

--- a/engines/collavre/test/services/collavre/topics/message_page_test.rb
+++ b/engines/collavre/test/services/collavre/topics/message_page_test.rb
@@ -127,6 +127,28 @@ module Collavre
         assert_equal %w[m2 m1], second.messages.map { |message| message[:content] }
       end
 
+      test "cursor excludes an older message moved into the topic after the snapshot" do
+        other_topic = @creative.topics.create!(name: "Other", user: @user)
+        moved_in = Comment.create!(
+          creative: @creative, topic: other_topic, user: @user, content: "moved in later",
+          skip_default_user: true, skip_dispatch: true
+        )
+        3.times { |i| post("m#{i}") }
+        first = page(limit: 1, order: "desc")
+
+        CommentMoveService.new(creative: @creative, user: @user).call(
+          comment_ids: [ moved_in.id ], target_topic_id: @topic.id
+        )
+        second = page(
+          limit: 10, order: "desc", offset: first.next_offset,
+          max_message_id: first.newest_message_id, cursor: first.next_cursor
+        )
+
+        assert_equal %w[m1 m0], second.messages.map { |message| message[:content] }
+        assert_equal 3, second.total_count
+        assert_not second.has_more?
+      end
+
       test "cursor follows created_at and id ordering rather than id alone" do
         oldest = post("oldest")
         newest = post("newest")

--- a/engines/collavre/test/services/collavre/topics/message_page_test.rb
+++ b/engines/collavre/test/services/collavre/topics/message_page_test.rb
@@ -19,8 +19,13 @@ module Collavre
         )
       end
 
-      def page(**options)
-        MessagePage.new(topic: @topic, user: @user, **options).call
+      # char_budget/format are spelled out here rather than in every caller,
+      # since what the tests are exercising is the cap, not how it is packaged.
+      def page(char_budget: nil, format: CharBudget::DEFAULT_FORMAT, **options)
+        MessagePage.new(
+          topic: @topic, user: @user,
+          budget: CharBudget.new(chars: char_budget, format: format), **options
+        ).call
       end
 
       test "offset counts back from the newest message" do
@@ -178,12 +183,12 @@ module Collavre
         result = page(limit: 3)
 
         assert_equal 6, result.returned_chars
-        assert_operator result.billed_chars, :>=, 6 + (3 * MessagePage::ENVELOPE_CHARS)
+        assert_operator result.billed_chars, :>=, 6 + (3 * CharBudget::ENVELOPE_CHARS)
       end
 
       test "char_budget counts the envelope, so tiny messages still cost something" do
         5.times { post("x") }
-        result = page(limit: 5, char_budget: 2 * MessagePage::ENVELOPE_CHARS)
+        result = page(limit: 5, char_budget: 2 * CharBudget::ENVELOPE_CHARS)
 
         assert_operator result.returned_count, :<, 5
         assert result.budget_exhausted

--- a/engines/collavre/test/services/collavre/topics/message_page_test.rb
+++ b/engines/collavre/test/services/collavre/topics/message_page_test.rb
@@ -19,6 +19,20 @@ module Collavre
         )
       end
 
+      def post_with_image(content: "", filename: "small.png")
+        comment = Comment.new(
+          creative: @creative, topic: @topic, user: @user, content: content,
+          skip_default_user: true, skip_dispatch: true
+        )
+        comment.images.attach(
+          io: StringIO.new(file_fixture("small.png").binread),
+          filename: filename,
+          content_type: "image/png"
+        )
+        comment.save!
+        comment
+      end
+
       # char_budget/format are spelled out here rather than in every caller,
       # since what the tests are exercising is the cap, not how it is packaged.
       def page(char_budget: nil, format: CharBudget::DEFAULT_FORMAT, **options)
@@ -114,6 +128,41 @@ module Collavre
         assert_equal "hello there", message[:content]
         assert message[:agent]
         assert_equal "Bot", message[:author]
+      end
+
+      test "an image-only comment exposes attachment metadata and a readable URL" do
+        post_with_image
+
+        content = page.messages.first[:content]
+        assert_includes content, "Image attachment 1: small.png (image/png,"
+        assert_match %r{/public-assets/blobs/[^/]+/small\.png}, content
+      end
+
+      test "an attached image is preserved alongside the message text" do
+        post_with_image(content: "See the screenshot")
+
+        content = page.messages.first[:content]
+        assert_includes content, "See the screenshot"
+        assert_includes content, "Image attachment 1: small.png"
+      end
+
+      test "attachment metadata follows content continuation without loss" do
+        post_with_image(filename: "#{'screenshot-' * 18}.png")
+        expected = page.messages.first[:content]
+        chunks = []
+        content_offset = 0
+
+        20.times do
+          result = page(limit: 1, char_budget: 260, content_offset: content_offset)
+          chunks << result.messages.first[:content]
+          content_offset = result.next_content_offset
+          break unless content_offset
+
+          assert_equal 0, result.next_offset
+        end
+
+        assert_nil content_offset
+        assert_equal expected, chunks.join
       end
 
       test "reports a nil author as system" do

--- a/engines/collavre/test/services/collavre/topics/message_page_test.rb
+++ b/engines/collavre/test/services/collavre/topics/message_page_test.rb
@@ -137,7 +137,7 @@ module Collavre
 
       # Stopping short of the *first* message would return an empty page at an
       # offset that has rows, and the caller would page against it forever. It
-      # is clipped instead — bounded, marked, and the offset still moves.
+      # is clipped instead — bounded, marked, and addressable within the row.
       test "a message wider than the whole budget is clipped, not emitted whole" do
         post("y" * 5_000)
         budget = 400
@@ -146,17 +146,45 @@ module Collavre
         assert_equal 1, result.returned_count
         assert_operator result.billed_chars, :<=, budget
         assert result.messages.first[:clipped]
-        assert_includes result.messages.first[:content], "clipped from 5000 chars"
+        assert_equal 0, result.messages.first[:content_offset]
+        assert_equal 5_000, result.messages.first[:content_total_chars]
+        assert_equal result.messages.first[:content_end_offset], result.next_content_offset
+        assert_includes result.messages.first[:clip_notice], "continue with content_offset"
         assert_equal 1, result.clipped_count
       end
 
-      test "a clipped message still advances the offset for the next page" do
+      test "a clipped message keeps its row offset and advances within its content" do
         post("y" * 5_000)
         post("z" * 5_000)
         result = page(limit: 3, char_budget: 400)
 
-        assert_equal 1, result.next_offset
+        assert_equal 0, result.next_offset
+        assert_operator result.next_content_offset, :>, 0
         assert result.has_more?
+      end
+
+      test "content continuation retrieves every character before consuming the row" do
+        content = ("0123456789" * 120).freeze
+        post(content)
+        chunks = []
+        content_offset = 0
+        anchor = nil
+
+        20.times do
+          result = page(
+            limit: 1, char_budget: 260, order: "desc",
+            content_offset: content_offset, max_message_id: anchor
+          )
+          anchor ||= result.newest_message_id
+          chunks << result.messages.first[:content]
+          content_offset = result.next_content_offset
+          break unless content_offset
+
+          assert_equal 0, result.next_offset
+        end
+
+        assert_nil content_offset
+        assert_equal content, chunks.join
       end
 
       # No honest fragment exists below the envelope and the notice, so the page
@@ -167,6 +195,8 @@ module Collavre
 
         assert_equal 0, result.returned_count
         assert result.budget_exhausted
+        assert_equal 0, result.next_offset
+        assert_equal 0, result.next_content_offset
       end
 
       test "clipped_count is zero when every message was emitted whole" do

--- a/engines/collavre/test/services/collavre/topics/message_page_test.rb
+++ b/engines/collavre/test/services/collavre/topics/message_page_test.rb
@@ -179,6 +179,22 @@ module Collavre
         assert_equal 0, second.messages.first.fetch(:content_offset, 0)
       end
 
+      test "content continuation resets when its clipped row is edited" do
+        clipped = post("x" * 5_000)
+        first = page(limit: 1, char_budget: 300, order: "desc")
+
+        clipped.update!(content: "replacement content")
+        second = page(
+          limit: 1, char_budget: 300, order: "desc",
+          offset: first.next_offset, max_message_id: first.newest_message_id,
+          cursor: first.next_cursor, content_offset: first.next_content_offset
+        )
+
+        assert_equal clipped.id, second.messages.first[:id]
+        assert_equal "replacement content", second.messages.first[:content]
+        assert_equal 0, second.messages.first.fetch(:content_offset, 0)
+      end
+
       test "newest_message_id reports the topic's newest id when unpinned" do
         post("a")
         newest = post("b")

--- a/engines/collavre/test/services/collavre/topics/message_page_test.rb
+++ b/engines/collavre/test/services/collavre/topics/message_page_test.rb
@@ -162,6 +162,23 @@ module Collavre
         assert_equal first.next_cursor, second.next_cursor
       end
 
+      test "content continuation resets when its cursor row leaves the topic" do
+        older = post("older message")
+        clipped = post("x" * 5_000)
+        first = page(limit: 1, char_budget: 300, order: "desc")
+
+        clipped.update!(topic: @creative.topics.create!(name: "Moved", user: @user))
+        second = page(
+          limit: 1, char_budget: 300, order: "desc",
+          offset: first.next_offset, max_message_id: first.newest_message_id,
+          cursor: first.next_cursor, content_offset: first.next_content_offset
+        )
+
+        assert_equal older.id, second.messages.first[:id]
+        assert_equal "older message", second.messages.first[:content]
+        assert_equal 0, second.messages.first.fetch(:content_offset, 0)
+      end
+
       test "newest_message_id reports the topic's newest id when unpinned" do
         post("a")
         newest = post("b")

--- a/engines/collavre/test/services/collavre/topics/message_page_test.rb
+++ b/engines/collavre/test/services/collavre/topics/message_page_test.rb
@@ -61,14 +61,25 @@ module Collavre
         assert_equal [ "public one" ], page.messages.map { |m| m[:content] }
       end
 
-      test "excludes authorless and approval-action rows unless include_system" do
+      test "excludes authorless rows unless include_system" do
         post("real message")
         Comment.create!(creative: @creative, topic: @topic, user: nil, content: "⏳ waiting",
                         skip_default_user: true, skip_dispatch: true)
-        post("approve me", action: '{"action":"approve_tool"}')
 
         assert_equal [ "real message" ], page.messages.map { |m| m[:content] }
-        assert_equal 3, page(include_system: true).total_count
+        assert_equal 2, page(include_system: true).total_count
+      end
+
+      # Comment.without_approval_action is an invariant, not a preference: an
+      # approval prompt must never reach an agent as history. include_system is
+      # about authorless furniture and does not reopen that door.
+      test "approval-action rows stay out even with include_system" do
+        post("real message")
+        post("approve me", action: '{"action":"approve_tool"}')
+
+        result = page(include_system: true)
+        assert_equal [ "real message" ], result.messages.map { |m| m[:content] }
+        assert_equal 1, result.total_count
       end
 
       test "max_message_id pins the window so later arrivals do not shift it" do
@@ -113,6 +124,25 @@ module Collavre
 
         assert_equal 2, result.returned_count
         assert_equal 200, result.returned_chars
+        assert result.budget_exhausted
+      end
+
+      # returned_chars is what the caller reads; billed_chars is what it pays.
+      # Charging content alone lets a run of short messages emit ids, timestamps
+      # and author names for free, and the response overruns max_chars.
+      test "billed_chars charges the rendered envelope on top of the prose" do
+        3.times { post("hi") }
+        result = page(limit: 3)
+
+        assert_equal 6, result.returned_chars
+        assert_operator result.billed_chars, :>=, 6 + (3 * MessagePage::ENVELOPE_CHARS)
+      end
+
+      test "char_budget counts the envelope, so tiny messages still cost something" do
+        5.times { post("x") }
+        result = page(limit: 5, char_budget: 2 * MessagePage::ENVELOPE_CHARS)
+
+        assert_operator result.returned_count, :<, 5
         assert result.budget_exhausted
       end
 

--- a/engines/collavre/test/services/collavre/topics/message_page_test.rb
+++ b/engines/collavre/test/services/collavre/topics/message_page_test.rb
@@ -118,13 +118,56 @@ module Collavre
         assert_equal "system", page(include_system: true).messages.first[:author]
       end
 
-      test "char_budget keeps the message that crosses the budget rather than cutting it" do
+      # The budget is a cap, so a message that would cross it ends the window
+      # instead of being emitted on top of it.
+      test "char_budget stops before a message that would cross it" do
         3.times { post("x" * 100) }
-        result = page(limit: 3, char_budget: 150)
+        budget = 150
+        result = page(limit: 3, char_budget: budget)
 
-        assert_equal 2, result.returned_count
-        assert_equal 200, result.returned_chars
+        assert_equal 1, result.returned_count
+        assert_operator result.billed_chars, :<=, budget
         assert result.budget_exhausted
+      end
+
+      # Stopping short of the *first* message would return an empty page at an
+      # offset that has rows, and the caller would page against it forever. It
+      # is clipped instead — bounded, marked, and the offset still moves.
+      test "a message wider than the whole budget is clipped, not emitted whole" do
+        post("y" * 5_000)
+        budget = 400
+        result = page(limit: 3, char_budget: budget)
+
+        assert_equal 1, result.returned_count
+        assert_operator result.billed_chars, :<=, budget
+        assert result.messages.first[:clipped]
+        assert_includes result.messages.first[:content], "clipped from 5000 chars"
+        assert_equal 1, result.clipped_count
+      end
+
+      test "a clipped message still advances the offset for the next page" do
+        post("y" * 5_000)
+        post("z" * 5_000)
+        result = page(limit: 3, char_budget: 400)
+
+        assert_equal 1, result.next_offset
+        assert result.has_more?
+      end
+
+      # No honest fragment exists below the envelope and the notice, so the page
+      # comes back empty and says the budget, not the topic, is why.
+      test "a budget too small for even the clip notice returns nothing" do
+        post("y" * 5_000)
+        result = page(limit: 3, char_budget: 10)
+
+        assert_equal 0, result.returned_count
+        assert result.budget_exhausted
+      end
+
+      test "clipped_count is zero when every message was emitted whole" do
+        3.times { post("m") }
+
+        assert_equal 0, page(limit: 3, char_budget: 10_000).clipped_count
       end
 
       # returned_chars is what the caller reads; billed_chars is what it pays.

--- a/engines/collavre/test/services/collavre/topics/message_page_test.rb
+++ b/engines/collavre/test/services/collavre/topics/message_page_test.rb
@@ -251,8 +251,28 @@ module Collavre
         assert_equal 0, result.total_count
         assert_equal 0, result.total_chars
         assert_empty result.messages
-        assert_nil result.newest_message_id
         assert_not result.has_more?
+      end
+
+      # nil is how the scope spells "unbounded", so an empty topic anchoring at
+      # nil was not anchored at all: the snapshot the rest of the call reads is
+      # whatever exists by the time each query runs, and the caller is handed no
+      # anchor to pin the next page with. Zero is below every id, so it names
+      # the empty snapshot instead of waiving the bound.
+      test "an empty topic anchors at zero rather than leaving the snapshot unbounded" do
+        assert_equal 0, page.newest_message_id
+      end
+
+      test "a message arriving mid-call cannot enter a snapshot that started empty" do
+        stats = MessageStats.method(:for)
+        MessageStats.stub(:for, ->(*args, **kwargs) { post("late"); stats.call(*args, **kwargs) }) do
+          @result = page(limit: 10)
+        end
+
+        assert_equal 0, @result.total_count
+        assert_empty @result.messages
+        assert_equal 0, @result.newest_message_id
+        assert_not @result.has_more?
       end
     end
   end

--- a/engines/collavre/test/services/collavre/topics/message_page_test.rb
+++ b/engines/collavre/test/services/collavre/topics/message_page_test.rb
@@ -1,0 +1,152 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  module Topics
+    class MessagePageTest < ActiveSupport::TestCase
+      setup do
+        @user = users(:one)
+        @other = users(:two)
+        @creative = Collavre::Creative.create!(description: "Paging Host", user: @user)
+        @topic = @creative.topics.create!(name: "Paged", user: @user)
+      end
+
+      def post(content, user: @user, private_flag: false, action: nil)
+        Comment.create!(
+          creative: @creative, topic: @topic, user: user, content: content,
+          private: private_flag, action: action, skip_default_user: true, skip_dispatch: true
+        )
+      end
+
+      def page(**options)
+        MessagePage.new(topic: @topic, user: @user, **options).call
+      end
+
+      test "offset counts back from the newest message" do
+        5.times { |i| post("m#{i}") }
+
+        assert_equal %w[m4 m3 m2], page(limit: 3, order: "desc").messages.map { |m| m[:content] }
+        assert_equal %w[m1 m0], page(offset: 3, limit: 3, order: "desc").messages.map { |m| m[:content] }
+      end
+
+      test "renders the window oldest-first by default while still selecting from the newest end" do
+        5.times { |i| post("m#{i}") }
+
+        assert_equal %w[m2 m3 m4], page(limit: 3).messages.map { |m| m[:content] }
+      end
+
+      test "reports totals for the whole topic, not the window" do
+        4.times { |i| post("m#{i}") }
+        result = page(limit: 2)
+
+        assert_equal 4, result.total_count
+        assert_equal 2, result.returned_count
+        assert result.has_more?
+        assert_equal 2, result.next_offset
+      end
+
+      test "has_more is false and next_offset nil once the window reaches the end" do
+        2.times { |i| post("m#{i}") }
+        result = page(limit: 10)
+
+        assert_not result.has_more?
+        assert_nil result.next_offset
+      end
+
+      test "excludes private comments the reader is not party to" do
+        post("public one")
+        post("secret", user: @other, private_flag: true)
+
+        assert_equal [ "public one" ], page.messages.map { |m| m[:content] }
+      end
+
+      test "excludes authorless and approval-action rows unless include_system" do
+        post("real message")
+        Comment.create!(creative: @creative, topic: @topic, user: nil, content: "⏳ waiting",
+                        skip_default_user: true, skip_dispatch: true)
+        post("approve me", action: '{"action":"approve_tool"}')
+
+        assert_equal [ "real message" ], page.messages.map { |m| m[:content] }
+        assert_equal 3, page(include_system: true).total_count
+      end
+
+      test "max_message_id pins the window so later arrivals do not shift it" do
+        first_batch = 3.times.map { |i| post("m#{i}") }
+        anchor = first_batch.last.id
+        post("arrived later")
+
+        result = page(limit: 2, max_message_id: anchor, order: "desc")
+        assert_equal %w[m2 m1], result.messages.map { |m| m[:content] }
+        assert_equal 3, result.total_count
+        assert_equal anchor, result.newest_message_id
+      end
+
+      test "newest_message_id reports the topic's newest id when unpinned" do
+        post("a")
+        newest = post("b")
+
+        assert_equal newest.id, page.newest_message_id
+      end
+
+      test "strips html from content and labels agent authors" do
+        agent = Collavre::User.create!(name: "Bot", email: "bot-#{SecureRandom.hex(4)}@test.test",
+                                       password: "password123", llm_vendor: "google")
+        post("<p>hello <b>there</b></p>", user: agent)
+
+        message = page.messages.first
+        assert_equal "hello there", message[:content]
+        assert message[:agent]
+        assert_equal "Bot", message[:author]
+      end
+
+      test "reports a nil author as system" do
+        Comment.create!(creative: @creative, topic: @topic, user: nil, content: "notice",
+                        skip_default_user: true, skip_dispatch: true)
+
+        assert_equal "system", page(include_system: true).messages.first[:author]
+      end
+
+      test "char_budget keeps the message that crosses the budget rather than cutting it" do
+        3.times { post("x" * 100) }
+        result = page(limit: 3, char_budget: 150)
+
+        assert_equal 2, result.returned_count
+        assert_equal 200, result.returned_chars
+        assert result.budget_exhausted
+      end
+
+      test "budget_exhausted is false when the window simply ran out of messages" do
+        2.times { |i| post("m#{i}") }
+
+        assert_not page(limit: 10, char_budget: 10_000).budget_exhausted
+      end
+
+      test "limit is clamped to the maximum and falls back to the default when non-positive" do
+        post("only")
+
+        assert_equal MessagePage::MAX_LIMIT, page(limit: 10_000).limit
+        assert_equal MessagePage::DEFAULT_LIMIT, page(limit: 0).limit
+        assert_equal MessagePage::DEFAULT_LIMIT, page(limit: -5).limit
+      end
+
+      test "negative offset is treated as zero and unknown order falls back to the default" do
+        2.times { |i| post("m#{i}") }
+        result = page(offset: -3, order: "sideways")
+
+        assert_equal 0, result.offset
+        assert_equal %w[m0 m1], result.messages.map { |m| m[:content] }
+      end
+
+      test "an empty topic returns an empty page rather than failing" do
+        result = page
+
+        assert_equal 0, result.total_count
+        assert_equal 0, result.total_chars
+        assert_empty result.messages
+        assert_nil result.newest_message_id
+        assert_not result.has_more?
+      end
+    end
+  end
+end

--- a/engines/collavre/test/services/collavre/topics/message_page_test.rb
+++ b/engines/collavre/test/services/collavre/topics/message_page_test.rb
@@ -138,6 +138,35 @@ module Collavre
         assert_equal %w[m0 m1], result.messages.map { |m| m[:content] }
       end
 
+      # The anchor is what makes an unanchored first page safe to paginate from.
+      # If it were read after the totals and the window, a message arriving
+      # mid-call would be counted but not returned, and named as the newest
+      # without ever having been in the window the caller was handed.
+      test "a message arriving mid-call is outside the snapshot the page reports" do
+        3.times { |i| post("m#{i}") }
+        arrived = nil
+
+        stats = MessageStats.method(:for)
+        MessageStats.stub(:for, ->(*args, **kwargs) { arrived ||= post("late"); stats.call(*args, **kwargs) }) do
+          @result = page(limit: 10)
+        end
+
+        assert_equal 3, @result.total_count
+        assert_equal %w[m0 m1 m2], @result.messages.map { |m| m[:content] }
+        assert_not_equal arrived.id, @result.newest_message_id
+        assert_not @result.has_more?
+      end
+
+      test "an explicit anchor still wins over the topic's newest message" do
+        3.times { |i| post("m#{i}") }
+        anchor = Comment.order(:id).pluck(:id).second
+
+        result = page(max_message_id: anchor, limit: 10)
+
+        assert_equal 2, result.total_count
+        assert_equal anchor, result.newest_message_id
+      end
+
       test "an empty topic returns an empty page rather than failing" do
         result = page
 

--- a/engines/collavre/test/services/collavre/topics/message_stats_test.rb
+++ b/engines/collavre/test/services/collavre/topics/message_stats_test.rb
@@ -17,6 +17,20 @@ module Collavre
                         skip_default_user: true, skip_dispatch: true)
       end
 
+      def post_with_image(topic)
+        comment = Comment.new(
+          creative: @creative, topic: topic, user: @user, content: "",
+          skip_default_user: true, skip_dispatch: true
+        )
+        comment.images.attach(
+          io: StringIO.new(file_fixture("small.png").binread),
+          filename: "small.png",
+          content_type: "image/png"
+        )
+        comment.save!
+        comment
+      end
+
       test "counts, sizes and dates each topic separately in one pass" do
         post(@a, "1234567890")
         post(@a, "12345")
@@ -57,6 +71,16 @@ module Collavre
         post(@a, "later")
 
         assert_equal 1, MessageStats.for([ @a ], user: @user, max_message_id: anchor.id)[@a.id].count
+      end
+
+      test "image attachment markers are included in the size estimate" do
+        post_with_image(@a)
+
+        stat = MessageStats.for([ @a ], user: @user)[@a.id]
+        page = MessagePage.new(topic: @a, user: @user).call
+
+        assert_operator stat.chars, :>=, page.messages.sole[:content].length
+        assert_operator stat.chars, :>, 0
       end
     end
   end

--- a/engines/collavre/test/services/collavre/topics/message_stats_test.rb
+++ b/engines/collavre/test/services/collavre/topics/message_stats_test.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  module Topics
+    class MessageStatsTest < ActiveSupport::TestCase
+      setup do
+        @user = users(:one)
+        @creative = Collavre::Creative.create!(description: "Stats Host", user: @user)
+        @a = @creative.topics.create!(name: "A", user: @user)
+        @b = @creative.topics.create!(name: "B", user: @user)
+      end
+
+      def post(topic, content, user: @user)
+        Comment.create!(creative: @creative, topic: topic, user: user, content: content,
+                        skip_default_user: true, skip_dispatch: true)
+      end
+
+      test "counts, sizes and dates each topic separately in one pass" do
+        post(@a, "1234567890")
+        post(@a, "12345")
+        post(@b, "abc")
+
+        stats = MessageStats.for([ @a, @b ], user: @user)
+
+        assert_equal 2, stats[@a.id].count
+        assert_equal 15, stats[@a.id].chars
+        assert_equal 1, stats[@b.id].count
+        assert_equal 3, stats[@b.id].chars
+        assert_not_nil stats[@a.id].last_at
+      end
+
+      test "a topic with no visible messages is reported as empty rather than missing" do
+        stats = MessageStats.for([ @a ], user: @user)
+
+        assert_equal MessageStats::EMPTY, stats[@a.id]
+        assert_equal 0, stats[@a.id].count
+        assert_nil stats[@a.id].last_at
+      end
+
+      test "returns nothing for an empty topic list" do
+        assert_empty MessageStats.for([], user: @user)
+      end
+
+      test "system rows are counted only when asked for" do
+        post(@a, "real")
+        Comment.create!(creative: @creative, topic: @a, user: nil, content: "⏳",
+                        skip_default_user: true, skip_dispatch: true)
+
+        assert_equal 1, MessageStats.for([ @a ], user: @user)[@a.id].count
+        assert_equal 2, MessageStats.for([ @a ], user: @user, include_system: true)[@a.id].count
+      end
+
+      test "max_message_id caps the totals at the snapshot" do
+        anchor = post(@a, "first")
+        post(@a, "later")
+
+        assert_equal 1, MessageStats.for([ @a ], user: @user, max_message_id: anchor.id)[@a.id].count
+      end
+    end
+  end
+end

--- a/engines/collavre/test/services/collavre/topics/next_name_test.rb
+++ b/engines/collavre/test/services/collavre/topics/next_name_test.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  module Topics
+    class NextNameTest < ActiveSupport::TestCase
+      setup do
+        @user = users(:one)
+        @creative = Collavre::Creative.create!(description: "Naming Host", user: @user)
+        @prefix = I18n.t("collavre.topics.default_name_prefix")
+      end
+
+      test "starts at one on a creative with no generated names" do
+        assert_equal "#{@prefix}1", NextName.for(@creative)
+      end
+
+      test "continues past the highest existing number rather than filling gaps" do
+        @creative.topics.create!(name: "#{@prefix}1", user: @user)
+        @creative.topics.create!(name: "#{@prefix}7", user: @user)
+
+        assert_equal "#{@prefix}8", NextName.for(@creative)
+      end
+
+      test "ignores names that share the prefix but are not numbered" do
+        @creative.topics.create!(name: "#{@prefix} planning", user: @user)
+
+        assert_equal "#{@prefix}1", NextName.for(@creative)
+      end
+
+      # Names are unique per creative regardless of archive state, so reusing an
+      # archived number would generate a name that cannot be saved.
+      test "counts archived topics so it never proposes a name that already exists" do
+        @creative.topics.create!(name: "#{@prefix}4", user: @user).archive!
+
+        assert_equal "#{@prefix}5", NextName.for(@creative)
+      end
+    end
+  end
+end

--- a/engines/collavre/test/services/collavre/topics/pin_rejection_test.rb
+++ b/engines/collavre/test/services/collavre/topics/pin_rejection_test.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  module Topics
+    class PinRejectionTest < ActiveSupport::TestCase
+      setup do
+        @agent = Collavre::User.create!(name: "Worker", email: "worker-#{SecureRandom.hex(4)}@test.test",
+                                        password: "password123", llm_vendor: "google")
+      end
+
+      test "a missing-permission rejection tells the caller to share the creative" do
+        message = PinRejection.message(@agent, :no_creative_access)
+
+        assert_includes message, "Worker"
+        assert_includes message, "Share the creative"
+      end
+
+      # Sharing cannot fix a session agent, so the advice must not mention it.
+      test "a session-agent rejection does not send the caller after a share" do
+        message = PinRejection.message(@agent, :session_agent_outside_session_topic)
+
+        assert_includes message, "session topic"
+        assert_not_includes message, "Share the creative"
+      end
+    end
+  end
+end

--- a/engines/collavre/test/services/collavre/topics/serializer_test.rb
+++ b/engines/collavre/test/services/collavre/topics/serializer_test.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  module Topics
+    class SerializerTest < ActiveSupport::TestCase
+      setup do
+        @user = users(:one)
+        @creative = Collavre::Creative.create!(description: "Serialize Host", user: @user)
+        @topic = @creative.topics.create!(name: "Work", user: @user)
+        @agent = Collavre::User.create!(name: "Pinned", email: "pin-#{SecureRandom.hex(4)}@test.test",
+                                        password: "password123", llm_vendor: "google")
+      end
+
+      test "the broadcast payload carries the pin, the lock flag and the unread count" do
+        @topic.set_primary_agent!(@agent)
+        data = Serializer.call(@topic, unread_count: 3)
+
+        assert_equal @topic.id, data[:id]
+        assert_equal "Pinned", data[:primary_agent][:name]
+        assert_equal false, data[:agent_locked]
+        assert_equal 3, data[:unread_count]
+      end
+
+      test "unread_count and archived_at are omitted when absent" do
+        data = Serializer.call(@topic)
+
+        assert_not data.key?(:unread_count)
+        assert_not data.key?(:archived_at)
+        assert_not data.key?(:primary_agent)
+      end
+
+      test "archived_at is included once the topic is archived" do
+        @topic.archive!
+
+        assert_not_nil Serializer.call(@topic)[:archived_at]
+      end
+
+      test "with_agent always carries primary_agent, explicitly nil when cleared" do
+        data = Serializer.with_agent(@topic, nil)
+
+        assert data.key?(:primary_agent)
+        assert_nil data[:primary_agent]
+      end
+
+      test "the tool payload names the agent and flags main topics" do
+        main = @creative.main_topic(fallback_user: @user)
+        @topic.set_primary_agent!(@agent)
+
+        assert Serializer.for_tool(main)[:main]
+        assert_equal({ id: @agent.id, name: "Pinned" }, Serializer.for_tool(@topic)[:primary_agent])
+      end
+
+      test "the tool payload drops absent stats instead of reporting them as zero" do
+        data = Serializer.for_tool(@topic)
+
+        assert_not data.key?(:message_count)
+        assert_equal false, data[:archived]
+      end
+
+      test "the tool payload reports stats when they are supplied" do
+        data = Serializer.for_tool(@topic, message_count: 4, message_chars: 90, last_message_at: Time.current)
+
+        assert_equal 4, data[:message_count]
+        assert_equal 90, data[:message_chars]
+        assert_match(/\A\d{4}-/, data[:last_message_at])
+      end
+    end
+  end
+end

--- a/engines/collavre/test/services/collavre/topics/serializer_test.rb
+++ b/engines/collavre/test/services/collavre/topics/serializer_test.rb
@@ -23,6 +23,40 @@ module Collavre
         assert_equal 3, data[:unread_count]
       end
 
+      # The controller built this payload through view_context, which carries the
+      # request; Serializer reaches the same helper through ApplicationController
+      # .helpers, which does not. user_avatar_url falls through to
+      # main_app.url_for(variant) for an attached avatar, and url_for outside a
+      # request needs a host — so an agent with an uploaded avatar is the case
+      # where the two paths could diverge or raise.
+      test "an agent with an attached avatar serializes without a request context" do
+        @agent.avatar.attach(
+          io: StringIO.new(file_fixture("small.png").binread),
+          filename: "avatar.png",
+          content_type: "image/png"
+        )
+        @topic.set_primary_agent!(@agent)
+
+        data = Serializer.call(@topic)
+
+        assert data[:primary_agent][:avatar_url].present?
+        assert_equal false, data[:primary_agent][:default_avatar]
+      end
+
+      # Serializer resolves the avatar itself instead of calling user_json, so
+      # pin the two payloads together for the case where user_json still works
+      # (no attached avatar, hence no main_app.url_for). Guards the keys the
+      # client merges from drifting apart. Compared with string keys because
+      # topic.slice returns a HashWithIndifferentAccess, which stringifies the
+      # nested hash on assignment — true of the controller code this replaced
+      # too, and invisible once the payload is JSON.
+      test "the agent payload matches user_json wherever user_json can run" do
+        @topic.set_primary_agent!(@agent)
+
+        assert_equal ::ApplicationController.helpers.user_json(@agent).deep_stringify_keys,
+          Serializer.call(@topic)[:primary_agent].deep_stringify_keys
+      end
+
       test "unread_count and archived_at are omitted when absent" do
         data = Serializer.call(@topic)
 

--- a/engines/collavre/test/services/collavre/topics/serializer_test.rb
+++ b/engines/collavre/test/services/collavre/topics/serializer_test.rb
@@ -86,6 +86,14 @@ module Collavre
         assert_equal({ id: @agent.id, name: "Pinned" }, Serializer.for_tool(@topic)[:primary_agent])
       end
 
+      test "the tool payload flags System only on an inbox creative" do
+        ordinary_system = @creative.topics.create!(name: Creative::SYSTEM_TOPIC_NAME, user: @user)
+        inbox = Creative.create!(description: "Inbox", user: @user, data: { "kind" => "inbox" })
+
+        assert_not Serializer.for_tool(ordinary_system)[:system]
+        assert Serializer.for_tool(inbox.system_topic)[:system]
+      end
+
       test "the tool payload drops absent stats instead of reporting them as zero" do
         data = Serializer.for_tool(@topic)
 

--- a/engines/collavre/test/services/collavre/topics/topic_move_test.rb
+++ b/engines/collavre/test/services/collavre/topics/topic_move_test.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  module Topics
+    class TopicMoveTest < ActiveSupport::TestCase
+      test "locks the topic before relocating its comments" do
+        user = users(:one)
+        source = Creative.create!(description: "Source", user: user)
+        destination = Creative.create!(description: "Destination", user: user)
+        topic = source.topics.create!(name: "Moving", user: user)
+        Comment.create!(creative: source, topic: topic, user: user, content: "message",
+                        skip_default_user: true, skip_dispatch: true)
+
+        calls = []
+        comments = topic.comments
+        original_update = comments.method(:update_all)
+        lock_topic = -> { calls << :topic_lock }
+        move_comments = lambda do |*arguments|
+          calls << :comments_update
+          original_update.call(*arguments)
+        end
+
+        topic.stub(:lock!, lock_topic) do
+          topic.stub(:comments, comments) do
+            comments.stub(:update_all, move_comments) do
+              TopicMove.new(topic: topic, target_creative: destination).call
+            end
+          end
+        end
+
+        assert_equal %i[topic_lock comments_update], calls
+      end
+    end
+  end
+end

--- a/engines/collavre/test/services/collavre/topics/topic_move_test.rb
+++ b/engines/collavre/test/services/collavre/topics/topic_move_test.rb
@@ -32,6 +32,27 @@ module Collavre
 
         assert_equal %i[topic_lock comments_update], calls
       end
+
+      test "rejects a move when the source changes before the lock is acquired" do
+        user = users(:one)
+        source = Creative.create!(description: "Source", user: user)
+        intervening = Creative.create!(description: "Intervening", user: user)
+        destination = Creative.create!(description: "Destination", user: user)
+        topic = source.topics.create!(name: "Moving", user: user)
+        comment = Comment.create!(creative: source, topic: topic, user: user, content: "message",
+                                  skip_default_user: true, skip_dispatch: true)
+        stale_move = TopicMove.new(topic: topic, target_creative: destination)
+
+        TopicMove.new(topic: topic, target_creative: intervening).call
+
+        error = assert_raises(TopicMove::SourceChangedError) do
+          stale_move.call
+        end
+
+        assert_includes error.message, "moved"
+        assert_equal intervening.id, topic.reload.creative_id
+        assert_equal intervening.id, comment.reload.creative_id
+      end
     end
   end
 end

--- a/engines/collavre/test/support/system_helpers.rb
+++ b/engines/collavre/test/support/system_helpers.rb
@@ -32,6 +32,20 @@ module SystemHelpers
     # Ignore for drivers that do not support resizing.
   end
 
+  def assert_docked_comments_loaded
+    assert_selector "#comments-popup", wait: 10 do |popup|
+      page.evaluate_script(<<~JS, popup)
+        ((element) => {
+          const controller = window.Stimulus?.getControllerForElementAndIdentifier(
+            element,
+            'comments--list'
+          );
+          return controller?.initialLoadComplete === true;
+        })(arguments[0])
+      JS
+    end
+  end
+
   def wait_for_network_idle(timeout: Capybara.default_max_wait_time)
     start = Time.now
     while Time.now - start < timeout

--- a/engines/collavre/test/system/creative_progress_toggle_keyboard_test.rb
+++ b/engines/collavre/test/system/creative_progress_toggle_keyboard_test.rb
@@ -26,8 +26,12 @@ class CreativeProgressToggleKeyboardTest < ApplicationSystemTestCase
   end
 
   def focus_checkbox
-    checkbox = find("#{toggle_selector} .progress-toggle-checkbox", visible: :all)
-    page.execute_script("arguments[0].focus()", checkbox)
+    selector = "#{toggle_selector} .progress-toggle-checkbox"
+    assert_selector selector, visible: :all
+    # The PATCH response and broadcast can replace the row between Capybara's
+    # lookup and Selenium's next command. Pass the selector instead of a node so
+    # the browser resolves and focuses the current checkbox atomically.
+    page.execute_script("document.querySelector(arguments[0]).focus()", selector)
     assert checkbox_focused?, "expected the progress checkbox to hold focus"
   end
 

--- a/engines/collavre/test/system/inline_scripts_test.rb
+++ b/engines/collavre/test/system/inline_scripts_test.rb
@@ -336,14 +336,19 @@ class InlineScriptsTest < ApplicationSystemTestCase
 
     visit collavre.creatives_path(id: creative.id)
     assert_selector "#comments-popup[data-creative-id='#{creative.id}']", visible: :visible, wait: 10
+    assert_docked_comments_loaded
     page.execute_script(<<~JS)
       document.querySelector('[data-controller="workspace-tree"]')
         .dataset.persistenceMarker = 'comment-link-mounted';
-      window.Turbo.visit(#{collavre.creative_comment_path(creative, target_comment).to_json}, {
-        action: 'advance',
-        frame: 'creative-workspace-content'
-      });
+      const link = document.createElement('a');
+      link.id = 'same-creative-comment-link';
+      link.href = #{collavre.creative_comment_path(creative, target_comment).to_json};
+      link.dataset.turboFrame = 'creative-workspace-content';
+      link.dataset.turboAction = 'advance';
+      link.textContent = 'Target comment';
+      document.body.appendChild(link);
     JS
+    find("#same-creative-comment-link").click
 
     assert_selector "#creative-workspace-content [data-workspace-navigation-state][data-creative-id='#{creative.id}']",
                     visible: :all, wait: 10
@@ -359,6 +364,7 @@ class InlineScriptsTest < ApplicationSystemTestCase
 
     visit collavre.creatives_path(id: branch.id)
     assert_selector ".creative-workspace-tree-link[data-creative-id='#{branch.id}'].is-current", wait: 10
+    assert_docked_comments_loaded
     page.execute_script(<<~JS)
       const link = document.createElement('a');
       link.id = 'inaccessible-workspace-link';
@@ -406,6 +412,7 @@ class InlineScriptsTest < ApplicationSystemTestCase
 
     visit collavre.creatives_path(id: leaf.id)
     assert_equal leaf.id.to_s, find("#comments-popup", visible: :visible)["data-creative-id"]
+    assert_docked_comments_loaded
 
     leaf.destroy!
     page.execute_script(<<~JS)

--- a/engines/collavre/test/system/topic_list_popup_test.rb
+++ b/engines/collavre/test/system/topic_list_popup_test.rb
@@ -29,6 +29,7 @@ class TopicListPopupTest < ApplicationSystemTestCase
     assert_selector "#comments-popup", wait: 5
     # Wait for topics to finish loading (active topic tab appears)
     assert_selector "#comment-topics .topic-tag", text: "Alpha", wait: 10
+    assert_docked_comments_loaded
   end
 
   test "list button opens a searchable popup of active + archived topics" do
@@ -91,9 +92,7 @@ class TopicListPopupTest < ApplicationSystemTestCase
     find("#comments-popup .topic-list-btn").click
     assert_selector "#topic-list-modal", visible: :visible, wait: 5
 
-    assert_equal true, page.evaluate_script(
-      "document.activeElement === document.querySelector('#topic-list-modal input')"
-    )
+    assert_selector "#topic-list-modal input:focus", wait: 5
   end
 
   test "search box stays unfocused on a mobile viewport so the keyboard stays down" do
@@ -105,8 +104,6 @@ class TopicListPopupTest < ApplicationSystemTestCase
     find("#comments-popup .topic-list-btn").click
     assert_selector "#topic-list-modal", visible: :visible, wait: 5
 
-    assert_equal false, page.evaluate_script(
-      "document.activeElement === document.querySelector('#topic-list-modal input')"
-    )
+    assert_no_selector "#topic-list-modal input:focus", wait: 5
   end
 end

--- a/engines/collavre/test/system/workspace_tree_drawer_test.rb
+++ b/engines/collavre/test/system/workspace_tree_drawer_test.rb
@@ -62,9 +62,11 @@ class WorkspaceTreeDrawerTest < ApplicationSystemTestCase
       find(".creative-workspace-tree-toggle").click
       assert_no_selector ".creative-workspace-tree-region.is-open"
       assert_selector ".creative-workspace-tree-toggle[aria-expanded='false']"
+      assert_drawer_settled(open: false)
       find(".creative-workspace-tree-toggle").click
 
       assert_selector ".creative-workspace-tree-region.is-open"
+      assert_drawer_settled(open: true)
       assert_selector ".creative-workspace-tree-link", text: "Root child", wait: 10
     end
   end
@@ -140,6 +142,13 @@ class WorkspaceTreeDrawerTest < ApplicationSystemTestCase
     page.evaluate_script(<<~JS)
       getComputedStyle(document.querySelector(#{selector.to_json})).getPropertyValue(#{property.to_json});
     JS
+  end
+
+  def assert_drawer_settled(open:)
+    assert_selector ".creative-workspace-tree-region" do |region|
+      rect = page.evaluate_script("arguments[0].getBoundingClientRect().toJSON()", region)
+      open ? rect.fetch("left").abs < 1 : rect.fetch("right").abs < 1
+    end
   end
 
   # `visible?` only proves the element is painted, not that a tap would land on

--- a/skills/collavre/SKILL.md
+++ b/skills/collavre/SKILL.md
@@ -99,10 +99,10 @@ collavre tool run topic_list --json '{"creative_id": 8849}'
 collavre tool run topic_messages --json '{"topic_ids": "12,45,78", "limit": 100}'
 
 # Page a long topic with the returned next_offset, next_cursor, and snapshot id
-collavre tool run topic_messages --json '{"topic_ids": 12, "offset": 100, "cursor": "1770000000000000:989", "max_message_id": 9931}'
+collavre tool run topic_messages --json '{"topic_ids": 12, "offset": 100, "cursor": "1770000000000000:989:1770000001000000", "max_message_id": 9931}'
 
 # Continue inside one clipped message, preserving its row cursor
-collavre tool run topic_messages --json '{"topic_ids": 12, "offset": 100, "cursor": "1770000000000000:989", "content_offset": 28400, "max_message_id": 9931}'
+collavre tool run topic_messages --json '{"topic_ids": 12, "offset": 100, "cursor": "1770000000000000:989:1770000001000000", "content_offset": 28400, "max_message_id": 9931}'
 
 # Fan work out: one topic per unit of work, with an agent pinned to each
 collavre tool run topic_create --json '{"creative_id": 8849, "name": "Research", "primary_agent": "Dev1Claude"}'

--- a/skills/collavre/SKILL.md
+++ b/skills/collavre/SKILL.md
@@ -84,6 +84,33 @@ ops.json format:
 ]
 ```
 
+### Topics and messages
+
+Topics are conversation threads on a Creative — and the unit of agent
+concurrency. Tasks in the same topic are serialized (one runs, the rest queue);
+tasks in different topics run in parallel. There is no dedicated CLI verb yet;
+drive them through `collavre tool run`:
+
+```bash
+# See what topics exist and how much conversation each holds
+collavre tool run topic_list --json '{"creative_id": 8849}'
+
+# Summarize three topics at once — offset/limit apply per topic, newest first
+collavre tool run topic_messages --json '{"topic_ids": "12,45,78", "limit": 100}'
+
+# Page a long topic, pinned to one snapshot
+collavre tool run topic_messages --json '{"topic_ids": 12, "offset": 100, "max_message_id": 9931}'
+
+# Fan work out: one topic per unit of work, with an agent pinned to each
+collavre tool run topic_create --json '{"creative_id": 8849, "name": "Research", "primary_agent": "Dev1Claude"}'
+
+# Put a finished thread away (messages are kept and stay readable by id)
+collavre tool run topic_update --json '{"topic_id": 12, "archived": true}'
+
+# Carry the messages that still matter into a fresh topic
+collavre tool run topic_branch --json '{"source_topic_id": 12, "comment_ids": "991,994"}'
+```
+
 ### Discover & run tools (meta)
 ```bash
 collavre tool list                                # list available tools
@@ -97,6 +124,12 @@ collavre tool run <tool_name> --key value         # run with flag args
 ## Key Concepts
 
 - **Tree structure**: Creatives nest via `parent_id`. Use `--level` to control depth.
+- **Topics**: conversation threads on a Creative, and the concurrency unit — same
+  topic serializes, different topics run in parallel. One topic = one thread
+  reaching one conclusion; archive it when it gets there rather than reusing it.
+- **Primary agent**: pinning an agent to a topic is exclusive — that agent alone
+  answers there. Use it for a dedicated 1:1 channel; leave it unset for a thread
+  several participants should hear.
 - **Progress**: Leaf = manual (0.0 or 1.0). Parent = auto-calculated from children.
 - **Import**: Markdown headings/bullets become nested Creatives.
 - **Batch**: All-or-nothing transaction. Requires approval.

--- a/skills/collavre/SKILL.md
+++ b/skills/collavre/SKILL.md
@@ -98,11 +98,11 @@ collavre tool run topic_list --json '{"creative_id": 8849}'
 # Summarize three topics at once — offset/limit apply per topic, newest first
 collavre tool run topic_messages --json '{"topic_ids": "12,45,78", "limit": 100}'
 
-# Page a long topic, pinned to one snapshot
-collavre tool run topic_messages --json '{"topic_ids": 12, "offset": 100, "max_message_id": 9931}'
+# Page a long topic with the returned next_offset, next_cursor, and snapshot id
+collavre tool run topic_messages --json '{"topic_ids": 12, "offset": 100, "cursor": "1770000000000000:989", "max_message_id": 9931}'
 
-# Continue inside one clipped message without consuming its row
-collavre tool run topic_messages --json '{"topic_ids": 12, "offset": 100, "content_offset": 28400, "max_message_id": 9931}'
+# Continue inside one clipped message, preserving its row cursor
+collavre tool run topic_messages --json '{"topic_ids": 12, "offset": 100, "cursor": "1770000000000000:989", "content_offset": 28400, "max_message_id": 9931}'
 
 # Fan work out: one topic per unit of work, with an agent pinned to each
 collavre tool run topic_create --json '{"creative_id": 8849, "name": "Research", "primary_agent": "Dev1Claude"}'

--- a/skills/collavre/SKILL.md
+++ b/skills/collavre/SKILL.md
@@ -101,6 +101,9 @@ collavre tool run topic_messages --json '{"topic_ids": "12,45,78", "limit": 100}
 # Page a long topic, pinned to one snapshot
 collavre tool run topic_messages --json '{"topic_ids": 12, "offset": 100, "max_message_id": 9931}'
 
+# Continue inside one clipped message without consuming its row
+collavre tool run topic_messages --json '{"topic_ids": 12, "offset": 100, "content_offset": 28400, "max_message_id": 9931}'
+
 # Fan work out: one topic per unit of work, with an agent pinned to each
 collavre tool run topic_create --json '{"creative_id": 8849, "name": "Research", "primary_agent": "Dev1Claude"}'
 

--- a/skills/collavre/SKILL.md
+++ b/skills/collavre/SKILL.md
@@ -114,6 +114,10 @@ collavre tool run topic_update --json '{"topic_id": 12, "archived": true}'
 collavre tool run topic_branch --json '{"source_topic_id": 12, "comment_ids": "991,994"}'
 ```
 
+`topic_messages` includes each comment image as a URL-bearing marker in the
+message content. Image-only comments are not blank, and a long attachment list
+uses the same `content_offset` continuation as long prose.
+
 ### Discover & run tools (meta)
 ```bash
 collavre tool list                                # list available tools

--- a/skills/collavre/SKILL.md
+++ b/skills/collavre/SKILL.md
@@ -95,10 +95,10 @@ drive them through `collavre tool run`:
 # See what topics exist and how much conversation each holds
 collavre tool run topic_list --json '{"creative_id": 8849}'
 
-# Summarize three topics at once — offset/limit apply per topic, newest first
+# Summarize three topics at once — first page only; offset/limit apply per topic
 collavre tool run topic_messages --json '{"topic_ids": "12,45,78", "limit": 100}'
 
-# Page a long topic with the returned next_offset, next_cursor, and snapshot id
+# Continue each topic separately with its own cursor and snapshot id
 collavre tool run topic_messages --json '{"topic_ids": 12, "offset": 100, "cursor": "1770000000000000:989:1770000001000000", "max_message_id": 9931}'
 
 # Continue inside one clipped message, preserving its row cursor

--- a/skills/collavre/SKILL.md
+++ b/skills/collavre/SKILL.md
@@ -99,10 +99,10 @@ collavre tool run topic_list --json '{"creative_id": 8849}'
 collavre tool run topic_messages --json '{"topic_ids": "12,45,78", "limit": 100}'
 
 # Continue each topic separately with its own cursor and snapshot id
-collavre tool run topic_messages --json '{"topic_ids": 12, "offset": 100, "cursor": "1770000000000000:989:1770000001000000", "max_message_id": 9931}'
+collavre tool run topic_messages --json '{"topic_ids": 12, "offset": 100, "cursor": "1770000000000000:989:1770000001000000:1770000002000000", "max_message_id": 9931}'
 
 # Continue inside one clipped message, preserving its row cursor
-collavre tool run topic_messages --json '{"topic_ids": 12, "offset": 100, "cursor": "1770000000000000:989:1770000001000000", "content_offset": 28400, "max_message_id": 9931}'
+collavre tool run topic_messages --json '{"topic_ids": 12, "offset": 100, "cursor": "1770000000000000:989:1770000001000000:1770000002000000", "content_offset": 28400, "max_message_id": 9931}'
 
 # Fan work out: one topic per unit of work, with an agent pinned to each
 collavre tool run topic_create --json '{"creative_id": 8849, "name": "Research", "primary_agent": "Dev1Claude"}'

--- a/skills/collavre/references/tool-reference.md
+++ b/skills/collavre/references/tool-reference.md
@@ -232,6 +232,10 @@ Archiving hides the topic from the active list but keeps every message, and
 `topic_messages` can still read it by id. Archive a topic when its thread has
 reached a conclusion rather than reusing it for the next subject.
 
+Main and an inbox Creative's System topic are reserved. Their names and archive
+state cannot change because message routing looks them up by name; their primary
+agent pin can still change.
+
 A Claude Channel session topic's pin is part of its session identity and cannot
 be changed here.
 
@@ -254,7 +258,8 @@ a silent trim. Requires **feedback** or better on the Creative.
 Approval prompts cannot be branched. The copy carries the content but not the
 approval action, so it would stop being excluded from agent history and read as
 an ordinary message. Passing one is an error — `topic_messages` never returns
-their ids in the first place.
+their ids in the first place. Image attachments, including image-only messages,
+remain attached to the copies.
 
 ## meta_tool
 

--- a/skills/collavre/references/tool-reference.md
+++ b/skills/collavre/references/tool-reference.md
@@ -110,7 +110,7 @@ use it before `topic_messages` to see how much conversation each topic holds.
 | Param | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `creative_id` | Integer | One of | — | List every topic on this Creative |
-| `topic_ids` | String | One of | — | Describe these topics, e.g. `"12,45,78"` |
+| `topic_ids` | String | One of | — | Describe these topics, e.g. `"12,45,78"` (max 20 per call) |
 | `include_archived` | Boolean | No | false | Include archived topics (listing by `creative_id`) |
 | `include_stats` | Boolean | No | true | Include `message_count` / `message_chars` / `last_message_at` |
 | `include_system` | Boolean | No | false | Count authorless notices. Approval prompts are never counted |
@@ -169,6 +169,12 @@ dropped — dropping it would return an empty page at an offset that has rows an
 the caller would page against it forever. The clip is announced in the message
 text and counted in the topic's `clipped_count`, which can be set even when
 `has_more` is false.
+
+Asking for more than 20 topics in one call is an error, not a silent trim — the
+ids past the cap were never read, so there would be no per-topic entry to say
+they were missing. Split them across calls. (Unknown or unreadable ids are
+different: those are reported per topic and the call continues.) `topic_list`
+applies the same cap to `topic_ids`.
 
 Requires **read** on each topic's Creative. Private messages you are not party
 to are always excluded.

--- a/skills/collavre/references/tool-reference.md
+++ b/skills/collavre/references/tool-reference.md
@@ -161,8 +161,14 @@ topic_messages(topic_ids: 12, offset: 100, content_offset: 28400, max_message_id
 `limit`, `returned_count`, `returned_chars`, `has_more`, `next_offset`,
 `next_content_offset`, `newest_message_id`, `messages[]`, and `budget_limited`
 when `max_chars` (rather than `limit`) ended the window. Each message: `id`,
-`author`, `author_id`, `agent`, `created_at`, `content` (plain text), plus content
-range fields when the row is continued.
+`author`, `author_id`, `agent`, `created_at`, `content` (plain text plus one
+URL-bearing metadata marker per image attachment), plus content range fields
+when the row is continued.
+
+Attachment markers include filename, content type, byte size, and a readable
+public-asset URL. Because they are part of `content`, image-only comments remain
+visible and long attachment lists page through `content_offset` without evading
+`max_chars`.
 
 A topic the budget could not reach at all comes back with `skipped_reason` and
 `returned_count: 0` rather than looking like an empty conversation.

--- a/skills/collavre/references/tool-reference.md
+++ b/skills/collavre/references/tool-reference.md
@@ -95,6 +95,131 @@ Import a markdown document as a Creative tree. Uses the built-in MarkdownImporte
 
 **Returns:** `{ success, parent_id, created_count, tree[] }`
 
+## Topic tools
+
+A **topic** is a conversation thread on a Creative, and it is also the unit of
+agent concurrency: tasks dispatched in the same topic are serialized (one holds
+the topic's slot, the rest queue), while tasks in different topics run in
+parallel. Splitting work across topics is what makes it run concurrently.
+
+### topic_list
+
+List a Creative's topics, or describe specific topics by id. The planning call —
+use it before `topic_messages` to see how much conversation each topic holds.
+
+| Param | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `creative_id` | Integer | One of | — | List every topic on this Creative |
+| `topic_ids` | String | One of | — | Describe these topics, e.g. `"12,45,78"` |
+| `include_archived` | Boolean | No | false | Include archived topics (listing by `creative_id`) |
+| `include_stats` | Boolean | No | true | Include `message_count` / `message_chars` / `last_message_at` |
+| `include_system` | Boolean | No | false | Count authorless notices and approval prompts |
+
+**Returns:** `{ topics[], errors[] }`. Each topic: `id`, `name`, `creative_id`,
+`archived`, `main`, `system`, `source_topic_id`, `primary_agent`,
+`agent_locked`, `message_count`, `message_chars`, `last_message_at`.
+
+`message_chars` is the length of the stored message HTML — an upper bound on the
+text `topic_messages` returns, good for relative sizing rather than exact
+budgeting. Requires **read** on each topic's Creative; unknown or unreadable ids
+come back in `errors`.
+
+### topic_messages
+
+Read messages from one or more topics, newest first, with paging.
+
+| Param | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `topic_ids` | String | **Yes** | — | `"12,45,78"` (max 20 per call); a single id also works |
+| `offset` | Integer | No | 0 | Messages back from the newest, **per topic** |
+| `limit` | Integer | No | 50 | Messages **per topic** (max 200) |
+| `order` | String | No | `"asc"` | Rendering order in the window: `asc` (transcript) or `desc` |
+| `max_message_id` | Integer | No | — | Snapshot anchor: only messages with `id <=` this |
+| `include_system` | Boolean | No | false | Include authorless notices and approval prompts |
+| `max_chars` | Integer | No | 40000 | Cap for the **whole response** (max 200000) |
+| `format` | String | No | `"markdown"` | `markdown` or `json` |
+
+**Windowing.** Selection is always from the newest end: `offset: 0` is the latest
+message. `order` only changes how the selected window is rendered, not which
+messages it contains. With several topics, `offset`/`limit` apply to **each topic
+independently** and results are grouped per topic — never merged into one
+timeline, so an offset stays reproducible.
+
+**Paging a long topic.** Take `newest_message_id` from the first page and pass it
+as `max_message_id` on every later page. Without it, messages arriving mid-read
+shift rows down and you re-read one message while never seeing another.
+
+```
+topic_messages(topic_ids: "12,45,78", limit: 100)          # summarize three topics
+topic_messages(topic_ids: 12, offset: 100, max_message_id: 9931)  # next page
+```
+
+**Returns (json):** `{ topics[], truncated, max_chars }`. Each topic entry:
+`topic_id`, `topic_name`, `creative_id`, `total_count`, `total_chars`, `offset`,
+`limit`, `returned_count`, `returned_chars`, `has_more`, `next_offset`,
+`newest_message_id`, `messages[]`, and `budget_limited` when `max_chars` (rather
+than `limit`) ended the window. Each message: `id`, `author`, `author_id`,
+`agent`, `created_at`, `content` (plain text).
+
+A topic the budget could not reach at all comes back with `skipped_reason` and
+`returned_count: 0` rather than looking like an empty conversation.
+
+Requires **read** on each topic's Creative. Private messages you are not party
+to are always excluded.
+
+### topic_create
+
+Create a topic on a Creative. The fan-out primitive.
+
+| Param | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `creative_id` | Integer | **Yes** | — | Creative to create the topic on |
+| `name` | String | No | `"Topic N"` | Must be unique on the Creative |
+| `primary_agent` | String | No | — | Agent to pin — id, email, or exact name |
+| `comment_ids` | String | No | — | Existing messages to **move** into the new topic |
+
+Pinning a `primary_agent` is **exclusive**: the pinned agent alone answers
+ambient messages in the topic and every other agent is silent. The agent must
+already hold **feedback** or better on the Creative, otherwise the pin is
+refused — a pinned agent that cannot answer would silence the topic entirely.
+
+Requires **write** on the Creative. Use `topic_branch` to copy messages instead
+of moving them.
+
+### topic_update
+
+Rename, archive/unarchive, or re-pin a topic. Pass only what changes.
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `topic_id` | Integer | **Yes** | Topic to update |
+| `name` | String | No | New name (requires **admin**) |
+| `archived` | Boolean | No | `true` archives, `false` unarchives (requires **write**) |
+| `primary_agent` | String | No | Agent id/email/name, or `"none"` to clear (requires **write**) |
+
+Archiving hides the topic from the active list but keeps every message, and
+`topic_messages` can still read it by id. Archive a topic when its thread has
+reached a conclusion rather than reusing it for the next subject.
+
+A Claude Channel session topic's pin is part of its session identity and cannot
+be changed here.
+
+**Returns:** the topic payload plus `changed[]` naming the fields that moved.
+
+### topic_branch
+
+Create a new topic containing **copies** of selected messages. The originals stay
+in place — the context-length escape hatch.
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `source_topic_id` | Integer | **Yes** | Topic to branch from |
+| `comment_ids` | String | **Yes** | Messages to copy, e.g. `"991,994,1002"` (max 100) |
+| `name` | String | No | Defaults to `"branch:<source name>"` |
+
+Get the ids from `topic_messages`. Asking for more than the cap is an error, not
+a silent trim. Requires **feedback** or better on the Creative.
+
 ## meta_tool
 
 Introspect and dynamically run any registered MCP tool. Enables tool discovery without CLI updates.

--- a/skills/collavre/references/tool-reference.md
+++ b/skills/collavre/references/tool-reference.md
@@ -136,7 +136,7 @@ Read messages from one or more topics, newest first, with paging.
 | `order` | String | No | `"asc"` | Rendering order in the window: `asc` (transcript) or `desc` |
 | `max_message_id` | Integer | No | — | Snapshot anchor: only messages with `id <=` this |
 | `include_system` | Boolean | No | false | Include authorless notices. Approval prompts are never returned |
-| `max_chars` | Integer | No | 40000 | Cap for the **whole response** (max 200000) |
+| `max_chars` | Integer | No | 40000 | Cap for the **whole response** (min 160, max 200000; smaller positive values are raised to 160) |
 | `format` | String | No | `"markdown"` | `markdown` or `json` |
 
 **Windowing.** Selection is always from the newest end: `offset: 0` is the latest
@@ -163,6 +163,10 @@ than `limit`) ended the window. Each message: `id`, `author`, `author_id`,
 
 A topic the budget could not reach at all comes back with `skipped_reason` and
 `returned_count: 0` rather than looking like an empty conversation.
+
+If the fixed topic metadata alone cannot fit — for example, because a topic
+name is unusually long — the tool returns a bounded error instead of emitting
+a response wider than `max_chars` or silently omitting a topic.
 
 A single message wider than the whole `max_chars` cap is clipped rather than
 dropped — dropping it would return an empty page at an offset that has rows and

--- a/skills/collavre/references/tool-reference.md
+++ b/skills/collavre/references/tool-reference.md
@@ -119,10 +119,10 @@ use it before `topic_messages` to see how much conversation each topic holds.
 `archived`, `main`, `system`, `source_topic_id`, `primary_agent`,
 `agent_locked`, `message_count`, `message_chars`, `last_message_at`.
 
-`message_chars` is the length of the stored message HTML — an upper bound on the
-text `topic_messages` returns, good for relative sizing rather than exact
-budgeting. Requires **read** on each topic's Creative; unknown or unreadable ids
-come back in `errors`.
+`message_chars` combines stored message HTML length with a conservative estimate
+for the image attachment markers emitted by `topic_messages`. It is good for
+relative sizing rather than exact budgeting. Requires **read** on each topic's
+Creative; unknown or unreadable ids come back in `errors`.
 
 ### topic_messages
 

--- a/skills/collavre/references/tool-reference.md
+++ b/skills/collavre/references/tool-reference.md
@@ -135,6 +135,7 @@ Read messages from one or more topics, newest first, with paging.
 | `limit` | Integer | No | 50 | Messages **per topic** (max 200) |
 | `order` | String | No | `"asc"` | Rendering order in the window: `asc` (transcript) or `desc` |
 | `max_message_id` | Integer | No | — | Snapshot anchor: only messages with `id <=` this |
+| `content_offset` | Integer | No | 0 | Character offset within the first message selected by `offset`; use the returned `next_content_offset` |
 | `include_system` | Boolean | No | false | Include authorless notices. Approval prompts are never returned |
 | `max_chars` | Integer | No | 40000 | Cap for the **whole response** (min 160, max 200000; smaller positive values are raised to 160) |
 | `format` | String | No | `"markdown"` | `markdown` or `json` |
@@ -152,14 +153,16 @@ shift rows down and you re-read one message while never seeing another.
 ```
 topic_messages(topic_ids: "12,45,78", limit: 100)          # summarize three topics
 topic_messages(topic_ids: 12, offset: 100, max_message_id: 9931)  # next page
+topic_messages(topic_ids: 12, offset: 100, content_offset: 28400, max_message_id: 9931)  # clipped tail
 ```
 
 **Returns (json):** `{ topics[], truncated, max_chars }`. Each topic entry:
 `topic_id`, `topic_name`, `creative_id`, `total_count`, `total_chars`, `offset`,
 `limit`, `returned_count`, `returned_chars`, `has_more`, `next_offset`,
-`newest_message_id`, `messages[]`, and `budget_limited` when `max_chars` (rather
-than `limit`) ended the window. Each message: `id`, `author`, `author_id`,
-`agent`, `created_at`, `content` (plain text).
+`next_content_offset`, `newest_message_id`, `messages[]`, and `budget_limited`
+when `max_chars` (rather than `limit`) ended the window. Each message: `id`,
+`author`, `author_id`, `agent`, `created_at`, `content` (plain text), plus content
+range fields when the row is continued.
 
 A topic the budget could not reach at all comes back with `skipped_reason` and
 `returned_count: 0` rather than looking like an empty conversation.
@@ -170,9 +173,11 @@ a response wider than `max_chars` or silently omitting a topic.
 
 A single message wider than the whole `max_chars` cap is clipped rather than
 dropped — dropping it would return an empty page at an offset that has rows and
-the caller would page against it forever. The clip is announced in the message
-text and counted in the topic's `clipped_count`, which can be set even when
-`has_more` is false.
+the caller would page against it forever. A clipped row keeps `next_offset` on
+the same message and returns `next_content_offset`; pass both values with the
+same `max_message_id` until `next_content_offset` disappears. Only then is the
+message row consumed. The clip notice is separate from `content`, so JSON
+callers can concatenate fragments without stripping tool text.
 
 Asking for more than 20 topics in one call is an error, not a silent trim — the
 ids past the cap were never read, so there would be no per-topic entry to say

--- a/skills/collavre/references/tool-reference.md
+++ b/skills/collavre/references/tool-reference.md
@@ -132,7 +132,7 @@ Read messages from one or more topics, newest first, with paging.
 |-------|------|----------|---------|-------------|
 | `topic_ids` | String | **Yes** | — | `"12,45,78"` (max 20 per call); a single id also works |
 | `offset` | Integer | No | 0 | Messages back from the newest, **per topic** |
-| `cursor` | String | No | — | Opaque per-topic keyset cursor returned as `next_cursor` |
+| `cursor` | String | No | — | Opaque per-topic snapshot/keyset cursor returned as `next_cursor` |
 | `limit` | Integer | No | 50 | Messages **per topic** (max 200) |
 | `order` | String | No | `"asc"` | Rendering order in the window: `asc` (transcript) or `desc` |
 | `max_message_id` | Integer | No | — | Snapshot anchor: only messages with `id <=` this |
@@ -149,15 +149,16 @@ timeline, so an offset stays reproducible.
 
 **Paging a long topic.** Take `newest_message_id` and `next_cursor` from the
 first page and pass them as `max_message_id` and `cursor` on every later page.
-The snapshot excludes later arrivals; the keyset cursor prevents already-read
-messages that are moved or deleted from shifting unread rows past the offset.
-It also binds a clipped continuation to the row's content version, so an edit
-restarts that changed message at character zero instead of skipping text.
+The snapshot excludes newly-created messages and older messages moved into the
+topic after page one. The keyset cursor also prevents messages that leave from
+shifting unread rows past the offset. It binds a clipped continuation to the
+row's content version, so an edit restarts that changed message at character
+zero instead of skipping text.
 
 ```
 topic_messages(topic_ids: "12,45,78", limit: 100)          # summarize three topics
-topic_messages(topic_ids: 12, offset: 100, cursor: "1770000000000000:9820:1770000001000000", max_message_id: 9931)  # next page
-topic_messages(topic_ids: 12, offset: 100, cursor: "1770000000000000:9820:1770000001000000", content_offset: 28400, max_message_id: 9931)  # clipped tail
+topic_messages(topic_ids: 12, offset: 100, cursor: "1770000000000000:9820:1770000001000000:1770000002000000", max_message_id: 9931)  # next page
+topic_messages(topic_ids: 12, offset: 100, cursor: "1770000000000000:9820:1770000001000000:1770000002000000", content_offset: 28400, max_message_id: 9931)  # clipped tail
 ```
 
 **Returns (json):** `{ topics[], truncated, max_chars }`. Each topic entry:

--- a/skills/collavre/references/tool-reference.md
+++ b/skills/collavre/references/tool-reference.md
@@ -113,7 +113,7 @@ use it before `topic_messages` to see how much conversation each topic holds.
 | `topic_ids` | String | One of | — | Describe these topics, e.g. `"12,45,78"` |
 | `include_archived` | Boolean | No | false | Include archived topics (listing by `creative_id`) |
 | `include_stats` | Boolean | No | true | Include `message_count` / `message_chars` / `last_message_at` |
-| `include_system` | Boolean | No | false | Count authorless notices and approval prompts |
+| `include_system` | Boolean | No | false | Count authorless notices. Approval prompts are never counted |
 
 **Returns:** `{ topics[], errors[] }`. Each topic: `id`, `name`, `creative_id`,
 `archived`, `main`, `system`, `source_topic_id`, `primary_agent`,
@@ -135,7 +135,7 @@ Read messages from one or more topics, newest first, with paging.
 | `limit` | Integer | No | 50 | Messages **per topic** (max 200) |
 | `order` | String | No | `"asc"` | Rendering order in the window: `asc` (transcript) or `desc` |
 | `max_message_id` | Integer | No | — | Snapshot anchor: only messages with `id <=` this |
-| `include_system` | Boolean | No | false | Include authorless notices and approval prompts |
+| `include_system` | Boolean | No | false | Include authorless notices. Approval prompts are never returned |
 | `max_chars` | Integer | No | 40000 | Cap for the **whole response** (max 200000) |
 | `format` | String | No | `"markdown"` | `markdown` or `json` |
 

--- a/skills/collavre/references/tool-reference.md
+++ b/skills/collavre/references/tool-reference.md
@@ -164,6 +164,12 @@ than `limit`) ended the window. Each message: `id`, `author`, `author_id`,
 A topic the budget could not reach at all comes back with `skipped_reason` and
 `returned_count: 0` rather than looking like an empty conversation.
 
+A single message wider than the whole `max_chars` cap is clipped rather than
+dropped — dropping it would return an empty page at an offset that has rows and
+the caller would page against it forever. The clip is announced in the message
+text and counted in the topic's `clipped_count`, which can be set even when
+`has_more` is false.
+
 Requires **read** on each topic's Creative. Private messages you are not party
 to are always excluded.
 
@@ -219,6 +225,11 @@ in place — the context-length escape hatch.
 
 Get the ids from `topic_messages`. Asking for more than the cap is an error, not
 a silent trim. Requires **feedback** or better on the Creative.
+
+Approval prompts cannot be branched. The copy carries the content but not the
+approval action, so it would stop being excluded from agent history and read as
+an ordinary message. Passing one is an error — `topic_messages` never returns
+their ids in the first place.
 
 ## meta_tool
 

--- a/skills/collavre/references/tool-reference.md
+++ b/skills/collavre/references/tool-reference.md
@@ -132,6 +132,7 @@ Read messages from one or more topics, newest first, with paging.
 |-------|------|----------|---------|-------------|
 | `topic_ids` | String | **Yes** | — | `"12,45,78"` (max 20 per call); a single id also works |
 | `offset` | Integer | No | 0 | Messages back from the newest, **per topic** |
+| `cursor` | String | No | — | Opaque per-topic keyset cursor returned as `next_cursor` |
 | `limit` | Integer | No | 50 | Messages **per topic** (max 200) |
 | `order` | String | No | `"asc"` | Rendering order in the window: `asc` (transcript) or `desc` |
 | `max_message_id` | Integer | No | — | Snapshot anchor: only messages with `id <=` this |
@@ -146,20 +147,21 @@ messages it contains. With several topics, `offset`/`limit` apply to **each topi
 independently** and results are grouped per topic — never merged into one
 timeline, so an offset stays reproducible.
 
-**Paging a long topic.** Take `newest_message_id` from the first page and pass it
-as `max_message_id` on every later page. Without it, messages arriving mid-read
-shift rows down and you re-read one message while never seeing another.
+**Paging a long topic.** Take `newest_message_id` and `next_cursor` from the
+first page and pass them as `max_message_id` and `cursor` on every later page.
+The snapshot excludes later arrivals; the keyset cursor prevents already-read
+messages that are moved or deleted from shifting unread rows past the offset.
 
 ```
 topic_messages(topic_ids: "12,45,78", limit: 100)          # summarize three topics
-topic_messages(topic_ids: 12, offset: 100, max_message_id: 9931)  # next page
-topic_messages(topic_ids: 12, offset: 100, content_offset: 28400, max_message_id: 9931)  # clipped tail
+topic_messages(topic_ids: 12, offset: 100, cursor: "1770000000000000:9820", max_message_id: 9931)  # next page
+topic_messages(topic_ids: 12, offset: 100, cursor: "1770000000000000:9820", content_offset: 28400, max_message_id: 9931)  # clipped tail
 ```
 
 **Returns (json):** `{ topics[], truncated, max_chars }`. Each topic entry:
 `topic_id`, `topic_name`, `creative_id`, `total_count`, `total_chars`, `offset`,
 `limit`, `returned_count`, `returned_chars`, `has_more`, `next_offset`,
-`next_content_offset`, `newest_message_id`, `messages[]`, and `budget_limited`
+`next_cursor`, `next_content_offset`, `newest_message_id`, `messages[]`, and `budget_limited`
 when `max_chars` (rather than `limit`) ended the window. Each message: `id`,
 `author`, `author_id`, `agent`, `created_at`, `content` (plain text plus one
 URL-bearing metadata marker per image attachment), plus content range fields
@@ -181,13 +183,14 @@ A single message wider than the whole `max_chars` cap is clipped rather than
 dropped — dropping it would return an empty page at an offset that has rows and
 the caller would page against it forever. A clipped row keeps `next_offset` on
 the same message and returns `next_content_offset`; pass both values with the
-same `max_message_id` until `next_content_offset` disappears. Only then is the
-message row consumed. The clip notice is separate from `content`, so JSON
-callers can concatenate fragments without stripping tool text.
+same `next_cursor` and `max_message_id` until `next_content_offset` disappears.
+Only then is the message row consumed. The clip notice is separate from
+`content`, so JSON callers can concatenate fragments without stripping tool
+text.
 
 Markdown `More:` calls repeat the resolved `limit` and `max_chars` alongside
-the snapshot, content offset, order, and system-message scope. Following the
-generated call therefore keeps the same page size and context budget.
+the cursor, snapshot, content offset, order, and system-message scope. Following
+the generated call therefore keeps the same page size and context budget.
 
 Asking for more than 20 topics in one call is an error, not a silent trim — the
 ids past the cap were never read, so there would be no per-topic entry to say

--- a/skills/collavre/references/tool-reference.md
+++ b/skills/collavre/references/tool-reference.md
@@ -151,11 +151,13 @@ timeline, so an offset stays reproducible.
 first page and pass them as `max_message_id` and `cursor` on every later page.
 The snapshot excludes later arrivals; the keyset cursor prevents already-read
 messages that are moved or deleted from shifting unread rows past the offset.
+It also binds a clipped continuation to the row's content version, so an edit
+restarts that changed message at character zero instead of skipping text.
 
 ```
 topic_messages(topic_ids: "12,45,78", limit: 100)          # summarize three topics
-topic_messages(topic_ids: 12, offset: 100, cursor: "1770000000000000:9820", max_message_id: 9931)  # next page
-topic_messages(topic_ids: 12, offset: 100, cursor: "1770000000000000:9820", content_offset: 28400, max_message_id: 9931)  # clipped tail
+topic_messages(topic_ids: 12, offset: 100, cursor: "1770000000000000:9820:1770000001000000", max_message_id: 9931)  # next page
+topic_messages(topic_ids: 12, offset: 100, cursor: "1770000000000000:9820:1770000001000000", content_offset: 28400, max_message_id: 9931)  # clipped tail
 ```
 
 **Returns (json):** `{ topics[], truncated, max_chars }`. Each topic entry:

--- a/skills/collavre/references/tool-reference.md
+++ b/skills/collavre/references/tool-reference.md
@@ -185,6 +185,10 @@ same `max_message_id` until `next_content_offset` disappears. Only then is the
 message row consumed. The clip notice is separate from `content`, so JSON
 callers can concatenate fragments without stripping tool text.
 
+Markdown `More:` calls repeat the resolved `limit` and `max_chars` alongside
+the snapshot, content offset, order, and system-message scope. Following the
+generated call therefore keeps the same page size and context budget.
+
 Asking for more than 20 topics in one call is an error, not a silent trim — the
 ids past the cap were never read, so there would be no per-topic entry to say
 they were missing. Split them across calls. (Unknown or unreadable ids are
@@ -202,7 +206,7 @@ Create a topic on a Creative. The fan-out primitive.
 |-------|------|----------|---------|-------------|
 | `creative_id` | Integer | **Yes** | — | Creative to create the topic on |
 | `name` | String | No | `"Topic N"` | Must be unique on the Creative |
-| `primary_agent` | String | No | — | Agent to pin — id, email, or exact name |
+| `primary_agent` | String | No | — | Agent to pin — id, email, or exact name; private agents already shared here resolve too |
 | `comment_ids` | String | No | — | Existing messages to **move** into the new topic |
 
 Pinning a `primary_agent` is **exclusive**: the pinned agent alone answers
@@ -222,7 +226,7 @@ Rename, archive/unarchive, or re-pin a topic. Pass only what changes.
 | `topic_id` | Integer | **Yes** | Topic to update |
 | `name` | String | No | New name (requires **admin**) |
 | `archived` | Boolean | No | `true` archives, `false` unarchives (requires **write**) |
-| `primary_agent` | String | No | Agent id/email/name, or `"none"` to clear (requires **write**) |
+| `primary_agent` | String | No | Agent id/email/name, or `"none"` to clear (requires **write**; private agents already shared here resolve too) |
 
 Archiving hides the topic from the active list but keeps every message, and
 `topic_messages` can still read it by id. Archive a topic when its thread has


### PR DESCRIPTION
## Why

Agents can create and update Creatives, but they could not touch **topics** at all. That matters more than it sounds: a topic is the concurrency unit — tasks dispatched into the same topic are serialized behind one slot, tasks in different topics run in parallel. Every way to create, pin, archive or branch a topic lived behind a UI slash command, so an agent could plan a split of work but not actually run it in parallel. A human had to do the fan-out by hand.

Agents also had no way to read a conversation they were not currently sitting in. "Summarize topics #a, #b and #c into a child creative" was not expressible.

## What

Five tools, following the existing `Collavre::Tools::*` service convention.

### Read

**`topic_list`** — a creative's topics, or specific topics by id (possibly on different creatives). Reports `message_count`, `message_chars` and `last_message_at` per topic. This is the planning call: see how much conversation exists before spending context on it.

**`topic_messages`** — paged messages from one or more topics.

- Selection is always from the **newest end**: `offset: 0` is the latest message. Within the window, rendering defaults to oldest→newest so the transcript reads forwards (`order: "desc"` for the raw order).
- **Multi-topic in one call, but windowed per topic and grouped** — never merged into one timeline. See the design note below.
- Reports `total_count` / `total_chars` for the whole topic, plus `has_more` / `next_offset`.
- Returns a `newest_message_id` **snapshot anchor**; passing it back as `max_message_id` pins later pages so a message arriving mid-read cannot shift rows between pages.
- Capped by a whole-response `max_chars` (default 40k). A topic the budget cannot reach comes back with `skipped_reason` rather than looking like an empty conversation.
- Markdown by default (prose reads better and costs far fewer characters than JSON escaping); `format: "json"` returns the identical payload the markdown renderer reads, so the two cannot disagree.

### Write

**`topic_create`** — create a topic, optionally pinning a `primary_agent` (accepts id, email or exact name) and moving existing messages in.

**`topic_update`** — rename (admin), archive/unarchive (write), set or clear the primary agent (write). Honours the Claude Channel session-topic pin lock.

**`topic_branch`** — copy selected messages into a new topic, leaving the originals. The context-length escape hatch.

## Design note: why multi-topic with per-topic windows

Both alternatives were considered.

A **merged timeline** across topics is the wrong answer to the question people actually ask. Three conversations shuffled by timestamp read as none of them, and a merged `offset` moves whenever *any* of the topics grows, so pagination stops being reproducible.

**One topic per call** is safe but makes `topic_messages(topic_ids: "12,45,78")` — the literal use case — three round trips with no shared budget, so nothing stops the three responses from together being three times the context the caller planned for.

The shipped shape takes both: several topics per call, each windowed independently by the same `offset`/`limit`, grouped in the response, with one shared `max_chars` ceiling across the whole thing. Offset stays reproducible, output stays bounded, and the response tells the caller exactly which topics still have more and at what offset.

## Permissions

Mirrored from `TopicsController` via `TopicAuthorizer` (read / write / admin, resolved on the `effective_origin` creative, with the same owner short-circuit). Private messages the caller is not party to are always excluded; authorless system notices and approval prompts are excluded by default.

Unknown and unreadable topic ids are reported **per topic** instead of failing the whole call — one stale id in a batch of three should not discard the two that worked. Both cases return the same message so topic existence cannot be probed.

## Refactor and two fixes

`TopicsController` now delegates `topic_json` and next-name generation to `Topics::Serializer` and `Topics::NextName`, so the tools' broadcasts and the controller's cannot drift.

Extracting those surfaced two real bugs, both fixed here:

1. **`NextName` counted only active topics.** Topic names are unique per creative regardless of archive state, so archiving "Topic 1" on an otherwise unnumbered creative made the next create propose "Topic 1" again and fail validation. Reachable by hand before; routine once an agent creates topics in a loop.
2. **`TopicBranchService` silently trims an oversized selection** and reports success for the shortened list. Correct for a UI that already capped the selection, wrong through a tool — a caller passing 150 ids would be told it branched them and be missing 50 with nothing saying so. The tool now refuses.

## Tests

New: 90 tests across the five tools and the six extracted POROs — paging arithmetic, snapshot anchoring, budget trimming, permission levels at each gate, agent resolution and ambiguity, markdown/JSON parity, broadcast payloads.

```
engines/collavre/test/services/collavre/{topics,tools}/
  188 runs, 494 assertions, 0 failures, 0 errors

topics_controller / topics_channel / topic_command / drop_trigger_job (regression)
  102 runs, 389 assertions, 0 failures, 0 errors

rubocop: 60 files inspected, no offenses
```

## Follow-up

`creative_share` — the remaining P0-b item. `topic_create`/`topic_update` refuse to pin an agent that lacks `feedback` on the creative, and an agent currently has no way to grant it, so full self-service fan-out still needs one human step. The share rules live inline in `CreativeSharesController#create` (ancestor `no_access` blocks, already-shared-in-parent, invitations, private-agent restriction) and want extracting to a service first, which is its own change rather than a rider on this one.

Agents need the new tool names added to their configured tool list before they can call them.