### PR TITLE
fix: keep mobile chat open during topic list scroll

### DIFF
--- a/engines/collavre/app/javascript/controllers/comments/__tests__/popup_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/popup_controller.test.js
@@ -97,6 +97,26 @@ describe('CommentsPopupController', () => {
         expect(popup.dataset.resized).toBeUndefined()
     })
 
+    test('keeps the mobile chat open while scrolling down inside the topic-list popup', () => {
+		const popup = document.getElementById('comments-popup')
+		const topicListModal = document.createElement('div')
+		const topicListItem = document.createElement('li')
+		topicListModal.id = 'topic-list-modal'
+		topicListModal.appendChild(topicListItem)
+		popup.appendChild(topicListModal)
+		jest.spyOn(controller, 'isMobile').mockReturnValue(true)
+		const close = jest.spyOn(controller, 'close')
+
+		controller.handleTouchStart({
+			target: topicListItem,
+			touches: [{ clientY: 100 }]
+		})
+		controller.handleTouchEnd({ changedTouches: [{ clientY: 180 }] })
+
+		expect(close).not.toHaveBeenCalled()
+		expect(controller.touchStartY).toBeNull()
+    })
+
     test('inherits auto-focus preference from trigger button', async () => {
         const triggerBtn = document.getElementById('trigger-btn')
         const popup = document.getElementById('comments-popup')

--- a/engines/collavre/app/javascript/controllers/comments/popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_controller.js
@@ -778,7 +778,7 @@ export default class extends Controller {
       this.touchStartY = null
       return
     }
-    if (event.target.closest('#comments-list') || event.target.closest('.chat-nav-dropdown')) {
+    if (event.target.closest('#comments-list, .chat-nav-dropdown, #topic-list-modal')) {
       this.touchStartY = null
     } else {
       this.touchStartY = event.touches[0].clientY

--- a/engines/collavre/test/system/topic_list_popup_test.rb
+++ b/engines/collavre/test/system/topic_list_popup_test.rb
@@ -109,4 +109,22 @@ class TopicListPopupTest < ApplicationSystemTestCase
       "document.activeElement === document.querySelector('#topic-list-modal input')"
     )
   end
+
+  test "scrolling down in the topic list keeps the mobile chat open" do
+    resize_window_to(390, 844)
+    open_comments_popup
+    find("#comments-popup .topic-list-btn").click
+    assert_selector "#topic-list-modal", visible: :visible, wait: 5
+
+    page.execute_script(<<~JS)
+      const item = document.querySelector('#topic-list-modal .common-popup-item');
+      const start = new Touch({ identifier: 1, target: item, clientX: 20, clientY: 100 });
+      const end = new Touch({ identifier: 1, target: item, clientX: 20, clientY: 180 });
+      item.dispatchEvent(new TouchEvent('touchstart', { bubbles: true, touches: [start] }));
+      item.dispatchEvent(new TouchEvent('touchend', { bubbles: true, changedTouches: [end] }));
+    JS
+
+    assert_selector "#comments-popup", visible: :visible
+    assert_selector "#topic-list-modal", visible: :visible
+  end
 end


### PR DESCRIPTION
## Summary

- exclude touch gestures that start inside the topic-list popup from the mobile chat swipe-to-close handler
- preserve the existing topic-list tap and scroll handling
- add Jest and browser-level regression coverage for downward scrolling on a mobile viewport

## Root cause

The comments popup listens for `touchstart` and `touchend` across the entire mobile chat. Touch events from the nested topic-list popup bubbled into that handler, so a downward list scroll was interpreted as the gesture that closes the chat.

## Validation

- `npm test -- --runInBand engines/collavre/app/javascript/controllers/comments/__tests__/popup_controller.test.js engines/collavre/app/javascript/controllers/__tests__/topic_list_controller.test.js engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_topic_list.test.js` — 66 tests passed
- `bin/rails test engines/collavre/test/system/topic_list_popup_test.rb` — 7 tests, 50 assertions passed
- `PARALLEL_WORKERS=1 bundle exec rake test` — 4,128 tests, 13,994 assertions passed
- `./bin/rubocop -a` — no offenses
- `bin/complexity_check` — passed

The full system suite ran 95 core-engine scenarios with two unrelated `InlineScriptsTest` navigation failures that also reproduce when run alone; the remaining engine system tests passed (3 runs, 10 assertions, 1 skip).