### PR TITLE
fix(comments): stop the slash command menu blinking on every keystroke

### DIFF
--- a/engines/collavre/app/javascript/lib/__tests__/common_popup_reshow.test.js
+++ b/engines/collavre/app/javascript/lib/__tests__/common_popup_reshow.test.js
@@ -1,0 +1,131 @@
+/**
+ * @jest-environment jsdom
+ */
+import { jest } from '@jest/globals'
+import CommonPopup from '../common_popup'
+
+// Typeahead menus (command menu, mention menu) call showAt on every keystroke to
+// re-anchor a popup that is already on screen. showAt used to blank the element
+// to visibility:hidden and wait a frame before revealing it again, so the menu
+// blinked off and back on once per character typed.
+describe('CommonPopup re-show while already open', () => {
+    let element
+    let frames
+
+    const build = ({ popupHeight = 100 } = {}) => {
+        element = document.createElement('div')
+        Object.defineProperty(element, 'offsetParent', { value: null, configurable: true })
+        Object.defineProperty(element, 'offsetWidth', { get: () => 320, configurable: true })
+        Object.defineProperty(element, 'offsetHeight', { get: () => popupHeight, configurable: true })
+        document.body.appendChild(element)
+        return new CommonPopup(element, { listElement: document.createElement('ul') })
+    }
+
+    const runFrames = () => {
+        const pending = frames.splice(0)
+        pending.forEach((fn) => fn())
+    }
+
+    beforeEach(() => {
+        frames = []
+        jest.spyOn(window, 'requestAnimationFrame').mockImplementation((fn) => {
+            frames.push(fn)
+            return frames.length
+        })
+        jest.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => { })
+        global.requestAnimationFrame = window.requestAnimationFrame
+        global.cancelAnimationFrame = window.cancelAnimationFrame
+    })
+
+    afterEach(() => {
+        jest.restoreAllMocks()
+        document.body.innerHTML = ''
+    })
+
+    test('the first open hides the popup for a frame while it is measured', () => {
+        const popup = build()
+        popup.showAt({ left: 10, top: 100, bottom: 120 })
+
+        expect(element.style.display).toBe('block')
+        expect(element.style.visibility).toBe('hidden')
+
+        runFrames()
+        expect(element.style.visibility).toBe('visible')
+    })
+
+    test('re-anchoring an open popup never blanks it', () => {
+        const popup = build()
+        popup.showAt({ left: 10, top: 100, bottom: 120 })
+        runFrames()
+
+        const seen = []
+        for (const left of [20, 30, 40, 50]) {
+            popup.showAt({ left, top: 100, bottom: 120 })
+            seen.push(element.style.visibility)
+        }
+
+        expect(seen).toEqual(['visible', 'visible', 'visible', 'visible'])
+        expect(element.style.display).toBe('block')
+    })
+
+    test('re-anchoring places the popup immediately instead of a frame late', () => {
+        const popup = build()
+        popup.showAt({ left: 10, top: 100, bottom: 120 })
+        runFrames()
+        expect(element.style.left).toBe('10px')
+
+        // No frame is run: the new position must already be applied.
+        popup.showAt({ left: 240, top: 100, bottom: 120 })
+        expect(element.style.left).toBe('240px')
+    })
+
+    test('a popup flipped above the caret stays above when re-anchored', () => {
+        // 400px popup with the caret pinned near the bottom of a 768px viewport:
+        // it cannot fit below, so the first placement flips it above.
+        const popup = build({ popupHeight: 400 })
+        window.visualViewport = {
+            offsetLeft: 0, offsetTop: 0, width: 1024, height: 768,
+            addEventListener: () => { }, removeEventListener: () => { },
+        }
+
+        popup.showAt({ left: 200, top: 700, bottom: 720 })
+        runFrames()
+        expect(popup._placedAbove).toBe(true)
+        const flippedTop = element.style.top
+
+        popup.showAt({ left: 210, top: 700, bottom: 720 })
+        expect(popup._placedAbove).toBe(true)
+        expect(element.style.top).toBe(flippedTop)
+
+        delete window.visualViewport
+    })
+
+    test('re-registers the outside-click listeners so a re-open cannot self-close', () => {
+        const addSpy = jest.spyOn(document, 'addEventListener')
+        const removeSpy = jest.spyOn(document, 'removeEventListener')
+        const popup = build()
+
+        popup.showAt({ left: 10, top: 100, bottom: 120 })
+        runFrames()
+        popup.showAt({ left: 20, top: 100, bottom: 120 })
+
+        expect(removeSpy).toHaveBeenCalledWith('mousedown', popup.handleOutsideClick)
+        runFrames()
+        expect(addSpy).toHaveBeenCalledWith('mousedown', popup.handleOutsideClick)
+        expect(popup.isOpen()).toBe(true)
+    })
+
+    test('hide() after a re-anchor still closes the popup', () => {
+        const popup = build()
+        popup.showAt({ left: 10, top: 100, bottom: 120 })
+        runFrames()
+        popup.showAt({ left: 20, top: 100, bottom: 120 })
+        popup.hide()
+
+        expect(element.style.display).toBe('none')
+        expect(popup.isOpen()).toBe(false)
+        // _placedAbove is recomputed by the next genuine open.
+        popup.showAt({ left: 10, top: 100, bottom: 120 })
+        expect(element.style.visibility).toBe('hidden')
+    })
+})

--- a/engines/collavre/app/javascript/lib/common_popup.js
+++ b/engines/collavre/app/javascript/lib/common_popup.js
@@ -30,6 +30,11 @@ export default class CommonPopup {
     // Set by showAt when the caller can re-measure its anchor — see anchorRect.
     this._anchorProvider = null
     this._anchorRect = null
+    // True once the placement frame has actually revealed the popup. isOpen() is
+    // already true during the frame between display:block and that reveal, so it
+    // cannot tell "on screen" apart from "measured but still blank" — and only
+    // the first of those may skip the blanking step. See showAt.
+    this._revealed = false
 
     this.handleOutsideClick = this.handleOutsideClick.bind(this)
     this.handleViewportResize = this.handleViewportResize.bind(this)
@@ -45,6 +50,12 @@ export default class CommonPopup {
   showAt(anchor, boundsElement = null) {
     if (!this.element) return
 
+    // Typeahead popups call showAt on every keystroke to re-anchor a menu that
+    // is already up (see modules/command_menu.js). Blanking it to
+    // visibility:hidden and waiting a frame would then blink the menu off and
+    // back on once per character, so a popup already on screen is only re-placed.
+    const wasRevealed = this._revealed && this.element.isConnected
+
     // When set, the popup is caged inside this element's rect (e.g. the chat
     // box) instead of the viewport — see updatePosition.
     this._boundsElement = boundsElement
@@ -53,7 +64,10 @@ export default class CommonPopup {
     // popup's content has changed size, and so a provider that stops resolving
     // has something to fall back on.
     this._anchorRect = this._anchorProvider ? null : anchor
-    this._placedAbove = false
+    // Keep the flip decision for the rest of this open: re-anchoring a menu
+    // that is already above the caret must not drop it back under the caret
+    // for a frame before it flips up again.
+    if (!wasRevealed) this._placedAbove = false
 
     // Re-opening while already open (e.g. clicking the same typo mark twice):
     // a listener from the previous open is still live, so the opening mousedown
@@ -64,7 +78,13 @@ export default class CommonPopup {
     document.removeEventListener('touchstart', this.handleOutsideClick)
 
     this.element.style.display = 'block'
-    this.element.style.visibility = 'hidden'
+    if (wasRevealed) {
+      // Already painted, so place it now rather than a frame late — otherwise
+      // the menu sits at the previous caret's position for one frame.
+      this.updatePosition(this.anchorRect())
+    } else {
+      this.element.style.visibility = 'hidden'
+    }
 
     cancelAnimationFrame(this._openFrame)
     this._openFrame = requestAnimationFrame(() => {
@@ -79,6 +99,7 @@ export default class CommonPopup {
 
       this.updatePosition(this.anchorRect())
       this.element.style.visibility = 'visible'
+      this._revealed = true
       // Register the outside-click listeners only after the opening event has
       // finished propagating. When a popup is opened from a mousedown handler
       // (e.g. clicking a typo highlight), registering synchronously here would
@@ -316,6 +337,7 @@ export default class CommonPopup {
     this._openFrame = null
     this.element.style.display = 'none'
     this.element.style.visibility = ''
+    this._revealed = false
     this.items = []
     this.activeIndex = -1
     this.updateActiveItem()

--- a/engines/collavre/app/javascript/modules/__tests__/command_menu_typeahead.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/command_menu_typeahead.test.js
@@ -1,0 +1,138 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { jest } from '@jest/globals'
+
+jest.unstable_mockModule('../creative_link_picker', () => ({
+  openCreativeLinkPicker: jest.fn(),
+}))
+
+await import('../command_menu')
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0))
+// flush() plus the placement frame CommonPopup defers its reveal to.
+const settle = () => flush().then(() => new Promise((resolve) => requestAnimationFrame(() => setTimeout(resolve, 0))))
+
+const COMMANDS = [
+  { name: 'task_create', label: '/task_create', aliases: [] },
+  { name: 'topic_list', label: '/topic_list', aliases: [] },
+]
+
+// The command list is fetched on every input event, so the menu's behaviour while
+// a lookup is in flight is what the user actually sees when typing "/task".
+describe('command menu typeahead', () => {
+  const originalFetch = global.fetch
+
+  const setup = () => {
+    document.body.innerHTML = `
+      <form id="new-comment-form"><textarea></textarea></form>
+      <div id="comments-popup" data-creative-id="7"></div>
+      <div id="command-menu" style="display:none">
+        <ul data-popup-list></ul>
+      </div>
+    `
+    document.dispatchEvent(new Event('turbo:load'))
+    return {
+      textarea: document.querySelector('textarea'),
+      menu: document.getElementById('command-menu'),
+    }
+  }
+
+  const type = (textarea, value) => {
+    textarea.value = value
+    textarea.setSelectionRange(value.length, value.length)
+    textarea.dispatchEvent(new Event('input', { bubbles: true }))
+  }
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+    global.fetch = originalFetch
+    jest.clearAllMocks()
+  })
+
+  test('shares one request across the keystrokes typed before it resolves', async () => {
+    let resolveFetch
+    global.fetch = jest.fn(() => new Promise((resolve) => { resolveFetch = resolve }))
+    const { textarea, menu } = setup()
+
+    for (const value of ['/', '/t', '/ta', '/tas', '/task']) type(textarea, value)
+    expect(global.fetch).toHaveBeenCalledTimes(1)
+
+    resolveFetch({ ok: true, json: () => Promise.resolve(COMMANDS) })
+    await flush()
+
+    expect(menu.style.display).toBe('block')
+    // Only the query the user actually ended on is rendered.
+    expect(menu.querySelectorAll('.common-popup-item')).toHaveLength(1)
+    expect(menu.textContent).toContain('/task_create')
+  })
+
+  test('a failed lookup is not cached, so the next keystroke retries', async () => {
+    global.fetch = jest.fn()
+      .mockRejectedValueOnce(new Error('offline'))
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(COMMANDS) })
+    const { textarea, menu } = setup()
+
+    type(textarea, '/')
+    await flush()
+    expect(menu.style.display).toBe('none')
+
+    type(textarea, '/t')
+    await flush()
+    expect(global.fetch).toHaveBeenCalledTimes(2)
+    expect(menu.style.display).toBe('block')
+  })
+
+  test('a lookup that lands after the "/" is deleted does not re-open the menu', async () => {
+    let resolveFetch
+    global.fetch = jest.fn(() => new Promise((resolve) => { resolveFetch = resolve }))
+    const { textarea, menu } = setup()
+
+    type(textarea, '/')
+    // The user backspaces before the command list arrives.
+    type(textarea, '')
+
+    resolveFetch({ ok: true, json: () => Promise.resolve(COMMANDS) })
+    await flush()
+
+    expect(menu.style.display).toBe('none')
+  })
+
+  test('a stale lookup cannot overwrite the menu with an outdated query', async () => {
+    const pending = []
+    global.fetch = jest.fn(() => new Promise((resolve) => { pending.push(resolve) }))
+    const { textarea, menu } = setup()
+
+    type(textarea, '/')
+    // Second keystroke reuses the in-flight request, so there is still only one.
+    type(textarea, '/topic')
+    expect(pending).toHaveLength(1)
+
+    pending[0]({ ok: true, json: () => Promise.resolve(COMMANDS) })
+    await flush()
+
+    // Rendered for "/topic", not for the earlier empty query that would have
+    // listed every command.
+    expect(menu.querySelectorAll('.common-popup-item')).toHaveLength(1)
+    expect(menu.textContent).toContain('/topic_list')
+  })
+
+  test('the popup is not blanked between keystrokes once it is open', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve(COMMANDS) })
+    const { textarea, menu } = setup()
+
+    type(textarea, '/')
+    // Let the placement frame reveal the popup, as it does for a real first open.
+    await settle()
+    expect(menu.style.visibility).toBe('visible')
+
+    // Every later keystroke must leave it on screen: blanking it here is what
+    // made the menu blink once per character.
+    for (const value of ['/t', '/ta', '/tas']) {
+      type(textarea, value)
+      await flush()
+      expect(menu.style.visibility).toBe('visible')
+    }
+  })
+})

--- a/engines/collavre/app/javascript/modules/command_menu.js
+++ b/engines/collavre/app/javascript/modules/command_menu.js
@@ -128,18 +128,25 @@ if (!commandMenuInitialized) {
       textarea.setSelectionRange(cleaned.length, cleaned.length)
     }
 
+    // Cached by creative id, and cached as the *promise* rather than its result:
+    // the list is fetched on every keystroke, so caching only after the response
+    // lands would fire one request per character of "/task" before the first one
+    // returns. In-flight callers share the request instead.
     function fetchCommands(creativeId) {
       if (!creativeId) return Promise.resolve([])
-      if (commandCache.has(creativeId)) return Promise.resolve(commandCache.get(creativeId))
+      if (commandCache.has(creativeId)) return commandCache.get(creativeId)
 
-      return fetch(`/creatives/${creativeId}/comments/commands`, { headers: { Accept: 'application/json' } })
+      const request = fetch(`/creatives/${creativeId}/comments/commands`, { headers: { Accept: 'application/json' } })
         .then((response) => (response.ok ? response.json() : []))
-        .then((data) => {
-          const list = Array.isArray(data) ? data : []
-          commandCache.set(creativeId, list)
-          return list
+        .then((data) => (Array.isArray(data) ? data : []))
+        .catch(() => {
+          // Don't leave a failed lookup cached — the next keystroke retries.
+          commandCache.delete(creativeId)
+          return []
         })
-        .catch(() => [])
+
+      commandCache.set(creativeId, request)
+      return request
     }
 
     function insert(command) {
@@ -184,10 +191,17 @@ if (!commandMenuInitialized) {
       if (popupMenu.handleKey(event)) return
     })
 
+    // Bumped by every input event, so a lookup that resolves after the user has
+    // typed on (or deleted the "/" entirely) is dropped instead of rendering the
+    // menu from a query that no longer matches the box — the late response would
+    // otherwise pop the menu back up over an unrelated draft.
+    let queryToken = 0
+
     textarea.addEventListener('input', function () {
       // If args form is open, don't show command menu
       if (argsForm.isOpen()) return
 
+      const token = ++queryToken
       const pos = textarea.selectionStart
       const before = textarea.value.slice(0, pos)
       // Only trigger when "/" is at the very beginning of the message
@@ -201,7 +215,10 @@ if (!commandMenuInitialized) {
       const query = match[1]
 
       fetchCommands(creativeId)
-        .then((commands) => show(commands, query))
+        .then((commands) => {
+          if (token !== queryToken) return
+          show(commands, query)
+        })
     })
   })
 }


### PR DESCRIPTION
## Problem

Typing a slash command made the command menu appear several times: it flashed
off and back on once per character of `/task`, and a slow lookup could pop it
back up after the `/` had already been deleted.

## Root cause

Two independent defects, both confirmed with failing tests before the fix.

**1. `CommonPopup#showAt` always ran the full open sequence.**

`showAt` sets `display:block`, blanks the element to `visibility:hidden`, and
reveals it one frame later so it can be measured off-screen. `command_menu`
calls `showAt` on *every* `input` event to re-anchor a menu that is already on
screen, so each keystroke blanked the popup for a frame — the blink the report
describes. Instrumenting the current code while typing `/task` shows:

```
showAt(open=false), showAt(open=true), showAt(open=true), showAt(open=true), showAt(open=true)
```

`showAt` also reset `_placedAbove` each time, so a menu flipped above the caret
(the normal case — the composer is pinned to the bottom) re-derived its flip on
every character.

**2. `command_menu` had no request dedup and no stale-response guard.**

`commandCache` was populated only once a response landed, so five fast
keystrokes fired five concurrent `/comments/commands` requests. Whichever
resolved last rendered the menu — which could be a response for a query the
user had already replaced, or one they had deleted entirely, re-opening the
menu over an unrelated draft.

## Fix

- `common_popup.js`: track `_revealed` (set by the placement frame, cleared by
  `hide()`). A popup that is already revealed is re-placed synchronously and
  keeps its flip, instead of being blanked and re-revealed a frame later.
  `isOpen()` alone cannot make this call — it is already true during the frame
  between `display:block` and the reveal, and that case still needs blanking.
- `command_menu.js`: cache the in-flight promise rather than its result so
  concurrent keystrokes share one request (a rejected lookup is evicted so the
  next keystroke retries), and drop responses whose query token has been
  superseded.

## Tests

`lib/__tests__/common_popup_reshow.test.js` (6) and
`modules/__tests__/command_menu_typeahead.test.js` (5). Verified red first:
reverting `common_popup.js` fails 4 of them, reverting `command_menu.js` fails
3 of them. Guard cases (first open still blanks, outside-click listeners still
re-register, `hide()` still closes) pass both before and after.

Full JS suite: 114 suites / 1565 tests pass. Complexity ratchet OK. Changed
lines are fully covered.