### PR TITLE
fix(desktop): stage the proxy npm install outside the repository

### DIFF
--- a/tools/desktop-app/README.md
+++ b/tools/desktop-app/README.md
@@ -119,6 +119,15 @@ its supplied SHA-256, requires a Darwin ARM64 runtime, then resolves and locks
 the exact npm package before `npm ci` installs it. The generated lockfile keeps
 the resolved tarball integrity values inside the signed application bundle.
 
+The proxy tree is installed in a staging directory under `TMPDIR`, outside the
+repository, and only moved into `vendor/proxy/` once it is complete. Node resolves
+modules by walking up the directory tree, so staging inside the repo would let a
+nested package bind to the Rails app's `node_modules` instead of its own — that is
+what made `esbuild` fail its postinstall with `Expected "<a>" but got "<b>"` on
+checkouts whose root `node_modules` carried a different `esbuild`. Point `TMPDIR`
+at a path that is not itself inside a `node_modules` tree; the script refuses to
+run otherwise.
+
 For a local DMG build, no Node runtime environment variables are required. The
 script downloads and verifies its pinned official Apple-Silicon Node archive
 (`v22.13.0`). Set `NODE_RUNTIME_DIR` only for a pre-verified expanded official

--- a/tools/desktop-app/scripts/bundle-proxy.sh
+++ b/tools/desktop-app/scripts/bundle-proxy.sh
@@ -45,6 +45,7 @@ mkdir -p "$DESKTOP_DIR/vendor"
 # esbuild versions differ. Outside the repo there is nothing to escape to, and
 # esbuild falls back to its integrity-checked download of the matching binary.
 stage="$(mktemp -d "${TMPDIR:-/tmp}/collavre-proxy.XXXXXX")"
+stage="$(cd -P "$stage" && pwd)"
 cleanup() { rm -rf "$stage"; }
 trap cleanup EXIT
 

--- a/tools/desktop-app/scripts/bundle-proxy.sh
+++ b/tools/desktop-app/scripts/bundle-proxy.sh
@@ -35,9 +35,31 @@ fail() {
   fail "CLI_OPENAI_PROXY_VERSION must be an exact semver, not a range"
 
 mkdir -p "$DESKTOP_DIR/vendor"
-stage="$(mktemp -d "$DESKTOP_DIR/vendor/.proxy.XXXXXX")"
+
+# The staging dir must live OUTSIDE the repository. Node resolves a module by
+# walking UP the directory tree, so a stage inside the repo lets a nested package
+# escape into the Rails app's own node_modules. Concretely: npm's tree for this
+# dependency set never installs @esbuild/darwin-arm64, so esbuild's postinstall
+# resolves "@esbuild/darwin-arm64/bin/esbuild" out of the stage, finds the app's
+# copy, and aborts the build with `Expected "<a>" but got "<b>"` whenever the two
+# esbuild versions differ. Outside the repo there is nothing to escape to, and
+# esbuild falls back to its integrity-checked download of the matching binary.
+stage="$(mktemp -d "${TMPDIR:-/tmp}/collavre-proxy.XXXXXX")"
 cleanup() { rm -rf "$stage"; }
 trap cleanup EXIT
+
+# Same hazard if TMPDIR itself sits under a node_modules tree: fail loudly rather
+# than bundling packages resolved from outside the stage.
+probe="$stage"
+while :; do
+  probe="$(dirname "$probe")"
+  if [[ -d "$probe/node_modules" ]]; then
+    fail "staging dir is nested under $probe/node_modules; set TMPDIR to a path outside any node_modules tree"
+  fi
+  if [[ "$probe" == "/" ]]; then
+    break
+  fi
+done
 
 if [[ -n "$NODE_RUNTIME_DIR" ]]; then
   [[ -x "$NODE_RUNTIME_DIR/bin/node" && -x "$NODE_RUNTIME_DIR/bin/npm" ]] || \
@@ -113,6 +135,10 @@ EOF
 
 rm -rf "$OUTPUT_DIR"
 cd "$DESKTOP_DIR"
-mv "$stage" "$OUTPUT_DIR"
+# TMPDIR may be on a different volume than the repo, so fall back to a copy.
+if ! mv "$stage" "$OUTPUT_DIR" 2>/dev/null; then
+  cp -Rp "$stage" "$OUTPUT_DIR"
+  rm -rf "$stage"
+fi
 trap - EXIT
 echo "[bundle-proxy] bundled $PACKAGE_NAME@$PACKAGE_VERSION with $node_version"


### PR DESCRIPTION
## 문제

`tools/desktop-app/scripts/build-macos.sh` 실행 시 2/7 단계(`bundle-proxy.sh`)에서 실패:

```
npm error path .../tools/desktop-app/vendor/.proxy.XfLN9q/node_modules/@paperclipai/adapter-utils/node_modules/esbuild
npm error Error: Expected "0.28.1" but got "0.25.12"
npm error     at validateBinaryVersion (.../esbuild/install.js:137:11)
```

## 근본 원인

`bundle-proxy.sh`가 npm staging 디렉토리를 **리포지토리 안**(`tools/desktop-app/vendor/.proxy.XXXXXX`)에 만들고 있었습니다. Node의 모듈 해석은 디렉토리 트리를 **위로** 거슬러 올라가므로, stage 안에 없는 패키지는 stage 밖 — 즉 Rails 앱 자신의 `node_modules` — 에서 해석됩니다.

`cli-openai-proxy`의 의존성 트리에서 npm은 중첩된 `esbuild@0.28.1`의 플랫폼 바이너리 `@esbuild/darwin-arm64`를 아예 설치하지 않습니다(락파일에는 `@esbuild/linux-x64`만 기록됨). 그래서 esbuild의 postinstall이 하는

```js
binPath = require.resolve(`@esbuild/darwin-arm64/bin/esbuild`)
```

가 stage를 탈출해 **앱 루트의 `node_modules/@esbuild/darwin-arm64`** 를 집어옵니다. 지금까지 빌드가 성공한 것은 그 버전이 우연히 일치했기 때문이고, 루트 `node_modules`가 다른 esbuild(예: 이전 `0.25.12`)를 갖고 있는 체크아웃에서는 검증에 걸려 빌드가 죽습니다.

`build-macos.sh`가 `bundle-proxy.sh`(2/7)를 `npm ci`(3/7)보다 먼저 돌리기 때문에 **깨끗한 체크아웃/CI에서는 루트 `node_modules`가 없어 우연히 통과**하고, 기존 워크트리에서만 재현되는 것도 같은 이유입니다.

## 수정

- staging 디렉토리를 `TMPDIR` 아래(리포 밖)로 옮겨 install을 hermetic하게 만듭니다. 탈출할 대상이 없으므로 esbuild는 자체 fallback으로 무결성 검증된 올바른 바이너리를 받아옵니다.
- `TMPDIR` 자체가 `node_modules` 트리 안에 있으면 조용히 밖에서 해석하지 않고 명확한 메시지로 실패합니다.
- `TMPDIR`이 다른 볼륨일 수 있으므로 최종 이동은 `mv` 실패 시 복사로 폴백합니다.
- README에 이유와 `TMPDIR` 제약을 문서화했습니다.

## 검증

실제 워크트리에서 루트 `node_modules/@esbuild/darwin-arm64`를 `0.25.12`로 되돌려 사용자 환경을 재현한 뒤:

| | 결과 |
|---|---|
| `origin/main` 버전 | ❌ `Error: Expected "0.28.1" but got "0.25.12"` (보고된 에러와 동일) |
| 이 PR | ✅ `[bundle-proxy] bundled cli-openai-proxy@0.1.0 with v22.13.0` |

번들 산출물 확인 (루트 `node_modules`는 stale `0.25.12`인 상태 그대로):

- `vendor/proxy/node_modules/@paperclipai/adapter-utils/node_modules/esbuild/bin/esbuild --version` → `0.28.1`
- `manifest.json` integrity/버전/플랫폼 정상
- `require('cli-openai-proxy/package.json').version` → `0.1.0`
- stage 잔여물 없음 (성공/실패 양쪽 모두 trap 정리 동작)

가드 경로도 확인: `TMPDIR=/tmp/x/node_modules/deep/tmp` → `[bundle-proxy] staging dir is nested under /tmp/x/node_modules; set TMPDIR to a path outside any node_modules tree`