### PR TITLE
fix: compact mobile chat popup actions

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -1019,6 +1019,12 @@ body.chat-fullscreen {
         transition: transform 0.3s;
     }
 
+    .comments-popup-action {
+        width: var(--space-px-4);
+        height: var(--space-px-4);
+        flex-basis: var(--space-px-4);
+    }
+
     #comments-popup.open {
         transform: translateY(0);
     }

--- a/engines/collavre/test/system/comments_popup_action_alignment_test.rb
+++ b/engines/collavre/test/system/comments_popup_action_alignment_test.rb
@@ -16,13 +16,34 @@ class CommentsPopupActionAlignmentTest < ApplicationSystemTestCase
   end
 
   test "close and fullscreen actions share centered dimensions" do
+    open_comments_popup
+
+    dimensions = action_dimensions
+
+    assert_action_dimensions dimensions, button_size: 24
+  end
+
+  test "mobile popup actions use compact video-control dimensions" do
+    resize_window_to(390, 844)
+    open_comments_popup
+
+    dimensions = action_dimensions
+
+    assert_action_dimensions dimensions, button_size: 20
+  end
+
+  private
+
+  def open_comments_popup
     visit root_path
     assert_selector "#creative-#{@creative.id}", wait: 5
     find("#creative-#{@creative.id}").hover
     within("#creative-#{@creative.id}") { find(".comments-btn").click }
     assert_selector "#comments-popup", visible: :visible, wait: 5
+  end
 
-    dimensions = page.evaluate_script(<<~JS)
+  def action_dimensions
+    page.evaluate_script(<<~JS)
       (() => {
         const box = (selector) => {
           const rect = document.querySelector(selector).getBoundingClientRect()
@@ -42,11 +63,13 @@ class CommentsPopupActionAlignmentTest < ApplicationSystemTestCase
         }
       })()
     JS
+  end
 
-    assert_equal 24, dimensions.dig("fullscreenButton", "width")
-    assert_equal 24, dimensions.dig("fullscreenButton", "height")
-    assert_equal 24, dimensions.dig("closeButton", "width")
-    assert_equal 24, dimensions.dig("closeButton", "height")
+  def assert_action_dimensions(dimensions, button_size:)
+    assert_equal button_size, dimensions.dig("fullscreenButton", "width")
+    assert_equal button_size, dimensions.dig("fullscreenButton", "height")
+    assert_equal button_size, dimensions.dig("closeButton", "width")
+    assert_equal button_size, dimensions.dig("closeButton", "height")
     assert_equal 16, dimensions.dig("fullscreenIcon", "width")
     assert_equal 16, dimensions.dig("fullscreenIcon", "height")
     assert_equal 16, dimensions.dig("closeIcon", "width")


### PR DESCRIPTION
## Summary

- Reduce mobile PiP chat header action hit areas from 24×24 to 20×20 while preserving 16×16 SVG icons.
- Keep the existing desktop sizing and centered alignment unchanged.
- Add browser regression coverage for desktop and 390px mobile viewports.

## Validation

- `bin/rails test engines/collavre/test/system/comments_popup_action_alignment_test.rb` (2 tests, 28 assertions)
- `./bin/rubocop -a` (1,253 files, no offenses)
- `bin/complexity_check` (passed)
- `bin/rake test` (4,355 tests, 14,827 assertions)
- `bin/rake test:system` (99 tests, 636 assertions, 2 skips)

## Notes

- `npm run lint:css` still reports the repository baseline of pre-existing Stylelint findings; the new declarations use existing design tokens and add no new reported finding.

Collavre Creative: 19229