### PR TITLE
revert: compact mobile chat popup actions

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -1019,12 +1019,6 @@ body.chat-fullscreen {
         transition: transform 0.3s;
     }
 
-    .comments-popup-action {
-        width: var(--space-px-4);
-        height: var(--space-px-4);
-        flex-basis: var(--space-px-4);
-    }
-
     #comments-popup.open {
         transform: translateY(0);
     }

--- a/engines/collavre/test/system/comments_popup_action_alignment_test.rb
+++ b/engines/collavre/test/system/comments_popup_action_alignment_test.rb
@@ -16,34 +16,13 @@ class CommentsPopupActionAlignmentTest < ApplicationSystemTestCase
   end
 
   test "close and fullscreen actions share centered dimensions" do
-    open_comments_popup
-
-    dimensions = action_dimensions
-
-    assert_action_dimensions dimensions, button_size: 24
-  end
-
-  test "mobile popup actions use compact video-control dimensions" do
-    resize_window_to(390, 844)
-    open_comments_popup
-
-    dimensions = action_dimensions
-
-    assert_action_dimensions dimensions, button_size: 20
-  end
-
-  private
-
-  def open_comments_popup
     visit root_path
     assert_selector "#creative-#{@creative.id}", wait: 5
     find("#creative-#{@creative.id}").hover
     within("#creative-#{@creative.id}") { find(".comments-btn").click }
     assert_selector "#comments-popup", visible: :visible, wait: 5
-  end
 
-  def action_dimensions
-    page.evaluate_script(<<~JS)
+    dimensions = page.evaluate_script(<<~JS)
       (() => {
         const box = (selector) => {
           const rect = document.querySelector(selector).getBoundingClientRect()
@@ -63,13 +42,11 @@ class CommentsPopupActionAlignmentTest < ApplicationSystemTestCase
         }
       })()
     JS
-  end
 
-  def assert_action_dimensions(dimensions, button_size:)
-    assert_equal button_size, dimensions.dig("fullscreenButton", "width")
-    assert_equal button_size, dimensions.dig("fullscreenButton", "height")
-    assert_equal button_size, dimensions.dig("closeButton", "width")
-    assert_equal button_size, dimensions.dig("closeButton", "height")
+    assert_equal 24, dimensions.dig("fullscreenButton", "width")
+    assert_equal 24, dimensions.dig("fullscreenButton", "height")
+    assert_equal 24, dimensions.dig("closeButton", "width")
+    assert_equal 24, dimensions.dig("closeButton", "height")
     assert_equal 16, dimensions.dig("fullscreenIcon", "width")
     assert_equal 16, dimensions.dig("fullscreenIcon", "height")
     assert_equal 16, dimensions.dig("closeIcon", "width")


### PR DESCRIPTION
## Summary

- revert the unrelated Collavre chat popup sizing change from #1573
- restore the original popup alignment regression test

## Verification

- confirmed both files exactly match the parent of merge commit `a3e52ba8`
- `git diff --check`
- local Ruby checks unavailable because the host only provides Ruby 2.6 while the lockfile requires Bundler 2.6.2; CI is required before merge

Reverts #1573.