### PR TITLE
feat: add topic message creation tool

### DIFF
--- a/engines/collavre/app/models/collavre/current.rb
+++ b/engines/collavre/app/models/collavre/current.rb
@@ -7,6 +7,8 @@ module Collavre
     attribute :mcp_tool_approval_required
     attribute :mcp_request
     attribute :user
+    attribute :workspace_user
+    attribute :workspace_user_resolved
     def user
       super || session&.user
     end

--- a/engines/collavre/app/models/collavre/current.rb
+++ b/engines/collavre/app/models/collavre/current.rb
@@ -7,8 +7,7 @@ module Collavre
     attribute :mcp_tool_approval_required
     attribute :mcp_request
     attribute :user
-    attribute :workspace_user
-    attribute :workspace_user_resolved
+    attribute :agent_turn
     def user
       super || session&.user
     end

--- a/engines/collavre/app/services/collavre/ai_agent_service.rb
+++ b/engines/collavre/app/services/collavre/ai_agent_service.rb
@@ -13,11 +13,12 @@ module Collavre
       @task = task
       @agent = task.agent
       @context = task.trigger_event_payload
+      @original_comment = find_original_comment
     end
 
     def call
       begin
-        Current.set(user: @agent) do
+        Current.set(user: @agent, workspace_user: workspace_user, workspace_user_resolved: true) do
           if @agent.claude_channel_agent?
             delegate_to_claude_channel
           else
@@ -73,7 +74,6 @@ module Collavre
     def execute_llm_conversation
       log_action("start", { message: "Starting agent execution" })
 
-      @original_comment = find_original_comment
       messages_data = build_messages
       log_action("prompt_generated", { messages: messages_data[:messages] })
 

--- a/engines/collavre/app/services/collavre/ai_agent_service.rb
+++ b/engines/collavre/app/services/collavre/ai_agent_service.rb
@@ -18,7 +18,7 @@ module Collavre
 
     def call
       begin
-        Current.set(user: @agent, workspace_user: workspace_user, workspace_user_resolved: true) do
+        Current.set(user: @agent, agent_turn: { user: workspace_user, parent: SystemEvents::Envelope.in(@context) }) do
           if @agent.claude_channel_agent?
             delegate_to_claude_channel
           else

--- a/engines/collavre/app/services/collavre/ai_agent_service.rb
+++ b/engines/collavre/app/services/collavre/ai_agent_service.rb
@@ -18,7 +18,7 @@ module Collavre
 
     def call
       begin
-        Current.set(user: @agent, agent_turn: { user: workspace_user, parent: SystemEvents::Envelope.in(@context) }) do
+        Current.set(user: @agent, agent_turn: { user: workspace_user, task: @task }) do
           if @agent.claude_channel_agent?
             delegate_to_claude_channel
           else

--- a/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
+++ b/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
@@ -18,6 +18,8 @@ module Collavre
 
       def self.select(event_name, context) = new(event_name: event_name, context: context).select
 
+      def self.prepare_selection(event_name, context) = new(event_name: event_name, context: context).prepare_selection
+
       def self.dequeue_next_for_topic(topic_id, creative_id = nil)
         task = claim_next_waiter(topic_id, creative_id)
         if task
@@ -436,12 +438,7 @@ module Collavre
         # revision later. Skip reviews and take the newest ordinary comment,
         # which in the worst case is the waiter's own anchor (a no-op refresh)
         # rather than nothing, so this cannot strand a live waiter.
-        scope = Comment.public_only.without_approval_action
-          .where(creative_id: creative_id, topic_id: topic_id)
-          .where.not(user_id: [ task.agent_id, nil ])
-          .where.not(id: Comment.review_messages.where(creative_id: creative_id, topic_id: topic_id).select(:id))
-          .order(id: :desc)
-        scope = TaskCoalescer.reanchor_scope_for_workspace_principal(scope, task)
+        scope = DeferredTriggerScope.for(task, context)
 
         # Narrowing the destination closes the door this call site opens, but the
         # promotion door still moves the anchor onto the newest comment in the
@@ -676,12 +673,17 @@ module Collavre
       end
 
       def select
-        Selection.new(@context, policy_resolver: policy_resolver).call
+        prepare_selection.commit!.agents
       end
 
-      def dispatch(selected_agents: nil, context_for: nil)
-        selected = selected_agents || select
+      def prepare_selection = Selection.new(@context, policy_resolver: policy_resolver).call
+
+      def dispatch(selected_agents: nil, selection: nil, context_for: nil)
+        selection ||= prepare_selection unless selected_agents
+        selected = selected_agents || selection.agents
         return [] if selected.empty?
+
+        selection&.commit!
 
         # Step 3: Schedule execution (Scheduler) - Phase 3
         # For now, immediate execution

--- a/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
+++ b/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
@@ -12,8 +12,8 @@ module Collavre
     #   AgentOrchestrator.dispatch("comment_created", context)
     #
     class AgentOrchestrator
-      def self.dispatch(event_name, context)
-        new(event_name: event_name, context: context).dispatch
+      def self.dispatch(event_name, context, on_selected: ->(_) { })
+        new(event_name: event_name, context: context).dispatch(on_selected: on_selected)
       end
 
       def self.dequeue_next_for_topic(topic_id, creative_id = nil)
@@ -673,7 +673,7 @@ module Collavre
         @context["event_name"] = event_name
       end
 
-      def dispatch
+      def dispatch(on_selected: ->(_) { })
         # Step 1: Find qualified agents (Matcher)
         candidates = matcher.match
         return [] if candidates.empty?
@@ -684,7 +684,7 @@ module Collavre
 
         # Step 3: Schedule execution (Scheduler) - Phase 3
         # For now, immediate execution
-        decisions = scheduler.schedule(selected)
+        decisions = scheduler.schedule(selected.tap(&on_selected))
 
         # Step 4: Enqueue jobs
         enqueue_jobs(decisions)

--- a/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
+++ b/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
@@ -12,9 +12,11 @@ module Collavre
     #   AgentOrchestrator.dispatch("comment_created", context)
     #
     class AgentOrchestrator
-      def self.dispatch(event_name, context, on_selected: ->(_) { })
-        new(event_name: event_name, context: context).dispatch(on_selected: on_selected)
+      def self.dispatch(event_name, context, **options)
+        new(event_name: event_name, context: context).dispatch(**options)
       end
+
+      def self.select(event_name, context) = new(event_name: event_name, context: context).select
 
       def self.dequeue_next_for_topic(topic_id, creative_id = nil)
         task = claim_next_waiter(topic_id, creative_id)
@@ -673,21 +675,20 @@ module Collavre
         @context["event_name"] = event_name
       end
 
-      def dispatch(on_selected: ->(_) { })
-        # Step 1: Find qualified agents (Matcher)
-        candidates = matcher.match
-        return [] if candidates.empty?
+      def select
+        Selection.new(@context, policy_resolver: policy_resolver).call
+      end
 
-        # Step 2: Select responders (Arbiter) - with policy-based floor control
-        selected = arbiter.select(candidates)
+      def dispatch(selected_agents: nil, context_for: nil)
+        selected = selected_agents || select
         return [] if selected.empty?
 
         # Step 3: Schedule execution (Scheduler) - Phase 3
         # For now, immediate execution
-        decisions = scheduler.schedule(selected.tap { @context.merge!(on_selected.call(_1) || {}) })
+        decisions = scheduler.schedule(selected)
 
         # Step 4: Enqueue jobs
-        enqueue_jobs(decisions)
+        enqueue_jobs(decisions, context_for: context_for)
       end
 
       private
@@ -696,21 +697,13 @@ module Collavre
         @policy_resolver ||= PolicyResolver.new(@context)
       end
 
-      def matcher
-        @matcher ||= Matcher.new(@context)
-      end
-
-      def arbiter
-        @arbiter ||= Arbiter.new(@context, policy_resolver: policy_resolver)
-      end
-
       def scheduler
         @scheduler ||= Scheduler.new(@context, policy_resolver: policy_resolver)
       end
 
-      def enqueue_jobs(decisions)
+      def enqueue_jobs(decisions, context_for:)
         decisions.filter_map do |decision|
-          agent = decision[:agent]
+          context = context_for_agent(agent = decision[:agent], context_for)
           log_decision(decision)
 
           # A rejected decision is not a dispatch, so neither guard below
@@ -729,7 +722,7 @@ module Collavre
           # Guard: skip if agent already has a running task for this comment.
           # Handled, not unscheduled — see the drop guard below for why the two
           # are different answers and what reads them apart.
-          comment_id = @context.dig("comment", "id")
+          comment_id = context.dig("comment", "id")
           if comment_id && Task.duplicate_running_for_comment?(agent.id, comment_id)
             Rails.logger.warn(
               "[AgentOrchestrator] Skipping enqueue: agent #{agent.id} already has a running task " \
@@ -761,7 +754,7 @@ module Collavre
           # was scheduled*: DropTriggerJob#dispatch_trigger raises
           # DispatchFailedError on an empty result and retries a trigger that
           # was covered, three times, and calls the job failed at the end of it.
-          covering = DeliveryRecord.covering_task(agent, comment_id, @context, @event_name)
+          covering = DeliveryRecord.covering_task(agent, comment_id, context, @event_name)
           if covering && DeliveryRecord.claim_drop!(covering, comment_id)
             Rails.logger.info(
               "[AgentOrchestrator] Dropping dispatch: comment #{comment_id} was already " \
@@ -772,15 +765,15 @@ module Collavre
 
           case decision[:timing]
           when :immediate
-            AiAgentJob.perform_later(agent.id, @event_name, @context)
+            AiAgentJob.perform_later(agent.id, @event_name, context)
             agent
           when :deferred
-            waiter = park_waiter(agent)
+            waiter = park_waiter(agent, context)
             post_waiting_notice(agent, decision, waiter: waiter)
             agent
           when :delayed
             AiAgentJob.set(wait: decision[:delay]).perform_later(
-              agent.id, @event_name, @context
+              agent.id, @event_name, context
             )
             post_waiting_notice(agent, decision)
             agent
@@ -788,6 +781,11 @@ module Collavre
             nil
           end
         end
+      end
+
+      def context_for_agent(agent, context_for)
+        override = context_for&.call(agent)
+        override.present? ? @context.deep_merge(override.deep_stringify_keys) : @context
       end
 
       # Park this dispatch as a queued waiter and fold the earlier ones into it.
@@ -807,9 +805,9 @@ module Collavre
       # (coalesce_at_start!), so this is not a duplicate turn — but two doors
       # onto one queue should not disagree about when a burst becomes one
       # waiter, and only the serialized one holds without those later passes.
-      def park_waiter(agent)
-        topic_id = @context.dig("topic", "id")
-        creative_id = @context.dig("creative", "id")
+      def park_waiter(agent, context)
+        topic_id = context.dig("topic", "id")
+        creative_id = context.dig("creative", "id")
         coalescing = policy_resolver.coalesce_pending_tasks_for?(agent)
         waiter = nil
 
@@ -819,7 +817,7 @@ module Collavre
             name: "Response to #{@event_name}",
             status: "queued",
             trigger_event_name: @event_name,
-            trigger_event_payload: @context,
+            trigger_event_payload: context,
             agent: agent,
             topic_id: topic_id,
             creative_id: creative_id,

--- a/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
+++ b/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
@@ -684,7 +684,7 @@ module Collavre
 
         # Step 3: Schedule execution (Scheduler) - Phase 3
         # For now, immediate execution
-        decisions = scheduler.schedule(selected.tap(&on_selected))
+        decisions = scheduler.schedule(selected.tap { @context.merge!(on_selected.call(_1) || {}) })
 
         # Step 4: Enqueue jobs
         enqueue_jobs(decisions)

--- a/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
+++ b/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
@@ -497,7 +497,7 @@ module Collavre
         # reanchor_payload also records the move when it is one, which is what
         # delivered_comment_ids reads below: a comment this turn was handed
         # without having been created for it.
-        context = TaskCoalescer.reanchor_payload(context, latest_comment)
+        context = DeferredTriggerScope.reanchor_payload(task, context, latest_comment)
         # absorb_into_payload also drops the new anchor from the merged list, so
         # a comment promoted from "merged" back to "trigger" is not sent twice.
         context = TaskCoalescer.absorb_into_payload(context, [ previous_anchor_id ].compact)

--- a/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
+++ b/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
@@ -18,7 +18,7 @@ module Collavre
 
       def self.select(event_name, context) = new(event_name: event_name, context: context).select
 
-      def self.prepare_selection(event_name, context) = new(event_name: event_name, context: context).prepare_selection
+      def self.prepare_selection(event_name, context, **options) = new(event_name: event_name, context: context).prepare_selection(**options)
 
       def self.dequeue_next_for_topic(topic_id, creative_id = nil)
         task = claim_next_waiter(topic_id, creative_id)
@@ -676,11 +676,10 @@ module Collavre
         prepare_selection.commit!.agents
       end
 
-      def prepare_selection = Selection.new(@context, policy_resolver: policy_resolver).call
+      def prepare_selection(**options) = Selection.new(@context, policy_resolver: policy_resolver, **options).call
 
-      def dispatch(selected_agents: nil, selection: nil, context_for: nil)
-        selection ||= prepare_selection unless selected_agents
-        selected = selected_agents || selection.agents
+      def dispatch(selected_agents: nil, selection: nil, context_for: nil, on_scheduled: nil)
+        selected = selected_agents || (selection ||= prepare_selection).agents
         return [] if selected.empty?
 
         selection&.commit!
@@ -688,6 +687,7 @@ module Collavre
         # Step 3: Schedule execution (Scheduler) - Phase 3
         # For now, immediate execution
         decisions = scheduler.schedule(selected)
+        on_scheduled&.call(decisions.filter_map { |decision| decision[:agent] unless decision[:timing] == :rejected })
 
         # Step 4: Enqueue jobs
         enqueue_jobs(decisions, context_for: context_for)

--- a/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
+++ b/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
@@ -678,7 +678,7 @@ module Collavre
 
       def prepare_selection(**options) = Selection.new(@context, policy_resolver: policy_resolver, **options).call
 
-      def dispatch(selected_agents: nil, selection: nil, context_for: nil, on_scheduled: nil)
+      def dispatch(selected_agents: nil, selection: nil, context_for: nil, scheduling_hooks: nil)
         selected = selected_agents || (selection ||= prepare_selection).agents
         return [] if selected.empty?
 
@@ -686,8 +686,8 @@ module Collavre
 
         # Step 3: Schedule execution (Scheduler) - Phase 3
         # For now, immediate execution
-        decisions = scheduler.schedule(selected)
-        on_scheduled&.call(decisions.filter_map { |decision| decision[:agent] unless decision[:timing] == :rejected })
+        decisions = scheduler.schedule(selected, scheduling_hooks: scheduling_hooks)
+        scheduling_hooks&.scheduled(decisions.filter_map { |decision| decision[:agent] unless decision[:timing] == :rejected })
 
         # Step 4: Enqueue jobs
         enqueue_jobs(decisions, context_for: context_for)

--- a/engines/collavre/app/services/collavre/orchestration/arbiter.rb
+++ b/engines/collavre/app/services/collavre/orchestration/arbiter.rb
@@ -22,7 +22,7 @@ module Collavre
       # Select which agents will respond from the candidates
       # @param candidates [Array<User>] Qualified agents from Matcher
       # @return [Array<User>] Agents that will actually respond
-      def select(candidates)
+      def select(candidates, commit: true)
         return [] if candidates.empty?
 
         # Review feedback is forced routing: the Matcher already restricts candidates
@@ -47,7 +47,16 @@ module Collavre
         max = @policy_resolver.max_responders
         selected = selected.take(max) if max.present? && max.positive?
 
+        commit_selection! if commit
         selected
+      end
+
+      def commit_selection!
+        pending = @pending_round_robin
+        return unless pending
+
+        Rails.cache.write(pending.first, pending.second, expires_in: 24.hours)
+        @pending_round_robin = nil
       end
 
       private
@@ -140,8 +149,7 @@ module Collavre
                      sorted_candidates.first
         end
 
-        # Store current responder for next rotation
-        Rails.cache.write(cache_key, selected.id, expires_in: 24.hours)
+        @pending_round_robin = [ cache_key, selected.id ]
 
         [ selected ]
       end

--- a/engines/collavre/app/services/collavre/orchestration/deferred_trigger_scope.rb
+++ b/engines/collavre/app/services/collavre/orchestration/deferred_trigger_scope.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Collavre
+  module Orchestration
+    # Keeps only comments that may become a deferred task's next trigger.
+    class DeferredTriggerScope
+      SELF_AUTHORED_COMMENT_ID_KEY = "self_authored_trigger_comment_id"
+
+      def self.for(task, context)
+        new(task, context).relation
+      end
+
+      def initialize(task, context)
+        @task = task
+        @context = context
+      end
+
+      def relation
+        scope = Comment.public_only.without_approval_action
+          .where(creative_id: @context.dig("creative", "id"), topic_id: @context.dig("topic", "id"))
+        eligible = scope.where.not(user_id: [ @task.agent_id, nil ])
+        eligible = eligible.or(deliberate_self_trigger(scope)) if deliberate_self_trigger_id
+        eligible = eligible.where.not(id: review_message_ids)
+
+        TaskCoalescer.reanchor_scope_for_workspace_principal(eligible.order(id: :desc), @task)
+      end
+
+      private
+
+      def deliberate_self_trigger(scope)
+        scope.where(id: deliberate_self_trigger_id, user_id: @task.agent_id)
+      end
+
+      def deliberate_self_trigger_id
+        @context[SELF_AUTHORED_COMMENT_ID_KEY]
+      end
+
+      def review_message_ids
+        Comment.review_messages
+          .where(creative_id: @context.dig("creative", "id"), topic_id: @context.dig("topic", "id"))
+          .select(:id)
+      end
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/orchestration/deferred_trigger_scope.rb
+++ b/engines/collavre/app/services/collavre/orchestration/deferred_trigger_scope.rb
@@ -10,6 +10,14 @@ module Collavre
         new(task, context).relation
       end
 
+      def self.reanchor_payload(task, context, comment)
+        payload = TaskCoalescer.reanchor_payload(context, comment)
+        deliberate_id = context[SELF_AUTHORED_COMMENT_ID_KEY]
+        return payload unless deliberate_id.to_i == comment.id && comment.user_id == task.agent_id
+
+        context.key?("sender") ? payload.merge("sender" => context["sender"]) : payload.except("sender")
+      end
+
       def initialize(task, context)
         @task = task
         @context = context

--- a/engines/collavre/app/services/collavre/orchestration/loop_breaker.rb
+++ b/engines/collavre/app/services/collavre/orchestration/loop_breaker.rb
@@ -38,12 +38,12 @@ module Collavre
       end
 
       # Main entry point - checks all loop conditions
-      def check
+      def check(prospective_interaction: nil)
         return Result.new(should_break: false, reason: nil, details: {}) unless enabled?
 
         # Check each condition
         checks = [
-          check_ping_pong,
+          check_ping_pong(prospective_interaction),
           check_creative_retry,
           check_task_timeout,
           check_token_spike
@@ -110,13 +110,14 @@ module Collavre
       end
 
       # Detect ping-pong between agents
-      def check_ping_pong
+      def check_ping_pong(prospective_interaction)
         creative_id = @context.dig("creative", "id")
         return safe_result unless creative_id
 
         # Check the ping-pong tracking key for this creative
         key = "#{CACHE_PREFIX}:ping_pong_history:#{creative_id}"
-        interactions = Rails.cache.read(key) || []
+        interactions = Array(Rails.cache.read(key)).dup
+        interactions << prospective_interaction_entry(prospective_interaction) if prospective_interaction
 
         # Count exchanges for each agent pair
         pair_exchanges = count_pair_exchanges(interactions)
@@ -137,6 +138,11 @@ module Collavre
         end
 
         safe_result
+      end
+
+      def prospective_interaction_entry(interaction)
+        edge = interaction.with_indifferent_access
+        { at: Time.current.to_i, from: edge[:from_agent_id], to: edge[:to_agent_id] }
       end
 
       # Detect too many tasks on same topic (per-topic, not per-creative)

--- a/engines/collavre/app/services/collavre/orchestration/scheduler.rb
+++ b/engines/collavre/app/services/collavre/orchestration/scheduler.rb
@@ -31,10 +31,10 @@ module Collavre
       # @param agents [Array<User>] Agents selected by Arbiter
       # @return [Array<Hash>] Scheduling decisions
       #   Each decision: { agent:, timing:, delay: (optional), reason: (optional) }
-      def schedule(agents)
+      def schedule(agents, scheduling_hooks: nil)
         topic_immediate_count = 0
         agents.map do |agent|
-          decision = evaluate(agent, topic_immediate_count: topic_immediate_count)
+          decision = evaluate(agent, topic_immediate_count: topic_immediate_count, scheduling_hooks: scheduling_hooks)
           topic_immediate_count += 1 if decision[:timing] == :immediate
           decision
         end
@@ -42,13 +42,13 @@ module Collavre
 
       private
 
-      def evaluate(agent, topic_immediate_count: 0)
+      def evaluate(agent, topic_immediate_count: 0, scheduling_hooks: nil)
         tracker = ResourceTracker.for(agent)
         config = @policy_resolver.scheduling_config_for(agent)
 
         # Check 0: Loop breaker
         if @policy_resolver.loop_breaker_enabled?
-          loop_result = LoopBreaker.new(@context, policy_resolver: @policy_resolver).check
+          loop_result = loop_breaker_result(agent, scheduling_hooks)
           if loop_result.should_break?
             return loop_broken_decision(agent, loop_result)
           end
@@ -84,6 +84,12 @@ module Collavre
 
         # All checks passed - immediate execution
         immediate_decision(agent)
+      end
+
+      def loop_breaker_result(agent, scheduling_hooks)
+        LoopBreaker.new(@context, policy_resolver: @policy_resolver).check(
+          prospective_interaction: scheduling_hooks&.interaction_for(agent)
+        )
       end
 
       def immediate_decision(agent)

--- a/engines/collavre/app/services/collavre/orchestration/scheduling_hooks.rb
+++ b/engines/collavre/app/services/collavre/orchestration/scheduling_hooks.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Collavre
+  module Orchestration
+    SchedulingHooks = Data.define(:interaction_callback, :scheduled_callback) do
+      def interaction_for(agent) = interaction_callback&.call(agent)
+      def scheduled(agents) = scheduled_callback&.call(agents)
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/orchestration/selection.rb
+++ b/engines/collavre/app/services/collavre/orchestration/selection.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Collavre
+  module Orchestration
+    # Resolves the exact responders for an event without scheduling work.
+    class Selection
+      def initialize(context, policy_resolver:)
+        @context = context
+        @policy_resolver = policy_resolver
+      end
+
+      def call
+        candidates = Matcher.new(@context).match
+        return [] if candidates.empty?
+
+        Arbiter.new(@context, policy_resolver: @policy_resolver).select(candidates)
+      end
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/orchestration/selection.rb
+++ b/engines/collavre/app/services/collavre/orchestration/selection.rb
@@ -4,6 +4,8 @@ module Collavre
   module Orchestration
     # Resolves the exact responders for an event without scheduling work.
     class Selection
+      attr_reader :agents
+
       def initialize(context, policy_resolver:)
         @context = context
         @policy_resolver = policy_resolver
@@ -11,9 +13,17 @@ module Collavre
 
       def call
         candidates = Matcher.new(@context).match
-        return [] if candidates.empty?
+        @agents = [] if candidates.empty?
+        return self if candidates.empty?
 
-        Arbiter.new(@context, policy_resolver: @policy_resolver).select(candidates)
+        @arbiter = Arbiter.new(@context, policy_resolver: @policy_resolver)
+        @agents = @arbiter.select(candidates, commit: false)
+        self
+      end
+
+      def commit!
+        @arbiter&.commit_selection!
+        self
       end
     end
   end

--- a/engines/collavre/app/services/collavre/orchestration/selection.rb
+++ b/engines/collavre/app/services/collavre/orchestration/selection.rb
@@ -6,13 +6,14 @@ module Collavre
     class Selection
       attr_reader :agents
 
-      def initialize(context, policy_resolver:)
+      def initialize(context, policy_resolver:, candidate_overrides: {})
         @context = context
         @policy_resolver = policy_resolver
+        @candidate_overrides = candidate_overrides
       end
 
       def call
-        candidates = Matcher.new(@context).match
+        candidates = candidates_for_contexts
         @agents = [] if candidates.empty?
         return self if candidates.empty?
 
@@ -24,6 +25,18 @@ module Collavre
       def commit!
         @arbiter&.commit_selection!
         self
+      end
+
+      private
+
+      def candidates_for_contexts
+        candidates = Matcher.new(@context).match
+        @candidate_overrides.each do |agent_id, override|
+          candidates = candidates.reject { |agent| agent.id == agent_id }
+          overridden = Matcher.new(@context.deep_merge(override.deep_stringify_keys)).match
+          candidates.concat(overridden.select { |agent| agent.id == agent_id })
+        end
+        candidates.uniq(&:id).sort_by(&:id)
       end
     end
   end

--- a/engines/collavre/app/services/collavre/system_events/dispatcher.rb
+++ b/engines/collavre/app/services/collavre/system_events/dispatcher.rb
@@ -6,16 +6,16 @@ module Collavre
     # stamps its envelope before the payload is persisted or scheduled.
     class Dispatcher
       def self.dispatch(event_name, context, source: nil, parent: nil, selected_agents: nil, selection: nil,
-                        context_for: nil, on_scheduled: nil)
+                        context_for: nil, scheduling_hooks: nil)
         new.dispatch(
           event_name, context, source: source, parent: parent,
           selected_agents: selected_agents, selection: selection, context_for: context_for,
-          on_scheduled: on_scheduled
+          scheduling_hooks: scheduling_hooks
         )
       end
 
       def dispatch(event_name, context, source: nil, parent: nil, selected_agents: nil, selection: nil,
-                   context_for: nil, on_scheduled: nil)
+                   context_for: nil, scheduling_hooks: nil)
         definition = Vocabulary.fetch(event_name)
         ctx = (context || {}).deep_stringify_keys
         envelope = resolve_envelope(definition.name, ctx, source, parent)
@@ -26,7 +26,7 @@ module Collavre
 
         Orchestration::AgentOrchestrator.dispatch(
           definition.name, ctx, selected_agents: selected_agents, selection: selection,
-          context_for: context_for, on_scheduled: on_scheduled
+          context_for: context_for, scheduling_hooks: scheduling_hooks
         )
       end
 

--- a/engines/collavre/app/services/collavre/system_events/dispatcher.rb
+++ b/engines/collavre/app/services/collavre/system_events/dispatcher.rb
@@ -5,14 +5,17 @@ module Collavre
     # The only entry point to orchestration. It validates the event type and
     # stamps its envelope before the payload is persisted or scheduled.
     class Dispatcher
-      def self.dispatch(event_name, context, source: nil, parent: nil, selected_agents: nil, selection: nil, context_for: nil)
+      def self.dispatch(event_name, context, source: nil, parent: nil, selected_agents: nil, selection: nil,
+                        context_for: nil, on_scheduled: nil)
         new.dispatch(
           event_name, context, source: source, parent: parent,
-          selected_agents: selected_agents, selection: selection, context_for: context_for
+          selected_agents: selected_agents, selection: selection, context_for: context_for,
+          on_scheduled: on_scheduled
         )
       end
 
-      def dispatch(event_name, context, source: nil, parent: nil, selected_agents: nil, selection: nil, context_for: nil)
+      def dispatch(event_name, context, source: nil, parent: nil, selected_agents: nil, selection: nil,
+                   context_for: nil, on_scheduled: nil)
         definition = Vocabulary.fetch(event_name)
         ctx = (context || {}).deep_stringify_keys
         envelope = resolve_envelope(definition.name, ctx, source, parent)
@@ -23,7 +26,7 @@ module Collavre
 
         Orchestration::AgentOrchestrator.dispatch(
           definition.name, ctx, selected_agents: selected_agents, selection: selection,
-          context_for: context_for
+          context_for: context_for, on_scheduled: on_scheduled
         )
       end
 

--- a/engines/collavre/app/services/collavre/system_events/dispatcher.rb
+++ b/engines/collavre/app/services/collavre/system_events/dispatcher.rb
@@ -5,11 +5,14 @@ module Collavre
     # The only entry point to orchestration. It validates the event type and
     # stamps its envelope before the payload is persisted or scheduled.
     class Dispatcher
-      def self.dispatch(event_name, context, source: nil, parent: nil, on_selected: ->(_) { })
-        new.dispatch(event_name, context, source: source, parent: parent, on_selected: on_selected)
+      def self.dispatch(event_name, context, source: nil, parent: nil, selected_agents: nil, context_for: nil)
+        new.dispatch(
+          event_name, context, source: source, parent: parent,
+          selected_agents: selected_agents, context_for: context_for
+        )
       end
 
-      def dispatch(event_name, context, source: nil, parent: nil, on_selected: ->(_) { })
+      def dispatch(event_name, context, source: nil, parent: nil, selected_agents: nil, context_for: nil)
         definition = Vocabulary.fetch(event_name)
         ctx = (context || {}).deep_stringify_keys
         envelope = resolve_envelope(definition.name, ctx, source, parent)
@@ -18,7 +21,9 @@ module Collavre
         warn_missing_keys(definition, ctx, envelope)
         log_dispatch(definition, ctx, envelope)
 
-        Orchestration::AgentOrchestrator.dispatch(definition.name, ctx, on_selected: on_selected)
+        Orchestration::AgentOrchestrator.dispatch(
+          definition.name, ctx, selected_agents: selected_agents, context_for: context_for
+        )
       end
 
       private

--- a/engines/collavre/app/services/collavre/system_events/dispatcher.rb
+++ b/engines/collavre/app/services/collavre/system_events/dispatcher.rb
@@ -5,11 +5,11 @@ module Collavre
     # The only entry point to orchestration. It validates the event type and
     # stamps its envelope before the payload is persisted or scheduled.
     class Dispatcher
-      def self.dispatch(event_name, context, source: nil, parent: nil)
-        new.dispatch(event_name, context, source: source, parent: parent)
+      def self.dispatch(event_name, context, source: nil, parent: nil, on_selected: ->(_) { })
+        new.dispatch(event_name, context, source: source, parent: parent, on_selected: on_selected)
       end
 
-      def dispatch(event_name, context, source: nil, parent: nil)
+      def dispatch(event_name, context, source: nil, parent: nil, on_selected: ->(_) { })
         definition = Vocabulary.fetch(event_name)
         ctx = (context || {}).deep_stringify_keys
         envelope = resolve_envelope(definition.name, ctx, source, parent)
@@ -18,7 +18,7 @@ module Collavre
         warn_missing_keys(definition, ctx, envelope)
         log_dispatch(definition, ctx, envelope)
 
-        Orchestration::AgentOrchestrator.dispatch(definition.name, ctx)
+        Orchestration::AgentOrchestrator.dispatch(definition.name, ctx, on_selected: on_selected)
       end
 
       private

--- a/engines/collavre/app/services/collavre/system_events/dispatcher.rb
+++ b/engines/collavre/app/services/collavre/system_events/dispatcher.rb
@@ -5,14 +5,14 @@ module Collavre
     # The only entry point to orchestration. It validates the event type and
     # stamps its envelope before the payload is persisted or scheduled.
     class Dispatcher
-      def self.dispatch(event_name, context, source: nil, parent: nil, selected_agents: nil, context_for: nil)
+      def self.dispatch(event_name, context, source: nil, parent: nil, selected_agents: nil, selection: nil, context_for: nil)
         new.dispatch(
           event_name, context, source: source, parent: parent,
-          selected_agents: selected_agents, context_for: context_for
+          selected_agents: selected_agents, selection: selection, context_for: context_for
         )
       end
 
-      def dispatch(event_name, context, source: nil, parent: nil, selected_agents: nil, context_for: nil)
+      def dispatch(event_name, context, source: nil, parent: nil, selected_agents: nil, selection: nil, context_for: nil)
         definition = Vocabulary.fetch(event_name)
         ctx = (context || {}).deep_stringify_keys
         envelope = resolve_envelope(definition.name, ctx, source, parent)
@@ -22,7 +22,8 @@ module Collavre
         log_dispatch(definition, ctx, envelope)
 
         Orchestration::AgentOrchestrator.dispatch(
-          definition.name, ctx, selected_agents: selected_agents, context_for: context_for
+          definition.name, ctx, selected_agents: selected_agents, selection: selection,
+          context_for: context_for
         )
       end
 

--- a/engines/collavre/app/services/collavre/tools/topic_authorizer.rb
+++ b/engines/collavre/app/services/collavre/tools/topic_authorizer.rb
@@ -20,6 +20,12 @@ module Collavre
         authorize!(topic, :read, user: user)
       end
 
+      # Posting a message is the topic equivalent of commenting through
+      # CommentsController, so it uses the same feedback permission floor.
+      def authorize_feedback!(topic, user: Collavre::Current.user)
+        authorize!(topic, :feedback, user: user)
+      end
+
       # Attaching a channel injects external messages into a topic, and creating
       # or archiving one restructures where conversation lands, so both are
       # write-equivalent mutations.

--- a/engines/collavre/app/services/collavre/tools/topic_message_create_service.rb
+++ b/engines/collavre/app/services/collavre/tools/topic_message_create_service.rb
@@ -36,13 +36,12 @@ module Tools
 
     sig { params(topic_id: Integer, content: String).returns(T::Hash[Symbol, T.untyped]) }
     def call(topic_id:, content:)
-      user = Current.user || raise("Current.user is required")
+      user = Current.user || raise(I18n.t("collavre.tools.topic_message_create.errors.current_user_required"))
       topic = Topic.find(topic_id)
       TopicAuthorizer.authorize_feedback!(topic, user: user)
       principal = workspace_user(user)
 
       comment = create_comment(topic, content, user, principal)
-      dispatch_agent_message(comment, user, principal) if user.ai_user?
 
       serialize(comment)
     end
@@ -56,22 +55,28 @@ module Tools
         reject_closed_topic!(topic)
         reject_unrunnable_self_dispatch!(topic, user, principal)
 
-        topic.comments.create!(
+        comment = topic.comments.create!(
           creative: topic.creative,
           content: content,
           user: user,
           private: false,
           skip_dispatch: user.ai_user?
         )
+        dispatch_agent_message(comment, user, principal) if user.ai_user?
+        comment
       end
     end
 
     def reject_closed_topic!(topic)
-      raise ArgumentError, "Archived creatives do not accept topic messages." if topic.creative.archived?
-      raise ArgumentError, "Archived topics do not accept messages." if topic.archived?
+      if topic.creative.archived?
+        raise ArgumentError, I18n.t("collavre.tools.topic_message_create.errors.archived_creative")
+      end
+      if topic.archived?
+        raise ArgumentError, I18n.t("collavre.tools.topic_message_create.errors.archived_topic")
+      end
       return unless topic.creative.inbox? && topic.name == Creative::SYSTEM_TOPIC_NAME
 
-      raise ArgumentError, "The inbox System topic does not accept user-authored messages."
+      raise ArgumentError, I18n.t("collavre.tools.topic_message_create.errors.system_topic")
     end
 
     def reject_unrunnable_self_dispatch!(topic, user, principal)
@@ -80,7 +85,7 @@ module Tools
       same_topic = Current.agent_turn&.dig(:task)&.topic_id == topic.id
       return unless same_topic || (principal.nil? && topic.primary_agent_id == user.id)
 
-      raise ArgumentError, "An agent cannot dispatch a topic message to its own current topic."
+      raise ArgumentError, I18n.t("collavre.tools.topic_message_create.errors.current_topic")
     end
 
     def dispatch_agent_message(comment, user, principal)
@@ -95,13 +100,24 @@ module Tools
       parent = SystemEvents::Envelope.in(Current.agent_turn&.dig(:task)&.trigger_event_payload)
       SystemEvents::Dispatcher.dispatch(
         "comment_created", payload, source: "a2a", parent: parent,
-        on_selected: ->(agents) { record_interactions(agents, user, comment.creative_id) }
+        on_selected: ->(agents) { handle_selected_agents!(agents, user, comment, principal) }
       )
+    end
+
+    def handle_selected_agents!(selected_agents, user, comment, principal)
+      self_selected = selected_agents.any? { |agent| agent.id == user.id }
+      if self_selected && (comment.topic.primary_agent_id != user.id || principal.nil?)
+        raise ArgumentError, I18n.t("collavre.tools.topic_message_create.errors.self_route")
+      end
+
+      record_interactions(selected_agents, user, comment.creative_id)
     end
 
     def record_interactions(selected_agents, user, creative_id)
       context = { "creative" => { "id" => creative_id } }
       selected_agents.each do |agent|
+        next if agent.id == user.id
+
         Orchestration::LoopBreaker.new(context).record_interaction(user.id, agent.id, creative_id)
       end
     end

--- a/engines/collavre/app/services/collavre/tools/topic_message_create_service.rb
+++ b/engines/collavre/app/services/collavre/tools/topic_message_create_service.rb
@@ -23,9 +23,8 @@ module Tools
       The caller remains the message author. Human-authored messages use normal
       comment dispatch, while agent-authored messages are dispatched as A2A work
       so an agent can fan work out without impersonating a human. The content is
-      stored as written and may use Markdown. An agent cannot post to the same
-      primary-agent topic it is currently handling; continue that work in the
-      current turn instead.
+      stored as written and may use Markdown. An agent cannot post to the topic
+      it is currently handling; continue that work in the current turn instead.
 
       Requires feedback permission or better on the topic's creative. Archived
       creatives, archived topics, and an inbox's reserved System topic do not
@@ -76,8 +75,10 @@ module Tools
     end
 
     def reject_unrunnable_self_dispatch!(topic, user, principal)
-      return unless user.ai_user? && topic.primary_agent_id == user.id
-      return if principal && Current.agent_turn&.dig(:task)&.topic_id != topic.id
+      return unless user.ai_user?
+
+      same_topic = Current.agent_turn&.dig(:task)&.topic_id == topic.id
+      return unless same_topic || (principal.nil? && topic.primary_agent_id == user.id)
 
       raise ArgumentError, "An agent cannot dispatch a topic message to its own current topic."
     end

--- a/engines/collavre/app/services/collavre/tools/topic_message_create_service.rb
+++ b/engines/collavre/app/services/collavre/tools/topic_message_create_service.rb
@@ -41,8 +41,12 @@ module Tools
       TopicAuthorizer.authorize_feedback!(topic, user: user)
       principal = workspace_user(user)
 
-      comment, selection = create_comment(topic, content, user, principal)
-      dispatch_agent_message(comment, user, principal, selection) if user.ai_user?
+      comment = create_comment(topic, content, user, principal)
+      if user.ai_user?
+        selection = prepare_selection(comment, principal)
+        reject_selected_self_route!(selection.agents, user, principal)
+        dispatch_agent_message(comment, user, principal, selection)
+      end
 
       serialize(comment)
     end
@@ -66,7 +70,7 @@ module Tools
         selection = prepare_selection(comment, principal) if user.ai_user?
         reject_selected_self_route!(selection&.agents, user, principal)
 
-        [ comment, selection ]
+        comment
       end
     end
 
@@ -123,7 +127,9 @@ module Tools
     end
 
     def dispatch_payload(comment, principal)
-      comment.dispatch_payload.merge(workspace_user_id: principal&.id)
+      comment.dispatch_payload.merge(workspace_user_id: principal&.id).tap do |payload|
+        payload[:comment][:from_ai] = comment.user.ai_user?
+      end
     end
 
     def reject_selected_self_route!(selected_agents, user, principal)

--- a/engines/collavre/app/services/collavre/tools/topic_message_create_service.rb
+++ b/engines/collavre/app/services/collavre/tools/topic_message_create_service.rb
@@ -91,14 +91,16 @@ module Tools
       if comment.topic.primary_agent_id == user.id && principal
         payload[:sender] = SystemEvents::ContextBuilder.sender_context_for(principal)
       end
-      record_interactions(payload, user, comment.creative_id)
       parent = SystemEvents::Envelope.in(Current.agent_turn&.dig(:task)&.trigger_event_payload)
-      SystemEvents::Dispatcher.dispatch("comment_created", payload, source: "a2a", parent: parent)
+      SystemEvents::Dispatcher.dispatch(
+        "comment_created", payload, source: "a2a", parent: parent,
+        on_selected: ->(agents) { record_interactions(agents, user, comment.creative_id) }
+      )
     end
 
-    def record_interactions(payload, user, creative_id)
-      context = SystemEvents::ContextBuilder.new(payload).build
-      Orchestration::Matcher.new(context).match.each do |agent|
+    def record_interactions(selected_agents, user, creative_id)
+      context = { "creative" => { "id" => creative_id } }
+      selected_agents.each do |agent|
         Orchestration::LoopBreaker.new(context).record_interaction(user.id, agent.id, creative_id)
       end
     end

--- a/engines/collavre/app/services/collavre/tools/topic_message_create_service.rb
+++ b/engines/collavre/app/services/collavre/tools/topic_message_create_service.rb
@@ -38,20 +38,24 @@ module Tools
       user = Current.user || raise("Current.user is required")
       topic = Topic.find(topic_id)
       TopicAuthorizer.authorize_feedback!(topic, user: user)
+      principal = workspace_user(user)
 
-      comment = create_comment(topic, content, user)
-      dispatch_agent_message(comment, user) if user.ai_user?
+      comment = create_comment(topic, content, user, principal)
+      dispatch_agent_message(comment, user, principal) if user.ai_user?
 
       serialize(comment)
     end
 
     private
 
-    def create_comment(topic, content, user)
+    def create_comment(topic, content, user, principal)
       Comment.transaction do
         topic.lock!
         TopicAuthorizer.authorize_feedback!(topic, user: user)
         reject_closed_topic!(topic)
+        if user.ai_user? && principal.nil? && topic.primary_agent_id == user.id
+          raise ArgumentError, "An agent without a workspace principal cannot dispatch a topic message to itself."
+        end
 
         topic.comments.create!(
           creative: topic.creative,
@@ -71,8 +75,7 @@ module Tools
       raise ArgumentError, "The inbox System topic does not accept user-authored messages."
     end
 
-    def dispatch_agent_message(comment, user)
-      principal = workspace_user(user)
+    def dispatch_agent_message(comment, user, principal)
       payload = comment.dispatch_payload.merge(workspace_user_id: principal&.id)
       # A coordinator may fan itself out into two topic slots. Treat the
       # carried human as that self-dispatch's sender so the downstream turn
@@ -81,11 +84,12 @@ module Tools
       if comment.topic.primary_agent_id == user.id && principal
         payload[:sender] = SystemEvents::ContextBuilder.sender_context_for(principal)
       end
-      SystemEvents::Dispatcher.dispatch("comment_created", payload, source: "a2a")
+      parent = Current.agent_turn&.dig(:parent)
+      SystemEvents::Dispatcher.dispatch("comment_created", payload, source: "a2a", parent: parent)
     end
 
     def workspace_user(user)
-      return Current.workspace_user if Current.workspace_user_resolved
+      return Current.agent_turn[:user] if Current.agent_turn
 
       creator = user.creator
       creator if creator && !creator.ai_user?

--- a/engines/collavre/app/services/collavre/tools/topic_message_create_service.rb
+++ b/engines/collavre/app/services/collavre/tools/topic_message_create_service.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+module Collavre
+require "sorbet-runtime"
+require "rails_mcp_engine"
+module Tools
+  # Posts one public message into an existing topic and starts the topic's
+  # normal orchestration route.
+  class TopicMessageCreateService
+    extend T::Sig
+    extend ToolMeta
+
+    tool_name "topic_message_create"
+    tool_description <<~DESC.strip
+      Post a public message to an existing Collavre topic.
+
+      Use this after topic_create to give the topic's primary agent its initial
+      instruction. A primary-agent pin is exclusive, so an ambient message here
+      starts that agent and no other agent. Messages posted to different topics
+      can run concurrently; messages posted to the same topic queue behind the
+      topic's current work.
+
+      The caller remains the message author. Human-authored messages use normal
+      comment dispatch, while agent-authored messages are dispatched as A2A work
+      so an agent can fan work out without impersonating a human. The content is
+      stored as written and may use Markdown.
+
+      Requires feedback permission or better on the topic's creative. Archived
+      creatives, archived topics, and an inbox's reserved System topic do not
+      accept messages through this tool.
+    DESC
+
+    tool_param :topic_id, description: "The topic to post the message to."
+    tool_param :content, description: "The public message body or initial instruction. Markdown is supported."
+
+    sig { params(topic_id: Integer, content: String).returns(T::Hash[Symbol, T.untyped]) }
+    def call(topic_id:, content:)
+      user = Current.user || raise("Current.user is required")
+      topic = Topic.find(topic_id)
+      TopicAuthorizer.authorize_feedback!(topic, user: user)
+
+      comment = create_comment(topic, content, user)
+      dispatch_agent_message(comment, user) if user.ai_user?
+
+      serialize(comment)
+    end
+
+    private
+
+    def create_comment(topic, content, user)
+      Comment.transaction do
+        topic.lock!
+        TopicAuthorizer.authorize_feedback!(topic, user: user)
+        reject_closed_topic!(topic)
+
+        topic.comments.create!(
+          creative: topic.creative,
+          content: content,
+          user: user,
+          private: false,
+          skip_dispatch: user.ai_user?
+        )
+      end
+    end
+
+    def reject_closed_topic!(topic)
+      raise ArgumentError, "Archived creatives do not accept topic messages." if topic.creative.archived?
+      raise ArgumentError, "Archived topics do not accept messages." if topic.archived?
+      return unless topic.creative.inbox? && topic.name == Creative::SYSTEM_TOPIC_NAME
+
+      raise ArgumentError, "The inbox System topic does not accept user-authored messages."
+    end
+
+    def dispatch_agent_message(comment, user)
+      principal = workspace_user(user)
+      payload = comment.dispatch_payload.merge(workspace_user_id: principal&.id)
+      # A coordinator may fan itself out into two topic slots. Treat the
+      # carried human as that self-dispatch's sender so the downstream turn
+      # reports to the requester instead of @mentioning itself and opening a
+      # fresh A2A turn on completion.
+      if comment.topic.primary_agent_id == user.id && principal
+        payload[:sender] = SystemEvents::ContextBuilder.sender_context_for(principal)
+      end
+      SystemEvents::Dispatcher.dispatch("comment_created", payload, source: "a2a")
+    end
+
+    def workspace_user(user)
+      creator = user.creator
+      creator if creator && !creator.ai_user?
+    end
+
+    def serialize(comment)
+      {
+        id: comment.id,
+        topic_id: comment.topic_id,
+        creative_id: comment.creative_id,
+        content: comment.content,
+        author: { id: comment.user_id, name: comment.user.display_name },
+        created_at: comment.created_at.iso8601
+      }
+    end
+  end
+end
+end

--- a/engines/collavre/app/services/collavre/tools/topic_message_create_service.rb
+++ b/engines/collavre/app/services/collavre/tools/topic_message_create_service.rb
@@ -23,7 +23,9 @@ module Tools
       The caller remains the message author. Human-authored messages use normal
       comment dispatch, while agent-authored messages are dispatched as A2A work
       so an agent can fan work out without impersonating a human. The content is
-      stored as written and may use Markdown.
+      stored as written and may use Markdown. An agent cannot post to the same
+      primary-agent topic it is currently handling; continue that work in the
+      current turn instead.
 
       Requires feedback permission or better on the topic's creative. Archived
       creatives, archived topics, and an inbox's reserved System topic do not
@@ -53,9 +55,7 @@ module Tools
         topic.lock!
         TopicAuthorizer.authorize_feedback!(topic, user: user)
         reject_closed_topic!(topic)
-        if user.ai_user? && principal.nil? && topic.primary_agent_id == user.id
-          raise ArgumentError, "An agent without a workspace principal cannot dispatch a topic message to itself."
-        end
+        reject_unrunnable_self_dispatch!(topic, user, principal)
 
         topic.comments.create!(
           creative: topic.creative,
@@ -75,6 +75,13 @@ module Tools
       raise ArgumentError, "The inbox System topic does not accept user-authored messages."
     end
 
+    def reject_unrunnable_self_dispatch!(topic, user, principal)
+      return unless user.ai_user? && topic.primary_agent_id == user.id
+      return if principal && Current.agent_turn&.dig(:task)&.topic_id != topic.id
+
+      raise ArgumentError, "An agent cannot dispatch a topic message to its own current topic."
+    end
+
     def dispatch_agent_message(comment, user, principal)
       payload = comment.dispatch_payload.merge(workspace_user_id: principal&.id)
       # A coordinator may fan itself out into two topic slots. Treat the
@@ -84,8 +91,16 @@ module Tools
       if comment.topic.primary_agent_id == user.id && principal
         payload[:sender] = SystemEvents::ContextBuilder.sender_context_for(principal)
       end
-      parent = Current.agent_turn&.dig(:parent)
+      record_interactions(payload, user, comment.creative_id)
+      parent = SystemEvents::Envelope.in(Current.agent_turn&.dig(:task)&.trigger_event_payload)
       SystemEvents::Dispatcher.dispatch("comment_created", payload, source: "a2a", parent: parent)
+    end
+
+    def record_interactions(payload, user, creative_id)
+      context = SystemEvents::ContextBuilder.new(payload).build
+      Orchestration::Matcher.new(context).match.each do |agent|
+        Orchestration::LoopBreaker.new(context).record_interaction(user.id, agent.id, creative_id)
+      end
     end
 
     def workspace_user(user)

--- a/engines/collavre/app/services/collavre/tools/topic_message_create_service.rb
+++ b/engines/collavre/app/services/collavre/tools/topic_message_create_service.rb
@@ -116,7 +116,14 @@ module Tools
       SystemEvents::Dispatcher.dispatch(
         "comment_created", payload, source: "a2a", parent: parent_envelope,
         selection: selection, context_for: context_for,
-        on_scheduled: ->(agents) { record_interactions(agents, user, comment.creative_id) }
+        scheduling_hooks: scheduling_hooks(user, comment)
+      )
+    end
+
+    def scheduling_hooks(user, comment)
+      Orchestration::SchedulingHooks.new(
+        interaction_callback: ->(agent) { interaction_for(agent, user, comment.creative_id) },
+        scheduled_callback: ->(agents) { record_interactions(agents, user, comment.creative_id) }
       )
     end
 
@@ -148,10 +155,19 @@ module Tools
     def record_interactions(selected_agents, user, creative_id)
       context = { "creative" => { "id" => creative_id } }
       selected_agents.each do |agent|
-        next if agent.id == user.id
+        interaction = interaction_for(agent, user, creative_id)
+        next unless interaction
 
-        Orchestration::LoopBreaker.new(context).record_interaction(user.id, agent.id, creative_id)
+        Orchestration::LoopBreaker.new(context).record_interaction(
+          interaction[:from_agent_id], interaction[:to_agent_id], creative_id
+        )
       end
+    end
+
+    def interaction_for(agent, user, creative_id)
+      return if agent.id == user.id
+
+      { from_agent_id: user.id, to_agent_id: agent.id, creative_id: creative_id }
     end
 
     def workspace_user(user)

--- a/engines/collavre/app/services/collavre/tools/topic_message_create_service.rb
+++ b/engines/collavre/app/services/collavre/tools/topic_message_create_service.rb
@@ -93,13 +93,13 @@ module Tools
 
     def prepare_selection(comment, principal)
       Orchestration::AgentOrchestrator.prepare_selection(
-        "comment_created", dispatch_payload(comment, principal)
+        "comment_created", dispatch_payload(comment, principal),
+        candidate_overrides: candidate_overrides(comment.user, principal)
       )
     end
 
     def dispatch_agent_message(comment, user, principal, selection)
       selected_agents = selection.agents
-      record_interactions(selected_agents, user, comment.creative_id)
       context_for = lambda do |agent|
         next {} unless agent.id == user.id && principal
 
@@ -111,8 +111,15 @@ module Tools
       end
       SystemEvents::Dispatcher.dispatch(
         "comment_created", payload, source: "a2a", parent: parent_envelope,
-        selection: selection, context_for: context_for
+        selection: selection, context_for: context_for,
+        on_scheduled: ->(agents) { record_interactions(agents, user, comment.creative_id) }
       )
+    end
+
+    def candidate_overrides(user, principal)
+      return {} unless principal
+
+      { user.id => { "sender" => SystemEvents::ContextBuilder.sender_context_for(principal) } }
     end
 
     def dispatch_payload(comment, principal)

--- a/engines/collavre/app/services/collavre/tools/topic_message_create_service.rb
+++ b/engines/collavre/app/services/collavre/tools/topic_message_create_service.rb
@@ -42,6 +42,7 @@ module Tools
       principal = workspace_user(user)
 
       comment = create_comment(topic, content, user, principal)
+      dispatch_agent_message(comment, user, principal) if user.ai_user?
 
       serialize(comment)
     end
@@ -55,15 +56,13 @@ module Tools
         reject_closed_topic!(topic)
         reject_unrunnable_self_dispatch!(topic, user, principal)
 
-        comment = topic.comments.create!(
+        topic.comments.create!(
           creative: topic.creative,
           content: content,
           user: user,
           private: false,
           skip_dispatch: user.ai_user?
         )
-        dispatch_agent_message(comment, user, principal) if user.ai_user?
-        comment
       end
     end
 
@@ -106,11 +105,15 @@ module Tools
 
     def handle_selected_agents!(selected_agents, user, comment, principal)
       self_selected = selected_agents.any? { |agent| agent.id == user.id }
-      if self_selected && (comment.topic.primary_agent_id != user.id || principal.nil?)
+      if self_selected && principal.nil?
+        comment.destroy!
         raise ArgumentError, I18n.t("collavre.tools.topic_message_create.errors.self_route")
       end
 
       record_interactions(selected_agents, user, comment.creative_id)
+      return unless self_selected
+
+      { "sender" => SystemEvents::ContextBuilder.sender_context_for(principal) }
     end
 
     def record_interactions(selected_agents, user, creative_id)

--- a/engines/collavre/app/services/collavre/tools/topic_message_create_service.rb
+++ b/engines/collavre/app/services/collavre/tools/topic_message_create_service.rb
@@ -85,6 +85,8 @@ module Tools
     end
 
     def workspace_user(user)
+      return Current.workspace_user if Current.workspace_user_resolved
+
       creator = user.creator
       creator if creator && !creator.ai_user?
     end

--- a/engines/collavre/app/services/collavre/tools/topic_message_create_service.rb
+++ b/engines/collavre/app/services/collavre/tools/topic_message_create_service.rb
@@ -41,8 +41,8 @@ module Tools
       TopicAuthorizer.authorize_feedback!(topic, user: user)
       principal = workspace_user(user)
 
-      comment = create_comment(topic, content, user, principal)
-      dispatch_agent_message(comment, user, principal) if user.ai_user?
+      comment, selected_agents = create_comment(topic, content, user, principal)
+      dispatch_agent_message(comment, user, principal, selected_agents) if user.ai_user?
 
       serialize(comment)
     end
@@ -56,13 +56,17 @@ module Tools
         reject_closed_topic!(topic)
         reject_unrunnable_self_dispatch!(topic, user, principal)
 
-        topic.comments.create!(
+        comment = topic.comments.create!(
           creative: topic.creative,
           content: content,
           user: user,
           private: false,
           skip_dispatch: user.ai_user?
         )
+        selected_agents = preselect_agents(comment, principal) if user.ai_user?
+        reject_selected_self_route!(selected_agents, user, principal)
+
+        [ comment, selected_agents ]
       end
     end
 
@@ -87,33 +91,38 @@ module Tools
       raise ArgumentError, I18n.t("collavre.tools.topic_message_create.errors.current_topic")
     end
 
-    def dispatch_agent_message(comment, user, principal)
-      payload = comment.dispatch_payload.merge(workspace_user_id: principal&.id)
-      # A coordinator may fan itself out into two topic slots. Treat the
-      # carried human as that self-dispatch's sender so the downstream turn
-      # reports to the requester instead of @mentioning itself and opening a
-      # fresh A2A turn on completion.
-      if comment.topic.primary_agent_id == user.id && principal
-        payload[:sender] = SystemEvents::ContextBuilder.sender_context_for(principal)
+    def preselect_agents(comment, principal)
+      Orchestration::AgentOrchestrator.select("comment_created", dispatch_payload(comment, principal))
+    end
+
+    def dispatch_agent_message(comment, user, principal, selected_agents)
+      record_interactions(selected_agents, user, comment.creative_id)
+      context_for = lambda do |agent|
+        next {} unless agent.id == user.id && principal
+
+        { "sender" => SystemEvents::ContextBuilder.sender_context_for(principal) }
       end
-      parent = SystemEvents::Envelope.in(Current.agent_turn&.dig(:task)&.trigger_event_payload)
       SystemEvents::Dispatcher.dispatch(
-        "comment_created", payload, source: "a2a", parent: parent,
-        on_selected: ->(agents) { handle_selected_agents!(agents, user, comment, principal) }
+        "comment_created", dispatch_payload(comment, principal), source: "a2a",
+        parent: parent_envelope, selected_agents: selected_agents, context_for: context_for
       )
     end
 
-    def handle_selected_agents!(selected_agents, user, comment, principal)
+    def dispatch_payload(comment, principal)
+      comment.dispatch_payload.merge(workspace_user_id: principal&.id)
+    end
+
+    def reject_selected_self_route!(selected_agents, user, principal)
+      return if selected_agents.nil?
+
       self_selected = selected_agents.any? { |agent| agent.id == user.id }
-      if self_selected && principal.nil?
-        comment.destroy!
-        raise ArgumentError, I18n.t("collavre.tools.topic_message_create.errors.self_route")
-      end
+      return unless self_selected && principal.nil?
 
-      record_interactions(selected_agents, user, comment.creative_id)
-      return unless self_selected
+      raise ArgumentError, I18n.t("collavre.tools.topic_message_create.errors.self_route")
+    end
 
-      { "sender" => SystemEvents::ContextBuilder.sender_context_for(principal) }
+    def parent_envelope
+      SystemEvents::Envelope.in(Current.agent_turn&.dig(:task)&.trigger_event_payload)
     end
 
     def record_interactions(selected_agents, user, creative_id)

--- a/engines/collavre/app/services/collavre/tools/topic_message_create_service.rb
+++ b/engines/collavre/app/services/collavre/tools/topic_message_create_service.rb
@@ -41,8 +41,8 @@ module Tools
       TopicAuthorizer.authorize_feedback!(topic, user: user)
       principal = workspace_user(user)
 
-      comment, selected_agents = create_comment(topic, content, user, principal)
-      dispatch_agent_message(comment, user, principal, selected_agents) if user.ai_user?
+      comment, selection = create_comment(topic, content, user, principal)
+      dispatch_agent_message(comment, user, principal, selection) if user.ai_user?
 
       serialize(comment)
     end
@@ -63,10 +63,10 @@ module Tools
           private: false,
           skip_dispatch: user.ai_user?
         )
-        selected_agents = preselect_agents(comment, principal) if user.ai_user?
-        reject_selected_self_route!(selected_agents, user, principal)
+        selection = prepare_selection(comment, principal) if user.ai_user?
+        reject_selected_self_route!(selection&.agents, user, principal)
 
-        [ comment, selected_agents ]
+        [ comment, selection ]
       end
     end
 
@@ -91,20 +91,27 @@ module Tools
       raise ArgumentError, I18n.t("collavre.tools.topic_message_create.errors.current_topic")
     end
 
-    def preselect_agents(comment, principal)
-      Orchestration::AgentOrchestrator.select("comment_created", dispatch_payload(comment, principal))
+    def prepare_selection(comment, principal)
+      Orchestration::AgentOrchestrator.prepare_selection(
+        "comment_created", dispatch_payload(comment, principal)
+      )
     end
 
-    def dispatch_agent_message(comment, user, principal, selected_agents)
+    def dispatch_agent_message(comment, user, principal, selection)
+      selected_agents = selection.agents
       record_interactions(selected_agents, user, comment.creative_id)
       context_for = lambda do |agent|
         next {} unless agent.id == user.id && principal
 
         { "sender" => SystemEvents::ContextBuilder.sender_context_for(principal) }
       end
+      payload = dispatch_payload(comment, principal)
+      if selected_agents.any? { |agent| agent.id == user.id }
+        payload[Orchestration::DeferredTriggerScope::SELF_AUTHORED_COMMENT_ID_KEY] = comment.id
+      end
       SystemEvents::Dispatcher.dispatch(
-        "comment_created", dispatch_payload(comment, principal), source: "a2a",
-        parent: parent_envelope, selected_agents: selected_agents, context_for: context_for
+        "comment_created", payload, source: "a2a", parent: parent_envelope,
+        selection: selection, context_for: context_for
       )
     end
 

--- a/engines/collavre/config/locales/tools.en.yml
+++ b/engines/collavre/config/locales/tools.en.yml
@@ -1,0 +1,11 @@
+en:
+  collavre:
+    tools:
+      topic_message_create:
+        errors:
+          current_user_required: Current.user is required.
+          archived_creative: Archived creatives do not accept topic messages.
+          archived_topic: Archived topics do not accept messages.
+          system_topic: The inbox System topic does not accept user-authored messages.
+          current_topic: An agent cannot dispatch a topic message to its own current topic.
+          self_route: An agent cannot route an unpinned topic message back to itself.

--- a/engines/collavre/config/locales/tools.ko.yml
+++ b/engines/collavre/config/locales/tools.ko.yml
@@ -1,0 +1,11 @@
+ko:
+  collavre:
+    tools:
+      topic_message_create:
+        errors:
+          current_user_required: Current.user가 필요합니다.
+          archived_creative: 보관된 크리에이티브에는 토픽 메시지를 작성할 수 없습니다.
+          archived_topic: 보관된 토픽에는 메시지를 작성할 수 없습니다.
+          system_topic: 받은 편지함의 System 토픽에는 사용자가 메시지를 작성할 수 없습니다.
+          current_topic: 에이전트는 현재 처리 중인 토픽에 토픽 메시지를 전달할 수 없습니다.
+          self_route: 에이전트는 고정되지 않은 토픽 메시지를 자신에게 다시 라우팅할 수 없습니다.

--- a/engines/collavre/skills/collavre/SKILL.md
+++ b/engines/collavre/skills/collavre/SKILL.md
@@ -146,7 +146,9 @@ collavre tool run <tool_name> --key value         # run with flag args
 - **Starting topic work**: after creating and pinning a topic, call
   `topic_message_create` with its initial instruction. Agent-authored messages
   dispatch as A2A work, so one coordinating agent can start independent work in
-  several topics without impersonating a human.
+  several topics without impersonating a human. Do not call it on the same
+  primary-agent topic the caller is currently handling; continue that work in
+  the current turn instead.
 - **Progress**: Leaf = manual (0.0 or 1.0). Parent = auto-calculated from children.
 - **Import**: Markdown headings/bullets become nested Creatives.
 - **Batch**: All-or-nothing transaction. Requires approval.

--- a/engines/collavre/skills/collavre/SKILL.md
+++ b/engines/collavre/skills/collavre/SKILL.md
@@ -104,8 +104,14 @@ collavre tool run topic_messages --json '{"topic_ids": 12, "offset": 100, "curso
 # Continue inside one clipped message, preserving its row cursor
 collavre tool run topic_messages --json '{"topic_ids": 12, "offset": 100, "cursor": "1770000000000000:989:1770000001000000:1770000002000000", "content_offset": 28400, "max_message_id": 9931}'
 
-# Fan work out: one topic per unit of work, with an agent pinned to each
+# Fan work out: one topic per unit of work, with an agent pinned to each;
+# keep each returned topic id for the initial-message calls
 collavre tool run topic_create --json '{"creative_id": 8849, "name": "Research", "primary_agent": "Dev1Claude"}'
+collavre tool run topic_create --json '{"creative_id": 8849, "name": "Delivery", "primary_agent": "Dev1Claude"}'
+
+# Start the pinned agent independently in both topics
+collavre tool run topic_message_create --json '{"topic_id": 12, "content": "Research the API options and report your recommendation."}'
+collavre tool run topic_message_create --json '{"topic_id": 13, "content": "Build the selected approach and verify it."}'
 
 # Put a finished thread away (messages are kept and stay readable by id)
 collavre tool run topic_update --json '{"topic_id": 12, "archived": true}'
@@ -137,6 +143,10 @@ collavre tool run <tool_name> --key value         # run with flag args
 - **Primary agent**: pinning an agent to a topic is exclusive — that agent alone
   answers there. Use it for a dedicated 1:1 channel; leave it unset for a thread
   several participants should hear.
+- **Starting topic work**: after creating and pinning a topic, call
+  `topic_message_create` with its initial instruction. Agent-authored messages
+  dispatch as A2A work, so one coordinating agent can start independent work in
+  several topics without impersonating a human.
 - **Progress**: Leaf = manual (0.0 or 1.0). Parent = auto-calculated from children.
 - **Import**: Markdown headings/bullets become nested Creatives.
 - **Batch**: All-or-nothing transaction. Requires approval.

--- a/engines/collavre/skills/collavre/SKILL.md
+++ b/engines/collavre/skills/collavre/SKILL.md
@@ -146,9 +146,8 @@ collavre tool run <tool_name> --key value         # run with flag args
 - **Starting topic work**: after creating and pinning a topic, call
   `topic_message_create` with its initial instruction. Agent-authored messages
   dispatch as A2A work, so one coordinating agent can start independent work in
-  several topics without impersonating a human. Do not call it on the same
-  primary-agent topic the caller is currently handling; continue that work in
-  the current turn instead.
+  several topics without impersonating a human. Do not call it on the topic the
+  caller is currently handling; continue that work in the current turn instead.
 - **Progress**: Leaf = manual (0.0 or 1.0). Parent = auto-calculated from children.
 - **Import**: Markdown headings/bullets become nested Creatives.
 - **Batch**: All-or-nothing transaction. Requires approval.

--- a/engines/collavre/skills/collavre/references/tool-reference.md
+++ b/engines/collavre/skills/collavre/references/tool-reference.md
@@ -223,6 +223,26 @@ refused — a pinned agent that cannot answer would silence the topic entirely.
 Requires **write** on the Creative. Use `topic_branch` to copy messages instead
 of moving them.
 
+### topic_message_create
+
+Post one public message to an existing topic and run the topic's normal agent
+routing. This is the step that turns a newly created, pinned topic into active
+work.
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `topic_id` | Integer | **Yes** | Topic to post to |
+| `content` | String | **Yes** | Message body or initial instruction; Markdown is supported |
+
+The caller remains the visible author. Human-authored messages follow ordinary
+comment dispatch. Agent-authored messages dispatch as A2A work, so a coordinator
+can create several topics, pin a primary agent on each, then start them with
+independent instructions. Different topics can run concurrently; repeated
+messages in one topic follow that topic's queue.
+
+Requires **feedback** or better on the topic's Creative. Archived Creatives,
+archived topics, and an inbox's reserved System topic reject new messages.
+
 ### topic_update
 
 Rename, archive/unarchive, or re-pin a topic. Pass only what changes.

--- a/engines/collavre/skills/collavre/references/tool-reference.md
+++ b/engines/collavre/skills/collavre/references/tool-reference.md
@@ -240,6 +240,9 @@ can create several topics, pin a primary agent on each, then start them with
 independent instructions. Different topics can run concurrently; repeated
 messages in one topic follow that topic's queue.
 
+An agent cannot call this tool on the topic of its current turn. Continue that
+work in the current turn; use this tool to start work in a different topic.
+
 Requires **feedback** or better on the topic's Creative. Archived Creatives,
 archived topics, and an inbox's reserved System topic reject new messages.
 

--- a/engines/collavre/test/services/ai_agent_service_test.rb
+++ b/engines/collavre/test/services/ai_agent_service_test.rb
@@ -219,7 +219,8 @@ class AiAgentServiceTest < ActiveSupport::TestCase
     assert_equal @user, captured_context[:workspace_user]
     assert_not_equal upstream_agent, captured_context[:workspace_user]
     assert_equal @user, current_agent_turn[:user]
-    assert_equal parent, current_agent_turn[:parent]
+    assert_equal @task, current_agent_turn[:task]
+    assert_equal parent, Collavre::SystemEvents::Envelope.in(current_agent_turn[:task].trigger_event_payload)
     assert_nil Current.agent_turn
   end
 

--- a/engines/collavre/test/services/ai_agent_service_test.rb
+++ b/engines/collavre/test/services/ai_agent_service_test.rb
@@ -203,8 +203,12 @@ class AiAgentServiceTest < ActiveSupport::TestCase
     def mock_client.handed_off? = true
 
     captured_context = nil
+    current_workspace_user = nil
+    current_workspace_user_resolved = nil
     client_factory = lambda do |**options|
       captured_context = options[:context]
+      current_workspace_user = Current.workspace_user
+      current_workspace_user_resolved = Current.workspace_user_resolved
       mock_client
     end
 
@@ -214,6 +218,10 @@ class AiAgentServiceTest < ActiveSupport::TestCase
 
     assert_equal @user, captured_context[:workspace_user]
     assert_not_equal upstream_agent, captured_context[:workspace_user]
+    assert_equal @user, current_workspace_user
+    assert current_workspace_user_resolved
+    assert_nil Current.workspace_user
+    assert_nil Current.workspace_user_resolved
   end
 
   test "does not fall back to the creator for an explicitly cleared workspace principal" do
@@ -266,13 +274,22 @@ class AiAgentServiceTest < ActiveSupport::TestCase
     mock_client.define_singleton_method(:last_handoff_failed?) { false }
     mock_client.define_singleton_method(:handed_off?) { true }
     dispatched = nil
+    current_workspace_user = :unset
+    current_workspace_user_resolved = nil
+    client_factory = lambda do |**_options|
+      current_workspace_user = Current.workspace_user
+      current_workspace_user_resolved = Current.workspace_user_resolved
+      mock_client
+    end
 
     SystemEvents::Dispatcher.stub(:dispatch, ->(_event_name, payload, **_options) { dispatched = payload }) do
-      AiClient.stub(:new, mock_client) { AiAgentService.new(@task).call }
+      AiClient.stub(:new, client_factory) { AiAgentService.new(@task).call }
     end
 
     assert dispatched.key?(:workspace_user_id)
     assert_nil dispatched[:workspace_user_id]
+    assert_nil current_workspace_user
+    assert current_workspace_user_resolved
   end
 
   test "does not dispatch A2A when AI response mentions a human user" do

--- a/engines/collavre/test/services/ai_agent_service_test.rb
+++ b/engines/collavre/test/services/ai_agent_service_test.rb
@@ -186,12 +186,14 @@ class AiAgentServiceTest < ActiveSupport::TestCase
       topic: @comment.topic,
       skip_dispatch: true
     )
+    parent = Collavre::SystemEvents::Envelope.root("comment_created", source: "test")
     @task.update!(
       trigger_event_payload: {
         "comment" => { "id" => upstream_reply.id, "content" => upstream_reply.content },
         "creative" => { "id" => @creative.id },
         "topic" => { "id" => upstream_reply.topic_id },
-        "workspace_user_id" => @user.id
+        "workspace_user_id" => @user.id,
+        "event" => parent.to_h
       }
     )
 
@@ -203,12 +205,10 @@ class AiAgentServiceTest < ActiveSupport::TestCase
     def mock_client.handed_off? = true
 
     captured_context = nil
-    current_workspace_user = nil
-    current_workspace_user_resolved = nil
+    current_agent_turn = nil
     client_factory = lambda do |**options|
       captured_context = options[:context]
-      current_workspace_user = Current.workspace_user
-      current_workspace_user_resolved = Current.workspace_user_resolved
+      current_agent_turn = Current.agent_turn
       mock_client
     end
 
@@ -218,10 +218,9 @@ class AiAgentServiceTest < ActiveSupport::TestCase
 
     assert_equal @user, captured_context[:workspace_user]
     assert_not_equal upstream_agent, captured_context[:workspace_user]
-    assert_equal @user, current_workspace_user
-    assert current_workspace_user_resolved
-    assert_nil Current.workspace_user
-    assert_nil Current.workspace_user_resolved
+    assert_equal @user, current_agent_turn[:user]
+    assert_equal parent, current_agent_turn[:parent]
+    assert_nil Current.agent_turn
   end
 
   test "does not fall back to the creator for an explicitly cleared workspace principal" do
@@ -274,11 +273,9 @@ class AiAgentServiceTest < ActiveSupport::TestCase
     mock_client.define_singleton_method(:last_handoff_failed?) { false }
     mock_client.define_singleton_method(:handed_off?) { true }
     dispatched = nil
-    current_workspace_user = :unset
-    current_workspace_user_resolved = nil
+    current_agent_turn = nil
     client_factory = lambda do |**_options|
-      current_workspace_user = Current.workspace_user
-      current_workspace_user_resolved = Current.workspace_user_resolved
+      current_agent_turn = Current.agent_turn
       mock_client
     end
 
@@ -288,8 +285,7 @@ class AiAgentServiceTest < ActiveSupport::TestCase
 
     assert dispatched.key?(:workspace_user_id)
     assert_nil dispatched[:workspace_user_id]
-    assert_nil current_workspace_user
-    assert current_workspace_user_resolved
+    assert_nil current_agent_turn[:user]
   end
 
   test "does not dispatch A2A when AI response mentions a human user" do

--- a/engines/collavre/test/services/collavre/orchestration/agent_orchestrator_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/agent_orchestrator_test.rb
@@ -119,7 +119,8 @@ module Collavre
           Arbiter.stub(:new, arbiter) do
             Scheduler.stub(:new, scheduler) do
               AgentOrchestrator.dispatch(
-                "comment_created", context, on_selected: ->(agents) { selected = agents }
+                "comment_created", context,
+                on_selected: ->(agents) { selected = agents; nil }
               )
             end
           end

--- a/engines/collavre/test/services/collavre/orchestration/agent_orchestrator_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/agent_orchestrator_test.rb
@@ -117,6 +117,31 @@ module Collavre
         end
       end
 
+      test "reports only scheduler-accepted agents before enqueue" do
+        accepted = @ai_agent
+        rejected = User.create!(
+          email: "rejected_scheduled_agent@example.com", name: "Rejected Scheduled Agent",
+          password: "password", llm_vendor: "google", llm_model: "gemini-1.5-flash"
+        )
+        scheduler = Object.new
+        scheduler.define_singleton_method(:schedule) do |_agents|
+          [
+            { agent: accepted, timing: :immediate },
+            { agent: rejected, timing: :rejected, reason: :quota_exceeded }
+          ]
+        end
+        scheduled = nil
+
+        Scheduler.stub(:new, scheduler) do
+          AgentOrchestrator.dispatch(
+            "comment_created", { "creative" => { "id" => @creative.id } },
+            selected_agents: [ accepted, rejected ], on_scheduled: ->(agents) { scheduled = agents }
+          )
+        end
+
+        assert_equal [ accepted ], scheduled
+      end
+
       # Deferred enqueue
       test "deferred decision creates queued task" do
         topic = Topic.create!(name: "Test Topic", creative: @creative, user: @user)

--- a/engines/collavre/test/services/collavre/orchestration/agent_orchestrator_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/agent_orchestrator_test.rb
@@ -94,6 +94,40 @@ module Collavre
         assert_empty result
       end
 
+      test "reports agents after arbitration before scheduling" do
+        other_agent = User.create!(
+          email: "dispatcher_other_agent@example.com",
+          name: "Dispatcher Other Agent",
+          password: "password",
+          llm_vendor: "google",
+          llm_model: "gemini-1.5-flash",
+          searchable: true
+        )
+        context = { "creative" => { "id" => @creative.id } }
+        selected_agent = @ai_agent
+        matcher = Object.new
+        matcher.define_singleton_method(:match) { [ selected_agent, other_agent ] }
+        arbiter = Object.new
+        arbiter.define_singleton_method(:select) { |_candidates| [ selected_agent ] }
+        scheduler = Object.new
+        scheduler.define_singleton_method(:schedule) do |agents|
+          agents.map { |agent| { agent: agent, timing: :rejected, reason: :test } }
+        end
+        selected = nil
+
+        Matcher.stub(:new, matcher) do
+          Arbiter.stub(:new, arbiter) do
+            Scheduler.stub(:new, scheduler) do
+              AgentOrchestrator.dispatch(
+                "comment_created", context, on_selected: ->(agents) { selected = agents }
+              )
+            end
+          end
+        end
+
+        assert_equal [ @ai_agent ], selected
+      end
+
       # Deferred enqueue
       test "deferred decision creates queued task" do
         topic = Topic.create!(name: "Test Topic", creative: @creative, user: @user)

--- a/engines/collavre/test/services/collavre/orchestration/agent_orchestrator_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/agent_orchestrator_test.rb
@@ -94,7 +94,7 @@ module Collavre
         assert_empty result
       end
 
-      test "reports agents after arbitration before scheduling" do
+      test "selects agents after arbitration without scheduling" do
         other_agent = User.create!(
           email: "dispatcher_other_agent@example.com",
           name: "Dispatcher Other Agent",
@@ -109,24 +109,11 @@ module Collavre
         matcher.define_singleton_method(:match) { [ selected_agent, other_agent ] }
         arbiter = Object.new
         arbiter.define_singleton_method(:select) { |_candidates| [ selected_agent ] }
-        scheduler = Object.new
-        scheduler.define_singleton_method(:schedule) do |agents|
-          agents.map { |agent| { agent: agent, timing: :rejected, reason: :test } }
-        end
-        selected = nil
-
         Matcher.stub(:new, matcher) do
           Arbiter.stub(:new, arbiter) do
-            Scheduler.stub(:new, scheduler) do
-              AgentOrchestrator.dispatch(
-                "comment_created", context,
-                on_selected: ->(agents) { selected = agents; nil }
-              )
-            end
+            assert_equal [ @ai_agent ], AgentOrchestrator.select("comment_created", context)
           end
         end
-
-        assert_equal [ @ai_agent ], selected
       end
 
       # Deferred enqueue

--- a/engines/collavre/test/services/collavre/orchestration/agent_orchestrator_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/agent_orchestrator_test.rb
@@ -108,7 +108,8 @@ module Collavre
         matcher = Object.new
         matcher.define_singleton_method(:match) { [ selected_agent, other_agent ] }
         arbiter = Object.new
-        arbiter.define_singleton_method(:select) { |_candidates| [ selected_agent ] }
+        arbiter.define_singleton_method(:select) { |_candidates, **| [ selected_agent ] }
+        arbiter.define_singleton_method(:commit_selection!) { }
         Matcher.stub(:new, matcher) do
           Arbiter.stub(:new, arbiter) do
             assert_equal [ @ai_agent ], AgentOrchestrator.select("comment_created", context)

--- a/engines/collavre/test/services/collavre/orchestration/agent_orchestrator_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/agent_orchestrator_test.rb
@@ -124,7 +124,7 @@ module Collavre
           password: "password", llm_vendor: "google", llm_model: "gemini-1.5-flash"
         )
         scheduler = Object.new
-        scheduler.define_singleton_method(:schedule) do |_agents|
+        scheduler.define_singleton_method(:schedule) do |_agents, **_options|
           [
             { agent: accepted, timing: :immediate },
             { agent: rejected, timing: :rejected, reason: :quota_exceeded }
@@ -133,9 +133,12 @@ module Collavre
         scheduled = nil
 
         Scheduler.stub(:new, scheduler) do
+          hooks = SchedulingHooks.new(
+            interaction_callback: nil, scheduled_callback: ->(agents) { scheduled = agents }
+          )
           AgentOrchestrator.dispatch(
             "comment_created", { "creative" => { "id" => @creative.id } },
-            selected_agents: [ accepted, rejected ], on_scheduled: ->(agents) { scheduled = agents }
+            selected_agents: [ accepted, rejected ], scheduling_hooks: hooks
           )
         end
 

--- a/engines/collavre/test/services/collavre/orchestration/arbiter_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/arbiter_test.rb
@@ -185,6 +185,25 @@ module Collavre
         assert_equal [ @agent1 ], selected
       end
 
+      test "round_robin can defer its cache update until selection commits" do
+        OrchestratorPolicy.create!(
+          policy_type: "arbitration",
+          config: { "strategy" => "round_robin" }
+        )
+        cache_key = "orchestrator:round_robin:topic:#{@topic.id}"
+        Rails.cache.delete(cache_key)
+        arbiter = Arbiter.new(@context)
+
+        selected = arbiter.select(@candidates, commit: false)
+
+        assert_equal [ @agent1 ], selected
+        assert_nil Rails.cache.read(cache_key)
+
+        arbiter.commit_selection!
+
+        assert_equal @agent1.id, Rails.cache.read(cache_key)
+      end
+
       # Edge cases
       test "returns empty array for empty candidates" do
         arbiter = Arbiter.new(@context)

--- a/engines/collavre/test/services/collavre/orchestration/loop_breaker_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/loop_breaker_test.rb
@@ -90,6 +90,25 @@ module Collavre
         assert result.safe?
       end
 
+      test "checks a prospective interaction without recording it" do
+        create_policy(@enabled_config)
+        resolver = PolicyResolver.new(@context)
+        breaker = LoopBreaker.new(@context, policy_resolver: resolver)
+        breaker.record_interaction(@agent1.id, @agent2.id, @creative.id)
+        breaker.record_interaction(@agent2.id, @agent1.id, @creative.id)
+        breaker.record_interaction(@agent1.id, @agent2.id, @creative.id)
+
+        result = breaker.check(
+          prospective_interaction: {
+            from_agent_id: @agent2.id, to_agent_id: @agent1.id, creative_id: @creative.id
+          }
+        )
+
+        assert result.should_break?
+        assert_equal :ping_pong, result.reason
+        assert breaker.check.safe?
+      end
+
       test "detects creative retry exceeded" do
         policy = create_policy(@enabled_config)
         resolver = PolicyResolver.new(@context)

--- a/engines/collavre/test/services/collavre/orchestration/scheduler_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/scheduler_test.rb
@@ -113,6 +113,27 @@ module Collavre
         assert_equal :immediate, decisions.first[:timing]
       end
 
+      test "checks a prospective handoff before accepting the schedule" do
+        OrchestratorPolicy.create!(
+          policy_type: "scheduling",
+          config: { "loop_breaker_enabled" => true, "ping_pong_threshold" => 1 }
+        )
+        breaker = LoopBreaker.new(@context)
+        breaker.record_interaction(@agent.id, @user.id, @creative.id)
+        hooks = SchedulingHooks.new(
+          interaction_callback: lambda do |_agent|
+            { from_agent_id: @user.id, to_agent_id: @agent.id, creative_id: @creative.id }
+          end,
+          scheduled_callback: nil
+        )
+
+        decisions = Scheduler.new(@context).schedule([ @agent ], scheduling_hooks: hooks)
+
+        assert_equal :rejected, decisions.first[:timing]
+        assert_equal :loop_detected, decisions.first[:reason]
+        assert breaker.check.safe?
+      end
+
       # Rate limiting
       test "delays when rate limited" do
         OrchestratorPolicy.create!(

--- a/engines/collavre/test/services/collavre/tools/topic_message_create_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/topic_message_create_service_test.rb
@@ -32,6 +32,7 @@ module Collavre
 
         SystemEvents::Dispatcher.stub(:dispatch, ->(event, payload, **options) {
           events << [ event, payload, options ]
+          []
         }) do
           service.call(topic_id: @topic.id, content: "Human instruction")
         end
@@ -59,6 +60,7 @@ module Collavre
 
         SystemEvents::Dispatcher.stub(:dispatch, ->(event, payload, **options) {
           events << [ event, payload, options ]
+          [ worker ]
         }) do
           topics.each do |topic|
             service.call(topic_id: topic[:id], content: "Continue #{topic[:name]} independently.")
@@ -88,7 +90,10 @@ module Collavre
         end
         events = []
 
-        SystemEvents::Dispatcher.stub(:dispatch, ->(_event, payload, **_options) { events << payload }) do
+        SystemEvents::Dispatcher.stub(:dispatch, ->(_event, payload, **_options) {
+          events << payload
+          [ coordinator ]
+        }) do
           topics.each do |topic|
             service.call(topic_id: topic[:id], content: "Continue #{topic[:name]} independently.")
           end
@@ -109,7 +114,10 @@ module Collavre
         Current.agent_turn = { user: nil, task: nil }
         payload = nil
 
-        SystemEvents::Dispatcher.stub(:dispatch, ->(_event, context, **_options) { payload = context }) do
+        SystemEvents::Dispatcher.stub(:dispatch, ->(_event, context, **_options) {
+          payload = context
+          []
+        }) do
           service.call(topic_id: @topic.id, content: "Agent instruction")
         end
 
@@ -124,7 +132,10 @@ module Collavre
         Current.agent_turn = { user: @reader, task: nil }
         payload = nil
 
-        SystemEvents::Dispatcher.stub(:dispatch, ->(_event, context, **_options) { payload = context }) do
+        SystemEvents::Dispatcher.stub(:dispatch, ->(_event, context, **_options) {
+          payload = context
+          []
+        }) do
           service.call(topic_id: @topic.id, content: "Carried instruction")
         end
 
@@ -140,7 +151,10 @@ module Collavre
         Current.agent_turn = { user: @reader, task: task }
         dispatch_options = nil
 
-        SystemEvents::Dispatcher.stub(:dispatch, ->(_event, _context, **options) { dispatch_options = options }) do
+        SystemEvents::Dispatcher.stub(:dispatch, ->(_event, _context, **options) {
+          dispatch_options = options
+          []
+        }) do
           service.call(topic_id: @topic.id, content: "Child instruction")
         end
 
@@ -180,18 +194,27 @@ module Collavre
       test "records tool-created A2A interactions for the selected agent" do
         coordinator = create_agent("Interaction Coordinator", creator: @owner)
         worker = create_agent("Interaction Worker", creator: @owner)
+        unselected = create_agent("Unselected Worker", creator: @owner)
         share!(coordinator, :feedback)
         share!(worker, :feedback)
-        @topic.update!(primary_agent: worker)
+        share!(unselected, :feedback)
         Current.user = coordinator
         Current.agent_turn = { user: @owner, task: running_task(coordinator, @creative.main_topic) }
         interactions = []
         breaker = Object.new
         breaker.define_singleton_method(:record_interaction) { |*args| interactions << args }
+        matcher = Object.new
+        matcher.define_singleton_method(:match) { [ worker, unselected ] }
 
         Orchestration::LoopBreaker.stub(:new, ->(_context) { breaker }) do
-          SystemEvents::Dispatcher.stub(:dispatch, nil) do
-            service.call(topic_id: @topic.id, content: "Track this handoff")
+          Orchestration::Matcher.stub(:new, matcher) do
+            dispatcher = lambda do |_event, _payload, **options|
+              options.fetch(:on_selected).call([ worker ])
+              [ worker ]
+            end
+            SystemEvents::Dispatcher.stub(:dispatch, dispatcher) do
+              service.call(topic_id: @topic.id, content: "Track this handoff")
+            end
           end
         end
 

--- a/engines/collavre/test/services/collavre/tools/topic_message_create_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/topic_message_create_service_test.rb
@@ -1,0 +1,204 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  module Tools
+    class TopicMessageCreateServiceTest < ActiveSupport::TestCase
+      setup do
+        @owner = users(:one)
+        @reader = users(:two)
+        @creative = Creative.create!(description: "Message Host", user: @owner)
+        @topic = @creative.topics.create!(name: "Work", user: @owner)
+        Current.user = @owner
+      end
+
+      teardown { Current.user = nil }
+
+      test "posts a public message and returns its identity" do
+        result = service.call(topic_id: @topic.id, content: "Start with the API contract.")
+        comment = Comment.find(result[:id])
+
+        assert_equal @topic.id, result[:topic_id]
+        assert_equal @creative.id, result[:creative_id]
+        assert_equal "Start with the API contract.", result[:content]
+        assert_equal({ id: @owner.id, name: @owner.display_name }, result[:author])
+        assert_equal @owner, comment.user
+        assert_not comment.private?
+      end
+
+      test "uses normal comment dispatch exactly once for a human author" do
+        events = []
+
+        SystemEvents::Dispatcher.stub(:dispatch, ->(event, payload, **options) {
+          events << [ event, payload, options ]
+        }) do
+          service.call(topic_id: @topic.id, content: "Human instruction")
+        end
+
+        assert_equal 1, events.size
+        assert_equal "comment_created", events.first[0]
+        assert_equal "comment_callback", events.first[2][:source]
+      end
+
+      test "an agent can create two pinned topics and start both with A2A instructions" do
+        coordinator = create_agent("Coordinator", creator: @owner)
+        worker = create_agent("Primary Worker", creator: @owner)
+        share!(coordinator, :write)
+        share!(worker, :feedback)
+        Current.user = coordinator
+
+        topics = %w[Research Delivery].map do |name|
+          TopicCreateService.new.call(
+            creative_id: @creative.id,
+            name: name,
+            primary_agent: worker.id.to_s
+          )
+        end
+        events = []
+
+        SystemEvents::Dispatcher.stub(:dispatch, ->(event, payload, **options) {
+          events << [ event, payload, options ]
+        }) do
+          topics.each do |topic|
+            service.call(topic_id: topic[:id], content: "Continue #{topic[:name]} independently.")
+          end
+        end
+
+        assert_equal topics.pluck(:id), events.map { |event| event[1].dig(:topic, :id) }
+        assert events.all? { |event| event[0] == "comment_created" && event[2][:source] == "a2a" }
+        assert events.all? { |event| event[1][:workspace_user_id] == @owner.id }
+        assert events.all? do |event|
+          context = SystemEvents::ContextBuilder.new(event[1]).build
+          Orchestration::Matcher.new(context).match == [ worker ]
+        end
+      end
+
+      test "an agent can pin itself to two topics without creating a self-handoff loop" do
+        coordinator = create_agent("Self Coordinator", creator: @owner)
+        share!(coordinator, :write)
+        Current.user = coordinator
+        topics = %w[TrackOne TrackTwo].map do |name|
+          TopicCreateService.new.call(
+            creative_id: @creative.id,
+            name: name,
+            primary_agent: coordinator.id.to_s
+          )
+        end
+        events = []
+
+        SystemEvents::Dispatcher.stub(:dispatch, ->(_event, payload, **_options) { events << payload }) do
+          topics.each do |topic|
+            service.call(topic_id: topic[:id], content: "Continue #{topic[:name]} independently.")
+          end
+        end
+
+        assert_equal topics.pluck(:id), events.map { |event| event.dig(:topic, :id) }
+        assert events.all? { |event| event.dig(:sender, "id") == @owner.id }
+        assert events.all? do |event|
+          context = SystemEvents::ContextBuilder.new(event).build
+          Orchestration::Matcher.new(context).match == [ coordinator ] && context.dig("sender", "is_ai") == false
+        end
+      end
+
+      test "an agent without a human creator carries an explicitly empty workspace principal" do
+        coordinator = create_agent("Unowned Coordinator", creator: nil)
+        share!(coordinator, :feedback)
+        Current.user = coordinator
+        payload = nil
+
+        SystemEvents::Dispatcher.stub(:dispatch, ->(_event, context, **_options) { payload = context }) do
+          service.call(topic_id: @topic.id, content: "Agent instruction")
+        end
+
+        assert payload.key?(:workspace_user_id)
+        assert_nil payload[:workspace_user_id]
+      end
+
+      test "feedback permission can post but read permission cannot" do
+        share!(@reader, :feedback)
+        Current.user = @reader
+
+        assert service.call(topic_id: @topic.id, content: "Feedback")[:id]
+
+        CreativeShare.find_by!(creative: @creative, user: @reader).update!(permission: :read)
+        assert_raises(PermissionDeniedError) do
+          service.call(topic_id: @topic.id, content: "Not allowed")
+        end
+      end
+
+      test "reauthorizes after locking a topic moved to an inaccessible creative" do
+        restricted = Creative.create!(description: "Restricted", user: @reader)
+        lock_after_move = lambda do
+          @topic.update_column(:creative_id, restricted.id)
+          @topic.reload
+        end
+
+        Topic.stub(:find, @topic) do
+          @topic.stub(:lock!, lock_after_move) do
+            assert_raises(PermissionDeniedError) do
+              service.call(topic_id: @topic.id, content: "Do not leak")
+            end
+          end
+        end
+
+        assert_not Comment.exists?(content: "Do not leak")
+      end
+
+      test "rejects blank content without creating a message" do
+        assert_raises(ActiveRecord::RecordInvalid) do
+          service.call(topic_id: @topic.id, content: "   ")
+        end
+
+        assert_not Comment.exists?(topic: @topic, content: "   ")
+      end
+
+      test "rejects archived topics and creatives" do
+        @topic.archive!
+        assert_raises(ArgumentError) { service.call(topic_id: @topic.id, content: "Closed") }
+
+        @topic.unarchive!
+        @creative.update!(archived_at: Time.current)
+        assert_raises(ArgumentError) { service.call(topic_id: @topic.id, content: "Closed creative") }
+      end
+
+      test "rejects the inbox System topic" do
+        inbox = Creative.create!(description: "Inbox", user: @owner, data: { "kind" => "inbox" })
+
+        error = assert_raises(ArgumentError) do
+          service.call(topic_id: inbox.system_topic.id, content: "Not a notification")
+        end
+
+        assert_includes error.message, "System topic"
+      end
+
+      test "requires a current user" do
+        Current.user = nil
+
+        assert_raises(RuntimeError) { service.call(topic_id: @topic.id, content: "No author") }
+      end
+
+      private
+
+      def service
+        TopicMessageCreateService.new
+      end
+
+      def create_agent(name, creator:)
+        User.create!(
+          name: name,
+          email: "#{name.parameterize}-#{SecureRandom.hex(4)}@test.test",
+          password: "password123",
+          llm_vendor: "google",
+          llm_model: "gemini-1.5-flash",
+          searchable: true,
+          creator: creator
+        )
+      end
+
+      def share!(user, permission)
+        CreativeShare.create!(creative: @creative, user: user, permission: permission, shared_by: @owner)
+      end
+    end
+  end
+end

--- a/engines/collavre/test/services/collavre/tools/topic_message_create_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/topic_message_create_service_test.rb
@@ -148,6 +148,7 @@ module Collavre
         Current.user = coordinator
         parent = SystemEvents::Envelope.root("comment_created", source: "test")
         task = running_task(coordinator, @topic, parent: parent)
+        destination = @creative.topics.create!(name: "Envelope Destination", user: @owner)
         Current.agent_turn = { user: @reader, task: task }
         dispatch_options = nil
 
@@ -155,7 +156,7 @@ module Collavre
           dispatch_options = options
           []
         }) do
-          service.call(topic_id: @topic.id, content: "Child instruction")
+          service.call(topic_id: destination.id, content: "Child instruction")
         end
 
         assert_equal parent, dispatch_options[:parent]
@@ -189,6 +190,21 @@ module Collavre
 
         assert_match(/cannot dispatch a topic message to its own current topic/, error.message)
         assert_not Comment.exists?(topic: @topic, content: "Queue behind myself")
+      end
+
+      test "an agent cannot self-route in its unpinned current topic" do
+        coordinator = create_agent("Expression Coordinator", creator: @owner)
+        coordinator.update!(routing_expression: "true")
+        share!(coordinator, :feedback)
+        Current.user = coordinator
+        Current.agent_turn = { user: @owner, task: running_task(coordinator, @topic) }
+
+        error = assert_raises(ArgumentError) do
+          service.call(topic_id: @topic.id, content: "Route back to my expression")
+        end
+
+        assert_match(/cannot dispatch a topic message to its own current topic/, error.message)
+        assert_not Comment.exists?(topic: @topic, content: "Route back to my expression")
       end
 
       test "records tool-created A2A interactions for the selected agent" do

--- a/engines/collavre/test/services/collavre/tools/topic_message_create_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/topic_message_create_service_test.rb
@@ -207,25 +207,47 @@ module Collavre
         assert_not Comment.exists?(topic: @topic, content: "Route back to my expression")
       end
 
-      test "an agent cannot self-route in a different unpinned topic" do
+      test "an agent uses its carried human when self-routed in a different unpinned topic" do
         coordinator = create_agent("Destination Coordinator", creator: @owner)
         coordinator.update!(routing_expression: "true")
         share!(coordinator, :feedback)
         destination = @creative.topics.create!(name: "Unpinned Destination", user: @owner)
         Current.user = coordinator
         Current.agent_turn = { user: @owner, task: running_task(coordinator, @topic) }
+        sender = nil
+        dispatcher = lambda do |_event, _payload, **options|
+          override = options.fetch(:on_selected).call([ coordinator ])
+          sender = override.fetch("sender")
+          [ coordinator ]
+        end
+
+        result = SystemEvents::Dispatcher.stub(:dispatch, dispatcher) do
+          service.call(topic_id: destination.id, content: "Route back from another topic")
+        end
+
+        assert_equal @owner.id, sender["id"]
+        assert Comment.exists?(id: result[:id], topic: destination)
+      end
+
+      test "an agent without a principal cannot self-route in a different unpinned topic" do
+        coordinator = create_agent("Principal-less Destination Coordinator", creator: @owner)
+        coordinator.update!(routing_expression: "true")
+        share!(coordinator, :feedback)
+        destination = @creative.topics.create!(name: "Principal-less Destination", user: @owner)
+        Current.user = coordinator
+        Current.agent_turn = { user: nil, task: running_task(coordinator, @topic) }
         dispatcher = lambda do |_event, _payload, **options|
           options.fetch(:on_selected).call([ coordinator ])
         end
 
         error = SystemEvents::Dispatcher.stub(:dispatch, dispatcher) do
           assert_raises(ArgumentError) do
-            service.call(topic_id: destination.id, content: "Route back from another topic")
+            service.call(topic_id: destination.id, content: "Unsafe self route")
           end
         end
 
         assert_equal I18n.t("collavre.tools.topic_message_create.errors.self_route"), error.message
-        assert_not Comment.exists?(topic: destination, content: "Route back from another topic")
+        assert_not Comment.exists?(topic: destination, content: "Unsafe self route")
       end
 
       test "does not count self-pinned fan-out as a ping-pong interaction" do

--- a/engines/collavre/test/services/collavre/tools/topic_message_create_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/topic_message_create_service_test.rb
@@ -240,7 +240,7 @@ module Collavre
         error = CommentNotificationJob.stub(:perform_later, recorder) do
           CommentBadgesBroadcastJob.stub(:perform_later, recorder) do
             Turbo::Streams::BroadcastJob.stub(:perform_later, recorder) do
-              Orchestration::AgentOrchestrator.stub(:select, [ coordinator ]) do
+              Orchestration::AgentOrchestrator.stub(:prepare_selection, selection_for(coordinator)) do
                 assert_raises(ArgumentError) do
                   service.call(topic_id: destination.id, content: "Unsafe self route")
                 end
@@ -269,7 +269,7 @@ module Collavre
         dispatcher = ->(_event, _payload, **_options) { [ coordinator ] }
 
         Orchestration::LoopBreaker.stub(:new, ->(_context) { breaker }) do
-          Orchestration::AgentOrchestrator.stub(:select, [ coordinator ]) do
+          Orchestration::AgentOrchestrator.stub(:prepare_selection, selection_for(coordinator)) do
             SystemEvents::Dispatcher.stub(:dispatch, dispatcher) do
               service.call(topic_id: destination.id, content: "Start independent work")
             end
@@ -277,6 +277,55 @@ module Collavre
         end
 
         assert_empty interactions
+      end
+
+      test "keeps a deliberate self-routed instruction eligible while deferred" do
+        coordinator = create_agent("Deferred Coordinator", creator: @owner)
+        blocker = create_agent("Deferred Blocker", creator: @owner)
+        share!(coordinator, :feedback)
+        share!(blocker, :feedback)
+        destination = @creative.topics.create!(
+          name: "Occupied Destination", user: @owner, primary_agent: coordinator
+        )
+        Task.create!(
+          name: "Destination blocker", status: "running", trigger_event_name: "comment_created",
+          trigger_event_payload: {}, agent: blocker, topic_id: destination.id, creative: @creative
+        )
+        Current.user = coordinator
+        Current.agent_turn = { user: @owner, task: running_task(coordinator, @topic) }
+
+        result = service.call(topic_id: destination.id, content: "Run after the blocker")
+        waiter = Task.find_by!(status: "queued", agent: coordinator, topic_id: destination.id)
+
+        Orchestration::AgentOrchestrator.send(:refresh_deferred_context!, waiter)
+
+        assert_equal "queued", waiter.reload.status
+        assert_equal result[:id], waiter.trigger_event_payload.dig("comment", "id")
+      end
+
+      test "does not advance round robin when a principal-less self-route is rejected" do
+        coordinator = create_agent("Round Robin Coordinator", creator: @owner)
+        worker = create_agent("Round Robin Worker", creator: @owner)
+        share!(coordinator, :feedback)
+        share!(worker, :feedback)
+        destination = @creative.topics.create!(name: "Round Robin Destination", user: @owner)
+        Current.user = coordinator
+        Current.agent_turn = { user: nil, task: running_task(coordinator, @topic) }
+        OrchestratorPolicy.create!(
+          policy_type: "arbitration", config: { "strategy" => "round_robin" }
+        )
+        cache_key = "orchestrator:round_robin:topic:#{destination.id}"
+        Rails.cache.delete(cache_key)
+        matcher = Object.new
+        matcher.define_singleton_method(:match) { [ coordinator, worker ] }
+
+        Orchestration::Matcher.stub(:new, matcher) do
+          assert_raises(ArgumentError) do
+            service.call(topic_id: destination.id, content: "Rejected rotation")
+          end
+        end
+
+        assert_nil Rails.cache.read(cache_key)
       end
 
       test "records tool-created A2A interactions for the selected agent" do
@@ -292,7 +341,7 @@ module Collavre
         breaker = Object.new
         breaker.define_singleton_method(:record_interaction) { |*args| interactions << args }
         Orchestration::LoopBreaker.stub(:new, ->(_context) { breaker }) do
-          Orchestration::AgentOrchestrator.stub(:select, [ worker ]) do
+          Orchestration::AgentOrchestrator.stub(:prepare_selection, selection_for(worker)) do
             dispatcher = ->(_event, _payload, **_options) { [ worker ] }
             SystemEvents::Dispatcher.stub(:dispatch, dispatcher) do
               service.call(topic_id: @topic.id, content: "Track this handoff")
@@ -321,7 +370,9 @@ module Collavre
           [ coordinator, worker ]
         end
 
-        Orchestration::AgentOrchestrator.stub(:select, [ coordinator, worker ]) do
+        Orchestration::AgentOrchestrator.stub(
+          :prepare_selection, selection_for(coordinator, worker)
+        ) do
           SystemEvents::Dispatcher.stub(:dispatch, dispatcher) do
             service.call(topic_id: destination.id, content: "Coordinate and review")
           end
@@ -444,6 +495,10 @@ module Collavre
           topic_id: topic.id,
           creative_id: topic.creative_id
         )
+      end
+
+      def selection_for(*agents)
+        Struct.new(:agents) { def commit! = self }.new(agents)
       end
 
       def share!(user, permission)

--- a/engines/collavre/test/services/collavre/tools/topic_message_create_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/topic_message_create_service_test.rb
@@ -414,7 +414,7 @@ module Collavre
         Orchestration::LoopBreaker.stub(:new, ->(_context) { breaker }) do
           Orchestration::AgentOrchestrator.stub(:prepare_selection, selection_for(worker)) do
             dispatcher = lambda do |_event, _payload, **options|
-              options.fetch(:on_scheduled).call([ worker ])
+              options.fetch(:scheduling_hooks).scheduled([ worker ])
               [ worker ]
             end
             SystemEvents::Dispatcher.stub(:dispatch, dispatcher) do
@@ -424,6 +424,33 @@ module Collavre
         end
 
         assert_equal [ [ coordinator.id, worker.id, @creative.id ] ], interactions
+      end
+
+      test "exposes the current handoff to scheduling before recording it" do
+        coordinator = create_agent("Prospective Coordinator", creator: @owner)
+        worker = create_agent("Prospective Worker", creator: @owner)
+        share!(coordinator, :feedback)
+        share!(worker, :feedback)
+        Current.user = coordinator
+        Current.agent_turn = { user: @owner, task: running_task(coordinator, @creative.main_topic) }
+        prospective = nil
+        dispatcher = lambda do |_event, _payload, **options|
+          hooks = options.fetch(:scheduling_hooks)
+          prospective = hooks.interaction_for(worker)
+          hooks.scheduled([ worker ])
+          [ worker ]
+        end
+
+        Orchestration::AgentOrchestrator.stub(:prepare_selection, selection_for(worker)) do
+          SystemEvents::Dispatcher.stub(:dispatch, dispatcher) do
+            service.call(topic_id: @topic.id, content: "Check this handoff before scheduling")
+          end
+        end
+
+        assert_equal(
+          { from_agent_id: coordinator.id, to_agent_id: worker.id, creative_id: @creative.id },
+          prospective
+        )
       end
 
       test "does not record interactions for scheduler-rejected agents" do
@@ -437,7 +464,7 @@ module Collavre
         breaker = Object.new
         breaker.define_singleton_method(:record_interaction) { |*args| interactions << args }
         dispatcher = lambda do |_event, _payload, **options|
-          options.fetch(:on_scheduled).call([])
+          options.fetch(:scheduling_hooks).scheduled([])
           []
         end
 

--- a/engines/collavre/test/services/collavre/tools/topic_message_create_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/topic_message_create_service_test.rb
@@ -209,7 +209,7 @@ module Collavre
 
       test "an agent uses its carried human when self-routed in a different unpinned topic" do
         coordinator = create_agent("Destination Coordinator", creator: @owner)
-        coordinator.update!(routing_expression: "true")
+        coordinator.update!(routing_expression: "sender.is_ai == false")
         share!(coordinator, :feedback)
         destination = @creative.topics.create!(name: "Unpinned Destination", user: @owner)
         Current.user = coordinator
@@ -226,6 +226,26 @@ module Collavre
 
         assert_equal @owner.id, sender["id"]
         assert Comment.exists?(id: result[:id], topic: destination)
+      end
+
+      test "does not self-route when the delivered human sender fails the expression" do
+        coordinator = create_agent("AI Sender Coordinator", creator: @owner)
+        coordinator.update!(routing_expression: "sender.is_ai == true")
+        share!(coordinator, :feedback)
+        destination = @creative.topics.create!(name: "Humanized Destination", user: @owner)
+        Current.user = coordinator
+        Current.agent_turn = { user: @owner, task: running_task(coordinator, @topic) }
+        selected = nil
+        dispatcher = lambda do |_event, _payload, **options|
+          selected = options.fetch(:selection).agents
+          []
+        end
+
+        SystemEvents::Dispatcher.stub(:dispatch, dispatcher) do
+          service.call(topic_id: destination.id, content: "Only route for an AI sender")
+        end
+
+        assert_not_includes selected, coordinator
       end
 
       test "an agent without a principal cannot self-route in a different unpinned topic" do
@@ -342,7 +362,10 @@ module Collavre
         breaker.define_singleton_method(:record_interaction) { |*args| interactions << args }
         Orchestration::LoopBreaker.stub(:new, ->(_context) { breaker }) do
           Orchestration::AgentOrchestrator.stub(:prepare_selection, selection_for(worker)) do
-            dispatcher = ->(_event, _payload, **_options) { [ worker ] }
+            dispatcher = lambda do |_event, _payload, **options|
+              options.fetch(:on_scheduled).call([ worker ])
+              [ worker ]
+            end
             SystemEvents::Dispatcher.stub(:dispatch, dispatcher) do
               service.call(topic_id: @topic.id, content: "Track this handoff")
             end
@@ -350,6 +373,32 @@ module Collavre
         end
 
         assert_equal [ [ coordinator.id, worker.id, @creative.id ] ], interactions
+      end
+
+      test "does not record interactions for scheduler-rejected agents" do
+        coordinator = create_agent("Rejected Coordinator", creator: @owner)
+        worker = create_agent("Rejected Worker", creator: @owner)
+        share!(coordinator, :feedback)
+        share!(worker, :feedback)
+        Current.user = coordinator
+        Current.agent_turn = { user: @owner, task: running_task(coordinator, @creative.main_topic) }
+        interactions = []
+        breaker = Object.new
+        breaker.define_singleton_method(:record_interaction) { |*args| interactions << args }
+        dispatcher = lambda do |_event, _payload, **options|
+          options.fetch(:on_scheduled).call([])
+          []
+        end
+
+        Orchestration::LoopBreaker.stub(:new, ->(_context) { breaker }) do
+          Orchestration::AgentOrchestrator.stub(:prepare_selection, selection_for(worker)) do
+            SystemEvents::Dispatcher.stub(:dispatch, dispatcher) do
+              service.call(topic_id: @topic.id, content: "Rejected handoff")
+            end
+          end
+        end
+
+        assert_empty interactions
       end
 
       test "scopes a carried human sender override to the selected coordinator" do

--- a/engines/collavre/test/services/collavre/tools/topic_message_create_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/topic_message_create_service_test.rb
@@ -125,6 +125,24 @@ module Collavre
         assert_nil payload[:workspace_user_id]
       end
 
+      test "marks a non-searchable agent tool message as AI-authored" do
+        coordinator = create_agent("Private Coordinator", creator: @owner)
+        coordinator.update!(searchable: false)
+        share!(coordinator, :feedback)
+        Current.user = coordinator
+        Current.agent_turn = { user: @owner, task: nil }
+        payload = nil
+
+        SystemEvents::Dispatcher.stub(:dispatch, ->(_event, context, **_options) {
+          payload = context
+          []
+        }) do
+          service.call(topic_id: @topic.id, content: "Private agent instruction")
+        end
+
+        assert_equal true, payload.dig(:comment, :from_ai)
+      end
+
       test "an agent preserves a carried human who is not its creator" do
         coordinator = create_agent("Carried Coordinator", creator: @owner)
         share!(coordinator, :feedback)
@@ -321,6 +339,39 @@ module Collavre
 
         assert_equal "queued", waiter.reload.status
         assert_equal result[:id], waiter.trigger_event_payload.dig("comment", "id")
+        assert_equal @owner.id, waiter.trigger_event_payload.dig("sender", "id")
+      end
+
+      test "reselects the current primary after the comment commits" do
+        coordinator = create_agent("Repin Coordinator", creator: @owner)
+        former = create_agent("Former Primary", creator: @owner)
+        current = create_agent("Current Primary", creator: @owner)
+        share!(coordinator, :feedback)
+        share!(former, :feedback)
+        share!(current, :feedback)
+        destination = @creative.topics.create!(
+          name: "Repinned Destination", user: @owner, primary_agent: former
+        )
+        Current.user = coordinator
+        Current.agent_turn = { user: @owner, task: running_task(coordinator, @topic) }
+        selections = [ selection_for(former), selection_for(current) ]
+        selected = nil
+        prepare = lambda do |*_args, **_options|
+          destination.update!(primary_agent: current) if selections.one?
+          selections.shift
+        end
+        dispatcher = lambda do |_event, _payload, **options|
+          selected = options.fetch(:selection).agents
+          []
+        end
+
+        Orchestration::AgentOrchestrator.stub(:prepare_selection, prepare) do
+          SystemEvents::Dispatcher.stub(:dispatch, dispatcher) do
+            service.call(topic_id: destination.id, content: "Use the current primary")
+          end
+        end
+
+        assert_equal [ current ], selected
       end
 
       test "does not advance round robin when a principal-less self-route is rejected" do

--- a/engines/collavre/test/services/collavre/tools/topic_message_create_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/topic_message_create_service_test.rb
@@ -207,6 +207,52 @@ module Collavre
         assert_not Comment.exists?(topic: @topic, content: "Route back to my expression")
       end
 
+      test "an agent cannot self-route in a different unpinned topic" do
+        coordinator = create_agent("Destination Coordinator", creator: @owner)
+        coordinator.update!(routing_expression: "true")
+        share!(coordinator, :feedback)
+        destination = @creative.topics.create!(name: "Unpinned Destination", user: @owner)
+        Current.user = coordinator
+        Current.agent_turn = { user: @owner, task: running_task(coordinator, @topic) }
+        dispatcher = lambda do |_event, _payload, **options|
+          options.fetch(:on_selected).call([ coordinator ])
+        end
+
+        error = SystemEvents::Dispatcher.stub(:dispatch, dispatcher) do
+          assert_raises(ArgumentError) do
+            service.call(topic_id: destination.id, content: "Route back from another topic")
+          end
+        end
+
+        assert_equal I18n.t("collavre.tools.topic_message_create.errors.self_route"), error.message
+        assert_not Comment.exists?(topic: destination, content: "Route back from another topic")
+      end
+
+      test "does not count self-pinned fan-out as a ping-pong interaction" do
+        coordinator = create_agent("Fan-out Coordinator", creator: @owner)
+        share!(coordinator, :feedback)
+        destination = @creative.topics.create!(
+          name: "Self Destination", user: @owner, primary_agent: coordinator
+        )
+        Current.user = coordinator
+        Current.agent_turn = { user: @owner, task: running_task(coordinator, @topic) }
+        interactions = []
+        breaker = Object.new
+        breaker.define_singleton_method(:record_interaction) { |*args| interactions << args }
+        dispatcher = lambda do |_event, _payload, **options|
+          options.fetch(:on_selected).call([ coordinator ])
+          [ coordinator ]
+        end
+
+        Orchestration::LoopBreaker.stub(:new, ->(_context) { breaker }) do
+          SystemEvents::Dispatcher.stub(:dispatch, dispatcher) do
+            service.call(topic_id: destination.id, content: "Start independent work")
+          end
+        end
+
+        assert_empty interactions
+      end
+
       test "records tool-created A2A interactions for the selected agent" do
         coordinator = create_agent("Interaction Coordinator", creator: @owner)
         worker = create_agent("Interaction Worker", creator: @owner)
@@ -277,11 +323,15 @@ module Collavre
 
       test "rejects archived topics and creatives" do
         @topic.archive!
-        assert_raises(ArgumentError) { service.call(topic_id: @topic.id, content: "Closed") }
+        error = assert_raises(ArgumentError) { service.call(topic_id: @topic.id, content: "Closed") }
+        assert_equal I18n.t("collavre.tools.topic_message_create.errors.archived_topic"), error.message
 
         @topic.unarchive!
         @creative.update!(archived_at: Time.current)
-        assert_raises(ArgumentError) { service.call(topic_id: @topic.id, content: "Closed creative") }
+        error = assert_raises(ArgumentError) do
+          service.call(topic_id: @topic.id, content: "Closed creative")
+        end
+        assert_equal I18n.t("collavre.tools.topic_message_create.errors.archived_creative"), error.message
       end
 
       test "rejects the inbox System topic" do
@@ -291,13 +341,24 @@ module Collavre
           service.call(topic_id: inbox.system_topic.id, content: "Not a notification")
         end
 
-        assert_includes error.message, "System topic"
+        assert_equal I18n.t("collavre.tools.topic_message_create.errors.system_topic"), error.message
       end
 
       test "requires a current user" do
         Current.user = nil
 
-        assert_raises(RuntimeError) { service.call(topic_id: @topic.id, content: "No author") }
+        error = assert_raises(RuntimeError) { service.call(topic_id: @topic.id, content: "No author") }
+        assert_equal I18n.t("collavre.tools.topic_message_create.errors.current_user_required"), error.message
+      end
+
+      test "provides English and Korean translations for every tool error" do
+        keys = %w[current_user_required archived_creative archived_topic system_topic current_topic self_route]
+
+        keys.each do |key|
+          path = "collavre.tools.topic_message_create.errors.#{key}"
+          assert I18n.exists?(path, :en)
+          assert I18n.exists?(path, :ko)
+        end
       end
 
       private

--- a/engines/collavre/test/services/collavre/tools/topic_message_create_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/topic_message_create_service_test.rb
@@ -13,7 +13,7 @@ module Collavre
         Current.user = @owner
       end
 
-      teardown { Current.user = nil }
+      teardown { Current.reset }
 
       test "posts a public message and returns its identity" do
         result = service.call(topic_id: @topic.id, content: "Start with the API contract.")
@@ -101,10 +101,12 @@ module Collavre
         end
       end
 
-      test "an agent without a human creator carries an explicitly empty workspace principal" do
-        coordinator = create_agent("Unowned Coordinator", creator: nil)
+      test "an agent preserves an explicitly empty workspace principal" do
+        coordinator = create_agent("Cleared Coordinator", creator: @owner)
         share!(coordinator, :feedback)
         Current.user = coordinator
+        Current.workspace_user = nil
+        Current.workspace_user_resolved = true
         payload = nil
 
         SystemEvents::Dispatcher.stub(:dispatch, ->(_event, context, **_options) { payload = context }) do
@@ -113,6 +115,21 @@ module Collavre
 
         assert payload.key?(:workspace_user_id)
         assert_nil payload[:workspace_user_id]
+      end
+
+      test "an agent preserves a carried human who is not its creator" do
+        coordinator = create_agent("Carried Coordinator", creator: @owner)
+        share!(coordinator, :feedback)
+        Current.user = coordinator
+        Current.workspace_user = @reader
+        Current.workspace_user_resolved = true
+        payload = nil
+
+        SystemEvents::Dispatcher.stub(:dispatch, ->(_event, context, **_options) { payload = context }) do
+          service.call(topic_id: @topic.id, content: "Carried instruction")
+        end
+
+        assert_equal @reader.id, payload[:workspace_user_id]
       end
 
       test "feedback permission can post but read permission cannot" do

--- a/engines/collavre/test/services/collavre/tools/topic_message_create_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/topic_message_create_service_test.rb
@@ -90,8 +90,8 @@ module Collavre
         end
         events = []
 
-        SystemEvents::Dispatcher.stub(:dispatch, ->(_event, payload, **_options) {
-          events << payload
+        SystemEvents::Dispatcher.stub(:dispatch, ->(_event, payload, **options) {
+          events << payload.deep_stringify_keys.deep_merge(options.fetch(:context_for).call(coordinator))
           [ coordinator ]
         }) do
           topics.each do |topic|
@@ -99,8 +99,8 @@ module Collavre
           end
         end
 
-        assert_equal topics.pluck(:id), events.map { |event| event.dig(:topic, :id) }
-        assert events.all? { |event| event.dig(:sender, "id") == @owner.id }
+        assert_equal topics.pluck(:id), events.map { |event| event.dig("topic", "id") }
+        assert events.all? { |event| event.dig("sender", "id") == @owner.id }
         assert events.all? do |event|
           context = SystemEvents::ContextBuilder.new(event).build
           Orchestration::Matcher.new(context).match == [ coordinator ] && context.dig("sender", "is_ai") == false
@@ -216,8 +216,7 @@ module Collavre
         Current.agent_turn = { user: @owner, task: running_task(coordinator, @topic) }
         sender = nil
         dispatcher = lambda do |_event, _payload, **options|
-          override = options.fetch(:on_selected).call([ coordinator ])
-          sender = override.fetch("sender")
+          sender = options.fetch(:context_for).call(coordinator).fetch("sender")
           [ coordinator ]
         end
 
@@ -236,15 +235,21 @@ module Collavre
         destination = @creative.topics.create!(name: "Principal-less Destination", user: @owner)
         Current.user = coordinator
         Current.agent_turn = { user: nil, task: running_task(coordinator, @topic) }
-        dispatcher = lambda do |_event, _payload, **options|
-          options.fetch(:on_selected).call([ coordinator ])
-        end
-
-        error = SystemEvents::Dispatcher.stub(:dispatch, dispatcher) do
-          assert_raises(ArgumentError) do
-            service.call(topic_id: destination.id, content: "Unsafe self route")
+        side_effects = []
+        recorder = ->(*) { side_effects << true }
+        error = CommentNotificationJob.stub(:perform_later, recorder) do
+          CommentBadgesBroadcastJob.stub(:perform_later, recorder) do
+            Turbo::Streams::BroadcastJob.stub(:perform_later, recorder) do
+              Orchestration::AgentOrchestrator.stub(:select, [ coordinator ]) do
+                assert_raises(ArgumentError) do
+                  service.call(topic_id: destination.id, content: "Unsafe self route")
+                end
+              end
+            end
           end
         end
+
+        assert_empty side_effects
 
         assert_equal I18n.t("collavre.tools.topic_message_create.errors.self_route"), error.message
         assert_not Comment.exists?(topic: destination, content: "Unsafe self route")
@@ -261,14 +266,13 @@ module Collavre
         interactions = []
         breaker = Object.new
         breaker.define_singleton_method(:record_interaction) { |*args| interactions << args }
-        dispatcher = lambda do |_event, _payload, **options|
-          options.fetch(:on_selected).call([ coordinator ])
-          [ coordinator ]
-        end
+        dispatcher = ->(_event, _payload, **_options) { [ coordinator ] }
 
         Orchestration::LoopBreaker.stub(:new, ->(_context) { breaker }) do
-          SystemEvents::Dispatcher.stub(:dispatch, dispatcher) do
-            service.call(topic_id: destination.id, content: "Start independent work")
+          Orchestration::AgentOrchestrator.stub(:select, [ coordinator ]) do
+            SystemEvents::Dispatcher.stub(:dispatch, dispatcher) do
+              service.call(topic_id: destination.id, content: "Start independent work")
+            end
           end
         end
 
@@ -287,15 +291,9 @@ module Collavre
         interactions = []
         breaker = Object.new
         breaker.define_singleton_method(:record_interaction) { |*args| interactions << args }
-        matcher = Object.new
-        matcher.define_singleton_method(:match) { [ worker, unselected ] }
-
         Orchestration::LoopBreaker.stub(:new, ->(_context) { breaker }) do
-          Orchestration::Matcher.stub(:new, matcher) do
-            dispatcher = lambda do |_event, _payload, **options|
-              options.fetch(:on_selected).call([ worker ])
-              [ worker ]
-            end
+          Orchestration::AgentOrchestrator.stub(:select, [ worker ]) do
+            dispatcher = ->(_event, _payload, **_options) { [ worker ] }
             SystemEvents::Dispatcher.stub(:dispatch, dispatcher) do
               service.call(topic_id: @topic.id, content: "Track this handoff")
             end
@@ -303,6 +301,36 @@ module Collavre
         end
 
         assert_equal [ [ coordinator.id, worker.id, @creative.id ] ], interactions
+      end
+
+      test "scopes a carried human sender override to the selected coordinator" do
+        coordinator = create_agent("Mixed Coordinator", creator: @owner)
+        worker = create_agent("Mixed Worker", creator: @owner)
+        share!(coordinator, :feedback)
+        share!(worker, :feedback)
+        Current.user = coordinator
+        Current.agent_turn = { user: @owner, task: running_task(coordinator, @topic) }
+        destination = @creative.topics.create!(name: "Mixed Destination", user: @owner)
+        contexts = {}
+        dispatcher = lambda do |_event, payload, **options|
+          [ coordinator, worker ].each do |agent|
+            contexts[agent.id] = payload.deep_stringify_keys.deep_merge(
+              options.fetch(:context_for).call(agent)
+            )
+          end
+          [ coordinator, worker ]
+        end
+
+        Orchestration::AgentOrchestrator.stub(:select, [ coordinator, worker ]) do
+          SystemEvents::Dispatcher.stub(:dispatch, dispatcher) do
+            service.call(topic_id: destination.id, content: "Coordinate and review")
+          end
+        end
+
+        assert_equal @owner.id, contexts.dig(coordinator.id, "sender", "id")
+        assert_equal false, contexts.dig(coordinator.id, "sender", "is_ai")
+        assert_equal coordinator.id, contexts.dig(worker.id, "comment", "user_id")
+        assert_nil contexts.dig(worker.id, "sender")
       end
 
       test "feedback permission can post but read permission cannot" do

--- a/engines/collavre/test/services/collavre/tools/topic_message_create_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/topic_message_create_service_test.rb
@@ -105,8 +105,7 @@ module Collavre
         coordinator = create_agent("Cleared Coordinator", creator: @owner)
         share!(coordinator, :feedback)
         Current.user = coordinator
-        Current.workspace_user = nil
-        Current.workspace_user_resolved = true
+        Current.agent_turn = { user: nil, parent: nil }
         payload = nil
 
         SystemEvents::Dispatcher.stub(:dispatch, ->(_event, context, **_options) { payload = context }) do
@@ -121,8 +120,7 @@ module Collavre
         coordinator = create_agent("Carried Coordinator", creator: @owner)
         share!(coordinator, :feedback)
         Current.user = coordinator
-        Current.workspace_user = @reader
-        Current.workspace_user_resolved = true
+        Current.agent_turn = { user: @reader, parent: nil }
         payload = nil
 
         SystemEvents::Dispatcher.stub(:dispatch, ->(_event, context, **_options) { payload = context }) do
@@ -130,6 +128,36 @@ module Collavre
         end
 
         assert_equal @reader.id, payload[:workspace_user_id]
+      end
+
+      test "an agent preserves its parent event envelope" do
+        coordinator = create_agent("Envelope Coordinator", creator: @owner)
+        share!(coordinator, :feedback)
+        Current.user = coordinator
+        parent = SystemEvents::Envelope.root("comment_created", source: "test")
+        Current.agent_turn = { user: @reader, parent: parent }
+        dispatch_options = nil
+
+        SystemEvents::Dispatcher.stub(:dispatch, ->(_event, _context, **options) { dispatch_options = options }) do
+          service.call(topic_id: @topic.id, content: "Child instruction")
+        end
+
+        assert_equal parent, dispatch_options[:parent]
+      end
+
+      test "an agent without a workspace principal cannot dispatch to itself" do
+        coordinator = create_agent("Principal-less Coordinator", creator: @owner)
+        share!(coordinator, :feedback)
+        @topic.update!(primary_agent: coordinator)
+        Current.user = coordinator
+        Current.agent_turn = { user: nil, parent: nil }
+
+        error = assert_raises(ArgumentError) do
+          service.call(topic_id: @topic.id, content: "Loop forever")
+        end
+
+        assert_match(/cannot dispatch a topic message to itself/, error.message)
+        assert_not Comment.exists?(topic: @topic, content: "Loop forever")
       end
 
       test "feedback permission can post but read permission cannot" do

--- a/engines/collavre/test/services/collavre/tools/topic_message_create_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/topic_message_create_service_test.rb
@@ -78,6 +78,7 @@ module Collavre
         coordinator = create_agent("Self Coordinator", creator: @owner)
         share!(coordinator, :write)
         Current.user = coordinator
+        Current.agent_turn = { user: @owner, task: running_task(coordinator, @topic) }
         topics = %w[TrackOne TrackTwo].map do |name|
           TopicCreateService.new.call(
             creative_id: @creative.id,
@@ -105,7 +106,7 @@ module Collavre
         coordinator = create_agent("Cleared Coordinator", creator: @owner)
         share!(coordinator, :feedback)
         Current.user = coordinator
-        Current.agent_turn = { user: nil, parent: nil }
+        Current.agent_turn = { user: nil, task: nil }
         payload = nil
 
         SystemEvents::Dispatcher.stub(:dispatch, ->(_event, context, **_options) { payload = context }) do
@@ -120,7 +121,7 @@ module Collavre
         coordinator = create_agent("Carried Coordinator", creator: @owner)
         share!(coordinator, :feedback)
         Current.user = coordinator
-        Current.agent_turn = { user: @reader, parent: nil }
+        Current.agent_turn = { user: @reader, task: nil }
         payload = nil
 
         SystemEvents::Dispatcher.stub(:dispatch, ->(_event, context, **_options) { payload = context }) do
@@ -135,7 +136,8 @@ module Collavre
         share!(coordinator, :feedback)
         Current.user = coordinator
         parent = SystemEvents::Envelope.root("comment_created", source: "test")
-        Current.agent_turn = { user: @reader, parent: parent }
+        task = running_task(coordinator, @topic, parent: parent)
+        Current.agent_turn = { user: @reader, task: task }
         dispatch_options = nil
 
         SystemEvents::Dispatcher.stub(:dispatch, ->(_event, _context, **options) { dispatch_options = options }) do
@@ -150,14 +152,50 @@ module Collavre
         share!(coordinator, :feedback)
         @topic.update!(primary_agent: coordinator)
         Current.user = coordinator
-        Current.agent_turn = { user: nil, parent: nil }
+        Current.agent_turn = { user: nil, task: nil }
 
         error = assert_raises(ArgumentError) do
           service.call(topic_id: @topic.id, content: "Loop forever")
         end
 
-        assert_match(/cannot dispatch a topic message to itself/, error.message)
+        assert_match(/cannot dispatch a topic message to its own current topic/, error.message)
         assert_not Comment.exists?(topic: @topic, content: "Loop forever")
+      end
+
+      test "an agent cannot dispatch to its own currently running topic" do
+        coordinator = create_agent("Busy Self Coordinator", creator: @owner)
+        share!(coordinator, :feedback)
+        @topic.update!(primary_agent: coordinator)
+        Current.user = coordinator
+        Current.agent_turn = { user: @owner, task: running_task(coordinator, @topic) }
+
+        error = assert_raises(ArgumentError) do
+          service.call(topic_id: @topic.id, content: "Queue behind myself")
+        end
+
+        assert_match(/cannot dispatch a topic message to its own current topic/, error.message)
+        assert_not Comment.exists?(topic: @topic, content: "Queue behind myself")
+      end
+
+      test "records tool-created A2A interactions for the selected agent" do
+        coordinator = create_agent("Interaction Coordinator", creator: @owner)
+        worker = create_agent("Interaction Worker", creator: @owner)
+        share!(coordinator, :feedback)
+        share!(worker, :feedback)
+        @topic.update!(primary_agent: worker)
+        Current.user = coordinator
+        Current.agent_turn = { user: @owner, task: running_task(coordinator, @creative.main_topic) }
+        interactions = []
+        breaker = Object.new
+        breaker.define_singleton_method(:record_interaction) { |*args| interactions << args }
+
+        Orchestration::LoopBreaker.stub(:new, ->(_context) { breaker }) do
+          SystemEvents::Dispatcher.stub(:dispatch, nil) do
+            service.call(topic_id: @topic.id, content: "Track this handoff")
+          end
+        end
+
+        assert_equal [ [ coordinator.id, worker.id, @creative.id ] ], interactions
       end
 
       test "feedback permission can post but read permission cannot" do
@@ -238,6 +276,23 @@ module Collavre
           llm_model: "gemini-1.5-flash",
           searchable: true,
           creator: creator
+        )
+      end
+
+      def running_task(agent, topic, parent: nil)
+        payload = {
+          "creative" => { "id" => topic.creative_id },
+          "topic" => { "id" => topic.id }
+        }
+        payload[SystemEvents::Envelope::KEY] = parent.to_h if parent
+        Task.create!(
+          name: "Running topic message turn",
+          status: "running",
+          trigger_event_name: "comment_created",
+          trigger_event_payload: payload,
+          agent: agent,
+          topic_id: topic.id,
+          creative_id: topic.creative_id
         )
       end
 

--- a/engines/collavre/test/services/system_events/dispatcher_test.rb
+++ b/engines/collavre/test/services/system_events/dispatcher_test.rb
@@ -102,16 +102,34 @@ module SystemEvents
       assert_equal "cron", Envelope.in(enqueued_context).source
     end
 
-    test "applies selected-agent context overrides before scheduling" do
+    test "applies context overrides only to their selected agent" do
       sender = { "id" => users(:one).id, "is_ai" => false }
+      other_agent = User.create!(
+        email: "dispatcher_other_context_agent@example.com",
+        name: "Dispatcher Other Context Agent",
+        password: "password",
+        llm_vendor: "google",
+        llm_model: "gemini-1.5-flash",
+        searchable: true
+      )
+      Collavre::CreativeShare.create!(
+        creative: @creative, user: other_agent, permission: :feedback, shared_by: users(:one)
+      )
+      Collavre::CreativeSharesCache.create!(
+        creative_id: @creative.id, user_id: other_agent.id, permission: :feedback
+      )
 
       SystemEvents::Dispatcher.dispatch(
         "comment_created", @context,
-        on_selected: ->(_agents) { { "sender" => sender } }
+        selected_agents: [ @agent, other_agent ],
+        context_for: ->(agent) { agent == @agent ? { "sender" => sender } : {} }
       )
 
-      assert_equal sender["id"], enqueued_context.dig("sender", "id")
-      assert_equal sender["is_ai"], enqueued_context.dig("sender", "is_ai")
+      contexts = ActiveJob::Base.queue_adapter.enqueued_jobs.last(2).to_h do |job|
+        [ job[:args][0], job[:args][2] ]
+      end
+      assert_equal sender["id"], contexts.dig(@agent.id, "sender", "id")
+      assert_nil contexts.dig(other_agent.id, "sender")
     end
 
     test "does not enqueue work when no agent matches" do

--- a/engines/collavre/test/services/system_events/dispatcher_test.rb
+++ b/engines/collavre/test/services/system_events/dispatcher_test.rb
@@ -102,6 +102,18 @@ module SystemEvents
       assert_equal "cron", Envelope.in(enqueued_context).source
     end
 
+    test "applies selected-agent context overrides before scheduling" do
+      sender = { "id" => users(:one).id, "is_ai" => false }
+
+      SystemEvents::Dispatcher.dispatch(
+        "comment_created", @context,
+        on_selected: ->(_agents) { { "sender" => sender } }
+      )
+
+      assert_equal sender["id"], enqueued_context.dig("sender", "id")
+      assert_equal sender["is_ai"], enqueued_context.dig("sender", "is_ai")
+    end
+
     test "does not enqueue work when no agent matches" do
       @agent.update!(routing_expression: "false")
 

--- a/skills/collavre/SKILL.md
+++ b/skills/collavre/SKILL.md
@@ -146,7 +146,9 @@ collavre tool run <tool_name> --key value         # run with flag args
 - **Starting topic work**: after creating and pinning a topic, call
   `topic_message_create` with its initial instruction. Agent-authored messages
   dispatch as A2A work, so one coordinating agent can start independent work in
-  several topics without impersonating a human.
+  several topics without impersonating a human. Do not call it on the same
+  primary-agent topic the caller is currently handling; continue that work in
+  the current turn instead.
 - **Progress**: Leaf = manual (0.0 or 1.0). Parent = auto-calculated from children.
 - **Import**: Markdown headings/bullets become nested Creatives.
 - **Batch**: All-or-nothing transaction. Requires approval.

--- a/skills/collavre/SKILL.md
+++ b/skills/collavre/SKILL.md
@@ -104,8 +104,14 @@ collavre tool run topic_messages --json '{"topic_ids": 12, "offset": 100, "curso
 # Continue inside one clipped message, preserving its row cursor
 collavre tool run topic_messages --json '{"topic_ids": 12, "offset": 100, "cursor": "1770000000000000:989:1770000001000000:1770000002000000", "content_offset": 28400, "max_message_id": 9931}'
 
-# Fan work out: one topic per unit of work, with an agent pinned to each
+# Fan work out: one topic per unit of work, with an agent pinned to each;
+# keep each returned topic id for the initial-message calls
 collavre tool run topic_create --json '{"creative_id": 8849, "name": "Research", "primary_agent": "Dev1Claude"}'
+collavre tool run topic_create --json '{"creative_id": 8849, "name": "Delivery", "primary_agent": "Dev1Claude"}'
+
+# Start the pinned agent independently in both topics
+collavre tool run topic_message_create --json '{"topic_id": 12, "content": "Research the API options and report your recommendation."}'
+collavre tool run topic_message_create --json '{"topic_id": 13, "content": "Build the selected approach and verify it."}'
 
 # Put a finished thread away (messages are kept and stay readable by id)
 collavre tool run topic_update --json '{"topic_id": 12, "archived": true}'
@@ -137,6 +143,10 @@ collavre tool run <tool_name> --key value         # run with flag args
 - **Primary agent**: pinning an agent to a topic is exclusive — that agent alone
   answers there. Use it for a dedicated 1:1 channel; leave it unset for a thread
   several participants should hear.
+- **Starting topic work**: after creating and pinning a topic, call
+  `topic_message_create` with its initial instruction. Agent-authored messages
+  dispatch as A2A work, so one coordinating agent can start independent work in
+  several topics without impersonating a human.
 - **Progress**: Leaf = manual (0.0 or 1.0). Parent = auto-calculated from children.
 - **Import**: Markdown headings/bullets become nested Creatives.
 - **Batch**: All-or-nothing transaction. Requires approval.

--- a/skills/collavre/SKILL.md
+++ b/skills/collavre/SKILL.md
@@ -146,9 +146,8 @@ collavre tool run <tool_name> --key value         # run with flag args
 - **Starting topic work**: after creating and pinning a topic, call
   `topic_message_create` with its initial instruction. Agent-authored messages
   dispatch as A2A work, so one coordinating agent can start independent work in
-  several topics without impersonating a human. Do not call it on the same
-  primary-agent topic the caller is currently handling; continue that work in
-  the current turn instead.
+  several topics without impersonating a human. Do not call it on the topic the
+  caller is currently handling; continue that work in the current turn instead.
 - **Progress**: Leaf = manual (0.0 or 1.0). Parent = auto-calculated from children.
 - **Import**: Markdown headings/bullets become nested Creatives.
 - **Batch**: All-or-nothing transaction. Requires approval.

--- a/skills/collavre/references/tool-reference.md
+++ b/skills/collavre/references/tool-reference.md
@@ -223,6 +223,26 @@ refused — a pinned agent that cannot answer would silence the topic entirely.
 Requires **write** on the Creative. Use `topic_branch` to copy messages instead
 of moving them.
 
+### topic_message_create
+
+Post one public message to an existing topic and run the topic's normal agent
+routing. This is the step that turns a newly created, pinned topic into active
+work.
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `topic_id` | Integer | **Yes** | Topic to post to |
+| `content` | String | **Yes** | Message body or initial instruction; Markdown is supported |
+
+The caller remains the visible author. Human-authored messages follow ordinary
+comment dispatch. Agent-authored messages dispatch as A2A work, so a coordinator
+can create several topics, pin a primary agent on each, then start them with
+independent instructions. Different topics can run concurrently; repeated
+messages in one topic follow that topic's queue.
+
+Requires **feedback** or better on the topic's Creative. Archived Creatives,
+archived topics, and an inbox's reserved System topic reject new messages.
+
 ### topic_update
 
 Rename, archive/unarchive, or re-pin a topic. Pass only what changes.

--- a/skills/collavre/references/tool-reference.md
+++ b/skills/collavre/references/tool-reference.md
@@ -240,6 +240,9 @@ can create several topics, pin a primary agent on each, then start them with
 independent instructions. Different topics can run concurrently; repeated
 messages in one topic follow that topic's queue.
 
+An agent cannot call this tool on the topic of its current turn. Continue that
+work in the current turn; use this tool to start work in a different topic.
+
 Requires **feedback** or better on the topic's Creative. Archived Creatives,
 archived topics, and an inbox's reserved System topic reject new messages.
 


### PR DESCRIPTION
## Summary

- add `topic_message_create` for posting public instructions to existing topics
- dispatch agent-authored messages as A2A work while preserving the visible author and human workspace principal
- support coordinator and self-pinned two-topic fan-out scenarios without self-handoff loops
- document the create, pin, and initial-message workflow in both Collavre skill mirrors

## Permissions and safeguards

- require feedback permission and reauthorize after locking the topic
- reject archived creatives, archived topics, and the inbox System topic

## Verification

- 278 relevant tests, 983 assertions, 0 failures
- RuboCop passed
- complexity ratchet passed
- packaged and repository skill mirrors match