### PR TITLE
fix(navigation): send the Home button to the top level

### DIFF
--- a/engines/collavre/app/controllers/collavre/application_controller.rb
+++ b/engines/collavre/app/controllers/collavre/application_controller.rb
@@ -40,11 +40,7 @@ module Collavre
     end
 
     def last_visited_creative_path
-      home_path = SystemSetting.home_page_path_authenticated.chomp("/")
-      mount_path = request.script_name.chomp("/")
-      if mount_path.present? && (home_path == mount_path || home_path.start_with?("#{mount_path}/"))
-        home_path = home_path.delete_prefix(mount_path)
-      end
+      home_path = HomePagePath.mount_relative(script_name: request.script_name)
       return unless home_path == "/creatives" || home_path == "/creatives.html"
 
       creative = Current.user.last_visited_creative

--- a/engines/collavre/app/helpers/collavre/navigation_helper.rb
+++ b/engines/collavre/app/helpers/collavre/navigation_helper.rb
@@ -61,6 +61,18 @@ module Collavre
       value.is_a?(Proc) ? instance_exec(&value) : value
     end
 
+    # Destination for the Home button.
+    #
+    # Authenticated users are sent to the configured home page directly instead
+    # of through "/". "/" means "app launch" and is rewritten to the last
+    # visited Creative, which made Home a no-op for anyone who had opened one.
+    # Guests keep "/" so the middleware rewrite still applies.
+    def home_navigation_path
+      return main_app.root_path unless authenticated?
+
+      HomePagePath.absolute(script_name: request.script_name) || main_app.root_path
+    end
+
     private
 
     def render_nav_button(item)

--- a/engines/collavre/app/services/collavre/home_page_path.rb
+++ b/engines/collavre/app/services/collavre/home_page_path.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module Collavre
+  # Resolves the configured authenticated home page into the two shapes the app
+  # needs.
+  #
+  # "/" is reserved for app launch: the middleware flags it and the controller
+  # turns it into the last visited Creative. Anything that means "take me to the
+  # top level" therefore has to link at the configured home page directly rather
+  # than at "/", or it gets swallowed by the launch redirect.
+  module HomePagePath
+    # Admins can disable the authenticated redirect by setting the path to "/".
+    ROOT_SENTINEL = "/"
+
+    module_function
+
+    # Configured path with the engine mount prefix removed, for comparing
+    # against engine-relative routes:
+    #   "/collavre/creatives" mounted at "/collavre" -> "/creatives"
+    def mount_relative(script_name: nil)
+      path = configured_path.chomp("/")
+      mount = normalized_mount(script_name)
+      return path if mount.blank? || !mounted_under?(path, mount)
+
+      path.delete_prefix(mount)
+    end
+
+    # Configured path with the engine mount prefix applied, for linking:
+    #   "/creatives" mounted at "/collavre" -> "/collavre/creatives"
+    #
+    # Returns nil when the authenticated home is disabled via the "/" sentinel
+    # so callers can fall back to the application root.
+    def absolute(script_name: nil)
+      path = configured_path
+      return nil if path.blank? || path == ROOT_SENTINEL
+
+      mount = normalized_mount(script_name)
+      return path if mount.blank? || mounted_under?(path, mount)
+
+      "#{mount}#{path}"
+    end
+
+    def configured_path
+      SystemSetting.home_page_path_authenticated.to_s.strip
+    end
+
+    def normalized_mount(script_name)
+      script_name.to_s.chomp("/")
+    end
+
+    def mounted_under?(path, mount)
+      path == mount || path.start_with?("#{mount}/")
+    end
+  end
+end

--- a/engines/collavre/lib/collavre/engine.rb
+++ b/engines/collavre/lib/collavre/engine.rb
@@ -285,7 +285,7 @@ module Collavre
           key: :home,
           label: "app.home",
           type: :button,
-          path: -> { main_app.root_path },
+          path: -> { home_navigation_path }, html_class: "home-nav-button",
           priority: 110
         )
 

--- a/engines/collavre/test/helpers/navigation_helper_test.rb
+++ b/engines/collavre/test/helpers/navigation_helper_test.rb
@@ -28,6 +28,57 @@ class NavigationHelperTest < ActionView::TestCase
     @authenticated = value
   end
 
+  test "home_navigation_path sends guests to the application root" do
+    self.authenticated = false
+
+    assert_equal "/", home_navigation_path
+  end
+
+  test "home_navigation_path sends signed in users straight to the configured home page" do
+    self.authenticated = true
+
+    Collavre::SystemSetting.stub(:home_page_path_authenticated, "/creatives") do
+      assert_equal "/creatives", home_navigation_path
+    end
+  end
+
+  test "home_navigation_path preserves the engine mount path" do
+    self.authenticated = true
+    request.script_name = "/collavre"
+
+    Collavre::SystemSetting.stub(:home_page_path_authenticated, "/creatives") do
+      assert_equal "/collavre/creatives", home_navigation_path
+    end
+  end
+
+  test "home_navigation_path falls back to the application root for the '/' sentinel" do
+    self.authenticated = true
+
+    Collavre::SystemSetting.stub(:home_page_path_authenticated, "/") do
+      assert_equal "/", home_navigation_path
+    end
+  end
+
+  test "home nav button links to the configured home page rather than '/'" do
+    self.authenticated = true
+    Navigation::Registry.instance.register(
+      key: :home,
+      label: "app.home",
+      type: :button,
+      path: -> { home_navigation_path },
+      html_class: "home-nav-button",
+      priority: 110
+    )
+
+    item = Navigation::Registry.instance.find(:home)
+    html = Collavre::SystemSetting.stub(:home_page_path_authenticated, "/creatives") do
+      render_navigation_item(item)
+    end
+
+    assert_match(%r{action="/creatives"}, html)
+    assert_match(/class="home-nav-button"/, html)
+  end
+
   test "navigation_items_for returns items for section" do
     Navigation::Registry.instance.register(key: :item1, label: "Item 1", section: :main)
     Navigation::Registry.instance.register(key: :item2, label: "Item 2", section: :user)

--- a/engines/collavre/test/integration/root_home_path_test.rb
+++ b/engines/collavre/test/integration/root_home_path_test.rb
@@ -171,6 +171,31 @@ class RootHomePathTest < ActionDispatch::IntegrationTest
     # "/" sentinel disables the redirect - middleware rewrite still applies
   end
 
+  test "home button targets the top level even when a last visited creative exists" do
+    creative = creatives(:tshirt)
+    @user.update!(last_visited_creative: creative)
+
+    sign_in_as(@user, password: "password")
+    get "/creatives"
+
+    assert_response :success
+    assert_select "form[action='/creatives'] .home-nav-button", minimum: 1
+    assert_select "form[action='/'] .home-nav-button", count: 0
+  end
+
+  test "home button follows through to the top level list" do
+    creative = creatives(:tshirt)
+    @user.update!(last_visited_creative: creative)
+
+    sign_in_as(@user, password: "password")
+    get "/creatives"
+    home_action = css_select("form:has(.home-nav-button)").first["action"]
+    get home_action
+
+    assert_response :success
+    assert_nil response.location
+  end
+
   test "authenticated user visiting the authenticated home directly does not loop" do
     SystemSetting.create!(key: "home_page_path_authenticated", value: "/users")
     Rails.cache.clear

--- a/engines/collavre/test/services/collavre/home_page_path_test.rb
+++ b/engines/collavre/test/services/collavre/home_page_path_test.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  class HomePagePathTest < ActiveSupport::TestCase
+    setup do
+      SystemSetting.where(key: "home_page_path_authenticated").destroy_all
+      Rails.cache.clear
+    end
+
+    teardown do
+      SystemSetting.where(key: "home_page_path_authenticated").destroy_all
+      Rails.cache.clear
+    end
+
+    test "mount_relative returns the configured path when the app is not mounted" do
+      set_home("/creatives")
+
+      assert_equal "/creatives", HomePagePath.mount_relative
+      assert_equal "/creatives", HomePagePath.mount_relative(script_name: "")
+    end
+
+    test "mount_relative strips a trailing slash" do
+      set_home("/creatives/")
+
+      assert_equal "/creatives", HomePagePath.mount_relative
+    end
+
+    test "mount_relative strips the engine mount prefix" do
+      set_home("/collavre/creatives")
+
+      assert_equal "/creatives", HomePagePath.mount_relative(script_name: "/collavre")
+    end
+
+    test "mount_relative keeps paths that only share a prefix with the mount" do
+      set_home("/collavre-docs/creatives")
+
+      assert_equal "/collavre-docs/creatives", HomePagePath.mount_relative(script_name: "/collavre")
+    end
+
+    test "mount_relative returns an empty path for the root sentinel" do
+      set_home("/")
+
+      assert_equal "", HomePagePath.mount_relative
+    end
+
+    test "absolute returns the configured path when the app is not mounted" do
+      set_home("/users")
+
+      assert_equal "/users", HomePagePath.absolute
+    end
+
+    test "absolute applies the engine mount prefix" do
+      set_home("/creatives")
+
+      assert_equal "/collavre/creatives", HomePagePath.absolute(script_name: "/collavre")
+    end
+
+    test "absolute leaves an already mounted path untouched" do
+      set_home("/collavre/creatives")
+
+      assert_equal "/collavre/creatives", HomePagePath.absolute(script_name: "/collavre")
+    end
+
+    test "absolute treats the mount itself as already mounted" do
+      set_home("/collavre")
+
+      assert_equal "/collavre", HomePagePath.absolute(script_name: "/collavre/")
+    end
+
+    test "absolute is nil for the root sentinel so callers fall back to the app root" do
+      set_home("/")
+
+      assert_nil HomePagePath.absolute
+    end
+
+    test "absolute falls back to the default home page when unset" do
+      assert_equal "/creatives", HomePagePath.absolute
+    end
+
+    private
+
+    def set_home(value)
+      SystemSetting.create!(key: "home_page_path_authenticated", value: value)
+      Rails.cache.clear
+    end
+  end
+end


### PR DESCRIPTION
## Problem

Pressing **Home** did nothing for any user who had already opened a Creative — it landed back on that Creative instead of the top-level list.

The Home button linked to `/`. But `/` is also the app-launch URL: `HomePathRewriter` flags it (`collavre.root_request`) and `Collavre::ApplicationController#redirect_authenticated_root_to_home` turns it into the user's last visited Creative (#1525). Since the launch redirect leaves the address bar on `/creatives?id=X`, the Home button was the *only* thing in the app still hitting `/` — so the two features collided 100% of the time.

Reproduced on `main`:

```
FORM ACTIONS: ["/creatives", "/", ...]        # Home button action = "/"
STATUS: 302 LOCATION: "http://www.example.com/creatives?id=754382202"
```

## Fix

Point the Home button at the configured authenticated home page directly instead of routing it through `/`.

- `/` keeps its launch-only meaning, so restore-on-launch (#1525) is unchanged.
- Guests still get `/` so the `HomePathRewriter` rewrite continues to apply.
- When an admin disables the authenticated home with the `/` sentinel, the button falls back to the application root — same semantics as before.

The mount-prefix handling that `last_visited_creative_path` already did inline is extracted into `Collavre::HomePagePath`, which now serves both shapes:

| | |
|---|---|
| `mount_relative` | `/collavre/creatives` mounted at `/collavre` → `/creatives` (what the controller compares against) |
| `absolute` | `/creatives` mounted at `/collavre` → `/collavre/creatives` (what the Home button links to) |

The Home button also gains a `home-nav-button` class so it can be asserted on.

## Changes

- `engines/collavre/app/services/collavre/home_page_path.rb` — new; resolves the authenticated home page into mount-relative and absolute forms
- `engines/collavre/app/helpers/collavre/navigation_helper.rb` — `home_navigation_path`
- `engines/collavre/lib/collavre/engine.rb` — Home nav item uses `home_navigation_path`
- `engines/collavre/app/controllers/collavre/application_controller.rb` — reuses `HomePagePath.mount_relative`

## Tests

- `engines/collavre/test/services/collavre/home_page_path_test.rb` (new, 11 cases): mount prefix applied / stripped / already present / prefix-lookalike, trailing slash, `/` sentinel, default fallback
- `engines/collavre/test/helpers/navigation_helper_test.rb`: guest → `/`, signed in → configured home, mount path preserved, `/` sentinel fallback, rendered button `action`
- `engines/collavre/test/integration/root_home_path_test.rb`: Home button targets the top level even with a last visited Creative, and following it renders without a bounce redirect

```
79 runs, 190 assertions, 0 failures, 0 errors, 0 skips
```

Rubocop clean, complexity ratchet OK (no entity grew).