### PR TITLE
feat: add topic move MCP tool

### DIFF
--- a/engines/collavre/app/controllers/collavre/api/v1/agents_controller.rb
+++ b/engines/collavre/app/controllers/collavre/api/v1/agents_controller.rb
@@ -156,55 +156,13 @@ module Collavre
             return
           end
 
-          creative = topic.creative&.effective_origin
-          unless creative
-            render json: { error: "Creative not found" }, status: :not_found
-            return
-          end
-
-          unless creative.has_permission?(current_user, :feedback)
-            render json: { error: "Not authorized" }, status: :forbidden
-            return
-          end
-
-          agent = resolve_reply_agent(topic, params[:task_id])
-          unless agent
-            render json: { error: "Not authorized" }, status: :forbidden
-            return
-          end
-
-          # Atomically claim the delegated task BEFORE saving the reply.
-          # Two concurrent /reply requests with the same task_id can both
-          # pass resolve_reply_agent (which is a read-only scope check) and,
-          # without an atomic WHERE status='delegated' transition, both would
-          # save separate comments and both would run completion logic —
-          # producing duplicate linked replies for one dispatch. Claim first,
-          # save second, so the loser sees rows_updated == 0 and bails out
-          # before touching the comments table.
-          claimed_task = claim_delegated_task(agent, topic, params[:task_id])
-          if params[:task_id].present? && claimed_task.nil?
-            render json: { error: "Task already completed or not delegated" }, status: :conflict
-            return
-          end
-
-          comment = creative.comments.build(
-            content: params[:text].to_s,
-            topic: topic,
-            user: agent,
-            skip_default_user: true,
-            skip_dispatch: true
-          )
-
-          if comment.save
-            task_claim_service.finalize(agent: agent, task: claimed_task, comment: comment) if claimed_task
-            dispatch_a2a(agent, comment, task: claimed_task)
-            render json: { comment_id: comment.id }, status: :created
-          else
-            # Restore the dispatch so the MCP client can retry — the failure
-            # is text-level (validation), not task-level.
-            claimed_task&.update!(status: "delegated")
-            render json: { errors: comment.errors.full_messages }, status: :unprocessable_entity
-          end
+          result = AiAgent::TaskReplyService.new(
+            topic: topic, current_user: current_user, text: params[:text], requested_task_id: params[:task_id],
+            agent_resolver: method(:resolve_reply_agent), task_claimer: method(:claim_delegated_task),
+            claim_service: task_claim_service
+          ).call
+          dispatch_a2a(result.agent, result.comment.reload, task: result.task) if result.comment
+          render json: result.body, status: result.status
         end
 
         # POST /api/v1/agent/notify

--- a/engines/collavre/app/controllers/collavre/api/v1/agents_controller.rb
+++ b/engines/collavre/app/controllers/collavre/api/v1/agents_controller.rb
@@ -447,7 +447,8 @@ module Collavre
 
           tracker = Orchestration::ResourceTracker.for(agent)
           tasks.find_each do |task|
-            task.update!(status: "cancelled", pending_tool_call: nil)
+            next unless task.cancel_if_active!(statuses: %w[delegated], pending_tool_call: nil)
+
             tracker.release!(task.id)
 
             Orchestration::AgentOrchestrator.dequeue_next_for_topic(task.topic_id, task.creative_id)
@@ -476,8 +477,10 @@ module Collavre
           tracker = Orchestration::ResourceTracker.for(agent)
           drained_topics = {}
           tasks.find_each do |task|
-            was_running = task.status == "running"
-            task.update!(status: "cancelled")
+            previous_status = task.cancel_if_active!(statuses: %w[queued pending running])
+            next unless previous_status
+
+            was_running = previous_status == "running"
             tracker.release!(task.id) if was_running
             drained_topics[task.topic_id] ||= task.creative_id
           end

--- a/engines/collavre/app/controllers/collavre/comment_read_pointers_controller.rb
+++ b/engines/collavre/app/controllers/collavre/comment_read_pointers_controller.rb
@@ -14,6 +14,8 @@ module Collavre
       Comment.broadcast_badge(creative, Current.user)
 
       render json: { success: true }
+    rescue Comments::ReadPointerWriter::StaleTopicError
+      head :unprocessable_entity
     end
 
     private

--- a/engines/collavre/app/controllers/collavre/comments_controller.rb
+++ b/engines/collavre/app/controllers/collavre/comments_controller.rb
@@ -247,7 +247,10 @@ module Collavre
         CommentMoveService.new(creative: @creative, user: Current.user).call(
           comment_ids: [ @comment.id ], target_topic_id: topic_id
         )
-        @comment.reload.update(attributes)
+        updated = @comment.reload.update(attributes)
+        raise ActiveRecord::Rollback unless updated
+
+        updated
       end
     rescue CommentMoveService::MoveError => e
       @comment.errors.add(:topic, e.message)

--- a/engines/collavre/app/controllers/collavre/comments_controller.rb
+++ b/engines/collavre/app/controllers/collavre/comments_controller.rb
@@ -75,7 +75,7 @@ module Collavre
         safe_params = comment_params.except(:quoted_comment_id, :quoted_text)
         validate_topic_id!(safe_params[:topic_id]) or return
 
-        if @comment.update(safe_params)
+        if update_comment(safe_params)
           @comment = Comment.with_attached_images.includes(:comment_reactions, :comment_versions, :selected_version).find(@comment.id)
           render partial: "collavre/comments/comment", locals: { comment: @comment, current_topic_id: current_topic_context }
         else
@@ -235,6 +235,22 @@ module Collavre
     def validate_topic_id!(topic_id)
       return true if topic_id.blank? || @creative.topics.where(id: topic_id).exists?
       render json: { error: I18n.t("collavre.comments.invalid_topic") }, status: :unprocessable_entity
+      false
+    end
+
+    def update_comment(attributes)
+      return @comment.update(attributes) unless attributes.key?(:topic_id)
+
+      attributes = attributes.dup
+      topic_id = attributes.delete(:topic_id)
+      Comment.transaction do
+        CommentMoveService.new(creative: @creative, user: Current.user).call(
+          comment_ids: [ @comment.id ], target_topic_id: topic_id
+        )
+        @comment.reload.update(attributes)
+      end
+    rescue CommentMoveService::MoveError => e
+      @comment.errors.add(:topic, e.message)
       false
     end
   end

--- a/engines/collavre/app/controllers/collavre/comments_controller.rb
+++ b/engines/collavre/app/controllers/collavre/comments_controller.rb
@@ -239,7 +239,7 @@ module Collavre
     end
 
     def update_comment(attributes)
-      return @comment.update(attributes) unless attributes.key?(:topic_id)
+      return update_comment_under_topic_lock(attributes) unless attributes.key?(:topic_id)
 
       attributes = attributes.dup
       topic_id = attributes.delete(:topic_id)
@@ -254,6 +254,21 @@ module Collavre
       end
     rescue CommentMoveService::MoveError => e
       @comment.errors.add(:topic, e.message)
+      false
+    end
+
+    def update_comment_under_topic_lock(attributes)
+      source_topic_id = @comment.topic_id
+      matching_context = false
+      updated = false
+      Comments::TopicMutation.call(source_topic_id, @creative.id) do
+        @comment.lock!
+        matching_context = @comment.creative_id == @creative.id && @comment.topic_id == source_topic_id
+        updated = @comment.update(attributes) if matching_context
+      end
+      return updated if matching_context
+
+      @comment.errors.add(:topic, I18n.t("collavre.comments.move_not_allowed"))
       false
     end
   end

--- a/engines/collavre/app/controllers/collavre/tasks_controller.rb
+++ b/engines/collavre/app/controllers/collavre/tasks_controller.rb
@@ -25,10 +25,6 @@ module Collavre
         return head :forbidden
       end
 
-      unless %w[running pending queued pending_approval delegated].include?(task.status)
-        return head :unprocessable_entity
-      end
-
       # These statuses count against the topic slot (occupying_topic_slot) yet no
       # live worker will run AiAgentJob's ensure-block drain for them:
       #   - delegated / pending_approval already returned from the job holding the
@@ -40,8 +36,10 @@ module Collavre
       # cancelling the blocker leaves agent capacity and the next waiter stuck
       # until stuck recovery. release!/dequeue are idempotent (dequeue is bounded
       # by topic_at_capacity?), so a racing live worker that also drains is harmless.
-      held_slot_without_worker = Task::HELD_SLOT_WITHOUT_WORKER.include?(task.status)
-      task.update!(status: "cancelled")
+      previous_status = task.cancel_if_active!
+      return head :unprocessable_entity unless previous_status
+
+      held_slot_without_worker = Task::HELD_SLOT_WITHOUT_WORKER.include?(previous_status)
 
       # The third door a waiter leaves the queue through without ever being
       # promoted — "queued" is in the whitelist above, so the user's own stop

--- a/engines/collavre/app/controllers/collavre/topics_controller.rb
+++ b/engines/collavre/app/controllers/collavre/topics_controller.rb
@@ -1,8 +1,7 @@
 module Collavre
   class TopicsController < ApplicationController
     rescue_from Topics::TopicMove::SourceChangedError, with: :render_source_changed
-    rescue_from Topics::TopicMove::ActiveTaskError, with: :render_active_tasks
-    rescue_from Topics::TopicMove::RecurringTaskError, with: :render_active_tasks
+    rescue_from Topics::TopicMove::MoveBlockedError, with: :render_active_tasks
 
     include Collavre::CreativePermissionGuard
 

--- a/engines/collavre/app/controllers/collavre/topics_controller.rb
+++ b/engines/collavre/app/controllers/collavre/topics_controller.rb
@@ -120,9 +120,9 @@ module Collavre
         render json: { error: I18n.t("collavre.topics.cannot_delete_main") }, status: :unprocessable_entity and return
       end
 
-      topic_id = topic.id
-      topic_name = topic.name
-      topic.destroy
+      topic_id, topic_name = Topics::TopicDestroy.new(
+        topic: topic, source_creative: @creative
+      ).call
 
       # Best-effort orphaned-cron notice. Must never break the core deletion:
       # if it raises, swallow + log so broadcast/head still run.

--- a/engines/collavre/app/controllers/collavre/topics_controller.rb
+++ b/engines/collavre/app/controllers/collavre/topics_controller.rb
@@ -165,18 +165,10 @@ module Collavre
         render json: { error: I18n.t("collavre.topics.move.session_topic_locked") }, status: :unprocessable_entity and return
       end
 
-      released_agent, released_reason = Topics::TopicMove.new(topic: topic, target_creative: target_creative).call
-
-      # update_all above skips counter-cache callbacks, so recompute
-      # comments_count on both sides after re-parenting the comments.
-      Creative.reset_counters(source_creative.id, :comments)
-      Creative.reset_counters(target_creative.id, :comments)
-
-      broadcast_topic_event("deleted", topic_id: topic.id)
-      # topic_json rather than a bare id/name slice: the pin decides who may
-      # speak, so the target's topic list has to show whether it survived the
-      # move (and, when it did not, show no avatar rather than a stale one).
-      broadcast_topic_event("created", creative: target_creative, topic: topic_json(topic))
+      effects = Topics::TopicMoveEffects.new(topic, source_creative, target_creative)
+      released_agent, released_reason = Topics::TopicMove.new(
+        topic: topic, target_creative: target_creative
+      ).call(after_commit: effects.method(:call))
 
       render json: {
         success: true,

--- a/engines/collavre/app/controllers/collavre/topics_controller.rb
+++ b/engines/collavre/app/controllers/collavre/topics_controller.rb
@@ -2,6 +2,7 @@ module Collavre
   class TopicsController < ApplicationController
     rescue_from Topics::TopicMove::SourceChangedError, with: :render_source_changed
     rescue_from Topics::TopicMove::ActiveTaskError, with: :render_active_tasks
+    rescue_from Topics::TopicMove::RecurringTaskError, with: :render_active_tasks
 
     include Collavre::CreativePermissionGuard
 

--- a/engines/collavre/app/controllers/collavre/topics_controller.rb
+++ b/engines/collavre/app/controllers/collavre/topics_controller.rb
@@ -105,7 +105,7 @@ module Collavre
     def update
       topic = @creative.topics.find(params[:id])
 
-      if topic.update(topic_params)
+      if mutate_locked_topic(topic) { |current_topic| current_topic.update(topic_params) }
         broadcast_topic_event("updated", topic: topic_json(topic))
         render json: topic_json(topic)
       else
@@ -186,7 +186,7 @@ module Collavre
 
     def archive
       topic = @creative.topics.find(params[:id])
-      topic.archive!
+      mutate_locked_topic(topic, &:archive!)
 
       broadcast_topic_event("archived", topic: topic.slice(:id, :name))
       render json: { success: true }
@@ -194,7 +194,7 @@ module Collavre
 
     def unarchive
       topic = @creative.topics.find(params[:id])
-      topic.unarchive!
+      mutate_locked_topic(topic, &:unarchive!)
 
       broadcast_topic_event("unarchived", topic: topic.slice(:id, :name, :archived_at))
       render json: { success: true }
@@ -237,7 +237,7 @@ module Collavre
       # needs a way back to an unassigned topic — otherwise a single avatar click
       # would permanently dedicate the topic to one agent.
       if params[:agent_id].blank?
-        topic.set_primary_agent!(nil)
+        mutate_locked_topic(topic) { |current_topic| current_topic.set_primary_agent!(nil) }
 
         broadcast_topic_event("updated", topic: topic_json_with_agent(topic, nil))
 
@@ -256,7 +256,7 @@ module Collavre
                status: :unprocessable_entity and return
       end
 
-      topic.set_primary_agent!(agent)
+      mutate_locked_topic(topic) { |current_topic| current_topic.set_primary_agent!(agent) }
 
       broadcast_topic_event("updated", topic: topic_json_with_agent(topic, agent))
 
@@ -276,6 +276,8 @@ module Collavre
     def set_creative
       @creative = Creative.find(params[:creative_id]).effective_origin
     end
+
+    def mutate_locked_topic(topic, &) = Topics::TopicMutation.new(topic: topic, source_creative: @creative).call(&)
 
     # A move can now release the pin for either reason, and the advice differs:
     # sharing the target creative fixes a missing-permission release, but a

--- a/engines/collavre/app/controllers/collavre/topics_controller.rb
+++ b/engines/collavre/app/controllers/collavre/topics_controller.rb
@@ -1,6 +1,7 @@
 module Collavre
   class TopicsController < ApplicationController
     rescue_from Topics::TopicMove::SourceChangedError, with: :render_source_changed
+    rescue_from Topics::TopicMove::ActiveTaskError, with: :render_active_tasks
 
     include Collavre::CreativePermissionGuard
 
@@ -274,6 +275,10 @@ module Collavre
 
     def render_source_changed(error)
       render json: { error: error.message }, status: :forbidden
+    end
+
+    def render_active_tasks(error)
+      render json: { error: error.message }, status: :unprocessable_entity
     end
 
     def set_creative

--- a/engines/collavre/app/controllers/collavre/user_creative_preferences_controller.rb
+++ b/engines/collavre/app/controllers/collavre/user_creative_preferences_controller.rb
@@ -36,9 +36,11 @@ module Collavre
       creative = Creative.find(params[:creative_id]).effective_origin
 
       return render_forbidden unless readable?(creative)
-      return render_invalid_topic unless valid_last_topic?(creative)
 
-      record, saved = persist_last_topic(creative)
+      result = persist_last_topic_selection(creative)
+      return render_invalid_topic unless result
+
+      record, saved = result
       broadcast_last_topic(creative, record) if saved
 
       render json: {
@@ -80,8 +82,16 @@ module Collavre
         record.last_topic_save_fence_issued.to_i.zero? && record.last_topic_save_fence_applied.to_i.zero?
     end
 
-    def valid_last_topic?(creative)
-      params[:last_topic_id].blank? || creative.topics.exists?(id: params[:last_topic_id])
+    def persist_last_topic_selection(creative)
+      topic_id = params[:last_topic_id].presence
+      return persist_last_topic(creative) unless topic_id
+
+      Topic.transaction do
+        topic = Topic.lock.find_by(id: topic_id)
+        next unless topic&.creative_id == creative.id
+
+        persist_last_topic(creative)
+      end
     end
 
     def persist_last_topic(creative)

--- a/engines/collavre/app/controllers/concerns/collavre/comments/batch_operations.rb
+++ b/engines/collavre/app/controllers/concerns/collavre/comments/batch_operations.rb
@@ -47,9 +47,7 @@ module Collavre
         visible_scope = @creative.comments.visible_to(Current.user)
         comments = visible_scope.where(id: comment_ids).to_a
 
-        if comments.length != comment_ids.length
-          render json: { error: I18n.t("collavre.comments.batch_delete_not_found") }, status: :not_found and return
-        end
+        return unless valid_merge_selection?(comments, comment_ids)
 
         # All comments must belong to the current user or their AI agents
         my_ai_agent_ids = Current.user.created_ai_users.pluck(:id)
@@ -87,6 +85,20 @@ module Collavre
         render json: { error: e.message }, status: :unprocessable_entity
       rescue ActiveRecord::RecordInvalid => e
         render json: { error: e.record.errors.full_messages.to_sentence }, status: :unprocessable_entity
+      end
+
+      private
+
+      def valid_merge_selection?(comments, comment_ids)
+        if comments.length != comment_ids.length
+          render json: { error: I18n.t("collavre.comments.batch_delete_not_found") }, status: :not_found
+          false
+        elsif comments.map(&:topic_id).uniq.size != 1
+          render json: { error: I18n.t("collavre.comments.merge.same_topic_required") }, status: :unprocessable_entity
+          false
+        else
+          true
+        end
       end
     end
   end

--- a/engines/collavre/app/jobs/collavre/ai_agent_job.rb
+++ b/engines/collavre/app/jobs/collavre/ai_agent_job.rb
@@ -158,15 +158,6 @@ module Collavre
         # in a topic limited to one. Re-check at the moment the row is created,
         # where the answer is authoritative, and defer into the queue instead.
         task = admit_or_defer!(agent, event_name, context)
-
-        # Counted where the row is created, not where the turn starts — and so
-        # before the deferral returns. Losing the admission race does not make
-        # this a different turn: the same dispatch, from the same burst, is
-        # parked instead of admitted, and the promotion that later runs it
-        # enters the resumed-Task branch above, which records nothing either. A
-        # count taken only on the winning side of a race is exactly blind to the
-        # bursts the threshold exists to catch.
-        record_loop_breaker_turn(agent, context)
         return if task.nil?
       end
 
@@ -290,20 +281,17 @@ module Collavre
         topic_id: context&.dig("topic", "id"),
         creative_id: context&.dig("creative", "id")
       }
-      return Task.create!(attrs.merge(status: "running")) unless topic_admission_scoped?(context)
+      unless topic_admission_scoped?(context)
+        return Task.create!(attrs.merge(status: "running")).tap { record_loop_breaker_turn(agent, context) }
+      end
 
-      topic_id = context.dig("topic", "id")
-      creative_id = context.dig("creative", "id")
-      admitted = false
-      task = nil
+      task, admitted, current_context = nil, false, false
       # A queued row here is a waiter, and what speaks for it is settled now, with
       # the row — not later, from whichever notices happen to be visible. Its
       # notice is posted in a separate transaction below, so between the two this
       # waiter is queued with nothing naming it, and a shared notice deleted in
       # that window would read an opted-out waiter as one of its own and cancel a
       # turn that was only deferred.
-      notice_scope = waiter_notice_scope(agent, context)
-
       # Counting occupants and claiming the slot must be ONE step. Two workers
       # starting within the same millisecond — the exact burst this job defends
       # against — otherwise both read an occupancy below the limit before either
@@ -312,20 +300,24 @@ module Collavre
       # admission for a topic takes the same lock, so the loser reads the
       # winner's committed row.
       Task.transaction do
-        Orchestration::TopicSlot.lock!(topic_id, creative_id)
-        admitted = Orchestration::TopicSlot.available_for?(agent.id, topic_id, creative_id, context)
+        next unless Orchestration::TopicSlot.lock_matches_context?(attrs[:topic_id], attrs[:creative_id])
+
+        current_context = true
+        admitted = Orchestration::TopicSlot.available_for?(agent.id, attrs[:topic_id], attrs[:creative_id], context)
         task = Task.create!(attrs.merge(
           status: admitted ? "running" : "queued",
           # Left nil on an admitted row: it is not waiting, so no notice speaks
           # for it and there is nothing for a stop control to represent.
-          waiting_notice_scope: admitted ? nil : notice_scope
+          waiting_notice_scope: admitted ? nil : waiter_notice_scope(agent, context)
         ))
       end
+      return unless current_context
 
-      return task if admitted
-
-      park_deferred_waiter(task, agent, event_name, context, topic_id, creative_id)
-      nil
+      park_deferred_waiter(task, agent, event_name, context, attrs[:topic_id], attrs[:creative_id]) unless admitted
+      # Count where the row is created, before an admitted turn starts and after
+      # a deferred turn is parked. A stale context creates no row and no count.
+      record_loop_breaker_turn(agent, context)
+      task if admitted
     end
 
     # Record a created turn for the loop breaker's creative-retry count.

--- a/engines/collavre/app/jobs/collavre/cancel_offline_delegated_tasks_job.rb
+++ b/engines/collavre/app/jobs/collavre/cancel_offline_delegated_tasks_job.rb
@@ -83,8 +83,10 @@ module Collavre
 
       tracker = Orchestration::ResourceTracker.for(agent)
       tasks.find_each do |task|
-        was_running = task.status == "running"
-        task.update!(status: "cancelled")
+        previous_status = task.cancel_if_active!(statuses: %w[queued pending running])
+        next unless previous_status
+
+        was_running = previous_status == "running"
         tracker.release!(task.id) if was_running
       end
     end
@@ -94,7 +96,8 @@ module Collavre
 
       tracker = Orchestration::ResourceTracker.for(agent)
       tasks.find_each do |task|
-        task.update!(status: "cancelled")
+        next unless task.cancel_if_active!(statuses: %w[delegated])
+
         tracker.release!(task.id)
 
         if task.topic_id.present?

--- a/engines/collavre/app/jobs/collavre/compress_job.rb
+++ b/engines/collavre/app/jobs/collavre/compress_job.rb
@@ -86,6 +86,9 @@ module Collavre
     private
 
     def persist_summary(comments, summary_content, agent, user, compress_pattern)
+      comments = lock_matching_comments(comments)
+      return unless comments
+
       creative = comments.first.creative
       topic_id = comments.first.topic_id
       # Author AI output as the agent so the comment is recognized as AI-generated
@@ -104,6 +107,17 @@ module Collavre
         result_comment: summary_comment
       )
       creative.comments.where(id: comments.map(&:id)).destroy_all
+    end
+
+    def lock_matching_comments(comments)
+      comment_ids = comments.map(&:id)
+      locked = Comment.where(id: comment_ids).order(:id).lock.index_by(&:id)
+      expected = comments.first
+      return unless locked.size == comment_ids.size && locked.values.all? do |comment|
+        comment.creative_id == expected.creative_id && comment.topic_id == expected.topic_id
+      end
+
+      comment_ids.map { |id| locked.fetch(id) }
     end
   end
 end

--- a/engines/collavre/app/jobs/collavre/compress_job.rb
+++ b/engines/collavre/app/jobs/collavre/compress_job.rb
@@ -39,7 +39,9 @@ module Collavre
 
       unless agent
         error_msg = I18n.t("collavre.comments.compress_command.no_agent")
-        creative.comments.create!(user: user, topic_id: topic_id, content: "⚠️ #{error_msg}", skip_dispatch: true)
+        Comments::TopicMutation.call(topic_id, creative_id) do
+          creative.comments.create!(user: user, topic_id: topic_id, content: "⚠️ #{error_msg}", skip_dispatch: true)
+        end
         Rails.logger.error("[CompressJob] No AI agent found for creative #{creative_id}, topic #{topic_id}")
         return
       end

--- a/engines/collavre/app/jobs/collavre/compress_job.rb
+++ b/engines/collavre/app/jobs/collavre/compress_job.rb
@@ -74,26 +74,25 @@ module Collavre
       title = I18n.t("collavre.comments.compress_command.summary_title", topic: topic_name)
       summary_content = "**#{title}**\n\n#{summary}"
 
-      # Store comment IDs to delete before creating the new one (all originals including /compress command)
-      comment_ids_to_delete = all_comments.pluck(:id)
+      Comments::TopicMutation.call(topic_id, creative_id) do
+        persist_summary(all_comments, summary_content, agent, user, compress_pattern)
+      end
+    rescue ActiveRecord::RecordNotFound => e
+      Rails.logger.error("[CompressJob] Record not found: #{e.message}")
+    end
 
-      # Create the summary comment in the same topic.
-      # Author it as the AI agent (not the human who ran /compress) so the
-      # comment is recognized as AI-generated content: this makes ai_user? true,
-      # which is what gates the "Review" button in the comment view. The summary
-      # body is AI output, so the agent is the correct author.
+    private
+
+    def persist_summary(comments, summary_content, agent, user, compress_pattern)
+      creative = comments.first.creative
+      topic_id = comments.first.topic_id
+      # Author AI output as the agent so the comment is recognized as AI-generated
+      # content and offers the Review action.
       summary_comment = creative.comments.create!(
-        user: agent,
-        topic_id: topic_id,
-        content: summary_content,
-        skip_dispatch: true  # system-generated summary, not user input
+        user: agent, topic_id: topic_id, content: summary_content, skip_dispatch: true
       )
-
-      # Save snapshot for recovery before deleting originals
-      # Exclude the last comment only if it's the /compress command trigger
-      last_comment = all_comments.last
-      last_is_command = last_comment&.content.to_s.strip.match?(compress_pattern)
-      restorable_comments = last_is_command ? all_comments[0..-2] : all_comments.to_a
+      last_is_command = comments.last&.content.to_s.strip.match?(compress_pattern)
+      restorable_comments = last_is_command ? comments[0..-2] : comments.to_a
       CommentSnapshot.create!(
         creative: creative,
         topic_id: topic_id,
@@ -102,11 +101,7 @@ module Collavre
         comments_data: serialize_comments(restorable_comments),
         result_comment: summary_comment
       )
-
-      # Delete original comments (excluding the newly created summary)
-      creative.comments.where(id: comment_ids_to_delete).destroy_all
-    rescue ActiveRecord::RecordNotFound => e
-      Rails.logger.error("[CompressJob] Record not found: #{e.message}")
+      creative.comments.where(id: comments.map(&:id)).destroy_all
     end
   end
 end

--- a/engines/collavre/app/jobs/collavre/cron_action_job.rb
+++ b/engines/collavre/app/jobs/collavre/cron_action_job.rb
@@ -11,7 +11,7 @@ module Collavre
     queue_as :default
 
     def perform(creative_id:, topic_id:, agent_id:, message:)
-      creative = Creative.find_by(id: creative_id)
+      creative = Creative.find_by(id: creative_id)&.effective_origin
       agent = User.find_by(id: agent_id)
 
       unless creative && agent
@@ -21,23 +21,14 @@ module Collavre
         return
       end
 
-      # topic_id nil means main topic; otherwise look up the topic
-      topic = nil
-      if topic_id.present?
-        topic = Topic.find_by(id: topic_id)
-        unless topic
-          Rails.logger.warn("[CronActionJob] Skipping: topic=#{topic_id} not found")
-          return
-        end
+      topic = topic_id.present? ? Topic.find_by(id: topic_id) : creative.main_topic(fallback_user: agent)
+      unless topic
+        Rails.logger.warn("[CronActionJob] Skipping: topic=#{topic_id} not found")
+        return
       end
 
-      comment = creative.comments.create!(
-        content: message,
-        user: agent,
-        topic_id: topic&.id,
-        private: false,
-        skip_dispatch: true  # manual dispatch below (AI user would skip model callback)
-      )
+      comment = create_comment(creative, topic, agent, message)
+      return unless comment
 
       # Dispatch system event to trigger agent orchestration pipeline
       # (manual because cron-initiated AI messages intentionally need dispatch)
@@ -71,6 +62,24 @@ module Collavre
       Rails.logger.info(
         "[CronActionJob] Posted cron message to creative #{creative_id}, topic #{topic_id || 'main'}"
       )
+    end
+
+    private
+
+    def create_comment(creative, topic, agent, message)
+      comment = nil
+      applied = Comments::TopicMutation.call(topic.id, creative.id) do
+        comment = creative.comments.create!(
+          content: message, user: agent, topic: topic, private: false,
+          skip_dispatch: true
+        )
+      end
+      return comment if applied
+
+      Rails.logger.warn(
+        "[CronActionJob] Skipping: topic=#{topic.id} no longer belongs to creative=#{creative.id}"
+      )
+      nil
     end
   end
 end

--- a/engines/collavre/app/jobs/collavre/drop_trigger_job.rb
+++ b/engines/collavre/app/jobs/collavre/drop_trigger_job.rb
@@ -35,13 +35,8 @@ module Collavre
       end
 
       topic = find_or_create_trigger_topic(child, agent)
-
-      # Initialize trigger loop state on the child creative
-      initialize_trigger_loop(child, topic)
-
-      # Step 1: Find existing or create new trigger comment (idempotent)
-      comment = find_trigger_comment(child, parent, topic) ||
-                create_trigger_comment(child, parent, agent, topic)
+      comment = prepare_trigger(child, parent, agent, topic)
+      return unless comment
 
       # Step 2: Skip if dispatch already produced a Task for this comment
       return if task_exists_for?(comment)
@@ -57,6 +52,19 @@ module Collavre
     end
 
     private
+
+    def prepare_trigger(child, parent, agent, topic)
+      comment = nil
+      applied = Comments::TopicMutation.call(topic.id, child.id) do
+        # The loop reference and its trigger comment must be created under the
+        # topic lock. A concurrent topic move either sees the reference and is
+        # rejected, or wins first and makes this stale job a no-op.
+        initialize_trigger_loop(child.reload, topic)
+        comment = find_trigger_comment(child, parent, topic) ||
+                  create_trigger_comment(child, parent, agent, topic)
+      end
+      comment if applied
+    end
 
     def post_trigger_failure_notice(child, parent)
       topic = child.topics.find_by(name: DROP_TRIGGER_TOPIC_NAME) ||

--- a/engines/collavre/app/jobs/collavre/merge_comments_job.rb
+++ b/engines/collavre/app/jobs/collavre/merge_comments_job.rb
@@ -24,7 +24,7 @@ module Collavre
         .includes(:user, images_attachments: :blob)
         .to_a
 
-      return if comments.size < 2
+      return unless mergeable_selection?(comments)
 
       target_comment = comments.first
       topic_id = target_comment.topic_id
@@ -68,12 +68,27 @@ module Collavre
         return
       end
 
-      Comments::TopicMutation.call(topic_id, creative_id) { persist_merge(comments, merged_content, user_id) }
+      Comments::TopicMutation.call(topic_id, creative_id) do
+        current_comments = lock_current_comments(comments, creative_id, topic_id)
+        persist_merge(current_comments, merged_content, user_id) if current_comments
+      end
     rescue ActiveRecord::RecordNotFound => e
       Rails.logger.error("[MergeCommentsJob] Record not found: #{e.message}")
     end
 
     private
+
+    def mergeable_selection?(comments)
+      comments.size >= 2 && comments.map(&:topic_id).uniq.size == 1
+    end
+
+    def lock_current_comments(comments, creative_id, topic_id)
+      current_comments = Comment.where(id: comments.map(&:id)).order(created_at: :asc).lock.to_a
+      return unless current_comments.size == comments.size
+      return unless current_comments.all? { |comment| comment.creative_id == creative_id && comment.topic_id == topic_id }
+
+      current_comments
+    end
 
     def persist_merge(comments, merged_content, user_id)
       target_comment = comments.first

--- a/engines/collavre/app/jobs/collavre/merge_comments_job.rb
+++ b/engines/collavre/app/jobs/collavre/merge_comments_job.rb
@@ -68,24 +68,26 @@ module Collavre
         return
       end
 
-      # Update the first comment and delete the rest atomically
-      remaining_ids = comments[1..].map(&:id)
-      ActiveRecord::Base.transaction do
-        # Save snapshot for recovery before modifying/deleting originals
-        CommentSnapshot.create!(
-          creative: creative,
-          topic_id: topic_id,
-          user_id: user_id,
-          operation: "merge",
-          comments_data: serialize_comments(comments),
-          result_comment: target_comment
-        )
-
-        target_comment.update!(content: merged_content)
-        creative.comments.where(id: remaining_ids).destroy_all
-      end
+      Comments::TopicMutation.call(topic_id, creative_id) { persist_merge(comments, merged_content, user_id) }
     rescue ActiveRecord::RecordNotFound => e
       Rails.logger.error("[MergeCommentsJob] Record not found: #{e.message}")
+    end
+
+    private
+
+    def persist_merge(comments, merged_content, user_id)
+      target_comment = comments.first
+      creative = target_comment.creative
+      CommentSnapshot.create!(
+        creative: creative,
+        topic_id: target_comment.topic_id,
+        user_id: user_id,
+        operation: "merge",
+        comments_data: serialize_comments(comments),
+        result_comment: target_comment
+      )
+      target_comment.update!(content: merged_content)
+      creative.comments.where(id: comments[1..].map(&:id)).destroy_all
     end
   end
 end

--- a/engines/collavre/app/models/collavre/comment/topic_membership.rb
+++ b/engines/collavre/app/models/collavre/comment/topic_membership.rb
@@ -8,6 +8,7 @@ module Collavre
       included do
         before_validation :assign_main_topic, on: :create
         before_validation :stamp_topic_assignment
+        before_create :lock_matching_topic
       end
 
       private
@@ -26,6 +27,14 @@ module Collavre
         return unless will_save_change_to_topic_id? || topic_assigned_at.nil?
 
         self.topic_assigned_at = Time.current
+      end
+
+      def lock_matching_topic
+        locked_topic = Topic.where(id: topic_id).lock.first
+        return if locked_topic&.creative_id == creative_id
+
+        errors.add(:topic, I18n.t("collavre.comments.invalid_topic"))
+        throw :abort
       end
     end
   end

--- a/engines/collavre/app/models/collavre/task.rb
+++ b/engines/collavre/app/models/collavre/task.rb
@@ -68,6 +68,19 @@ module Collavre
       ACTIVE_STATUSES.include?(status)
     end
 
+    # Cancellation callers often select an active row before waiting on another
+    # request's task lock. Reload under that lock so a completed reply cannot be
+    # overwritten by a stale running/delegated instance.
+    def cancel_if_active!(statuses: ACTIVE_STATUSES, **attributes)
+      with_lock do
+        next unless status.in?(statuses)
+
+        previous_status = status
+        update!(attributes.merge(status: "cancelled"))
+        previous_status
+      end
+    end
+
     # Check if agent already has an in-flight task triggered by the same comment.
     # Treats "delegated" as in-flight: a Claude Channel task that is waiting on
     # an external MCP reply is still active work — re-dispatching the same

--- a/engines/collavre/app/services/collavre/ai_agent/task_claim_service.rb
+++ b/engines/collavre/app/services/collavre/ai_agent/task_claim_service.rb
@@ -56,20 +56,21 @@ module Collavre
         comment.update_column(:task_id, task.id)
       end
 
-      # Post-claim side effects, run only after the reply comment transaction has
-      # committed. The topic lock plus the active running state make the gap
-      # move-safe. Finalization takes the same topic lock, commits done, then
-      # releases the ResourceTracker slot the
+      # Finalize the claimed row inside TaskReplyService's topic-lock
+      # transaction. Completion effects are registered after commit, when the
+      # linked comment and done status are both visible. This leaves no gap for
+      # cancellation or TopicMove between reply persistence and completion.
+      # The effects release the ResourceTracker slot the
       # AiAgentJob held under task.id, and drains the topic queue — mirroring AiAgentJob#perform's success path for
       # non-delegated runs.
       def finalize(agent:, task:, comment:)
-        topic = Topic.find(task.topic_id)
-        topic.with_lock do
-          Task.where(id: task.id, status: "running").update_all(status: "done", updated_at: Time.current)
-          task.reload
-          ActiveRecord.after_all_transactions_commit do
-            run_completion_effects(agent, task, comment)
-          end
+        completed = Task.where(id: task.id, status: "running")
+                        .update_all(status: "done", updated_at: Time.current)
+        raise ActiveRecord::RecordNotSaved, "claimed reply task was not running" unless completed == 1
+
+        task.reload
+        ActiveRecord.after_all_transactions_commit do
+          run_completion_effects(agent, task, comment)
         end
       end
 

--- a/engines/collavre/app/services/collavre/ai_agent/task_claim_service.rb
+++ b/engines/collavre/app/services/collavre/ai_agent/task_claim_service.rb
@@ -14,12 +14,15 @@ module Collavre
       #      echoes the dispatch's task_id). Without task_id (legacy clients),
       #      oldest-first.
       #   2. Inside a transaction: SELECT FOR UPDATE the row, re-check
-      #      status == 'delegated' under the lock, then update! to 'done'.
+      #      status == 'delegated' under the lock, then update it to 'running'.
       #      Concurrent claimers block on the lock; the loser sees the
       #      already-flipped status post-lock and returns nil so the caller can
       #      refuse the duplicate.
-      # update_all (NOT update!) is required to skip Task's after_update_commit
-      # callbacks at claim time. The callbacks fire check_trigger_loop_completion
+      # running is a transient claimed-reply state. It remains active while the
+      # comment transaction commits, so TopicMove cannot slip between claim and
+      # finalize; another /reply cannot claim it because only delegated rows are
+      # eligible. update_all (NOT update!) is required to skip callbacks at
+      # claim time. The callbacks fire check_trigger_loop_completion
       # (which enqueues TriggerLoopCheckJob) and broadcast_stop_button_removal
       # (which reads reply_comment). Both depend on the reply comment already
       # existing — but reply() claims BEFORE comment.save to win the race against
@@ -43,19 +46,36 @@ module Collavre
           locked = Task.lock.find_by(id: candidate.id)
           next unless locked && locked.status == "delegated"
 
-          Task.where(id: locked.id).update_all(status: "done", pending_tool_call: nil, updated_at: Time.current)
+          Task.where(id: locked.id).update_all(status: "running", pending_tool_call: nil, updated_at: Time.current)
           claimed = locked.reload
         end
         claimed
       end
 
-      # Post-claim side effects, run only after the reply comment is saved. Links
-      # the comment to the claimed task, releases the ResourceTracker slot the
+      def link_reply(task:, comment:)
+        comment.update_column(:task_id, task.id)
+      end
+
+      # Post-claim side effects, run only after the reply comment transaction has
+      # committed. The topic lock plus the active running state make the gap
+      # move-safe. Finalization takes the same topic lock, commits done, then
+      # releases the ResourceTracker slot the
       # AiAgentJob held under task.id, and drains the topic queue — mirroring AiAgentJob#perform's success path for
       # non-delegated runs.
       def finalize(agent:, task:, comment:)
-        comment.update_column(:task_id, task.id)
+        topic = Topic.find(task.topic_id)
+        topic.with_lock do
+          Task.where(id: task.id, status: "running").update_all(status: "done", updated_at: Time.current)
+          task.reload
+          ActiveRecord.after_all_transactions_commit do
+            run_completion_effects(agent, task, comment)
+          end
+        end
+      end
 
+      private
+
+      def run_completion_effects(agent, task, comment)
         Orchestration::ResourceTracker.for(agent).release!(task.id)
 
         Orchestration::AgentOrchestrator.dequeue_next_for_topic(task.topic_id, task.creative_id)
@@ -73,8 +93,6 @@ module Collavre
         # drops the moment Claude's reply lands.
         broadcast_claude_idle(agent, task, comment)
       end
-
-      private
 
       # Clear the chat typing indicator via the canonical status broadcaster (the
       # same one AiAgentService uses for every other agent), so the Claude path

--- a/engines/collavre/app/services/collavre/ai_agent/task_reply_service.rb
+++ b/engines/collavre/app/services/collavre/ai_agent/task_reply_service.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module Collavre
+  module AiAgent
+    # Keeps a delegated Claude reply's claim, comment insert, and completion on
+    # the topic lock used by TopicMove. A move therefore sees the delegated task
+    # and waits, or runs after the complete reply is committed.
+    class TaskReplyService
+      Result = Data.define(:status, :body, :comment, :agent, :task)
+
+      def initialize(topic:, current_user:, text:, requested_task_id:, agent_resolver:, task_claimer:, claim_service:)
+        @topic = topic
+        @current_user = current_user
+        @text = text
+        @requested_task_id = requested_task_id
+        @agent_resolver = agent_resolver
+        @task_claimer = task_claimer
+        @claim_service = claim_service
+      end
+
+      def call
+        result = topic.with_lock { build_result }
+        claim_service.finalize(agent: result.agent, task: result.task, comment: result.comment) if result.task
+        result
+      end
+
+      private
+
+      attr_reader :topic, :current_user, :text, :requested_task_id, :agent_resolver, :task_claimer, :claim_service
+
+      def build_result
+        creative = topic.creative&.effective_origin
+        return result(:not_found, error: "Creative not found") unless creative
+        return result(:forbidden, error: "Not authorized") unless creative.has_permission?(current_user, :feedback)
+
+        agent = agent_resolver.call(topic, requested_task_id)
+        return result(:forbidden, error: "Not authorized") unless agent
+
+        task = task_claimer.call(agent, topic, requested_task_id)
+        if requested_task_id.present? && task.nil?
+          return result(:conflict, error: "Task already completed or not delegated")
+        end
+
+        persist_reply(creative, agent, task)
+      end
+
+      def persist_reply(creative, agent, task)
+        comment = creative.comments.build(
+          content: text.to_s, topic: topic, user: agent,
+          skip_default_user: true, skip_dispatch: true
+        )
+        return failed_result(comment, task) unless comment.save
+
+        claim_service.link_reply(task: task, comment: comment) if task
+        Result.new(status: :created, body: { comment_id: comment.id }, comment: comment, agent: agent, task: task)
+      end
+
+      def failed_result(comment, task)
+        task&.update!(status: "delegated")
+        result(:unprocessable_entity, errors: comment.errors.full_messages)
+      end
+
+      def result(status, **body)
+        Result.new(status: status, body: body, comment: nil, agent: nil, task: nil)
+      end
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/ai_agent/task_reply_service.rb
+++ b/engines/collavre/app/services/collavre/ai_agent/task_reply_service.rb
@@ -19,9 +19,7 @@ module Collavre
       end
 
       def call
-        result = topic.with_lock { build_result }
-        claim_service.finalize(agent: result.agent, task: result.task, comment: result.comment) if result.task
-        result
+        topic.with_lock { build_result }
       end
 
       private
@@ -52,6 +50,7 @@ module Collavre
         return failed_result(comment, task) unless comment.save
 
         claim_service.link_reply(task: task, comment: comment) if task
+        claim_service.finalize(agent: agent, task: task, comment: comment) if task
         Result.new(status: :created, body: { comment_id: comment.id }, comment: comment, agent: agent, task: task)
       end
 

--- a/engines/collavre/app/services/collavre/comment_move_service.rb
+++ b/engines/collavre/app/services/collavre/comment_move_service.rb
@@ -37,7 +37,7 @@ module Collavre
         target_origin = target_creative.effective_origin
         [ target_origin, target_origin.main_topic.id ]
       elsif !target_topic_id.nil?
-        new_topic_id = target_topic_id.presence
+        new_topic_id = target_topic_id.presence&.to_i
         if new_topic_id.present? && !creative.topics.exists?(id: new_topic_id)
           raise MoveError, I18n.t("collavre.comments.move_invalid_topic", default: "Invalid topic")
         end
@@ -63,12 +63,11 @@ module Collavre
     def perform_move(comments, target_origin, new_topic_id)
       moved_count = 0
       ActiveRecord::Base.transaction do
-        # MessagePage holds the destination topic lock while fixing its
-        # membership anchor. Serialize move-ins on the same row so a comment
-        # cannot be stamped before the snapshot but committed after its reads.
-        Topic.lock.find(new_topic_id)
+        locked_topics = lock_move_topics(comments, new_topic_id)
+        validate_destination_topic!(locked_topics, new_topic_id, target_origin)
 
         comments.each do |comment|
+          validate_source_comment!(comment, locked_topics)
           same_creative = comment.creative_id == target_origin.id
           same_topic = comment.topic_id.to_s == new_topic_id.to_s
           next if same_creative && same_topic
@@ -89,6 +88,30 @@ module Collavre
         end
       end
       moved_count
+    end
+
+    # TopicMove takes the source topic lock before sweeping its comments. Lock
+    # every source plus the destination in one deterministic order, so an
+    # existing-comment move cannot write a stale topic_id after that sweep.
+    def lock_move_topics(comments, destination_topic_id)
+      topic_ids = (comments.map(&:topic_id) + [ destination_topic_id ]).compact.uniq.sort
+      Topic.where(id: topic_ids).order(:id).lock.index_by(&:id)
+    end
+
+    def validate_destination_topic!(locked_topics, topic_id, target_origin)
+      return if locked_topics[topic_id]&.creative_id == target_origin.id
+
+      raise MoveError, I18n.t("collavre.comments.move_invalid_topic", default: "Invalid topic")
+    end
+
+    def validate_source_comment!(comment, locked_topics)
+      original_topic_id = comment.topic_id
+      comment.reload
+      source_topic = locked_topics[original_topic_id]
+      return if comment.creative_id == creative.id && comment.topic_id == original_topic_id &&
+                source_topic&.creative_id == creative.id
+
+      raise MoveError, I18n.t("collavre.comments.move_not_allowed")
     end
 
     # A topic watermark is an ordered cursor, so a comment moved into a topic

--- a/engines/collavre/app/services/collavre/comment_move_service.rb
+++ b/engines/collavre/app/services/collavre/comment_move_service.rb
@@ -63,8 +63,8 @@ module Collavre
     def perform_move(comments, target_origin, new_topic_id)
       moved_count = 0
       ActiveRecord::Base.transaction do
-        locked_source_creative = lock_legacy_source_creative(comments)
         locked_topics = lock_move_topics(comments, new_topic_id)
+        locked_source_creative = lock_legacy_source_creative(comments)
         validate_destination_topic!(locked_topics, new_topic_id, target_origin)
 
         comments.each do |comment|

--- a/engines/collavre/app/services/collavre/comment_move_service.rb
+++ b/engines/collavre/app/services/collavre/comment_move_service.rb
@@ -63,14 +63,14 @@ module Collavre
     def perform_move(comments, target_origin, new_topic_id)
       moved_count = 0
       ActiveRecord::Base.transaction do
+        locked_source_creative = lock_legacy_source_creative(comments)
         locked_topics = lock_move_topics(comments, new_topic_id)
         validate_destination_topic!(locked_topics, new_topic_id, target_origin)
 
         comments.each do |comment|
-          validate_source_comment!(comment, locked_topics)
+          validate_source_comment!(comment, locked_topics, locked_source_creative)
           same_creative = comment.creative_id == target_origin.id
-          same_topic = comment.topic_id.to_s == new_topic_id.to_s
-          next if same_creative && same_topic
+          next if same_creative && comment.topic_id.to_s == new_topic_id.to_s
 
           if same_creative
             preserve_unread_state_for_topic_move(comment, new_topic_id)
@@ -90,6 +90,12 @@ module Collavre
       moved_count
     end
 
+    def lock_legacy_source_creative(comments)
+      return creative unless comments.any? { |comment| comment.topic_id.nil? }
+
+      Creative.lock.find(creative.id)
+    end
+
     # TopicMove takes the source topic lock before sweeping its comments. Lock
     # every source plus the destination in one deterministic order, so an
     # existing-comment move cannot write a stale topic_id after that sweep.
@@ -104,12 +110,13 @@ module Collavre
       raise MoveError, I18n.t("collavre.comments.move_invalid_topic", default: "Invalid topic")
     end
 
-    def validate_source_comment!(comment, locked_topics)
+    def validate_source_comment!(comment, locked_topics, locked_source_creative)
       original_topic_id = comment.topic_id
       comment.reload
       source_topic = locked_topics[original_topic_id]
+      source_membership_valid = original_topic_id.nil? || source_topic&.creative_id == locked_source_creative.id
       return if comment.creative_id == creative.id && comment.topic_id == original_topic_id &&
-                source_topic&.creative_id == creative.id
+                source_membership_valid
 
       raise MoveError, I18n.t("collavre.comments.move_not_allowed")
     end

--- a/engines/collavre/app/services/collavre/comment_snapshot_restore_service.rb
+++ b/engines/collavre/app/services/collavre/comment_snapshot_restore_service.rb
@@ -11,14 +11,13 @@ module Collavre
 
     def call
       ActiveRecord::Base.transaction do
-        # Lock the snapshot row to prevent concurrent restore (P2 fix)
-        locked_snapshot = CommentSnapshot.lock.find(@snapshot.id)
+        locked_snapshot = lock_snapshot
 
         if locked_snapshot.restored_at.present?
           raise RestoreError, I18n.t("collavre.comment_snapshots.already_restored")
         end
 
-        validate_permission!
+        validate_permission!(locked_snapshot)
 
         # Build a mapping from old comment IDs to new comments for quoted_comment_id restoration
         old_id_to_new = {}
@@ -71,8 +70,15 @@ module Collavre
 
     private
 
-    def validate_permission!
-      creative = @snapshot.creative
+    # TopicMove locks topic -> snapshots. Match that order so restoration
+    # cannot deadlock relocation while recreating comments.
+    def lock_snapshot
+      Topic.lock.find(@snapshot.topic_id) if @snapshot.topic_id
+      CommentSnapshot.lock.find(@snapshot.id)
+    end
+
+    def validate_permission!(snapshot)
+      creative = snapshot.creative
       unless creative.has_permission?(@user, :write)
         raise RestoreError, I18n.t("collavre.comment_snapshots.not_authorized")
       end

--- a/engines/collavre/app/services/collavre/comments/read_pointer_writer.rb
+++ b/engines/collavre/app/services/collavre/comments/read_pointer_writer.rb
@@ -44,10 +44,10 @@ module Collavre
         return [] if last_ids_by_topic_id.empty?
 
         ActiveRecord::Base.transaction do
-          lock_named_topics!(last_ids_by_topic_id.keys)
+          locked_topic_ids = lock_named_topics!(last_ids_by_topic_id.keys)
           existing = existing_watermarks
           changes = last_ids_by_topic_id.map { |topic_id, last_id| change_for(existing, topic_id, last_id) }
-          store(changes, existing)
+          store(changes, existing, locked_topic_ids)
           # The request's own view of the watermark is not what the row now holds:
           # a concurrent writer may have advanced past it, in which case the
           # forward-only SQL kept *their* value. Broadcasting this request's
@@ -62,11 +62,13 @@ module Collavre
       attr_reader :creative, :user
 
       def lock_named_topics!(topic_ids)
-        ids = topic_ids.compact.map(&:to_i).uniq.sort
-        return if ids.empty?
+        ids = topic_ids.compact.map(&:to_i)
+        ids.concat(creative.topics.ids) if topic_ids.include?(nil)
+        ids = ids.uniq.sort
+        return ids if ids.empty?
 
         locked = Topic.where(id: ids).order(:id).lock.pluck(:id, :creative_id)
-        return if locked.length == ids.length && locked.all? { |_, creative_id| creative_id == creative.id }
+        return ids if locked.length == ids.length && locked.all? { |_, creative_id| creative_id == creative.id }
 
         raise StaleTopicError, I18n.t("collavre.comments.invalid_topic")
       end
@@ -88,13 +90,13 @@ module Collavre
         )
       end
 
-      def store(changes, existing)
+      def store(changes, existing, locked_topic_ids)
         named, legacy = changes.partition { |change| change.topic_id.present? }
         upsert_named(named.select(&:stored?))
         legacy_change = legacy.first
         return unless legacy_change&.stored?
 
-        preserve_named_fallbacks(legacy_change, existing, named) if legacy_change.advanced?
+        preserve_named_fallbacks(legacy_change, existing, named, locked_topic_ids) if legacy_change.advanced?
         store_legacy(legacy_change)
       end
 
@@ -166,10 +168,10 @@ module Collavre
       # without its own row. Before moving it forward, pin those topics at the
       # fallback they were already showing, so an unseen older topic does not
       # silently inherit the new legacy value.
-      def preserve_named_fallbacks(change, existing, named_changes)
+      def preserve_named_fallbacks(change, existing, named_changes, locked_topic_ids)
         covered_topic_ids = existing.keys.compact + named_changes.map(&:topic_id)
         now = Time.current
-        rows = creative.topics.where.not(id: covered_topic_ids).pluck(:id).map do |topic_id|
+        rows = (locked_topic_ids - covered_topic_ids).map do |topic_id|
           {
             user_id: user.id,
             creative_id: creative.id,

--- a/engines/collavre/app/services/collavre/comments/read_pointer_writer.rb
+++ b/engines/collavre/app/services/collavre/comments/read_pointer_writer.rb
@@ -18,6 +18,8 @@ module Collavre
     # Because of that the request's own view can be stale, so the positions it
     # reports for broadcasting are read back after the write.
     class ReadPointerWriter
+      class StaleTopicError < StandardError; end
+
       Change = Struct.new(:topic_id, :previous_id, :updated_id, :created, keyword_init: true) do
         def stored?
           created || previous_id != updated_id
@@ -41,20 +43,33 @@ module Collavre
       def call(last_ids_by_topic_id)
         return [] if last_ids_by_topic_id.empty?
 
-        existing = existing_watermarks
-        changes = last_ids_by_topic_id.map { |topic_id, last_id| change_for(existing, topic_id, last_id) }
-        store(changes, existing)
-        # The request's own view of the watermark is not what the row now holds:
-        # a concurrent writer may have advanced past it, in which case the
-        # forward-only SQL kept *their* value. Broadcasting this request's
-        # updated_id would repaint the receipt at a position the database has
-        # already moved beyond, so read back what was actually retained.
-        positions(changes, existing, existing_watermarks)
+        ActiveRecord::Base.transaction do
+          lock_named_topics!(last_ids_by_topic_id.keys)
+          existing = existing_watermarks
+          changes = last_ids_by_topic_id.map { |topic_id, last_id| change_for(existing, topic_id, last_id) }
+          store(changes, existing)
+          # The request's own view of the watermark is not what the row now holds:
+          # a concurrent writer may have advanced past it, in which case the
+          # forward-only SQL kept *their* value. Broadcasting this request's
+          # updated_id would repaint the receipt at a position the database has
+          # already moved beyond, so read back what was actually retained.
+          positions(changes, existing, existing_watermarks)
+        end
       end
 
       private
 
       attr_reader :creative, :user
+
+      def lock_named_topics!(topic_ids)
+        ids = topic_ids.compact.map(&:to_i).uniq.sort
+        return if ids.empty?
+
+        locked = Topic.where(id: ids).order(:id).lock.pluck(:id, :creative_id)
+        return if locked.length == ids.length && locked.all? { |_, creative_id| creative_id == creative.id }
+
+        raise StaleTopicError, I18n.t("collavre.comments.invalid_topic")
+      end
 
       def existing_watermarks
         CommentReadPointer.where(user: user, creative: creative).pluck(:topic_id, :last_read_comment_id).to_h

--- a/engines/collavre/app/services/collavre/comments/read_pointer_writer.rb
+++ b/engines/collavre/app/services/collavre/comments/read_pointer_writer.rb
@@ -63,14 +63,17 @@ module Collavre
 
       def lock_named_topics!(topic_ids)
         ids = topic_ids.compact.map(&:to_i)
-        ids.concat(creative.topics.ids) if topic_ids.include?(nil)
         ids = ids.uniq.sort
-        return ids if ids.empty?
+        unless ids.empty?
+          locked = Topic.where(id: ids).order(:id).lock.pluck(:id, :creative_id)
+          unless locked.length == ids.length && locked.all? { |_, creative_id| creative_id == creative.id }
+            raise StaleTopicError, I18n.t("collavre.comments.invalid_topic")
+          end
+        end
+        return ids unless topic_ids.include?(nil)
 
-        locked = Topic.where(id: ids).order(:id).lock.pluck(:id, :creative_id)
-        return ids if locked.length == ids.length && locked.all? { |_, creative_id| creative_id == creative.id }
-
-        raise StaleTopicError, I18n.t("collavre.comments.invalid_topic")
+        creative.lock!
+        (ids + creative.topics.ids).uniq
       end
 
       def existing_watermarks

--- a/engines/collavre/app/services/collavre/comments/topic_mutation.rb
+++ b/engines/collavre/app/services/collavre/comments/topic_mutation.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Collavre
+  module Comments
+    module TopicMutation
+      module_function
+
+      def call(topic_id, creative_id)
+        applied = false
+        ActiveRecord::Base.transaction do
+          next unless Orchestration::TopicSlot.lock_matches_context?(topic_id, creative_id)
+
+          yield
+          applied = true
+        end
+        applied
+      end
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/crons/recurring_topic_tasks.rb
+++ b/engines/collavre/app/services/collavre/crons/recurring_topic_tasks.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Collavre
+  module Crons
+    class RecurringTopicTasks
+      include RecurringTaskArguments
+
+      def initialize(topic_id)
+        @topic_id = topic_id.to_i
+      end
+
+      def any?
+        SolidQueue::RecurringTask.where(static: false).any? do |task|
+          parse_arguments(task)["topic_id"].to_i == topic_id
+        end
+      end
+
+      private
+
+      attr_reader :topic_id
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
+++ b/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
@@ -695,13 +695,9 @@ module Collavre
 
       private
 
-      def policy_resolver
-        @policy_resolver ||= PolicyResolver.new(@context)
-      end
+      def policy_resolver = @policy_resolver ||= PolicyResolver.new(@context)
 
-      def scheduler
-        @scheduler ||= Scheduler.new(@context, policy_resolver: policy_resolver)
-      end
+      def scheduler = @scheduler ||= Scheduler.new(@context, policy_resolver: policy_resolver)
 
       def enqueue_jobs(decisions, context_for:)
         decisions.filter_map do |decision|
@@ -895,7 +891,7 @@ module Collavre
       end
 
       def create_waiting_notice(creative, topic_id, reason_text, deferred:, shared:, waiter:)
-        creative.comments.create!(
+        creative.comments.build(
           content: I18n.t("collavre.orchestration.waiting_notice", reason: reason_text),
           topic_id: topic_id,
           private: false,
@@ -908,7 +904,11 @@ module Collavre
           # Comment#cancel_queued_tasks_for_waiting_notice.
           waiting_notice_scope: deferred ? (shared ? Comment::WAITING_NOTICE_TOPIC : Comment::WAITING_NOTICE_TASK) : nil,
           waiting_notice_task_id: (waiter&.id unless shared)
-        )
+        ).tap(&:save!)
+      rescue ActiveRecord::RecordNotSaved => error
+        # A delayed job is already queued when this notice is posted. Topic
+        # relocation may invalidate only the stale notice in that gap.
+        raise unless error.record.errors.include?(:topic)
       end
 
       # Human-readable reason for the "⏳" waiting notice. For topic-concurrency

--- a/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
+++ b/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
@@ -770,7 +770,8 @@ module Collavre
             AiAgentJob.perform_later(agent.id, @event_name, context)
             agent
           when :deferred
-            waiter = park_waiter(agent, context)
+            next unless (waiter = park_waiter(agent, context))
+
             post_waiting_notice(agent, decision, waiter: waiter)
             agent
           when :delayed
@@ -814,7 +815,8 @@ module Collavre
         waiter = nil
 
         Task.transaction do
-          TopicSlot.lock!(topic_id, creative_id)
+          next unless TopicSlot.matches_context?(TopicSlot.lock!(topic_id, creative_id), topic_id, creative_id)
+
           waiter = Task.create!(
             name: "Response to #{@event_name}",
             status: "queued",

--- a/engines/collavre/app/services/collavre/orchestration/delivery_record.rb
+++ b/engines/collavre/app/services/collavre/orchestration/delivery_record.rb
@@ -340,9 +340,7 @@ module Collavre
         failed
       end
 
-      def self.worker_settling?(payload)
-        payload.is_a?(Hash) && payload[WORKER_SETTLING_KEY] == true
-      end
+      def self.worker_settling?(payload) = payload.is_a?(Hash) && payload[WORKER_SETTLING_KEY] == true
 
       # The original worker has left the provider call, so the handoff records
       # now carry the best answer this attempt can give. Clearing under the row
@@ -407,8 +405,10 @@ module Collavre
 
       def self.pending_restoration?(task)
         payload = task&.trigger_event_payload
-        task&.ended_undelivered? &&
-          (dropped_ids_in(payload) - handed_off_ids_in(payload) - claimed_comment_ids(task)).any?
+        return false unless task&.ended_undelivered? && task.agent
+
+        pending = dropped_ids_in(payload) - handed_off_ids_in(payload) - claimed_comment_ids(task)
+        restorable_comments(task, pending).exists?
       end
 
       # Take responsibility for a dispatch about to be discarded, or refuse it.
@@ -526,11 +526,7 @@ module Collavre
         # Same eligibility the refresh applies when it moves an anchor: a
         # comment that was deleted, made private, or turned into an approval
         # action while the turn ran has nothing left to answer.
-        Comment.public_only.without_approval_action
-          .where(id: orphaned, topic_id: task.topic_id, creative_id: task.creative_id)
-          .where.not(user_id: [ agent.id, nil ])
-          .order(:id)
-          .each do |comment|
+        restorable_comments(task, orphaned).order(:id).each do |comment|
           begin
             enqueue_restored(task, agent, task.trigger_event_name, restored_context(payload, comment))
           rescue StandardError => e
@@ -703,6 +699,13 @@ module Collavre
         end
       end
       private_class_method :enqueue_restored
+
+      def self.restorable_comments(task, ids)
+        Comment.public_only.without_approval_action
+          .where(id: ids, topic_id: task.topic_id, creative_id: task.creative_id)
+          .where.not(user_id: [ task.agent_id, nil ])
+      end
+      private_class_method :restorable_comments
 
       # Claim the comment, then enqueue — and only in that order. The job leaves
       # no row until a worker runs it, so between the two the comment reads as

--- a/engines/collavre/app/services/collavre/orchestration/delivery_record.rb
+++ b/engines/collavre/app/services/collavre/orchestration/delivery_record.rb
@@ -360,11 +360,7 @@ module Collavre
         task.reload
       end
 
-      def self.restored_ids_in(payload)
-        return [] unless payload.is_a?(Hash)
-
-        Array(payload[RESTORED_KEY]).compact.map(&:to_i)
-      end
+      def self.restored_ids_in(payload) = payload.is_a?(Hash) ? Array(payload[RESTORED_KEY]).compact.map(&:to_i) : []
 
       # Take responsibility for putting one dispatch back, or refuse it because
       # somebody already has.
@@ -407,10 +403,12 @@ module Collavre
         end
       end
 
-      def self.dropped_ids_in(payload)
-        return [] unless payload.is_a?(Hash)
+      def self.dropped_ids_in(payload) = payload.is_a?(Hash) ? Array(payload[DROPPED_KEY]).compact.map(&:to_i) : []
 
-        Array(payload[DROPPED_KEY]).compact.map(&:to_i)
+      def self.pending_restoration?(task)
+        payload = task&.trigger_event_payload
+        task&.ended_undelivered? &&
+          (dropped_ids_in(payload) - handed_off_ids_in(payload) - claimed_comment_ids(task)).any?
       end
 
       # Take responsibility for a dispatch about to be discarded, or refuse it.
@@ -519,7 +517,7 @@ module Collavre
         return unless payload.is_a?(Hash) && payload.key?("topic")
 
         orphaned = dropped_ids_in(payload) - handed_off_ids_in(payload) -
-                   claimed_comment_ids(task) - restored_ids_in(payload)
+          claimed_comment_ids(task) - restored_ids_in(payload)
         return if orphaned.empty?
 
         agent = task.agent

--- a/engines/collavre/app/services/collavre/orchestration/topic_slot.rb
+++ b/engines/collavre/app/services/collavre/orchestration/topic_slot.rb
@@ -34,6 +34,17 @@ module Collavre
         nil
       end
 
+      def self.matches_context?(locked_scope, topic_id, creative_id)
+        expected_class = topic_id ? Topic : Creative
+        expected_id = topic_id || creative_id
+        locked_scope.is_a?(expected_class) && locked_scope.id.to_s == expected_id.to_s &&
+          (topic_id.nil? || locked_scope.creative_id.to_s == creative_id.to_s)
+      end
+
+      def self.lock_matches_context?(topic_id, creative_id)
+        matches_context?(lock!(topic_id, creative_id), topic_id, creative_id)
+      end
+
       # May `agent_id` take a slot in this topic scope right now?
       #
       # Deliberately NOT gated on coalesce_pending_tasks?: that switch governs

--- a/engines/collavre/app/services/collavre/tools/cron_create_service.rb
+++ b/engines/collavre/app/services/collavre/tools/cron_create_service.rb
@@ -33,8 +33,8 @@ module Tools
         return { error: "No write permission on this Creative", id: creative_id }
       end
 
-      topic_id = resolve_topic_id(creative, topic_name)
-      return topic_id if topic_id.is_a?(Hash) && topic_id[:error]
+      topic = resolve_topic(creative, topic_name)
+      return topic if topic.is_a?(Hash) && topic[:error]
 
       parsed = Fugit.parse(schedule)
       unless parsed.is_a?(Fugit::Cron)
@@ -44,20 +44,11 @@ module Tools
       suffix = SecureRandom.hex(4)
       key = "cron_#{creative_id}_#{suffix}"
 
-      task = SolidQueue::RecurringTask.create!(
-        key: key,
-        class_name: "Collavre::CronActionJob",
-        schedule: schedule,
-        queue_name: "default",
-        static: false,
-        description: description || "Cron job for creative #{creative_id}",
-        arguments: [ {
-          creative_id: creative_id,
-          topic_id: topic_id,
-          agent_id: Current.user.id,
-          message: message
-        } ]
+      task = create_task(
+        topic: topic, creative: creative, creative_id: creative_id,
+        key: key, schedule: schedule, message: message, description: description
       )
+      return task if task.is_a?(Hash) && task[:error]
 
       {
         success: true,
@@ -72,15 +63,38 @@ module Tools
 
     private
 
-    def resolve_topic_id(creative, topic_name)
+    def create_task(topic:, creative:, creative_id:, key:, schedule:, message:, description:)
+      topic.with_lock do
+        unless topic.creative_id == creative.effective_origin.id
+          return { error: I18n.t("collavre.comments.invalid_topic") }
+        end
+
+        SolidQueue::RecurringTask.create!(
+          key: key,
+          class_name: "Collavre::CronActionJob",
+          schedule: schedule,
+          queue_name: "default",
+          static: false,
+          description: description || "Cron job for creative #{creative_id}",
+          arguments: [ {
+            creative_id: creative_id,
+            topic_id: topic.id,
+            agent_id: Current.user.id,
+            message: message
+          } ]
+        )
+      end
+    end
+
+    def resolve_topic(creative, topic_name)
       origin = creative.effective_origin
       if topic_name.casecmp(Creative::MAIN_TOPIC_NAME).zero?
-        origin.main_topic(fallback_user: Current.user).id
+        origin.main_topic(fallback_user: Current.user)
       else
         topic = Topic.find_by(name: topic_name, creative_id: origin.id)
         return { error: "Topic '#{topic_name}' not found for this creative" } unless topic
 
-        topic.id
+        topic
       end
     end
   end

--- a/engines/collavre/app/services/collavre/tools/topic_move_service.rb
+++ b/engines/collavre/app/services/collavre/tools/topic_move_service.rb
@@ -25,7 +25,8 @@ module Tools
       creative; the topic moves to its origin. Topic names are unique per
       creative. Main, an inbox's System topic, and live agent session topics
       cannot be moved. Wait for or cancel active agent work before moving its
-      topic.
+      topic. Cancel recurring cron jobs targeting the topic and recreate them
+      after the move.
     DESC
 
     tool_param :topic_id, description: "The topic to move."

--- a/engines/collavre/app/services/collavre/tools/topic_move_service.rb
+++ b/engines/collavre/app/services/collavre/tools/topic_move_service.rb
@@ -40,11 +40,9 @@ module Tools
       authorize_target!(target, user)
       source = topic.creative.effective_origin
 
-      released_agent, released_reason = move(topic, target, user)
-      reset_comment_counters(source, target)
-      broadcast_move(source, target, topic)
+      released_agent, released_reason = move(topic, target, source, user)
 
-      Topics::Serializer.for_tool(topic.reload).merge(
+      Topics::Serializer.for_tool(topic).merge(
         moved_from_creative_id: source.id,
         released_primary_agent: released_agent_payload(released_agent, released_reason, target)
       ).compact
@@ -52,8 +50,9 @@ module Tools
 
     private
 
-    def move(topic, target, user)
-      Topics::TopicMove.new(topic: topic, target_creative: target).call do |locked_topic|
+    def move(topic, target, source, user)
+      effects = Topics::TopicMoveEffects.new(topic, source, target)
+      Topics::TopicMove.new(topic: topic, target_creative: target).call(after_commit: effects.method(:call)) do |locked_topic|
         authorize_source!(locked_topic, user)
         authorize_target!(target, user)
         validate_move!(locked_topic, target)
@@ -84,16 +83,6 @@ module Tools
     def reserved?(topic, target)
       Topics::ReservedName.reserved?(topic.creative, topic.name) ||
         Topics::ReservedName.reserved?(target, topic.name)
-    end
-
-    def reset_comment_counters(source, target)
-      Creative.reset_counters(source.id, :comments)
-      Creative.reset_counters(target.id, :comments)
-    end
-
-    def broadcast_move(source, target, topic)
-      TopicsChannel.broadcast_to(source, { action: "deleted", topic_id: topic.id })
-      TopicsChannel.broadcast_to(target, { action: "created", topic: Topics::Serializer.call(topic) })
     end
 
     def released_agent_payload(agent, reason, target)

--- a/engines/collavre/app/services/collavre/tools/topic_move_service.rb
+++ b/engines/collavre/app/services/collavre/tools/topic_move_service.rb
@@ -24,7 +24,8 @@ module Tools
       permission on the destination. The destination id may be a linked
       creative; the topic moves to its origin. Topic names are unique per
       creative. Main, an inbox's System topic, and live agent session topics
-      cannot be moved.
+      cannot be moved. Wait for or cancel active agent work before moving its
+      topic.
     DESC
 
     tool_param :topic_id, description: "The topic to move."

--- a/engines/collavre/app/services/collavre/tools/topic_move_service.rb
+++ b/engines/collavre/app/services/collavre/tools/topic_move_service.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+module Collavre
+require "sorbet-runtime"
+require "rails_mcp_engine"
+module Tools
+  # Moves one complete topic to another creative using the same relocation
+  # primitive as the drag-and-drop UI.
+  class TopicMoveService
+    extend T::Sig
+    extend ToolMeta
+
+    tool_name "topic_move"
+    tool_description <<~DESC.strip
+      Move a complete topic to another creative while keeping its topic id,
+      messages, archive state, and read cursors.
+
+      The primary-agent pin moves too when that agent can still respond on the
+      destination. Otherwise the pin is released and the result explains why,
+      so the moved topic remains routable. Creative permissions do not move:
+      people who could read the source may lose access at the destination.
+
+      Requires admin permission on the topic's current creative and write
+      permission on the destination. The destination id may be a linked
+      creative; the topic moves to its origin. Topic names are unique per
+      creative. Main, an inbox's System topic, and live agent session topics
+      cannot be moved.
+    DESC
+
+    tool_param :topic_id, description: "The topic to move."
+    tool_param :creative_id, description: "The destination creative. Linked creatives resolve to their origin."
+
+    sig { params(topic_id: Integer, creative_id: Integer).returns(T::Hash[Symbol, T.untyped]) }
+    def call(topic_id:, creative_id:)
+      user = Current.user || raise(I18n.t("collavre.tools.topic_move.errors.current_user_required"))
+      topic = Topic.find(topic_id)
+      authorize_source!(topic, user)
+      target = Creative.find(creative_id).effective_origin
+      authorize_target!(target, user)
+      source = topic.creative.effective_origin
+
+      released_agent, released_reason = move(topic, target, user)
+      reset_comment_counters(source, target)
+      broadcast_move(source, target, topic)
+
+      Topics::Serializer.for_tool(topic.reload).merge(
+        moved_from_creative_id: source.id,
+        released_primary_agent: released_agent_payload(released_agent, released_reason, target)
+      ).compact
+    end
+
+    private
+
+    def move(topic, target, user)
+      Topics::TopicMove.new(topic: topic, target_creative: target).call do |locked_topic|
+        authorize_source!(locked_topic, user)
+        authorize_target!(target, user)
+        validate_move!(locked_topic, target)
+      end
+    end
+
+    def authorize_source!(topic, user)
+      TopicAuthorizer.authorize_admin!(topic, user: user)
+    rescue PermissionDeniedError
+      raise PermissionDeniedError, I18n.t("collavre.tools.topic_move.errors.source_permission")
+    end
+
+    def authorize_target!(target, user)
+      TopicAuthorizer.authorize_creative!(target, :write, user: user)
+    rescue PermissionDeniedError
+      raise PermissionDeniedError, I18n.t("collavre.tools.topic_move.errors.target_permission")
+    end
+
+    def validate_move!(topic, target)
+      raise ArgumentError, I18n.t("collavre.tools.topic_move.errors.same_creative") if topic.creative_id == target.id
+      raise ArgumentError, I18n.t("collavre.tools.topic_move.errors.reserved_topic") if reserved?(topic, target)
+      raise ArgumentError, I18n.t("collavre.tools.topic_move.errors.session_topic") if topic.session_id.present?
+      return unless target.topics.where(name: topic.name).exists?
+
+      raise ArgumentError, I18n.t("collavre.tools.topic_move.errors.duplicate_name", name: topic.name)
+    end
+
+    def reserved?(topic, target)
+      Topics::ReservedName.reserved?(topic.creative, topic.name) ||
+        Topics::ReservedName.reserved?(target, topic.name)
+    end
+
+    def reset_comment_counters(source, target)
+      Creative.reset_counters(source.id, :comments)
+      Creative.reset_counters(target.id, :comments)
+    end
+
+    def broadcast_move(source, target, topic)
+      TopicsChannel.broadcast_to(source, { action: "deleted", topic_id: topic.id })
+      TopicsChannel.broadcast_to(target, { action: "created", topic: Topics::Serializer.call(topic) })
+    end
+
+    def released_agent_payload(agent, reason, target)
+      return unless agent
+
+      {
+        id: agent.id,
+        name: agent.display_name,
+        reason: reason.to_s,
+        message: released_agent_message(agent, reason, target)
+      }
+    end
+
+    def released_agent_message(agent, reason, target)
+      key = reason == :session_agent_outside_session_topic ?
+        "primary_agent_released_session_agent" : "primary_agent_released"
+      I18n.t("collavre.topics.move.#{key}", agent: agent.display_name, creative: target.creative_snippet)
+    end
+  end
+end
+end

--- a/engines/collavre/app/services/collavre/tools/topic_move_service.rb
+++ b/engines/collavre/app/services/collavre/tools/topic_move_service.rb
@@ -26,7 +26,7 @@ module Tools
       creative. Main, an inbox's System topic, and live agent session topics
       cannot be moved. Wait for or cancel active agent work before moving its
       topic. Cancel recurring cron jobs targeting the topic and recreate them
-      after the move.
+      after the move. A topic referenced by a Drop Trigger loop cannot move.
     DESC
 
     tool_param :topic_id, description: "The topic to move."

--- a/engines/collavre/app/services/collavre/tools/topic_move_service.rb
+++ b/engines/collavre/app/services/collavre/tools/topic_move_service.rb
@@ -25,8 +25,9 @@ module Tools
       creative; the topic moves to its origin. Topic names are unique per
       creative. Main, an inbox's System topic, and live agent session topics
       cannot be moved. Wait for or cancel active agent work before moving its
-      topic. Cancel recurring cron jobs targeting the topic and recreate them
-      after the move. A topic referenced by a Drop Trigger loop cannot move.
+      topic, and wait for any dropped-message restoration to settle. Cancel
+      recurring cron jobs targeting the topic and recreate them after the move.
+      A topic referenced by a Drop Trigger loop cannot move.
     DESC
 
     tool_param :topic_id, description: "The topic to move."

--- a/engines/collavre/app/services/collavre/topics/move_blocker.rb
+++ b/engines/collavre/app/services/collavre/topics/move_blocker.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Collavre
+  module Topics
+    class MoveBlocker
+      class ActiveTaskError < StandardError; end
+      class RecurringTaskError < StandardError; end
+
+      def initialize(topic)
+        @topic = topic
+      end
+
+      def call
+        if Task.where(topic_id: topic.id, status: Task::ACTIVE_STATUSES).exists?
+          raise ActiveTaskError, I18n.t("collavre.topics.move.active_tasks")
+        end
+        return unless Crons::RecurringTopicTasks.new(topic.id).any?
+
+        raise RecurringTaskError, I18n.t("collavre.topics.move.recurring_tasks")
+      end
+
+      private
+
+      attr_reader :topic
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/topics/move_blocker.rb
+++ b/engines/collavre/app/services/collavre/topics/move_blocker.rb
@@ -5,6 +5,7 @@ module Collavre
     class MoveBlocker
       class MoveBlockedError < StandardError; end
       class ActiveTaskError < MoveBlockedError; end
+      class PendingDeliveryError < MoveBlockedError; end
       class RecurringTaskError < MoveBlockedError; end
       class TriggerLoopError < MoveBlockedError; end
 
@@ -15,6 +16,9 @@ module Collavre
       def call
         if Task.where(topic_id: topic.id, status: Task::ACTIVE_STATUSES).exists?
           raise ActiveTaskError, I18n.t("collavre.topics.move.active_tasks")
+        end
+        if pending_delivery_restoration?
+          raise PendingDeliveryError, I18n.t("collavre.topics.move.pending_deliveries")
         end
         if trigger_loop_topic?
           raise TriggerLoopError, I18n.t("collavre.topics.move.trigger_loop")
@@ -27,6 +31,12 @@ module Collavre
       private
 
       attr_reader :topic
+
+      def pending_delivery_restoration?
+        Task.where(topic_id: topic.id).where.not(status: Task::ACTIVE_STATUSES).find_each.any? do |task|
+          Orchestration::DeliveryRecord.pending_restoration?(task)
+        end
+      end
 
       def trigger_loop_topic?
         creative_data = Creative.where(id: topic.creative_id).pick(:data)

--- a/engines/collavre/app/services/collavre/topics/move_blocker.rb
+++ b/engines/collavre/app/services/collavre/topics/move_blocker.rb
@@ -3,8 +3,10 @@
 module Collavre
   module Topics
     class MoveBlocker
-      class ActiveTaskError < StandardError; end
-      class RecurringTaskError < StandardError; end
+      class MoveBlockedError < StandardError; end
+      class ActiveTaskError < MoveBlockedError; end
+      class RecurringTaskError < MoveBlockedError; end
+      class TriggerLoopError < MoveBlockedError; end
 
       def initialize(topic)
         @topic = topic
@@ -14,6 +16,9 @@ module Collavre
         if Task.where(topic_id: topic.id, status: Task::ACTIVE_STATUSES).exists?
           raise ActiveTaskError, I18n.t("collavre.topics.move.active_tasks")
         end
+        if trigger_loop_topic?
+          raise TriggerLoopError, I18n.t("collavre.topics.move.trigger_loop")
+        end
         return unless Crons::RecurringTopicTasks.new(topic.id).any?
 
         raise RecurringTaskError, I18n.t("collavre.topics.move.recurring_tasks")
@@ -22,6 +27,11 @@ module Collavre
       private
 
       attr_reader :topic
+
+      def trigger_loop_topic?
+        creative_data = Creative.where(id: topic.creative_id).pick(:data)
+        creative_data&.dig("trigger", "loop", "trigger_topic_id").to_i == topic.id
+      end
     end
   end
 end

--- a/engines/collavre/app/services/collavre/topics/topic_destroy.rb
+++ b/engines/collavre/app/services/collavre/topics/topic_destroy.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Collavre
+  module Topics
+    class TopicDestroy
+      def initialize(topic:, source_creative:)
+        @topic = topic
+        @source_creative = source_creative
+      end
+
+      def call
+        Topic.transaction do
+          topic.lock!
+          reject_changed_source!
+          [ topic.id, topic.name ].tap { topic.destroy! }
+        end
+      end
+
+      private
+
+      attr_reader :topic, :source_creative
+
+      def reject_changed_source!
+        return if topic.creative_id == source_creative.id
+
+        raise TopicMove::SourceChangedError, I18n.t("collavre.topics.move.source_changed")
+      end
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/topics/topic_move.rb
+++ b/engines/collavre/app/services/collavre/topics/topic_move.rb
@@ -6,6 +6,7 @@ module Collavre
       class SourceChangedError < StandardError; end
       MoveBlockedError = MoveBlocker::MoveBlockedError
       ActiveTaskError = MoveBlocker::ActiveTaskError
+      PendingDeliveryError = MoveBlocker::PendingDeliveryError
       RecurringTaskError = MoveBlocker::RecurringTaskError
       TriggerLoopError = MoveBlocker::TriggerLoopError
 
@@ -48,8 +49,10 @@ module Collavre
 
       def schedule_after_commit(&callback)
         ActiveRecord.after_all_transactions_commit do
-          current_topic = Topic.find(topic.id)
-          current_topic.with_lock { callback.call(current_topic) }
+          Topic.transaction do
+            current_topic = Topic.lock.find_by(id: topic.id)
+            callback.call(current_topic)
+          end
         end
       end
 

--- a/engines/collavre/app/services/collavre/topics/topic_move.rb
+++ b/engines/collavre/app/services/collavre/topics/topic_move.rb
@@ -19,6 +19,7 @@ module Collavre
           # relocated the topic's comment rows to the new one.
           topic.lock!
           reject_changed_source!
+          yield topic if block_given?
           topic.comments.update_all(creative_id: target_creative.id)
           ReadPointerRelocator.new(topic: topic, target_creative: target_creative).call
           topic.update!(creative: target_creative)

--- a/engines/collavre/app/services/collavre/topics/topic_move.rb
+++ b/engines/collavre/app/services/collavre/topics/topic_move.rb
@@ -24,6 +24,7 @@ module Collavre
           # relocated the topic's comment rows to the new one.
           topic.lock!
           reject_changed_source!
+          lock_creative_memberships!
           yield topic if block_given?
           MoveBlocker.new(topic).call
           clear_source_last_topic_preferences
@@ -45,6 +46,10 @@ module Collavre
         return if topic.creative_id == source_creative_id
 
         raise SourceChangedError, I18n.t("collavre.topics.move.source_changed")
+      end
+
+      def lock_creative_memberships!
+        Creative.where(id: [ source_creative_id, target_creative.id ].uniq).order(:id).lock.load
       end
 
       def schedule_after_commit(&callback)

--- a/engines/collavre/app/services/collavre/topics/topic_move.rb
+++ b/engines/collavre/app/services/collavre/topics/topic_move.rb
@@ -4,6 +4,7 @@ module Collavre
   module Topics
     class TopicMove
       class SourceChangedError < StandardError; end
+      class ActiveTaskError < StandardError; end
 
       def initialize(topic:, target_creative:)
         @topic = topic
@@ -20,7 +21,9 @@ module Collavre
           topic.lock!
           reject_changed_source!
           yield topic if block_given?
+          reject_active_tasks!
           topic.comments.update_all(creative_id: target_creative.id)
+          topic.comment_snapshots.update_all(creative_id: target_creative.id)
           ReadPointerRelocator.new(topic: topic, target_creative: target_creative).call
           topic.update!(creative: target_creative)
           release_unroutable_primary_agent
@@ -35,6 +38,12 @@ module Collavre
         return if topic.creative_id == source_creative_id
 
         raise SourceChangedError, I18n.t("collavre.topics.move.source_changed")
+      end
+
+      def reject_active_tasks!
+        return unless Task.where(topic_id: topic.id, status: Task::ACTIVE_STATUSES).exists?
+
+        raise ActiveTaskError, I18n.t("collavre.topics.move.active_tasks")
       end
 
       def release_unroutable_primary_agent

--- a/engines/collavre/app/services/collavre/topics/topic_move.rb
+++ b/engines/collavre/app/services/collavre/topics/topic_move.rb
@@ -4,8 +4,10 @@ module Collavre
   module Topics
     class TopicMove
       class SourceChangedError < StandardError; end
+      MoveBlockedError = MoveBlocker::MoveBlockedError
       ActiveTaskError = MoveBlocker::ActiveTaskError
       RecurringTaskError = MoveBlocker::RecurringTaskError
+      TriggerLoopError = MoveBlocker::TriggerLoopError
 
       def initialize(topic:, target_creative:)
         @topic = topic

--- a/engines/collavre/app/services/collavre/topics/topic_move.rb
+++ b/engines/collavre/app/services/collavre/topics/topic_move.rb
@@ -4,7 +4,8 @@ module Collavre
   module Topics
     class TopicMove
       class SourceChangedError < StandardError; end
-      class ActiveTaskError < StandardError; end
+      ActiveTaskError = MoveBlocker::ActiveTaskError
+      RecurringTaskError = MoveBlocker::RecurringTaskError
 
       def initialize(topic:, target_creative:)
         @topic = topic
@@ -21,7 +22,7 @@ module Collavre
           topic.lock!
           reject_changed_source!
           yield topic if block_given?
-          reject_active_tasks!
+          MoveBlocker.new(topic).call
           topic.comments.update_all(creative_id: target_creative.id)
           topic.comment_snapshots.update_all(creative_id: target_creative.id)
           ReadPointerRelocator.new(topic: topic, target_creative: target_creative).call
@@ -40,12 +41,6 @@ module Collavre
         return if topic.creative_id == source_creative_id
 
         raise SourceChangedError, I18n.t("collavre.topics.move.source_changed")
-      end
-
-      def reject_active_tasks!
-        return unless Task.where(topic_id: topic.id, status: Task::ACTIVE_STATUSES).exists?
-
-        raise ActiveTaskError, I18n.t("collavre.topics.move.active_tasks")
       end
 
       def synchronize_after_commit

--- a/engines/collavre/app/services/collavre/topics/topic_move.rb
+++ b/engines/collavre/app/services/collavre/topics/topic_move.rb
@@ -31,7 +31,7 @@ module Collavre
           topic.update!(creative: target_creative)
           release_unroutable_primary_agent
         end
-        synchronize_after_commit(&after_commit) if after_commit
+        schedule_after_commit(&after_commit) if after_commit
         result
       end
 
@@ -45,9 +45,11 @@ module Collavre
         raise SourceChangedError, I18n.t("collavre.topics.move.source_changed")
       end
 
-      def synchronize_after_commit
-        current_topic = Topic.find(topic.id)
-        current_topic.with_lock { yield current_topic }
+      def schedule_after_commit(&callback)
+        ActiveRecord.after_all_transactions_commit do
+          current_topic = Topic.find(topic.id)
+          current_topic.with_lock { callback.call(current_topic) }
+        end
       end
 
       def release_unroutable_primary_agent

--- a/engines/collavre/app/services/collavre/topics/topic_move.rb
+++ b/engines/collavre/app/services/collavre/topics/topic_move.rb
@@ -25,6 +25,7 @@ module Collavre
           reject_changed_source!
           yield topic if block_given?
           MoveBlocker.new(topic).call
+          clear_source_last_topic_preferences
           topic.comments.update_all(creative_id: target_creative.id)
           topic.comment_snapshots.update_all(creative_id: target_creative.id)
           ReadPointerRelocator.new(topic: topic, target_creative: target_creative).call
@@ -50,6 +51,12 @@ module Collavre
           current_topic = Topic.find(topic.id)
           current_topic.with_lock { callback.call(current_topic) }
         end
+      end
+
+      def clear_source_last_topic_preferences
+        topic.user_creative_preferences_as_last_topic
+             .where(creative_id: source_creative_id)
+             .update_all("last_topic_id = NULL, last_topic_revision = last_topic_revision + 1")
       end
 
       def release_unroutable_primary_agent

--- a/engines/collavre/app/services/collavre/topics/topic_move.rb
+++ b/engines/collavre/app/services/collavre/topics/topic_move.rb
@@ -12,8 +12,8 @@ module Collavre
         @source_creative_id = topic.creative_id
       end
 
-      def call
-        Topic.transaction do
+      def call(after_commit: nil)
+        result = Topic.transaction do
           # TopicBranchService locks the source before reading its comments.
           # Take the same parent-first lock order here so a branch cannot
           # authorize the old creative while this transaction has already
@@ -28,6 +28,8 @@ module Collavre
           topic.update!(creative: target_creative)
           release_unroutable_primary_agent
         end
+        synchronize_after_commit(&after_commit) if after_commit
+        result
       end
 
       private
@@ -44,6 +46,11 @@ module Collavre
         return unless Task.where(topic_id: topic.id, status: Task::ACTIVE_STATUSES).exists?
 
         raise ActiveTaskError, I18n.t("collavre.topics.move.active_tasks")
+      end
+
+      def synchronize_after_commit
+        current_topic = Topic.find(topic.id)
+        current_topic.with_lock { yield current_topic }
       end
 
       def release_unroutable_primary_agent

--- a/engines/collavre/app/services/collavre/topics/topic_move_effects.rb
+++ b/engines/collavre/app/services/collavre/topics/topic_move_effects.rb
@@ -10,8 +10,7 @@ module Collavre
       end
 
       def call(current_topic)
-        Creative.reset_counters(source_creative.id, :comments)
-        Creative.reset_counters(target_creative.id, :comments)
+        reset_comment_counters
         unless current_topic&.creative_id == source_creative.id
           TopicsChannel.broadcast_to(source_creative, { action: "deleted", topic_id: topic.id })
         end
@@ -25,6 +24,12 @@ module Collavre
       private
 
       attr_reader :topic, :source_creative, :target_creative
+
+      def reset_comment_counters
+        [ source_creative, target_creative ].uniq(&:id).sort_by(&:id).each do |creative|
+          Creative.reset_counters(creative.id, :comments)
+        end
+      end
     end
   end
 end

--- a/engines/collavre/app/services/collavre/topics/topic_move_effects.rb
+++ b/engines/collavre/app/services/collavre/topics/topic_move_effects.rb
@@ -13,7 +13,7 @@ module Collavre
         Creative.reset_counters(source_creative.id, :comments)
         Creative.reset_counters(target_creative.id, :comments)
         TopicsChannel.broadcast_to(source_creative, { action: "deleted", topic_id: topic.id })
-        return unless current_topic.creative_id == target_creative.id
+        return unless current_topic&.creative_id == target_creative.id
 
         TopicsChannel.broadcast_to(
           target_creative, { action: "created", topic: Serializer.call(current_topic) }

--- a/engines/collavre/app/services/collavre/topics/topic_move_effects.rb
+++ b/engines/collavre/app/services/collavre/topics/topic_move_effects.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Collavre
+  module Topics
+    class TopicMoveEffects
+      def initialize(topic, source_creative, target_creative)
+        @topic = topic
+        @source_creative = source_creative
+        @target_creative = target_creative
+      end
+
+      def call(current_topic)
+        Creative.reset_counters(source_creative.id, :comments)
+        Creative.reset_counters(target_creative.id, :comments)
+        TopicsChannel.broadcast_to(source_creative, { action: "deleted", topic_id: topic.id })
+        return unless current_topic.creative_id == target_creative.id
+
+        TopicsChannel.broadcast_to(
+          target_creative, { action: "created", topic: Serializer.call(topic) }
+        )
+      end
+
+      private
+
+      attr_reader :topic, :source_creative, :target_creative
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/topics/topic_move_effects.rb
+++ b/engines/collavre/app/services/collavre/topics/topic_move_effects.rb
@@ -12,7 +12,9 @@ module Collavre
       def call(current_topic)
         Creative.reset_counters(source_creative.id, :comments)
         Creative.reset_counters(target_creative.id, :comments)
-        TopicsChannel.broadcast_to(source_creative, { action: "deleted", topic_id: topic.id })
+        unless current_topic&.creative_id == source_creative.id
+          TopicsChannel.broadcast_to(source_creative, { action: "deleted", topic_id: topic.id })
+        end
         return unless current_topic&.creative_id == target_creative.id
 
         TopicsChannel.broadcast_to(

--- a/engines/collavre/app/services/collavre/topics/topic_move_effects.rb
+++ b/engines/collavre/app/services/collavre/topics/topic_move_effects.rb
@@ -16,7 +16,7 @@ module Collavre
         return unless current_topic.creative_id == target_creative.id
 
         TopicsChannel.broadcast_to(
-          target_creative, { action: "created", topic: Serializer.call(topic) }
+          target_creative, { action: "created", topic: Serializer.call(current_topic) }
         )
       end
 

--- a/engines/collavre/app/services/collavre/topics/topic_mutation.rb
+++ b/engines/collavre/app/services/collavre/topics/topic_mutation.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Collavre
+  module Topics
+    class TopicMutation
+      def initialize(topic:, source_creative:)
+        @topic = topic
+        @source_creative = source_creative
+      end
+
+      def call
+        Topic.transaction do
+          topic.lock!
+          unless topic.creative_id == source_creative.id
+            raise TopicMove::SourceChangedError, I18n.t("collavre.topics.move.source_changed")
+          end
+
+          yield topic
+        end
+      end
+
+      private
+
+      attr_reader :topic, :source_creative
+    end
+  end
+end

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -23,6 +23,7 @@ en:
         no_target_permission: You don't have write permission on the target creative.
         source_changed: The topic moved to another creative while this request was waiting. Reload it and try again from its current creative.
         active_tasks: This topic has active agent work. Wait for it to finish or cancel it before moving the topic.
+        recurring_tasks: This topic has a recurring cron job. Cancel it with cron_cancel and recreate it after moving the topic.
         duplicate_name: A topic named '%{name}' already exists in the target creative.
         session_topic_locked: This topic belongs to a live agent session and cannot be moved.
         primary_agent_released: '@%{agent} was released as primary agent because it has no feedback access in "%{creative}". Share that creative with the agent and assign it again to keep it on this topic.'

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -153,6 +153,7 @@ en:
         minimum_required: "Select at least 2 messages to merge."
         not_authorized: "You don't have permission to merge messages."
         own_messages_only: "You can only merge your own messages or messages from your AI agents."
+        same_topic_required: "You can only merge messages from the same topic."
       branch:
         no_selection: "Select at least one message to branch."
         not_authorized: "You don't have permission to branch messages."

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -23,6 +23,7 @@ en:
         no_target_permission: You don't have write permission on the target creative.
         source_changed: The topic moved to another creative while this request was waiting. Reload it and try again from its current creative.
         active_tasks: This topic has active agent work. Wait for it to finish or cancel it before moving the topic.
+        pending_deliveries: This topic still has agent messages waiting to be restored. Wait for restoration to finish before moving the topic.
         recurring_tasks: This topic has a recurring cron job. Cancel it with cron_cancel and recreate it after moving the topic.
         trigger_loop: This topic controls a Drop Trigger loop and cannot move while that loop configuration references it.
         duplicate_name: A topic named '%{name}' already exists in the target creative.

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -24,6 +24,7 @@ en:
         source_changed: The topic moved to another creative while this request was waiting. Reload it and try again from its current creative.
         active_tasks: This topic has active agent work. Wait for it to finish or cancel it before moving the topic.
         recurring_tasks: This topic has a recurring cron job. Cancel it with cron_cancel and recreate it after moving the topic.
+        trigger_loop: This topic controls a Drop Trigger loop and cannot move while that loop configuration references it.
         duplicate_name: A topic named '%{name}' already exists in the target creative.
         session_topic_locked: This topic belongs to a live agent session and cannot be moved.
         primary_agent_released: '@%{agent} was released as primary agent because it has no feedback access in "%{creative}". Share that creative with the agent and assign it again to keep it on this topic.'

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -22,6 +22,7 @@ en:
       move:
         no_target_permission: You don't have write permission on the target creative.
         source_changed: The topic moved to another creative while this request was waiting. Reload it and try again from its current creative.
+        active_tasks: This topic has active agent work. Wait for it to finish or cancel it before moving the topic.
         duplicate_name: A topic named '%{name}' already exists in the target creative.
         session_topic_locked: This topic belongs to a live agent session and cannot be moved.
         primary_agent_released: '@%{agent} was released as primary agent because it has no feedback access in "%{creative}". Share that creative with the agent and assign it again to keep it on this topic.'

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -23,6 +23,7 @@ ko:
         no_target_permission: 대상 크리에이티브에 대한 쓰기 권한이 없습니다.
         source_changed: 요청이 대기하는 동안 토픽이 다른 크리에이티브로 이동했습니다. 현재 크리에이티브에서 다시 불러온 뒤 재시도하세요.
         active_tasks: 이 토픽에서 에이전트 작업이 진행 중입니다. 작업이 끝날 때까지 기다리거나 취소한 뒤 토픽을 이동하세요.
+        pending_deliveries: 이 토픽에는 아직 복구 중인 에이전트 메시지가 있습니다. 복구가 끝난 뒤 토픽을 이동하세요.
         recurring_tasks: 이 토픽을 대상으로 하는 반복 크론 작업이 있습니다. cron_cancel로 취소하고 토픽을 이동한 뒤 다시 생성하세요.
         trigger_loop: 이 토픽은 Drop Trigger loop의 제어 토픽이므로 loop 설정이 참조하는 동안 이동할 수 없습니다.
         duplicate_name: "'%{name}' 토픽이 대상 크리에이티브에 이미 존재합니다."

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -23,6 +23,7 @@ ko:
         no_target_permission: 대상 크리에이티브에 대한 쓰기 권한이 없습니다.
         source_changed: 요청이 대기하는 동안 토픽이 다른 크리에이티브로 이동했습니다. 현재 크리에이티브에서 다시 불러온 뒤 재시도하세요.
         active_tasks: 이 토픽에서 에이전트 작업이 진행 중입니다. 작업이 끝날 때까지 기다리거나 취소한 뒤 토픽을 이동하세요.
+        recurring_tasks: 이 토픽을 대상으로 하는 반복 크론 작업이 있습니다. cron_cancel로 취소하고 토픽을 이동한 뒤 다시 생성하세요.
         duplicate_name: "'%{name}' 토픽이 대상 크리에이티브에 이미 존재합니다."
         session_topic_locked: 이 토픽은 실행 중인 에이전트 세션에 속해 있어 이동할 수 없습니다.
         primary_agent_released: '@%{agent}은(는) "%{creative}"에 피드백 권한이 없어 Primary Agent 지정이 해제되었습니다. 계속 담당하게 하려면 해당 크리에이티브를 에이전트와 공유한 뒤 다시 지정하세요.'

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -22,6 +22,7 @@ ko:
       move:
         no_target_permission: 대상 크리에이티브에 대한 쓰기 권한이 없습니다.
         source_changed: 요청이 대기하는 동안 토픽이 다른 크리에이티브로 이동했습니다. 현재 크리에이티브에서 다시 불러온 뒤 재시도하세요.
+        active_tasks: 이 토픽에서 에이전트 작업이 진행 중입니다. 작업이 끝날 때까지 기다리거나 취소한 뒤 토픽을 이동하세요.
         duplicate_name: "'%{name}' 토픽이 대상 크리에이티브에 이미 존재합니다."
         session_topic_locked: 이 토픽은 실행 중인 에이전트 세션에 속해 있어 이동할 수 없습니다.
         primary_agent_released: '@%{agent}은(는) "%{creative}"에 피드백 권한이 없어 Primary Agent 지정이 해제되었습니다. 계속 담당하게 하려면 해당 크리에이티브를 에이전트와 공유한 뒤 다시 지정하세요.'

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -150,6 +150,7 @@ ko:
         minimum_required: "병합하려면 2개 이상의 메시지를 선택하세요."
         not_authorized: "메시지를 병합할 권한이 없습니다."
         own_messages_only: "자신의 메시지 또는 자신의 AI 에이전트 메시지만 병합할 수 있습니다."
+        same_topic_required: "같은 토픽의 메시지만 병합할 수 있습니다."
       branch:
         no_selection: "분기할 메시지를 선택하세요."
         not_authorized: "메시지를 분기할 권한이 없습니다."

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -24,6 +24,7 @@ ko:
         source_changed: 요청이 대기하는 동안 토픽이 다른 크리에이티브로 이동했습니다. 현재 크리에이티브에서 다시 불러온 뒤 재시도하세요.
         active_tasks: 이 토픽에서 에이전트 작업이 진행 중입니다. 작업이 끝날 때까지 기다리거나 취소한 뒤 토픽을 이동하세요.
         recurring_tasks: 이 토픽을 대상으로 하는 반복 크론 작업이 있습니다. cron_cancel로 취소하고 토픽을 이동한 뒤 다시 생성하세요.
+        trigger_loop: 이 토픽은 Drop Trigger loop의 제어 토픽이므로 loop 설정이 참조하는 동안 이동할 수 없습니다.
         duplicate_name: "'%{name}' 토픽이 대상 크리에이티브에 이미 존재합니다."
         session_topic_locked: 이 토픽은 실행 중인 에이전트 세션에 속해 있어 이동할 수 없습니다.
         primary_agent_released: '@%{agent}은(는) "%{creative}"에 피드백 권한이 없어 Primary Agent 지정이 해제되었습니다. 계속 담당하게 하려면 해당 크리에이티브를 에이전트와 공유한 뒤 다시 지정하세요.'

--- a/engines/collavre/config/locales/tools.en.yml
+++ b/engines/collavre/config/locales/tools.en.yml
@@ -9,3 +9,12 @@ en:
           system_topic: The inbox System topic does not accept user-authored messages.
           current_topic: An agent cannot dispatch a topic message to its own current topic.
           self_route: An agent cannot route an unpinned topic message back to itself.
+      topic_move:
+        errors:
+          current_user_required: Current.user is required.
+          source_permission: Admin permission is required on the topic's current creative.
+          target_permission: Write permission is required on the destination creative.
+          same_creative: The topic already belongs to the destination creative.
+          reserved_topic: Main and an inbox's System topic cannot be moved.
+          session_topic: A live agent session topic cannot be moved.
+          duplicate_name: A topic named '%{name}' already exists in the destination creative.

--- a/engines/collavre/config/locales/tools.ko.yml
+++ b/engines/collavre/config/locales/tools.ko.yml
@@ -9,3 +9,12 @@ ko:
           system_topic: 받은 편지함의 System 토픽에는 사용자가 메시지를 작성할 수 없습니다.
           current_topic: 에이전트는 현재 처리 중인 토픽에 토픽 메시지를 전달할 수 없습니다.
           self_route: 에이전트는 고정되지 않은 토픽 메시지를 자신에게 다시 라우팅할 수 없습니다.
+      topic_move:
+        errors:
+          current_user_required: Current.user가 필요합니다.
+          source_permission: 토픽의 현재 크리에이티브에 대한 관리자 권한이 필요합니다.
+          target_permission: 대상 크리에이티브에 대한 쓰기 권한이 필요합니다.
+          same_creative: 토픽이 이미 대상 크리에이티브에 속해 있습니다.
+          reserved_topic: Main 토픽과 받은 편지함의 System 토픽은 이동할 수 없습니다.
+          session_topic: 실행 중인 에이전트 세션 토픽은 이동할 수 없습니다.
+          duplicate_name: "'%{name}' 토픽이 대상 크리에이티브에 이미 존재합니다."

--- a/engines/collavre/skills/collavre/SKILL.md
+++ b/engines/collavre/skills/collavre/SKILL.md
@@ -116,6 +116,9 @@ collavre tool run topic_message_create --json '{"topic_id": 13, "content": "Buil
 # Put a finished thread away (messages are kept and stay readable by id)
 collavre tool run topic_update --json '{"topic_id": 12, "archived": true}'
 
+# Move a complete thread, including its messages and read cursors
+collavre tool run topic_move --json '{"topic_id": 13, "creative_id": 9023}'
+
 # Carry the messages that still matter into a fresh topic
 collavre tool run topic_branch --json '{"source_topic_id": 12, "comment_ids": "991,994"}'
 ```
@@ -148,6 +151,9 @@ collavre tool run <tool_name> --key value         # run with flag args
   dispatch as A2A work, so one coordinating agent can start independent work in
   several topics without impersonating a human. Do not call it on the topic the
   caller is currently handling; continue that work in the current turn instead.
+- **Moving topics**: `topic_move` keeps the thread and its messages together,
+  but Creative permissions stay with each Creative. Verify that participants
+  can access the destination after moving.
 - **Progress**: Leaf = manual (0.0 or 1.0). Parent = auto-calculated from children.
 - **Import**: Markdown headings/bullets become nested Creatives.
 - **Batch**: All-or-nothing transaction. Requires approval.

--- a/engines/collavre/skills/collavre/SKILL.md
+++ b/engines/collavre/skills/collavre/SKILL.md
@@ -154,7 +154,8 @@ collavre tool run <tool_name> --key value         # run with flag args
 - **Moving topics**: `topic_move` keeps the thread and its messages together,
   but Creative permissions stay with each Creative. Verify that participants
   can access the destination after moving. Wait for or cancel active agent work
-  in the topic before moving it.
+  in the topic before moving it. Cancel recurring cron jobs that target the
+  topic and recreate them after the move.
 - **Progress**: Leaf = manual (0.0 or 1.0). Parent = auto-calculated from children.
 - **Import**: Markdown headings/bullets become nested Creatives.
 - **Batch**: All-or-nothing transaction. Requires approval.

--- a/engines/collavre/skills/collavre/SKILL.md
+++ b/engines/collavre/skills/collavre/SKILL.md
@@ -154,9 +154,9 @@ collavre tool run <tool_name> --key value         # run with flag args
 - **Moving topics**: `topic_move` keeps the thread and its messages together,
   but Creative permissions stay with each Creative. Verify that participants
   can access the destination after moving. Wait for or cancel active agent work
-  in the topic before moving it. Cancel recurring cron jobs that target the
-  topic and recreate them after the move. Topics referenced by a Drop Trigger
-  loop cannot move.
+  in the topic before moving it, and wait for dropped-message restoration to
+  settle. Cancel recurring cron jobs that target the topic and recreate them
+  after the move. Topics referenced by a Drop Trigger loop cannot move.
 - **Progress**: Leaf = manual (0.0 or 1.0). Parent = auto-calculated from children.
 - **Import**: Markdown headings/bullets become nested Creatives.
 - **Batch**: All-or-nothing transaction. Requires approval.

--- a/engines/collavre/skills/collavre/SKILL.md
+++ b/engines/collavre/skills/collavre/SKILL.md
@@ -155,7 +155,8 @@ collavre tool run <tool_name> --key value         # run with flag args
   but Creative permissions stay with each Creative. Verify that participants
   can access the destination after moving. Wait for or cancel active agent work
   in the topic before moving it. Cancel recurring cron jobs that target the
-  topic and recreate them after the move.
+  topic and recreate them after the move. Topics referenced by a Drop Trigger
+  loop cannot move.
 - **Progress**: Leaf = manual (0.0 or 1.0). Parent = auto-calculated from children.
 - **Import**: Markdown headings/bullets become nested Creatives.
 - **Batch**: All-or-nothing transaction. Requires approval.

--- a/engines/collavre/skills/collavre/SKILL.md
+++ b/engines/collavre/skills/collavre/SKILL.md
@@ -153,7 +153,8 @@ collavre tool run <tool_name> --key value         # run with flag args
   caller is currently handling; continue that work in the current turn instead.
 - **Moving topics**: `topic_move` keeps the thread and its messages together,
   but Creative permissions stay with each Creative. Verify that participants
-  can access the destination after moving.
+  can access the destination after moving. Wait for or cancel active agent work
+  in the topic before moving it.
 - **Progress**: Leaf = manual (0.0 or 1.0). Parent = auto-calculated from children.
 - **Import**: Markdown headings/bullets become nested Creatives.
 - **Batch**: All-or-nothing transaction. Requires approval.

--- a/engines/collavre/skills/collavre/references/tool-reference.md
+++ b/engines/collavre/skills/collavre/references/tool-reference.md
@@ -283,7 +283,8 @@ The topic keeps its id, messages, archive state, and read cursors. Its primary
 agent stays pinned only when it can still respond on the destination; otherwise
 the result reports that the pin was released. Creative permissions do not move,
 so verify that participants can access the destination. Active agent work must
-finish or be cancelled before the topic can move.
+finish or be cancelled before the topic can move. Recurring cron jobs targeting
+the topic must be cancelled and recreated after the move.
 
 Requires **admin** on the source and **write** on the destination. Topic names
 must be unique on the destination. Main, an inbox's System topic, and live agent

--- a/engines/collavre/skills/collavre/references/tool-reference.md
+++ b/engines/collavre/skills/collavre/references/tool-reference.md
@@ -283,9 +283,10 @@ The topic keeps its id, messages, archive state, and read cursors. Its primary
 agent stays pinned only when it can still respond on the destination; otherwise
 the result reports that the pin was released. Creative permissions do not move,
 so verify that participants can access the destination. Active agent work must
-finish or be cancelled before the topic can move. Recurring cron jobs targeting
-the topic must be cancelled and recreated after the move. Topics referenced by
-a Drop Trigger loop cannot move.
+finish or be cancelled before the topic can move, and dropped-message
+restoration must settle. Recurring cron jobs targeting the topic must be
+cancelled and recreated after the move. Topics referenced by a Drop Trigger loop
+cannot move.
 
 Requires **admin** on the source and **write** on the destination. Topic names
 must be unique on the destination. Main, an inbox's System topic, and live agent

--- a/engines/collavre/skills/collavre/references/tool-reference.md
+++ b/engines/collavre/skills/collavre/references/tool-reference.md
@@ -284,7 +284,8 @@ agent stays pinned only when it can still respond on the destination; otherwise
 the result reports that the pin was released. Creative permissions do not move,
 so verify that participants can access the destination. Active agent work must
 finish or be cancelled before the topic can move. Recurring cron jobs targeting
-the topic must be cancelled and recreated after the move.
+the topic must be cancelled and recreated after the move. Topics referenced by
+a Drop Trigger loop cannot move.
 
 Requires **admin** on the source and **write** on the destination. Topic names
 must be unique on the destination. Main, an inbox's System topic, and live agent

--- a/engines/collavre/skills/collavre/references/tool-reference.md
+++ b/engines/collavre/skills/collavre/references/tool-reference.md
@@ -270,6 +270,27 @@ be changed here.
 
 **Returns:** the topic payload plus `changed[]` naming the fields that moved.
 
+### topic_move
+
+Move one complete topic to another Creative.
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `topic_id` | Integer | **Yes** | Topic to move |
+| `creative_id` | Integer | **Yes** | Destination Creative; links resolve to their origin |
+
+The topic keeps its id, messages, archive state, and read cursors. Its primary
+agent stays pinned only when it can still respond on the destination; otherwise
+the result reports that the pin was released. Creative permissions do not move,
+so verify that participants can access the destination.
+
+Requires **admin** on the source and **write** on the destination. Topic names
+must be unique on the destination. Main, an inbox's System topic, and live agent
+session topics cannot move.
+
+**Returns:** the moved topic payload, `moved_from_creative_id`, and an optional
+`released_primary_agent` explanation.
+
 ### topic_branch
 
 Create a new topic containing **copies** of selected messages. The originals stay

--- a/engines/collavre/skills/collavre/references/tool-reference.md
+++ b/engines/collavre/skills/collavre/references/tool-reference.md
@@ -282,7 +282,8 @@ Move one complete topic to another Creative.
 The topic keeps its id, messages, archive state, and read cursors. Its primary
 agent stays pinned only when it can still respond on the destination; otherwise
 the result reports that the pin was released. Creative permissions do not move,
-so verify that participants can access the destination.
+so verify that participants can access the destination. Active agent work must
+finish or be cancelled before the topic can move.
 
 Requires **admin** on the source and **write** on the destination. Topic names
 must be unique on the destination. Main, an inbox's System topic, and live agent

--- a/engines/collavre/test/controllers/comment_read_pointers_query_count_test.rb
+++ b/engines/collavre/test/controllers/comment_read_pointers_query_count_test.rb
@@ -34,8 +34,9 @@ class CommentReadPointersQueryCountTest < ActionDispatch::IntegrationTest
     end
 
     assert_response :success
-    # ~8 of these are session/authentication overhead outside this controller.
-    assert_operator count, :<=, 26, "topic switch took #{count} queries"
+    # ~8 are session/authentication overhead. The topic lock adds one fixed
+    # transaction plus one SELECT, independent of the number of topics.
+    assert_operator count, :<=, 29, "topic switch took #{count} queries"
   end
 
   private

--- a/engines/collavre/test/controllers/comments_controller_test.rb
+++ b/engines/collavre/test/controllers/comments_controller_test.rb
@@ -459,6 +459,32 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
     assert comment.private?, "Comment should be private after checking"
   end
 
+  test "topic update rejects a comment whose source topic moved after validation" do
+    source_topic = @creative.topics.create!(name: "Update source", user: @user)
+    target_topic = @creative.topics.create!(name: "Update target", user: @user)
+    destination = Creative.create!(description: "Update destination", user: @user)
+    comment = @creative.comments.create!(content: "Original", user: @user, topic: source_topic)
+    service = Collavre::CommentMoveService.new(creative: @creative, user: @user)
+    fetch_after_relocation = lambda do |_ids|
+      Collavre::Topics::TopicMove.new(topic: source_topic, target_creative: destination).call
+      [ comment ]
+    end
+
+    Collavre::CommentMoveService.stub(:new, ->(**) { service }) do
+      service.stub(:fetch_visible_comments, fetch_after_relocation) do
+        patch creative_comment_path(@creative, comment), params: {
+          comment: { content: "Stale update", topic_id: target_topic.id }
+        }
+      end
+    end
+
+    assert_response :unprocessable_entity
+    assert_equal @creative.id, comment.reload.creative_id
+    assert_equal source_topic.id, comment.topic_id
+    assert_equal "Original", comment.content
+    assert_equal @creative.id, source_topic.reload.creative_id
+  end
+
   test "user can move comments to another creative" do
     target = creatives(:childless_creative)
     comment = @creative.comments.create!(content: "Move me", user: @user)

--- a/engines/collavre/test/controllers/comments_controller_test.rb
+++ b/engines/collavre/test/controllers/comments_controller_test.rb
@@ -485,6 +485,20 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
     assert_equal @creative.id, source_topic.reload.creative_id
   end
 
+  test "topic update rolls back the move when another attribute is invalid" do
+    source_topic = @creative.topics.create!(name: "Rollback source", user: @user)
+    target_topic = @creative.topics.create!(name: "Rollback target", user: @user)
+    comment = @creative.comments.create!(content: "Original", user: @user, topic: source_topic)
+
+    patch creative_comment_path(@creative, comment), params: {
+      comment: { content: "", topic_id: target_topic.id }
+    }
+
+    assert_response :unprocessable_entity
+    assert_equal source_topic.id, comment.reload.topic_id
+    assert_equal "Original", comment.content
+  end
+
   test "user can move comments to another creative" do
     target = creatives(:childless_creative)
     comment = @creative.comments.create!(content: "Move me", user: @user)

--- a/engines/collavre/test/controllers/comments_controller_test.rb
+++ b/engines/collavre/test/controllers/comments_controller_test.rb
@@ -24,6 +24,20 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
 
   public
 
+  test "merge rejects comments from different topics" do
+    first_topic = @creative.topics.create!(name: "First merge topic", user: @user)
+    second_topic = @creative.topics.create!(name: "Second merge topic", user: @user)
+    first = @creative.comments.create!(content: "First merge comment", user: @user, topic: first_topic)
+    second = @creative.comments.create!(content: "Second merge comment", user: @user, topic: second_topic)
+
+    Collavre::MergeCommentsJob.stub(:perform_later, ->(*) { flunk("merge job should not be enqueued") }) do
+      post merge_creative_comments_path(@creative), params: { comment_ids: [ first.id, second.id ] }, as: :json
+    end
+
+    assert_response :unprocessable_entity
+    assert_equal I18n.t("collavre.comments.merge.same_topic_required"), response.parsed_body["error"]
+  end
+
   test "index renders version navigator only for comments with versions" do
     with_versions = @creative.comments.create!(content: "has versions", user: @user)
     Collavre::CommentVersion.create!(comment: with_versions, content: "v1", version_number: 1)

--- a/engines/collavre/test/controllers/comments_controller_test.rb
+++ b/engines/collavre/test/controllers/comments_controller_test.rb
@@ -499,6 +499,28 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Original", comment.content
   end
 
+  test "content update rejects a comment whose topic moved before its lock" do
+    source_topic = @creative.topics.create!(name: "Edit source", user: @user)
+    destination = Creative.create!(description: "Edit destination", user: @user)
+    comment = @creative.comments.create!(content: "Original", user: @user, topic: source_topic)
+    topic_mutation = Collavre::Comments::TopicMutation.method(:call)
+    mutate_after_relocation = lambda do |*args, &block|
+      Collavre::Topics::TopicMove.new(topic: source_topic, target_creative: destination).call
+      topic_mutation.call(*args, &block)
+    end
+
+    Collavre::Comments::TopicMutation.stub(:call, mutate_after_relocation) do
+      patch creative_comment_path(@creative, comment), params: {
+        comment: { content: "Stale update" }
+      }
+    end
+
+    assert_response :unprocessable_entity
+    assert_equal destination.id, comment.reload.creative_id
+    assert_equal source_topic.id, comment.topic_id
+    assert_equal "Original", comment.content
+  end
+
   test "user can move comments to another creative" do
     target = creatives(:childless_creative)
     comment = @creative.comments.create!(content: "Move me", user: @user)

--- a/engines/collavre/test/controllers/topics_controller_test.rb
+++ b/engines/collavre/test/controllers/topics_controller_test.rb
@@ -223,6 +223,33 @@ class TopicsControllerTest < ActionDispatch::IntegrationTest
     assert_equal ai_agent.id, json["primary_agent"]["id"]
   end
 
+  test "update rejects a topic that moved before its lock" do
+    assert_topic_source_change_rejected do
+      patch collavre.creative_topic_url(@creative, @topic),
+        params: { topic: { name: "Stale rename" } }, as: :json
+    end
+
+    assert_equal "Existing Topic", @topic.reload.name
+  end
+
+  test "archive rejects a topic that moved before its lock" do
+    assert_topic_source_change_rejected do
+      patch archive_creative_topic_url(@creative, @topic), as: :json
+    end
+
+    assert_nil @topic.reload.archived_at
+  end
+
+  test "unarchive rejects a topic that moved before its lock" do
+    @topic.archive!
+
+    assert_topic_source_change_rejected do
+      patch unarchive_creative_topic_url(@creative, @topic), as: :json
+    end
+
+    assert_not_nil @topic.reload.archived_at
+  end
+
   test "should not update topic without permission" do
     other_user = users(:two)
     sign_in_as other_user, password: "password"
@@ -695,6 +722,20 @@ class TopicsControllerTest < ActionDispatch::IntegrationTest
     assert_nil body["topic"]["primary_agent"]
   end
 
+  test "primary agent update rejects a topic that moved before its lock" do
+    ai_agent = User.create!(
+      email: "stale-pin@test.local", password: "password123", name: "StalePinAgent",
+      llm_vendor: "openai", llm_model: "gpt-4", searchable: true
+    )
+    @topic.set_primary_agent!(ai_agent)
+
+    assert_topic_source_change_rejected do
+      patch set_primary_agent_creative_topic_url(@creative, @topic), params: { agent_id: nil }, as: :json
+    end
+
+    assert_equal ai_agent.id, @topic.reload.primary_agent_id
+  end
+
   # On a session topic primary_agent_id is session identity, not a routing pin:
   # clearing it makes the live session unroutable and makes the next registration
   # create a second topic instead of reusing the conversation.
@@ -955,6 +996,23 @@ class TopicsControllerTest < ActionDispatch::IntegrationTest
   end
 
   private
+
+  def assert_topic_source_change_rejected
+    destination = Collavre::Creative.create!(description: "Destination", user: @user)
+    topics = @creative.topics
+    lock_topic = lambda do
+      @topic.update_column(:creative_id, destination.id)
+      @topic.reload
+    end
+
+    Collavre::Creative.stub(:find, @creative) do
+      topics.stub(:find, @topic) do
+        @topic.stub(:lock!, lock_topic) { yield }
+      end
+    end
+
+    assert_response :forbidden
+  end
 
   def move_test_agent(email, name)
     User.create!(

--- a/engines/collavre/test/controllers/topics_controller_test.rb
+++ b/engines/collavre/test/controllers/topics_controller_test.rb
@@ -329,20 +329,19 @@ class TopicsControllerTest < ActionDispatch::IntegrationTest
   test "should not broadcast an obsolete destination after a consecutive move" do
     target_creative = creatives(:root_parent)
     final_target = Collavre::Creative.create!(description: "Final target", user: @user)
-    original_find = Collavre::Topic.method(:find)
     moved_again = false
     broadcasts = []
-    find_topic = lambda do |id|
+    run_after_commit = lambda do |&callback|
       unless moved_again
         moved_again = true
         Collavre::Topics::TopicMove.new(
-          topic: original_find.call(id), target_creative: final_target
+          topic: @topic.reload, target_creative: final_target
         ).call
       end
-      original_find.call(id)
+      callback.call
     end
 
-    Collavre::Topic.stub(:find, find_topic) do
+    ActiveRecord.stub(:after_all_transactions_commit, run_after_commit) do
       Collavre::TopicsChannel.stub(:broadcast_to, ->(creative, payload) { broadcasts << [ creative.id, payload ] }) do
         patch move_creative_topic_url(@creative, @topic),
           params: { target_creative_id: target_creative.id }, as: :json

--- a/engines/collavre/test/controllers/topics_controller_test.rb
+++ b/engines/collavre/test/controllers/topics_controller_test.rb
@@ -312,6 +312,20 @@ class TopicsControllerTest < ActionDispatch::IntegrationTest
     task&.destroy
   end
 
+  test "should reject moving a topic referenced by a trigger loop" do
+    target_creative = creatives(:root_parent)
+    @creative.update!(data: {
+      "trigger" => { "loop" => { "state" => "running", "trigger_topic_id" => @topic.id } }
+    })
+
+    patch move_creative_topic_url(@creative, @topic),
+      params: { target_creative_id: target_creative.id }, as: :json
+
+    assert_response :unprocessable_entity
+    assert_equal I18n.t("collavre.topics.move.trigger_loop"), JSON.parse(response.body).fetch("error")
+    assert_equal @creative.id, @topic.reload.creative_id
+  end
+
   test "should not broadcast an obsolete destination after a consecutive move" do
     target_creative = creatives(:root_parent)
     final_target = Collavre::Creative.create!(description: "Final target", user: @user)

--- a/engines/collavre/test/controllers/topics_controller_test.rb
+++ b/engines/collavre/test/controllers/topics_controller_test.rb
@@ -292,6 +292,26 @@ class TopicsControllerTest < ActionDispatch::IntegrationTest
     assert_equal @creative.id, @topic.reload.creative_id
   end
 
+  test "should reject moving a topic targeted by a recurring cron job" do
+    target_creative = creatives(:root_parent)
+    task = SolidQueue::RecurringTask.create!(
+      key: "cron_#{@creative.id}_#{SecureRandom.hex(4)}",
+      class_name: "Collavre::CronActionJob", schedule: "0 9 * * *",
+      queue_name: "default", static: false,
+      arguments: [ { creative_id: @creative.id, topic_id: @topic.id,
+                     agent_id: @user.id, message: "Daily" } ]
+    )
+
+    patch move_creative_topic_url(@creative, @topic),
+      params: { target_creative_id: target_creative.id }, as: :json
+
+    assert_response :unprocessable_entity
+    assert_equal I18n.t("collavre.topics.move.recurring_tasks"), JSON.parse(response.body).fetch("error")
+    assert_equal @creative.id, @topic.reload.creative_id
+  ensure
+    task&.destroy
+  end
+
   test "should not broadcast an obsolete destination after a consecutive move" do
     target_creative = creatives(:root_parent)
     final_target = Collavre::Creative.create!(description: "Final target", user: @user)

--- a/engines/collavre/test/controllers/topics_controller_test.rb
+++ b/engines/collavre/test/controllers/topics_controller_test.rb
@@ -292,10 +292,39 @@ class TopicsControllerTest < ActionDispatch::IntegrationTest
     assert_equal @creative.id, @topic.reload.creative_id
   end
 
+  test "should not broadcast an obsolete destination after a consecutive move" do
+    target_creative = creatives(:root_parent)
+    final_target = Collavre::Creative.create!(description: "Final target", user: @user)
+    original_find = Collavre::Topic.method(:find)
+    moved_again = false
+    broadcasts = []
+    find_topic = lambda do |id|
+      unless moved_again
+        moved_again = true
+        Collavre::Topics::TopicMove.new(
+          topic: original_find.call(id), target_creative: final_target
+        ).call
+      end
+      original_find.call(id)
+    end
+
+    Collavre::Topic.stub(:find, find_topic) do
+      Collavre::TopicsChannel.stub(:broadcast_to, ->(creative, payload) { broadcasts << [ creative.id, payload ] }) do
+        patch move_creative_topic_url(@creative, @topic),
+          params: { target_creative_id: target_creative.id }, as: :json
+      end
+    end
+
+    assert_response :success
+    assert_equal final_target.id, @topic.reload.creative_id
+    assert_equal target_creative.id, JSON.parse(response.body).fetch("target_creative_id")
+    assert_equal [ @creative.id ], broadcasts.map(&:first)
+  end
+
   test "a source changed while waiting for the move lock is forbidden" do
     target_creative = creatives(:root_parent)
     failed_move = Object.new
-    failed_move.define_singleton_method(:call) do
+    failed_move.define_singleton_method(:call) do |**|
       raise Collavre::Topics::TopicMove::SourceChangedError,
         I18n.t("collavre.topics.move.source_changed")
     end

--- a/engines/collavre/test/controllers/topics_controller_test.rb
+++ b/engines/collavre/test/controllers/topics_controller_test.rb
@@ -277,6 +277,21 @@ class TopicsControllerTest < ActionDispatch::IntegrationTest
     assert_equal target_creative.id, comment.creative_id, "Comment should move with topic"
   end
 
+  test "should reject moving a topic with active agent work" do
+    target_creative = creatives(:root_parent)
+    Collavre::Task.create!(
+      name: "Queued topic work", agent: @user, creative: @creative,
+      topic_id: @topic.id, status: :queued
+    )
+
+    patch move_creative_topic_url(@creative, @topic),
+      params: { target_creative_id: target_creative.id }, as: :json
+
+    assert_response :unprocessable_entity
+    assert_equal I18n.t("collavre.topics.move.active_tasks"), JSON.parse(response.body).fetch("error")
+    assert_equal @creative.id, @topic.reload.creative_id
+  end
+
   test "a source changed while waiting for the move lock is forbidden" do
     target_creative = creatives(:root_parent)
     failed_move = Object.new

--- a/engines/collavre/test/controllers/user_creative_preferences_controller_test.rb
+++ b/engines/collavre/test/controllers/user_creative_preferences_controller_test.rb
@@ -379,6 +379,29 @@ class UserCreativePreferencesControllerTest < ActionDispatch::IntegrationTest
     assert_response :unprocessable_entity
   end
 
+  test "update_last_topic rejects a topic moved before its membership lock" do
+    destination = Collavre::Creative.create!(user: @user, description: "Destination")
+    topic = Collavre::Topic.create!(creative: @creative, user: @user, name: "Moving Topic")
+    locked_topics = Collavre::Topic.lock
+    moved = false
+
+    Collavre::Topic.stub(:lock, lambda {
+      unless moved
+        moved = true
+        Collavre::Topics::TopicMove.new(topic: topic, target_creative: destination).call
+      end
+      locked_topics
+    }) do
+      patch "/creatives/#{@creative.id}/user_creative_preferences/update_last_topic",
+            params: { last_topic_id: topic.id },
+            as: :json
+    end
+
+    assert_response :unprocessable_entity
+    assert_equal destination.id, topic.reload.creative_id
+    assert_nil Collavre::UserCreativePreference.find_by(creative: @creative, user: @user)
+  end
+
   test "update_last_topic requires permission" do
     other_user = users(:two)
     other_user.update!(email_verified_at: Time.current)

--- a/engines/collavre/test/jobs/collavre/ai_agent_job_topic_slot_test.rb
+++ b/engines/collavre/test/jobs/collavre/ai_agent_job_topic_slot_test.rb
@@ -166,6 +166,29 @@ module Collavre
              "a task should have been created and executed"
     end
 
+    test "drops a scheduled job whose topic moved before task admission" do
+      c = comment("scheduled before move")
+      stale_context = context_for(c)
+      destination = Creative.create!(description: "Moved destination", user: @user)
+      Topics::TopicMove.new(topic: @topic, target_creative: destination).call
+      matcher = Struct.new(:agent) do
+        def assignment_permits?(_candidate)
+          true
+        end
+      end.new(@agent)
+      service_started = false
+
+      Orchestration::Matcher.stub(:new, matcher) do
+        AiAgentService.stub(:new, ->(*) { service_started = true }) do
+          AiAgentJob.new.perform(@agent.id, "comment_created", stale_context)
+        end
+      end
+
+      assert_not service_started
+      assert_not Task.where(topic_id: @topic.id, creative_id: @creative.id).exists?
+      assert_equal destination.id, @topic.reload.creative_id
+    end
+
     test "does not defer when the context carries no topic" do
       c = Comment.create!(creative: @creative, user: @user, content: "no topic", skip_dispatch: true)
       context = {
@@ -243,12 +266,12 @@ module Collavre
     # slot before either inserts — the TOCTOU race this check exists to close.
     test "admission counts and claims the slot inside one locked transaction" do
       locked_topic_ids = []
-      lock_relation = Struct.new(:sink) do
+      lock_relation = Struct.new(:sink, :record) do
         def find_by(id:)
           sink << id
-          nil
+          record
         end
-      end.new(locked_topic_ids)
+      end.new(locked_topic_ids, @topic)
 
       # The suite already runs inside a transaction, so `transaction_open?` is
       # always true — compare the nesting depth against the ambient one instead.
@@ -282,12 +305,12 @@ module Collavre
     # both read a free slot before either inserts.
     test "admission on the Main topic serializes on the creative row" do
       locked_creative_ids = []
-      lock_relation = Struct.new(:sink) do
+      lock_relation = Struct.new(:sink, :record) do
         def find_by(id:)
           sink << id
-          nil
+          record
         end
-      end.new(locked_creative_ids)
+      end.new(locked_creative_ids, @creative)
 
       baseline_depth = Task.connection.open_transactions
       check_depth = nil

--- a/engines/collavre/test/jobs/collavre/cron_action_job_test.rb
+++ b/engines/collavre/test/jobs/collavre/cron_action_job_test.rb
@@ -69,6 +69,23 @@ module Collavre
       end
     end
 
+    test "drops an enqueued cron action whose topic moved" do
+      destination = Creative.create!(description: "Cron destination", user: @user)
+      Collavre::Topics::TopicMove.new(topic: @topic, target_creative: destination).call
+
+      assert_no_difference("Comment.count") do
+        CronActionJob.perform_now(
+          creative_id: @creative.id,
+          topic_id: @topic.id,
+          agent_id: @agent.id,
+          message: "Stale scheduled check-in"
+        )
+      end
+
+      assert_empty @creative.comments.where(content: "Stale scheduled check-in")
+      assert_empty destination.comments.where(content: "Stale scheduled check-in")
+    end
+
     # `topic_id: nil` describes the cron's *argument*, not the row: the comment
     # goes through Comment#assign_main_topic, which files it under the
     # creative's real Main topic. A payload that repeats the argument therefore

--- a/engines/collavre/test/jobs/collavre/drop_trigger_job_test.rb
+++ b/engines/collavre/test/jobs/collavre/drop_trigger_job_test.rb
@@ -66,6 +66,21 @@ module Collavre
       end
     end
 
+    test "does not initialize a trigger loop after its topic moves" do
+      topic = @child.topics.create!(name: DropTriggerJob::DROP_TRIGGER_TOPIC_NAME, user: @owner)
+      dispatched = false
+
+      Orchestration::TopicSlot.stub(:lock_matches_context?, false) do
+        SystemEvents::Dispatcher.stub(:dispatch, ->(*_args) { dispatched = true; [ @ai_bot ] }) do
+          DropTriggerJob.perform_now(@parent.id, @child.id)
+        end
+      end
+
+      assert_nil @child.reload.data&.dig("trigger", "loop")
+      assert_empty @child.comments.where(topic_id: topic.id)
+      refute dispatched
+    end
+
     test "finds existing comment and retries dispatch on retry" do
       # First run: create comment, dispatch fails
       SystemEvents::Dispatcher.stub(:dispatch, ->(*_args) { raise "dispatch error" }) do

--- a/engines/collavre/test/jobs/compress_job_test.rb
+++ b/engines/collavre/test/jobs/compress_job_test.rb
@@ -227,6 +227,29 @@ class Collavre::CompressJobTest < ActiveSupport::TestCase
     assert_not Collavre::CommentSnapshot.where(topic: @topic).exists?
   end
 
+  test "does not compress when a selected comment changes topics during the AI call" do
+    create_ai_agent_for_creative
+    other_topic = @creative.topics.create!(name: "Moved comment", user: @user)
+    mock_client = Minitest::Mock.new
+    mock_client.expect(:chat, "summary") do |_messages, **_kwargs, &block|
+      block.call("summary")
+      Collavre::CommentMoveService.new(creative: @creative, user: @user).call(
+        comment_ids: [ @comment2.id ], target_topic_id: other_topic.id
+      )
+      true
+    end
+
+    Collavre::AiClient.stub(:new, mock_client) do
+      Collavre::CompressJob.perform_now(@creative.id, @topic.id, @user.id)
+    end
+
+    assert_equal other_topic.id, @comment2.reload.topic_id
+    assert Collavre::Comment.exists?(@comment1.id)
+    assert Collavre::Comment.exists?(@comment3.id)
+    assert_not Collavre::CommentSnapshot.where(topic: @topic).exists?
+    assert_equal 2, @creative.comments.where(topic: @topic).count
+  end
+
   private
 
   def create_ai_agent_for_creative

--- a/engines/collavre/test/jobs/compress_job_test.rb
+++ b/engines/collavre/test/jobs/compress_job_test.rb
@@ -207,6 +207,26 @@ class Collavre::CompressJobTest < ActiveSupport::TestCase
     assert_empty summary_comments
   end
 
+  test "does not persist a summary when the topic moves during the AI call" do
+    create_ai_agent_for_creative
+    destination = Collavre::Creative.create!(description: "Moved compression", user: @user)
+    mock_client = Minitest::Mock.new
+    mock_client.expect(:chat, "summary") do |_messages, **_kwargs, &block|
+      block.call("summary")
+      Collavre::Topics::TopicMove.new(topic: @topic, target_creative: destination).call
+      true
+    end
+
+    Collavre::AiClient.stub(:new, mock_client) do
+      Collavre::CompressJob.perform_now(@creative.id, @topic.id, @user.id)
+    end
+
+    assert_equal destination.id, @topic.reload.creative_id
+    assert_equal [ @comment1.id, @comment2.id, @comment3.id ].sort,
+                 destination.comments.where(topic: @topic).pluck(:id).sort
+    assert_not Collavre::CommentSnapshot.where(topic: @topic).exists?
+  end
+
   private
 
   def create_ai_agent_for_creative

--- a/engines/collavre/test/jobs/merge_comments_job_test.rb
+++ b/engines/collavre/test/jobs/merge_comments_job_test.rb
@@ -191,4 +191,37 @@ class Collavre::MergeCommentsJobTest < ActiveSupport::TestCase
     assert Collavre::Comment.exists?(@comment3.id)
     assert_not Collavre::CommentSnapshot.where(topic: @topic).exists?
   end
+
+  test "does not merge comments selected from different topics" do
+    other_topic = Collavre::Topic.create!(creative: @creative, user: @user, name: "other-topic")
+    @comment2.update!(topic: other_topic)
+
+    Collavre::AiClient.stub(:new, ->(**) { flunk("AI client should not be created") }) do
+      Collavre::MergeCommentsJob.perform_now(@creative.id, [ @comment1.id, @comment2.id ], @user.id)
+    end
+
+    assert_equal "First message content", @comment1.reload.content
+    assert Collavre::Comment.exists?(@comment2.id)
+    assert_not Collavre::CommentSnapshot.where(creative: @creative).exists?
+  end
+
+  test "does not merge when a selected comment changes topics during the AI call" do
+    other_topic = Collavre::Topic.create!(creative: @creative, user: @user, name: "moved-comment-topic")
+    mock_client = Minitest::Mock.new
+    mock_client.expect(:chat, "merged") do |_messages, **_kwargs, &block|
+      block.call("merged")
+      Collavre::CommentMoveService.new(creative: @creative, user: @user).call(
+        comment_ids: [ @comment2.id ], target_topic_id: other_topic.id
+      )
+      true
+    end
+
+    Collavre::AiClient.stub(:new, mock_client) do
+      Collavre::MergeCommentsJob.perform_now(@creative.id, [ @comment1.id, @comment2.id ], @user.id)
+    end
+
+    assert_equal "First message content", @comment1.reload.content
+    assert_equal other_topic.id, @comment2.reload.topic_id
+    assert_not Collavre::CommentSnapshot.where(creative: @creative).exists?
+  end
 end

--- a/engines/collavre/test/jobs/merge_comments_job_test.rb
+++ b/engines/collavre/test/jobs/merge_comments_job_test.rb
@@ -169,4 +169,26 @@ class Collavre::MergeCommentsJobTest < ActiveSupport::TestCase
     assert Collavre::Comment.exists?(c2.id)
     assert_equal "Message one", c1.reload.content
   end
+
+  test "does not merge comments when the topic moves during the AI call" do
+    destination = Collavre::Creative.create!(description: "Moved merge", user: @user)
+    mock_client = Minitest::Mock.new
+    mock_client.expect(:chat, "merged") do |_messages, **_kwargs, &block|
+      block.call("merged")
+      Collavre::Topics::TopicMove.new(topic: @topic, target_creative: destination).call
+      true
+    end
+
+    Collavre::AiClient.stub(:new, mock_client) do
+      Collavre::MergeCommentsJob.perform_now(
+        @creative.id, [ @comment1.id, @comment2.id, @comment3.id ], @user.id
+      )
+    end
+
+    assert_equal destination.id, @topic.reload.creative_id
+    assert_equal "First message content", @comment1.reload.content
+    assert Collavre::Comment.exists?(@comment2.id)
+    assert Collavre::Comment.exists?(@comment3.id)
+    assert_not Collavre::CommentSnapshot.where(topic: @topic).exists?
+  end
 end

--- a/engines/collavre/test/models/comment_test.rb
+++ b/engines/collavre/test/models/comment_test.rb
@@ -137,6 +137,19 @@ class CommentTest < ActiveSupport::TestCase
     assert_equal origin, comment.creative
   end
 
+  test "rejects a stale topic membership after the topic moves" do
+    owner = users(:one)
+    source = Creative.create!(user: owner, description: "Comment source")
+    destination = Creative.create!(user: owner, description: "Comment destination")
+    topic = source.topics.create!(name: "Moving topic", user: owner)
+    comment = source.comments.build(user: owner, topic: topic, content: "Late comment")
+
+    Collavre::Topics::TopicMove.new(topic: topic, target_creative: destination).call
+
+    assert_no_difference("Comment.count") { assert_not comment.save }
+    assert_includes comment.errors[:topic], I18n.t("collavre.comments.invalid_topic")
+  end
+
   test "streaming placeholder does not create inbox comments" do
     owner = users(:one)
     ai_agent = users(:ai_bot)

--- a/engines/collavre/test/models/task_status_enum_test.rb
+++ b/engines/collavre/test/models/task_status_enum_test.rb
@@ -35,5 +35,14 @@ module Collavre
       Task.where(id: task.id).update_all(status: "done")
       assert task.reload.done?
     end
+
+    test "stale cancellation does not overwrite a completed task" do
+      task = Task.create!(name: "T", status: "running", agent: @agent)
+      stale_task = Task.find(task.id)
+      Task.where(id: task.id).update_all(status: "done")
+
+      assert_nil stale_task.cancel_if_active!
+      assert task.reload.done?
+    end
   end
 end

--- a/engines/collavre/test/services/collavre/ai_agent/task_reply_service_test.rb
+++ b/engines/collavre/test/services/collavre/ai_agent/task_reply_service_test.rb
@@ -30,10 +30,10 @@ module Collavre
           assert result.comment.persisted?
         end
 
-        assert_equal %i[lock claim link unlock finalize], events
+        assert_equal %i[lock claim link finalize unlock], events
       end
 
-      test "active claimed reply blocks a topic move before finalize" do
+      test "active claimed reply blocks a topic move until finalize" do
         user = users(:one)
         source = Creative.create!(description: "Replies", user: user)
         destination = Creative.create!(description: "Destination", user: user)
@@ -43,10 +43,11 @@ module Collavre
         finalizer = Object.new
         test_case = self
         finalizer.define_singleton_method(:link_reply) { |**args| claim_service.link_reply(**args) }
-        finalizer.define_singleton_method(:finalize) do |**|
+        finalizer.define_singleton_method(:finalize) do |**args|
           test_case.assert_raises(Topics::TopicMove::ActiveTaskError) do
             Topics::TopicMove.new(topic: topic, target_creative: destination).call
           end
+          claim_service.finalize(**args)
         end
 
         result = TaskReplyService.new(
@@ -59,7 +60,7 @@ module Collavre
         ).call
 
         assert_equal :created, result.status
-        assert_equal "running", task.reload.status
+        assert_equal "done", task.reload.status
         assert_equal source.id, topic.reload.creative_id
         assert_equal task.id, result.comment.reload.task_id
       end

--- a/engines/collavre/test/services/collavre/ai_agent/task_reply_service_test.rb
+++ b/engines/collavre/test/services/collavre/ai_agent/task_reply_service_test.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  module AiAgent
+    class TaskReplyServiceTest < ActiveSupport::TestCase
+      test "keeps an active claim between locked comment save and locked finalize" do
+        user = users(:one)
+        creative = Creative.create!(description: "Replies", user: user)
+        topic = creative.topics.create!(name: "Delegated", user: user)
+        events = []
+        task = Object.new
+        claim_service = Object.new
+        claim_service.define_singleton_method(:link_reply) { |**| events << :link }
+        claim_service.define_singleton_method(:finalize) { |**| events << :finalize }
+        lock = lambda do |&block|
+          events << :lock
+          block.call.tap { events << :unlock }
+        end
+
+        topic.stub(:with_lock, lock) do
+          result = TaskReplyService.new(
+            topic: topic, current_user: user, text: "done", requested_task_id: 123,
+            agent_resolver: ->(*) { user }, task_claimer: ->(*) { events << :claim; task },
+            claim_service: claim_service
+          ).call
+
+          assert_equal :created, result.status
+          assert result.comment.persisted?
+        end
+
+        assert_equal %i[lock claim link unlock finalize], events
+      end
+
+      test "active claimed reply blocks a topic move before finalize" do
+        user = users(:one)
+        source = Creative.create!(description: "Replies", user: user)
+        destination = Creative.create!(description: "Destination", user: user)
+        topic = source.topics.create!(name: "Delegated", user: user)
+        task = Task.create!(name: "Reply", creative: source, topic_id: topic.id, agent: user, status: "delegated")
+        claim_service = TaskClaimService.new
+        finalizer = Object.new
+        test_case = self
+        finalizer.define_singleton_method(:link_reply) { |**args| claim_service.link_reply(**args) }
+        finalizer.define_singleton_method(:finalize) do |**|
+          test_case.assert_raises(Topics::TopicMove::ActiveTaskError) do
+            Topics::TopicMove.new(topic: topic, target_creative: destination).call
+          end
+        end
+
+        result = TaskReplyService.new(
+          topic: topic, current_user: user, text: "done", requested_task_id: task.id,
+          agent_resolver: ->(*) { user },
+          task_claimer: ->(agent, locked_topic, task_id) {
+            claim_service.claim(agent: agent, topic: locked_topic, requested_task_id: task_id)
+          },
+          claim_service: finalizer
+        ).call
+
+        assert_equal :created, result.status
+        assert_equal "running", task.reload.status
+        assert_equal source.id, topic.reload.creative_id
+        assert_equal task.id, result.comment.reload.task_id
+      end
+    end
+  end
+end

--- a/engines/collavre/test/services/collavre/orchestration/agent_orchestrator_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/agent_orchestrator_test.rb
@@ -173,6 +173,22 @@ module Collavre
         assert_equal topic.id, queued_task.topic_id
       end
 
+      test "deferred decision creates no waiter after its topic moves" do
+        topic = Topic.create!(name: "Moved deferred topic", creative: @creative, user: @user)
+        destination = Creative.create!(description: "Deferred destination", user: @user)
+        context = {
+          "creative" => { "id" => @creative.id },
+          "topic" => { "id" => topic.id },
+          "comment" => { "content" => "stale deferred dispatch" }
+        }
+        orchestrator = AgentOrchestrator.new(event_name: "comment_created", context: context)
+        Topics::TopicMove.new(topic: topic, target_creative: destination).call
+
+        assert_no_difference -> { Task.where(topic_id: topic.id).count } do
+          assert_nil orchestrator.send(:park_waiter, @ai_agent, context)
+        end
+      end
+
       # The "⏳" waiting notice must name the agent holding the running slot, so a
       # waiting user sees *who* is blocking them (and can reach that task's stop
       # button) instead of an anonymous "another task is running" dead end.

--- a/engines/collavre/test/services/collavre/orchestration/agent_orchestrator_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/agent_orchestrator_test.rb
@@ -189,6 +189,35 @@ module Collavre
         end
       end
 
+      test "delayed enqueue survives a topic move before its waiting notice" do
+        topic = Topic.create!(name: "Moved delayed topic", creative: @creative, user: @user)
+        destination = Creative.create!(description: "Delayed destination", user: @user)
+        context = {
+          "creative" => { "id" => @creative.id },
+          "topic" => { "id" => topic.id },
+          "comment" => { "content" => "stale delayed dispatch" }
+        }
+        orchestrator = AgentOrchestrator.new(event_name: "comment_created", context: context)
+        queued_job = Object.new
+        queued_job.define_singleton_method(:perform_later) do |*|
+          Topics::TopicMove.new(topic: topic, target_creative: destination).call
+        end
+
+        result = nil
+        assert_no_difference -> { Comment.where(topic_id: topic.id, user_id: nil).count } do
+          AiAgentJob.stub(:set, ->(**) { queued_job }) do
+            result = orchestrator.send(
+              :enqueue_jobs,
+              [ { agent: @ai_agent, timing: :delayed, delay: 1.minute, reason: :busy } ],
+              context_for: nil
+            )
+          end
+        end
+
+        assert_equal [ @ai_agent ], result
+        assert_equal destination, topic.reload.creative
+      end
+
       # The "⏳" waiting notice must name the agent holding the running slot, so a
       # waiting user sees *who* is blocking them (and can reach that task's stop
       # button) instead of an anonymous "another task is running" dead end.

--- a/engines/collavre/test/services/collavre/orchestration/task_coalescing_integration_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/task_coalescing_integration_test.rb
@@ -478,7 +478,7 @@ module Collavre
         locked_before_fold = nil
         fold_depth = nil
 
-        TopicSlot.stub(:lock!, ->(topic_id, _creative_id = nil) { locked << topic_id; nil }) do
+        TopicSlot.stub(:lock!, ->(topic_id, _creative_id = nil) { locked << topic_id; @topic }) do
           TaskCoalescer.stub(:coalesce!, ->(_task, **_opts) {
             locked_before_fold ||= locked.dup
             fold_depth ||= Task.connection.open_transactions

--- a/engines/collavre/test/services/collavre/tools/cron_create_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/cron_create_service_test.rb
@@ -143,6 +143,24 @@ module Collavre
 
         assert_not_equal result1[:key], result2[:key]
       end
+
+      test "rejects a topic that moved after resolution and before creation" do
+        destination = Creative.create!(description: "Cron destination", user: @user)
+        service = CronCreateService.new
+        Collavre::Topics::TopicMove.new(topic: @topic, target_creative: destination).call
+
+        result = service.stub(:resolve_topic, @topic) do
+          service.call(
+            creative_id: @creative.id,
+            topic_name: @topic.name,
+            schedule: "0 9 * * *",
+            message: "Stale cron"
+          )
+        end
+
+        assert_equal I18n.t("collavre.comments.invalid_topic"), result[:error]
+        assert_empty SolidQueue::RecurringTask.where(static: false)
+      end
     end
   end
 end

--- a/engines/collavre/test/services/collavre/tools/topic_move_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/topic_move_service_test.rb
@@ -16,9 +16,13 @@ module Collavre
 
       teardown { Current.user = nil }
 
-      test "moves the topic, messages, read cursors, and comment counters" do
+      test "moves the topic, messages, snapshots, read cursors, and comment counters" do
         comment = Comment.create!(creative: @source, topic: @topic, user: @owner, content: "Keep together",
                                   skip_default_user: true, skip_dispatch: true)
+        snapshot = CommentSnapshot.create!(
+          creative: @source, topic: @topic, user: @owner, operation: "compress",
+          comments_data: [ { "id" => comment.id, "topic_id" => @topic.id, "content" => comment.content } ]
+        )
         pointer = CommentReadPointer.create!(
           user: @owner, creative: @source, topic: @topic, last_read_comment: comment
         )
@@ -29,6 +33,7 @@ module Collavre
 
         assert_equal @target.id, @topic.reload.creative_id
         assert_equal @target.id, comment.reload.creative_id
+        assert_equal @target.id, snapshot.reload.creative_id
         assert_equal @target.id, pointer.reload.creative_id
         assert_equal source_before - 1, @source.reload.comments_count
         assert_equal target_before + 1, @target.reload.comments_count
@@ -186,6 +191,17 @@ module Collavre
         @topic.update!(session_id: "session-1")
 
         assert_error(:session_topic, creative_id: @target.id)
+      end
+
+      test "rejects a topic with active agent work" do
+        Task.create!(name: "Moving work", agent: @owner, creative: @source, topic_id: @topic.id, status: :queued)
+
+        error = assert_raises(Topics::TopicMove::ActiveTaskError) do
+          TopicMoveService.new.call(topic_id: @topic.id, creative_id: @target.id)
+        end
+
+        assert_equal I18n.t("collavre.topics.move.active_tasks"), error.message
+        assert_equal @source.id, @topic.reload.creative_id
       end
 
       test "rejects a stale move when the topic changes creatives before its lock" do

--- a/engines/collavre/test/services/collavre/tools/topic_move_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/topic_move_service_test.rb
@@ -249,6 +249,19 @@ module Collavre
         task&.destroy
       end
 
+      test "rejects a topic referenced by a trigger loop" do
+        @source.update!(data: {
+          "trigger" => { "loop" => { "state" => "awaiting_user", "trigger_topic_id" => @topic.id } }
+        })
+
+        error = assert_raises(Topics::TopicMove::TriggerLoopError) do
+          TopicMoveService.new.call(topic_id: @topic.id, creative_id: @target.id)
+        end
+
+        assert_equal I18n.t("collavre.topics.move.trigger_loop"), error.message
+        assert_equal @source.id, @topic.reload.creative_id
+      end
+
       test "rejects a stale move when the topic changes creatives before its lock" do
         intervening = Creative.create!(description: "Intervening", user: @owner)
         stale_move = Topics::TopicMove.new(topic: @topic, target_creative: @target)

--- a/engines/collavre/test/services/collavre/tools/topic_move_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/topic_move_service_test.rb
@@ -57,17 +57,13 @@ module Collavre
       end
 
       test "broadcasts topic state reloaded under the post-commit lock" do
-        original_find = Topic.method(:find)
-        find_calls = 0
         broadcasts = []
-        find_topic = lambda do |id|
-          find_calls += 1
-          record = original_find.call(id)
-          record.update_column(:name, "Renamed after move") if find_calls == 2
-          original_find.call(id)
+        run_after_commit = lambda do |&callback|
+          @topic.update_column(:name, "Renamed after move")
+          callback.call
         end
 
-        Topic.stub(:find, find_topic) do
+        ActiveRecord.stub(:after_all_transactions_commit, run_after_commit) do
           TopicsChannel.stub(:broadcast_to, ->(creative, payload) { broadcasts << [ creative.id, payload ] }) do
             TopicMoveService.new.call(topic_id: @topic.id, creative_id: @target.id)
           end
@@ -79,18 +75,17 @@ module Collavre
 
       test "does not broadcast an obsolete destination after a consecutive move" do
         final_target = Creative.create!(description: "Final target", user: @owner)
-        original_find = Topic.method(:find)
-        find_calls = 0
+        moved_again = false
         broadcasts = []
-        find_topic = lambda do |id|
-          find_calls += 1
-          if find_calls == 2
-            Topics::TopicMove.new(topic: original_find.call(id), target_creative: final_target).call
+        run_after_commit = lambda do |&callback|
+          unless moved_again
+            moved_again = true
+            Topics::TopicMove.new(topic: @topic.reload, target_creative: final_target).call
           end
-          original_find.call(id)
+          callback.call
         end
 
-        result = Topic.stub(:find, find_topic) do
+        result = ActiveRecord.stub(:after_all_transactions_commit, run_after_commit) do
           TopicsChannel.stub(:broadcast_to, ->(creative, payload) { broadcasts << [ creative.id, payload ] }) do
             TopicMoveService.new.call(topic_id: @topic.id, creative_id: @target.id)
           end

--- a/engines/collavre/test/services/collavre/tools/topic_move_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/topic_move_service_test.rb
@@ -1,0 +1,246 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  module Tools
+    class TopicMoveServiceTest < ActiveSupport::TestCase
+      setup do
+        @owner = users(:one)
+        @member = users(:two)
+        @source = Creative.create!(description: "Move source", user: @owner)
+        @target = Creative.create!(description: "Move target", user: @owner)
+        @topic = @source.topics.create!(name: "Relocate", user: @owner)
+        Current.user = @owner
+      end
+
+      teardown { Current.user = nil }
+
+      test "moves the topic, messages, read cursors, and comment counters" do
+        comment = Comment.create!(creative: @source, topic: @topic, user: @owner, content: "Keep together",
+                                  skip_default_user: true, skip_dispatch: true)
+        pointer = CommentReadPointer.create!(
+          user: @owner, creative: @source, topic: @topic, last_read_comment: comment
+        )
+        source_before = @source.reload.comments_count
+        target_before = @target.reload.comments_count
+
+        result = TopicMoveService.new.call(topic_id: @topic.id, creative_id: @target.id)
+
+        assert_equal @target.id, @topic.reload.creative_id
+        assert_equal @target.id, comment.reload.creative_id
+        assert_equal @target.id, pointer.reload.creative_id
+        assert_equal source_before - 1, @source.reload.comments_count
+        assert_equal target_before + 1, @target.reload.comments_count
+        assert_equal @target.id, result[:creative_id]
+        assert_equal @source.id, result[:moved_from_creative_id]
+        assert_nil result[:released_primary_agent]
+      end
+
+      test "broadcasts removal from the source and creation on the destination after moving" do
+        broadcasts = []
+
+        TopicsChannel.stub(:broadcast_to, ->(creative, payload) { broadcasts << [ creative.id, payload ] }) do
+          TopicMoveService.new.call(topic_id: @topic.id, creative_id: @target.id)
+        end
+
+        assert_equal [ @source.id, @target.id ], broadcasts.map(&:first)
+        assert_equal "deleted", broadcasts.first.last[:action]
+        assert_equal @topic.id, broadcasts.first.last[:topic_id]
+        assert_equal "created", broadcasts.second.last[:action]
+        assert_equal @topic.id, broadcasts.second.last.dig(:topic, :id)
+      end
+
+      test "a linked destination resolves to its origin" do
+        link = Creative.create!(description: "Target link", user: @owner, origin: @target)
+
+        result = TopicMoveService.new.call(topic_id: @topic.id, creative_id: link.id)
+
+        assert_equal @target.id, result[:creative_id]
+        assert_equal @target.id, @topic.reload.creative_id
+      end
+
+      test "keeps a primary agent that can respond on the destination" do
+        agent = create_agent("kept")
+        share!(@source, agent, :feedback)
+        share!(@target, agent, :feedback)
+        @topic.set_primary_agent!(agent)
+
+        result = TopicMoveService.new.call(topic_id: @topic.id, creative_id: @target.id)
+
+        assert_equal agent.id, @topic.reload.primary_agent_id
+        assert_equal agent.id, result.dig(:primary_agent, :id)
+        assert_nil result[:released_primary_agent]
+      end
+
+      test "releases and explains a primary agent that cannot respond on the destination" do
+        agent = create_agent("released")
+        share!(@source, agent, :feedback)
+        @topic.set_primary_agent!(agent)
+
+        result = TopicMoveService.new.call(topic_id: @topic.id, creative_id: @target.id)
+
+        assert_nil @topic.reload.primary_agent_id
+        assert_equal agent.id, result.dig(:released_primary_agent, :id)
+        assert_equal "no_creative_access", result.dig(:released_primary_agent, :reason)
+        assert_includes result.dig(:released_primary_agent, :message), agent.display_name
+      end
+
+      test "explains session confinement when releasing a session agent in an inbox" do
+        agent = create_agent("session")
+        agent.update!(llm_vendor: "anthropic", llm_model: "claude-code")
+        inbox = Creative.create!(description: "Inbox", user: @owner, data: { "kind" => "inbox" })
+        share!(@source, agent, :feedback)
+        share!(inbox, agent, :feedback)
+        @topic.set_primary_agent!(agent)
+
+        result = TopicMoveService.new.call(topic_id: @topic.id, creative_id: inbox.id)
+
+        assert_nil @topic.reload.primary_agent_id
+        assert_equal "session_agent_outside_session_topic", result.dig(:released_primary_agent, :reason)
+        assert_equal I18n.t(
+          "collavre.topics.move.primary_agent_released_session_agent",
+          agent: agent.display_name, creative: inbox.creative_snippet
+        ), result.dig(:released_primary_agent, :message)
+      end
+
+      test "requires admin permission on the source" do
+        share!(@source, @member, :write)
+        @target.update!(user: @member)
+        Current.user = @member
+
+        error = assert_raises(PermissionDeniedError) do
+          TopicMoveService.new.call(topic_id: @topic.id, creative_id: @target.id)
+        end
+
+        assert_equal I18n.t("collavre.tools.topic_move.errors.source_permission"), error.message
+        assert_equal @source.id, @topic.reload.creative_id
+      end
+
+      test "requires write permission on the destination" do
+        @target.update!(user: @member)
+
+        error = assert_raises(PermissionDeniedError) do
+          TopicMoveService.new.call(topic_id: @topic.id, creative_id: @target.id)
+        end
+
+        assert_equal I18n.t("collavre.tools.topic_move.errors.target_permission"), error.message
+        assert_equal @source.id, @topic.reload.creative_id
+      end
+
+      test "reauthorizes the source after acquiring the topic lock" do
+        share!(@source, @member, :admin)
+        share!(@target, @member, :write)
+        Current.user = @member
+        checks = 0
+        authorize = lambda do |*_arguments, **_keywords|
+          checks += 1
+          next if checks == 1
+
+          raise PermissionDeniedError, "revoked"
+        end
+
+        TopicAuthorizer.stub(:authorize_admin!, authorize) do
+          assert_raises(PermissionDeniedError) do
+            TopicMoveService.new.call(topic_id: @topic.id, creative_id: @target.id)
+          end
+        end
+
+        assert_equal 2, checks
+        assert_equal @source.id, @topic.reload.creative_id
+      end
+
+      test "rejects moving to the current creative" do
+        assert_error(:same_creative, creative_id: @source.id)
+      end
+
+      test "rejects a duplicate topic name without moving messages" do
+        comment = Comment.create!(creative: @source, topic: @topic, user: @owner, content: "Still here",
+                                  skip_default_user: true, skip_dispatch: true)
+        @target.topics.create!(name: @topic.name, user: @owner)
+
+        assert_error(:duplicate_name, creative_id: @target.id, interpolation: { name: @topic.name })
+        assert_equal @source.id, comment.reload.creative_id
+      end
+
+      test "rejects Main and an inbox destination's reserved System topic" do
+        main = @source.main_topic
+        main_error = assert_raises(ArgumentError) do
+          TopicMoveService.new.call(topic_id: main.id, creative_id: @target.id)
+        end
+
+        ordinary_system = @source.topics.create!(name: Creative::SYSTEM_TOPIC_NAME, user: @owner)
+        inbox = Creative.create!(description: "Inbox", user: @owner, data: { "kind" => "inbox" })
+        system_error = assert_raises(ArgumentError) do
+          TopicMoveService.new.call(topic_id: ordinary_system.id, creative_id: inbox.id)
+        end
+
+        expected = I18n.t("collavre.tools.topic_move.errors.reserved_topic")
+        assert_equal expected, main_error.message
+        assert_equal expected, system_error.message
+        assert_equal @source.id, main.reload.creative_id
+        assert_equal @source.id, ordinary_system.reload.creative_id
+      end
+
+      test "rejects a live agent session topic" do
+        @topic.update!(session_id: "session-1")
+
+        assert_error(:session_topic, creative_id: @target.id)
+      end
+
+      test "rejects a stale move when the topic changes creatives before its lock" do
+        intervening = Creative.create!(description: "Intervening", user: @owner)
+        stale_move = Topics::TopicMove.new(topic: @topic, target_creative: @target)
+        Topics::TopicMove.new(topic: @topic, target_creative: intervening).call
+
+        assert_raises(Topics::TopicMove::SourceChangedError) { stale_move.call }
+        assert_equal intervening.id, @topic.reload.creative_id
+      end
+
+      test "requires a current user" do
+        Current.user = nil
+
+        error = assert_raises(RuntimeError) do
+          TopicMoveService.new.call(topic_id: @topic.id, creative_id: @target.id)
+        end
+
+        assert_equal I18n.t("collavre.tools.topic_move.errors.current_user_required"), error.message
+      end
+
+      test "every explicit tool error is translated in English and Korean" do
+        keys = %i[
+          current_user_required source_permission target_permission same_creative
+          reserved_topic session_topic duplicate_name
+        ]
+
+        keys.each do |key|
+          path = "collavre.tools.topic_move.errors.#{key}"
+          assert I18n.exists?(path, :en), "missing en translation for #{path}"
+          assert I18n.exists?(path, :ko), "missing ko translation for #{path}"
+        end
+      end
+
+      private
+
+      def create_agent(suffix)
+        User.create!(
+          name: "Move Agent #{suffix}", email: "move-agent-#{suffix}-#{SecureRandom.hex(3)}@test.test",
+          password: "password123", llm_vendor: "openai", llm_model: "gpt-4", searchable: true
+        )
+      end
+
+      def share!(creative, user, permission)
+        CreativeShare.create!(creative: creative, user: user, permission: permission, shared_by: @owner)
+      end
+
+      def assert_error(key, creative_id:, interpolation: {})
+        error = assert_raises(ArgumentError) do
+          TopicMoveService.new.call(topic_id: @topic.id, creative_id: creative_id)
+        end
+
+        assert_equal I18n.t("collavre.tools.topic_move.errors.#{key}", **interpolation), error.message
+        assert_equal @source.id, @topic.reload.creative_id
+      end
+    end
+  end
+end

--- a/engines/collavre/test/services/collavre/tools/topic_move_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/topic_move_service_test.rb
@@ -56,6 +56,32 @@ module Collavre
         assert_equal @topic.id, broadcasts.second.last.dig(:topic, :id)
       end
 
+      test "does not broadcast an obsolete destination after a consecutive move" do
+        final_target = Creative.create!(description: "Final target", user: @owner)
+        original_find = Topic.method(:find)
+        find_calls = 0
+        broadcasts = []
+        find_topic = lambda do |id|
+          find_calls += 1
+          if find_calls == 2
+            Topics::TopicMove.new(topic: original_find.call(id), target_creative: final_target).call
+          end
+          original_find.call(id)
+        end
+
+        result = Topic.stub(:find, find_topic) do
+          TopicsChannel.stub(:broadcast_to, ->(creative, payload) { broadcasts << [ creative.id, payload ] }) do
+            TopicMoveService.new.call(topic_id: @topic.id, creative_id: @target.id)
+          end
+        end
+
+        assert_equal final_target.id, @topic.reload.creative_id
+        assert_equal @target.id, result[:creative_id]
+        assert_equal @source.id, result[:moved_from_creative_id]
+        assert_equal [ @source.id ], broadcasts.map(&:first)
+        assert_equal "deleted", broadcasts.first.last[:action]
+      end
+
       test "a linked destination resolves to its origin" do
         link = Creative.create!(description: "Target link", user: @owner, origin: @target)
 

--- a/engines/collavre/test/services/collavre/tools/topic_move_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/topic_move_service_test.rb
@@ -230,6 +230,25 @@ module Collavre
         assert_equal @source.id, @topic.reload.creative_id
       end
 
+      test "rejects a topic targeted by a recurring cron job" do
+        task = SolidQueue::RecurringTask.create!(
+          key: "cron_#{@source.id}_#{SecureRandom.hex(4)}",
+          class_name: "Collavre::CronActionJob", schedule: "0 9 * * *",
+          queue_name: "default", static: false,
+          arguments: [ { creative_id: @source.id, topic_id: @topic.id,
+                         agent_id: @owner.id, message: "Daily" } ]
+        )
+
+        error = assert_raises(Topics::TopicMove::RecurringTaskError) do
+          TopicMoveService.new.call(topic_id: @topic.id, creative_id: @target.id)
+        end
+
+        assert_equal I18n.t("collavre.topics.move.recurring_tasks"), error.message
+        assert_equal @source.id, @topic.reload.creative_id
+      ensure
+        task&.destroy
+      end
+
       test "rejects a stale move when the topic changes creatives before its lock" do
         intervening = Creative.create!(description: "Intervening", user: @owner)
         stale_move = Topics::TopicMove.new(topic: @topic, target_creative: @target)

--- a/engines/collavre/test/services/collavre/tools/topic_move_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/topic_move_service_test.rb
@@ -56,6 +56,27 @@ module Collavre
         assert_equal @topic.id, broadcasts.second.last.dig(:topic, :id)
       end
 
+      test "broadcasts topic state reloaded under the post-commit lock" do
+        original_find = Topic.method(:find)
+        find_calls = 0
+        broadcasts = []
+        find_topic = lambda do |id|
+          find_calls += 1
+          record = original_find.call(id)
+          record.update_column(:name, "Renamed after move") if find_calls == 2
+          original_find.call(id)
+        end
+
+        Topic.stub(:find, find_topic) do
+          TopicsChannel.stub(:broadcast_to, ->(creative, payload) { broadcasts << [ creative.id, payload ] }) do
+            TopicMoveService.new.call(topic_id: @topic.id, creative_id: @target.id)
+          end
+        end
+
+        created = broadcasts.find { |_creative_id, payload| payload[:action] == "created" }
+        assert_equal "Renamed after move", created.last.dig(:topic, :name)
+      end
+
       test "does not broadcast an obsolete destination after a consecutive move" do
         final_target = Creative.create!(description: "Final target", user: @owner)
         original_find = Topic.method(:find)

--- a/engines/collavre/test/services/collavre/topics/topic_destroy_test.rb
+++ b/engines/collavre/test/services/collavre/topics/topic_destroy_test.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  module Topics
+    class TopicDestroyTest < ActiveSupport::TestCase
+      test "rejects deletion when the topic moved before its lock" do
+        user = users(:one)
+        source = Creative.create!(description: "Source", user: user)
+        destination = Creative.create!(description: "Destination", user: user)
+        topic = source.topics.create!(name: "Moving", user: user)
+        destroy = TopicDestroy.new(topic: topic, source_creative: source)
+
+        TopicMove.new(topic: topic, target_creative: destination).call
+
+        error = assert_raises(TopicMove::SourceChangedError) { destroy.call }
+
+        assert_equal I18n.t("collavre.topics.move.source_changed"), error.message
+        assert_equal destination.id, topic.reload.creative_id
+      end
+
+      test "locks the topic before destroying it" do
+        user = users(:one)
+        source = Creative.create!(description: "Source", user: user)
+        topic = source.topics.create!(name: "Delete", user: user)
+        calls = []
+        lock_topic = -> { calls << :topic_lock }
+        destroy_topic = -> { calls << :destroy; true }
+
+        topic.stub(:lock!, lock_topic) do
+          topic.stub(:destroy!, destroy_topic) do
+            TopicDestroy.new(topic: topic, source_creative: source).call
+          end
+        end
+
+        assert_equal %i[topic_lock destroy], calls
+      end
+    end
+  end
+end

--- a/engines/collavre/test/services/collavre/topics/topic_move_test.rb
+++ b/engines/collavre/test/services/collavre/topics/topic_move_test.rb
@@ -5,7 +5,7 @@ require "test_helper"
 module Collavre
   module Topics
     class TopicMoveTest < ActiveSupport::TestCase
-      test "locks the topic before relocating its comments" do
+      test "locks the topic and creatives before relocating its comments" do
         user = users(:one)
         source = Creative.create!(description: "Source", user: user)
         destination = Creative.create!(description: "Destination", user: user)
@@ -16,21 +16,25 @@ module Collavre
         calls = []
         comments = topic.comments
         original_update = comments.method(:update_all)
+        move = TopicMove.new(topic: topic, target_creative: destination)
         lock_topic = -> { calls << :topic_lock }
+        lock_creatives = -> { calls << :creative_locks }
         move_comments = lambda do |*arguments|
           calls << :comments_update
           original_update.call(*arguments)
         end
 
-        topic.stub(:lock!, lock_topic) do
-          topic.stub(:comments, comments) do
-            comments.stub(:update_all, move_comments) do
-              TopicMove.new(topic: topic, target_creative: destination).call
+        move.stub(:lock_creative_memberships!, lock_creatives) do
+          topic.stub(:lock!, lock_topic) do
+            topic.stub(:comments, comments) do
+              comments.stub(:update_all, move_comments) do
+                move.call
+              end
             end
           end
         end
 
-        assert_equal %i[topic_lock comments_update], calls
+        assert_equal %i[topic_lock creative_locks comments_update], calls
       end
 
       test "rejects a move when the source changes before the lock is acquired" do

--- a/engines/collavre/test/services/collavre/topics/topic_move_test.rb
+++ b/engines/collavre/test/services/collavre/topics/topic_move_test.rb
@@ -130,6 +130,23 @@ module Collavre
         assert_equal [ nil ], effect_topics
       end
 
+      test "does not delete the source sidebar topic after a reverse move" do
+        user = users(:one)
+        source = Creative.create!(description: "Source", user: user)
+        destination = Creative.create!(description: "Destination", user: user)
+        topic = source.topics.create!(name: "Moving", user: user)
+        effects = TopicMoveEffects.new(topic, source, destination)
+        broadcasts = []
+
+        TopicMove.new(topic: topic, target_creative: destination).call
+        TopicMove.new(topic: topic.reload, target_creative: source).call
+        TopicsChannel.stub(:broadcast_to, ->(creative, payload) { broadcasts << [ creative.id, payload ] }) do
+          effects.call(topic.reload)
+        end
+
+        assert_empty broadcasts
+      end
+
       test "moves comment snapshots with the topic" do
         user = users(:one)
         source = Creative.create!(description: "Source", user: user)

--- a/engines/collavre/test/services/collavre/topics/topic_move_test.rb
+++ b/engines/collavre/test/services/collavre/topics/topic_move_test.rb
@@ -74,6 +74,42 @@ module Collavre
         assert_equal source.id, comment.reload.creative_id
       end
 
+      test "defers move effects until an enclosing transaction commits" do
+        user = users(:one)
+        source = Creative.create!(description: "Source", user: user)
+        destination = Creative.create!(description: "Destination", user: user)
+        topic = source.topics.create!(name: "Moving", user: user)
+        effects = []
+
+        ApplicationRecord.transaction do
+          TopicMove.new(topic: topic, target_creative: destination).call(
+            after_commit: ->(current_topic) { effects << current_topic.creative_id }
+          )
+
+          assert_empty effects
+        end
+
+        assert_equal [ destination.id ], effects
+      end
+
+      test "discards move effects when an enclosing transaction rolls back" do
+        user = users(:one)
+        source = Creative.create!(description: "Source", user: user)
+        destination = Creative.create!(description: "Destination", user: user)
+        topic = source.topics.create!(name: "Moving", user: user)
+        effects = []
+
+        ApplicationRecord.transaction do
+          TopicMove.new(topic: topic, target_creative: destination).call(
+            after_commit: ->(current_topic) { effects << current_topic.creative_id }
+          )
+          raise ActiveRecord::Rollback
+        end
+
+        assert_empty effects
+        assert_equal source.id, topic.reload.creative_id
+      end
+
       test "moves comment snapshots with the topic" do
         user = users(:one)
         source = Creative.create!(description: "Source", user: user)

--- a/engines/collavre/test/services/collavre/topics/topic_move_test.rb
+++ b/engines/collavre/test/services/collavre/topics/topic_move_test.rb
@@ -297,6 +297,34 @@ module Collavre
         assert_equal destination.id, topic.reload.creative_id
       end
 
+      test "allows a terminal task whose dropped comments are no longer restorable" do
+        user = users(:one)
+        source = Creative.create!(description: "Source", user: user)
+        destination = Creative.create!(description: "Destination", user: user)
+        topic = source.topics.create!(name: "Moving", user: user)
+        create_comment = lambda do |**attributes|
+          Comment.create!(creative: source, topic: topic, content: "Dropped",
+                          skip_default_user: true, skip_dispatch: true, **attributes)
+        end
+        deleted = create_comment.call(user: users(:two)).tap(&:destroy!)
+        private_comment = create_comment.call(user: users(:two), private: true)
+        approval = create_comment.call(user: users(:two), action: "approve")
+        agent_comment = create_comment.call(user: user)
+        system_comment = create_comment.call(user: nil)
+        dropped_ids = [ deleted, private_comment, approval, agent_comment, system_comment ].map(&:id)
+        Task.create!(
+          name: "Cancelled turn", agent: user, creative: source, topic_id: topic.id, status: "cancelled",
+          trigger_event_payload: {
+            "topic" => { "id" => topic.id }, "creative" => { "id" => source.id },
+            Orchestration::DeliveryRecord::DROPPED_KEY => dropped_ids
+          }
+        )
+
+        TopicMove.new(topic: topic, target_creative: destination).call
+
+        assert_equal destination.id, topic.reload.creative_id
+      end
+
       test "rejects a topic targeted by a recurring cron job" do
         user = users(:one)
         source = Creative.create!(description: "Source", user: user)

--- a/engines/collavre/test/services/collavre/topics/topic_move_test.rb
+++ b/engines/collavre/test/services/collavre/topics/topic_move_test.rb
@@ -110,6 +110,26 @@ module Collavre
         assert_equal source.id, topic.reload.creative_id
       end
 
+      test "runs source cleanup when the moved topic is deleted before post-commit effects" do
+        user = users(:one)
+        source = Creative.create!(description: "Source", user: user)
+        destination = Creative.create!(description: "Destination", user: user)
+        topic = source.topics.create!(name: "Moving", user: user)
+        effect_topics = []
+        run_after_commit = lambda do |&callback|
+          topic.destroy!
+          callback.call
+        end
+
+        ActiveRecord.stub(:after_all_transactions_commit, run_after_commit) do
+          TopicMove.new(topic: topic, target_creative: destination).call(
+            after_commit: ->(current_topic) { effect_topics << current_topic }
+          )
+        end
+
+        assert_equal [ nil ], effect_topics
+      end
+
       test "moves comment snapshots with the topic" do
         user = users(:one)
         source = Creative.create!(description: "Source", user: user)
@@ -225,6 +245,52 @@ module Collavre
         %w[done failed cancelled escalated].each do |status|
           Task.create!(name: status, agent: user, creative: source, topic_id: topic.id, status: status)
         end
+
+        TopicMove.new(topic: topic, target_creative: destination).call
+
+        assert_equal destination.id, topic.reload.creative_id
+      end
+
+      test "rejects a terminal task that still owes a dropped dispatch" do
+        user = users(:one)
+        source = Creative.create!(description: "Source", user: user)
+        destination = Creative.create!(description: "Destination", user: user)
+        topic = source.topics.create!(name: "Moving", user: user)
+        dropped = Comment.create!(creative: source, topic: topic, user: users(:two), content: "Dropped",
+                                  skip_default_user: true, skip_dispatch: true)
+        Task.create!(
+          name: "Cancelled turn", agent: user, creative: source, topic_id: topic.id, status: "cancelled",
+          trigger_event_payload: {
+            "topic" => { "id" => topic.id }, "creative" => { "id" => source.id },
+            Orchestration::DeliveryRecord::DROPPED_KEY => [ dropped.id ],
+            Orchestration::DeliveryRecord::RESTORED_KEY => [ dropped.id ]
+          }
+        )
+
+        error = assert_raises(TopicMove::PendingDeliveryError) do
+          TopicMove.new(topic: topic, target_creative: destination).call
+        end
+
+        assert_equal I18n.t("collavre.topics.move.pending_deliveries"), error.message
+        assert_equal source.id, topic.reload.creative_id
+      end
+
+      test "allows a terminal task whose dropped dispatch reached the provider" do
+        user = users(:one)
+        source = Creative.create!(description: "Source", user: user)
+        destination = Creative.create!(description: "Destination", user: user)
+        topic = source.topics.create!(name: "Moving", user: user)
+        dropped = Comment.create!(creative: source, topic: topic, user: users(:two), content: "Delivered",
+                                  skip_default_user: true, skip_dispatch: true)
+        Task.create!(
+          name: "Completed turn", agent: user, creative: source, topic_id: topic.id, status: "done",
+          trigger_event_payload: {
+            "topic" => { "id" => topic.id }, "creative" => { "id" => source.id },
+            Orchestration::DeliveryRecord::DROPPED_KEY => [ dropped.id ],
+            Orchestration::DeliveryRecord::HANDED_OFF_KEY => true,
+            Orchestration::DeliveryRecord::HANDED_OFF_IDS_KEY => [ dropped.id ]
+          }
+        )
 
         TopicMove.new(topic: topic, target_creative: destination).call
 

--- a/engines/collavre/test/services/collavre/topics/topic_move_test.rb
+++ b/engines/collavre/test/services/collavre/topics/topic_move_test.rb
@@ -53,6 +53,26 @@ module Collavre
         assert_equal intervening.id, topic.reload.creative_id
         assert_equal intervening.id, comment.reload.creative_id
       end
+
+      test "runs validation after locking and before relocating comments" do
+        user = users(:one)
+        source = Creative.create!(description: "Source", user: user)
+        destination = Creative.create!(description: "Destination", user: user)
+        topic = source.topics.create!(name: "Moving", user: user)
+        comment = Comment.create!(creative: source, topic: topic, user: user, content: "message",
+                                  skip_default_user: true, skip_dispatch: true)
+
+        error = assert_raises(ArgumentError) do
+          TopicMove.new(topic: topic, target_creative: destination).call do |locked_topic|
+            assert_equal topic, locked_topic
+            raise ArgumentError, "rejected"
+          end
+        end
+
+        assert_equal "rejected", error.message
+        assert_equal source.id, topic.reload.creative_id
+        assert_equal source.id, comment.reload.creative_id
+      end
     end
   end
 end

--- a/engines/collavre/test/services/collavre/topics/topic_move_test.rb
+++ b/engines/collavre/test/services/collavre/topics/topic_move_test.rb
@@ -151,6 +151,21 @@ module Collavre
         assert_empty broadcasts
       end
 
+      test "resets source and destination counters in creative id order" do
+        user = users(:one)
+        destination = Creative.create!(description: "Destination", user: user)
+        source = Creative.create!(description: "Source", user: user)
+        topic = source.topics.create!(name: "Moving", user: user)
+        reset_ids = []
+
+        Creative.stub(:reset_counters, ->(creative_id, *) { reset_ids << creative_id }) do
+          TopicMoveEffects.new(topic, source, destination).call(nil)
+        end
+
+        assert_operator source.id, :>, destination.id
+        assert_equal [ destination.id, source.id ], reset_ids
+      end
+
       test "moves comment snapshots with the topic" do
         user = users(:one)
         source = Creative.create!(description: "Source", user: user)

--- a/engines/collavre/test/services/collavre/topics/topic_move_test.rb
+++ b/engines/collavre/test/services/collavre/topics/topic_move_test.rb
@@ -95,6 +95,27 @@ module Collavre
         assert_equal topic.id, restored.first.topic_id
       end
 
+      test "snapshot restoration locks the topic before the snapshot" do
+        user = users(:one)
+        source = Creative.create!(description: "Source", user: user)
+        topic = source.topics.create!(name: "Restore", user: user)
+        snapshot = CommentSnapshot.create!(
+          creative: source, topic: topic, user: user, operation: "compress",
+          comments_data: [ { "id" => 1, "user_id" => user.id, "topic_id" => topic.id, "content" => "original" } ]
+        )
+        calls = []
+        topic_scope = Topic.lock
+        snapshot_scope = CommentSnapshot.lock
+
+        Topic.stub(:lock, -> { calls << :topic; topic_scope }) do
+          CommentSnapshot.stub(:lock, -> { calls << :snapshot; snapshot_scope }) do
+            CommentSnapshotRestoreService.new(snapshot: snapshot, user: user).call
+          end
+        end
+
+        assert_equal %i[topic snapshot], calls.first(2)
+      end
+
       test "rejects every active task status before relocating topic data" do
         user = users(:one)
         source = Creative.create!(description: "Source", user: user)
@@ -159,8 +180,60 @@ module Collavre
         task&.destroy
       end
 
+      test "rejects a topic referenced by a trigger loop in every resumable state" do
+        user = users(:one)
+        source = Creative.create!(description: "Source", user: user)
+        destination = Creative.create!(description: "Destination", user: user)
+
+        %w[idle running pending_verification paused awaiting_user stuck completed max_reached].each do |state|
+          topic = source.topics.create!(name: "Trigger #{state}", user: user)
+          source.update!(data: {
+            "trigger" => { "loop" => { "state" => state, "trigger_topic_id" => topic.id } }
+          })
+
+          error = assert_raises(TopicMove::TriggerLoopError) do
+            TopicMove.new(topic: topic, target_creative: destination).call
+          end
+
+          assert_equal I18n.t("collavre.topics.move.trigger_loop"), error.message
+          assert_equal source.id, topic.reload.creative_id
+        end
+      end
+
+      test "allows a topic not referenced by the creative trigger loop to move" do
+        user = users(:one)
+        source = Creative.create!(description: "Source", user: user)
+        destination = Creative.create!(description: "Destination", user: user)
+        trigger_topic = source.topics.create!(name: "Trigger", user: user)
+        moving_topic = source.topics.create!(name: "Moving", user: user)
+        source.update!(data: {
+          "trigger" => { "loop" => { "state" => "running", "trigger_topic_id" => trigger_topic.id } }
+        })
+
+        TopicMove.new(topic: moving_topic, target_creative: destination).call
+
+        assert_equal destination.id, moving_topic.reload.creative_id
+      end
+
+      test "reads trigger loop configuration after acquiring the topic lock" do
+        user = users(:one)
+        source = Creative.create!(description: "Source", user: user)
+        destination = Creative.create!(description: "Destination", user: user)
+        topic = source.topics.create!(name: "Trigger", user: user)
+        topic.creative
+        Creative.find(source.id).update!(data: {
+          "trigger" => { "loop" => { "state" => "running", "trigger_topic_id" => topic.id } }
+        })
+
+        assert_raises(TopicMove::TriggerLoopError) do
+          TopicMove.new(topic: topic, target_creative: destination).call
+        end
+
+        assert_equal source.id, topic.reload.creative_id
+      end
+
       test "active task error is translated in English and Korean" do
-        %w[active_tasks recurring_tasks].each do |key|
+        %w[active_tasks recurring_tasks trigger_loop].each do |key|
           assert I18n.exists?("collavre.topics.move.#{key}", :en)
           assert I18n.exists?("collavre.topics.move.#{key}", :ko)
         end

--- a/engines/collavre/test/services/collavre/topics/topic_move_test.rb
+++ b/engines/collavre/test/services/collavre/topics/topic_move_test.rb
@@ -73,6 +73,73 @@ module Collavre
         assert_equal source.id, topic.reload.creative_id
         assert_equal source.id, comment.reload.creative_id
       end
+
+      test "moves comment snapshots with the topic" do
+        user = users(:one)
+        source = Creative.create!(description: "Source", user: user)
+        destination = Creative.create!(description: "Destination", user: user)
+        topic = source.topics.create!(name: "Moving", user: user)
+        snapshot = CommentSnapshot.create!(
+          creative: source, topic: topic, user: user, operation: "compress",
+          comments_data: [
+            { "id" => 1, "user_id" => user.id, "topic_id" => topic.id, "content" => "original" }
+          ]
+        )
+
+        TopicMove.new(topic: topic, target_creative: destination).call
+        restored = CommentSnapshotRestoreService.new(snapshot: snapshot, user: user).call
+
+        assert_equal destination.id, snapshot.reload.creative_id
+        assert_equal topic.id, snapshot.topic_id
+        assert_equal destination.id, restored.first.creative_id
+        assert_equal topic.id, restored.first.topic_id
+      end
+
+      test "rejects every active task status before relocating topic data" do
+        user = users(:one)
+        source = Creative.create!(description: "Source", user: user)
+        destination = Creative.create!(description: "Destination", user: user)
+
+        Task::ACTIVE_STATUSES.each do |status|
+          topic = source.topics.create!(name: "Moving #{status}", user: user)
+          comment = Comment.create!(creative: source, topic: topic, user: user, content: "message",
+                                    skip_default_user: true, skip_dispatch: true)
+          snapshot = CommentSnapshot.create!(
+            creative: source, topic: topic, user: user, operation: "compress",
+            comments_data: [ { "id" => comment.id, "topic_id" => topic.id, "content" => "message" } ]
+          )
+          Task.create!(name: status, agent: user, creative: source, topic_id: topic.id, status: status)
+
+          error = assert_raises(TopicMove::ActiveTaskError) do
+            TopicMove.new(topic: topic, target_creative: destination).call
+          end
+
+          assert_equal I18n.t("collavre.topics.move.active_tasks"), error.message
+          assert_equal source.id, topic.reload.creative_id
+          assert_equal source.id, comment.reload.creative_id
+          assert_equal source.id, snapshot.reload.creative_id
+        end
+      end
+
+      test "allows a topic with only terminal tasks to move" do
+        user = users(:one)
+        source = Creative.create!(description: "Source", user: user)
+        destination = Creative.create!(description: "Destination", user: user)
+        topic = source.topics.create!(name: "Moving", user: user)
+
+        %w[done failed cancelled escalated].each do |status|
+          Task.create!(name: status, agent: user, creative: source, topic_id: topic.id, status: status)
+        end
+
+        TopicMove.new(topic: topic, target_creative: destination).call
+
+        assert_equal destination.id, topic.reload.creative_id
+      end
+
+      test "active task error is translated in English and Korean" do
+        assert I18n.exists?("collavre.topics.move.active_tasks", :en)
+        assert I18n.exists?("collavre.topics.move.active_tasks", :ko)
+      end
     end
   end
 end

--- a/engines/collavre/test/services/collavre/topics/topic_move_test.rb
+++ b/engines/collavre/test/services/collavre/topics/topic_move_test.rb
@@ -136,9 +136,34 @@ module Collavre
         assert_equal destination.id, topic.reload.creative_id
       end
 
+      test "rejects a topic targeted by a recurring cron job" do
+        user = users(:one)
+        source = Creative.create!(description: "Source", user: user)
+        destination = Creative.create!(description: "Destination", user: user)
+        topic = source.topics.create!(name: "Recurring", user: user)
+        task = SolidQueue::RecurringTask.create!(
+          key: "cron_#{source.id}_#{SecureRandom.hex(4)}",
+          class_name: "Collavre::CronActionJob", schedule: "0 9 * * *",
+          queue_name: "default", static: false,
+          arguments: [ { creative_id: source.id, topic_id: topic.id,
+                         agent_id: user.id, message: "Daily" } ]
+        )
+
+        error = assert_raises(TopicMove::RecurringTaskError) do
+          TopicMove.new(topic: topic, target_creative: destination).call
+        end
+
+        assert_equal I18n.t("collavre.topics.move.recurring_tasks"), error.message
+        assert_equal source.id, topic.reload.creative_id
+      ensure
+        task&.destroy
+      end
+
       test "active task error is translated in English and Korean" do
-        assert I18n.exists?("collavre.topics.move.active_tasks", :en)
-        assert I18n.exists?("collavre.topics.move.active_tasks", :ko)
+        %w[active_tasks recurring_tasks].each do |key|
+          assert I18n.exists?("collavre.topics.move.#{key}", :en)
+          assert I18n.exists?("collavre.topics.move.#{key}", :ko)
+        end
       end
     end
   end

--- a/engines/collavre/test/services/collavre/topics/topic_move_test.rb
+++ b/engines/collavre/test/services/collavre/topics/topic_move_test.rb
@@ -131,6 +131,44 @@ module Collavre
         assert_equal topic.id, restored.first.topic_id
       end
 
+      test "clears source last-topic preferences and advances their revisions" do
+        user = users(:one)
+        other_user = users(:two)
+        source = Creative.create!(description: "Source", user: user)
+        destination = Creative.create!(description: "Destination", user: user)
+        topic = source.topics.create!(name: "Moving", user: user)
+        preference = UserCreativePreference.create!(
+          creative: source, user: other_user, expanded_status: {},
+          last_topic: topic, last_topic_revision: 4
+        )
+
+        TopicMove.new(topic: topic, target_creative: destination).call
+
+        preference.reload
+        assert_nil preference.last_topic_id
+        assert_equal 5, preference.last_topic_revision
+      end
+
+      test "restores source last-topic preferences when the move rolls back" do
+        user = users(:one)
+        source = Creative.create!(description: "Source", user: user)
+        destination = Creative.create!(description: "Destination", user: user)
+        topic = source.topics.create!(name: "Moving", user: user)
+        preference = UserCreativePreference.create!(
+          creative: source, user: users(:two), expanded_status: {},
+          last_topic: topic, last_topic_revision: 4
+        )
+
+        ApplicationRecord.transaction do
+          TopicMove.new(topic: topic, target_creative: destination).call
+          raise ActiveRecord::Rollback
+        end
+
+        preference.reload
+        assert_equal topic.id, preference.last_topic_id
+        assert_equal 4, preference.last_topic_revision
+      end
+
       test "snapshot restoration locks the topic before the snapshot" do
         user = users(:one)
         source = Creative.create!(description: "Source", user: user)

--- a/engines/collavre/test/services/comment_move_service_test.rb
+++ b/engines/collavre/test/services/comment_move_service_test.rb
@@ -110,5 +110,29 @@ module Collavre
       assert_equal moved.id - 1, pointer.last_read_comment_id
       assert_operator Collavre::Creatives::CommentBadgeIndex.new(user: @user).unread_counts_by_topic(destination_creative)[destination_creative.main_topic.id], :>=, 1
     end
+
+    test "rejects a stale existing-comment move after its source topic relocates" do
+      destination_creative = Creative.create!(user: @user, description: "Destination")
+      source_topic = @creative.topics.create!(name: "Source", user: @user)
+      target_topic = @creative.topics.create!(name: "Target", user: @user)
+      comment = Comment.create!(creative: @creative, topic: source_topic, user: @user, content: "move me")
+      service = CommentMoveService.new(creative: @creative, user: @user)
+
+      fetch_after_relocation = lambda do |_ids|
+        Topics::TopicMove.new(topic: source_topic, target_creative: destination_creative).call
+        [ comment ]
+      end
+
+      service.stub(:fetch_visible_comments, fetch_after_relocation) do
+        assert_raises(CommentMoveService::MoveError) do
+          service.call(comment_ids: [ comment.id ], target_topic_id: target_topic.id)
+        end
+      end
+
+      assert_equal destination_creative.id, comment.reload.creative_id
+      assert_equal source_topic.id, comment.topic_id
+      assert_equal destination_creative.id, source_topic.reload.creative_id
+      assert_equal @creative.id, target_topic.reload.creative_id
+    end
   end
 end

--- a/engines/collavre/test/services/comment_move_service_test.rb
+++ b/engines/collavre/test/services/comment_move_service_test.rb
@@ -58,6 +58,29 @@ module Collavre
       assert_equal destination.id, comment.topic_id
     end
 
+    test "locks topics before the source Creative for a mixed legacy move" do
+      source = @creative.topics.create!(name: "Source", user: @user)
+      destination = @creative.topics.create!(name: "Destination", user: @user)
+      named = Comment.create!(creative: @creative, topic: source, user: @user, content: "named")
+      legacy = Comment.create!(creative: @creative, user: @user, content: "legacy")
+      legacy.update_column(:topic_id, nil)
+      service = CommentMoveService.new(creative: @creative, user: @user)
+      original_topic_lock = service.method(:lock_move_topics)
+      original_creative_lock = service.method(:lock_legacy_source_creative)
+      calls = []
+
+      service.stub(:lock_move_topics, ->(*args) { calls << :topics; original_topic_lock.call(*args) }) do
+        service.stub(:lock_legacy_source_creative, lambda { |*args|
+          calls << :creative
+          original_creative_lock.call(*args)
+        }) do
+          service.call(comment_ids: [ named.id, legacy.id ], target_topic_id: destination.id)
+        end
+      end
+
+      assert_equal %i[topics creative], calls.first(2)
+    end
+
     test "moving an unread comment does not let the destination pointer hide it" do
       source = @creative.topics.create!(name: "Source", user: @user)
       destination = @creative.topics.create!(name: "Destination", user: @user)

--- a/engines/collavre/test/services/comment_move_service_test.rb
+++ b/engines/collavre/test/services/comment_move_service_test.rb
@@ -44,6 +44,20 @@ module Collavre
       assert_equal @creative.main_topic.id, comment.reload.topic_id
     end
 
+    test "moves a retained legacy comment without a source topic" do
+      destination = @creative.topics.create!(name: "Destination", user: @user)
+      comment = Comment.create!(creative: @creative, user: @user, content: "legacy message")
+      comment.update_column(:topic_id, nil)
+
+      result = CommentMoveService.new(creative: @creative, user: @user).call(
+        comment_ids: [ comment.id ], target_topic_id: destination.id
+      )
+
+      assert_equal 1, result[:moved_count]
+      assert_equal @creative.id, comment.reload.creative_id
+      assert_equal destination.id, comment.topic_id
+    end
+
     test "moving an unread comment does not let the destination pointer hide it" do
       source = @creative.topics.create!(name: "Source", user: @user)
       destination = @creative.topics.create!(name: "Destination", user: @user)

--- a/engines/collavre/test/services/comments/read_pointer_writer_test.rb
+++ b/engines/collavre/test/services/comments/read_pointer_writer_test.rb
@@ -95,6 +95,18 @@ module Collavre
         assert_empty writer.call({})
       end
 
+      test "rejects a named pointer after its topic moves to another creative" do
+        destination = Creative.create!(description: "Destination", user: @user)
+        stale_writer = writer
+        Topics::TopicMove.new(topic: @topic, target_creative: destination).call
+
+        assert_raises(ReadPointerWriter::StaleTopicError) do
+          stale_writer.call(@topic.id => @comments.last.id)
+        end
+
+        assert_nil CommentReadPointer.find_by(user: @user, creative: @creative, topic: @topic)
+      end
+
       private
 
       # Only the read that precedes the write is stale; the writer's read-back

--- a/engines/collavre/test/services/comments/read_pointer_writer_test.rb
+++ b/engines/collavre/test/services/comments/read_pointer_writer_test.rb
@@ -107,6 +107,24 @@ module Collavre
         assert_nil CommentReadPointer.find_by(user: @user, creative: @creative, topic: @topic)
       end
 
+      test "locks archived topics before preserving their legacy fallback" do
+        archived = @creative.topics.create!(name: "Archived fallback", user: @user, archived_at: Time.current)
+        original_where = Topic.method(:where)
+        locked_ids = []
+        where_spy = lambda do |*args|
+          criteria = args.first
+          locked_ids.concat(Array(criteria[:id])) if criteria.is_a?(Hash) && criteria.key?(:id)
+          original_where.call(*args)
+        end
+
+        Topic.stub(:where, where_spy) do
+          writer.call(nil => @comments.last.id)
+        end
+
+        assert_includes locked_ids, archived.id
+        assert CommentReadPointer.exists?(user: @user, creative: @creative, topic: archived)
+      end
+
       private
 
       # Only the read that precedes the write is stale; the writer's read-back

--- a/engines/collavre/test/services/comments/read_pointer_writer_test.rb
+++ b/engines/collavre/test/services/comments/read_pointer_writer_test.rb
@@ -107,22 +107,43 @@ module Collavre
         assert_nil CommentReadPointer.find_by(user: @user, creative: @creative, topic: @topic)
       end
 
-      test "locks archived topics before preserving their legacy fallback" do
+      test "locks the creative before snapshotting archived topic fallbacks" do
         archived = @creative.topics.create!(name: "Archived fallback", user: @user, archived_at: Time.current)
-        original_where = Topic.method(:where)
-        locked_ids = []
-        where_spy = lambda do |*args|
-          criteria = args.first
-          locked_ids.concat(Array(criteria[:id])) if criteria.is_a?(Hash) && criteria.key?(:id)
-          original_where.call(*args)
+        topics = @creative.topics
+        original_ids = topics.method(:ids)
+        creative_locked = false
+        ids_after_lock = lambda do
+          assert creative_locked
+          original_ids.call
         end
 
-        Topic.stub(:where, where_spy) do
-          writer.call(nil => @comments.last.id)
+        @creative.stub(:lock!, -> { creative_locked = true; @creative }) do
+          @creative.stub(:topics, topics) do
+            topics.stub(:ids, ids_after_lock) do
+              writer.call(nil => @comments.last.id)
+            end
+          end
         end
 
-        assert_includes locked_ids, archived.id
         assert CommentReadPointer.exists?(user: @user, creative: @creative, topic: archived)
+      end
+
+      test "snapshots an incoming topic after locking the destination creative" do
+        source = Creative.create!(description: "Incoming source", user: @user)
+        incoming = source.topics.create!(name: "Incoming", user: @user)
+        Comment.create!(creative: source, topic: incoming, user: users(:two), content: "unread incoming")
+        legacy = Comment.create!(creative: @creative, user: users(:two), content: "destination legacy")
+        move_before_lock = lambda do
+          Topics::TopicMove.new(topic: incoming, target_creative: @creative).call
+          @creative
+        end
+
+        @creative.stub(:lock!, move_before_lock) do
+          writer.call(nil => legacy.id)
+        end
+
+        pointer = CommentReadPointer.find_by!(user: @user, creative: @creative, topic: incoming)
+        assert_nil pointer.last_read_comment_id
       end
 
       private

--- a/skills/collavre/SKILL.md
+++ b/skills/collavre/SKILL.md
@@ -116,6 +116,9 @@ collavre tool run topic_message_create --json '{"topic_id": 13, "content": "Buil
 # Put a finished thread away (messages are kept and stay readable by id)
 collavre tool run topic_update --json '{"topic_id": 12, "archived": true}'
 
+# Move a complete thread, including its messages and read cursors
+collavre tool run topic_move --json '{"topic_id": 13, "creative_id": 9023}'
+
 # Carry the messages that still matter into a fresh topic
 collavre tool run topic_branch --json '{"source_topic_id": 12, "comment_ids": "991,994"}'
 ```
@@ -148,6 +151,9 @@ collavre tool run <tool_name> --key value         # run with flag args
   dispatch as A2A work, so one coordinating agent can start independent work in
   several topics without impersonating a human. Do not call it on the topic the
   caller is currently handling; continue that work in the current turn instead.
+- **Moving topics**: `topic_move` keeps the thread and its messages together,
+  but Creative permissions stay with each Creative. Verify that participants
+  can access the destination after moving.
 - **Progress**: Leaf = manual (0.0 or 1.0). Parent = auto-calculated from children.
 - **Import**: Markdown headings/bullets become nested Creatives.
 - **Batch**: All-or-nothing transaction. Requires approval.

--- a/skills/collavre/SKILL.md
+++ b/skills/collavre/SKILL.md
@@ -154,7 +154,8 @@ collavre tool run <tool_name> --key value         # run with flag args
 - **Moving topics**: `topic_move` keeps the thread and its messages together,
   but Creative permissions stay with each Creative. Verify that participants
   can access the destination after moving. Wait for or cancel active agent work
-  in the topic before moving it.
+  in the topic before moving it. Cancel recurring cron jobs that target the
+  topic and recreate them after the move.
 - **Progress**: Leaf = manual (0.0 or 1.0). Parent = auto-calculated from children.
 - **Import**: Markdown headings/bullets become nested Creatives.
 - **Batch**: All-or-nothing transaction. Requires approval.

--- a/skills/collavre/SKILL.md
+++ b/skills/collavre/SKILL.md
@@ -154,9 +154,9 @@ collavre tool run <tool_name> --key value         # run with flag args
 - **Moving topics**: `topic_move` keeps the thread and its messages together,
   but Creative permissions stay with each Creative. Verify that participants
   can access the destination after moving. Wait for or cancel active agent work
-  in the topic before moving it. Cancel recurring cron jobs that target the
-  topic and recreate them after the move. Topics referenced by a Drop Trigger
-  loop cannot move.
+  in the topic before moving it, and wait for dropped-message restoration to
+  settle. Cancel recurring cron jobs that target the topic and recreate them
+  after the move. Topics referenced by a Drop Trigger loop cannot move.
 - **Progress**: Leaf = manual (0.0 or 1.0). Parent = auto-calculated from children.
 - **Import**: Markdown headings/bullets become nested Creatives.
 - **Batch**: All-or-nothing transaction. Requires approval.

--- a/skills/collavre/SKILL.md
+++ b/skills/collavre/SKILL.md
@@ -155,7 +155,8 @@ collavre tool run <tool_name> --key value         # run with flag args
   but Creative permissions stay with each Creative. Verify that participants
   can access the destination after moving. Wait for or cancel active agent work
   in the topic before moving it. Cancel recurring cron jobs that target the
-  topic and recreate them after the move.
+  topic and recreate them after the move. Topics referenced by a Drop Trigger
+  loop cannot move.
 - **Progress**: Leaf = manual (0.0 or 1.0). Parent = auto-calculated from children.
 - **Import**: Markdown headings/bullets become nested Creatives.
 - **Batch**: All-or-nothing transaction. Requires approval.

--- a/skills/collavre/SKILL.md
+++ b/skills/collavre/SKILL.md
@@ -153,7 +153,8 @@ collavre tool run <tool_name> --key value         # run with flag args
   caller is currently handling; continue that work in the current turn instead.
 - **Moving topics**: `topic_move` keeps the thread and its messages together,
   but Creative permissions stay with each Creative. Verify that participants
-  can access the destination after moving.
+  can access the destination after moving. Wait for or cancel active agent work
+  in the topic before moving it.
 - **Progress**: Leaf = manual (0.0 or 1.0). Parent = auto-calculated from children.
 - **Import**: Markdown headings/bullets become nested Creatives.
 - **Batch**: All-or-nothing transaction. Requires approval.

--- a/skills/collavre/references/tool-reference.md
+++ b/skills/collavre/references/tool-reference.md
@@ -283,7 +283,8 @@ The topic keeps its id, messages, archive state, and read cursors. Its primary
 agent stays pinned only when it can still respond on the destination; otherwise
 the result reports that the pin was released. Creative permissions do not move,
 so verify that participants can access the destination. Active agent work must
-finish or be cancelled before the topic can move.
+finish or be cancelled before the topic can move. Recurring cron jobs targeting
+the topic must be cancelled and recreated after the move.
 
 Requires **admin** on the source and **write** on the destination. Topic names
 must be unique on the destination. Main, an inbox's System topic, and live agent

--- a/skills/collavre/references/tool-reference.md
+++ b/skills/collavre/references/tool-reference.md
@@ -283,9 +283,10 @@ The topic keeps its id, messages, archive state, and read cursors. Its primary
 agent stays pinned only when it can still respond on the destination; otherwise
 the result reports that the pin was released. Creative permissions do not move,
 so verify that participants can access the destination. Active agent work must
-finish or be cancelled before the topic can move. Recurring cron jobs targeting
-the topic must be cancelled and recreated after the move. Topics referenced by
-a Drop Trigger loop cannot move.
+finish or be cancelled before the topic can move, and dropped-message
+restoration must settle. Recurring cron jobs targeting the topic must be
+cancelled and recreated after the move. Topics referenced by a Drop Trigger loop
+cannot move.
 
 Requires **admin** on the source and **write** on the destination. Topic names
 must be unique on the destination. Main, an inbox's System topic, and live agent

--- a/skills/collavre/references/tool-reference.md
+++ b/skills/collavre/references/tool-reference.md
@@ -284,7 +284,8 @@ agent stays pinned only when it can still respond on the destination; otherwise
 the result reports that the pin was released. Creative permissions do not move,
 so verify that participants can access the destination. Active agent work must
 finish or be cancelled before the topic can move. Recurring cron jobs targeting
-the topic must be cancelled and recreated after the move.
+the topic must be cancelled and recreated after the move. Topics referenced by
+a Drop Trigger loop cannot move.
 
 Requires **admin** on the source and **write** on the destination. Topic names
 must be unique on the destination. Main, an inbox's System topic, and live agent

--- a/skills/collavre/references/tool-reference.md
+++ b/skills/collavre/references/tool-reference.md
@@ -270,6 +270,27 @@ be changed here.
 
 **Returns:** the topic payload plus `changed[]` naming the fields that moved.
 
+### topic_move
+
+Move one complete topic to another Creative.
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `topic_id` | Integer | **Yes** | Topic to move |
+| `creative_id` | Integer | **Yes** | Destination Creative; links resolve to their origin |
+
+The topic keeps its id, messages, archive state, and read cursors. Its primary
+agent stays pinned only when it can still respond on the destination; otherwise
+the result reports that the pin was released. Creative permissions do not move,
+so verify that participants can access the destination.
+
+Requires **admin** on the source and **write** on the destination. Topic names
+must be unique on the destination. Main, an inbox's System topic, and live agent
+session topics cannot move.
+
+**Returns:** the moved topic payload, `moved_from_creative_id`, and an optional
+`released_primary_agent` explanation.
+
 ### topic_branch
 
 Create a new topic containing **copies** of selected messages. The originals stay

--- a/skills/collavre/references/tool-reference.md
+++ b/skills/collavre/references/tool-reference.md
@@ -282,7 +282,8 @@ Move one complete topic to another Creative.
 The topic keeps its id, messages, archive state, and read cursors. Its primary
 agent stays pinned only when it can still respond on the destination; otherwise
 the result reports that the pin was released. Creative permissions do not move,
-so verify that participants can access the destination.
+so verify that participants can access the destination. Active agent work must
+finish or be cancelled before the topic can move.
 
 Requires **admin** on the source and **write** on the destination. Topic names
 must be unique on the destination. Main, an inbox's System topic, and live agent


### PR DESCRIPTION
## Summary

- add a `topic_move(topic_id, creative_id)` MCP tool that reuses the existing atomic topic relocation path
- preserve messages, read cursors, counters, broadcasts, archive state, and valid primary-agent pins
- enforce source admin and destination write permissions, reserved/session topic rules, unique names, and bilingual errors
- document the tool in both provisioned Collavre skill copies

## Tests

- `./bin/rubocop -a` (1,260 files)
- `bundle exec rake test` (4,407 runs, 15,003 assertions)
- `PARALLEL_WORKERS=1 bundle exec rake test:system` (98 runs, 621 assertions, 0 failures, 2 skips)
- topic tools/controllers regression suite (386 runs, 1,402 assertions)