### PR TITLE
Fix immediate channel chip removal

### DIFF
--- a/engines/collavre/app/javascript/controllers/comments/__tests__/presence_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/presence_controller.test.js
@@ -448,6 +448,58 @@ describe('CommentsPresenceController typing-row horizontal scroll', () => {
     expect(scrollLeftValue).toBe(0)
   })
 
+  describe('detaching a channel', () => {
+    const flush = () => new Promise((resolve) => setTimeout(resolve, 0))
+
+    const appendChannelChip = () => {
+      controller.channelChipsTarget.innerHTML = `
+        <span class="channel-chip" data-channel-id="42">
+          Pull request
+          <button data-channel-id="42">Detach</button>
+        </span>
+      `
+      return controller.channelChipsTarget.querySelector('button')
+    }
+
+    test('removes the channel chip immediately after a successful request', async () => {
+      const button = appendChannelChip()
+      global.fetch.mockResolvedValueOnce({ ok: true, headers: new Headers() })
+
+      controller.detachChannel({ currentTarget: button })
+      await flush()
+
+      expect(global.fetch).toHaveBeenCalledWith('/channels/42', expect.objectContaining({
+        method: 'DELETE',
+      }))
+      expect(controller.channelChipsTarget.querySelector('.channel-chip')).toBeNull()
+    })
+
+    test('keeps the channel chip when the request fails', async () => {
+      const button = appendChannelChip()
+      global.fetch.mockResolvedValueOnce({ ok: false, headers: new Headers() })
+
+      controller.detachChannel({ currentTarget: button })
+      await flush()
+
+      expect(controller.channelChipsTarget.querySelector('.channel-chip')).not.toBeNull()
+    })
+
+    test('keeps the channel chip when the request is interrupted', async () => {
+      const button = appendChannelChip()
+      jest.spyOn(console, 'warn').mockImplementation(() => {})
+      global.fetch.mockRejectedValueOnce(new Error('offline'))
+
+      controller.detachChannel({ currentTarget: button })
+      await flush()
+
+      expect(controller.channelChipsTarget.querySelector('.channel-chip')).not.toBeNull()
+      expect(console.warn).toHaveBeenCalledWith(
+        '[presence] detach channel failed:',
+        expect.any(Error),
+      )
+    })
+  })
+
   describe('agent task status poll', () => {
     const flush = () => new Promise((resolve) => setTimeout(resolve, 0))
 

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/presence_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/presence_controller.test.js
@@ -463,7 +463,7 @@ describe('CommentsPresenceController typing-row horizontal scroll', () => {
 
     test('removes the channel chip immediately after a successful request', async () => {
       const button = appendChannelChip()
-      global.fetch.mockResolvedValueOnce({ ok: true, headers: new Headers() })
+      global.fetch.mockResolvedValueOnce({ status: 204, redirected: false, headers: new Headers() })
 
       controller.detachChannel({ currentTarget: button })
       await flush()
@@ -476,7 +476,27 @@ describe('CommentsPresenceController typing-row horizontal scroll', () => {
 
     test('keeps the channel chip when the request fails', async () => {
       const button = appendChannelChip()
-      global.fetch.mockResolvedValueOnce({ ok: false, headers: new Headers() })
+      global.fetch.mockResolvedValueOnce({ status: 500, redirected: false, headers: new Headers() })
+
+      controller.detachChannel({ currentTarget: button })
+      await flush()
+
+      expect(controller.channelChipsTarget.querySelector('.channel-chip')).not.toBeNull()
+    })
+
+    test('keeps the channel chip when the request is redirected', async () => {
+      const button = appendChannelChip()
+      global.fetch.mockResolvedValueOnce({ status: 200, redirected: true, headers: new Headers() })
+
+      controller.detachChannel({ currentTarget: button })
+      await flush()
+
+      expect(controller.channelChipsTarget.querySelector('.channel-chip')).not.toBeNull()
+    })
+
+    test('keeps the channel chip for an unexpected non-redirect response', async () => {
+      const button = appendChannelChip()
+      global.fetch.mockResolvedValueOnce({ status: 200, redirected: false, headers: new Headers() })
 
       controller.detachChannel({ currentTarget: button })
       await flush()

--- a/engines/collavre/app/javascript/controllers/comments/presence_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/presence_controller.js
@@ -716,9 +716,7 @@ export default class extends Controller {
       method: 'DELETE',
       headers: { Accept: 'application/json' },
     })
-      .then((response) => {
-        if (response.ok) btn.closest('.channel-chip')?.remove()
-      })
+      .then((response) => response.status === 204 && !response.redirected && btn.closest('.channel-chip')?.remove())
       .catch((err) => console.warn('[presence] detach channel failed:', err))
   }
 

--- a/engines/collavre/app/javascript/controllers/comments/presence_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/presence_controller.js
@@ -715,7 +715,11 @@ export default class extends Controller {
     csrfFetch(`/channels/${id}`, {
       method: 'DELETE',
       headers: { Accept: 'application/json' },
-    }).catch((err) => console.warn('[presence] detach channel failed:', err))
+    })
+      .then((response) => {
+        if (response.ok) btn.closest('.channel-chip')?.remove()
+      })
+      .catch((err) => console.warn('[presence] detach channel failed:', err))
   }
 
   clearTypingTimers() {


### PR DESCRIPTION
## Summary

- remove a channel chip from the current UI as soon as its detach request succeeds
- keep the chip visible when the server rejects the request or the request is interrupted
- cover successful, rejected, and interrupted detach flows in the presence controller tests

## Tests

- `npm test -- --runInBand`
- `npm test -- --runInBand engines/collavre/app/javascript/controllers/comments/__tests__/presence_controller.test.js`
- `mise exec -- bin/rails test engines/collavre/test/controllers/collavre/channels_controller_test.rb`
- `mise exec -- bin/complexity_check`
- `mise exec -- ./bin/rubocop -a`