### PR TITLE
feat(github): add pr_state_set tool to correct missed PR state

### DIFF
--- a/engines/collavre_github/app/models/collavre_github/github_pr_channel.rb
+++ b/engines/collavre_github/app/models/collavre_github/github_pr_channel.rb
@@ -114,6 +114,19 @@ module CollavreGithub
       )
     end
 
+    # Closing message for `state` (merged / closed_without_merge). Public so
+    # the out-of-band corrector (PrChannelStateUpdater) posts the exact same
+    # text the webhook would have, instead of maintaining a second copy.
+    def closed_message(state = pr_state)
+      verb = state.to_s == "merged" ? t("state_merged") : t("state_closed")
+      Collavre::Channel::InjectedMessage.new(
+        speaker: channel_bot_user,
+        message: t("closed_message", label: label, verb: verb),
+        label: label,
+        link: pr_url
+      )
+    end
+
     def reopened_message
       Collavre::Channel::InjectedMessage.new(
         speaker: channel_bot_user,
@@ -153,7 +166,6 @@ module CollavreGithub
       return nil unless payload["action"] == "closed"
       pr = payload["pull_request"]
       new_state = pr["merged"] ? "merged" : "closed_without_merge"
-      verb = pr["merged"] ? t("state_merged") : t("state_closed")
 
       # pr_state is updated atomically with the closing comment: the dispatch
       # path wraps both `handle` and `inject_into_topic!` in a single with_lock
@@ -163,12 +175,7 @@ module CollavreGithub
       self.pr_state = new_state
       save!
 
-      Collavre::Channel::InjectedMessage.new(
-        speaker: channel_bot_user,
-        message: t("closed_message", label: label, verb: verb),
-        label: label,
-        link: pr_url
-      )
+      closed_message(new_state)
       # Detach is performed by the webhook controller AFTER injecting this
       # message, so the chip stays visible until the closing comment lands.
     end

--- a/engines/collavre_github/app/services/collavre_github/pr_channel_state_updater.rb
+++ b/engines/collavre_github/app/services/collavre_github/pr_channel_state_updater.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+module CollavreGithub
+  # Out-of-band PR state correction: applies the same end-state the webhook
+  # would have produced when a `pull_request` event was never delivered (hook
+  # added after the merge, delivery failure, repo renamed mid-flight).
+  #
+  # The webhook path does NOT route through here on purpose. There, `handle`
+  # only *returns* the closing message and WebhooksController injects it and
+  # detaches, because the controller owns the per-channel lock that also
+  # de-duplicates GitHub retries. This class owns the whole transition instead,
+  # so it takes the lock itself. Both paths share the message builders on
+  # GithubPrChannel, which is the part that would otherwise drift.
+  class PrChannelStateUpdater
+    # status ∈ :updated / :noop
+    Result = Struct.new(:status, :channel, :previous_state, keyword_init: true)
+
+    def self.call(channel:, state:)
+      new(channel: channel, state: state).call
+    end
+
+    def initialize(channel:, state:)
+      @channel = channel
+      @state = state.to_s
+      unless GithubPrChannel::PR_STATES.include?(@state)
+        raise ArgumentError, "Invalid pr_state: #{state.inspect}"
+      end
+    end
+
+    def call
+      channel.with_lock do
+        previous_state = channel.pr_state
+        next Result.new(status: :noop, channel: channel, previous_state: previous_state) if settled?
+
+        if state == "open"
+          reopen!
+        else
+          close!
+        end
+        Result.new(status: :updated, channel: channel, previous_state: previous_state)
+      end
+    end
+
+    private
+
+    attr_reader :channel, :state
+
+    # A repeat call must not inject a second timeline message. "Same state" is
+    # not enough on its own: a channel can read "open" while sitting detached
+    # (dismissed by the user, or reopened only in GitHub), and that still needs
+    # the reactivation half of the transition applied.
+    def settled?
+      return false unless channel.pr_state == state
+
+      if state == "open"
+        channel.active? && !channel.dismissed?
+      else
+        channel.detached?
+      end
+    end
+
+    # Mirrors WebhooksController's reopen handling: state back to active and
+    # the chip un-dismissed, so the channel resurfaces under `not_dismissed`
+    # and resumes receiving events.
+    def reopen!
+      channel.state = :active
+      channel.dismissed_at = nil
+      channel.pr_state = "open"
+      channel.save!
+      channel.inject_into_topic!(channel.reopened_message)
+    end
+
+    # Mirrors the closed-event path: set the badge, post the closing message,
+    # then detach — in that order, so the chip stays visible (now merged /
+    # closed) until the user dismisses it.
+    def close!
+      channel.pr_state = state
+      channel.save!
+      channel.inject_into_topic!(channel.closed_message(state))
+      channel.detach! if channel.active?
+    end
+  end
+end

--- a/engines/collavre_github/app/services/collavre_github/tools/concerns/pr_channel_locator.rb
+++ b/engines/collavre_github/app/services/collavre_github/tools/concerns/pr_channel_locator.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module CollavreGithub
+  module Tools
+    module Concerns
+      # Shared PR-URL parsing and channel lookup for the PR-channel tools
+      # (pr_monitor attaches, pr_state_set corrects). Both must agree on how a
+      # URL maps to a stored channel or a state correction would silently miss
+      # the very channel the monitor created.
+      module PrChannelLocator
+        extend ActiveSupport::Concern
+
+        PR_URL_RE = %r{\Ahttps?://github\.com/([^/]+/[^/]+)/pull/(\d+)\z}.freeze
+
+        private
+
+        # GitHub owner/repo identifiers are case-insensitive but webhook
+        # payloads always carry the canonical case. Normalize on parse so user
+        # input like "Owner/Repo" still matches incoming events.
+        #
+        # @return [[String, Integer]] downcased repo full name and PR number
+        def parse_pr_url(pr_url)
+          m = pr_url.to_s.match(PR_URL_RE)
+          raise ArgumentError, "Invalid PR URL: #{pr_url}" unless m
+
+          [ m[1].downcase, m[2].to_i ]
+        end
+
+        # Ruby-level compare instead of a WHERE: legacy rows can carry
+        # mixed-case repo names, and the dispatch path matches the same way.
+        def lookup_channel(topic, repo, pr_number)
+          CollavreGithub::GithubPrChannel.where(topic_id: topic.id).find do |c|
+            c.repo_full_name.to_s.downcase == repo.downcase && c.pr_number == pr_number
+          end
+        end
+
+        # Creatives whose RepositoryLinks govern this topic: the topic's own
+        # creative plus its ancestors. Mirrors pr_monitor's provisioning scope,
+        # so a tool can never reach a GitHub account the monitor itself could
+        # not have used.
+        def scoped_creative_ids(topic)
+          creative = topic.creative
+          return [] unless creative
+
+          [ creative.id ] + creative.ancestors.pluck(:id)
+        end
+      end
+    end
+  end
+end

--- a/engines/collavre_github/app/services/collavre_github/tools/pr_monitor_service.rb
+++ b/engines/collavre_github/app/services/collavre_github/tools/pr_monitor_service.rb
@@ -8,8 +8,7 @@ module CollavreGithub
     class PrMonitorService
       extend T::Sig
       extend ToolMeta
-
-      PR_URL_RE = %r{\Ahttps?://github\.com/([^/]+/[^/]+)/pull/(\d+)\z}.freeze
+      include Concerns::PrChannelLocator
 
       tool_name "pr_monitor"
       tool_description <<~DESC.strip
@@ -23,13 +22,7 @@ module CollavreGithub
 
       sig { params(topic_id: Integer, pr_url: String).returns(T::Hash[Symbol, T.untyped]) }
       def call(topic_id:, pr_url:)
-        m = pr_url.match(PR_URL_RE)
-        raise ArgumentError, "Invalid PR URL: #{pr_url}" unless m
-        # GitHub owner/repo identifiers are case-insensitive but webhook payloads
-        # always carry the canonical case. Normalize on store so user input
-        # like "Owner/Repo" still matches incoming events.
-        repo = m[1].downcase
-        pr_number = m[2].to_i
+        repo, pr_number = parse_pr_url(pr_url)
 
         topic = Collavre::Topic.find(topic_id)
         Collavre::Tools::TopicAuthorizer.authorize_write!(topic)
@@ -68,13 +61,6 @@ module CollavreGithub
             channel.pr_state = "open" if channel.pr_state != "open"
           }
         )
-      end
-
-      sig { params(topic: Collavre::Topic, repo: String, pr_number: Integer).returns(T.nilable(CollavreGithub::GithubPrChannel)) }
-      def lookup_channel(topic, repo, pr_number)
-        CollavreGithub::GithubPrChannel.where(topic_id: topic.id).find do |c|
-          c.repo_full_name.to_s.downcase == repo.downcase && c.pr_number == pr_number
-        end
       end
 
       # Make sure the repo's webhook subscribes to the PR-channel events
@@ -122,10 +108,9 @@ module CollavreGithub
       end
 
       def scoped_repository_ids(topic, repo)
-        creative = topic.creative
-        return [] unless creative
+        candidate_ids = scoped_creative_ids(topic)
+        return [] if candidate_ids.empty?
 
-        candidate_ids = [ creative.id ] + creative.ancestors.pluck(:id)
         CollavreGithub::RepositoryLink
           .where("LOWER(repository_full_name) = ?", repo.downcase)
           .where(creative_id: candidate_ids)
@@ -140,10 +125,9 @@ module CollavreGithub
       # is not safe provisioning evidence because GitHub can reuse a renamed
       # repository's old name.
       def verified_scoped_repository_links_for(topic, repo, repository_id:)
-        creative = topic.creative
-        return [] unless creative
+        candidate_ids = scoped_creative_ids(topic)
+        return [] if candidate_ids.empty?
 
-        candidate_ids = [ creative.id ] + creative.ancestors.pluck(:id)
         candidates = CollavreGithub::RepositoryLink
           .where("LOWER(repository_full_name) = ?", repo.downcase)
           .where(creative_id: candidate_ids)

--- a/engines/collavre_github/app/services/collavre_github/tools/pr_state_set_service.rb
+++ b/engines/collavre_github/app/services/collavre_github/tools/pr_state_set_service.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+require "rails_mcp_engine"
+
+module CollavreGithub
+  module Tools
+    class PrStateSetService
+      extend T::Sig
+      extend ToolMeta
+      include Concerns::PrChannelLocator
+
+      tool_name "pr_state_set"
+      tool_description <<~DESC.strip
+        Correct the state of a GitHub PR channel attached with pr_monitor, for
+        when a `pull_request` webhook was missed (hook added after the merge,
+        delivery failure) and the chip is stuck on the wrong badge.
+
+        Omit `state` to resynchronize from the GitHub API — that is the
+        preferred form, because it cannot record a state the PR does not
+        actually have. Pass `state` explicitly only as a fallback when no
+        GitHub account is connected for the repository.
+
+        Closing the channel (merged / closed_without_merge) posts the closing
+        message and detaches it; reopening it resumes monitoring. Idempotent.
+      DESC
+
+      tool_param :topic_id, description: "The Collavre topic id the PR channel is attached to."
+      tool_param :pr_url, description: "Full GitHub PR URL, e.g. https://github.com/owner/repo/pull/123"
+      tool_param :state,
+        description: "Target state. Omit to read the real state from GitHub.",
+        required: false,
+        enum: CollavreGithub::GithubPrChannel::PR_STATES
+
+      sig do
+        params(
+          topic_id: Integer,
+          pr_url: String,
+          state: T.nilable(String)
+        ).returns(T::Hash[Symbol, T.untyped])
+      end
+      def call(topic_id:, pr_url:, state: nil)
+        repo, pr_number = parse_pr_url(pr_url)
+
+        topic = Collavre::Topic.find(topic_id)
+        Collavre::Tools::TopicAuthorizer.authorize_write!(topic)
+
+        channel = lookup_channel(topic, repo, pr_number)
+        unless channel
+          return {
+            ok: false,
+            error: "No PR channel for #{repo}##{pr_number} on topic #{topic_id}. Attach it with pr_monitor first."
+          }
+        end
+
+        target, source = resolve_state(topic, repo, pr_number, state)
+        return target if target.is_a?(Hash) # error payload
+
+        result = CollavreGithub::PrChannelStateUpdater.call(channel: channel, state: target)
+        {
+          ok: true,
+          channel_id: channel.id,
+          repo: repo,
+          pr_number: pr_number,
+          pr_state: target,
+          previous_state: result.previous_state,
+          status: result.status.to_s,
+          state_source: source
+        }
+      end
+
+      private
+
+      # Returns [state, source] or an error hash. An explicit `state` is
+      # validated here rather than at the updater so a typo surfaces as an
+      # ArgumentError naming the tool parameter the caller actually passed.
+      sig do
+        params(
+          topic: Collavre::Topic,
+          repo: String,
+          pr_number: Integer,
+          state: T.nilable(String)
+        ).returns([ T.any(String, T::Hash[Symbol, T.untyped]), String ])
+      end
+      def resolve_state(topic, repo, pr_number, state)
+        if state.present?
+          unless CollavreGithub::GithubPrChannel::PR_STATES.include?(state)
+            raise ArgumentError,
+              "Invalid state: #{state.inspect} (expected one of #{CollavreGithub::GithubPrChannel::PR_STATES.join(', ')})"
+          end
+          return [ state, "explicit" ]
+        end
+
+        client = github_client_for(topic, repo)
+        unless client
+          return [ {
+            ok: false,
+            error: "No connected GitHub account for #{repo} in this topic's creative scope, " \
+                   "so the state could not be read from GitHub. Pass `state` explicitly instead."
+          }, "github" ]
+        end
+
+        remote = remote_state(client, repo, pr_number)
+        unless remote
+          return [ {
+            ok: false,
+            error: "Could not read #{repo}##{pr_number} from GitHub (not found, or the API call failed). " \
+                   "Pass `state` explicitly instead."
+          }, "github" ]
+        end
+
+        [ remote, "github" ]
+      end
+
+      # GitHub reports merge and closure separately: `merged` is the
+      # authoritative merge flag, and `state` only distinguishes open from
+      # closed. Checking `merged` first is what keeps a squash-merged PR from
+      # being recorded as closed_without_merge.
+      def remote_state(client, repo, pr_number)
+        pr = client.pull_request_details(repo, pr_number)
+        return nil unless pr
+        return "merged" if pr.merged
+
+        pr.state.to_s == "closed" ? "closed_without_merge" : "open"
+      end
+
+      # Case-insensitive because channels store the repo name downcased while
+      # RepositoryLink keeps GitHub's canonical case.
+      def github_client_for(topic, repo)
+        candidate_ids = scoped_creative_ids(topic)
+        return nil if candidate_ids.empty?
+
+        link = CollavreGithub::RepositoryLink
+          .where("LOWER(repository_full_name) = ?", repo.downcase)
+          .where(creative_id: candidate_ids)
+          .order(:id)
+          .find(&:github_account)
+        return nil unless link
+
+        CollavreGithub::Client.new(link.github_account)
+      end
+    end
+  end
+end

--- a/engines/collavre_github/app/services/collavre_github/tools/pr_state_set_service.rb
+++ b/engines/collavre_github/app/services/collavre_github/tools/pr_state_set_service.rb
@@ -126,8 +126,9 @@ module CollavreGithub
 
       # A repository name is not an identity: GitHub can reuse it after a
       # rename. Keep only accounts whose live repository id matches a stable id
-      # stored on an in-scope RepositoryLink, then let resync try each account
-      # until one can read the PR.
+      # stored on an in-scope RepositoryLink, and reject the entire inherited
+      # scope when another link claims the same name with a conflicting id.
+      # Then let resync try each verified account until one can read the PR.
       def verified_github_clients_for(topic, repo)
         candidate_ids = scoped_creative_ids(topic)
         return [] if candidate_ids.empty?
@@ -140,13 +141,19 @@ module CollavreGithub
           .to_a
 
         links.group_by(&:github_account_id).filter_map do |account_id, account_links|
-          verified_client_for(account_id, account_links, repo)
+          verified_client_for(account_id, account_links, topic, repo)
         end
       end
 
-      def verified_client_for(account_id, links, repo)
+      def verified_client_for(account_id, links, topic, repo)
         client = CollavreGithub::Client.new(links.first.github_account)
         identity = client.repository_identity(repo)
+        return nil if CollavreGithub::RepositoryLink.conflicting_repository_in_scope?(
+          creative: topic.creative,
+          full_name: repo,
+          repository_id: identity.id
+        )
+
         return client if links.any? { |link| link.repository_id.to_s == identity.id.to_s }
 
         nil

--- a/engines/collavre_github/app/services/collavre_github/tools/pr_state_set_service.rb
+++ b/engines/collavre_github/app/services/collavre_github/tools/pr_state_set_service.rb
@@ -91,25 +91,25 @@ module CollavreGithub
           return [ state, "explicit" ]
         end
 
-        client = github_client_for(topic, repo)
-        unless client
+        clients = verified_github_clients_for(topic, repo)
+        if clients.empty?
           return [ {
             ok: false,
-            error: "No connected GitHub account for #{repo} in this topic's creative scope, " \
+            error: "No verified connected GitHub account for #{repo} in this topic's creative scope, " \
                    "so the state could not be read from GitHub. Pass `state` explicitly instead."
           }, "github" ]
         end
 
-        remote = remote_state(client, repo, pr_number)
-        unless remote
-          return [ {
-            ok: false,
-            error: "Could not read #{repo}##{pr_number} from GitHub (not found, or the API call failed). " \
-                   "Pass `state` explicitly instead."
-          }, "github" ]
+        clients.each do |client|
+          remote = remote_state(client, repo, pr_number)
+          return [ remote, "github" ] if remote
         end
 
-        [ remote, "github" ]
+        [ {
+          ok: false,
+          error: "Could not read #{repo}##{pr_number} from GitHub (not found, or the API call failed). " \
+                 "Pass `state` explicitly instead."
+        }, "github" ]
       end
 
       # GitHub reports merge and closure separately: `merged` is the
@@ -124,20 +124,39 @@ module CollavreGithub
         pr.state.to_s == "closed" ? "closed_without_merge" : "open"
       end
 
-      # Case-insensitive because channels store the repo name downcased while
-      # RepositoryLink keeps GitHub's canonical case.
-      def github_client_for(topic, repo)
+      # A repository name is not an identity: GitHub can reuse it after a
+      # rename. Keep only accounts whose live repository id matches a stable id
+      # stored on an in-scope RepositoryLink, then let resync try each account
+      # until one can read the PR.
+      def verified_github_clients_for(topic, repo)
         candidate_ids = scoped_creative_ids(topic)
-        return nil if candidate_ids.empty?
+        return [] if candidate_ids.empty?
 
-        link = CollavreGithub::RepositoryLink
+        links = CollavreGithub::RepositoryLink
           .where("LOWER(repository_full_name) = ?", repo.downcase)
           .where(creative_id: candidate_ids)
+          .where.not(repository_id: nil)
           .order(:id)
-          .find(&:github_account)
-        return nil unless link
+          .to_a
 
-        CollavreGithub::Client.new(link.github_account)
+        links.group_by(&:github_account_id).filter_map do |account_id, account_links|
+          verified_client_for(account_id, account_links, repo)
+        end
+      end
+
+      def verified_client_for(account_id, links, repo)
+        client = CollavreGithub::Client.new(links.first.github_account)
+        identity = client.repository_identity(repo)
+        return client if links.any? { |link| link.repository_id.to_s == identity.id.to_s }
+
+        nil
+      rescue Octokit::Error, Faraday::Error => e
+        Rails.logger.warn(
+          "[pr_state_set] repository identity lookup failed for #{repo} through " \
+          "account #{account_id}: #{e.class}: #{e.message}"
+        )
+
+        nil
       end
     end
   end

--- a/engines/collavre_github/db/seeds.rb
+++ b/engines/collavre_github/db/seeds.rb
@@ -77,6 +77,7 @@ module CollavreGithub
       creative_retrieval_service
       creative_batch_service
       pr_monitor
+      pr_state_set
     ].freeze
 
     def self.call

--- a/engines/collavre_github/test/services/collavre_github/pr_channel_state_updater_test.rb
+++ b/engines/collavre_github/test/services/collavre_github/pr_channel_state_updater_test.rb
@@ -1,0 +1,153 @@
+# frozen_string_literal: true
+
+require_relative "../../test_helper"
+
+module CollavreGithub
+  class PrChannelStateUpdaterTest < ActiveSupport::TestCase
+    setup do
+      @user = users(:one)
+      @creative = creatives(:tshirt)
+      @topic = Collavre::Topic.create!(name: "T", creative: @creative, user: @user)
+      @channel = GithubPrChannel.create!(
+        topic_id: @topic.id,
+        config: { "repo_full_name" => "owner/repo", "pr_number" => 77, "pr_state" => "open" }
+      )
+    end
+
+    test "merged: sets state, injects the closing message and detaches" do
+      assert_difference -> { @creative.comments.count }, 1 do
+        result = PrChannelStateUpdater.call(channel: @channel, state: "merged")
+        assert_equal :updated, result.status
+        assert_equal "open", result.previous_state
+      end
+
+      @channel.reload
+      assert_equal "merged", @channel.pr_state
+      assert @channel.detached?
+      comment = @creative.comments.order(:created_at).last
+      assert_equal @topic.id, comment.topic_id
+      assert_includes comment.content, "PR #77"
+    end
+
+    test "closed_without_merge posts the closed verb, not the merged one" do
+      PrChannelStateUpdater.call(channel: @channel, state: "closed_without_merge")
+
+      assert_equal "closed_without_merge", @channel.reload.pr_state
+      content = @creative.comments.order(:created_at).last.content
+      assert_includes content, I18n.t("collavre_github.channel.pr.state_closed")
+      assert_not_includes content, I18n.t("collavre_github.channel.pr.state_merged")
+    end
+
+    test "closing message is identical to the one the webhook would have posted" do
+      webhook_channel = GithubPrChannel.create!(
+        topic_id: @topic.id,
+        config: { "repo_full_name" => "owner/repo", "pr_number" => 78, "pr_state" => "open" }
+      )
+      webhook_message = webhook_channel.send(
+        :handle_pull_request,
+        "action" => "closed",
+        "pull_request" => { "merged" => true }
+      )
+
+      PrChannelStateUpdater.call(channel: @channel, state: "merged")
+      manual_content = @creative.comments.order(:created_at).last.content
+
+      assert_equal webhook_message.message.sub("PR #78", "PR #77"), manual_content
+    end
+
+    test "reopening a merged channel reactivates it and resumes monitoring" do
+      PrChannelStateUpdater.call(channel: @channel, state: "merged")
+
+      assert_difference -> { @creative.comments.count }, 1 do
+        result = PrChannelStateUpdater.call(channel: @channel, state: "open")
+        assert_equal :updated, result.status
+        assert_equal "merged", result.previous_state
+      end
+
+      @channel.reload
+      assert_equal "open", @channel.pr_state
+      assert @channel.active?
+      assert_includes @creative.comments.order(:created_at).last.content, "PR #77"
+    end
+
+    test "reopening clears dismissed_at so the chip resurfaces" do
+      @channel.dismiss!
+      assert @channel.reload.dismissed?
+
+      PrChannelStateUpdater.call(channel: @channel, state: "open")
+
+      @channel.reload
+      assert_nil @channel.dismissed_at
+      assert @channel.active?
+    end
+
+    test "repeating a close is a noop and injects no second message" do
+      PrChannelStateUpdater.call(channel: @channel, state: "merged")
+
+      assert_no_difference -> { @creative.comments.count } do
+        result = PrChannelStateUpdater.call(channel: @channel, state: "merged")
+        assert_equal :noop, result.status
+        assert_equal "merged", result.previous_state
+      end
+    end
+
+    test "repeating open on an active channel is a noop" do
+      assert_no_difference -> { @creative.comments.count } do
+        assert_equal :noop, PrChannelStateUpdater.call(channel: @channel, state: "open").status
+      end
+    end
+
+    # A channel can read "open" while sitting detached — the user dismissed the
+    # chip, or a reopen event was missed. Matching state alone must not be read
+    # as "already settled" or the reactivation half never runs.
+    test "open on a detached but open-state channel still reactivates" do
+      @channel.detach!
+
+      assert_difference -> { @creative.comments.count }, 1 do
+        assert_equal :updated, PrChannelStateUpdater.call(channel: @channel, state: "open").status
+      end
+      assert @channel.reload.active?
+    end
+
+    test "merged on an already-merged but still active channel completes the detach" do
+      @channel.update!(config: @channel.config.merge("pr_state" => "merged"))
+      assert @channel.active?
+
+      assert_equal :updated, PrChannelStateUpdater.call(channel: @channel, state: "merged").status
+      assert @channel.reload.detached?
+    end
+
+    # Closing a channel the user already dismissed still has to record the
+    # merge — the badge is what a later reattach reads to decide its color.
+    test "merging an already-detached open channel records the state without a second detach" do
+      @channel.detach!
+
+      assert_difference -> { @creative.comments.count }, 1 do
+        assert_equal :updated, PrChannelStateUpdater.call(channel: @channel, state: "merged").status
+      end
+
+      @channel.reload
+      assert_equal "merged", @channel.pr_state
+      assert @channel.detached?
+    end
+
+    test "rejects a state outside PR_STATES before touching the channel" do
+      assert_raises(ArgumentError) do
+        PrChannelStateUpdater.call(channel: @channel, state: "merged_")
+      end
+      assert_equal "open", @channel.reload.pr_state
+    end
+
+    test "a failed injection rolls the state change back" do
+      @channel.stub(:inject_into_topic!, ->(_msg) { raise "boom" }) do
+        assert_raises(RuntimeError) do
+          PrChannelStateUpdater.call(channel: @channel, state: "merged")
+        end
+      end
+
+      @channel.reload
+      assert_equal "open", @channel.pr_state
+      assert @channel.active?
+    end
+  end
+end

--- a/engines/collavre_github/test/services/collavre_github/tools/concerns/pr_channel_locator_test.rb
+++ b/engines/collavre_github/test/services/collavre_github/tools/concerns/pr_channel_locator_test.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require_relative "../../../../test_helper"
+
+module CollavreGithub
+  module Tools
+    module Concerns
+      # Exercises the locator through a bare host class: pr_monitor and
+      # pr_state_set both authorize the topic before reaching these methods, so
+      # the creative-less guard is not reachable through either tool's `call`.
+      class PrChannelLocatorTest < ActiveSupport::TestCase
+        class Host
+          include CollavreGithub::Tools::Concerns::PrChannelLocator
+          public :parse_pr_url, :lookup_channel, :scoped_creative_ids
+        end
+
+        setup do
+          @host = Host.new
+          @user = users(:one)
+          @creative = creatives(:tshirt)
+          @topic = Collavre::Topic.create!(name: "T", creative: @creative, user: @user)
+        end
+
+        test "downcases the repo and casts the PR number" do
+          assert_equal [ "owner/repo", 77 ], @host.parse_pr_url("https://github.com/Owner/Repo/pull/77")
+        end
+
+        test "accepts http as well as https" do
+          assert_equal [ "owner/repo", 5 ], @host.parse_pr_url("http://github.com/owner/repo/pull/5")
+        end
+
+        test "rejects a URL that is not a GitHub PR" do
+          assert_raises(ArgumentError) { @host.parse_pr_url("https://github.com/owner/repo/issues/77") }
+          assert_raises(ArgumentError) { @host.parse_pr_url("https://example.com/owner/repo/pull/77") }
+          assert_raises(ArgumentError) { @host.parse_pr_url(nil) }
+        end
+
+        test "finds a channel regardless of the stored repo name's case" do
+          channel = GithubPrChannel.create!(
+            topic_id: @topic.id,
+            config: { "repo_full_name" => "Owner/Repo", "pr_number" => 77 }
+          )
+
+          assert_equal channel, @host.lookup_channel(@topic, "owner/repo", 77)
+          assert_nil @host.lookup_channel(@topic, "owner/repo", 78)
+          assert_nil @host.lookup_channel(@topic, "other/repo", 77)
+        end
+
+        test "scopes to the topic's creative and its ancestors" do
+          child = Collavre::Creative.create!(user: @user, description: "child", parent: @creative)
+          topic = Collavre::Topic.create!(name: "Child T", creative: child, user: @user)
+
+          ids = @host.scoped_creative_ids(topic)
+
+          assert_includes ids, child.id
+          assert_includes ids, @creative.id
+        end
+
+        test "returns an empty scope when the topic has no creative" do
+          @topic.stub(:creative, nil) do
+            assert_empty @host.scoped_creative_ids(@topic)
+          end
+        end
+      end
+    end
+  end
+end

--- a/engines/collavre_github/test/services/collavre_github/tools/pr_state_set_service_test.rb
+++ b/engines/collavre_github/test/services/collavre_github/tools/pr_state_set_service_test.rb
@@ -172,6 +172,29 @@ module CollavreGithub
         assert_not_requested :get, "https://api.github.com/repos/owner/repo/pulls/77"
       end
 
+      test "resync rejects conflicting repository identities in the topic scope" do
+        child = Collavre::Creative.create!(user: @user, description: "child", parent: @creative)
+        topic = Collavre::Topic.create!(name: "Child T", creative: child, user: @user)
+        channel = GithubPrChannel.create!(
+          topic_id: topic.id,
+          config: { "repo_full_name" => "owner/repo", "pr_number" => 77, "pr_state" => "open" }
+        )
+        account = connect_github_account(repository_id: 111, remote_repository_id: 111)
+        CollavreGithub::RepositoryLink.create!(
+          creative: child,
+          github_account: account,
+          repository_full_name: "owner/repo",
+          repository_id: 222
+        )
+
+        result = PrStateSetService.new.call(topic_id: topic.id, pr_url: PR_URL)
+
+        assert_equal false, result[:ok]
+        assert_includes result[:error], "No verified connected GitHub account"
+        assert_equal "open", channel.reload.pr_state
+        assert_not_requested :get, "https://api.github.com/repos/owner/repo/pulls/77"
+      end
+
       test "resync tries the next identity-valid account when the first cannot read the PR" do
         child = Collavre::Creative.create!(user: @user, description: "child", parent: @creative)
         topic = Collavre::Topic.create!(name: "Child T", creative: child, user: @user)

--- a/engines/collavre_github/test/services/collavre_github/tools/pr_state_set_service_test.rb
+++ b/engines/collavre_github/test/services/collavre_github/tools/pr_state_set_service_test.rb
@@ -1,0 +1,241 @@
+# frozen_string_literal: true
+
+# Load the engine's test_helper (not the app's) so WebMock + GitHub stubs are
+# available for the API-resync tests below.
+require_relative "../../../test_helper"
+
+module CollavreGithub
+  module Tools
+    class PrStateSetServiceTest < ActiveSupport::TestCase
+      PR_URL = "https://github.com/owner/repo/pull/77"
+
+      setup do
+        @user = users(:one)
+        @creative = creatives(:tshirt)
+        @topic = Collavre::Topic.create!(name: "T", creative: @creative, user: @user)
+        Collavre::Current.user = @user
+        @channel = GithubPrChannel.create!(
+          topic_id: @topic.id,
+          config: { "repo_full_name" => "owner/repo", "pr_number" => 77, "pr_state" => "open" }
+        )
+      end
+
+      teardown do
+        Collavre::Current.user = nil
+      end
+
+      def connect_github_account(repository_full_name: "owner/repo", creative: @creative)
+        account = CollavreGithub::Account.create!(
+          user: @user,
+          github_uid: "12345",
+          login: "testuser",
+          name: "Test User",
+          token: "test-token"
+        )
+        CollavreGithub::RepositoryLink.create!(
+          creative: creative,
+          github_account: account,
+          repository_full_name: repository_full_name
+        )
+        account
+      end
+
+      def stub_pull_request(state:, merged:, repo: "owner/repo", number: 77)
+        stub_request(:get, "https://api.github.com/repos/#{repo}/pulls/#{number}")
+          .to_return(
+            status: 200,
+            body: { number: number, state: state, merged: merged }.to_json,
+            headers: { "Content-Type" => "application/json" }
+          )
+      end
+
+      # --- explicit state ------------------------------------------------
+
+      test "explicit merged state closes the channel and reports the transition" do
+        result = PrStateSetService.new.call(topic_id: @topic.id, pr_url: PR_URL, state: "merged")
+
+        assert result[:ok]
+        assert_equal @channel.id, result[:channel_id]
+        assert_equal "owner/repo", result[:repo]
+        assert_equal 77, result[:pr_number]
+        assert_equal "merged", result[:pr_state]
+        assert_equal "open", result[:previous_state]
+        assert_equal "updated", result[:status]
+        assert_equal "explicit", result[:state_source]
+        assert @channel.reload.detached?
+      end
+
+      test "explicit state re-applied is reported as a noop" do
+        PrStateSetService.new.call(topic_id: @topic.id, pr_url: PR_URL, state: "merged")
+        result = PrStateSetService.new.call(topic_id: @topic.id, pr_url: PR_URL, state: "merged")
+
+        assert result[:ok]
+        assert_equal "noop", result[:status]
+      end
+
+      test "explicit open reopens a channel closed by a stale merge" do
+        PrStateSetService.new.call(topic_id: @topic.id, pr_url: PR_URL, state: "merged")
+        result = PrStateSetService.new.call(topic_id: @topic.id, pr_url: PR_URL, state: "open")
+
+        assert_equal "open", result[:pr_state]
+        assert @channel.reload.active?
+      end
+
+      test "rejects a state outside PR_STATES" do
+        error = assert_raises(ArgumentError) do
+          PrStateSetService.new.call(topic_id: @topic.id, pr_url: PR_URL, state: "merged_")
+        end
+        assert_includes error.message, "merged_"
+        assert_equal "open", @channel.reload.pr_state
+      end
+
+      # --- GitHub resync -------------------------------------------------
+
+      test "omitting state reads merged from the GitHub API" do
+        connect_github_account
+        stub_pull_request(state: "closed", merged: true)
+
+        result = PrStateSetService.new.call(topic_id: @topic.id, pr_url: PR_URL)
+
+        assert result[:ok]
+        assert_equal "merged", result[:pr_state]
+        assert_equal "github", result[:state_source]
+        assert_equal "merged", @channel.reload.pr_state
+        assert @channel.detached?
+      end
+
+      # `merged` is the authoritative flag; `state` reads "closed" for both a
+      # merge and an abandonment, so ordering the checks the other way would
+      # record every merged PR as closed_without_merge.
+      test "a closed but unmerged PR resyncs to closed_without_merge" do
+        connect_github_account
+        stub_pull_request(state: "closed", merged: false)
+
+        result = PrStateSetService.new.call(topic_id: @topic.id, pr_url: PR_URL)
+
+        assert_equal "closed_without_merge", result[:pr_state]
+      end
+
+      test "a still-open PR resyncs to open" do
+        connect_github_account
+        stub_pull_request(state: "open", merged: false)
+        @channel.update!(config: @channel.config.merge("pr_state" => "merged"))
+        @channel.detach!
+
+        result = PrStateSetService.new.call(topic_id: @topic.id, pr_url: PR_URL)
+
+        assert_equal "open", result[:pr_state]
+        assert @channel.reload.active?
+      end
+
+      test "resync matches a RepositoryLink stored in GitHub's canonical case" do
+        connect_github_account(repository_full_name: "Owner/Repo")
+        stub_pull_request(state: "closed", merged: true)
+
+        result = PrStateSetService.new.call(topic_id: @topic.id, pr_url: PR_URL)
+
+        assert result[:ok]
+        assert_equal "merged", result[:pr_state]
+      end
+
+      test "resync uses a RepositoryLink on an ancestor creative" do
+        child = Collavre::Creative.create!(user: @user, description: "child", parent: @creative)
+        topic = Collavre::Topic.create!(name: "Child T", creative: child, user: @user)
+        channel = GithubPrChannel.create!(
+          topic_id: topic.id,
+          config: { "repo_full_name" => "owner/repo", "pr_number" => 77, "pr_state" => "open" }
+        )
+        connect_github_account
+        stub_pull_request(state: "closed", merged: true)
+
+        result = PrStateSetService.new.call(topic_id: topic.id, pr_url: PR_URL)
+
+        assert result[:ok]
+        assert_equal "merged", channel.reload.pr_state
+      end
+
+      test "reports a usable fallback when no GitHub account is connected" do
+        result = PrStateSetService.new.call(topic_id: @topic.id, pr_url: PR_URL)
+
+        assert_equal false, result[:ok]
+        assert_includes result[:error], "state` explicitly"
+        assert_equal "open", @channel.reload.pr_state
+      end
+
+      test "reports a usable fallback when the GitHub API call fails" do
+        connect_github_account
+        stub_request(:get, "https://api.github.com/repos/owner/repo/pulls/77")
+          .to_return(status: 404, body: "{}", headers: { "Content-Type" => "application/json" })
+
+        result = PrStateSetService.new.call(topic_id: @topic.id, pr_url: PR_URL)
+
+        assert_equal false, result[:ok]
+        assert_includes result[:error], "state` explicitly"
+        assert_equal "open", @channel.reload.pr_state
+      end
+
+      # --- lookup and authorization ---------------------------------------
+
+      test "reports no channel when the PR was never attached" do
+        result = PrStateSetService.new.call(
+          topic_id: @topic.id,
+          pr_url: "https://github.com/owner/repo/pull/999",
+          state: "merged"
+        )
+
+        assert_equal false, result[:ok]
+        assert_includes result[:error], "pr_monitor"
+      end
+
+      test "matches a legacy channel row stored in mixed case" do
+        @channel.update!(config: @channel.config.merge("repo_full_name" => "Owner/Repo"))
+
+        result = PrStateSetService.new.call(topic_id: @topic.id, pr_url: PR_URL, state: "merged")
+
+        assert result[:ok]
+        assert_equal @channel.id, result[:channel_id]
+      end
+
+      test "raises on an invalid PR URL" do
+        assert_raises(ArgumentError) do
+          PrStateSetService.new.call(topic_id: @topic.id, pr_url: "https://example.com/nope", state: "merged")
+        end
+      end
+
+      test "denies the change when the current user lacks write permission" do
+        Collavre::Current.user = users(:two)
+
+        assert_raises(CollavreGithub::Tools::PermissionDeniedError) do
+          PrStateSetService.new.call(topic_id: @topic.id, pr_url: PR_URL, state: "merged")
+        end
+        assert_equal "open", @channel.reload.pr_state
+      end
+
+      test "does not reach a channel attached to a different topic" do
+        other_topic = Collavre::Topic.create!(name: "Other", creative: @creative, user: @user)
+
+        result = PrStateSetService.new.call(topic_id: other_topic.id, pr_url: PR_URL, state: "merged")
+
+        assert_equal false, result[:ok]
+        assert_equal "open", @channel.reload.pr_state
+      end
+
+      # The tool's own authorization gate rejects a creative-less topic before
+      # this runs, so the guard is exercised directly rather than through call.
+      test "resolves no GitHub client when the topic has no creative scope" do
+        service = PrStateSetService.new
+
+        @topic.stub(:creative, nil) do
+          assert_nil service.send(:github_client_for, @topic, "owner/repo")
+        end
+      end
+
+      test "is registered as an MCP tool named pr_state_set" do
+        assert_equal "pr_state_set", PrStateSetService.tool_metadata[:name]
+        state_param = PrStateSetService.tool_metadata[:params].find { |p| p[:name] == :state }
+        assert_equal false, state_param[:required]
+        assert_equal GithubPrChannel::PR_STATES, state_param[:enum]
+      end
+    end
+  end
+end

--- a/engines/collavre_github/test/services/collavre_github/tools/pr_state_set_service_test.rb
+++ b/engines/collavre_github/test/services/collavre_github/tools/pr_state_set_service_test.rb
@@ -24,7 +24,12 @@ module CollavreGithub
         Collavre::Current.user = nil
       end
 
-      def connect_github_account(repository_full_name: "owner/repo", creative: @creative)
+      def connect_github_account(
+        repository_full_name: "owner/repo",
+        creative: @creative,
+        repository_id: 101,
+        remote_repository_id: repository_id
+      )
         account = CollavreGithub::Account.create!(
           user: @user,
           github_uid: "12345",
@@ -35,8 +40,10 @@ module CollavreGithub
         CollavreGithub::RepositoryLink.create!(
           creative: creative,
           github_account: account,
-          repository_full_name: repository_full_name
+          repository_full_name: repository_full_name,
+          repository_id: repository_id
         )
+        stub_github_repository(repository_full_name.downcase, id: remote_repository_id) if remote_repository_id
         account
       end
 
@@ -154,6 +161,106 @@ module CollavreGithub
         assert_equal "merged", channel.reload.pr_state
       end
 
+      test "resync rejects a reused repository name whose stable id does not match" do
+        connect_github_account(repository_id: 111, remote_repository_id: 222)
+
+        result = PrStateSetService.new.call(topic_id: @topic.id, pr_url: PR_URL)
+
+        assert_equal false, result[:ok]
+        assert_includes result[:error], "No verified connected GitHub account"
+        assert_equal "open", @channel.reload.pr_state
+        assert_not_requested :get, "https://api.github.com/repos/owner/repo/pulls/77"
+      end
+
+      test "resync tries the next identity-valid account when the first cannot read the PR" do
+        child = Collavre::Creative.create!(user: @user, description: "child", parent: @creative)
+        topic = Collavre::Topic.create!(name: "Child T", creative: child, user: @user)
+        channel = GithubPrChannel.create!(
+          topic_id: topic.id,
+          config: { "repo_full_name" => "owner/repo", "pr_number" => 77, "pr_state" => "open" }
+        )
+        first_account = connect_github_account(remote_repository_id: nil)
+        second_user = users(:two)
+        second_account = CollavreGithub::Account.create!(
+          user: second_user,
+          github_uid: "67890",
+          login: "second-user",
+          name: "Second User",
+          token: "second-token"
+        )
+        CollavreGithub::RepositoryLink.create!(
+          creative: child,
+          github_account: second_account,
+          repository_full_name: "owner/repo",
+          repository_id: 101
+        )
+        identity = CollavreGithub::Client::RepositoryIdentity.new(id: 101, full_name: "owner/repo")
+        attempts = []
+        first_client = Object.new
+        first_client.define_singleton_method(:repository_identity) { |_repo| identity }
+        first_client.define_singleton_method(:pull_request_details) do |_repo, _number|
+          attempts << first_account.id
+          nil
+        end
+        second_client = Object.new
+        second_client.define_singleton_method(:repository_identity) { |_repo| identity }
+        second_client.define_singleton_method(:pull_request_details) do |_repo, _number|
+          attempts << second_account.id
+          Struct.new(:merged, :state).new(true, "closed")
+        end
+        clients = { first_account.id => first_client, second_account.id => second_client }
+
+        result = CollavreGithub::Client.stub(:new, ->(account) { clients.fetch(account.id) }) do
+          PrStateSetService.new.call(topic_id: topic.id, pr_url: PR_URL)
+        end
+
+        assert result[:ok]
+        assert_equal [ first_account.id, second_account.id ], attempts
+        assert_equal "merged", channel.reload.pr_state
+      end
+
+      test "resync skips an account whose repository identity lookup fails" do
+        child = Collavre::Creative.create!(user: @user, description: "child", parent: @creative)
+        topic = Collavre::Topic.create!(name: "Child T", creative: child, user: @user)
+        channel = GithubPrChannel.create!(
+          topic_id: topic.id,
+          config: { "repo_full_name" => "owner/repo", "pr_number" => 77, "pr_state" => "open" }
+        )
+        first_account = connect_github_account(remote_repository_id: nil)
+        second_user = users(:two)
+        second_account = CollavreGithub::Account.create!(
+          user: second_user,
+          github_uid: "67890",
+          login: "second-user",
+          name: "Second User",
+          token: "second-token"
+        )
+        CollavreGithub::RepositoryLink.create!(
+          creative: child,
+          github_account: second_account,
+          repository_full_name: "owner/repo",
+          repository_id: 101
+        )
+        identity = CollavreGithub::Client::RepositoryIdentity.new(id: 101, full_name: "owner/repo")
+        first_client = Object.new
+        first_client.define_singleton_method(:repository_identity) do |_repo|
+          raise Octokit::Unauthorized
+        end
+        second_client = Object.new
+        second_client.define_singleton_method(:repository_identity) { |_repo| identity }
+        second_client.define_singleton_method(:pull_request_details) do |_repo, _number|
+          Struct.new(:merged, :state).new(true, "closed")
+        end
+        clients = { first_account.id => first_client, second_account.id => second_client }
+
+        result = CollavreGithub::Client.stub(:new, ->(account) { clients.fetch(account.id) }) do
+          PrStateSetService.new.call(topic_id: topic.id, pr_url: PR_URL)
+        end
+
+        assert result[:ok]
+        assert_equal "merged", channel.reload.pr_state
+      end
+
       test "reports a usable fallback when no GitHub account is connected" do
         result = PrStateSetService.new.call(topic_id: @topic.id, pr_url: PR_URL)
 
@@ -222,11 +329,11 @@ module CollavreGithub
 
       # The tool's own authorization gate rejects a creative-less topic before
       # this runs, so the guard is exercised directly rather than through call.
-      test "resolves no GitHub client when the topic has no creative scope" do
+      test "resolves no verified GitHub clients when the topic has no creative scope" do
         service = PrStateSetService.new
 
         @topic.stub(:creative, nil) do
-          assert_nil service.send(:github_client_for, @topic, "owner/repo")
+          assert_empty service.send(:verified_github_clients_for, @topic, "owner/repo")
         end
       end
 


### PR DESCRIPTION
## Problem

A GitHub PR channel's state could only ever change through a `pull_request` webhook. When that delivery was missed — the hook was added after the merge, GitHub failed to deliver, the repo was renamed mid-flight — the chip stayed green on `open` forever, no closing message landed in the topic, and the channel was never detached.

The only user-facing action available was the chip's X (`dismiss!`), which hides the problem rather than fixing it. There was no way to correct the state at all.

## What this adds

`pr_state_set`, an MCP tool that applies the same end-state the webhook would have produced.

| param | required | notes |
|---|---|---|
| `topic_id` | yes | topic the PR channel is attached to |
| `pr_url` | yes | full GitHub PR URL |
| `state` | no | `open` / `merged` / `closed_without_merge` |

**Omitting `state` resynchronizes from the GitHub API**, and that is the preferred form: it structurally cannot record a state the PR does not actually have. `merged` is checked before `state`, because GitHub reports `state: "closed"` for both a merge and an abandonment — reading them the other way round would file every merged PR as `closed_without_merge`.

An explicit `state` remains available as a fallback for repositories with no connected GitHub account, and returns `state_source: "explicit"` so the caller can tell the two apart. When resync is impossible (no account in scope, API call failed) the tool returns `ok: false` with an error that names the fallback rather than guessing.

Scoped to the topic creative and its ancestors — the same RepositoryLink scope `pr_monitor` uses for webhook provisioning, so the tool can never reach a GitHub account the monitor itself could not have used. Before reading a PR, resync verifies that the live repository's stable ID matches a non-null `RepositoryLink#repository_id`, preventing a renamed repository's reused name from targeting the wrong PR. It then tries every identity-valid scoped account until one succeeds. Gated at `authorize_write!`, matching `pr_monitor`.

## Design notes

**`PrChannelStateUpdater` owns the transition.** Closing sets the badge, posts the closing message, then detaches — in that order, so the chip stays visible (now merged/closed) until the user dismisses it. Reopening reactivates, clears `dismissed_at`, and posts the reopened message. The whole transition runs under the channel's row lock in one transaction, so a failed injection rolls the state change back and the chip cannot flash `merged` without the matching timeline message.

**Idempotency is lifecycle-aware, not just state-equality.** A channel can read `open` while sitting detached — the user dismissed the chip, or a reopen event was missed. Treating matching state alone as "already settled" would skip the reactivation half, so `settled?` also checks that the channel's active/detached lifecycle matches the target.

**The webhook path deliberately does not route through the updater.** There, `handle` only *returns* the closing message and `WebhooksController` injects and detaches, because the controller owns the per-channel lock that also de-duplicates GitHub retries. Instead, `closed_message` was extracted as a public method on `GithubPrChannel` and both paths call it — that is the part that would actually drift. A test asserts the manual message is byte-identical to the webhook's.

**Message text is reused verbatim, not distinguished.** A correction is meant to leave the topic reading exactly as it would have if the event had arrived, so recovery is complete rather than annotated. Trade-off: the timeline does not mark that the state was set manually. If an audit marker is wanted later, it is a new i18n key, not a structural change.

**`PrChannelLocator` extracted** so `pr_monitor` and `pr_state_set` resolve a PR URL to a stored channel through identical logic. A mismatch there would mean the corrector silently misses the channel the monitor created. `pr_monitor` was refactored onto it; behavior is unchanged.

## Not in this PR

The chip badge stays a non-interactive `<span>`. The UI for manual state changes is deliberately deferred — `PrChannelStateUpdater` and `PATCH /channels/:id` are the seam it will land on, and `Channel#broadcast_chips_changed` already handles the realtime refresh.

## Tests

- `PrChannelStateUpdaterTest` (12): every transition, both noop shapes, the detached-but-open and merged-but-active edge cases, invalid state, injection-failure rollback, and webhook-message parity.
- `PrStateSetServiceTest` (21): explicit and resync paths, merged-vs-closed disambiguation, stable repository identity verification, reused-name rejection, multi-account fallback, identity lookup failure fallback, canonical-case RepositoryLink, ancestor-creative scope, both fallback errors, mixed-case legacy channel rows, cross-topic isolation, permission denial, tool registration.
- `PrChannelLocatorTest` (6): URL parsing, case-insensitive lookup, ancestor scoping.

All three new files are at **100% line and branch coverage**; every changed line in `github_pr_channel.rb` is covered.

```
engines/collavre_github: 312 runs, 1140 assertions, 0 failures, 0 errors, 0 skips
rubocop: 59 files inspected, no offenses detected
complexity ratchet: OK — 416 entities over budget (417 before), none grew
```