### PR TITLE
fix: prevent blank scroll during Agent Gateway navigation

### DIFF
--- a/engines/collavre/app/views/collavre/users/_llm_fields.html.erb
+++ b/engines/collavre/app/views/collavre/users/_llm_fields.html.erb
@@ -35,7 +35,8 @@
                     data: { agent_vendor_target: "gatewaySelect" } %>
     <small class="form-text text-muted">
       <%= t("collavre.users.new_ai.agent_gateway_help") %>
-      <%= link_to t("collavre.users.new_ai.manage_gateways"), collavre.agent_gateways_path %>
+      <%= link_to t("collavre.users.new_ai.manage_gateways"), collavre.agent_gateways_path,
+                  data: { turbo: false } %>
     </small>
     <% if selected_gateway %>
       <div class="alert alert-info mt-2">

--- a/engines/collavre/app/views/collavre/users/show.html.erb
+++ b/engines/collavre/app/views/collavre/users/show.html.erb
@@ -121,7 +121,8 @@
         <br>
         <%= link_to t('collavre.users.webauthn.manage'), collavre.passkeys_user_path(@user) %>
         <br>
-        <%= link_to t('collavre.agent_gateways.manage'), collavre.agent_gateways_path %>
+        <%= link_to t('collavre.agent_gateways.manage'), collavre.agent_gateways_path,
+                    data: { turbo: false } %>
         <br>
         <%= link_to t('doorkeeper.my_applications'), main_app.oauth_applications_path %>
         <% if @user.system_admin? %>

--- a/engines/collavre/test/controllers/users_controller_ai_test.rb
+++ b/engines/collavre/test/controllers/users_controller_ai_test.rb
@@ -16,6 +16,8 @@ class UsersControllerAiTest < ActionDispatch::IntegrationTest
     assert_select "form[action=?]", create_ai_users_path
     assert_select "input[name='llm_model'][maxlength=?]", Collavre::LlmModel::MAX_NAME_LENGTH.to_s
     assert_select "input[type='text'][name='llm_api_key'].masked-secret-field[autocomplete='off'][autocapitalize='none'][spellcheck='false']"
+    assert_select "a[href=?][data-turbo='false']", agent_gateways_path,
+                  text: I18n.t("collavre.users.new_ai.manage_gateways")
     assert_select "[data-controller='llm-model']" do |nodes|
       models = JSON.parse(nodes.first["data-llm-model-models-value"])
       assert_includes models, {

--- a/engines/collavre/test/controllers/users_controller_test.rb
+++ b/engines/collavre/test/controllers/users_controller_test.rb
@@ -526,6 +526,16 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_select "small", text: description, count: 0
   end
 
+  test "profile opens agent gateway settings outside Turbo navigation" do
+    sign_in_as(@regular_user, password: "password")
+
+    get collavre.user_path(@regular_user)
+
+    assert_response :success
+    assert_select "a[href=?][data-turbo='false']", collavre.agent_gateways_path,
+                  text: I18n.t("collavre.agent_gateways.manage")
+  end
+
   test "admin link appears in profile for system admin" do
     sign_in_as(@admin, password: "password")
     get collavre.user_path(@admin)


### PR DESCRIPTION
## Summary

- disable Turbo visits for Agent Gateway settings links in the profile and AI agent forms
- force a clean document navigation when leaving pages with a different scroll root
- add regression assertions for both entry points

## Verification

- `./bin/rubocop -a`
- `bin/complexity_check`
- `bin/rails test engines/collavre/test/controllers/users_controller_ai_test.rb engines/collavre/test/controllers/users_controller_test.rb` (58 tests, 352 assertions)
- `bundle exec rake test:system` (96 tests)
- browser instrumentation confirmed the settings visit no longer emits Turbo navigation events and lands at `scrollY = 0`

## Known local suite issue

- the full host suite reports 11 unrelated Active Record encryption configuration errors in GitHub webhook tests when run above the parallelization threshold; the affected test file passes independently
