### PR TITLE
fix(collavre): stop the folded bottom-left corner on the nav pill and the empty-state disc

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/creatives.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/creatives.css
@@ -1111,11 +1111,25 @@ creative-tree-row.is-being-edited .creative-tree {
     padding: var(--space-7) var(--space-3) var(--space-8);
 }
 
+/* The disc is painted by a gradient rather than by a border-radius background
+ * on purpose. Some Android devices (reproduced on a Galaxy S24 / Android 16,
+ * screenshot measured pixel by pixel) draw the *last* corner of a rounded-rect
+ * background fill — bottom-left — as the straight chord of its arc instead of
+ * the arc, which reads as a folded-over corner. It is the fill only; rounded
+ * borders on the same page come out correct. It is also independent of the
+ * radius value: `1e5px`, `9999px` and `50%` all resolve to the identical used
+ * radius (exactly 28 for this 56px box), so swapping the radius cannot help.
+ * A gradient never asks the rasteriser for a rounded rect in the first place.
+ *
+ * So: no border-radius on this rule. Putting one back reinstates the rounded
+ * background clip, and the artifact with it.
+ */
 .creative-empty-state-icon {
     width: 56px;
     height: 56px;
-    border-radius: var(--radius-round);
-    background: var(--surface-btn);
+    background: radial-gradient(circle closest-side,
+                                var(--surface-btn) calc(100% - 0.5px),
+                                transparent 100%);
     display: flex;
     align-items: center;
     justify-content: center;

--- a/engines/collavre/app/assets/stylesheets/collavre/gnb.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/gnb.css
@@ -61,9 +61,7 @@ nav #search {
 .progress-filter-btn {
     border-radius: var(--radius-3);
     border: none;
-    background: transparent;
     padding: var(--space-1) var(--space-2);
-    transition: background 0.2s var(--ease-out-2);
 }
 
 .progress-filter-btn:first-child {
@@ -79,9 +77,72 @@ nav #search {
 }
 
 .progress-filter-btn.active {
-    background: var(--surface-hover);
     color: var(--text-primary);
     font-weight: var(--weight-5);
+}
+
+/*
+ * Nav pills that toggle their selected surface in place
+ * -----------------------------------------------------
+ * The chat filter and the search trigger flip `.active` on a live page during
+ * turbo-frame navigation, so their surface changes where it sits instead of
+ * arriving already painted in a fresh document. Animating `background` there
+ * re-rasterises the pill's rounded corners on every frame of the transition,
+ * and mobile GPU rasterisers have been observed to mis-composite a corner arc
+ * under that load: the bottom-left arc is replaced by its own chord and the
+ * clipped sliver is drawn back on top, which reads as a folded corner.
+ *
+ * Put the surface on an overlay pseudo-element and cross-fade it with
+ * `opacity`, which the compositor animates without repainting. The rounded
+ * rect is rasterised once and only its alpha moves.
+ *
+ * `z-index: -1` keeps the overlay above the button's own background box and
+ * below its text; that needs the button to be a stacking context, hence
+ * `position: relative` + `z-index: 0`.
+ */
+.progress-filter-btn,
+.search-popup-trigger {
+    position: relative;
+    z-index: 0;
+    transition: color 0.2s var(--ease-out-2);
+}
+
+.progress-filter-btn::before,
+.search-popup-trigger::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    z-index: -1;
+    border-radius: inherit;
+    background: var(--surface-hover);
+    opacity: 0;
+    transition: opacity 0.2s var(--ease-out-2);
+    pointer-events: none;
+    will-change: opacity;
+}
+
+.progress-filter-btn:hover::before,
+.progress-filter-btn:active::before,
+.progress-filter-btn.active::before,
+.search-popup-trigger:hover::before,
+.search-popup-trigger:active::before,
+.search-popup-trigger.active::before {
+    opacity: 1;
+}
+
+/*
+ * The button itself has to stay transparent in every state, otherwise the
+ * `nav a/button` surfaces above would stack on top of the overlay.
+ */
+.progress-filter-btn,
+.progress-filter-btn:hover,
+.progress-filter-btn:active,
+.progress-filter-btn.active,
+.search-popup-trigger,
+.search-popup-trigger:hover,
+.search-popup-trigger:active,
+.search-popup-trigger.active {
+    background: transparent;
 }
 
 /* ChatGPT-style popup menu overrides */

--- a/engines/collavre/app/assets/stylesheets/collavre/search_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/search_popup.css
@@ -41,8 +41,8 @@
   text-overflow: ellipsis;
 }
 
+/* The selected surface is drawn by the overlay pseudo-element in gnb.css. */
 .search-popup-trigger.active {
-  background: var(--surface-hover);
   color: var(--text-primary);
   font-weight: var(--weight-5);
 }

--- a/engines/collavre/app/views/collavre/creatives/_empty_state.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/_empty_state.html.erb
@@ -17,8 +17,15 @@
       <rect x="3" y="3" width="7" height="5" rx="1"/>
       <rect x="14" y="10" width="7" height="5" rx="1"/>
       <rect x="14" y="17.5" width="7" height="5" rx="1" opacity="0.45"/>
-      <path d="M6.5 8v9a2 2 0 0 0 2 2H14M6.5 10.5V12.5"/>
-      <path d="M6.5 8v2.5a2 2 0 0 0 2 2H14"/>
+      <%# Trunk plus the elbow into the lower node. The elbow has to land on the
+          node's vertical centre (y=20 for a rect at y=17.5, height 5) — ending
+          at y=19 ran the connector into the node's rounded top-left corner,
+          which at this icon's 28px render size reads as a folded corner. %>
+      <path d="M6.5 8v10a2 2 0 0 0 2 2H14"/>
+      <%# Elbow into the upper node. It starts at the branch point instead of
+          re-drawing the trunk from y=8: two separately antialiased strokes over
+          the same pixels leave a visible step where the overlap ends. %>
+      <path d="M6.5 10.5a2 2 0 0 0 2 2H14"/>
     </svg>
   </div>
   <h3 class="creative-empty-state-heading"><%= heading %></h3>

--- a/engines/collavre/test/controllers/creatives_controller_empty_state_test.rb
+++ b/engines/collavre/test/controllers/creatives_controller_empty_state_test.rb
@@ -187,4 +187,26 @@ class CreativesControllerEmptyStateTest < ActionDispatch::IntegrationTest
     assert_select "#creatives div[data-creatives-empty-state]", count: 0
     assert_select "#creatives > div[data-creatives-tree-loading]", count: 1
   end
+
+  # The empty-state icon is a hand-authored SVG rendered at 28px, where a 1-unit
+  # geometry error is a visible defect. Two rules keep it clean:
+  #   * each connector ends on its node's vertical centre, so it does not run
+  #     into the node's rounded corner and read as a folded corner;
+  #   * the two connectors never re-trace the same run of trunk, because two
+  #     separately antialiased strokes over the same pixels leave a step.
+  test "empty state tree icon connectors land on their node centres and do not overlap" do
+    sign_in_as(users(:one), password: "password")
+
+    get creatives_path
+
+    assert_response :success
+    icon = css_select(".creative-empty-state-icon svg").first
+    assert_not_nil icon
+
+    nodes = icon.css("rect").map { |r| r["y"].to_f + r["height"].to_f / 2 }
+    assert_equal [ 5.5, 12.5, 20.0 ], nodes
+
+    paths = icon.css("path").map { |p| p["d"] }
+    assert_equal [ "M6.5 8v10a2 2 0 0 0 2 2H14", "M6.5 10.5a2 2 0 0 0 2 2H14" ], paths
+  end
 end

--- a/engines/collavre/test/system/creative_empty_state_icon_disc_test.rb
+++ b/engines/collavre/test/system/creative_empty_state_icon_disc_test.rb
@@ -1,0 +1,85 @@
+require_relative "../application_system_test_case"
+
+# The empty-state disc is painted by a radial-gradient rather than by a
+# border-radius background, to dodge an Android rasteriser defect that draws the
+# last corner of a rounded-rect *fill* — bottom-left — as the straight chord of
+# its arc. On a Galaxy S24 that turns the 56px disc into a shape with one folded
+# corner. Rounded borders on the same page are unaffected, and the radius value
+# makes no difference (1e5px, 9999px and 50% all resolve to the same used radius
+# of 28px for this box), so the only fix available to us is to stop asking for a
+# rounded rect at all.
+#
+# These guard the two halves of that: no rounded background clip may come back,
+# and the disc must still actually be painted and actually be circular.
+class CreativeEmptyStateIconDiscTest < ApplicationSystemTestCase
+  ICON = ".creative-empty-state-icon".freeze
+
+  setup do
+    @user = User.create!(
+      email: "user@example.com",
+      password: SystemHelpers::PASSWORD,
+      name: "User",
+      email_verified_at: Time.current,
+      notifications_enabled: false
+    )
+    @parent_creative = Creative.create!(description: "Parent", user: @user)
+
+    resize_window_to
+    sign_in_via_ui(@user)
+    visit collavre.creative_path(@parent_creative)
+    wait_for_network_idle(timeout: 10)
+    assert_selector ICON, visible: true, wait: 5
+  end
+
+  # The regression guard. Re-adding any border-radius reinstates the rounded
+  # background clip, and the folded corner with it.
+  test "the disc carries no rounded-rect background clip" do
+    radii = computed(ICON, %w[
+      borderTopLeftRadius borderTopRightRadius
+      borderBottomRightRadius borderBottomLeftRadius
+    ])
+
+    radii.each do |corner, value|
+      assert_equal 0.0, value.to_f,
+        "#{corner} is #{value}; a rounded background clip is what folds on Android"
+    end
+  end
+
+  test "the disc is still painted, as a gradient" do
+    background = computed(ICON, %w[backgroundImage backgroundColor])
+
+    assert_match(/radial-gradient/, background["backgroundImage"],
+      "the disc is no longer painted at all")
+    assert_match(/closest-side/, background["backgroundImage"],
+      "without closest-side the gradient sizes to the corner, not the edge")
+    assert_match(/rgba\(0,\s*0,\s*0,\s*0\)|transparent/, background["backgroundColor"],
+      "a flat background-color would paint a square behind the disc")
+  end
+
+  # `circle closest-side` inscribes the disc in the *shorter* side, so a
+  # non-square box would render a circle with two flat sides rather than the
+  # ellipse a percentage radius used to give. Keep the box square.
+  test "the icon box is square, so closest-side yields a full circle" do
+    box = page.evaluate_script(
+      "(() => { const r = document.querySelector(#{ICON.to_json}).getBoundingClientRect();" \
+      " return { w: r.width, h: r.height }; })()"
+    )
+
+    assert_operator box["w"], :>, 0
+    assert_in_delta box["w"], box["h"], 0.5,
+      "icon box is #{box['w']}x#{box['h']}; closest-side would flatten two sides"
+  end
+
+  private
+
+  def computed(selector, properties)
+    page.evaluate_script(<<~JS)
+      (() => {
+        const style = getComputedStyle(document.querySelector(#{selector.to_json}));
+        const out = {};
+        #{properties.to_json}.forEach((p) => { out[p] = style[p]; });
+        return out;
+      })()
+    JS
+  end
+end

--- a/engines/collavre/test/system/creative_filter_navigation_test.rb
+++ b/engines/collavre/test/system/creative_filter_navigation_test.rb
@@ -89,6 +89,68 @@ class CreativeFilterNavigationTest < ApplicationSystemTestCase
     assert_selector "turbo-frame#creative-workspace-content"
   end
 
+  # The pill's selected surface must live on the ::before overlay and cross-fade
+  # with opacity. Animating `background` on the button itself re-rasterises its
+  # rounded corners on every frame, which is what produced the folded-corner
+  # artifact on mobile once the filter started toggling `.active` in place
+  # instead of reloading the page.
+  def computed(element, property, pseudo = nil)
+    target = pseudo ? "'#{pseudo}'" : "null"
+    page.evaluate_script(
+      "getComputedStyle(arguments[0], #{target}).getPropertyValue('#{property}').trim()",
+      element
+    )
+  end
+
+  def assert_eventually_equal(expected, element, property, pseudo = nil)
+    deadline = Time.current + Capybara.default_max_wait_time
+    actual = computed(element, property, pseudo)
+    while actual != expected && Time.current < deadline
+      sleep 0.05
+      actual = computed(element, property, pseudo)
+    end
+    assert_equal expected, actual
+  end
+
+  TRANSPARENT = "rgba(0, 0, 0, 0)".freeze
+
+  test "chat filter draws its selected surface on an opacity overlay" do
+    visit collavre.creatives_path
+    button = find(COMMENT_BUTTON)
+
+    assert_equal TRANSPARENT, computed(button, "background-color")
+    assert_equal "0", computed(button, "opacity", "::before")
+    assert_equal "opacity", computed(button, "transition-property", "::before")
+    refute_includes computed(button, "transition-property"), "background"
+    refute_equal TRANSPARENT, computed(button, "background-color", "::before")
+
+    button.click
+    assert_selector "#{COMMENT_BUTTON}.active"
+
+    assert_eventually_equal "1", button, "opacity", "::before"
+    assert_equal TRANSPARENT, computed(button, "background-color"),
+                 "the active button must stay transparent so the overlay is the only surface"
+  end
+
+  test "search trigger draws its selected surface on an opacity overlay" do
+    visit collavre.creatives_path
+    trigger = find(".search-popup-trigger")
+
+    assert_equal TRANSPARENT, computed(trigger, "background-color")
+    assert_equal "0", computed(trigger, "opacity", "::before")
+    assert_equal "opacity", computed(trigger, "transition-property", "::before")
+    refute_includes computed(trigger, "transition-property"), "background"
+
+    trigger.click
+    fill_in "search", with: "Root"
+    find("#search").send_keys(:enter)
+
+    assert_selector ".search-popup-trigger.active"
+    trigger = find(".search-popup-trigger")
+    assert_eventually_equal "1", trigger, "opacity", "::before"
+    assert_equal TRANSPARENT, computed(trigger, "background-color")
+  end
+
   test "tree navigation clears persistent search controls with the filter URL" do
     visit collavre.creatives_path
     find(".search-popup-trigger").click


### PR DESCRIPTION
Two mobile reports, one device-side cause, two different levers.

Both are the same shape defect: on a Galaxy S24 / Android 16, the **bottom-left
corner of a rounded-rect background fill** is drawn as the straight chord of its
arc instead of the arc. Bottom-left is the last corner Skia emits when it builds
a rounded-rect path, and the artifact is the arc for that corner coming out as a
line segment.

## Evidence

Measured from the reported screenshot (1080x2340, original JPEG, per-row
boundary extraction), not inferred:

| element | radius (device px) | bottom-left | other three corners |
|---|---|---|---|
| empty-state disc | 76 | straight, **exactly** +1px/row for 67 rows | perfect arcs (within JPEG noise) |
| nav avatar `<img>` | 43 | straight, 21-row linear run | arcs |
| facet chip x3 | 27 | straight, 20-22 row linear run | arcs |
| concept block **fill** | 27 | straight, 17-row linear run | arcs |
| concept block **border ring** | 27 | arc | arcs |

For the disc, the chord runs between the exact two endpoints of the bottom-left
quarter-arc — the top/right/bottom-right boundary tracks a perfect circle to
within +/-1px while the bottom-left tracks the chord exactly.

Two things follow:

* **It is the fill, not the border.** The concept block's blue border ring is a
  correct arc while the background fill *behind it* is beveled.
* **It is not the radius value.** Replaying Blink's
  `FloatRoundedRect::ConstrainRadii` in float32: `1e5px`, `9999px` and `50%` all
  produce a used radius of exactly `28.0` for a 56px box. They hand the
  rasteriser a bit-identical rounded rect, so changing radius notation is a
  no-op. (This kills the "use `border-radius: 50%`" theory — worth stating,
  because it looks like a fix and isn't one.)

Not reproducible in desktop Chromium at the same scale, on either CPU or forced
GPU raster — consistent with it being in the device's rasteriser.

Nothing in our CSS asks for a beveled corner: no `corner-shape`, no per-corner
radius, no `clip-path`, no `mask` anywhere in the codebase.

## What this PR changes

**1. Empty-state disc — painted as a gradient instead of a rounded rect.**

The only lever we have is to stop asking for a rounded rect. A
`radial-gradient` paints the disc with a shader over a plain rect, so there is
no rounded-rect geometry to degrade.

Rendering is unchanged: diffing the icon as the app renders it, before against
after, 5.8% of channels differ by at most 19/255 (mean 0.275) and all of them
sit on the antialiased edge ring. In isolation across DPR 1 / 2 / 2.7 / 3 the
mean difference is 0.27-0.41 of 255.

**2. Nav pill — cross-fade with `opacity` instead of `background`.**

`.progress-filter-btn` / `.search-popup-trigger` moved their surface onto a
`::before` layer that cross-fades with `opacity`. Since #1506 these pills toggle
`.active` in place on a live page rather than reloading, so
`transition: background` repaints the rounded surface every frame for 200ms.
`opacity` is composited, so the surface is not re-rasterised at all.

That removes the *repaint*, which is what made this one loud: the reported pill
showed the beveled sliver at doubled alpha (background 24, pill 42, sliver 59 —
`1-0.92^2` over `--surface-nav`), i.e. a correct paint and a beveled paint
overlapping. Removing the repaint removes the doubling. A residual plain bevel
on a 16px radius may still be there on that device; see below.

Also applied to `.search-popup-trigger`, the adjacent pill, which toggles
`.active` identically and would grow the same problem next.

One behaviour change: these two buttons' press tint is now the same surface as
hover. It was `color-mix(in srgb, var(--surface-hover) 80%, var(--text-primary) 5%)`,
whose percentages sum to 85% and therefore scale the result alpha to 0.098 vs
hover's 0.08 — under 2% apart, and brighter rather than darker. Other `nav a:active`
buttons are untouched.

**3.** The empty-state tree glyph's connectors were straightened (elbow landing
on the lower node's centre instead of its rounded corner, trunk no longer drawn
twice). Unrelated polish — it is not the reported fold, which is the disc behind
the glyph.

## Tests

* `creative_empty_state_icon_disc_test.rb` (new) — no rounded background clip
  may come back on the disc, the gradient must still paint it, and the box must
  stay square so `closest-side` yields a full circle rather than a
  flat-sided one.
* `creative_filter_navigation_test.rb` — both pills carry a transparent own
  background, the surface lives on `::before`, `opacity` goes 0 -> 1 on
  activation, and `transition-property` is `opacity`. The last one is the guard:
  re-adding a `background` transition fails it.
* `creatives_controller_empty_state_test.rb` — connector geometry.

All verified to fail against the pre-fix CSS before being kept:
`borderBottomLeftRadius is 100000px` and `Expected /radial-gradient/ to match "none"`
for the disc, 2 failures for the pills.

`31 runs, 278 assertions, 0 failures` across the empty-state and nav suites.
Rubocop clean.

## Not covered

* **Unconfirmed on the hardware.** The defect is not reproducible off-device, so
  this removes the mechanism by construction rather than by observation. A probe
  page comparing nine techniques (`border-radius`, `50%`, gradient, `clip-path`,
  `mask-image`, `will-change`, border-vs-fill, rounded square, SVG) is served
  from the preview for a device screenshot to settle which techniques survive.
  Not committed — it is a diagnostic, not product.
* The avatar, the facet chips and the concept block have the same defect on that
  device with a much smaller bevel. Left alone until the probe says which
  workaround actually holds, rather than spreading an unverified one.
* nav buttons render 41px tall against a 32px layout on that device — Blink text
  autosizing scales fonts but not `rem` lengths, so nav sizing does not survive
  the browser's text-size setting.
* Creative titles are clipped on the left while the nav is intact — horizontal
  overflow of the creative list on mobile.

Both look like separate creatives.