### PR TITLE
fix: return to contacts after updating AI agent

### DIFF
--- a/engines/collavre/app/controllers/concerns/collavre/users_controller/ai_user_management.rb
+++ b/engines/collavre/app/controllers/concerns/collavre/users_controller/ai_user_management.rb
@@ -55,7 +55,7 @@ module Collavre
       end
 
       if saved
-        redirect_to user_path(Current.user, tab: "contacts"), notice: I18n.t("collavre.users.create_ai.success")
+        redirect_to current_user_contacts_path, notice: I18n.t("collavre.users.create_ai.success")
       else
         flash.now[:alert] = @user.errors.full_messages.to_sentence
         @available_tools = load_available_tools
@@ -106,7 +106,7 @@ module Collavre
       end
 
       if updated
-        redirect_to edit_ai_user_path(@user), notice: I18n.t("collavre.users.update_ai.success")
+        redirect_to current_user_contacts_path, notice: I18n.t("collavre.users.update_ai.success")
       else
         @available_tools = load_available_tools
         @llm_models = Collavre::LlmModel.suggestions
@@ -117,6 +117,10 @@ module Collavre
     end
 
     private
+
+    def current_user_contacts_path
+      user_path(Current.user, tab: "contacts")
+    end
 
     def remember_llm_model(user)
       Collavre::LlmModel.remember!(

--- a/engines/collavre/test/controllers/users_controller_ai_test.rb
+++ b/engines/collavre/test/controllers/users_controller_ai_test.rb
@@ -177,7 +177,7 @@ class UsersControllerAiTest < ActionDispatch::IntegrationTest
       }
     }
 
-    assert_redirected_to edit_ai_user_path(@ai_user)
+    assert_redirected_to user_path(@admin, tab: "contacts")
     assert_equal "Renamed inactive proxy agent", @ai_user.reload.name
     assert_equal gateway, @ai_user.agent_gateway
   end
@@ -239,7 +239,7 @@ class UsersControllerAiTest < ActionDispatch::IntegrationTest
     assert_equal "This user is not an AI agent.", flash[:alert]
   end
 
-  test "should update ai user" do
+  test "should update ai user and redirect to contacts" do
     patch update_ai_user_url(@ai_user), params: {
       user: {
         name: "Updated Bot Name",
@@ -248,7 +248,7 @@ class UsersControllerAiTest < ActionDispatch::IntegrationTest
         searchable: true
       }
     }
-    assert_redirected_to edit_ai_user_path(@ai_user)
+    assert_redirected_to user_path(@admin, tab: "contacts")
     @ai_user.reload
     assert_equal "Updated Bot Name", @ai_user.name
     assert_equal "New prompt", @ai_user.system_prompt
@@ -378,7 +378,7 @@ class UsersControllerAiTest < ActionDispatch::IntegrationTest
       user: { name: "Updated Bot Name", llm_api_key: "" }
     }
 
-    assert_redirected_to edit_ai_user_path(@ai_user)
+    assert_redirected_to user_path(@admin, tab: "contacts")
     assert_equal "existing-secret-key", @ai_user.reload.llm_api_key
   end
 
@@ -389,7 +389,7 @@ class UsersControllerAiTest < ActionDispatch::IntegrationTest
       user: { llm_api_key: "", clear_llm_api_key: "1" }
     }
 
-    assert_redirected_to edit_ai_user_path(@ai_user)
+    assert_redirected_to user_path(@admin, tab: "contacts")
     assert_nil @ai_user.reload.llm_api_key
   end
 
@@ -413,7 +413,7 @@ class UsersControllerAiTest < ActionDispatch::IntegrationTest
       user: { llm_api_key: "replacement-secret-key" }
     }
 
-    assert_redirected_to edit_ai_user_path(@ai_user)
+    assert_redirected_to user_path(@admin, tab: "contacts")
     assert_equal "replacement-secret-key", @ai_user.reload.llm_api_key
   end
 
@@ -440,7 +440,7 @@ class UsersControllerAiTest < ActionDispatch::IntegrationTest
         routing_expression: 'chat.content contains "help"'
       }
     }
-    assert_redirected_to edit_ai_user_path(@ai_user)
+    assert_redirected_to user_path(@admin, tab: "contacts")
     @ai_user.reload
     assert_equal 'chat.content contains "help"', @ai_user.routing_expression
   end
@@ -451,7 +451,7 @@ class UsersControllerAiTest < ActionDispatch::IntegrationTest
         routing_expression: 'event_name == "comment_created"'
       }
     }
-    assert_redirected_to edit_ai_user_path(@ai_user)
+    assert_redirected_to user_path(@admin, tab: "contacts")
     @ai_user.reload
     assert_equal 'event_name == "comment_created"', @ai_user.routing_expression
   end


### PR DESCRIPTION
## Summary
- redirect successful AI agent updates to the signed-in user's contacts list
- reuse a shared contacts path helper for AI agent create and update redirects
- update controller tests to cover the contacts redirect

## Testing
- `mise exec -- ./bin/rubocop -a`
- `mise exec -- bin/complexity_check`
- `mise exec -- bin/rails test engines/collavre/test/controllers/users_controller_ai_test.rb` (27 tests, 176 assertions)
- `mise exec -- bundle exec rake test:system` (99 tests, 629 assertions, 2 skips)

## Local suite note
- `mise exec -- bin/rails test` currently reports 11 existing Active Record encryption credential errors in GitHub webhook tests; the 11 affected tests pass when run directly.