### PR TITLE
test(collavre): guard the nav pill's active overlay against hover masking

### DIFF
--- a/engines/collavre/test/system/creative_filter_navigation_test.rb
+++ b/engines/collavre/test/system/creative_filter_navigation_test.rb
@@ -114,6 +114,18 @@ class CreativeFilterNavigationTest < ApplicationSystemTestCase
 
   TRANSPARENT = "rgba(0, 0, 0, 0)".freeze
 
+  # Selenium parks the pointer wherever it last clicked, so `:hover::before`
+  # holds the overlay at opacity 1 on its own. Asserting the active surface
+  # while the pill is still hovered proves nothing -- the assertion would pass
+  # with `.active::before` deleted, even though keyboard activation and a
+  # filter restored from the URL would then render no selected surface. Park
+  # the pointer in the corner and confirm the pill really lost `:hover`.
+  def unhover(element)
+    page.driver.browser.action.move_to_location(0, 0).perform
+    refute page.evaluate_script("arguments[0].matches(':hover')", element),
+           "pointer still rests on the pill, so :hover would mask .active"
+  end
+
   test "chat filter draws its selected surface on an opacity overlay" do
     visit collavre.creatives_path
     button = find(COMMENT_BUTTON)
@@ -126,6 +138,8 @@ class CreativeFilterNavigationTest < ApplicationSystemTestCase
 
     button.click
     assert_selector "#{COMMENT_BUTTON}.active"
+    button = find(COMMENT_BUTTON)
+    unhover(button)
 
     assert_eventually_equal "1", button, "opacity", "::before"
     assert_equal TRANSPARENT, computed(button, "background-color"),
@@ -147,6 +161,8 @@ class CreativeFilterNavigationTest < ApplicationSystemTestCase
 
     assert_selector ".search-popup-trigger.active"
     trigger = find(".search-popup-trigger")
+    unhover(trigger)
+
     assert_eventually_equal "1", trigger, "opacity", "::before"
     assert_equal TRANSPARENT, computed(trigger, "background-color")
   end


### PR DESCRIPTION
Follow-up to #1581, addressing the Codex review comment on that PR.

## The problem

The two overlay tests added in #1581 asserted `opacity: 1` on `::before` right after `button.click` / `trigger.click`. Selenium leaves the pointer parked where it clicked, so `.progress-filter-btn:hover::before` (and `.search-popup-trigger:hover::before`) drove the pseudo-element to opacity 1 on its own. The `.active::before` half of that selector list was never exercised.

That matters because `.active` is the state a filter lands in when it is activated by keyboard, or when the page is loaded with the filter already in the URL — neither of which involves a pointer. Dropping `.active::before` would have shipped a selected filter with no visible surface, and CI would have stayed green.

Confirmed by mutation on the merged code — with both `.active::before` selectors deleted:

```
8 runs, 47 assertions, 0 failures, 0 errors, 0 skips
```

## The fix

Park the pointer at the viewport corner before asserting, and assert the pill no longer matches `:hover`, so only `.active` can be holding the overlay up.

```ruby
def unhover(element)
  page.driver.browser.action.move_to_location(0, 0).perform
  refute page.evaluate_script("arguments[0].matches(':hover')", element),
         "pointer still rests on the pill, so :hover would mask .active"
end
```

## Verification

Same mutation, with the guard in place — both tests now fail, for the right reason:

```
CreativeFilterNavigationTest#test_chat_filter_draws_its_selected_surface_on_an_opacity_overlay
Expected: "1"
  Actual: "0"
```

With `.active::before` restored:

```
8 runs, 49 assertions, 0 failures, 0 errors, 0 skips
```

Tests only — no production code changes.