### PR TITLE
Fix pr_monitor response destination context

### DIFF
--- a/engines/collavre_github/app/services/collavre_github/tools/pr_monitor_service.rb
+++ b/engines/collavre_github/app/services/collavre_github/tools/pr_monitor_service.rb
@@ -14,7 +14,8 @@ module CollavreGithub
       tool_description <<~DESC.strip
         Attach a GitHub PR monitor to a Collavre topic. After attachment,
         PR comments, review comments, and review submissions are injected
-        into the topic as chat messages. Idempotent.
+        into the topic as chat messages. The response identifies the attached
+        topic and creative and uses a typed channel reference. Idempotent.
       DESC
 
       tool_param :topic_id, description: "The Collavre topic id to attach the PR channel to."
@@ -34,7 +35,14 @@ module CollavreGithub
           channel.inject_into_topic!(channel.attached_message)
         end
 
-        result = { ok: true, channel_id: channel.id, repo: repo, pr_number: pr_number }
+        result = {
+          ok: true,
+          channel_ref: "ch_#{channel.id}",
+          topic: { id: topic.id, name: topic.name },
+          creative: { id: topic.creative.id, title: topic.creative.creative_snippet },
+          repo: repo,
+          pr_number: pr_number
+        }
         warning = ensure_webhook_events(topic, repo)
         result[:webhook_warning] = warning if warning
         result

--- a/engines/collavre_github/test/services/collavre_github/tools/pr_monitor_service_test.rb
+++ b/engines/collavre_github/test/services/collavre_github/tools/pr_monitor_service_test.rb
@@ -30,12 +30,28 @@ module CollavreGithub
         assert_equal 77, channel.pr_number
       end
 
-      test "first attach seeds chip label and link so the chip is clickable before any webhook fires" do
+      test "returns a tagged channel reference and semantic destination context" do
+        creative = creatives(:unconvert_target)
+        topic = Collavre::Topic.create!(name: "Review", creative: creative, user: @user)
+
         result = PrMonitorService.new.call(
+          topic_id: topic.id,
+          pr_url: "https://github.com/owner/repo/pull/77"
+        )
+
+        channel = GithubPrChannel.last
+        assert_equal "ch_#{channel.id}", result[:channel_ref]
+        assert_not result.key?(:channel_id)
+        assert_equal({ id: topic.id, name: "Review" }, result[:topic])
+        assert_equal({ id: creative.id, title: "Unconvert Target" }, result[:creative])
+      end
+
+      test "first attach seeds chip label and link so the chip is clickable before any webhook fires" do
+        PrMonitorService.new.call(
           topic_id: @topic.id,
           pr_url: "https://github.com/owner/repo/pull/77"
         )
-        channel = GithubPrChannel.find(result[:channel_id])
+        channel = GithubPrChannel.last
         assert_equal "PR #77", channel.latest_label
         assert_equal "https://github.com/owner/repo/pull/77", channel.latest_link
       end
@@ -79,7 +95,7 @@ module CollavreGithub
           pr_url: "https://github.com/Owner/Repo/pull/88"
         )
         assert result[:ok]
-        channel = GithubPrChannel.find(result[:channel_id])
+        channel = GithubPrChannel.last
         assert_equal "owner/repo", channel.repo_full_name
       end
 
@@ -92,7 +108,7 @@ module CollavreGithub
           topic_id: @topic.id,
           pr_url: "https://github.com/OWNER/REPO/pull/99"
         )
-        assert_equal first[:channel_id], second[:channel_id]
+        assert_equal first[:channel_ref], second[:channel_ref]
         assert_equal 1, GithubPrChannel.where(topic_id: @topic.id).count
       end
 
@@ -122,7 +138,7 @@ module CollavreGithub
         )
 
         assert result[:ok]
-        assert_equal channel.id, result[:channel_id]
+        assert_equal "ch_#{channel.id}", result[:channel_ref]
         assert channel.reload.active?
       end
 


### PR DESCRIPTION
## Summary

- replace the raw channel ID with a typed `ch_` channel reference
- return the attached topic ID/name and its creative ID/title in the success response
- omit ancestor creatives so the response exposes only the topic destination creative
- cover the response contract and update existing channel assertions

## Tests

- `mise exec -- bundle exec rails test engines/collavre_github/test/services/collavre_github/tools/pr_monitor_service_test.rb`
- `mise exec -- bundle exec rubocop engines/collavre_github/app/services/collavre_github/tools/pr_monitor_service.rb engines/collavre_github/test/services/collavre_github/tools/pr_monitor_service_test.rb`
- `mise exec -- bin/complexity_check`