### PR TITLE
fix: prevent duplicate topic scroll after fullscreen exit

### DIFF
--- a/engines/collavre/app/javascript/controllers/comments/__tests__/popup_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/popup_controller.test.js
@@ -73,6 +73,48 @@ describe('CommentsPopupController', () => {
         expect(document.body.classList.contains('chat-fullscreen')).toBe(false)
     })
 
+    test('scrolls to the active topic only once after exiting fullscreen', () => {
+        jest.useFakeTimers()
+        const popup = document.getElementById('comments-popup')
+        const scrollToActiveTopic = jest.fn()
+        Object.defineProperty(controller, 'topicsController', {
+            configurable: true,
+            value: {
+                clearOverrideTopicId: jest.fn(),
+                onPopupClosed: jest.fn(),
+                onPopupOpened: jest.fn(),
+                scrollToActiveTopic,
+            },
+        })
+        popup.dataset.fullscreen = 'true'
+        popup.dataset.creativeId = '123'
+        controller._savedStyles = {
+            top: '10px',
+            right: '20px',
+            left: '',
+            width: '300px',
+            height: '400px',
+        }
+        const addEventListener = jest.spyOn(popup, 'addEventListener')
+
+        try {
+            controller.toggleFullscreen()
+            const transitionCleanup = addEventListener.mock.calls.find(
+                ([type]) => type === 'transitionend',
+            )[1]
+            transitionCleanup()
+            transitionCleanup()
+            jest.advanceTimersByTime(300)
+
+            expect(scrollToActiveTopic).toHaveBeenCalledTimes(1)
+            expect(jest.getTimerCount()).toBe(0)
+        } finally {
+            addEventListener.mockRestore()
+            delete controller.topicsController
+            jest.useRealTimers()
+        }
+    })
+
     test('clears resized dataset attribute on close', () => {
         const triggerBtn = document.getElementById('trigger-btn')
         const popup = document.getElementById('comments-popup')

--- a/engines/collavre/app/javascript/controllers/comments/popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_controller.js
@@ -1183,7 +1183,15 @@ export default class extends Controller {
       el.style.width = `${animWidth}px`
       el.style.height = `${animHeight}px`
 
+      let cleanupTimer = null
+      let cleanedUp = false
       const cleanup = () => {
+        if (cleanedUp) return
+        cleanedUp = true
+        if (cleanupTimer !== null) {
+          clearTimeout(cleanupTimer)
+          cleanupTimer = null
+        }
         el.removeEventListener('transitionend', cleanup)
         // Popup is always position: fixed — just apply final coords
         el.style.transition = 'none'
@@ -1224,7 +1232,7 @@ export default class extends Controller {
         this.topicsController?.scrollToActiveTopic()
       }
       el.addEventListener('transitionend', cleanup, { once: true })
-      setTimeout(cleanup, 300)
+      cleanupTimer = setTimeout(cleanup, 300)
 
       // Update URL — append open_comments=true so the popup stays open on refresh
       let backUrl = this._previousUrl || (creativeId ? `/creatives/${creativeId}` : null)


### PR DESCRIPTION
## Summary

- make the desktop fullscreen-exit cleanup idempotent
- cancel the fallback timer after `transitionend` completes cleanup
- add regression coverage for duplicate active-topic scrolling

## Testing

- `npm test -- engines/collavre/app/javascript/controllers/comments/__tests__/popup_controller.test.js --runInBand --coverage --collectCoverageFrom=engines/collavre/app/javascript/controllers/comments/popup_controller.js --coverageReporters=json`
- `npm run build`
- `mise exec -- bin/complexity_check`