### PR TITLE
Fix slash command popup focus after submit

### DIFF
--- a/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_stashed_draft_failure.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_stashed_draft_failure.test.js
@@ -44,6 +44,7 @@ const buildController = () => {
   }
 
   const controller = Object.create(CommentsFormController.prototype)
+  Object.defineProperty(controller, 'element', { get: () => document.getElementById('comments-popup') })
   Object.defineProperty(controller, 'textareaTarget', { get: () => textarea })
   Object.defineProperty(controller, 'formTarget', { get: () => form })
   Object.defineProperty(controller, 'listController', { get: () => listCtrl })
@@ -127,6 +128,8 @@ describe('CommentsFormController stashed draft across a send failure', () => {
 
   test('still restores the draft into the box a successful send cleared', async () => {
     const { controller, textarea } = buildController()
+    const settled = jest.fn()
+    controller.element.addEventListener('comments--form:submit-settled', settled)
     global.fetch.mockResolvedValue({ ok: true, text: () => Promise.resolve('<div></div>') })
 
     stash(controller, 'roadmap notes')
@@ -137,6 +140,7 @@ describe('CommentsFormController stashed draft across a send failure', () => {
 
     expect(controller.resetForm).toHaveBeenCalledTimes(1)
     expect(textarea.value).toBe('roadmap notes')
+    expect(settled).toHaveBeenCalledTimes(1)
   })
 
   test('a failure with nothing stashed leaves the submitted text for a retry', async () => {

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_stashed_draft_failure.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_stashed_draft_failure.test.js
@@ -88,7 +88,7 @@ const COMMAND_TEXT = '/calendar 2026-08-14 10:00 Sync'
 describe('CommentsFormController stashed draft across a send failure', () => {
   beforeEach(() => {
     global.fetch = jest.fn()
-    alertDialog.mockClear()
+    alertDialog.mockReset().mockResolvedValue()
   })
 
   test('restores the draft over the command text a failed send left behind', async () => {
@@ -152,5 +152,26 @@ describe('CommentsFormController stashed draft across a send failure', () => {
     await flush()
 
     expect(textarea.value).toBe('an ordinary message')
+  })
+
+  test('announces settlement only after the failure dialog is dismissed', async () => {
+    const { controller, textarea } = buildController()
+    const settled = jest.fn()
+    let dismissDialog
+    controller.element.addEventListener('comments--form:submit-settled', settled)
+    global.fetch.mockResolvedValue(failedResponse())
+    alertDialog.mockReturnValue(new Promise((resolve) => { dismissDialog = resolve }))
+
+    textarea.value = COMMAND_TEXT
+    controller.handleSend(new Event('submit'))
+    await flush()
+
+    expect(alertDialog).toHaveBeenCalledTimes(1)
+    expect(settled).not.toHaveBeenCalled()
+
+    dismissDialog()
+    await flush()
+
+    expect(settled).toHaveBeenCalledTimes(1)
   })
 })

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -930,6 +930,7 @@ export default class extends Controller {
       method = 'PATCH'
     }
 
+    let settlementUi = Promise.resolve()
     const doFetch = () => fetch(url, {
       method,
       headers: { 'X-CSRF-Token': document.querySelector('meta[name=csrf-token]').content },
@@ -1090,7 +1091,7 @@ export default class extends Controller {
           this._updateSubmitButton()
         }
         this._persistFailedSubmissionDraft(submittedDraft)
-        alertDialog(error?.message || 'Failed to submit comment')
+        settlementUi = alertDialog(error?.message || 'Failed to submit comment')
       })
       .finally(() => {
         this._pendingDraftSubmissions.delete(submittedDraft)
@@ -1105,7 +1106,10 @@ export default class extends Controller {
         } else {
           this._stashedDraft = null
         }
-        this.element.dispatchEvent(new CustomEvent('comments--form:submit-settled'))
+        const announceSettlement = () => {
+          this.element.dispatchEvent(new CustomEvent('comments--form:submit-settled'))
+        }
+        settlementUi.then(announceSettlement, announceSettlement)
       })
   }
 

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -1105,6 +1105,7 @@ export default class extends Controller {
         } else {
           this._stashedDraft = null
         }
+        this.element.dispatchEvent(new CustomEvent('comments--form:submit-settled'))
       })
   }
 

--- a/engines/collavre/app/javascript/modules/__tests__/command_menu_typeahead.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/command_menu_typeahead.test.js
@@ -136,7 +136,7 @@ describe('command menu typeahead', () => {
     }
   })
 
-  test('submitting command arguments keeps the menu closed and returns focus to chat input', async () => {
+  test('submitting command arguments keeps the menu closed and refocuses after the send settles', async () => {
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
       json: () => Promise.resolve([{
@@ -172,7 +172,13 @@ describe('command menu typeahead', () => {
 
     expect(document.getElementById('command-args-dialog')).toBeNull()
     expect(menu.style.display).toBe('none')
-    expect(document.activeElement).toBe(textarea)
     expect(submitClick).toHaveBeenCalledTimes(1)
+    expect(document.activeElement).not.toBe(textarea)
+
+    document.getElementById('comments-popup').dispatchEvent(
+      new CustomEvent('comments--form:submit-settled'),
+    )
+
+    expect(document.activeElement).toBe(textarea)
   })
 })

--- a/engines/collavre/app/javascript/modules/__tests__/command_menu_typeahead.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/command_menu_typeahead.test.js
@@ -148,9 +148,10 @@ describe('command menu typeahead', () => {
     })
     const { textarea, menu } = setup()
     const submit = document.createElement('button')
+    const submitClick = jest.fn()
     submit.type = 'button'
-    submit.dataset.commentsFormTarget = 'submit'
-    submit.addEventListener('click', jest.fn())
+    submit.setAttribute('data-comments--form-target', 'submit')
+    submit.addEventListener('click', submitClick)
     document.getElementById('new-comment-form').appendChild(submit)
 
     type(textarea, '/task')
@@ -172,5 +173,6 @@ describe('command menu typeahead', () => {
     expect(document.getElementById('command-args-dialog')).toBeNull()
     expect(menu.style.display).toBe('none')
     expect(document.activeElement).toBe(textarea)
+    expect(submitClick).toHaveBeenCalledTimes(1)
   })
 })

--- a/engines/collavre/app/javascript/modules/__tests__/command_menu_typeahead.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/command_menu_typeahead.test.js
@@ -136,7 +136,7 @@ describe('command menu typeahead', () => {
     }
   })
 
-  test('submitting command arguments keeps the menu closed and refocuses after the send settles', async () => {
+  test('command arguments refocus after settlement without stealing deliberate focus', async () => {
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
       json: () => Promise.resolve([{
@@ -180,5 +180,29 @@ describe('command menu typeahead', () => {
     )
 
     expect(document.activeElement).toBe(textarea)
+
+    type(textarea, '/task')
+    await settle()
+    textarea.dispatchEvent(new KeyboardEvent('keydown', {
+      key: 'Enter',
+      bubbles: true,
+      cancelable: true,
+    }))
+    document.querySelector('#command-args-dialog textarea').dispatchEvent(new KeyboardEvent('keydown', {
+      key: 'Enter',
+      bubbles: true,
+      cancelable: true,
+    }))
+    await flush()
+
+    const otherControl = document.createElement('button')
+    document.body.appendChild(otherControl)
+    otherControl.focus()
+    document.getElementById('comments-popup').dispatchEvent(
+      new CustomEvent('comments--form:submit-settled'),
+    )
+
+    expect(submitClick).toHaveBeenCalledTimes(2)
+    expect(document.activeElement).toBe(otherControl)
   })
 })

--- a/engines/collavre/app/javascript/modules/__tests__/command_menu_typeahead.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/command_menu_typeahead.test.js
@@ -135,4 +135,42 @@ describe('command menu typeahead', () => {
       expect(menu.style.visibility).toBe('visible')
     }
   })
+
+  test('submitting command arguments keeps the menu closed and returns focus to chat input', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([{
+        name: 'task_create',
+        label: '/task_create',
+        aliases: [],
+        input_schema: [{ name: 'title', type: 'string', required: false }],
+      }]),
+    })
+    const { textarea, menu } = setup()
+    const submit = document.createElement('button')
+    submit.type = 'button'
+    submit.dataset.commentsFormTarget = 'submit'
+    submit.addEventListener('click', jest.fn())
+    document.getElementById('new-comment-form').appendChild(submit)
+
+    type(textarea, '/task')
+    await settle()
+    textarea.dispatchEvent(new KeyboardEvent('keydown', {
+      key: 'Enter',
+      bubbles: true,
+      cancelable: true,
+    }))
+
+    const titleInput = document.querySelector('#command-args-dialog textarea')
+    titleInput.dispatchEvent(new KeyboardEvent('keydown', {
+      key: 'Enter',
+      bubbles: true,
+      cancelable: true,
+    }))
+    await flush()
+
+    expect(document.getElementById('command-args-dialog')).toBeNull()
+    expect(menu.style.display).toBe('none')
+    expect(document.activeElement).toBe(textarea)
+  })
 })

--- a/engines/collavre/app/javascript/modules/command_menu.js
+++ b/engines/collavre/app/javascript/modules/command_menu.js
@@ -16,6 +16,7 @@ if (!commandMenuInitialized) {
 
     const list = menu.querySelector('[data-popup-list]')
     const commandCache = new Map()
+    let skipNextMenuInput = false
 
     const argsForm = new CommandArgsForm({
       container: popup,
@@ -47,12 +48,18 @@ if (!commandMenuInitialized) {
           }))
         }
         textarea.value = commandText
+        // Keep the normal input listeners (drafts, resize, submit state) in
+        // sync without treating this programmatic command as a new typeahead
+        // query. A schema command with no entered values is just "/name", so
+        // the command menu would otherwise reopen as soon as the form closes.
+        skipNextMenuInput = true
         textarea.dispatchEvent(new Event('input', { bubbles: true }))
         // Trigger form submission directly
         const submitBtn = document.querySelector('#new-comment-form [data-comments--form-target="submit"]')
         if (submitBtn) {
           submitBtn.click()
         }
+        textarea.focus()
       },
       onCancel: () => {
         popupMenu.hide()
@@ -198,10 +205,16 @@ if (!commandMenuInitialized) {
     let queryToken = 0
 
     textarea.addEventListener('input', function () {
+      const token = ++queryToken
+      if (skipNextMenuInput) {
+        skipNextMenuInput = false
+        popupMenu.hide()
+        return
+      }
+
       // If args form is open, don't show command menu
       if (argsForm.isOpen()) return
 
-      const token = ++queryToken
       const pos = textarea.selectionStart
       const before = textarea.value.slice(0, pos)
       // Only trigger when "/" is at the very beginning of the message

--- a/engines/collavre/app/javascript/modules/command_menu.js
+++ b/engines/collavre/app/javascript/modules/command_menu.js
@@ -57,9 +57,12 @@ if (!commandMenuInitialized) {
         // Trigger form submission directly
         const submitBtn = document.querySelector('#new-comment-form [data-comments--form-target="submit"]')
         if (submitBtn) {
+          // Keep focus out of the textarea while its value is still the command
+          // being sent. The form announces settlement after success/failure
+          // cleanup, so typing cannot append to the in-flight command.
+          popup.addEventListener('comments--form:submit-settled', () => textarea.focus(), { once: true })
           submitBtn.click()
         }
-        textarea.focus()
       },
       onCancel: () => {
         popupMenu.hide()

--- a/engines/collavre/app/javascript/modules/command_menu.js
+++ b/engines/collavre/app/javascript/modules/command_menu.js
@@ -60,7 +60,10 @@ if (!commandMenuInitialized) {
           // Keep focus out of the textarea while its value is still the command
           // being sent. The form announces settlement after success/failure
           // cleanup, so typing cannot append to the in-flight command.
-          popup.addEventListener('comments--form:submit-settled', () => textarea.focus(), { once: true })
+          popup.addEventListener('comments--form:submit-settled', () => {
+            const active = document.activeElement
+            if (!active || active === document.body) textarea.focus()
+          }, { once: true })
           submitBtn.click()
         }
       },


### PR DESCRIPTION
## Summary

- prevent the command menu from reopening after an argument form submits a slash command with no entered optional values
- return keyboard focus to the chat textarea after submission
- add regression coverage for Enter-key submission

## Root cause

The programmatic input event used to synchronize the submitted command also retriggered command typeahead. Commands with no entered values remained in the `/name` shape, so the menu immediately reopened after the argument dialog closed.

## Test

- `npm test -- --runInBand engines/collavre/app/javascript/modules/__tests__/command_menu_typeahead.test.js engines/collavre/app/javascript/modules/__tests__/command_args_form.test.js engines/collavre/app/javascript/modules/__tests__/command_menu_creative_picker.test.js`