### PR TITLE
Fix topic scroll interruption on user input

### DIFF
--- a/engines/collavre/app/javascript/controllers/comments/__tests__/list_controller_deep_link_topic.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/list_controller_deep_link_topic.test.js
@@ -65,6 +65,33 @@ describe('CommentsListController deep-linked topic resolution', () => {
     expect(topicsController.selectTopic).toHaveBeenCalledWith('3', { userInitiated: true })
   })
 
+  test('marks topic creation from the move popup as user initiated', () => {
+    const controller = buildListController()
+    controller.selection = new Set(['comment-1'])
+    controller.clearSelection = jest.fn()
+    controller.switchToTopic = jest.fn()
+    const topicSearchController = {
+      openForCreative: jest.fn((_creativeId, _rect, onSelect) => {
+        onSelect({ id: '9', created: true })
+      }),
+    }
+    const modal = document.createElement('div')
+    modal.id = 'topic-search-modal'
+    document.body.appendChild(modal)
+    Object.defineProperty(controller, 'application', {
+      value: {
+        getControllerForElementAndIdentifier: jest.fn(() => topicSearchController),
+      },
+    })
+
+    controller.openTopicSearchPopup({
+      currentTarget: { getBoundingClientRect: () => ({}) },
+    })
+
+    expect(controller.clearSelection).toHaveBeenCalledTimes(1)
+    expect(controller.switchToTopic).toHaveBeenCalledWith('9')
+  })
+
   // updateSelectionUI only repaints chips: it neither expands the archived
   // section nor tells form_controller which conversation the reply belongs to.
   test('routes the server-resolved topic through selectTopic', async () => {

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/list_controller_deep_link_topic.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/list_controller_deep_link_topic.test.js
@@ -56,6 +56,15 @@ describe('CommentsListController deep-linked topic resolution', () => {
     jest.clearAllMocks()
   })
 
+  test('marks a comment topic-link switch as user initiated', () => {
+    const topicsController = { selectTopic: jest.fn() }
+    const controller = buildListController({ topicsController })
+
+    controller.switchToTopic('3')
+
+    expect(topicsController.selectTopic).toHaveBeenCalledWith('3', { userInitiated: true })
+  })
+
   // updateSelectionUI only repaints chips: it neither expands the archived
   // section nor tells form_controller which conversation the reply belongs to.
   test('routes the server-resolved topic through selectTopic', async () => {

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_action_errors.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_action_errors.test.js
@@ -95,18 +95,24 @@ describe('TopicsController topic action failures', () => {
 
     test('deleteTopic surfaces the localized delete error', async () => {
       global.fetch = failingFetch()
+      controller.serverLastTopicId = '1'
+      controller._topicScrollInterrupted = true
 
       await controller.deleteTopic(eventFor(1))
 
       expect(alertDialog).toHaveBeenCalledWith(LOCALIZED.topicDeleteError)
+      expect(controller._topicScrollInterrupted).toBe(true)
     })
 
     test('archiveTopic surfaces the localized archive error', async () => {
       global.fetch = failingFetch()
+      controller.serverLastTopicId = '1'
+      controller._topicScrollInterrupted = true
 
       await controller.archiveTopic(eventFor(1))
 
       expect(alertDialog).toHaveBeenCalledWith(LOCALIZED.topicArchiveError)
+      expect(controller._topicScrollInterrupted).toBe(true)
     })
 
     test('unarchiveTopic surfaces the localized restore error', async () => {

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_archived.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_archived.test.js
@@ -507,6 +507,23 @@ describe('TopicsController archived topic messages', () => {
       expect(controller.currentTopicId).toBe('1')
     })
 
+    test('allows All Messages to scroll into view after archiving the selected topic', async () => {
+      controller.serverLastTopicId = '2'
+      controller._topicScrollInterrupted = true
+      const interruptionStatesAtLoad = []
+      controller.loadTopics = jest.fn(() => {
+        interruptionStatesAtLoad.push(controller._topicScrollInterrupted)
+      })
+      global.fetch = jest.fn().mockResolvedValue({ ok: true })
+
+      await controller.archiveTopic({
+        stopPropagation: jest.fn(),
+        currentTarget: { dataset: { id: '2' } },
+      })
+
+      expect(interruptionStatesAtLoad).toEqual([false])
+    })
+
     test('leaves the archived section collapsed instead of revealing the archived topic', async () => {
       controller.serverLastTopicId = '2'
       render()

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_archived.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_archived.test.js
@@ -524,6 +524,23 @@ describe('TopicsController archived topic messages', () => {
       expect(interruptionStatesAtLoad).toEqual([false])
     })
 
+    test('preserves the user scroll lock after archiving an inactive topic', async () => {
+      controller.serverLastTopicId = '1'
+      controller._topicScrollInterrupted = true
+      const interruptionStatesAtLoad = []
+      controller.loadTopics = jest.fn(() => {
+        interruptionStatesAtLoad.push(controller._topicScrollInterrupted)
+      })
+      global.fetch = jest.fn().mockResolvedValue({ ok: true })
+
+      await controller.archiveTopic({
+        stopPropagation: jest.fn(),
+        currentTarget: { dataset: { id: '2' } },
+      })
+
+      expect(interruptionStatesAtLoad).toEqual([true])
+    })
+
     test('leaves the archived section collapsed instead of revealing the archived topic', async () => {
       controller.serverLastTopicId = '2'
       render()

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_creation_scroll.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_creation_scroll.test.js
@@ -1,0 +1,87 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { jest } from '@jest/globals'
+
+const createTopicWithComments = jest.fn()
+
+jest.unstable_mockModule('../../../lib/api/topics', () => ({
+  fetchNextTopicName: jest.fn(),
+  createTopicWithComments,
+  saveLastTopic: jest.fn(),
+}))
+
+const { Application } = await import('@hotwired/stimulus')
+const TopicsController = (await import('../topics_controller')).default
+
+describe('TopicsController user-created topic scrolling', () => {
+  let application
+  let controller
+
+  beforeEach(async () => {
+    document.head.innerHTML = '<meta name="csrf-token" content="test-csrf">'
+    document.body.innerHTML = `
+      <div id="topics" data-controller="comments--topics">
+        <div data-comments--topics-target="list"></div>
+      </div>
+    `
+
+    application = Application.start()
+    application.register('comments--topics', TopicsController)
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    controller = application.getControllerForElementAndIdentifier(
+      document.getElementById('topics'), 'comments--topics'
+    )
+    controller.creativeIdValue = '42'
+    controller._topicScrollInterrupted = true
+    controller.debounceSaveLastTopic = jest.fn()
+    controller.flushSaveLastTopic = jest.fn().mockResolvedValue()
+    controller.loadTopics = jest.fn(async () => {
+      expect(controller._topicScrollInterrupted).toBe(false)
+    })
+    controller.dispatch = jest.fn()
+  })
+
+  afterEach(() => {
+    application.stop()
+    document.head.innerHTML = ''
+    document.body.innerHTML = ''
+    jest.clearAllMocks()
+    delete global.fetch
+  })
+
+  test('allows the new topic to scroll into view after name entry', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: 9, name: 'New topic' }),
+    })
+
+    await controller.createTopic('New topic')
+
+    expect(controller.loadTopics).toHaveBeenCalledTimes(1)
+  })
+
+  test('allows the new topic to scroll into view after moving comments', async () => {
+    createTopicWithComments.mockResolvedValue({
+      ok: true,
+      topic: { id: 10, name: 'Moved comments' },
+    })
+
+    await controller.createTopicAndMoveComments(['comment-1'], 'Moved comments')
+
+    expect(controller.loadTopics).toHaveBeenCalledTimes(1)
+  })
+
+  test('allows the new topic to scroll into view after an agent drop', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: 11, name: 'Talk to Reviewer' }),
+    })
+
+    await controller.createTopicWithAgent({ id: 5, name: 'Reviewer' })
+
+    expect(controller.loadTopics).toHaveBeenCalledTimes(1)
+  })
+})

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_creation_scroll.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_creation_scroll.test.js
@@ -18,6 +18,7 @@ const TopicsController = (await import('../topics_controller')).default
 describe('TopicsController user-created topic scrolling', () => {
   let application
   let controller
+  let interruptionStatesAtLoad
 
   beforeEach(async () => {
     document.head.innerHTML = '<meta name="csrf-token" content="test-csrf">'
@@ -38,8 +39,9 @@ describe('TopicsController user-created topic scrolling', () => {
     controller._topicScrollInterrupted = true
     controller.debounceSaveLastTopic = jest.fn()
     controller.flushSaveLastTopic = jest.fn().mockResolvedValue()
+    interruptionStatesAtLoad = []
     controller.loadTopics = jest.fn(async () => {
-      expect(controller._topicScrollInterrupted).toBe(false)
+      interruptionStatesAtLoad.push(controller._topicScrollInterrupted)
     })
     controller.dispatch = jest.fn()
   })
@@ -61,6 +63,7 @@ describe('TopicsController user-created topic scrolling', () => {
     await controller.createTopic('New topic')
 
     expect(controller.loadTopics).toHaveBeenCalledTimes(1)
+    expect(interruptionStatesAtLoad).toEqual([false])
   })
 
   test('allows the new topic to scroll into view after moving comments', async () => {
@@ -72,6 +75,7 @@ describe('TopicsController user-created topic scrolling', () => {
     await controller.createTopicAndMoveComments(['comment-1'], 'Moved comments')
 
     expect(controller.loadTopics).toHaveBeenCalledTimes(1)
+    expect(interruptionStatesAtLoad).toEqual([false])
   })
 
   test('allows the new topic to scroll into view after an agent drop', async () => {
@@ -83,5 +87,6 @@ describe('TopicsController user-created topic scrolling', () => {
     await controller.createTopicWithAgent({ id: 5, name: 'Reviewer' })
 
     expect(controller.loadTopics).toHaveBeenCalledTimes(1)
+    expect(interruptionStatesAtLoad).toEqual([false])
   })
 })

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_delete.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_delete.test.js
@@ -92,6 +92,23 @@ describe('TopicsController#deleteTopic', () => {
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
+  test('allows All Messages to scroll into view after deleting the selected topic', async () => {
+    controller.serverLastTopicId = '99'
+    controller._topicScrollInterrupted = true
+    const interruptionStatesAtLoad = []
+    controller.loadTopics = jest.fn(() => {
+      interruptionStatesAtLoad.push(controller._topicScrollInterrupted)
+    })
+    global.fetch = jest.fn().mockResolvedValue({ ok: true })
+    confirmDialog.mockResolvedValue(true)
+    const button = document.createElement('button')
+    button.dataset.id = '99'
+
+    await controller.deleteTopic({ stopPropagation: jest.fn(), currentTarget: button })
+
+    expect(interruptionStatesAtLoad).toEqual([false])
+  })
+
   // Assigning "" only moves serverLastTopicId, and both deep-link sources
   // outrank it in the currentTopicId getter — so without the release the
   // deleted id keeps answering for every later restoreSelection().

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_delete.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_delete.test.js
@@ -86,10 +86,12 @@ describe('TopicsController#deleteTopic', () => {
     const event = { stopPropagation: jest.fn(), currentTarget: button }
 
     confirmDialog.mockResolvedValue(false)
+    controller._topicScrollInterrupted = true
 
     await controller.deleteTopic(event)
 
     expect(fetchMock).not.toHaveBeenCalled()
+    expect(controller._topicScrollInterrupted).toBe(true)
   })
 
   test('allows All Messages to scroll into view after deleting the selected topic', async () => {
@@ -107,6 +109,23 @@ describe('TopicsController#deleteTopic', () => {
     await controller.deleteTopic({ stopPropagation: jest.fn(), currentTarget: button })
 
     expect(interruptionStatesAtLoad).toEqual([false])
+  })
+
+  test('preserves the user scroll lock after deleting an inactive topic', async () => {
+    controller.serverLastTopicId = '1'
+    controller._topicScrollInterrupted = true
+    const interruptionStatesAtLoad = []
+    controller.loadTopics = jest.fn(() => {
+      interruptionStatesAtLoad.push(controller._topicScrollInterrupted)
+    })
+    global.fetch = jest.fn().mockResolvedValue({ ok: true })
+    confirmDialog.mockResolvedValue(true)
+    const button = document.createElement('button')
+    button.dataset.id = '99'
+
+    await controller.deleteTopic({ stopPropagation: jest.fn(), currentTarget: button })
+
+    expect(interruptionStatesAtLoad).toEqual([true])
   })
 
   // Assigning "" only moves serverLastTopicId, and both deep-link sources

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_delete.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_delete.test.js
@@ -111,6 +111,58 @@ describe('TopicsController#deleteTopic', () => {
     expect(interruptionStatesAtLoad).toEqual([false])
   })
 
+  test('allows All Messages to scroll into view when the deleted broadcast arrives before the response', async () => {
+    controller.serverLastTopicId = '99'
+    controller._topicScrollInterrupted = true
+    controller.topics = [{ id: 99, name: 'Selected topic' }]
+    controller.renderTopics = jest.fn()
+    controller.restoreSelection = jest.fn()
+    const interruptionStatesAtLoad = []
+    controller.loadTopics = jest.fn(() => {
+      interruptionStatesAtLoad.push(controller._topicScrollInterrupted)
+    })
+    let resolveDelete
+    global.fetch = jest.fn(() => new Promise(resolve => { resolveDelete = resolve }))
+    confirmDialog.mockResolvedValue(true)
+    const button = document.createElement('button')
+    button.dataset.id = '99'
+
+    const deletion = controller.deleteTopic({ stopPropagation: jest.fn(), currentTarget: button })
+    await Promise.resolve()
+    controller.removeTopic('99')
+    resolveDelete({ ok: true })
+    await deletion
+
+    expect(controller.currentTopicId).toBe('')
+    expect(interruptionStatesAtLoad).toEqual([false])
+  })
+
+  test('preserves a newer user scroll after the deleted broadcast', async () => {
+    controller.serverLastTopicId = '99'
+    controller._topicScrollInterrupted = true
+    controller.topics = [{ id: 99, name: 'Selected topic' }]
+    controller.renderTopics = jest.fn()
+    controller.restoreSelection = jest.fn()
+    const interruptionStatesAtLoad = []
+    controller.loadTopics = jest.fn(() => {
+      interruptionStatesAtLoad.push(controller._topicScrollInterrupted)
+    })
+    let resolveDelete
+    global.fetch = jest.fn(() => new Promise(resolve => { resolveDelete = resolve }))
+    confirmDialog.mockResolvedValue(true)
+    const button = document.createElement('button')
+    button.dataset.id = '99'
+
+    const deletion = controller.deleteTopic({ stopPropagation: jest.fn(), currentTarget: button })
+    await Promise.resolve()
+    controller.removeTopic('99')
+    controller.handleTopicScrollInput()
+    resolveDelete({ ok: true })
+    await deletion
+
+    expect(interruptionStatesAtLoad).toEqual([true])
+  })
+
   test('preserves the user scroll lock after deleting an inactive topic', async () => {
     controller.serverLastTopicId = '1'
     controller._topicScrollInterrupted = true

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_scroll.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_scroll.test.js
@@ -151,4 +151,32 @@ describe('TopicsController topic strip scrolling', () => {
 
         expect(requestAnimationFrame).not.toHaveBeenCalled()
     })
+
+    test('allows All Messages to scroll into view after moving the selected topic away', () => {
+        controller.creativeIdValue = '42'
+        controller.serverLastTopicId = '1'
+        controller._topicScrollInterrupted = true
+        const interruptionStatesAtLoad = []
+        controller.loadTopics = jest.fn(() => {
+            interruptionStatesAtLoad.push(controller._topicScrollInterrupted)
+        })
+
+        controller.handleTopicMoved({ detail: { sourceCreativeId: '42', topicId: '1' } })
+
+        expect(interruptionStatesAtLoad).toEqual([false])
+    })
+
+    test('preserves the user scroll lock when moving an inactive topic away', () => {
+        controller.creativeIdValue = '42'
+        controller.serverLastTopicId = '1'
+        controller._topicScrollInterrupted = true
+        const interruptionStatesAtLoad = []
+        controller.loadTopics = jest.fn(() => {
+            interruptionStatesAtLoad.push(controller._topicScrollInterrupted)
+        })
+
+        controller.handleTopicMoved({ detail: { sourceCreativeId: '42', topicId: '2' } })
+
+        expect(interruptionStatesAtLoad).toEqual([true])
+    })
 })

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_scroll.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_scroll.test.js
@@ -18,7 +18,7 @@ describe('TopicsController topic strip scrolling', () => {
         document.body.innerHTML = `
           <div data-controller="comments--topics">
             <div data-comments--topics-target="list">
-              <span class="topic-tag active"></span>
+              <span class="topic-tag active" data-id="1"></span>
             </div>
           </div>
         `
@@ -73,8 +73,23 @@ describe('TopicsController topic strip scrolling', () => {
             expect(controller._topicScrollFrame).toBeNull()
             expect(frames.has(pendingFrameId)).toBe(false)
             expect(list.scrollLeft).toBe(interruptedAt)
+
+            requestAnimationFrame.mockClear()
+            controller.scrollToActiveTopic()
+
+            expect(requestAnimationFrame).not.toHaveBeenCalled()
+            expect(list.scrollLeft).toBe(interruptedAt)
         },
     )
+
+    test('allows a new active-topic scroll after an explicit topic pick', () => {
+        list.dispatchEvent(new Event('wheel', { bubbles: true }))
+
+        controller.updateSelectionUI('1', { pick: true, persist: false })
+
+        expect(requestAnimationFrame).toHaveBeenCalledTimes(1)
+        expect(controller._topicScrollInterrupted).toBe(false)
+    })
 
     test('finishes the active-topic scroll at the centered position', () => {
         controller.scrollToActiveTopic()
@@ -93,6 +108,16 @@ describe('TopicsController topic strip scrolling', () => {
         controller.scrollToActiveTopic()
 
         expect(requestAnimationFrame).not.toHaveBeenCalled()
+        expect(controller._topicScrollFrame).toBeNull()
+    })
+
+    test('cancels an active-topic scroll when the popup closes', () => {
+        controller.scrollToActiveTopic()
+        const pendingFrameId = controller._topicScrollFrame
+
+        controller.onPopupClosed()
+
+        expect(cancelAnimationFrame).toHaveBeenCalledWith(pendingFrameId)
         expect(controller._topicScrollFrame).toBeNull()
     })
 })

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_scroll.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_scroll.test.js
@@ -82,13 +82,39 @@ describe('TopicsController topic strip scrolling', () => {
         },
     )
 
-    test('allows a new active-topic scroll after an explicit topic pick', () => {
+    test('does not resume scrolling for a non-user pick', () => {
         list.dispatchEvent(new Event('wheel', { bubbles: true }))
 
         controller.updateSelectionUI('1', { pick: true, persist: false })
 
+        expect(requestAnimationFrame).not.toHaveBeenCalled()
+        expect(controller._topicScrollInterrupted).toBe(true)
+    })
+
+    test('allows a new active-topic scroll after an explicit user pick', () => {
+        list.dispatchEvent(new Event('wheel', { bubbles: true }))
+
+        controller.updateSelectionUI('1', {
+            pick: true,
+            persist: false,
+            userInitiated: true,
+        })
+
         expect(requestAnimationFrame).toHaveBeenCalledTimes(1)
         expect(controller._topicScrollInterrupted).toBe(false)
+    })
+
+    test('marks branch-icon navigation as user initiated', () => {
+        activeTopic.dataset.sourceTopicId = '2'
+        activeTopic.innerHTML = '<span class="topic-branch-icon"></span>'
+        const selectTopic = jest.spyOn(controller, 'selectTopic').mockImplementation(() => {})
+
+        controller.select({
+            target: activeTopic.querySelector('.topic-branch-icon'),
+            currentTarget: activeTopic,
+        })
+
+        expect(selectTopic).toHaveBeenCalledWith('2', { userInitiated: true })
     })
 
     test('finishes the active-topic scroll at the centered position', () => {
@@ -119,5 +145,10 @@ describe('TopicsController topic strip scrolling', () => {
 
         expect(cancelAnimationFrame).toHaveBeenCalledWith(pendingFrameId)
         expect(controller._topicScrollFrame).toBeNull()
+
+        requestAnimationFrame.mockClear()
+        controller.scrollToActiveTopic()
+
+        expect(requestAnimationFrame).not.toHaveBeenCalled()
     })
 })

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_scroll.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_scroll.test.js
@@ -1,0 +1,98 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { Application } from '@hotwired/stimulus'
+import { jest } from '@jest/globals'
+import TopicsController from '../topics_controller'
+
+describe('TopicsController topic strip scrolling', () => {
+    let application
+    let controller
+    let list
+    let activeTopic
+    let frames
+    let nextFrameId
+
+    beforeEach(async () => {
+        document.body.innerHTML = `
+          <div data-controller="comments--topics">
+            <div data-comments--topics-target="list">
+              <span class="topic-tag active"></span>
+            </div>
+          </div>
+        `
+        frames = new Map()
+        nextFrameId = 1
+        global.requestAnimationFrame = jest.fn(callback => {
+            const frameId = nextFrameId++
+            frames.set(frameId, callback)
+            return frameId
+        })
+        global.cancelAnimationFrame = jest.fn(frameId => frames.delete(frameId))
+        jest.spyOn(performance, 'now').mockReturnValue(0)
+        application = Application.start()
+        application.register('comments--topics', TopicsController)
+        await new Promise(resolve => setTimeout(resolve, 0))
+
+        const element = document.querySelector('[data-controller="comments--topics"]')
+        controller = application.getControllerForElementAndIdentifier(element, 'comments--topics')
+        list = controller.listTarget
+        activeTopic = list.querySelector('.active')
+        Object.defineProperties(list, {
+            scrollLeft: { configurable: true, value: 0, writable: true },
+            scrollWidth: { configurable: true, value: 1_000 },
+            clientWidth: { configurable: true, value: 200 },
+        })
+        list.getBoundingClientRect = jest.fn(() => ({ left: 100, width: 200 }))
+        activeTopic.getBoundingClientRect = jest.fn(() => ({ left: 800, width: 100 }))
+    })
+
+    afterEach(() => {
+        application.stop()
+        document.body.innerHTML = ''
+        jest.restoreAllMocks()
+        delete global.requestAnimationFrame
+        delete global.cancelAnimationFrame
+    })
+
+    test.each(['wheel', 'touchstart'])(
+        'cancels a smooth active-topic scroll when the user starts a %s gesture',
+        eventName => {
+            controller.scrollToActiveTopic()
+            const firstFrameId = controller._topicScrollFrame
+            const firstFrame = frames.get(firstFrameId)
+            frames.delete(firstFrameId)
+            firstFrame(50)
+            const pendingFrameId = controller._topicScrollFrame
+            const interruptedAt = list.scrollLeft
+
+            list.dispatchEvent(new Event(eventName, { bubbles: true }))
+
+            expect(cancelAnimationFrame).toHaveBeenCalledWith(pendingFrameId)
+            expect(controller._topicScrollFrame).toBeNull()
+            expect(frames.has(pendingFrameId)).toBe(false)
+            expect(list.scrollLeft).toBe(interruptedAt)
+        },
+    )
+
+    test('finishes the active-topic scroll at the centered position', () => {
+        controller.scrollToActiveTopic()
+        const frame = frames.get(controller._topicScrollFrame)
+
+        frame(250)
+
+        expect(list.scrollLeft).toBe(650)
+        expect(controller._topicScrollFrame).toBeNull()
+    })
+
+    test('does not schedule a scroll when the topic is already centered', () => {
+        list.scrollLeft = 650
+        activeTopic.getBoundingClientRect.mockReturnValue({ left: 150, width: 100 })
+
+        controller.scrollToActiveTopic()
+
+        expect(requestAnimationFrame).not.toHaveBeenCalled()
+        expect(controller._topicScrollFrame).toBeNull()
+    })
+})

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_topic_list.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_topic_list.test.js
@@ -104,8 +104,10 @@ describe('TopicsController#openTopicListPopup', () => {
 		controller.element.appendChild(modal)
 		const popup = { popup: { isOpen: jest.fn(() => false) }, openForTopics: jest.fn() }
 		jest.spyOn(controller.application, 'getControllerForElementAndIdentifier').mockReturnValue(popup)
+		const selectTopic = jest.spyOn(controller, 'selectTopic').mockImplementation(() => {})
 
 		controller.openTopicListPopup({ currentTarget: btn })
+		popup.openForTopics.mock.calls[0][2]({ id: 2 })
 
 		expect(popup.openForTopics).toHaveBeenCalledWith(
 			expect.objectContaining({
@@ -116,6 +118,7 @@ describe('TopicsController#openTopicListPopup', () => {
 			expect.any(Function),
 			controller.element
 		)
+		expect(selectTopic).toHaveBeenCalledWith(2, { userInitiated: true })
     })
 
     test('reloads authoritative unread counts without incrementing the cached snapshot', async () => {

--- a/engines/collavre/app/javascript/controllers/comments/list_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/list_controller.js
@@ -1185,7 +1185,7 @@ export default class extends Controller {
     if (!topicId) return
     const topicsController = this.popupController?.topicsController
     if (topicsController?.selectTopic) {
-      topicsController.selectTopic(topicId)
+      topicsController.selectTopic(topicId, { userInitiated: true })
     } else {
       this.currentTopicId = topicId
       this.resetToLatest()

--- a/engines/collavre/app/javascript/controllers/comments/list_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/list_controller.js
@@ -991,9 +991,8 @@ export default class extends Controller {
         btnRect,
         (topic) => {
           if (topic.created) {
-            // Topic was just created with comments moved — refresh
             this.clearSelection()
-            this.loadInitialComments()
+            this.switchToTopic(topic.id)
           } else {
             this.handleMoveToTopic({ detail: { commentIds, targetTopicId: topic.id } })
           }

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -1370,7 +1370,7 @@ export default class extends Controller {
 
             if (response.ok) {
                 const topic = await response.json()
-				this._topicScrollInterrupted = false
+                this._topicScrollInterrupted = false
                 this.currentTopicId = topic.id
                 // Flush save immediately so loadTopics gets the correct value from server
                 await this.flushSaveLastTopic(topic.id)
@@ -2573,7 +2573,7 @@ export default class extends Controller {
 
         const result = await createTopicWithComments(this.creativeId, name, commentIds)
         if (result.ok) {
-			this._topicScrollInterrupted = false
+            this._topicScrollInterrupted = false
             this.currentTopicId = result.topic.id
             await this.flushSaveLastTopic(result.topic.id)
             await this.loadTopics()
@@ -2678,7 +2678,7 @@ export default class extends Controller {
 
             if (response.ok) {
                 const topic = await response.json()
-				this._topicScrollInterrupted = false
+                this._topicScrollInterrupted = false
                 this.currentTopicId = topic.id
                 await this.flushSaveLastTopic(topic.id)
                 await this.loadTopics()

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -42,6 +42,7 @@ export default class extends Controller {
         this._loadTopicsVersion ||= 0
         this._unreadCountsOverlay = null
         this._topicScrollFrame = null
+        this._topicScrollInterrupted = false
         // Initial load if creativeId is available (e.g. from dataset if set server-side)
         if (this.creativeId && this.element.dataset.docked !== 'true') {
             this.loadTopics()
@@ -50,12 +51,12 @@ export default class extends Controller {
         this.handleNewMessage = this.handleNewMessage.bind(this)
         this.handleTopicMoved = this.handleTopicMoved.bind(this)
         this.handleTopicListClose = this.handleTopicListClose.bind(this)
-        this.cancelProgrammaticScroll = this.cancelProgrammaticScroll.bind(this)
+        this.handleTopicScrollInput = this.handleTopicScrollInput.bind(this)
         window.addEventListener('comments--topics:new-message', this.handleNewMessage)
         window.addEventListener('collavre:topic-moved', this.handleTopicMoved)
         this.element.addEventListener('topic-list:close', this.handleTopicListClose)
-        this.listTarget.addEventListener('wheel', this.cancelProgrammaticScroll, { passive: true })
-        this.listTarget.addEventListener('touchstart', this.cancelProgrammaticScroll, { passive: true })
+        this.listTarget.addEventListener('wheel', this.handleTopicScrollInput, { passive: true })
+        this.listTarget.addEventListener('touchstart', this.handleTopicScrollInput, { passive: true })
     }
 
     disconnect() {
@@ -63,14 +64,16 @@ export default class extends Controller {
         window.removeEventListener('comments--topics:new-message', this.handleNewMessage)
         window.removeEventListener('collavre:topic-moved', this.handleTopicMoved)
         this.element.removeEventListener('topic-list:close', this.handleTopicListClose)
-        this.listTarget.removeEventListener('wheel', this.cancelProgrammaticScroll)
-        this.listTarget.removeEventListener('touchstart', this.cancelProgrammaticScroll)
+        this.listTarget.removeEventListener('wheel', this.handleTopicScrollInput)
+        this.listTarget.removeEventListener('touchstart', this.handleTopicScrollInput)
         this._loadTopicsVersion += 1
         this.cancelUnreadCountRefresh()
         this.unsubscribe()
     }
 
     onPopupOpened({ creativeId }) {
+        this.cancelProgrammaticScroll()
+        this._topicScrollInterrupted = false
         this._popupClosed = false
         const previousCreativeId = this.creativeIdValue
         this.creativeIdValue = creativeId
@@ -109,6 +112,7 @@ export default class extends Controller {
     }
 
     onPopupClosed() {
+        this.cancelProgrammaticScroll()
         this._popupClosed = true
         this.releaseAcknowledgedPendingSelfEchoes()
         this.markPendingSelfEchoesAsPossiblyMissed()
@@ -1233,6 +1237,7 @@ export default class extends Controller {
     }
 
     updateSelectionUI(id, { pick = true, persist = true, pending = false } = {}) {
+        if (pick) this._topicScrollInterrupted = false
         this.applySelection(id, { pick, persist, pending })
         // Update UI
         let activeEl = null
@@ -1253,6 +1258,8 @@ export default class extends Controller {
     }
 
     scrollTopicIntoView(topic) {
+        if (this._topicScrollInterrupted) return
+
         this.cancelProgrammaticScroll()
         const list = this.listTarget
         const listRect = list.getBoundingClientRect()
@@ -1286,6 +1293,11 @@ export default class extends Controller {
 
         cancelAnimationFrame(this._topicScrollFrame)
         this._topicScrollFrame = null
+    }
+
+    handleTopicScrollInput() {
+        this._topicScrollInterrupted = true
+        this.cancelProgrammaticScroll()
     }
 
     handleTopicMoved(event) {

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -43,6 +43,7 @@ export default class extends Controller {
         this._unreadCountsOverlay = null
         this._topicScrollFrame = null
         this._topicScrollInterrupted = false
+        this._topicScrollInterruptionVersion ||= 0
         // Initial load if creativeId is available (e.g. from dataset if set server-side)
         if (this.creativeId && this.element.dataset.docked !== 'true') {
             this.loadTopics()
@@ -756,6 +757,9 @@ export default class extends Controller {
 
         if (!topicId) return
 
+        const deletingSelectedTopic = String(this.currentTopicId) === String(topicId)
+        const scrollInterruptionVersion = this._topicScrollInterruptionVersion
+
         try {
             const response = await fetch(`/creatives/${this.creativeId}/topics/${topicId}`, {
                 method: 'DELETE',
@@ -765,8 +769,15 @@ export default class extends Controller {
             })
 
             if (response.ok) {
-                if (String(this.currentTopicId) === String(topicId)) {
+                // The server can broadcast "deleted" before this response. In
+                // that case removeTopic() has already cleared currentTopicId,
+                // but this local removal should still reveal All Messages.
+                // A newer wheel/touch gesture always wins, though.
+                if (deletingSelectedTopic
+                    && this._topicScrollInterruptionVersion === scrollInterruptionVersion) {
                     this._topicScrollInterrupted = false
+                }
+                if (String(this.currentTopicId) === String(topicId)) {
                     // Same deep-link hazard as the "deleted" broadcast: this
                     // path reaches restoreSelection through loadTopics instead
                     // of removeTopic, but the getter is the same one.
@@ -1298,6 +1309,7 @@ export default class extends Controller {
     }
 
     handleTopicScrollInput() {
+        this._topicScrollInterruptionVersion += 1
         this._topicScrollInterrupted = true
         this.cancelProgrammaticScroll()
     }

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -766,6 +766,7 @@ export default class extends Controller {
 
             if (response.ok) {
                 if (String(this.currentTopicId) === String(topicId)) {
+                    this._topicScrollInterrupted = false
                     // Same deep-link hazard as the "deleted" broadcast: this
                     // path reaches restoreSelection through loadTopics instead
                     // of removeTopic, but the getter is the same one.
@@ -797,6 +798,7 @@ export default class extends Controller {
 
             if (response.ok) {
                 if (String(this.currentTopicId) === String(topicId)) {
+                    this._topicScrollInterrupted = false
                     // Archiving the topic in view switches to All Messages, but
                     // the preference save is debounced 500ms and both this
                     // reload and the "archived" broadcast's own reload can beat

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -1308,6 +1308,7 @@ export default class extends Controller {
         if (String(sourceCreativeId) === String(this.creativeId)) {
             // If we were viewing the moved topic, switch to Main
             if (String(this.currentTopicId) === String(topicId)) {
+                this._topicScrollInterrupted = false
                 this.currentTopicId = ""
                 this.dispatch("change", { detail: { topicId: "", mainTopicId: this.mainTopicId } })
             }

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -1370,6 +1370,7 @@ export default class extends Controller {
 
             if (response.ok) {
                 const topic = await response.json()
+				this._topicScrollInterrupted = false
                 this.currentTopicId = topic.id
                 // Flush save immediately so loadTopics gets the correct value from server
                 await this.flushSaveLastTopic(topic.id)
@@ -2572,6 +2573,7 @@ export default class extends Controller {
 
         const result = await createTopicWithComments(this.creativeId, name, commentIds)
         if (result.ok) {
+			this._topicScrollInterrupted = false
             this.currentTopicId = result.topic.id
             await this.flushSaveLastTopic(result.topic.id)
             await this.loadTopics()
@@ -2676,6 +2678,7 @@ export default class extends Controller {
 
             if (response.ok) {
                 const topic = await response.json()
+				this._topicScrollInterrupted = false
                 this.currentTopicId = topic.id
                 await this.flushSaveLastTopic(topic.id)
                 await this.loadTopics()

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -8,6 +8,7 @@ const ICON_RESTORE = `<svg width="12" height="12" viewBox="0 0 24 24" fill="none
 const AMBIGUOUS_SAVE_CLAIM_TIMEOUT = 5_000
 const SAVE_REQUEST_TIMEOUT = 5_000
 const UNREAD_COUNT_REFRESH_DELAY = 250
+const TOPIC_SCROLL_DURATION = 250
 const LAST_TOPIC_SAVE_SESSION_STORAGE_KEY = "collavre:last-topic-save-session-id"
 const LAST_TOPIC_SAVE_SEQUENCE_STORAGE_KEY = "collavre:last-topic-save-sequence"
 const LAST_TOPIC_SAVE_WINDOW_NAME_PREFIX = "collavre:last-topic-save-session:"
@@ -40,6 +41,7 @@ export default class extends Controller {
         this.topicsSubscription = null
         this._loadTopicsVersion ||= 0
         this._unreadCountsOverlay = null
+        this._topicScrollFrame = null
         // Initial load if creativeId is available (e.g. from dataset if set server-side)
         if (this.creativeId && this.element.dataset.docked !== 'true') {
             this.loadTopics()
@@ -48,15 +50,21 @@ export default class extends Controller {
         this.handleNewMessage = this.handleNewMessage.bind(this)
         this.handleTopicMoved = this.handleTopicMoved.bind(this)
         this.handleTopicListClose = this.handleTopicListClose.bind(this)
+        this.cancelProgrammaticScroll = this.cancelProgrammaticScroll.bind(this)
         window.addEventListener('comments--topics:new-message', this.handleNewMessage)
         window.addEventListener('collavre:topic-moved', this.handleTopicMoved)
         this.element.addEventListener('topic-list:close', this.handleTopicListClose)
+        this.listTarget.addEventListener('wheel', this.cancelProgrammaticScroll, { passive: true })
+        this.listTarget.addEventListener('touchstart', this.cancelProgrammaticScroll, { passive: true })
     }
 
     disconnect() {
+        this.cancelProgrammaticScroll()
         window.removeEventListener('comments--topics:new-message', this.handleNewMessage)
         window.removeEventListener('collavre:topic-moved', this.handleTopicMoved)
         this.element.removeEventListener('topic-list:close', this.handleTopicListClose)
+        this.listTarget.removeEventListener('wheel', this.cancelProgrammaticScroll)
+        this.listTarget.removeEventListener('touchstart', this.cancelProgrammaticScroll)
         this._loadTopicsVersion += 1
         this.cancelUnreadCountRefresh()
         this.unsubscribe()
@@ -1236,17 +1244,48 @@ export default class extends Controller {
                 activeEl = el
             }
         })
-        // Scroll active topic into view
-        if (activeEl) {
-            activeEl.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'center' })
-        }
+        if (activeEl) this.scrollTopicIntoView(activeEl)
     }
 
     scrollToActiveTopic() {
         const activeEl = this.listTarget.querySelector('.topic-tag.active')
-        if (activeEl) {
-            activeEl.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'center' })
+        if (activeEl) this.scrollTopicIntoView(activeEl)
+    }
+
+    scrollTopicIntoView(topic) {
+        this.cancelProgrammaticScroll()
+        const list = this.listTarget
+        const listRect = list.getBoundingClientRect()
+        const topicRect = topic.getBoundingClientRect()
+        const maxLeft = Math.max(0, list.scrollWidth - list.clientWidth)
+        const targetLeft = Math.max(0, Math.min(
+            maxLeft,
+            list.scrollLeft + topicRect.left + (topicRect.width / 2)
+                - listRect.left - (listRect.width / 2),
+        ))
+        const startLeft = list.scrollLeft
+        const distance = targetLeft - startLeft
+        if (Math.abs(distance) < 1) return
+
+        const startedAt = performance.now()
+        const step = now => {
+            const progress = Math.min((now - startedAt) / TOPIC_SCROLL_DURATION, 1)
+            const easedProgress = 1 - ((1 - progress) ** 3)
+            list.scrollLeft = startLeft + (distance * easedProgress)
+            if (progress < 1) {
+                this._topicScrollFrame = requestAnimationFrame(step)
+            } else {
+                this._topicScrollFrame = null
+            }
         }
+        this._topicScrollFrame = requestAnimationFrame(step)
+    }
+
+    cancelProgrammaticScroll() {
+        if (this._topicScrollFrame === null) return
+
+        cancelAnimationFrame(this._topicScrollFrame)
+        this._topicScrollFrame = null
     }
 
     handleTopicMoved(event) {

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -880,7 +880,7 @@ export default class extends Controller {
             popup.openForTopics(
                 this.topicListData(),
                 btnRect,
-                (item) => this.selectTopic(item.id),
+                (item) => this.selectTopic(item.id, { userInitiated: true }),
                 this.element
             )
             this.setTopicListButtonExpanded(true)
@@ -1121,7 +1121,7 @@ export default class extends Controller {
         if (event.target.closest('.topic-branch-icon')) {
             const sourceTopicId = event.currentTarget.dataset.sourceTopicId
             if (sourceTopicId) {
-                this.selectTopic(sourceTopicId)
+                this.selectTopic(sourceTopicId, { userInitiated: true })
                 return
             }
         }
@@ -1134,10 +1134,10 @@ export default class extends Controller {
             return
         }
 
-        this.selectTopic(id)
+        this.selectTopic(id, { userInitiated: true })
     }
 
-    selectTopic(id, { reveal = true, pick = true, persist = true } = {}) {
+    selectTopic(id, { reveal = true, pick = true, persist = true, userInitiated = false } = {}) {
         // Only restoreSelection() is guarded, so reaching selectTopic with this
         // id means the user deliberately went back into the archived topic.
         // The transition is over.
@@ -1145,7 +1145,7 @@ export default class extends Controller {
             this.archivedAwayTopicId = null
         }
         if (reveal) this.revealArchivedTopic(id)
-        this.updateSelectionUI(id, { pick, persist, pending: pick })
+        this.updateSelectionUI(id, { pick, persist, pending: pick, userInitiated })
         if (id) {
             this.clearNewMessageBadge(id)
         }
@@ -1236,8 +1236,8 @@ export default class extends Controller {
         }
     }
 
-    updateSelectionUI(id, { pick = true, persist = true, pending = false } = {}) {
-        if (pick) this._topicScrollInterrupted = false
+    updateSelectionUI(id, { pick = true, persist = true, pending = false, userInitiated = false } = {}) {
+        if (userInitiated) this._topicScrollInterrupted = false
         this.applySelection(id, { pick, persist, pending })
         // Update UI
         let activeEl = null
@@ -1258,7 +1258,7 @@ export default class extends Controller {
     }
 
     scrollTopicIntoView(topic) {
-        if (this._topicScrollInterrupted) return
+        if (this._popupClosed || this._topicScrollInterrupted) return
 
         this.cancelProgrammaticScroll()
         const list = this.listTarget


### PR DESCRIPTION
## Summary

- replace the browser-owned smooth topic scroll with a cancellable animation
- cancel an in-progress active-topic scroll as soon as wheel or touch input starts
- preserve that interruption across delayed restore/layout callbacks
- resume automatic centering only for explicit user topic navigation or a newly opened popup
- cancel and block topic scrolling after popup close
- add regression coverage for wheel, touch, delayed calls, remote picks, explicit navigation, popup close, completion, and already-centered states

## Testing

- related JavaScript suites: 19 suites, 369 tests passed
- JavaScript patch coverage: 100%
- `npm run build`
- `bin/complexity_check --base origin/main`
- browser preview: active topic centered at 0 px error; wheel interruption and delayed/remote calls produced no position drift; explicit navigation resumed centering; closed popup blocked delayed scrolling; no JavaScript errors