### PR TITLE
fix: correlate slash command focus with its submission

### DIFF
--- a/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_stashed_draft_failure.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_stashed_draft_failure.test.js
@@ -128,19 +128,25 @@ describe('CommentsFormController stashed draft across a send failure', () => {
 
   test('still restores the draft into the box a successful send cleared', async () => {
     const { controller, textarea } = buildController()
+    const started = jest.fn()
     const settled = jest.fn()
+    controller.element.addEventListener('comments--form:submit-started', started)
     controller.element.addEventListener('comments--form:submit-settled', settled)
     global.fetch.mockResolvedValue({ ok: true, text: () => Promise.resolve('<div></div>') })
 
     stash(controller, 'roadmap notes')
     textarea.value = COMMAND_TEXT
 
-    controller.handleSend(new Event('submit'))
+    const event = new Event('submit')
+    event.commandSubmissionId = 'command-1'
+    controller.handleSend(event)
     await flush()
 
     expect(controller.resetForm).toHaveBeenCalledTimes(1)
     expect(textarea.value).toBe('roadmap notes')
+    expect(started.mock.calls[0][0].detail).toEqual({ submissionId: 'command-1' })
     expect(settled).toHaveBeenCalledTimes(1)
+    expect(settled.mock.calls[0][0].detail).toEqual({ submissionId: 'command-1' })
   })
 
   test('a failure with nothing stashed leaves the submitted text for a retry', async () => {

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -822,6 +822,7 @@ export default class extends Controller {
 
   handleSend(event) {
     event.preventDefault()
+    const commandSubmissionId = event.commandSubmissionId || null
 
     // If active quote exists, handle based on type
     const store = this._reviewStore
@@ -845,6 +846,11 @@ export default class extends Controller {
     this.sending = true
     this.setSendingState(true)
     this.presenceController?.stoppedTyping()
+    if (commandSubmissionId) {
+      this.element.dispatchEvent(new CustomEvent('comments--form:submit-started', {
+        detail: { submissionId: commandSubmissionId },
+      }))
+    }
 
     // Cancel any pending input debounce before capturing the submission. A
     // write while the request is in flight looks like a newer draft and can
@@ -1107,7 +1113,9 @@ export default class extends Controller {
           this._stashedDraft = null
         }
         const announceSettlement = () => {
-          this.element.dispatchEvent(new CustomEvent('comments--form:submit-settled'))
+          this.element.dispatchEvent(new CustomEvent('comments--form:submit-settled', {
+            detail: { submissionId: commandSubmissionId },
+          }))
         }
         settlementUi.then(announceSettlement, announceSettlement)
       })

--- a/engines/collavre/app/javascript/modules/__tests__/command_menu_typeahead.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/command_menu_typeahead.test.js
@@ -149,9 +149,16 @@ describe('command menu typeahead', () => {
     const { textarea, menu } = setup()
     const submit = document.createElement('button')
     const submitClick = jest.fn()
+    let submissionId
     submit.type = 'button'
     submit.setAttribute('data-comments--form-target', 'submit')
-    submit.addEventListener('click', submitClick)
+    submit.addEventListener('click', (event) => {
+      submitClick()
+      submissionId = event.commandSubmissionId
+      document.getElementById('comments-popup').dispatchEvent(
+        new CustomEvent('comments--form:submit-started', { detail: { submissionId } }),
+      )
+    })
     document.getElementById('new-comment-form').appendChild(submit)
 
     type(textarea, '/task')
@@ -176,7 +183,14 @@ describe('command menu typeahead', () => {
     expect(document.activeElement).not.toBe(textarea)
 
     document.getElementById('comments-popup').dispatchEvent(
-      new CustomEvent('comments--form:submit-settled'),
+      new CustomEvent('comments--form:submit-settled', {
+        detail: { submissionId: 'an-unrelated-send' },
+      }),
+    )
+    expect(document.activeElement).not.toBe(textarea)
+
+    document.getElementById('comments-popup').dispatchEvent(
+      new CustomEvent('comments--form:submit-settled', { detail: { submissionId } }),
     )
 
     expect(document.activeElement).toBe(textarea)
@@ -199,10 +213,55 @@ describe('command menu typeahead', () => {
     document.body.appendChild(otherControl)
     otherControl.focus()
     document.getElementById('comments-popup').dispatchEvent(
-      new CustomEvent('comments--form:submit-settled'),
+      new CustomEvent('comments--form:submit-settled', { detail: { submissionId } }),
     )
 
     expect(submitClick).toHaveBeenCalledTimes(2)
+    expect(document.activeElement).toBe(otherControl)
+  })
+
+  test('a rejected command submission removes its settlement listener', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([{
+        name: 'task_create',
+        label: '/task_create',
+        aliases: [],
+        input_schema: [{ name: 'title', type: 'string', required: false }],
+      }]),
+    })
+    const { textarea } = setup()
+    const submit = document.createElement('button')
+    let rejectedSubmissionId
+    submit.type = 'button'
+    submit.setAttribute('data-comments--form-target', 'submit')
+    submit.addEventListener('click', (event) => {
+      rejectedSubmissionId = event.commandSubmissionId
+      // No submit-started event: the form controller rejected this attempt.
+    })
+    document.getElementById('new-comment-form').appendChild(submit)
+
+    type(textarea, '/task')
+    await settle()
+    textarea.dispatchEvent(new KeyboardEvent('keydown', {
+      key: 'Enter', bubbles: true, cancelable: true,
+    }))
+    document.querySelector('#command-args-dialog textarea').dispatchEvent(new KeyboardEvent('keydown', {
+      key: 'Enter', bubbles: true, cancelable: true,
+    }))
+    await flush()
+
+    expect(document.activeElement).toBe(textarea)
+
+    const otherControl = document.createElement('button')
+    document.body.appendChild(otherControl)
+    otherControl.focus()
+    document.getElementById('comments-popup').dispatchEvent(
+      new CustomEvent('comments--form:submit-settled', {
+        detail: { submissionId: rejectedSubmissionId },
+      }),
+    )
+
     expect(document.activeElement).toBe(otherControl)
   })
 })

--- a/engines/collavre/app/javascript/modules/command_menu.js
+++ b/engines/collavre/app/javascript/modules/command_menu.js
@@ -4,6 +4,7 @@ import CommandArgsForm from './command_args_form'
 import { openCreativeLinkPicker } from './creative_link_picker'
 
 let commandMenuInitialized = false
+let commandSubmissionSequence = 0
 
 if (!commandMenuInitialized) {
   commandMenuInitialized = true
@@ -57,14 +58,31 @@ if (!commandMenuInitialized) {
         // Trigger form submission directly
         const submitBtn = document.querySelector('#new-comment-form [data-comments--form-target="submit"]')
         if (submitBtn) {
+          const submissionId = String(++commandSubmissionSequence)
+          let submissionStarted = false
+          const markSubmission = (event) => { event.commandSubmissionId = submissionId }
+          const onSubmissionStarted = (event) => {
+            if (event.detail?.submissionId === submissionId) submissionStarted = true
+          }
           // Keep focus out of the textarea while its value is still the command
           // being sent. The form announces settlement after success/failure
           // cleanup, so typing cannot append to the in-flight command.
-          popup.addEventListener('comments--form:submit-settled', () => {
+          const onSubmissionSettled = (event) => {
+            if (event.detail?.submissionId !== submissionId) return
+            popup.removeEventListener('comments--form:submit-settled', onSubmissionSettled)
             const active = document.activeElement
             if (!active || active === document.body) textarea.focus()
-          }, { once: true })
+          }
+          submitBtn.addEventListener('click', markSubmission, { capture: true, once: true })
+          popup.addEventListener('comments--form:submit-started', onSubmissionStarted)
+          popup.addEventListener('comments--form:submit-settled', onSubmissionSettled)
           submitBtn.click()
+          submitBtn.removeEventListener('click', markSubmission, true)
+          popup.removeEventListener('comments--form:submit-started', onSubmissionStarted)
+          if (!submissionStarted) {
+            popup.removeEventListener('comments--form:submit-settled', onSubmissionSettled)
+            textarea.focus()
+          }
         }
       },
       onCancel: () => {


### PR DESCRIPTION
## Summary

- correlate slash-command focus restoration events with the exact form submission
- ignore unrelated settlement events so concurrent sends cannot consume the listener
- restore focus immediately and remove listeners when the form rejects a command submission
- add regression coverage for correlation and rejected submissions

Follow-up to #1595.

## Testing

- npm test -- --runInBand (1,578 tests)
- npm test -- --runInBand engines/collavre/app/javascript/modules/__tests__/command_menu_typeahead.test.js engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_stashed_draft_failure.test.js (12 tests)
- ./bin/rubocop -a (1,278 files)
- bin/complexity_check