### PR TITLE
fix: return to the originating list after editing an AI agent

### DIFF
--- a/engines/collavre/app/controllers/concerns/collavre/users_controller/ai_user_management.rb
+++ b/engines/collavre/app/controllers/concerns/collavre/users_controller/ai_user_management.rb
@@ -70,6 +70,7 @@ module Collavre
       @llm_models = Collavre::LlmModel.suggestions
       @agent_gateways = editable_agent_gateways(@user)
       @has_stored_llm_api_key = @user.llm_api_key.present?
+      @return_to = safe_return_to(params[:return_to].presence || request.referer)
     end
 
     def update_ai
@@ -106,13 +107,9 @@ module Collavre
       end
 
       if updated
-        redirect_to current_user_contacts_path, notice: I18n.t("collavre.users.update_ai.success")
+        redirect_to update_ai_destination, notice: I18n.t("collavre.users.update_ai.success")
       else
-        @available_tools = load_available_tools
-        @llm_models = Collavre::LlmModel.suggestions
-        @agent_gateways = editable_agent_gateways(@user)
-        flash.now[:alert] = @user.errors.full_messages.to_sentence
-        render :edit_ai, status: :unprocessable_entity
+        render_ai_edit_failure
       end
     end
 
@@ -120,6 +117,40 @@ module Collavre
 
     def current_user_contacts_path
       user_path(Current.user, tab: "contacts")
+    end
+
+    def render_ai_edit_failure
+      @available_tools = load_available_tools
+      @llm_models = Collavre::LlmModel.suggestions
+      @agent_gateways = editable_agent_gateways(@user)
+      @return_to = safe_return_to(params[:return_to])
+      flash.now[:alert] = @user.errors.full_messages.to_sentence
+      render :edit_ai, status: :unprocessable_entity
+    end
+
+    # Saving should land back on whatever list opened the form (the admin user
+    # list, a profile's contacts tab, the org chart), not a fixed page.
+    def update_ai_destination
+      safe_return_to(params[:return_to]) || current_user_contacts_path
+    end
+
+    def safe_return_to(candidate)
+      path = local_path_for(candidate)
+      return nil if path.nil? || path.split("?").first == edit_ai_user_path(@user)
+
+      path
+    end
+
+    def local_path_for(candidate)
+      return nil if candidate.blank?
+
+      uri = URI.parse(candidate)
+      return nil if uri.host.present? && uri.host != request.host
+      return nil unless uri.path.to_s.start_with?("/") && !uri.path.start_with?("//")
+
+      [ uri.path, uri.query ].compact_blank.join("?")
+    rescue URI::InvalidURIError
+      nil
     end
 
     def remember_llm_model(user)

--- a/engines/collavre/app/views/collavre/users/edit_ai.html.erb
+++ b/engines/collavre/app/views/collavre/users/edit_ai.html.erb
@@ -5,7 +5,9 @@
               url: collavre.update_ai_user_path(@user),
               method: :patch,
               class: "stacked-form",
-              data: { controller: "agent-vendor", agent_vendor_default_model_value: "paperclip/claude_local" } do |form| %>
+              data: { controller: "agent-vendor", agent_vendor_default_model_value: "paperclip/claude_local", turbo_action: "replace" } do |form| %>
+  <%= hidden_field_tag :return_to, @return_to if @return_to.present? %>
+
   <div class="form-group">
     <%= form.label :name, t('collavre.users.new_ai.name_label') %>
     <%= form.text_field :name, required: true, class: "stacked-form-control", placeholder: "e.g. My Bot" %>

--- a/engines/collavre/test/controllers/users_controller_ai_test.rb
+++ b/engines/collavre/test/controllers/users_controller_ai_test.rb
@@ -466,4 +466,100 @@ class UsersControllerAiTest < ActionDispatch::IntegrationTest
     assert_equal "Name can't be blank", flash[:alert]
     assert_select "form[action=?]", update_ai_user_path(@ai_user)
   end
+
+  test "edit_ai keeps the originating list so saving returns there" do
+    get edit_ai_user_url(@ai_user), headers: { "HTTP_REFERER" => users_url }
+
+    assert_response :success
+    assert_select "form[data-turbo-action='replace']"
+    assert_select "input[type='hidden'][name='return_to'][value=?]", users_path
+  end
+
+  test "edit_ai ignores an off-site origin" do
+    get edit_ai_user_url(@ai_user), headers: { "HTTP_REFERER" => "https://evil.example.com/users" }
+
+    assert_response :success
+    assert_select "input[name='return_to']", false
+  end
+
+  test "edit_ai ignores itself as an origin" do
+    get edit_ai_user_url(@ai_user), headers: { "HTTP_REFERER" => edit_ai_user_url(@ai_user) }
+
+    assert_response :success
+    assert_select "input[name='return_to']", false
+  end
+
+  test "updating an ai user returns to the originating list" do
+    patch update_ai_user_url(@ai_user), params: {
+      return_to: users_path,
+      user: { name: "Back To List Bot" }
+    }
+
+    assert_redirected_to users_path
+    assert_equal "Back To List Bot", @ai_user.reload.name
+  end
+
+  test "updating an ai user keeps the origin query string" do
+    patch update_ai_user_url(@ai_user), params: {
+      return_to: "#{user_path(@admin)}?tab=contacts",
+      user: { name: "Contacts Tab Bot" }
+    }
+
+    assert_redirected_to user_path(@admin, tab: "contacts")
+  end
+
+  test "updating an ai user rejects an off-site return_to" do
+    patch update_ai_user_url(@ai_user), params: {
+      return_to: "https://evil.example.com/steal",
+      user: { name: "Safe Bot" }
+    }
+
+    assert_redirected_to user_path(@admin, tab: "contacts")
+  end
+
+  test "updating an ai user rejects a protocol relative return_to" do
+    patch update_ai_user_url(@ai_user), params: {
+      return_to: "//evil.example.com/steal",
+      user: { name: "Safe Bot 2" }
+    }
+
+    assert_redirected_to user_path(@admin, tab: "contacts")
+  end
+
+  test "updating an ai user rejects a non http return_to" do
+    patch update_ai_user_url(@ai_user), params: {
+      return_to: "javascript:alert(1)",
+      user: { name: "Safe Bot 3" }
+    }
+
+    assert_redirected_to user_path(@admin, tab: "contacts")
+  end
+
+  test "updating an ai user rejects a malformed return_to" do
+    patch update_ai_user_url(@ai_user), params: {
+      return_to: "http://[bad",
+      user: { name: "Safe Bot 4" }
+    }
+
+    assert_redirected_to user_path(@admin, tab: "contacts")
+  end
+
+  test "updating an ai user rejects the edit page as return_to" do
+    patch update_ai_user_url(@ai_user), params: {
+      return_to: edit_ai_user_path(@ai_user),
+      user: { name: "No Loop Bot" }
+    }
+
+    assert_redirected_to user_path(@admin, tab: "contacts")
+  end
+
+  test "a failed ai user update keeps the originating list" do
+    patch update_ai_user_url(@ai_user), params: {
+      return_to: users_path,
+      user: { name: "" }
+    }
+
+    assert_response :unprocessable_entity
+    assert_select "input[type='hidden'][name='return_to'][value=?]", users_path
+  end
 end

--- a/engines/collavre/test/system/ai_agent_edit_back_navigation_test.rb
+++ b/engines/collavre/test/system/ai_agent_edit_back_navigation_test.rb
@@ -1,0 +1,42 @@
+require_relative "../application_system_test_case"
+
+# Saving an AI agent used to push a new history entry and land on a fixed page,
+# so the browser back button walked back into the edit form instead of the list
+# the user opened it from.
+class AiAgentEditBackNavigationTest < ApplicationSystemTestCase
+  setup do
+    @admin = User.create!(
+      email: "ai-back-nav@example.com",
+      password: SystemHelpers::PASSWORD,
+      name: "AI Back Nav",
+      email_verified_at: Time.current,
+      notifications_enabled: false,
+      system_admin: true
+    )
+    @agent = User.create!(
+      email: "back-nav-bot@ai.local",
+      password: SecureRandom.hex(36),
+      name: "Back Nav Bot",
+      system_prompt: "Be helpful",
+      llm_vendor: "google",
+      llm_model: "gemini-1.5-pro",
+      email_verified_at: Time.current,
+      created_by_id: @admin.id
+    )
+
+    resize_window_to
+    sign_in_via_ui(@admin)
+  end
+
+  test "saving an ai agent returns to the user list and back does not reopen the form" do
+    visit collavre.users_path
+    click_link @agent.name
+    assert_current_path collavre.edit_ai_user_path(@agent)
+
+    click_button I18n.t("common.save")
+
+    assert_current_path collavre.users_path
+    page.go_back
+    assert_current_path collavre.users_path
+  end
+end


### PR DESCRIPTION
## Problem

Follow-up to #1590, which did not fix the reported behaviour.

Opening an AI agent from **Settings → Users** (`/users`) and saving it landed on
`/users/:current_user_id?tab=contacts` — the signed-in user's profile page, not
the list the form was opened from. Pressing browser back then went *into* the
edit form again, because the post-save redirect pushed a new history entry.

Reproduced against a local preview:

| step | URL |
|---|---|
| user list | `/users` |
| click agent | `/users/3/edit_ai` |
| save | `/users/1?tab=contacts` |
| back | `/users/3/edit_ai` |
| back | `/users` |

## Root cause

Two independent defects:

1. `update_ai` redirected to a hardcoded `current_user_contacts_path`, ignoring
   where the form was opened from. `edit_ai` is linked from the admin user list,
   a profile's contacts tab, the org chart and the agent's own profile.
2. The redirect target differed from the form URL, so Turbo's
   `#getDefaultAction` chose `advance` and pushed a history entry, leaving the
   stale edit form one back-press away.

## Fix

- `edit_ai` records the page it was opened from (explicit `return_to` param, or
  the referer) and renders it as a hidden field; `update_ai` redirects there.
- Origins are validated as same-host local paths, so an off-site, protocol
  relative, non-HTTP or malformed value falls back to the contacts list. The
  edit page itself is rejected as an origin to avoid a self-redirect loop.
- The form submits with `data-turbo-action="replace"`, so a successful save
  replaces the edit entry instead of stacking on top of it. Back no longer
  reopens the form.
- `update_ai`'s failure branch moved into `render_ai_edit_failure` to stay
  inside the complexity budget.

After the fix: save → `/users`, back → `/users`, back → previous section.

## Testing

- `mise exec -- bin/rails test engines/collavre/test/controllers/users_controller_ai_test.rb engines/collavre/test/controllers/users_controller_test.rb engines/collavre/test/system/ai_agent_edit_back_navigation_test.rb` (70 runs, 401 assertions, 0 failures)
- New system test `ai_agent_edit_back_navigation_test.rb` drives the real
  browser-back path; verified it fails on the pre-fix controller/view.
- 10 new controller tests cover the origin round trip, the query-string case,
  and every rejected-origin branch.
- `mise exec -- ./bin/rubocop -a` — no offenses
- `mise exec -- bin/complexity_check` — ratchet OK, none grew
- Manual verification in a headless browser against a local preview server.