### PR TITLE
test: isolate local system tests from stale assets

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -18,6 +18,12 @@ Rails.application.configure do
   # Configure public file server for tests with cache-control for performance.
   config.public_file_server.headers = { "cache-control" => "public, max-age=3600" }
 
+  # A local assets:precompile leaves a manifest under public/assets. Propshaft
+  # treats any manifest there as authoritative, so system tests can load stale
+  # CSS and JavaScript instead of the source under test. Give every test boot a
+  # fresh, non-public manifest path so its resolver always reads current assets.
+  config.assets.manifest_path = Rails.root.join("tmp/test-assets/#{Process.pid}/.manifest.json")
+
   # Show full error reports.
   config.consider_all_requests_local = true
   # config.cache_store = :null_store

--- a/engines/collavre/test/system/creative_filter_navigation_test.rb
+++ b/engines/collavre/test/system/creative_filter_navigation_test.rb
@@ -72,6 +72,7 @@ class CreativeFilterNavigationTest < ApplicationSystemTestCase
     visit collavre.creatives_path
     find(COMMENT_BUTTON).click
     assert_selector "#{COMMENT_BUTTON}.active"
+    assert_current_path(/comment=true/, url: false)
 
     find(COMMENT_BUTTON).click
 

--- a/test/config/environments/test_environment_test.rb
+++ b/test/config/environments/test_environment_test.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestEnvironmentTest < ActiveSupport::TestCase
+  test "resolves assets from current source instead of a public precompile manifest" do
+    manifest_path = Rails.application.config.assets.manifest_path
+
+    assert_match %r{\A#{Regexp.escape(Rails.root.to_s)}/tmp/test-assets/\d+/\.manifest\.json\z}, manifest_path.to_s
+    refute_predicate manifest_path, :exist?
+    assert_instance_of Propshaft::Resolver::Dynamic, Rails.application.assets.resolver
+  end
+end


### PR DESCRIPTION
## Summary

- isolate test asset resolution from stale `public/assets/.manifest.json` files
- add a regression test that requires the dynamic Propshaft resolver in test
- wait for the first chat-filter URL transition before toggling it off

## Root cause

A local `assets:precompile` left a public manifest that made Propshaft serve old CSS and JavaScript. Reproducing with an old empty-state stylesheet produced the same `100000px` radius and missing gradient failures. The stale JavaScript also explains the login, modal, drag, and filter failures that passed in CI.

## Verification

- stale-manifest reproduction before fix: 3 runs, 2 failures
- stale-manifest regression after fix: 4 runs, 21 assertions, 0 failures
- changed config, empty-state, and filter suites: 12 runs, 72 assertions, 0 failures
- filter toggle repeated across 5 seeds: all passed
- RuboCop: 3 files, no offenses
- complexity ratchet: passed

The full system directory was exercised as well. The reported stale-asset failures did not recur; separate existing drawer and browser-navigation flakes were observed and are outside this change.