### PR TITLE
test: stabilize workspace UI timing

### DIFF
--- a/engines/collavre/test/system/inline_scripts_test.rb
+++ b/engines/collavre/test/system/inline_scripts_test.rb
@@ -224,6 +224,7 @@ class InlineScriptsTest < ApplicationSystemTestCase
     assert_selector ".creative-workspace-tree-link[data-creative-id='#{second_branch.id}'].is-current"
     assert_equal "mounted", find("[data-controller='workspace-tree']")["data-persistence-marker"]
     assert_equal second_branch.id.to_s, find("#comments-popup", visible: :visible)["data-creative-id"]
+    assert_eventually { page.evaluate_script("window.Turbo?.navigator?.currentVisit == null") }
 
     page.go_back
 

--- a/engines/collavre/test/system/workspace_tree_drawer_test.rb
+++ b/engines/collavre/test/system/workspace_tree_drawer_test.rb
@@ -75,6 +75,7 @@ class WorkspaceTreeDrawerTest < ApplicationSystemTestCase
     visit_workspace(MOBILE_WIDTH)
     find(".creative-workspace-tree-toggle").click
     assert_selector ".creative-workspace-tree-region.is-open"
+    assert_drawer_settled(open: true)
 
     # The docked chat is normally closed below 768px. Show it at its mobile
     # position to exercise the exact overlap that previously hid the drawer.


### PR DESCRIPTION
## Summary
- wait for Turbo navigation to finish before exercising browser history
- wait for the mobile workspace drawer transition before hit-testing its stacking order

## Verification
- mise exec -- npm test (1,599 tests)
- mise exec -- bundle exec rake test (4,544 runs, 15,486 assertions)
- mise exec -- bundle exec rake test:system (105 runs, 671 assertions, 2 existing skips)
- mise exec -- ./bin/rubocop -a (1,280 files)
- workspace history test: 8 consecutive passes
- mobile drawer overlap test: 12 consecutive passes