### PR TITLE
fix: keep Turbo history state when switching profile tabs

### DIFF
--- a/engines/collavre/app/javascript/controllers/__tests__/tabs_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/tabs_controller.test.js
@@ -1,0 +1,137 @@
+/**
+ * @jest-environment jsdom
+ */
+import { Application } from '@hotwired/stimulus'
+
+const { default: TabsController } = await import('../tabs_controller')
+
+describe('TabsController', () => {
+  let application
+
+  // jsdom's window.location is unforgeable, so drive it through history.
+  function setLocation(href, state = {}) {
+    window.history.replaceState(state, '', href)
+  }
+
+  async function mount({ activeTab = 'profile' } = {}) {
+    document.body.innerHTML = `
+      <div data-controller="tabs" data-tabs-active-tab-value="${activeTab}">
+        <div class="tab-list">
+          <button class="tab-button" data-action="click->tabs#switch"
+                  data-tabs-tab-param="profile" data-tabs-target="tabButton">Profile</button>
+          <button class="tab-button" data-action="click->tabs#switch"
+                  data-tabs-tab-param="contacts" data-tabs-target="tabButton">User management</button>
+        </div>
+        <div class="tab-panels">
+          <section class="tab-panel" data-tabs-target="panel" data-tab-name="profile"></section>
+          <section class="tab-panel" data-tabs-target="panel" data-tab-name="contacts"></section>
+        </div>
+      </div>
+    `
+
+    application = Application.start()
+    application.register('tabs', TabsController)
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  }
+
+  function clickTab(tab) {
+    document.querySelector(`[data-tabs-tab-param="${tab}"]`).click()
+  }
+
+  function panel(name) {
+    return document.querySelector(`[data-tab-name="${name}"]`)
+  }
+
+  beforeEach(() => {
+    setLocation('http://localhost/users/1')
+  })
+
+  afterEach(() => {
+    application?.stop()
+    document.body.innerHTML = ''
+  })
+
+  test('shows the server-rendered tab on connect', async () => {
+    await mount({ activeTab: 'contacts' })
+
+    expect(panel('contacts').classList.contains('active')).toBe(true)
+    expect(panel('profile').classList.contains('active')).toBe(false)
+  })
+
+  test('defaults to the profile tab when none is set', async () => {
+    document.body.innerHTML = `
+      <div data-controller="tabs">
+        <div class="tab-panels">
+          <section class="tab-panel" data-tabs-target="panel" data-tab-name="profile"></section>
+          <section class="tab-panel" data-tabs-target="panel" data-tab-name="contacts"></section>
+        </div>
+      </div>
+    `
+    application = Application.start()
+    application.register('tabs', TabsController)
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(panel('profile').classList.contains('active')).toBe(true)
+  })
+
+  test('switching a tab activates its panel and button', async () => {
+    await mount()
+
+    clickTab('contacts')
+
+    expect(panel('contacts').classList.contains('active')).toBe(true)
+    expect(document.querySelector('[data-tabs-tab-param="contacts"]').classList.contains('active')).toBe(true)
+    expect(document.querySelector('[data-tabs-tab-param="profile"]').classList.contains('active')).toBe(false)
+  })
+
+  test('switching a tab records it in the query string', async () => {
+    await mount()
+
+    clickTab('contacts')
+
+    expect(window.location.search).toBe('?tab=contacts')
+  })
+
+  test('leaving the contacts tab drops its pagination cursor', async () => {
+    setLocation('http://localhost/users/1?tab=contacts&contact_page=3')
+    await mount({ activeTab: 'contacts' })
+
+    clickTab('profile')
+
+    expect(window.location.search).toBe('?tab=profile')
+  })
+
+  test('staying on the contacts tab keeps its pagination cursor', async () => {
+    setLocation('http://localhost/users/1?tab=contacts&contact_page=3')
+    await mount({ activeTab: 'contacts' })
+
+    clickTab('contacts')
+
+    expect(window.location.search).toBe('?tab=contacts&contact_page=3')
+  })
+
+  test('ignores a click that names no tab', async () => {
+    await mount()
+    const button = document.querySelector('[data-tabs-tab-param="contacts"]')
+    delete button.dataset.tabsTabParam
+
+    button.click()
+
+    expect(panel('profile').classList.contains('active')).toBe(true)
+    expect(window.location.search).toBe('')
+  })
+
+  // Turbo Drive only restores a history entry whose state still carries its
+  // restorationIdentifier. Overwriting the state here left back navigation
+  // changing the URL while the previous page stayed on screen — leaving the
+  // AI agent edit form up after backing out of it.
+  test('switching a tab keeps the Turbo history state intact', async () => {
+    const turboState = { turbo: { restorationIdentifier: 'abc-123', restorationIndex: 4 } }
+    setLocation('http://localhost/users/1', turboState)
+    await mount()
+
+    clickTab('contacts')
+
+    expect(window.history.state).toEqual(turboState)
+  })
+})

--- a/engines/collavre/app/javascript/controllers/tabs_controller.js
+++ b/engines/collavre/app/javascript/controllers/tabs_controller.js
@@ -38,6 +38,10 @@ export default class extends Controller {
     if (tab !== "contacts") {
       url.searchParams.delete("contact_page")
     }
-    window.history.replaceState({}, "", url)
+    // Keep the entry's existing state: Turbo Drive stores its
+    // restorationIdentifier there and only restores a popped entry that still
+    // carries one. Dropping it makes back navigation change the URL while the
+    // page the user backed out of stays on screen.
+    window.history.replaceState(window.history.state, "", url)
   }
 }

--- a/engines/collavre/test/system/ai_agent_edit_back_navigation_test.rb
+++ b/engines/collavre/test/system/ai_agent_edit_back_navigation_test.rb
@@ -39,4 +39,24 @@ class AiAgentEditBackNavigationTest < ApplicationSystemTestCase
     page.go_back
     assert_current_path collavre.users_path
   end
+
+  # Opening the form from the profile's user management tab used to leave the
+  # edit form on screen after going back: switching tabs overwrote the history
+  # entry's Turbo state, so Turbo skipped the restore and only the URL changed.
+  test "backing out of the ai agent form restores the user management tab" do
+    Collavre::Contact.ensure(user: @admin, contact_user: @agent)
+
+    visit collavre.user_path(@admin)
+    click_button I18n.t("collavre.users.tabs.user_management")
+    assert_selector ".tab-panel.active[data-tab-name='contacts']"
+
+    click_link I18n.t("collavre.users.edit_ai.link")
+    assert_current_path collavre.edit_ai_user_path(@agent)
+
+    page.go_back
+
+    assert_current_path collavre.user_path(@admin), ignore_query: true
+    assert_no_selector "form[action='#{collavre.update_ai_user_path(@agent)}']"
+    assert_selector ".tab-panel.active[data-tab-name='contacts']"
+  end
 end


### PR DESCRIPTION
## Problem

Reported: opening the AI agent edit page from user settings and pressing Back leaves the browser on the edit form instead of returning to the list.

PR #1590 and #1598 fixed the *save* redirect and the entry opened from the admin user list. Neither covered the path the report was actually about: the profile page's **User management** tab.

## Root cause

`tabs_controller#updateUrl` records the active tab with:

```js
window.history.replaceState({}, "", url)
```

That replaces the history entry's state wholesale, discarding the `restorationIdentifier` Turbo Drive keeps there. Turbo only performs a restore visit for a popped entry that still carries one (`shouldHandlePopState`). Without it, the traversal updates the URL and renders nothing, so the page the user backed out of stays on screen.

Reproduction on `main` (headless Chromium against a dev server):

| step | URL | `<h1>` |
| --- | --- | --- |
| profile → User management tab | `/users/1?tab=contacts` | User Details |
| → Edit AI | `/users/3/edit_ai` | Edit AI Agent |
| → Back | `/users/1?tab=contacts` | **Edit AI Agent** |

`history.state` after the tab click was `{}`.

## Fix

Pass the entry's existing state through, the same way `topics_controller#clearUrlTopicId` already does:

```js
window.history.replaceState(window.history.state, "", url)
```

After the fix the same walk-through ends on `User Details` with the User management panel active and no `update_ai` form in the DOM.

## Tests

- New `tabs_controller.test.js` (8 cases): panel/button activation, query-string updates, `contact_page` cursor handling, no-op click, and the regression guard asserting the Turbo state survives a tab switch. 100% line coverage on the file.
- New system test `backing out of the ai agent form restores the user management tab`. Verified it fails on the unpatched controller (finds the `update_ai` form after `go_back`) and passes with the fix.
- Full Jest suite: 117 suites, 1607 tests, 0 failures.
- RuboCop clean on the changed Ruby file.

## Known related defect, not in this PR

`engines/collavre/app/javascript/modules/slide_view.js:38` calls `history.replaceState(null, '', url)` — the same defect class, on slide view pages. That module has no JS test harness today, so covering it is a separate piece of work rather than a drive-by change here.