### PR TITLE
feat: add back button to feature guide hub

### DIFF
--- a/engines/collavre/app/views/collavre/features/index.html.erb
+++ b/engines/collavre/app/views/collavre/features/index.html.erb
@@ -6,10 +6,6 @@
 <div class="landing">
   <section class="landing-section landing-features">
     <div class="landing-container">
-      <nav class="feature-guide-breadcrumb">
-        <%= link_to t('collavre.features.nav.landing'), collavre.landing_path(locale: I18n.locale, script_name: request.script_name) %>
-      </nav>
-
       <h1 class="landing-section-title"><%= t('collavre.features.index.title') %></h1>
       <p class="landing-section-sub"><%= t('collavre.features.index.subtitle') %></p>
 
@@ -23,6 +19,10 @@
           <% end %>
         <% end %>
       </div>
+
+      <p class="feature-guide-back">
+        <%= link_to t('collavre.features.nav.back_home'), collavre.landing_path(locale: I18n.locale, script_name: request.script_name), class: "landing-btn landing-btn-ghost" %>
+      </p>
     </div>
   </section>
 

--- a/engines/collavre/config/locales/features.en.yml
+++ b/engines/collavre/config/locales/features.en.yml
@@ -4,6 +4,7 @@ en:
     features:
       nav:
         landing: "Home"
+        back_home: "← Home"
         all: "All features"
         all_arrow: "← All features"
         separator: "/"

--- a/engines/collavre/config/locales/features.ko.yml
+++ b/engines/collavre/config/locales/features.ko.yml
@@ -4,6 +4,7 @@ ko:
     features:
       nav:
         landing: "홈"
+        back_home: "← 홈"
         all: "전체 기능"
         all_arrow: "← 전체 기능"
         separator: "/"

--- a/engines/collavre/test/controllers/collavre/features_controller_test.rb
+++ b/engines/collavre/test/controllers/collavre/features_controller_test.rb
@@ -39,6 +39,18 @@ module Collavre
       assert_includes I18n.t("collavre.features.index.card_more", locale: :ko), "→"
     end
 
+    test "index renders a localized home button and preserves the mount prefix" do
+      request_env = { "SCRIPT_NAME" => "/collavre" }
+
+      %i[en ko].each do |locale|
+        get "/features", params: { locale: locale }, env: request_env
+
+        assert_response :success
+        assert_select "a.landing-btn.landing-btn-ghost[href=?]", "/collavre/landing?locale=#{locale}",
+                      text: I18n.t("collavre.features.nav.back_home", locale: locale), count: 1
+      end
+    end
+
     test "index is readable without signing in" do
       get "/features"
 

--- a/engines/collavre/test/system/feature_guide_test.rb
+++ b/engines/collavre/test/system/feature_guide_test.rb
@@ -34,11 +34,19 @@ class FeatureGuideTest < ApplicationSystemTestCase
     original_help_item ? registry.register(original_help_item) : registry.unregister(:help)
   end
 
-  test "the hub breadcrumb is visible" do
+  test "the hub home button is visible" do
     visit collavre.features_path
 
-    assert_selector "nav.feature-guide-breadcrumb"
-    assert_link I18n.t("collavre.features.nav.landing")
+    assert_selector ".feature-guide-back"
+    assert_link I18n.t("collavre.features.nav.back_home"), class: "landing-btn-ghost"
+  end
+
+  test "the hub offers a back button to the landing page" do
+    visit collavre.features_path
+
+    click_link I18n.t("collavre.features.nav.back_home")
+
+    assert_current_path collavre.landing_path(locale: I18n.locale)
   end
 
   test "a guide breadcrumb is visible and walks back to the hub" do


### PR DESCRIPTION
## Summary

- add a visible back button to the feature guide hub
- preserve the selected locale and engine mount prefix
- provide English and Korean labels

## Tests

- `bin/rails test engines/collavre/test/controllers/collavre/features_controller_test.rb test/i18n_completeness_test.rb`
- `bin/rails test engines/collavre/test/system/feature_guide_test.rb`
- `./bin/rubocop -a`
- `bin/complexity_check`
