### PR TITLE
test(comments): cover entity list callback wiring

### DIFF
--- a/engines/collavre/app/javascript/controllers/__tests__/entity_list_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/entity_list_controller.test.js
@@ -199,6 +199,17 @@ describe('EntityListController', () => {
         expect(controller.popup.isOpen()).toBe(false)
     })
 
+    test('Escape closes the popup when filtering leaves no items', () => {
+	controller.openForItems(ITEMS, RECT, () => {})
+	controller.inputTarget.value = 'nothing'
+	controller._onInput()
+
+	controller.handleInputKeydown({ key: 'Escape', preventDefault: jest.fn() })
+
+	expect(controller.popup.items).toEqual([])
+	expect(controller.popup.isOpen()).toBe(false)
+    })
+
     test('Tab closes without selecting or preventing focus traversal', () => {
         const cb = jest.fn()
         const preventDefault = jest.fn()

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/contexts_controller_context_list.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/contexts_controller_context_list.test.js
@@ -158,6 +158,20 @@ describe('CommentsContextsController — pinned add/list buttons', () => {
         expect(controller.listButtonTarget.getAttribute('aria-expanded')).toBe('false')
     })
 
+    test('routes popup selection through the context-list handler', () => {
+	const modal = document.createElement('div')
+	modal.id = 'context-list-modal'
+	controller.element.appendChild(modal)
+	const popup = { popup: { isOpen: () => false }, openForItems: jest.fn() }
+	jest.spyOn(controller.application, 'getControllerForElementAndIdentifier').mockReturnValue(popup)
+	const select = jest.spyOn(controller, 'selectContextListItem').mockReturnValue(true)
+
+	controller.openContextListPopup(anchorEvent())
+	popup.openForItems.mock.calls[0][2]({ id: 'self' })
+
+	expect(select).toHaveBeenCalledWith({ id: 'self' })
+    })
+
     test('ignores close events from another popup sharing the entity-list controller', () => {
         controller.setContextListButtonExpanded(true)
         const other = document.createElement('div')
@@ -244,6 +258,17 @@ describe('CommentsContextsController — pinned add/list buttons', () => {
 
         expect(keepOpen).toBe(true)
         expect(controller.contexts[0].disabled).toBe(true)
+    })
+
+    test('routes chip clicks through the shared context toggle', () => {
+	const target = document.createElement('span')
+	const currentTarget = document.createElement('button')
+	currentTarget.dataset.contextId = '1'
+	const toggle = jest.spyOn(controller, 'toggleContextById')
+
+	controller.toggleContext({ target, currentTarget })
+
+	expect(toggle).toHaveBeenCalledWith('1')
     })
 
     test('selecting the self entry toggles the self context', () => {

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/presence_controller_participant_list.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/presence_controller_participant_list.test.js
@@ -150,6 +150,21 @@ describe('CommentsPresenceController — pinned add/list buttons', () => {
         expect(controller.participantListButtonTarget.getAttribute('aria-expanded')).toBe('false')
     })
 
+    test('routes popup selection through the participant-list handler', () => {
+	controller.participantsData = USERS
+	const modal = document.createElement('div')
+	modal.id = 'participant-list-modal'
+	controller.element.appendChild(modal)
+	const popup = { popup: { isOpen: () => false }, openForItems: jest.fn() }
+	jest.spyOn(controller.application, 'getControllerForElementAndIdentifier').mockReturnValue(popup)
+	const select = jest.spyOn(controller, 'selectParticipantListItem').mockImplementation(() => {})
+
+	controller.openParticipantListPopup(anchorEvent())
+	popup.openForItems.mock.calls[0][2]({ id: 1 })
+
+	expect(select).toHaveBeenCalledWith({ id: 1 })
+    })
+
     test('ignores close events from another popup sharing the entity-list controller', () => {
         controller.setParticipantListButtonExpanded(true)
         const other = document.createElement('div')

--- a/engines/collavre/app/javascript/controllers/entity_list_controller.js
+++ b/engines/collavre/app/javascript/controllers/entity_list_controller.js
@@ -126,8 +126,7 @@ export default class extends CommonPopupController {
             this.close()
             return
         }
-        if (this.handleKey(event)) return
-        if (event.key === 'Escape') this.close()
+	this.handleKey(event)
     }
 
     select(item) {

--- a/engines/collavre/app/javascript/controllers/entity_list_controller.js
+++ b/engines/collavre/app/javascript/controllers/entity_list_controller.js
@@ -126,6 +126,10 @@ export default class extends CommonPopupController {
             this.close()
             return
         }
+	if (event.key === 'Escape') {
+	    this.close()
+	    return
+	}
 	this.handleKey(event)
     }
 


### PR DESCRIPTION
## Summary

- verify context and participant popup callbacks route selections to their handlers
- verify context chip clicks route through the shared toggle handler
- handle Escape before shared list navigation so empty search results still close the popup

## Verification

- `npm run test:coverage` (121 suites, 1,692 tests)
- all changed executable lines covered
- `bin/complexity_check --base origin/main`