### PR TITLE
feat: improve admin user table

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -383,18 +383,30 @@ input[type="password"] {
     overflow-x: auto;
 }
 
-.contacts-table {
+.contacts-table,
+.users-table {
     width: 100%;
     min-width: 720px;
     border-collapse: collapse;
 }
 
 .contacts-table th,
-.contacts-table td {
+.contacts-table td,
+.users-table th,
+.users-table td {
     padding: 0.5em;
     text-align: left;
     border-bottom: 1px solid var(--color-border);
     vertical-align: top;
+}
+
+.users-table {
+    min-width: 960px;
+}
+
+.users-table th:last-child,
+.users-table td:last-child {
+    min-width: 280px;
 }
 
 .contacts-table th:nth-child(1),

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_20_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_03_070800) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -1013,6 +1013,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_20_000000) do
     t.datetime "updated_at", null: false
     t.string "webauthn_id"
     t.index ["agent_gateway_id"], name: "index_users_on_agent_gateway_id"
+    t.index ["created_at", "id"], name: "index_users_on_created_at_and_id"
     t.index ["desktop_preset_adapter"], name: "index_users_on_desktop_preset_adapter", unique: true, where: "desktop_preset_adapter IS NOT NULL"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["last_visited_creative_id"], name: "index_users_on_last_visited_creative_id"

--- a/engines/collavre/app/controllers/concerns/collavre/users_controller/admin_operations.rb
+++ b/engines/collavre/app/controllers/concerns/collavre/users_controller/admin_operations.rb
@@ -23,7 +23,7 @@ module Collavre
       @user = Collavre::User.find(params[:id])
 
       if @user == Current.user
-        redirect_to users_path, alert: I18n.t("collavre.users.destroy.cannot_delete_self")
+        redirect_to users_index_redirect_path, alert: I18n.t("collavre.users.destroy.cannot_delete_self")
         return
       end
 
@@ -37,10 +37,9 @@ module Collavre
       end
 
       if @user.destroy
-        fallback = Current.user.system_admin? ? users_path : user_path(Current.user, tab: "contacts")
-        redirect_back fallback_location: fallback, notice: I18n.t("collavre.users.destroy.success")
+        redirect_after_user_destroy
       else
-        redirect_to users_path, alert: I18n.t("collavre.users.destroy.failure")
+        redirect_to users_index_redirect_path, alert: I18n.t("collavre.users.destroy.failure")
       end
     end
 
@@ -48,9 +47,9 @@ module Collavre
       @user = Collavre::User.find(params[:id])
 
       if @user.update(system_admin: true)
-        redirect_to users_path, notice: I18n.t("collavre.users.system_admin.granted")
+        redirect_to users_index_redirect_path, notice: I18n.t("collavre.users.system_admin.granted")
       else
-        redirect_to users_path, alert: I18n.t("collavre.users.system_admin.failed")
+        redirect_to users_index_redirect_path, alert: I18n.t("collavre.users.system_admin.failed")
       end
     end
 
@@ -58,26 +57,44 @@ module Collavre
       @user = Collavre::User.find(params[:id])
 
       if @user.update(system_admin: false)
-        redirect_to users_path, notice: I18n.t("collavre.users.system_admin.revoked")
+        redirect_to users_index_redirect_path, notice: I18n.t("collavre.users.system_admin.revoked")
       else
-        redirect_to users_path, alert: I18n.t("collavre.users.system_admin.failed")
+        redirect_to users_index_redirect_path, alert: I18n.t("collavre.users.system_admin.failed")
       end
     end
 
     def unlock
       @user = Collavre::User.find(params[:id])
       @user.unlock_account!
-      redirect_to users_path, notice: I18n.t("collavre.users.unlock.success", name: @user.display_name)
+      redirect_to users_index_redirect_path, notice: I18n.t("collavre.users.unlock.success", name: @user.display_name)
     end
 
     def lock
       @user = Collavre::User.find(params[:id])
       if @user == Current.user
-        redirect_to users_path, alert: I18n.t("collavre.users.lock.cannot_lock_self")
+        redirect_to users_index_redirect_path, alert: I18n.t("collavre.users.lock.cannot_lock_self")
         return
       end
       @user.lock_account!
-      redirect_to users_path, notice: I18n.t("collavre.users.lock.success", name: @user.display_name)
+      redirect_to users_index_redirect_path, notice: I18n.t("collavre.users.lock.success", name: @user.display_name)
+    end
+
+    private
+
+    def redirect_after_user_destroy
+      fallback = Current.user.system_admin? ? users_path : user_path(Current.user, tab: "contacts")
+      return redirect_to users_index_redirect_path, notice: I18n.t("collavre.users.destroy.success") if Current.user.system_admin? && params[:page].present?
+
+      redirect_back fallback_location: fallback, notice: I18n.t("collavre.users.destroy.success")
+    end
+
+    def users_index_redirect_path
+      requested_page = params[:page].to_i
+      return users_path if requested_page <= 1
+
+      total_pages = [ (Collavre::User.count.to_f / USERS_PER_PAGE).ceil, 1 ].max
+      redirect_page = [ requested_page, total_pages ].min
+      redirect_page == 1 ? users_path : users_path(page: redirect_page)
     end
   end
 end

--- a/engines/collavre/app/controllers/concerns/collavre/users_controller/admin_operations.rb
+++ b/engines/collavre/app/controllers/concerns/collavre/users_controller/admin_operations.rb
@@ -2,12 +2,21 @@ module Collavre
   module UsersController::AdminOperations
     extend ActiveSupport::Concern
 
+    USERS_PER_PAGE = 20
+
     included do
       before_action :require_system_admin!, only: [ :index, :grant_system_admin, :revoke_system_admin, :unlock, :lock ]
     end
 
     def index
-      @users = Collavre::User.includes(:sessions, :devices)
+      users = Collavre::User.all
+      @total_user_pages = [ (users.count.to_f / USERS_PER_PAGE).ceil, 1 ].max
+      @user_page = [ [ params[:page].to_i, 1 ].max, @total_user_pages ].min
+      @users = users
+        .includes(:sessions, :devices)
+        .order(created_at: :desc, id: :desc)
+        .offset((@user_page - 1) * USERS_PER_PAGE)
+        .limit(USERS_PER_PAGE)
     end
 
     def destroy

--- a/engines/collavre/app/views/collavre/users/index.html.erb
+++ b/engines/collavre/app/views/collavre/users/index.html.erb
@@ -38,7 +38,7 @@
             <% end %>
           </td>
           <td><%= user.email %></td>
-          <td><%= I18n.l(user.created_at, format: :short) %></td>
+          <td><%= I18n.l(user.created_at, format: :collavre_users_joined_at) %></td>
           <td>
             <% if last_login_at %>
               <%= I18n.l(last_login_at, format: :short) %>

--- a/engines/collavre/app/views/collavre/users/index.html.erb
+++ b/engines/collavre/app/views/collavre/users/index.html.erb
@@ -6,90 +6,106 @@
 
 <%= render "admin/shared/tabs" %>
 
-<table>
-  <thead>
-    <tr>
-      <th><%= t('collavre.users.table.avatar') %></th>
-      <th><%= t('collavre.users.table.name') %></th>
-      <th><%= t('collavre.users.table.email') %></th>
-      <th><%= t('collavre.users.table.last_login_at') %></th>
-      <th><%= t('collavre.users.table.push_token') %></th>
-      <th><%= t('collavre.users.table.notifications') %></th>
-      <th><%= t('collavre.users.table.actions') %></th>
-    </tr>
-  </thead>
-  <tbody>
-    <% @users.each do |user| %>
-      <% last_login_at = user.sessions.max_by(&:updated_at)&.updated_at %>
+<div class="table-scroll">
+  <table class="users-table">
+    <thead>
       <tr>
-        <td>
-          <%= render Collavre::AvatarComponent.new(
-                user: user,
-                size: 20,
-                classes: "avatar comment-presence-avatar#{' inactive' if user.sessions.empty?}" ) %>
-        </td>
-        <td>
-          <% if user.ai_user? %>
-            <%= link_to user.display_name, collavre.edit_ai_user_path(user) %>
-          <% else %>
-            <%= user.display_name %>
-          <% end %>
-        </td>
-        <td><%= user.email %></td>
-        <td>
-          <% if last_login_at %>
-            <%= I18n.l(last_login_at, format: :short) %>
-          <% else %>
-            <%= t('collavre.users.table.last_login_unknown') %>
-          <% end %>
-        </td>
-        <td><%= user.devices.any? ? t('collavre.users.push_token_present') : t('collavre.users.push_token_absent') %></td>
-        <td>
-          <% case user.notifications_enabled %>
-          <% when true %>
-            <%= t('collavre.users.table.notifications_enabled') %>
-          <% when false %>
-            <%= t('collavre.users.table.notifications_disabled') %>
-          <% else %>
-            <%= t('collavre.users.table.notifications_unset') %>
-          <% end %>
-        </td>
-        <td>
-          <% if user != Current.user %>
-            <% if user.system_admin? %>
-              <%= button_to t('collavre.users.make_normal_user'),
-                            collavre.revoke_system_admin_user_path(user),
-                            method: :patch,
-                            class: 'btn btn-xs btn-secondary' %>
-            <% else %>
-              <%= button_to t('collavre.users.make_system_admin'),
-                            collavre.grant_system_admin_user_path(user),
-                            method: :patch,
-                            class: 'btn btn-xs btn-success',
-                            form: { data: { turbo_confirm: t('collavre.users.confirm_grant_system_admin') } } %>
-            <% end %>
-            <% if user.locked? %>
-              <%= button_to t('collavre.users.unlock.button'),
-                            collavre.unlock_user_path(user),
-                            method: :patch,
-                            class: 'btn btn-xs btn-secondary' %>
-            <% else %>
-              <%= button_to t('collavre.users.lock.button'),
-                            collavre.lock_user_path(user),
-                            method: :patch,
-                            class: 'btn btn-xs btn-danger',
-                            form: { data: { turbo_confirm: t('collavre.users.lock.confirm') } } %>
-            <% end %>
-            <%= button_to t('collavre.users.delete'),
-                          collavre.user_path(user),
-                          method: :delete,
-                          class: 'btn btn-xs btn-danger',
-                          form: { data: { turbo_confirm: t('collavre.users.confirm_destroy') } } %>
-          <% else %>
-            <span class="text-muted"><%= t('collavre.users.table.current_user') %></span>
-          <% end %>
-        </td>
+        <th><%= t('collavre.users.table.avatar') %></th>
+        <th><%= t('collavre.users.table.name') %></th>
+        <th><%= t('collavre.users.table.email') %></th>
+        <th><%= t('collavre.users.table.joined_at') %></th>
+        <th><%= t('collavre.users.table.last_login_at') %></th>
+        <th><%= t('collavre.users.table.push_token') %></th>
+        <th><%= t('collavre.users.table.notifications') %></th>
+        <th><%= t('collavre.users.table.actions') %></th>
       </tr>
+    </thead>
+    <tbody>
+      <% @users.each do |user| %>
+        <% last_login_at = user.sessions.max_by(&:updated_at)&.updated_at %>
+        <tr>
+          <td>
+            <%= render Collavre::AvatarComponent.new(
+                  user: user,
+                  size: 20,
+                  classes: "avatar comment-presence-avatar#{' inactive' if user.sessions.empty?}" ) %>
+          </td>
+          <td>
+            <% if user.ai_user? %>
+              <%= link_to user.display_name, collavre.edit_ai_user_path(user) %>
+            <% else %>
+              <%= user.display_name %>
+            <% end %>
+          </td>
+          <td><%= user.email %></td>
+          <td><%= I18n.l(user.created_at, format: :short) %></td>
+          <td>
+            <% if last_login_at %>
+              <%= I18n.l(last_login_at, format: :short) %>
+            <% else %>
+              <%= t('collavre.users.table.last_login_unknown') %>
+            <% end %>
+          </td>
+          <td><%= user.devices.any? ? t('collavre.users.push_token_present') : t('collavre.users.push_token_absent') %></td>
+          <td>
+            <% case user.notifications_enabled %>
+            <% when true %>
+              <%= t('collavre.users.table.notifications_enabled') %>
+            <% when false %>
+              <%= t('collavre.users.table.notifications_disabled') %>
+            <% else %>
+              <%= t('collavre.users.table.notifications_unset') %>
+            <% end %>
+          </td>
+          <td>
+            <% if user != Current.user %>
+              <% if user.system_admin? %>
+                <%= button_to t('collavre.users.make_normal_user'),
+                              collavre.revoke_system_admin_user_path(user),
+                              method: :patch,
+                              class: 'btn btn-xs btn-secondary' %>
+              <% else %>
+                <%= button_to t('collavre.users.make_system_admin'),
+                              collavre.grant_system_admin_user_path(user),
+                              method: :patch,
+                              class: 'btn btn-xs btn-success',
+                              form: { data: { turbo_confirm: t('collavre.users.confirm_grant_system_admin') } } %>
+              <% end %>
+              <% if user.locked? %>
+                <%= button_to t('collavre.users.unlock.button'),
+                              collavre.unlock_user_path(user),
+                              method: :patch,
+                              class: 'btn btn-xs btn-secondary' %>
+              <% else %>
+                <%= button_to t('collavre.users.lock.button'),
+                              collavre.lock_user_path(user),
+                              method: :patch,
+                              class: 'btn btn-xs btn-danger',
+                              form: { data: { turbo_confirm: t('collavre.users.lock.confirm') } } %>
+              <% end %>
+              <%= button_to t('collavre.users.delete'),
+                            collavre.user_path(user),
+                            method: :delete,
+                            class: 'btn btn-xs btn-danger',
+                            form: { data: { turbo_confirm: t('collavre.users.confirm_destroy') } } %>
+            <% else %>
+              <span class="text-muted"><%= t('collavre.users.table.current_user') %></span>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>
+
+<% if @total_user_pages > 1 %>
+  <nav class="contact-pagination" aria-label="<%= t('collavre.users.pagination.label') %>">
+    <% if @user_page > 1 %>
+      <%= link_to t('collavre.users.pagination.prev'), collavre.users_path(page: @user_page - 1), class: 'pagination-button' %>
     <% end %>
-  </tbody>
-</table>
+    <span class="pagination-status"><%= t('collavre.users.pagination.page_info', current: @user_page, total: @total_user_pages) %></span>
+    <% if @user_page < @total_user_pages %>
+      <%= link_to t('collavre.users.pagination.next'), collavre.users_path(page: @user_page + 1), class: 'pagination-button' %>
+    <% end %>
+  </nav>
+<% end %>

--- a/engines/collavre/app/views/collavre/users/index.html.erb
+++ b/engines/collavre/app/views/collavre/users/index.html.erb
@@ -61,30 +61,30 @@
             <% if user != Current.user %>
               <% if user.system_admin? %>
                 <%= button_to t('collavre.users.make_normal_user'),
-                              collavre.revoke_system_admin_user_path(user),
+                              collavre.revoke_system_admin_user_path(user, page: @user_page),
                               method: :patch,
                               class: 'btn btn-xs btn-secondary' %>
               <% else %>
                 <%= button_to t('collavre.users.make_system_admin'),
-                              collavre.grant_system_admin_user_path(user),
+                              collavre.grant_system_admin_user_path(user, page: @user_page),
                               method: :patch,
                               class: 'btn btn-xs btn-success',
                               form: { data: { turbo_confirm: t('collavre.users.confirm_grant_system_admin') } } %>
               <% end %>
               <% if user.locked? %>
                 <%= button_to t('collavre.users.unlock.button'),
-                              collavre.unlock_user_path(user),
+                              collavre.unlock_user_path(user, page: @user_page),
                               method: :patch,
                               class: 'btn btn-xs btn-secondary' %>
               <% else %>
                 <%= button_to t('collavre.users.lock.button'),
-                              collavre.lock_user_path(user),
+                              collavre.lock_user_path(user, page: @user_page),
                               method: :patch,
                               class: 'btn btn-xs btn-danger',
                               form: { data: { turbo_confirm: t('collavre.users.lock.confirm') } } %>
               <% end %>
               <%= button_to t('collavre.users.delete'),
-                            collavre.user_path(user),
+                            collavre.user_path(user, page: @user_page),
                             method: :delete,
                             class: 'btn btn-xs btn-danger',
                             form: { data: { turbo_confirm: t('collavre.users.confirm_destroy') } } %>

--- a/engines/collavre/config/locales/users.en.yml
+++ b/engines/collavre/config/locales/users.en.yml
@@ -176,6 +176,7 @@ en:
         avatar: Avatar
         name: Name
         email: Email
+        joined_at: Joined
         last_login_at: Last login
         last_login_unknown: Never
         push_token: Push token
@@ -186,6 +187,11 @@ en:
         actions: Actions
         current_user: This is you
         system_admin: System admin
+      pagination:
+        label: User list pages
+        prev: Previous
+        next: Next
+        page_info: Page %{current} of %{total}
     user_mailer:
       email_verification:
         subject: Verify your email

--- a/engines/collavre/config/locales/users.en.yml
+++ b/engines/collavre/config/locales/users.en.yml
@@ -1,5 +1,8 @@
 ---
 en:
+  time:
+    formats:
+      collavre_users_joined_at: "%b %-d, %Y %H:%M"
   collavre:
     users:
       app_header:

--- a/engines/collavre/config/locales/users.ko.yml
+++ b/engines/collavre/config/locales/users.ko.yml
@@ -170,6 +170,7 @@ ko:
         avatar: 아바타
         name: 이름
         email: 이메일
+        joined_at: 가입일
         last_login_at: 마지막 로그인
         last_login_unknown: 로그인 기록 없음
         push_token: 푸시 토큰
@@ -180,6 +181,11 @@ ko:
         actions: 작업
         current_user: 현재 사용자
         system_admin: 시스템 관리자
+      pagination:
+        label: 사용자 목록 페이지
+        prev: 이전
+        next: 다음
+        page_info: "%{current} / %{total} 페이지"
     user_mailer:
       email_verification:
         subject: 이메일 인증

--- a/engines/collavre/config/locales/users.ko.yml
+++ b/engines/collavre/config/locales/users.ko.yml
@@ -1,5 +1,8 @@
 ---
 ko:
+  time:
+    formats:
+      collavre_users_joined_at: "%Y-%m-%d %H:%M"
   collavre:
     users:
       app_header:

--- a/engines/collavre/db/migrate/20260903070800_add_joined_at_order_index_to_users.rb
+++ b/engines/collavre/db/migrate/20260903070800_add_joined_at_order_index_to_users.rb
@@ -1,0 +1,23 @@
+class AddJoinedAtOrderIndexToUsers < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def up
+    add_index :users, %i[created_at id],
+      name: "index_users_on_created_at_and_id",
+      algorithm: concurrent_algorithm,
+      if_not_exists: true
+  end
+
+  def down
+    remove_index :users,
+      name: "index_users_on_created_at_and_id",
+      algorithm: concurrent_algorithm,
+      if_exists: true
+  end
+
+  private
+
+  def concurrent_algorithm
+    :concurrently if connection.adapter_name.match?(/postgres/i)
+  end
+end

--- a/engines/collavre/test/controllers/users_controller_test.rb
+++ b/engines/collavre/test/controllers/users_controller_test.rb
@@ -70,6 +70,30 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     refute @regular_user.reload.system_admin?
   end
 
+  test "system admin row actions preserve and clamp the user page" do
+    sign_in_as(@admin, password: "password")
+    (20 - User.count).times do |index|
+      User.create!(email: "page-filler-#{index}@example.com", password: "password", name: "Page Filler #{index}")
+    end
+    target = User.create!(email: "page-target@example.com", password: "password", name: "Page Target")
+    final_target = User.create!(email: "final-page-target@example.com", password: "password", name: "Final Page Target")
+    page_two = collavre.users_path(page: 2)
+
+    patch collavre.grant_system_admin_user_path(target, page: 2)
+    assert_redirected_to page_two
+    patch collavre.revoke_system_admin_user_path(target, page: 2)
+    assert_redirected_to page_two
+    patch collavre.lock_user_path(target, page: 2)
+    assert_redirected_to page_two
+    patch collavre.unlock_user_path(target, page: 2)
+    assert_redirected_to page_two
+
+    delete collavre.user_path(target, page: 2)
+    assert_redirected_to page_two
+    delete collavre.user_path(final_target, page: 2)
+    assert_redirected_to collavre.users_path
+  end
+
   test "system admin cannot delete themselves" do
     sign_in_as(@admin, password: "password")
 

--- a/engines/collavre/test/integration/users_index_test.rb
+++ b/engines/collavre/test/integration/users_index_test.rb
@@ -23,16 +23,18 @@ class UsersIndexTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select "div.table-scroll > table.users-table"
     assert_select "th", text: I18n.t("collavre.users.table.joined_at")
-    assert_includes response.body, I18n.l(user.created_at, format: :short)
+    assert_includes response.body, I18n.l(user.created_at, format: :collavre_users_joined_at)
+    assert_includes response.body, user.created_at.year.to_s
   end
 
   test "paginates users by joined date with newest users first" do
+    oldest_joined_at = 30.days.ago.change(usec: 0)
     users = 21.times.map do |index|
       User.create!(
         email: "page-user-#{index}@example.com",
         password: TEST_PASSWORD,
         name: "Page User #{index}",
-        created_at: Time.utc(2040, 1, 1) + index.days
+        created_at: oldest_joined_at + [ index, 19 ].min.days
       )
     end
 
@@ -41,6 +43,8 @@ class UsersIndexTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_includes response.body, users.last.email
     assert_not_includes response.body, users.first.email
+    assert_equal users[-2].created_at, users.last.created_at
+    assert_operator users.last.id, :>, users[-2].id
     assert_operator response.body.index(users.last.email), :<, response.body.index(users[-2].email)
     assert_select "nav[aria-label=?]", I18n.t("collavre.users.pagination.label")
     assert_select "a[href=?]", users_path(page: 2), text: I18n.t("collavre.users.pagination.next")

--- a/engines/collavre/test/integration/users_index_test.rb
+++ b/engines/collavre/test/integration/users_index_test.rb
@@ -15,6 +15,43 @@ class UsersIndexTest < ActionDispatch::IntegrationTest
     assert_includes response.body, user.email
   end
 
+  test "uses a horizontally scrollable table and displays joined date" do
+    user = User.create!(email: "joined@example.com", password: TEST_PASSWORD, name: "Joined User")
+
+    get users_path
+
+    assert_response :success
+    assert_select "div.table-scroll > table.users-table"
+    assert_select "th", text: I18n.t("collavre.users.table.joined_at")
+    assert_includes response.body, I18n.l(user.created_at, format: :short)
+  end
+
+  test "paginates users by joined date with newest users first" do
+    users = 21.times.map do |index|
+      User.create!(
+        email: "page-user-#{index}@example.com",
+        password: TEST_PASSWORD,
+        name: "Page User #{index}",
+        created_at: Time.utc(2040, 1, 1) + index.days
+      )
+    end
+
+    get users_path
+
+    assert_response :success
+    assert_includes response.body, users.last.email
+    assert_not_includes response.body, users.first.email
+    assert_operator response.body.index(users.last.email), :<, response.body.index(users[-2].email)
+    assert_select "nav[aria-label=?]", I18n.t("collavre.users.pagination.label")
+    assert_select "a[href=?]", users_path(page: 2), text: I18n.t("collavre.users.pagination.next")
+
+    get users_path(page: 2)
+
+    assert_response :success
+    assert_includes response.body, users.first.email
+    assert_select "a[href=?]", users_path(page: 1), text: I18n.t("collavre.users.pagination.prev")
+  end
+
   test "shows last login timestamp and inactive avatar count" do
     initial_inactive = User.left_outer_joins(:sessions).where(sessions: { id: nil }).count
 

--- a/engines/collavre/test/integration/users_index_test.rb
+++ b/engines/collavre/test/integration/users_index_test.rb
@@ -56,6 +56,24 @@ class UsersIndexTest < ActionDispatch::IntegrationTest
     assert_select "a[href=?]", users_path(page: 1), text: I18n.t("collavre.users.pagination.prev")
   end
 
+  test "preserves the current page in row action forms" do
+    older_admin = User.create!(email: "older-admin@example.com", password: TEST_PASSWORD, name: "Older Admin", system_admin: true, created_at: 1.year.ago)
+    older_locked = User.create!(email: "older-locked@example.com", password: TEST_PASSWORD, name: "Older Locked", created_at: 2.years.ago)
+    older_locked.lock_account!
+    19.times do |index|
+      User.create!(email: "newer-user-#{index}@example.com", password: TEST_PASSWORD, name: "Newer User #{index}")
+    end
+
+    get users_path(page: 2)
+
+    assert_response :success
+    assert_select "form[action=?]", revoke_system_admin_user_path(older_admin, page: 2)
+    assert_select "form[action=?]", lock_user_path(older_admin, page: 2)
+    assert_select "form[action=?]", unlock_user_path(older_locked, page: 2)
+    assert_select "form[action=?]", grant_system_admin_user_path(older_locked, page: 2)
+    assert_select "form[action=?]", user_path(older_locked, page: 2)
+  end
+
   test "shows last login timestamp and inactive avatar count" do
     initial_inactive = User.left_outer_joins(:sessions).where(sessions: { id: nil }).count
 


### PR DESCRIPTION
## Summary

- Paginate admin users by newest signup date.
- Add the joined-date column and horizontal table scrolling.
- Preserve the current page after user actions.
- Add an index for efficient signup-date ordering.

## Testing

- Related Rails tests, RuboCop, and complexity checks passed.
- All GitHub Actions checks passed.