### PR TITLE
feat(desktop): support unsigned GitHub releases

### DIFF
--- a/script/release-desktop.sh
+++ b/script/release-desktop.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Build, notarize, and publish one signed Apple-Silicon Collavre Desktop DMG.
+# Build and publish one Apple-Silicon Collavre Desktop DMG, either signed and
+# notarized or explicitly unsigned for developer-only distribution.
 #
 # The Tauri config is the canonical desktop version. Cargo.toml is kept in sync
 # because Cargo requires a package version too. This script is deliberately
@@ -16,6 +17,8 @@ CARGO_LOCK="$TAURI_DIR/Cargo.lock"
 TAG_PREFIX="desktop-v"
 ARTIFACT_DIR="$PROJECT_ROOT/build/desktop-release"
 RELEASE_ARTIFACT=""
+UNSIGNED_RELEASE=0
+RESUME_VERSION=""
 
 die() {
   echo "[release-desktop] $*" >&2
@@ -24,6 +27,42 @@ die() {
 
 require_command() {
   command -v "$1" >/dev/null 2>&1 || die "required command is unavailable: $1"
+}
+
+usage() {
+  printf 'usage: %s [--unsigned] [--resume VERSION]\n' "$0" >&2
+}
+
+parse_release_options() {
+  UNSIGNED_RELEASE=0
+  RESUME_VERSION=""
+
+  while (($#)); do
+    case "$1" in
+      --unsigned)
+	((UNSIGNED_RELEASE == 0)) || die "--unsigned was provided more than once"
+	UNSIGNED_RELEASE=1
+	shift
+	;;
+      --resume)
+	[[ -z "$RESUME_VERSION" ]] || die "--resume was provided more than once"
+	[[ $# -ge 2 && "$2" != --* ]] || { usage; die "--resume requires a version"; }
+	RESUME_VERSION="$2"
+	shift 2
+	;;
+      *)
+	usage
+	die "unknown option: $1"
+	;;
+    esac
+  done
+
+  [[ -z "$RESUME_VERSION" ]] || valid_semver "$RESUME_VERSION" || \
+    die "resume version must be valid semver"
+}
+
+release_is_unsigned() {
+  ((UNSIGNED_RELEASE))
 }
 
 check_desktop_build_prerequisites() {
@@ -182,6 +221,11 @@ release_notes() {
 
   {
     printf '# Collavre Desktop %s\n\n' "$version"
+    if release_is_unsigned; then
+      printf '## Installation notice\n\n'
+      printf 'This developer build is not code signed or notarized. '
+      printf 'On first launch, right-click the app and choose Open.\n\n'
+    fi
     printf '## Changes\n\n'
     git log --format='- %s (%h)' "$range"
   } > "$ARTIFACT_DIR/release-notes.md"
@@ -441,22 +485,39 @@ check_prerequisites() {
   [[ "$(git branch --show-current)" == "main" ]] || die "run from the main branch"
   [[ -z "$(git status --porcelain)" ]] || die "working tree is not clean"
 
-  for command in git gh ruby node npm bundle cargo codesign security spctl xcrun shasum hdiutil curl tar; do
+  local command
+  local -a commands=(git gh ruby node npm bundle cargo shasum hdiutil curl tar)
+  if ! release_is_unsigned; then
+    commands+=(codesign security spctl xcrun)
+  fi
+  for command in "${commands[@]}"; do
     require_command "$command"
   done
   check_desktop_build_prerequisites
 
+  check_node_runtime_configuration
+  check_distribution_prerequisites
+  gh auth status >/dev/null 2>&1 || die "GitHub CLI is not authenticated"
+}
+
+check_node_runtime_configuration() {
+  if [[ -z "${NODE_RUNTIME_DIR:-}" && ( -n "${NODE_RUNTIME_URL:-}" || -n "${NODE_RUNTIME_SHA256:-}" ) ]]; then
+    [[ -n "${NODE_RUNTIME_URL:-}" && -n "${NODE_RUNTIME_SHA256:-}" ]] || die "set both NODE_RUNTIME_URL and NODE_RUNTIME_SHA256"
+  fi
+}
+
+check_distribution_prerequisites() {
+  release_is_unsigned || check_signing_prerequisites
+}
+
+check_signing_prerequisites() {
   [[ -n "${APPLE_SIGNING_IDENTITY:-}" ]] || die "APPLE_SIGNING_IDENTITY is required"
   [[ -n "${APPLE_ID:-}" ]] || die "APPLE_ID is required"
   [[ -n "${APPLE_APP_SPECIFIC_PASSWORD:-}" ]] || die "APPLE_APP_SPECIFIC_PASSWORD is required"
   [[ -n "${APPLE_TEAM_ID:-}" ]] || die "APPLE_TEAM_ID is required"
-  if [[ -z "${NODE_RUNTIME_DIR:-}" && ( -n "${NODE_RUNTIME_URL:-}" || -n "${NODE_RUNTIME_SHA256:-}" ) ]]; then
-    [[ -n "${NODE_RUNTIME_URL:-}" && -n "${NODE_RUNTIME_SHA256:-}" ]] || die "set both NODE_RUNTIME_URL and NODE_RUNTIME_SHA256"
-  fi
 
   security find-identity -v -p codesigning | grep -Fq "$APPLE_SIGNING_IDENTITY" || \
     die "APPLE_SIGNING_IDENTITY is not available in this keychain"
-  gh auth status >/dev/null 2>&1 || die "GitHub CLI is not authenticated"
 }
 
 run_checks() {
@@ -532,16 +593,39 @@ build_notarized_dmg() {
   RELEASE_ARTIFACT="$artifact"
 }
 
+build_unsigned_dmg() {
+  local version="$1"
+  local source_dmg artifact checksum target_dir mount_dir dmg_attached=0
+
+  echo "[release-desktop] Building unsigned DMG..."
+  target_dir="$(tauri_target_dir)"
+  rm -rf "$target_dir/release/bundle/dmg"
+  "$DESKTOP_DIR/scripts/build-macos.sh" --no-sign
+
+  source_dmg="$(find "$target_dir/release/bundle/dmg" -maxdepth 1 -type f -name '*.dmg' -print -quit 2>/dev/null || true)"
+  [[ -n "$source_dmg" ]] || die "Tauri DMG was not created"
+  artifact="$ARTIFACT_DIR/Collavre-Desktop_${version}_aarch64-unsigned.dmg"
+  cp "$source_dmg" "$artifact"
+
+  mount_dir="$(mktemp -d)"
+  (
+    trap 'cleanup_mounted_dmg "$mount_dir" "$dmg_attached"' EXIT
+    hdiutil attach "$artifact" -readonly -nobrowse -mountpoint "$mount_dir" >/dev/null
+    dmg_attached=1
+    [[ -d "$mount_dir/Collavre Desktop.app" ]] || die "DMG does not contain Collavre Desktop.app"
+  )
+
+  checksum="${artifact}.sha256"
+  write_checksum "$artifact" "$checksum"
+  RELEASE_ARTIFACT="$artifact"
+}
+
 main() {
   cd "$PROJECT_ROOT"
+  parse_release_options "$@"
   check_prerequisites
 
-  local current_version previous_tag range bump suggested_version selected_version tag artifact resume_version="" prerelease_promotion=0
-  if (($#)); then
-    [[ $# -eq 2 && "$1" == "--resume" ]] || die "usage: $0 [--resume VERSION]"
-    resume_version="$2"
-    valid_semver "$resume_version" || die "resume version must be valid semver"
-  fi
+  local current_version previous_tag range bump suggested_version selected_version tag artifact resume_version="$RESUME_VERSION" prerelease_promotion=0
 
   git fetch origin main --tags
   if [[ -z "$resume_version" ]]; then
@@ -619,9 +703,17 @@ main() {
   printf '\nBundled source commits included in this release:\n'
   git log --oneline "$range"
   if [[ -n "$resume_version" ]]; then
-    read -r -p "Rebuild, notarize, and resume publishing $tag? [y/N] " confirm
+    if release_is_unsigned; then
+      read -r -p "Rebuild unsigned DMG and resume publishing $tag? [y/N] " confirm
+    else
+      read -r -p "Rebuild, notarize, and resume publishing $tag? [y/N] " confirm
+    fi
   else
-    read -r -p "Commit version $selected_version, build, notarize, and publish $tag? [y/N] " confirm
+    if release_is_unsigned; then
+      read -r -p "Commit version $selected_version, build unsigned DMG, and publish $tag? [y/N] " confirm
+    else
+      read -r -p "Commit version $selected_version, build, notarize, and publish $tag? [y/N] " confirm
+    fi
   fi
   [[ "$confirm" =~ ^[Yy]$ ]] || die "release cancelled"
 
@@ -636,7 +728,11 @@ main() {
   fi
 
   run_checks
-  build_notarized_dmg "$selected_version"
+  if release_is_unsigned; then
+    build_unsigned_dmg "$selected_version"
+  else
+    build_notarized_dmg "$selected_version"
+  fi
   artifact="$RELEASE_ARTIFACT"
 
   ensure_release_tag "$tag" "$selected_version"

--- a/script/release-desktop.sh
+++ b/script/release-desktop.sh
@@ -224,7 +224,9 @@ release_notes() {
     if release_is_unsigned; then
       printf '## Installation notice\n\n'
       printf 'This developer build is not code signed or notarized. '
-      printf 'On first launch, right-click the app and choose Open.\n\n'
+      printf 'On macOS 15 or later, first try to open the app, then go to '
+      printf 'System Settings > Privacy & Security and choose Open Anyway. '
+      printf 'On earlier macOS versions, right-click the app and choose Open.\n\n'
     fi
     printf '## Changes\n\n'
     git log --format='- %s (%h)' "$range"
@@ -455,6 +457,7 @@ publish_release() {
       # A failed upload can leave a draft with only one stale asset. Replace
       # both artifacts from this build before publishing so the checksum and
       # DMG always describe the same release output.
+      remove_opposite_mode_assets "$tag" "$version"
       gh release upload "$tag" "$artifact" "$checksum" --clobber
       publish_draft_release "$tag" "$version"
     fi
@@ -466,6 +469,23 @@ publish_release() {
   gh "${create_args[@]}"
   gh release upload "$tag" "$artifact" "$checksum" --clobber
   publish_draft_release "$tag" "$version"
+}
+
+remove_opposite_mode_assets() {
+  local tag="$1"
+  local version="$2"
+  local opposite_artifact assets asset
+
+  if release_is_unsigned; then
+    opposite_artifact="Collavre-Desktop_${version}_aarch64.dmg"
+  else
+    opposite_artifact="Collavre-Desktop_${version}_aarch64-unsigned.dmg"
+  fi
+  assets="$(gh release view "$tag" --json assets --jq '.assets[].name')"
+  for asset in "$opposite_artifact" "${opposite_artifact}.sha256"; do
+    grep -Fqx -- "$asset" <<< "$assets" || continue
+    gh release delete-asset "$tag" "$asset" --yes
+  done
 }
 
 publish_draft_release() {

--- a/script/release-desktop.sh
+++ b/script/release-desktop.sh
@@ -46,7 +46,7 @@ parse_release_options() {
 	;;
       --resume)
 	[[ -z "$RESUME_VERSION" ]] || die "--resume was provided more than once"
-	[[ $# -ge 2 && "$2" != --* ]] || { usage; die "--resume requires a version"; }
+	[[ $# -ge 2 && -n "$2" && "$2" != --* ]] || { usage; die "--resume requires a version"; }
 	RESUME_VERSION="$2"
 	shift 2
 	;;

--- a/script/test/release_desktop_test.sh
+++ b/script/test/release_desktop_test.sh
@@ -47,6 +47,7 @@ parse_release_options
 assert_equal "0" "$UNSIGNED_RELEASE"
 assert_equal "" "$RESUME_VERSION"
 if (parse_release_options --resume) 2>/dev/null || \
+  (parse_release_options --resume "") 2>/dev/null || \
   (parse_release_options --unknown) 2>/dev/null || \
   (parse_release_options --unsigned --unsigned) 2>/dev/null; then
   echo "invalid release options were accepted" >&2

--- a/script/test/release_desktop_test.sh
+++ b/script/test/release_desktop_test.sh
@@ -37,6 +37,70 @@ if valid_semver "1.02.3" || valid_semver "v1.2.3" || valid_semver "1.2" || \
   exit 1
 fi
 
+parse_release_options --unsigned --resume 2.3.4
+assert_equal "1" "$UNSIGNED_RELEASE"
+assert_equal "2.3.4" "$RESUME_VERSION"
+parse_release_options --resume 2.3.5 --unsigned
+assert_equal "1" "$UNSIGNED_RELEASE"
+assert_equal "2.3.5" "$RESUME_VERSION"
+parse_release_options
+assert_equal "0" "$UNSIGNED_RELEASE"
+assert_equal "" "$RESUME_VERSION"
+if (parse_release_options --resume) 2>/dev/null || \
+  (parse_release_options --unknown) 2>/dev/null || \
+  (parse_release_options --unsigned --unsigned) 2>/dev/null; then
+  echo "invalid release options were accepted" >&2
+  exit 1
+fi
+
+distribution_prerequisite_output="$(
+  check_signing_prerequisites() { printf 'signing\n'; }
+  UNSIGNED_RELEASE=1
+  check_distribution_prerequisites
+  UNSIGNED_RELEASE=0
+  check_distribution_prerequisites
+)"
+assert_equal "signing" "$distribution_prerequisite_output"
+
+prerequisite_commands="$(
+  uname() {
+    [[ "$1" == "-s" ]] && printf 'Darwin\n' || printf 'arm64\n'
+  }
+  git() {
+    [[ "$1" == "branch" ]] && printf 'main\n'
+  }
+  require_command() { printf '%s\n' "$1"; }
+  check_desktop_build_prerequisites() { :; }
+  check_distribution_prerequisites() { :; }
+  gh() { :; }
+
+  UNSIGNED_RELEASE=1
+  check_prerequisites
+  printf '%s\n' signed-mode
+  UNSIGNED_RELEASE=0
+  check_prerequisites
+)"
+unsigned_commands="${prerequisite_commands%%signed-mode*}"
+signed_commands="${prerequisite_commands#*signed-mode}"
+grep -Fqx "hdiutil" <<< "$unsigned_commands"
+if grep -Eq '^(codesign|security|spctl|xcrun)$' <<< "$unsigned_commands"; then
+  echo "unsigned release required Apple signing commands" >&2
+  exit 1
+fi
+for signing_command in codesign security spctl xcrun; do
+  grep -Fqx "$signing_command" <<< "$signed_commands"
+done
+
+NODE_RUNTIME_URL="https://example.test/node.tar.gz"
+unset NODE_RUNTIME_DIR NODE_RUNTIME_SHA256
+if (check_node_runtime_configuration) 2>/dev/null; then
+  echo "partial Node runtime configuration was accepted" >&2
+  exit 1
+fi
+NODE_RUNTIME_SHA256="fixture-checksum"
+check_node_runtime_configuration
+unset NODE_RUNTIME_URL NODE_RUNTIME_SHA256
+
 assert_equal "1.0.0" "$(bump_version "0.9.7" major)"
 assert_equal "0.10.0" "$(bump_version "0.9.7" minor)"
 assert_equal "0.9.8" "$(bump_version "0.9.7" patch)"
@@ -253,6 +317,47 @@ printf 'dmg fixture\n' > "$artifact_dir/Collavre-Desktop_2.3.4_aarch64.dmg"
 write_checksum "$artifact_dir/Collavre-Desktop_2.3.4_aarch64.dmg" "$artifact_dir/Collavre-Desktop_2.3.4_aarch64.dmg.sha256"
 assert_equal "Collavre-Desktop_2.3.4_aarch64.dmg" "$(awk '{print $2}' "$artifact_dir/Collavre-Desktop_2.3.4_aarch64.dmg.sha256")"
 (cd "$artifact_dir" && shasum -a 256 -c "Collavre-Desktop_2.3.4_aarch64.dmg.sha256" >/dev/null)
+
+unsigned_notes_dir="$fixture_dir/unsigned-notes"
+mkdir -p "$unsigned_notes_dir"
+(
+  cd "$repo_dir"
+  ARTIFACT_DIR="$unsigned_notes_dir"
+  UNSIGNED_RELEASE=1
+  release_notes HEAD 2.3.4
+)
+grep -Fqx "This developer build is not code signed or notarized. On first launch, right-click the app and choose Open." \
+  "$unsigned_notes_dir/release-notes.md"
+
+unsigned_desktop_dir="$fixture_dir/unsigned-desktop"
+unsigned_target_dir="$fixture_dir/unsigned-target"
+unsigned_artifact_dir="$fixture_dir/unsigned-artifacts"
+unsigned_build_log="$fixture_dir/unsigned-build.log"
+mkdir -p "$unsigned_desktop_dir/scripts" "$unsigned_target_dir/release/bundle/dmg" "$unsigned_artifact_dir"
+printf '#!/usr/bin/env bash\nprintf "%%s\\n" "$*" > "%s"\nmkdir -p "%s/release/bundle/dmg"\nprintf "unsigned dmg fixture\\n" > "%s/release/bundle/dmg/source.dmg"\n' \
+  "$unsigned_build_log" "$unsigned_target_dir" "$unsigned_target_dir" \
+  > "$unsigned_desktop_dir/scripts/build-macos.sh"
+chmod +x "$unsigned_desktop_dir/scripts/build-macos.sh"
+hdiutil() {
+  if [[ "$1" == "attach" ]]; then
+    local index
+    for ((index = 1; index <= $#; index += 1)); do
+      if [[ "${!index}" == "-mountpoint" ]]; then
+	index=$((index + 1))
+	mkdir -p "${!index}/Collavre Desktop.app"
+	return
+      fi
+    done
+  fi
+}
+DESKTOP_DIR="$unsigned_desktop_dir"
+CARGO_TARGET_DIR="$unsigned_target_dir"
+ARTIFACT_DIR="$unsigned_artifact_dir"
+build_unsigned_dmg 2.3.4
+assert_equal "--no-sign" "$(<"$unsigned_build_log")"
+assert_equal "$unsigned_artifact_dir/Collavre-Desktop_2.3.4_aarch64-unsigned.dmg" "$RELEASE_ARTIFACT"
+(cd "$unsigned_artifact_dir" && shasum -a 256 -c "Collavre-Desktop_2.3.4_aarch64-unsigned.dmg.sha256" >/dev/null)
+ARTIFACT_DIR="$artifact_dir"
 
 gh_log="$fixture_dir/gh.log"
 gh() {

--- a/script/test/release_desktop_test.sh
+++ b/script/test/release_desktop_test.sh
@@ -327,7 +327,7 @@ mkdir -p "$unsigned_notes_dir"
   UNSIGNED_RELEASE=1
   release_notes HEAD 2.3.4
 )
-grep -Fqx "This developer build is not code signed or notarized. On first launch, right-click the app and choose Open." \
+grep -Fqx "This developer build is not code signed or notarized. On macOS 15 or later, first try to open the app, then go to System Settings > Privacy & Security and choose Open Anyway. On earlier macOS versions, right-click the app and choose Open." \
   "$unsigned_notes_dir/release-notes.md"
 
 unsigned_desktop_dir="$fixture_dir/unsigned-desktop"
@@ -361,18 +361,36 @@ assert_equal "$unsigned_artifact_dir/Collavre-Desktop_2.3.4_aarch64-unsigned.dmg
 ARTIFACT_DIR="$artifact_dir"
 
 gh_log="$fixture_dir/gh.log"
+release_assets="$(printf '%s\n' \
+  'Collavre-Desktop_2.3.4_aarch64-unsigned.dmg' \
+  'Collavre-Desktop_2.3.4_aarch64-unsigned.dmg.sha256' \
+  'unrelated.txt')"
 gh() {
   printf '%s\n' "$*" >> "$gh_log"
   if [[ "$1 $2 $3" == "release view desktop-v2.3.4" ]]; then
-    if [[ "${4:-}" == "--json" ]]; then
+    if [[ "${5:-}" == "isDraft" ]]; then
       printf 'true\n'
+    elif [[ "${5:-}" == "assets" ]]; then
+      printf '%s\n' "$release_assets"
     fi
     return 0
   fi
 }
 publish_release "desktop-v2.3.4" "2.3.4" "$artifact_dir/Collavre-Desktop_2.3.4_aarch64.dmg"
+grep -Fqx "release delete-asset desktop-v2.3.4 Collavre-Desktop_2.3.4_aarch64-unsigned.dmg --yes" "$gh_log"
+grep -Fqx "release delete-asset desktop-v2.3.4 Collavre-Desktop_2.3.4_aarch64-unsigned.dmg.sha256 --yes" "$gh_log"
 grep -Fqx "release upload desktop-v2.3.4 $artifact_dir/Collavre-Desktop_2.3.4_aarch64.dmg $artifact_dir/Collavre-Desktop_2.3.4_aarch64.dmg.sha256 --clobber" "$gh_log"
 grep -Fqx "release edit desktop-v2.3.4 --draft=false --title Collavre Desktop 2.3.4 --notes-file $artifact_dir/release-notes.md" "$gh_log"
+
+: > "$gh_log"
+release_assets="$(printf '%s\n' \
+  'Collavre-Desktop_2.3.4_aarch64.dmg' \
+  'Collavre-Desktop_2.3.4_aarch64.dmg.sha256')"
+UNSIGNED_RELEASE=1
+remove_opposite_mode_assets "desktop-v2.3.4" "2.3.4"
+UNSIGNED_RELEASE=0
+grep -Fqx "release delete-asset desktop-v2.3.4 Collavre-Desktop_2.3.4_aarch64.dmg --yes" "$gh_log"
+grep -Fqx "release delete-asset desktop-v2.3.4 Collavre-Desktop_2.3.4_aarch64.dmg.sha256 --yes" "$gh_log"
 
 ci_log="$fixture_dir/ci.log"
 gh() {

--- a/tools/desktop-app/README.md
+++ b/tools/desktop-app/README.md
@@ -189,13 +189,14 @@ source commits, then requires an explicit version that advances the current
 version and final confirmation before creating the version commit.
 
 It runs the desktop Rust and Rails test suites, creates the Apple-Silicon DMG,
-checks its code signature, submits and staples it with Apple notarization,
-writes a SHA-256 checksum, and only then creates a GitHub Release. The Git tag
-format is `desktop-v<semver>` and release notes are generated from bundled
-source commits since the preceding desktop tag. If publication fails after the
-version commit, rerun `script/release-desktop.sh --resume <version>` from that clean
-release checkout; it safely rebases an unpushed release commit onto current
-`origin/main` before rebuilding.
+writes a SHA-256 checksum, and only then creates a GitHub Release. By default it
+also checks the code signature and submits and staples the DMG with Apple
+notarization. The Git tag format is `desktop-v<semver>` and release notes are
+generated from bundled source commits since the preceding desktop tag. If
+publication fails after the version commit, rerun
+`script/release-desktop.sh --resume <version>` from that clean release checkout;
+it safely rebases an unpushed release commit onto current `origin/main` before
+rebuilding.
 
 Run it only from a clean, current `main` checkout on an Apple-Silicon Mac:
 
@@ -206,6 +207,19 @@ export APPLE_APP_SPECIFIC_PASSWORD='xxxx-xxxx-xxxx-xxxx'
 export APPLE_TEAM_ID='TEAMID'
 script/release-desktop.sh
 ```
+
+For developer-only distribution without an Apple Developer account, explicitly
+select the unsigned mode:
+
+```bash
+script/release-desktop.sh --unsigned
+```
+
+The unsigned asset is named
+`Collavre-Desktop_<version>_aarch64-unsigned.dmg`. Its release notes warn that
+macOS Gatekeeper will require the developer to right-click the app and choose
+Open on first launch. Resume an interrupted unsigned release with
+`script/release-desktop.sh --unsigned --resume <version>`.
 
 The release script defaults to a pinned, verified official Apple-Silicon Node
 archive. To use a different runtime archive, set both `NODE_RUNTIME_URL` and

--- a/tools/desktop-app/README.md
+++ b/tools/desktop-app/README.md
@@ -217,8 +217,10 @@ script/release-desktop.sh --unsigned
 
 The unsigned asset is named
 `Collavre-Desktop_<version>_aarch64-unsigned.dmg`. Its release notes warn that
-macOS Gatekeeper will require the developer to right-click the app and choose
-Open on first launch. Resume an interrupted unsigned release with
+macOS Gatekeeper requires an explicit override. On macOS 15 or later, first
+attempt to open the app, then go to System Settings > Privacy & Security and
+choose Open Anyway. On earlier macOS versions, right-click the app and choose
+Open. Resume an interrupted unsigned release with
 `script/release-desktop.sh --unsigned --resume <version>`.
 
 The release script defaults to a pinned, verified official Apple-Silicon Node

--- a/tools/desktop-app/scripts/build-macos.sh
+++ b/tools/desktop-app/scripts/build-macos.sh
@@ -130,7 +130,8 @@ echo "[build-macos] 7/7 building the Tauri bundle"
   # Finder, which needs Automation (TCC) permission and fails with "failed to run
   # bundle_dmg.sh" on managed or headless Macs. Skipping it yields a plain but fully
   # functional .dmg; the .app target is unaffected. Preserve a real CI value if set.
-  CI="${CI:-true}" cargo tauri build
+  # Release tooling passes --no-sign for developer-only GitHub Releases.
+  CI="${CI:-true}" cargo tauri build "$@"
 )
 
 # Verify the exact runtime copied into the .app, not merely the source vendor


### PR DESCRIPTION
## Summary

- add an explicit `--unsigned` desktop release mode that does not require Apple signing credentials or tools
- pass Tauri `--no-sign`, validate the DMG contents, and publish an `-unsigned.dmg` asset with its SHA-256 checksum
- include a Gatekeeper installation notice in unsigned release notes and document new/resume usage
- preserve the existing signed and notarized release flow as the default

## Tests

- `script/test/release_desktop_test.sh`
- `bash -n script/release-desktop.sh script/test/release_desktop_test.sh tools/desktop-app/scripts/build-macos.sh`
- `cargo tauri build --no-sign --help`