### PR TITLE
feat: record creative change sets

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_09_03_070800) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_03_180000) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -262,6 +262,45 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_03_070800) do
     t.index ["user_id"], name: "index_contacts_on_user_id"
   end
 
+  create_table "creative_change_sets", force: :cascade do |t|
+    t.string "actor_kind", null: false
+    t.integer "anchor_creative_id"
+    t.string "anchor_source"
+    t.datetime "applied_at"
+    t.string "change_group_token"
+    t.datetime "created_at", null: false
+    t.string "origin", null: false
+    t.integer "reverted_by_id"
+    t.integer "reverts_id"
+    t.string "status", default: "applied", null: false
+    t.text "summary"
+    t.integer "task_id"
+    t.integer "topic_id"
+    t.datetime "updated_at", null: false
+    t.integer "user_id"
+    t.index ["anchor_creative_id", "created_at"], name: "idx_on_anchor_creative_id_created_at_15aafa2718"
+    t.index ["change_group_token", "user_id"], name: "index_creative_change_sets_on_change_group_token_and_user_id"
+    t.index ["status"], name: "index_creative_change_sets_on_status"
+    t.index ["task_id"], name: "index_creative_change_sets_on_task_id"
+  end
+
+  create_table "creative_changes", force: :cascade do |t|
+    t.json "after", default: {}, null: false
+    t.json "before", default: {}, null: false
+    t.json "conflict", default: {}, null: false
+    t.datetime "created_at", null: false
+    t.integer "creative_change_set_id", null: false
+    t.integer "creative_id", null: false
+    t.integer "previous_parent_id"
+    t.string "operation", null: false
+    t.integer "position", default: 0, null: false
+    t.datetime "updated_at", null: false
+    t.index ["creative_change_set_id", "creative_id"], name: "idx_creative_changes_on_set_and_creative", unique: true
+    t.index ["creative_change_set_id"], name: "index_creative_changes_on_creative_change_set_id"
+    t.index ["creative_id", "id"], name: "index_creative_changes_on_creative_id_and_id"
+    t.index ["previous_parent_id"], name: "index_creative_changes_on_previous_parent_id"
+  end
+
   create_table "creative_hierarchies", id: false, force: :cascade do |t|
     t.integer "ancestor_id", null: false
     t.integer "descendant_id", null: false
@@ -305,6 +344,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_03_070800) do
     t.integer "origin_id"
     t.integer "parent_id"
     t.float "progress", default: 0.0
+    t.integer "revision", default: 0, null: false
     t.integer "sequence", default: 0, null: false
     t.datetime "updated_at", null: false
     t.integer "user_id", null: false
@@ -1064,6 +1104,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_03_070800) do
   add_foreign_key "comments", "users", column: "approver_id"
   add_foreign_key "contacts", "users"
   add_foreign_key "contacts", "users", column: "contact_user_id"
+  add_foreign_key "creative_changes", "creative_change_sets", on_delete: :cascade
   add_foreign_key "creative_shares", "creatives"
   add_foreign_key "creative_shares", "users"
   add_foreign_key "creative_shares", "users", column: "shared_by_id", on_delete: :nullify

--- a/docs/superpowers/plans/2026-09-03-creative-change-history.md
+++ b/docs/superpowers/plans/2026-09-03-creative-change-history.md
@@ -1,0 +1,32 @@
+# Creative Change History Rollout
+
+## Goal
+
+Add append-only, auditable version history for Creative trees. One logical actor turn is a `CreativeChangeSet`; each touched Creative is one `CreativeChange`. The system must support multi-Creative document diffs and atomic revert without inventing a page boundary.
+
+## Product decisions
+
+- AI delete archives instead of hard deleting.
+- AI writes apply automatically by default and expose undo; review mode is opt-in.
+- Human autosaves use a client change-group token and merge until five minutes of inactivity.
+- Retention defaults to 50 changes per Creative and 90 days, with admin overrides.
+- History is presented in a dedicated `History` topic.
+
+## Data and grouping invariants
+
+- History is append-only. Revert creates a new change set and links it through `reverts_id` / `reverted_by_id`.
+- Snapshots contain only Markdown-canonical content and structural fields: `markdown_source`, `content_type`, `editor`, conditional `description`, `parent_id`, `sequence`, `progress`, and `archived_at`.
+- `creative_changes` has one row per `[creative_change_set_id, creative_id]`. Repeated writes preserve the first `before` and replace only `after`.
+- Change-set lookup joins touched Creative IDs against the viewed Creative's closure-tree descendants. It does not store or infer a page root.
+- Diff rendering uses the observed actor location as `anchor_creative_id`. Changes outside that anchor render as multiple top-level groups while revert remains change-set atomic.
+- Synced read-only history is hidden by default and cannot be reverted.
+
+## Rollout
+
+1. Add the two history tables, Creative revision, recording hooks, observed anchors, human idle grouping, and read-only history queries. This is shadow-only.
+2. Add Markdown document reconstruction, inline/split diff rendering, apply/revert services, conflict handling, permissions, and the dedicated History topic.
+3. Change AI deletion to archive, publish applied-change comments, and show a 30-second undo toast.
+4. Add inherited `ai_write_policy`, draft change sets, and diff-based approve/reject actions.
+5. Add retention cleanup, guarded `SystemSetting` accessors, and English/Korean admin settings.
+
+Each rollout PR targets `feature-revision`. After Codex review and CI pass, it is squash-merged and its Collavre Creatives are completed. When all five are merged, `feature-revision` is squash-merged into `main`.

--- a/engines/collavre/app/controllers/collavre/concerns/creative_history_trackable.rb
+++ b/engines/collavre/app/controllers/collavre/concerns/creative_history_trackable.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Collavre
+  module Concerns
+    module CreativeHistoryTrackable
+      extend ActiveSupport::Concern
+
+      included do
+        around_action :track_creative_history,
+                      only: %i[create update destroy unconvert update_contexts update_metadata archive unarchive
+                               trigger_action reorder link_drop]
+      end
+
+      private
+
+      def track_creative_history(&block)
+        requested_anchor = Creative.find_by(id: params[:history_anchor_id])
+        anchor = requested_anchor if requested_anchor&.has_permission?(Current.user, :read)
+        anchor ||= @creative
+        Creatives::History.track(
+          actor: Current.user,
+          origin: :editor,
+          anchor: anchor,
+          anchor_source: :view_root,
+          change_group_token: params[:change_group_token],
+          &block
+        )
+      end
+    end
+  end
+end

--- a/engines/collavre/app/controllers/collavre/creative_imports_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creative_imports_controller.rb
@@ -14,7 +14,15 @@ module Collavre
         render json: { error: I18n.t("collavre.creatives.errors.no_permission") }, status: :forbidden and return
       end
 
-      created = ::Creatives::Importer.new(file: params[:markdown], user: Current.user, parent: parent).call
+      created = Creatives::History.track(
+        actor: Current.user,
+        origin: :import,
+        anchor: parent,
+        anchor_source: :import_target,
+        change_group_token: params[:change_group_token]
+      ) do
+        ::Creatives::Importer.new(file: params[:markdown], user: Current.user, parent: parent).call
+      end
 
       if created.any?
         render json: { success: true, created: created.map(&:id) }

--- a/engines/collavre/app/controllers/collavre/creatives_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creatives_controller.rb
@@ -21,6 +21,7 @@ module Collavre
     before_action :enforce_creatives_login_policy, only: %i[ index children export_markdown show slide_view ]
     before_action :set_creative, only: %i[ show edit update destroy slide_view request_permission unconvert contexts update_contexts update_metadata archive unarchive trigger_action remember_last_visited ]
     before_action :require_creative_write!, only: %i[archive unarchive]
+    include Collavre::Concerns::CreativeHistoryTrackable
 
     def index
       respond_to do |format|
@@ -301,15 +302,11 @@ module Collavre
         # Because if @creative is Linked, params might include origin_id.
         # Passing origin_id to the Origin creative causes it to fail validation (cannot changes if has origin)
         # or creates a self-cycle.
-        permitted.delete("origin_id")
-        permitted.delete(:origin_id)
+        permitted.except!("origin_id", :origin_id)
 
         success &&= base.update(permitted)
         if success && requested_progress.present? && requested_progress.to_f >= 1 && previous_progress.to_f < 1
-          if base.children.exists?
-            base.self_and_descendants.where(origin_id: nil)
-              .update_all(progress: 1.0, updated_at: Time.current)
-          end
+          base.complete_self_and_descendants! if base.children.exists?
         end
 
         if success

--- a/engines/collavre/app/javascript/modules/__tests__/creative_row_editor_empty_state_recovery.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/creative_row_editor_empty_state_recovery.test.js
@@ -112,6 +112,21 @@ describe('empty-state recovery when the first inline save fails', () => {
     expect(saveStatus()).toBe('error')
   })
 
+  test('submits the observed history anchor and editing-session token', async () => {
+    document.getElementById('inline-history-anchor-id').value = '42'
+    document.getElementById('inline-change-group-token').value = 'edit-session-1'
+    saveMock.mockImplementation(() => Promise.reject(new Error('network down')))
+    await startFirstRowWithContent()
+
+    document.getElementById('inline-close').click()
+    await flush()
+
+    const submittedForm = saveMock.mock.calls[0][2]
+    const submittedData = new FormData(submittedForm)
+    expect(submittedData.get('history_anchor_id')).toBe('42')
+    expect(submittedData.get('change_group_token')).toBe('edit-session-1')
+  })
+
   test('keeps the failed first draft when the save resolves with a non-ok response', async () => {
     saveMock.mockImplementation(() => Promise.resolve({ ok: false, status: 500 }))
     const emptyState = await startFirstRowWithContent()

--- a/engines/collavre/app/javascript/modules/__tests__/support/inline_editor_dom.js
+++ b/engines/collavre/app/javascript/modules/__tests__/support/inline_editor_dom.js
@@ -20,6 +20,7 @@ export const HIDDEN_INPUT_IDS = [
   'inline-method', 'inline-creative-description', 'inline-content-type',
   'inline-markdown-editor', 'inline-markdown-source', 'inline-parent-id',
   'inline-before-id', 'inline-after-id', 'inline-child-id', 'inline-origin-id',
+  'inline-history-anchor-id', 'inline-change-group-token',
 ]
 
 export const DIV_IDS = [
@@ -48,6 +49,8 @@ export function buildEditorDom(container, {
     const input = document.createElement('input')
     input.type = 'hidden'
     input.id = id
+    if (id === 'inline-history-anchor-id') input.name = 'history_anchor_id'
+    if (id === 'inline-change-group-token') input.name = 'change_group_token'
     form.appendChild(input)
   })
   const progress = document.createElement('input')

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -196,6 +196,8 @@ function setupEditorSession() {
     const afterInput = document.getElementById('inline-after-id');
     const childInput = document.getElementById('inline-child-id');
     const originIdInput = document.getElementById('inline-origin-id');
+    const historyAnchorInput = document.getElementById('inline-history-anchor-id');
+    const changeGroupTokenInput = document.getElementById('inline-change-group-token');
     const metadataBtn = document.getElementById('inline-metadata-btn');
     const metadataPopup = document.getElementById('metadata-popup');
     const metadataEditor = document.getElementById('metadata-yaml-editor');
@@ -1203,6 +1205,8 @@ function setupEditorSession() {
 
       // Always include parent_id, even if empty (for moving to root)
       body['creative[parent_id]'] = currentParentId;
+      if (historyAnchorInput?.value) body.history_anchor_id = historyAnchorInput.value;
+      if (changeGroupTokenInput?.value) body.change_group_token = changeGroupTokenInput.value;
 
       if (currentBeforeId) {
         body['before_id'] = currentBeforeId;  // Top-level, not creative[before_id]

--- a/engines/collavre/app/models/collavre/creative.rb
+++ b/engines/collavre/app/models/collavre/creative.rb
@@ -71,6 +71,7 @@ module Collavre
     include Permissible
     include Describable
     include RealtimeBroadcastable
+    include HistoryTrackable
 
     has_many :comments, class_name: "Collavre::Comment", dependent: :destroy
     has_many :comment_read_pointers, class_name: "Collavre::CommentReadPointer", dependent: :delete_all
@@ -303,22 +304,9 @@ module Collavre
     def archive!
       now = Time.current
       self.class.transaction do
-        # Archive self and descendants
-        self_and_descendants.where(archived_at: nil).update_all(archived_at: now)
-
-        # If this is a linked creative, also archive the origin and its descendants
-        origin = effective_origin(Set.new)
-        if origin != self
-          origin.self_and_descendants.where(archived_at: nil).update_all(archived_at: now)
-          # Archive all other linked creatives of the origin
-          origin.linked_creatives.where.not(id: id).find_each do |linked|
-            linked.self_and_descendants.where(archived_at: nil).update_all(archived_at: now)
-          end
-        end
-
-        # Also archive any linked creatives that point to this one
-        linked_creatives.find_each do |linked|
-          linked.self_and_descendants.where(archived_at: nil).update_all(archived_at: now)
+        targets = self.class.where(id: archive_family_ids).where(archived_at: nil)
+        Creatives::History.record_bulk(targets, operation: "archive") do
+          targets.update_all(archived_at: now)
         end
 
         reload
@@ -329,22 +317,9 @@ module Collavre
 
     def unarchive!
       self.class.transaction do
-        # Unarchive self and descendants
-        self_and_descendants.where.not(archived_at: nil).update_all(archived_at: nil)
-
-        # If this is a linked creative, also unarchive the origin and its descendants
-        origin = effective_origin(Set.new)
-        if origin != self
-          origin.self_and_descendants.where.not(archived_at: nil).update_all(archived_at: nil)
-          # Unarchive all other linked creatives of the origin
-          origin.linked_creatives.where.not(id: id).find_each do |linked|
-            linked.self_and_descendants.where.not(archived_at: nil).update_all(archived_at: nil)
-          end
-        end
-
-        # Also unarchive any linked creatives that point to this one
-        linked_creatives.find_each do |linked|
-          linked.self_and_descendants.where.not(archived_at: nil).update_all(archived_at: nil)
+        targets = self.class.where(id: archive_family_ids).where.not(archived_at: nil)
+        Creatives::History.record_bulk(targets, operation: "unarchive") do
+          targets.update_all(archived_at: nil)
         end
 
         reload

--- a/engines/collavre/app/models/collavre/creative/history_trackable.rb
+++ b/engines/collavre/app/models/collavre/creative/history_trackable.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Collavre
+  class Creative < ApplicationRecord
+    module HistoryTrackable
+      extend ActiveSupport::Concern
+
+      included do
+        around_save :record_change_history
+        before_destroy :record_destroy_history
+
+        has_many :creative_changes, class_name: "Collavre::CreativeChange", dependent: nil
+      end
+
+      def complete_self_and_descendants!
+        targets = self_and_descendants.where(origin_id: nil)
+        Creatives::History.record_bulk(targets, operation: "update") do
+          targets.update_all(progress: 1.0, updated_at: Time.current)
+        end
+      end
+
+      private
+
+      def record_change_history(&block)
+        Creatives::History.capture(self, &block)
+      end
+
+      def record_destroy_history
+        Creatives::History.record(
+          self,
+          operation: "destroy",
+          before: Creatives::History.snapshot(self),
+          after: {}
+        )
+      end
+
+      def archive_family_ids
+        origin = effective_origin(Set.new)
+        family = [ self, origin, *linked_creatives, *origin.linked_creatives ].uniq
+        family.flat_map { |creative| creative.self_and_descendants.pluck(:id) }.uniq
+      end
+    end
+  end
+end

--- a/engines/collavre/app/models/collavre/creative_change.rb
+++ b/engines/collavre/app/models/collavre/creative_change.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Collavre
+  class CreativeChange < ApplicationRecord
+    self.table_name = "creative_changes"
+
+    OPERATIONS = %w[create update move reorder archive unarchive destroy].freeze
+
+    belongs_to :change_set, class_name: "Collavre::CreativeChangeSet",
+                            foreign_key: :creative_change_set_id,
+                            inverse_of: :creative_changes
+    belongs_to :creative, class_name: "Collavre::Creative"
+
+    validates :operation, inclusion: { in: OPERATIONS }
+    validates :creative_id, uniqueness: { scope: :creative_change_set_id }
+  end
+end

--- a/engines/collavre/app/models/collavre/creative_change_set.rb
+++ b/engines/collavre/app/models/collavre/creative_change_set.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module Collavre
+  class CreativeChangeSet < ApplicationRecord
+    self.table_name = "creative_change_sets"
+
+    ACTOR_KINDS = %w[human agent sync system].freeze
+    ANCHOR_SOURCES = %w[agent_topic view_root import_target explicit none].freeze
+    ORIGINS = %w[editor tool mcp import revert sync system].freeze
+    STATUSES = %w[draft applied rejected reverted].freeze
+
+    belongs_to :anchor_creative, class_name: "Collavre::Creative", optional: true
+    belongs_to :user, class_name: Collavre.configuration.user_class_name, optional: true
+    belongs_to :task, class_name: "Collavre::Task", optional: true
+    belongs_to :topic, class_name: "Collavre::Topic", optional: true
+    belongs_to :reverts, class_name: "Collavre::CreativeChangeSet", optional: true
+    belongs_to :reverted_by, class_name: "Collavre::CreativeChangeSet", optional: true
+
+    has_many :creative_changes, class_name: "Collavre::CreativeChange",
+                                foreign_key: :creative_change_set_id,
+                                inverse_of: :change_set,
+                                dependent: :destroy
+
+    validates :actor_kind, inclusion: { in: ACTOR_KINDS }
+    validates :anchor_source, inclusion: { in: ANCHOR_SOURCES }, allow_nil: true
+    validates :origin, inclusion: { in: ORIGINS }
+    validates :status, inclusion: { in: STATUSES }
+
+    after_rollback :clear_current_reference, on: :create
+
+    scope :visible_by_default, -> { where.not(origin: "sync") }
+    scope :newest_first, -> { reorder(created_at: :desc, id: :desc) }
+
+    def self.for_creative_scope(creative)
+      changes = CreativeChange.arel_table
+      condition = scope_condition(changes, creative.self_and_descendants)
+      origin = creative.effective_origin
+      condition = condition.or(scope_condition(changes, origin.self_and_descendants)) if origin != creative
+
+      joins(:creative_changes).where(condition).distinct.newest_first
+    end
+
+    def self.scope_condition(changes, scope)
+      ids = scope.select(:id).arel
+      changes[:creative_id].in(ids).or(changes[:previous_parent_id].in(ids))
+    end
+    private_class_method :scope_condition
+
+    private
+
+    def clear_current_reference
+      Current.change_set = nil if Current.change_set.equal?(self)
+    end
+  end
+end

--- a/engines/collavre/app/models/collavre/current.rb
+++ b/engines/collavre/app/models/collavre/current.rb
@@ -8,6 +8,9 @@ module Collavre
     attribute :mcp_request
     attribute :user
     attribute :agent_turn
+    attribute :change_set
+    attribute :creative_history_context
+
     def user
       super || session&.user
     end

--- a/engines/collavre/app/services/collavre/creatives/create_service.rb
+++ b/engines/collavre/app/services/collavre/creatives/create_service.rb
@@ -77,7 +77,9 @@ module Collavre
       end
 
       def resequence(siblings)
-        siblings.each_with_index { |c, idx| c.update_column(:sequence, idx) }
+        Creatives::History.record_bulk(siblings, operation: "reorder") do
+          siblings.each_with_index { |creative, index| creative.update_column(:sequence, index) }
+        end
       end
 
       def apply_tags(creative)

--- a/engines/collavre/app/services/collavre/creatives/history.rb
+++ b/engines/collavre/app/services/collavre/creatives/history.rb
@@ -1,0 +1,221 @@
+# frozen_string_literal: true
+
+module Collavre
+  module Creatives
+    module History
+      MERGE_IDLE_WINDOW = 5.minutes
+      SNAPSHOT_KEYS = %w[markdown_source content_type editor description parent_id sequence progress archived_at].freeze
+      OPERATION_PRIORITY = {
+        "update" => 0,
+        "reorder" => 1,
+        "move" => 2,
+        "archive" => 3,
+        "unarchive" => 3,
+        "destroy" => 4,
+        "create" => 5
+      }.freeze
+
+      module_function
+
+      def track(actor:, origin:, **options)
+        return yield if Current.creative_history_context || Current.agent_turn&.dig(:task)
+
+        tracking_started = true
+        previous_change_set = Current.change_set
+        Current.change_set = nil
+        Current.creative_history_context = context_for(options.merge(actor: actor, origin: origin))
+
+        yield
+      ensure
+        if tracking_started
+          discard_empty_change_set
+          Current.change_set = previous_change_set
+          Current.creative_history_context = nil
+        end
+      end
+
+      def capture(creative)
+        was_new = creative.new_record?
+        before = was_new ? {} : locked_snapshot(creative)
+        result = yield
+        return result unless result && creative.persisted?
+
+        after = snapshot(creative)
+        record(creative, operation: operation_for(was_new, before, after), before: before, after: after)
+        result
+      end
+
+      def record_bulk(creatives, operation:)
+        records = creatives.to_a
+        before = records.to_h { |creative| [ creative.id, locked_snapshot(creative) ] }
+        result = yield
+        records.each do |creative|
+          creative.reload
+          record(creative, operation: operation, before: before.fetch(creative.id), after: snapshot(creative))
+        end
+        result
+      end
+
+      def record(creative, operation:, before:, after:)
+        return if before == after || !recordable?
+
+        change_set = current_change_set(creative)
+        change = change_set.with_lock do
+          persist_change(change_set, creative, operation, before, after)
+        end
+        bump_revision!(creative)
+        change
+      end
+
+      def persist_change(change_set, creative, operation, before, after)
+        change = change_set.creative_changes.find_or_initialize_by(creative_id: creative.id)
+        if change.new_record?
+          change.before = before
+          change.position = next_position(change_set)
+          change.previous_parent_id = before["parent_id"] if operation.to_s == "destroy"
+        end
+        change.after = after
+        if change.persisted? && change.before == after
+          change.destroy!
+          change_set.touch
+          return
+        end
+        change.operation = merged_operation(change.operation, operation.to_s)
+        change.conflict ||= {}
+        change.save!
+        change_set.touch
+        change
+      end
+
+      def snapshot(creative, persisted: false)
+        source = persisted ? creative.class.unscoped.find(creative.id) : creative
+        data = source.data
+        content_type = data.is_a?(Hash) ? data["content_type"] : nil
+        snapshot = {
+          "markdown_source" => data.is_a?(Hash) ? data["markdown_source"] : nil,
+          "content_type" => content_type,
+          "editor" => data.is_a?(Hash) ? data["editor"] : nil,
+          "parent_id" => source.parent_id,
+          "sequence" => source.sequence,
+          "progress" => source.progress,
+          "archived_at" => source.archived_at&.iso8601(6)
+        }
+        snapshot["description"] = source.description unless content_type == "markdown"
+        snapshot.slice(*SNAPSHOT_KEYS)
+      end
+
+      def locked_snapshot(creative)
+        snapshot(creative.class.unscoped.lock.find(creative.id))
+      end
+
+      def operation_for(was_new, before, after)
+        return "create" if was_new
+        return "archive" if before["archived_at"].nil? && after["archived_at"].present?
+        return "unarchive" if before["archived_at"].present? && after["archived_at"].nil?
+        return "move" if before["parent_id"] != after["parent_id"]
+        return "reorder" if before["sequence"] != after["sequence"]
+
+        "update"
+      end
+
+      def recordable?
+        Current.creative_history_context.present? || Current.user.present?
+      end
+
+      def current_change_set(creative)
+        Current.creative_history_context ||= inferred_context(creative)
+        Current.change_set ||= find_or_create_change_set(Current.creative_history_context)
+      end
+
+      def inferred_context(creative)
+        task = Current.agent_turn&.dig(:task)
+        topic = task&.topic_id ? Topic.find_by(id: task.topic_id) : nil
+        actor = Current.user
+        origin = Current.mcp_request ? "mcp" : (task ? "tool" : "editor")
+        context_for(
+          actor: actor,
+          origin: origin,
+          anchor: topic&.creative || creative,
+          anchor_source: topic ? :agent_topic : :explicit,
+          task: task,
+          topic: topic
+        )
+      end
+
+      def context_for(attributes)
+        actor = attributes[:actor]
+        origin = attributes[:origin]
+        {
+          actor: actor,
+          actor_kind: actor_kind(actor, origin),
+          origin: origin.to_s,
+          anchor: attributes[:anchor],
+          anchor_source: attributes.fetch(:anchor_source, :none).to_s,
+          task: attributes[:task],
+          topic: attributes[:topic],
+          summary: attributes[:summary],
+          change_group_token: attributes[:change_group_token].to_s.first(255).presence,
+          status: attributes.fetch(:status, "applied").to_s
+        }
+      end
+
+      def actor_kind(actor, origin)
+        return "sync" if origin.to_s == "sync"
+        return "system" unless actor
+
+        actor.respond_to?(:ai_user?) && actor.ai_user? ? "agent" : "human"
+      end
+
+      def find_or_create_change_set(context)
+        mergeable = mergeable_human_change_set(context)
+        return mergeable if mergeable
+
+        CreativeChangeSet.create!(
+          anchor_creative_id: context[:anchor]&.id,
+          anchor_source: context[:anchor_source],
+          user_id: context[:actor]&.id,
+          actor_kind: context[:actor_kind],
+          origin: context[:origin],
+          task_id: context[:task]&.id,
+          topic_id: context[:topic]&.id,
+          status: context[:status],
+          change_group_token: context[:change_group_token],
+          summary: context[:summary],
+          applied_at: context[:status] == "applied" ? Time.current : nil
+        )
+      end
+
+      def mergeable_human_change_set(context)
+        return unless context[:actor_kind] == "human" && context[:origin] == "editor"
+        return unless context[:change_group_token]
+
+        CreativeChangeSet
+          .where(user_id: context[:actor]&.id, change_group_token: context[:change_group_token], status: "applied")
+          .where(updated_at: MERGE_IDLE_WINDOW.ago..)
+          .newest_first
+          .first
+      end
+
+      def next_position(change_set)
+        (change_set.creative_changes.maximum(:position) || -1) + 1
+      end
+
+      def merged_operation(existing, incoming)
+        return incoming if existing.blank?
+
+        OPERATION_PRIORITY.fetch(existing) >= OPERATION_PRIORITY.fetch(incoming) ? existing : incoming
+      end
+
+      def bump_revision!(creative)
+        creative.class.increment_counter(:revision, creative.id)
+        creative.revision = creative.class.unscoped.where(id: creative.id).pick(:revision)
+        creative.send(:clear_attribute_change, :revision)
+      end
+
+      def discard_empty_change_set
+        change_set = Current.change_set
+        change_set&.destroy! if change_set&.persisted? && !change_set.creative_changes.exists?
+      end
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/creatives/reorderer.rb
+++ b/engines/collavre/app/services/collavre/creatives/reorderer.rb
@@ -186,8 +186,10 @@ module Creatives
         cases.when(creative.id).then(index)
       end
 
-      Creative.where(id: creatives.map(&:id))
-        .update_all(sequence: cases)
+      relation = Creative.where(id: creatives.map(&:id))
+      Creatives::History.record_bulk(relation, operation: "reorder") do
+        relation.update_all(sequence: cases)
+      end
 
       creatives.each_with_index do |creative, index|
         creative.write_attribute(:sequence, index)

--- a/engines/collavre/app/services/collavre/tools/creative_create_service.rb
+++ b/engines/collavre/app/services/collavre/tools/creative_create_service.rb
@@ -87,7 +87,13 @@ module Tools
         end
       end
 
-      siblings.each_with_index { |c, idx| c.update_column(:sequence, idx) }
+      resequence(siblings)
+    end
+
+    def resequence(siblings)
+      Creatives::History.record_bulk(siblings, operation: "reorder") do
+        siblings.each_with_index { |creative, index| creative.update_column(:sequence, index) }
+      end
     end
   end
 end

--- a/engines/collavre/app/services/collavre/tools/creative_import_service.rb
+++ b/engines/collavre/app/services/collavre/tools/creative_import_service.rb
@@ -32,7 +32,14 @@ module Collavre
         return { error: "Parent Creative not found", id: parent_id } unless parent
         return { error: "No write permission on parent Creative", id: parent_id } unless parent.has_permission?(Current.user, :write)
 
-        created = MarkdownImporter.import(markdown, parent: parent, user: Current.user)
+        created = Creatives::History.track(
+          actor: Current.user,
+          origin: :import,
+          anchor: parent,
+          anchor_source: :import_target
+        ) do
+          MarkdownImporter.import(markdown, parent: parent, user: Current.user)
+        end
 
         {
           success: true,

--- a/engines/collavre/app/views/collavre/creatives/_inline_edit_form.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/_inline_edit_form.html.erb
@@ -12,6 +12,8 @@
     <input type="hidden" id="inline-after-id" name="after_id" />
     <input type="hidden" id="inline-child-id" name="child_id" />
     <input type="hidden" id="inline-origin-id" name="creative[origin_id]" />
+    <input type="hidden" id="inline-history-anchor-id" name="history_anchor_id" value="<%= @parent_creative&.id %>" />
+    <input type="hidden" id="inline-change-group-token" name="change_group_token" value="<%= SecureRandom.uuid %>" />
     <div id="lexical-inline-editor"
          data-lexical-editor-root
          class="lexical-inline-editor"

--- a/engines/collavre/db/migrate/20260903180000_create_creative_change_history.rb
+++ b/engines/collavre/db/migrate/20260903180000_create_creative_change_history.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+class CreateCreativeChangeHistory < ActiveRecord::Migration[8.0]
+  def change
+    add_column :creatives, :revision, :integer, null: false, default: 0
+
+    create_table :creative_change_sets do |t|
+      t.integer :anchor_creative_id
+      t.string :anchor_source
+      t.integer :user_id
+      t.string :actor_kind, null: false
+      t.string :origin, null: false
+      t.integer :task_id
+      t.integer :topic_id
+      t.string :status, null: false, default: "applied"
+      t.string :change_group_token
+      t.text :summary
+      t.integer :reverts_id
+      t.integer :reverted_by_id
+      t.datetime :applied_at
+      t.timestamps
+
+      t.index %i[anchor_creative_id created_at]
+      t.index :status
+      t.index :task_id
+      t.index %i[change_group_token user_id]
+    end
+
+    create_table :creative_changes do |t|
+      t.references :creative_change_set, null: false, foreign_key: { on_delete: :cascade }
+      t.integer :creative_id, null: false
+      t.integer :previous_parent_id
+      t.string :operation, null: false
+      t.json :before, null: false, default: {}
+      t.json :after, null: false, default: {}
+      t.integer :position, null: false, default: 0
+      t.json :conflict, null: false, default: {}
+      t.timestamps
+
+      t.index %i[creative_id id]
+      t.index :previous_parent_id
+      t.index %i[creative_change_set_id creative_id], unique: true,
+                                                        name: "idx_creative_changes_on_set_and_creative"
+    end
+  end
+end

--- a/engines/collavre/test/controllers/creatives_controller_update_test.rb
+++ b/engines/collavre/test/controllers/creatives_controller_update_test.rb
@@ -38,6 +38,83 @@ class CreativesControllerUpdateTest < ActionDispatch::IntegrationTest
     assert_equal 0.5, @b1_origin.reload.progress
   end
 
+  test "records the viewing anchor and merges autosaves by change group token" do
+    2.times do |index|
+      patch creative_url(@b1_origin), params: {
+        history_anchor_id: @b.id,
+        change_group_token: "browser-edit-session",
+        creative: { description: "Edit #{index}" }
+      }
+      assert_response :redirect
+    end
+
+    change_set = Collavre::CreativeChangeSet.sole
+    change = change_set.creative_changes.sole
+    assert_equal @b.id, change_set.anchor_creative_id
+    assert_equal "view_root", change_set.anchor_source
+    assert_equal "browser-edit-session", change_set.change_group_token
+    assert_equal "B1 Origin", change.before.fetch("description")
+    assert_equal "Edit 1", change.after.fetch("description")
+  end
+
+  test "renders a page-scoped autosave token and history anchor" do
+    get creatives_url(id: @b.id)
+
+    assert_response :success
+    assert_select "input[name='history_anchor_id'][value='#{@b.id}']", count: 1
+    assert_select "input[name='change_group_token'][value]", count: 1
+  end
+
+  test "does not accept an unreadable history anchor" do
+    unreadable = Creative.create!(description: "Private", user: users(:two))
+
+    patch creative_url(@b1_origin), params: {
+      history_anchor_id: unreadable.id,
+      creative: { description: "Safe anchor" }
+    }
+
+    assert_response :redirect
+    assert_equal @b1_origin.id, Collavre::CreativeChangeSet.sole.anchor_creative_id
+  end
+
+  test "records every descendant completed by the progress cascade" do
+    child = Creative.create!(description: "Child", user: @user, parent: @b1_origin)
+    grandchild = Creative.create!(description: "Grandchild", user: @user, parent: child)
+
+    patch creative_url(@b1_origin), params: {
+      history_anchor_id: @b.id,
+      change_group_token: "completion-session",
+      creative: { progress: 1.0 }
+    }
+
+    assert_response :redirect
+    change_set = Collavre::CreativeChangeSet.sole
+    assert_equal [ @a.id, @b.id, @b1_origin.id, child.id, grandchild.id ].sort,
+                 change_set.creative_changes.pluck(:creative_id).sort
+    assert_equal [ 1, 1, 1 ], [ @b1_origin, child, grandchild ].map { |creative| creative.reload.revision }
+  end
+
+  test "records sibling resequencing when creating at a requested position" do
+    parent = Creative.create!(description: "Parent", user: @user)
+    first = Creative.create!(description: "First", user: @user, parent: parent, sequence: 0)
+    second = Creative.create!(description: "Second", user: @user, parent: parent, sequence: 1)
+
+    post creatives_url, params: {
+      before_id: second.id,
+      history_anchor_id: parent.id,
+      creative: { description: "Inserted", parent_id: parent.id }
+    }
+
+    assert_response :success
+    created = Creative.find(JSON.parse(response.body).fetch("id"))
+    changes = Collavre::CreativeChangeSet.sole.creative_changes.index_by(&:creative_id)
+    assert_equal [ created.id, second.id ].sort, changes.keys.sort
+    assert_equal "create", changes.fetch(created.id).operation
+    assert_equal 1, changes.fetch(created.id).after.fetch("sequence")
+    assert_equal [ 2, 1 ], [ created, second ].map { |creative| creative.reload.revision }
+    assert_equal 0, first.reload.revision
+  end
+
   test "update_metadata posts drop trigger warning when enabling without write-permission AI agent" do
     creative = Creative.create!(description: "Documentation", user: @user, data: {})
     feedback_ai = users(:ai_bot)

--- a/engines/collavre/test/services/collavre/creatives/history_test.rb
+++ b/engines/collavre/test/services/collavre/creatives/history_test.rb
@@ -1,0 +1,385 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  module Creatives
+    class HistoryTest < ActiveSupport::TestCase
+      include ActiveSupport::Testing::TimeHelpers
+
+      setup do
+        @user = users(:one)
+        @root = Creative.create!(description: "Root", user: @user)
+        @child = Creative.create!(description: "Child", user: @user, parent: @root)
+      end
+
+      test "groups repeated writes and keeps the first before and latest after snapshots" do
+        History.track(
+          actor: @user,
+          origin: :editor,
+          anchor: @root,
+          anchor_source: :view_root,
+          change_group_token: "editing-session"
+        ) do
+          @child.update!(description: "First")
+          @child.update!(description: "Second")
+        end
+
+        change_set = CreativeChangeSet.sole
+        change = change_set.creative_changes.sole
+
+        assert_equal @root.id, change_set.anchor_creative_id
+        assert_equal "view_root", change_set.anchor_source
+        assert_equal "human", change_set.actor_kind
+        assert_equal "editor", change_set.origin
+        assert_equal "editing-session", change_set.change_group_token
+        assert_equal "Child", change.before.fetch("description")
+        assert_equal "Second", change.after.fetch("description")
+        assert_equal "update", change.operation
+        assert_equal 2, @child.reload.revision
+      end
+
+      test "serializes writes against the change set row" do
+        change_set = CreativeChangeSet.create!(
+          actor_kind: "human",
+          origin: "editor",
+          status: "applied",
+          user: @user,
+          applied_at: Time.current
+        )
+        locked = false
+        lock = lambda do |&block|
+          locked = true
+          block.call
+        end
+        before = History.snapshot(@child)
+        @child.update_column(:description, "Serialized")
+
+        change_set.stub(:with_lock, lock) do
+          History.stub(:current_change_set, change_set) do
+            History.track(actor: @user, origin: :editor) do
+              History.record(@child.reload, operation: :update, before: before, after: History.snapshot(@child))
+            end
+          end
+        end
+
+        assert locked
+        assert_equal "Serialized", change_set.creative_changes.sole.after.fetch("description")
+      end
+
+      test "stores canonical markdown without its generated HTML" do
+        History.track(actor: @user, origin: :editor, anchor: @root) do
+          @child.content_type_input = "markdown"
+          @child.markdown_source = "# Updated"
+          @child.markdown_editor = "rich"
+          @child.save!
+        end
+
+        after = CreativeChange.sole.after
+        assert_equal "# Updated", after.fetch("markdown_source")
+        assert_equal "markdown", after.fetch("content_type")
+        assert_equal "rich", after.fetch("editor")
+        assert_not after.key?("description")
+      end
+
+      test "merges human edits with the same token inside the idle window" do
+        travel_to Time.zone.local(2026, 9, 3, 10, 0, 0) do
+          track_editor_change("same-token") { @child.update!(description: "First") }
+          travel 4.minutes
+          track_editor_change("same-token") { @child.update!(description: "Second") }
+        end
+
+        assert_equal 1, CreativeChangeSet.count
+        assert_equal "Child", CreativeChange.sole.before.fetch("description")
+        assert_equal "Second", CreativeChange.sole.after.fetch("description")
+      end
+
+      test "starts a new human change set after five idle minutes" do
+        travel_to Time.zone.local(2026, 9, 3, 10, 0, 0) do
+          track_editor_change("same-token") { @child.update!(description: "First") }
+          travel 6.minutes
+          track_editor_change("same-token") { @child.update!(description: "Second") }
+        end
+
+        assert_equal 2, CreativeChangeSet.count
+      end
+
+      test "rolls history back with the creative write" do
+        Creative.transaction do
+          History.track(actor: @user, origin: :editor, anchor: @root) do
+            @child.update!(description: "Rolled back")
+            raise ActiveRecord::Rollback
+          end
+        end
+
+        assert_equal "Child", @child.reload.description
+        assert_empty CreativeChangeSet.all
+      end
+
+      test "recovers implicit turn tracking after a transaction rollback" do
+        Current.set(user: @user) do
+          Creative.transaction do
+            @child.update!(description: "Rolled back")
+            raise ActiveRecord::Rollback
+          end
+
+          @child.update!(description: "Retried")
+        end
+
+        assert_equal "Retried", @child.reload.description
+        assert_equal 1, CreativeChangeSet.count
+        assert_equal "Child", CreativeChange.sole.before.fetch("description")
+        assert_equal "Retried", CreativeChange.sole.after.fetch("description")
+      end
+
+      test "increments revisions atomically across stale model instances" do
+        first = Creative.find(@child.id)
+        second = Creative.find(@child.id)
+
+        track_editor_change("first") { first.update!(description: "First") }
+        Current.reset
+        track_editor_change("second") { second.update!(description: "Second") }
+
+        assert_equal 2, second.revision
+        assert_equal 2, @child.reload.revision
+      end
+
+      test "captures the baseline after locking and reloading a stale creative" do
+        stale = Creative.find(@child.id)
+        @child.update_column(:description, "Concurrent edit")
+
+        track_editor_change("stale") { stale.update!(description: "Final edit") }
+
+        change = CreativeChange.sole
+        assert_equal "Concurrent edit", change.before.fetch("description")
+        assert_equal "Final edit", change.after.fetch("description")
+      end
+
+      test "does not record an unscoped write without a current actor" do
+        @child.update!(description: "Background maintenance")
+
+        assert_empty CreativeChangeSet.all
+        assert_equal 0, @child.reload.revision
+      end
+
+      test "records a create as one change with an empty before snapshot" do
+        created = nil
+        History.track(actor: @user, origin: :import, anchor: @root, anchor_source: :import_target) do
+          created = Creative.create!(description: "Imported", user: @user, parent: @root)
+        end
+
+        change = CreativeChange.sole
+        assert_equal "create", change.operation
+        assert_equal({}, change.before)
+        assert_equal "Imported", change.after.fetch("description")
+        assert_equal 1, created.reload.revision
+      end
+
+      test "records an explicit hard destroy for audit history" do
+        child_id = @child.id
+
+        History.track(actor: @user, origin: :editor, anchor: @root) do
+          Creatives::DestroyService.new(creative: @child, user: @user, delete_with_children: true).call
+        end
+
+        change = CreativeChange.sole
+        assert_equal child_id, change.creative_id
+        assert_equal "destroy", change.operation
+        assert_equal "Child", change.before.fetch("description")
+        assert_equal({}, change.after)
+      end
+
+      test "discards a change that returns to its initial state" do
+        History.track(actor: @user, origin: :editor, anchor: @root) do
+          @child.update!(description: "Temporary")
+          @child.update!(description: "Child")
+        end
+
+        assert_empty CreativeChangeSet.all
+        assert_equal 2, @child.reload.revision
+      end
+
+      test "preserves an outer change set through nested tracking" do
+        History.track(actor: @user, origin: :tool, anchor: @root) do
+          @child.update!(description: "Outer")
+          History.track(actor: @user, origin: :import, anchor: @child) do
+            @root.update!(description: "Nested")
+          end
+        end
+
+        assert_equal 1, CreativeChangeSet.count
+        assert_equal [ @root.id, @child.id ].sort, CreativeChange.pluck(:creative_id).sort
+        assert_equal "tool", CreativeChangeSet.sole.origin
+      end
+
+      test "captures agent turn attribution" do
+        agent = users(:ai_bot)
+        topic = Topic.create!(creative: @root, user: @user, name: "Agent work")
+        task = Task.create!(agent: agent, creative: @root, topic_id: topic.id, name: "Edit", status: "running")
+
+        History.track(
+          actor: agent,
+          origin: :tool,
+          anchor: @root,
+          anchor_source: :agent_topic,
+          task: task,
+          topic: topic,
+          summary: "Update the child"
+        ) { @child.update!(description: "Agent edit") }
+
+        change_set = CreativeChangeSet.sole
+        assert_equal "agent", change_set.actor_kind
+        assert_equal agent.id, change_set.user_id
+        assert_equal task.id, change_set.task_id
+        assert_equal topic.id, change_set.topic_id
+        assert_equal "Update the child", change_set.summary
+        assert change_set.applied_at.present?
+      end
+
+      test "implicitly groups all writes in one agent turn" do
+        agent = users(:ai_bot)
+        sibling = Creative.create!(description: "Sibling", user: @user, parent: @root)
+        topic = Topic.create!(creative: @root, user: @user, name: "Agent turn")
+        task = Task.create!(agent: agent, creative: @root, topic_id: topic.id, name: "Edit", status: "running")
+
+        Current.set(user: agent, agent_turn: { user: @user, task: task }) do
+          @child.update!(description: "First tool write")
+          sibling.update!(description: "Second tool write")
+        end
+
+        change_set = CreativeChangeSet.sole
+        assert_equal task.id, change_set.task_id
+        assert_equal topic.id, change_set.topic_id
+        assert_equal @root.id, change_set.anchor_creative_id
+        assert_equal [ @child.id, sibling.id ].sort, change_set.creative_changes.pluck(:creative_id).sort
+      end
+
+      test "keeps nested import tracking in the enclosing agent turn" do
+        agent = users(:ai_bot)
+        topic = Topic.create!(creative: @root, user: @user, name: "Agent import")
+        task = Task.create!(agent: agent, creative: @root, topic_id: topic.id, name: "Import", status: "running")
+
+        Current.set(user: agent, agent_turn: { user: @user, task: task }) do
+          History.track(actor: agent, origin: :import, anchor: @child, anchor_source: :import_target) do
+            @child.update!(description: "Imported")
+          end
+          @root.update!(description: "Same turn")
+        end
+
+        change_set = CreativeChangeSet.sole
+        assert_equal "tool", change_set.origin
+        assert_equal task.id, change_set.task_id
+        assert_equal topic.id, change_set.topic_id
+        assert_equal @root.id, change_set.anchor_creative_id
+        assert_equal [ @root.id, @child.id ].sort, change_set.creative_changes.pluck(:creative_id).sort
+      end
+
+      test "infers MCP attribution when a write is not explicitly scoped" do
+        Current.set(user: @user, mcp_request: true) do
+          @child.update!(description: "MCP edit")
+        end
+
+        change_set = CreativeChangeSet.sole
+        assert_equal "mcp", change_set.origin
+        assert_equal @child.id, change_set.anchor_creative_id
+        assert_equal "explicit", change_set.anchor_source
+      end
+
+      test "hides sync history from the default scope and leaves drafts unapplied" do
+        History.track(actor: nil, origin: :sync, anchor: @root, status: "draft") do
+          @child.update!(description: "Synced draft")
+        end
+
+        change_set = CreativeChangeSet.sole
+        assert_equal "sync", change_set.actor_kind
+        assert_nil change_set.applied_at
+        assert_empty CreativeChangeSet.visible_by_default
+      end
+
+      test "records every propagated archive and unarchive" do
+        linked = Creative.create!(description: "Linked", user: @user, origin_id: @root.id)
+
+        History.track(actor: @user, origin: :editor, anchor: @root) { @root.archive! }
+        archived_set = CreativeChangeSet.sole
+        assert_equal [ @root.id, @child.id, linked.id ].sort,
+                     archived_set.creative_changes.pluck(:creative_id).sort
+        assert archived_set.creative_changes.all? { |change| change.operation == "archive" }
+        root_change = archived_set.creative_changes.find_by!(creative_id: @root.id)
+        assert_equal History.snapshot(@root.reload), root_change.reload.after
+
+        Current.reset
+        History.track(actor: @user, origin: :editor, anchor: @root) { @root.unarchive! }
+        restored_set = CreativeChangeSet.newest_first.first
+        assert_equal [ @root.id, @child.id, linked.id ].sort,
+                     restored_set.creative_changes.pluck(:creative_id).sort
+        assert restored_set.creative_changes.all? { |change| change.operation == "unarchive" }
+      end
+
+      test "queries change sets touching the viewed subtree newest first" do
+        unrelated = Creative.create!(description: "Unrelated", user: @user)
+        track_editor_change("root") { @child.update!(description: "Older") }
+        travel 1.second
+        track_editor_change("root-2") { @root.update!(description: "Newer") }
+        track_editor_change("other") { unrelated.update!(description: "Elsewhere") }
+
+        sets = CreativeChangeSet.for_creative_scope(@root).to_a
+        assert_equal 2, sets.size
+        assert_equal @root.id, sets.first.creative_changes.sole.creative_id
+        assert_equal @child.id, sets.second.creative_changes.sole.creative_id
+      end
+
+      test "keeps a destroyed subtree discoverable from its surviving parent" do
+        grandchild = Creative.create!(description: "Grandchild", user: @user, parent: @child)
+
+        History.track(actor: @user, origin: :editor, anchor: @root) do
+          grandchild.destroy!
+          @child.destroy!
+        end
+
+        change_set = CreativeChangeSet.sole
+        assert_equal [ @child.id, grandchild.id ].sort, change_set.creative_changes.pluck(:creative_id).sort
+        assert_equal @root.id, change_set.creative_changes.find_by!(creative_id: @child.id).previous_parent_id
+        assert_equal [ change_set ], CreativeChangeSet.for_creative_scope(@root).to_a
+      end
+
+      test "queries both a linked shell and its effective origin subtree" do
+        folder = Creative.create!(description: "Folder", user: @user)
+        linked = Creative.create!(user: @user, parent: folder, origin_id: @root.id)
+        shell_child = Creative.create!(description: "Shell child", user: @user, parent: linked)
+
+        track_editor_change("origin") { @child.update!(description: "Origin child edit") }
+        Current.reset
+        track_editor_change("shell") { shell_child.update!(description: "Shell edit") }
+
+        changes = CreativeChangeSet.for_creative_scope(linked).flat_map(&:creative_changes)
+        assert_equal [ @child.id, shell_child.id ].sort, changes.map(&:creative_id).sort
+      end
+
+      test "validates change set and change vocabularies" do
+        change_set = CreativeChangeSet.new(
+          actor_kind: "unknown",
+          anchor_source: "unknown",
+          origin: "unknown",
+          status: "unknown"
+        )
+        assert_not change_set.valid?
+
+        change = CreativeChange.new(operation: "unknown")
+        assert_not change.valid?
+      end
+
+      private
+
+      def track_editor_change(token, &block)
+        History.track(
+          actor: @user,
+          origin: :editor,
+          anchor: @root,
+          anchor_source: :view_root,
+          change_group_token: token,
+          &block
+        )
+      end
+    end
+  end
+end

--- a/engines/collavre/test/services/creatives/reorderer_test.rb
+++ b/engines/collavre/test/services/creatives/reorderer_test.rb
@@ -65,6 +65,26 @@ module Creatives
       ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
     end
 
+    test "records bulk sequence changes in one change set" do
+      Collavre::Creatives::History.track(
+        actor: @user,
+        origin: :editor,
+        anchor: @root,
+        anchor_source: :view_root
+      ) do
+        @reorderer.reorder(
+          dragged_id: @child_c.id,
+          target_id: @child_a.id,
+          direction: "up"
+        )
+      end
+
+      change_set = Collavre::CreativeChangeSet.sole
+      assert_equal [ @child_a.id, @child_b.id, @child_c.id ].sort,
+                   change_set.creative_changes.pluck(:creative_id).sort
+      assert change_set.creative_changes.all? { |change| change.operation == "reorder" }
+    end
+
     test "reorder_multiple raises when selection contains duplicate ids" do
       assert_raises(Reorderer::Error) do
         @reorderer.reorder_multiple(

--- a/engines/collavre/test/services/tools/creative_create_service_test.rb
+++ b/engines/collavre/test/services/tools/creative_create_service_test.rb
@@ -109,6 +109,29 @@ module Collavre
         assert_equal @user, creative.user
       end
 
+      test "records sibling resequencing when inserting before a sibling" do
+        Collavre::CreativeChangeSet.destroy_all
+        Current.reset
+        first = Creative.create!(description: "First", user: @user, parent: @parent_creative, sequence: 0)
+        second = Creative.create!(description: "Second", user: @user, parent: @parent_creative, sequence: 1)
+        Current.user = @user
+
+        result = CreativeCreateService.new.call(
+          parent_id: @parent_creative.id,
+          description: "Inserted",
+          before_id: second.id
+        )
+
+        assert result[:success]
+        created = Creative.find(result.fetch(:id))
+        changes = CreativeChangeSet.sole.creative_changes.index_by(&:creative_id)
+        assert_equal [ created.id, second.id ].sort, changes.keys.sort
+        assert_equal "create", changes.fetch(created.id).operation
+        assert_equal 1, changes.fetch(created.id).after.fetch("sequence")
+        assert_equal [ 2, 1 ], [ created, second ].map { |creative| creative.reload.revision }
+        assert_equal 0, first.reload.revision
+      end
+
       test "returns error when parent not found" do
         service = CreativeCreateService.new
 

--- a/engines/collavre/test/services/tools/creative_import_service_test.rb
+++ b/engines/collavre/test/services/tools/creative_import_service_test.rb
@@ -29,6 +29,12 @@ module Collavre
         project = @parent.children.first
         assert_includes project.description, "Project Plan"
         assert_equal 2, project.children.count
+
+        change_set = CreativeChangeSet.sole
+        assert_equal "import", change_set.origin
+        assert_equal "import_target", change_set.anchor_source
+        assert_equal @parent.id, change_set.anchor_creative_id
+        assert_equal 3, change_set.creative_changes.count
       end
 
       test "imports bullet lists as children" do
@@ -45,6 +51,26 @@ module Collavre
 
         tasks = @parent.children.first
         assert_equal 2, tasks.children.count
+      end
+
+      test "keeps import and later writes in one agent turn change set" do
+        agent = users(:ai_bot)
+        CreativeShare.create!(creative: @parent, user: agent, shared_by: @user, permission: :write)
+        topic = Topic.create!(creative: @parent, user: @user, name: "Agent import")
+        task = Task.create!(agent: agent, creative: @parent, topic_id: topic.id, name: "Import", status: "running")
+
+        Current.set(user: agent, agent_turn: { user: @user, task: task }) do
+          result = @service.call(markdown: "# Imported", parent_id: @parent.id)
+          assert result[:success]
+          @parent.update!(description: "Updated in the same turn")
+        end
+
+        change_set = CreativeChangeSet.sole
+        assert_equal "tool", change_set.origin
+        assert_equal task.id, change_set.task_id
+        assert_equal topic.id, change_set.topic_id
+        assert_equal @parent.id, change_set.anchor_creative_id
+        assert_equal 2, change_set.creative_changes.count
       end
 
       test "returns error for invalid parent_id" do

--- a/engines/collavre/test/system/creative_inline_edit_test.rb
+++ b/engines/collavre/test/system/creative_inline_edit_test.rb
@@ -62,7 +62,7 @@ class CreativeInlineEditTest < ApplicationSystemTestCase
 
   def close_inline_editor
     find("#inline-close", wait: 5).click
-    assert_no_selector ".lexical-content-editable", visible: true, wait: 5
+    assert_no_selector ".lexical-content-editable", visible: true, wait: 10
     wait_for_network_idle(timeout: 10)
   end
 

--- a/engines/collavre_github/app/jobs/collavre_github/initial_markdown_sync_job.rb
+++ b/engines/collavre_github/app/jobs/collavre_github/initial_markdown_sync_job.rb
@@ -10,10 +10,12 @@ module CollavreGithub
       user = link.creative.user
       return unless user
 
-      CollavreGithub::MarkdownSync::InitialImportService.new(
-        repository_link: link,
-        user: user
-      ).call
+      Collavre::Creatives::History.track(actor: nil, origin: :sync) do
+        CollavreGithub::MarkdownSync::InitialImportService.new(
+          repository_link: link,
+          user: user
+        ).call
+      end
     end
   end
 end

--- a/engines/collavre_github/app/jobs/collavre_github/markdown_sync_job.rb
+++ b/engines/collavre_github/app/jobs/collavre_github/markdown_sync_job.rb
@@ -7,10 +7,12 @@ module CollavreGithub
       link = CollavreGithub::RepositoryLink.find_by(id: repository_link_id)
       return unless link&.markdown_sync_enabled?
 
-      CollavreGithub::MarkdownSync::IncrementalSyncService.new(
-        repository_link: link,
-        push_payload: push_payload
-      ).call
+      Collavre::Creatives::History.track(actor: nil, origin: :sync) do
+        CollavreGithub::MarkdownSync::IncrementalSyncService.new(
+          repository_link: link,
+          push_payload: push_payload
+        ).call
+      end
     end
   end
 end

--- a/engines/collavre_github/app/services/collavre_github/markdown_sync/incremental_sync_service.rb
+++ b/engines/collavre_github/app/services/collavre_github/markdown_sync/incremental_sync_service.rb
@@ -184,8 +184,11 @@ module CollavreGithub
               is_dir = path.end_with?("/") || path == ""
               [ is_dir ? 0 : 1, c.description.to_s.downcase ]
             end
-            sorted.each_with_index do |c, idx|
-              c.update_column(:sequence, idx) if c.sequence != idx
+            changes = sorted.each_with_index.filter_map do |creative, index|
+              [ creative, index ] if creative.sequence != index
+            end
+            Collavre::Creatives::History.record_bulk(changes.map(&:first), operation: "reorder") do
+              changes.each { |creative, index| creative.update_column(:sequence, index) }
             end
           end
         end

--- a/engines/collavre_github/app/services/collavre_github/markdown_sync/initial_import_service.rb
+++ b/engines/collavre_github/app/services/collavre_github/markdown_sync/initial_import_service.rb
@@ -148,8 +148,10 @@ module CollavreGithub
               is_dir = path.end_with?("/") || path == ""
               [ is_dir ? 0 : 1, c.description.to_s.downcase ]
             end
-            sorted.each_with_index do |c, idx|
-              c.update_column(:sequence, idx)
+            Collavre::Creatives::History.record_bulk(sorted, operation: "reorder") do
+              sorted.each_with_index do |creative, index|
+                creative.update_column(:sequence, index)
+              end
             end
           end
         end

--- a/engines/collavre_github/test/jobs/collavre_github/markdown_sync_job_test.rb
+++ b/engines/collavre_github/test/jobs/collavre_github/markdown_sync_job_test.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require_relative "../../test_helper"
+
+module CollavreGithub
+  class MarkdownSyncJobTest < ActiveSupport::TestCase
+    setup do
+      @user = users(:one)
+      @creative = creatives(:tshirt)
+      account = Account.create!(
+        user: @user,
+        github_uid: "markdown-sync-job",
+        login: "sync-job",
+        token: "test-token"
+      )
+      @link = RepositoryLink.create!(
+        creative: @creative,
+        github_account: account,
+        repository_full_name: "owner/repo",
+        markdown_sync_enabled: true
+      )
+    end
+
+    test "records incremental GitHub writes as hidden sync history" do
+      creative = @creative
+      service = Object.new
+      service.define_singleton_method(:call) { creative.update!(description: "GitHub update") }
+
+      MarkdownSync::IncrementalSyncService.stub(:new, ->(**) { service }) do
+        MarkdownSyncJob.perform_now(@link.id, {})
+      end
+
+      assert_hidden_sync_history
+    end
+
+    test "records initial GitHub imports as hidden sync history" do
+      creative = @creative
+      service = Object.new
+      service.define_singleton_method(:call) { creative.update!(description: "Initial GitHub import") }
+
+      MarkdownSync::InitialImportService.stub(:new, ->(**) { service }) do
+        InitialMarkdownSyncJob.perform_now(@link.id)
+      end
+
+      assert_hidden_sync_history
+    end
+
+    test "records initial import directory-first resequencing" do
+      parent = Collavre::Creative.create!(description: "Ordered", user: @user)
+      file = sourced_creative(parent, "a.md", 0)
+      directory = sourced_creative(parent, "z/", 1)
+      service = MarkdownSync::InitialImportService.new(repository_link: @link, user: @user)
+
+      Collavre::Creatives::History.track(actor: nil, origin: :sync) do
+        service.send(:resequence_directories_first, [ file, directory ])
+      end
+
+      assert_equal 0, directory.reload.sequence
+      assert_equal 1, file.reload.sequence
+      assert_equal [ file.id, directory.id ].sort,
+                   Collavre::CreativeChangeSet.sole.creative_changes.pluck(:creative_id).sort
+    end
+
+    private
+
+    def assert_hidden_sync_history
+      change_set = Collavre::CreativeChangeSet.sole
+      assert_equal "sync", change_set.origin
+      assert_equal "sync", change_set.actor_kind
+      assert_nil change_set.anchor_creative_id
+      assert_empty Collavre::CreativeChangeSet.visible_by_default
+    end
+
+    def sourced_creative(parent, path, sequence)
+      Collavre::Creative.create!(
+        description: path,
+        parent: parent,
+        user: @user,
+        sequence: sequence,
+        data: { "source" => { "path" => path } }
+      )
+    end
+  end
+end

--- a/engines/collavre_github/test/services/collavre_github/markdown_sync/incremental_sync_service_test.rb
+++ b/engines/collavre_github/test/services/collavre_github/markdown_sync/incremental_sync_service_test.rb
@@ -96,6 +96,33 @@ module CollavreGithub
 
         assert_not_includes synced.values, @no_source
       end
+
+      test "resequence_affected_parents records every changed sibling" do
+        parent = Collavre::Creative.create!(description: "Ordered", user: @user)
+        file = sourced_creative(parent, "a.md", 0)
+        directory = sourced_creative(parent, "z/", 1)
+
+        Collavre::Creatives::History.track(actor: nil, origin: :sync) do
+          @service.send(:resequence_affected_parents, [ file, directory ])
+        end
+
+        assert_equal 0, directory.reload.sequence
+        assert_equal 1, file.reload.sequence
+        assert_equal [ file.id, directory.id ].sort,
+                     Collavre::CreativeChangeSet.sole.creative_changes.pluck(:creative_id).sort
+      end
+
+      private
+
+      def sourced_creative(parent, path, sequence)
+        Collavre::Creative.create!(
+          description: path,
+          parent: parent,
+          user: @user,
+          sequence: sequence,
+          data: { "source" => { "path" => path } }
+        )
+      end
     end
   end
 end

--- a/engines/collavre_linear/app/jobs/collavre_linear/inbound_apply_job.rb
+++ b/engines/collavre_linear/app/jobs/collavre_linear/inbound_apply_job.rb
@@ -50,7 +50,9 @@ module CollavreLinear
         return
       end
 
-      CollavreLinear::InboundApplier.new(payload).apply!
+      Collavre::Creatives::History.track(actor: nil, origin: :sync) do
+        CollavreLinear::InboundApplier.new(payload).apply!
+      end
     end
   end
 end

--- a/engines/collavre_linear/test/jobs/collavre_linear/inbound_apply_job_test.rb
+++ b/engines/collavre_linear/test/jobs/collavre_linear/inbound_apply_job_test.rb
@@ -59,6 +59,22 @@ module CollavreLinear
       assert applied, "job must call apply! on the InboundApplier"
     end
 
+    test "records actorless inbound writes as hidden sync history" do
+      creative = creatives(:tshirt)
+      applier = Object.new
+      applier.define_singleton_method(:apply!) { creative.update!(description: "Linear update") }
+
+      CollavreLinear::InboundApplier.stub(:new, ->(*) { applier }) do
+        CollavreLinear::InboundApplyJob.perform_now({ "action" => "update" })
+      end
+
+      change_set = Collavre::CreativeChangeSet.sole
+      assert_equal "sync", change_set.origin
+      assert_equal "sync", change_set.actor_kind
+      assert_nil change_set.anchor_creative_id
+      assert_empty Collavre::CreativeChangeSet.visible_by_default
+    end
+
     test "a transient ActiveRecord::Deadlocked re-enqueues (retry) instead of dropping the event" do
       # WebhooksController acks Linear (200) before this job runs, so a dropped
       # apply is never re-delivered. A transient deadlock must retry, not park.


### PR DESCRIPTION
## Summary

- add append-only CreativeChangeSet and CreativeChange persistence with Creative revisions
- record model, bulk archive/unarchive, reorder, import, browser, MCP, and agent-turn writes
- preserve observed anchors and merge human autosaves by editing-session token for five minutes
- expose descendant-scoped, sync-filtered read queries while keeping this rollout shadow-only

## Verification

- `./bin/rubocop -a`
- `bin/complexity_check`
- `bundle exec rake test` (4,569 runs, 15,631 assertions)
- `npm test -- --runInBand` (1,689 tests)
- explicit engine system suite: 112/113 scenarios completed; the unrelated parallel SSE MCP scenario timed out, then passed in isolation
- attachment inline-edit regression passed after increasing its upload-aware close wait to 10 seconds

## Notes

- `bin/rails test:system` currently exits before engine discovery because the host `test/system` path does not exist; engine system files were invoked explicitly.
- This is rollout PR 1/5 and targets `feature-revision`.