### PR TITLE
feat: add creative history diff and revert

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,6 +61,7 @@ PATH
       bcrypt
       closure_tree
       commonmarker
+      diff-lcs
       httparty
       liquid
       nokogiri
@@ -219,6 +220,7 @@ GEM
       irb (~> 1.10)
       reline (>= 0.3.8)
     declarative (0.0.20)
+    diff-lcs (1.6.2)
     doorkeeper (5.9.5)
       railties (>= 5)
     dotenv (3.2.0)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_09_03_180000) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_03_190000) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -964,11 +964,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_03_180000) do
     t.integer "primary_agent_id"
     t.string "session_id"
     t.integer "source_topic_id"
+    t.string "system_kind"
     t.datetime "updated_at", null: false
     t.integer "user_id", null: false
     t.index ["archived_at"], name: "index_topics_on_archived_at", where: "archived_at IS NOT NULL"
     t.index ["creative_id", "name"], name: "index_topics_on_creative_id_and_name", unique: true
     t.index ["creative_id", "position"], name: "index_topics_on_creative_id_and_position"
+    t.index ["creative_id", "system_kind"], name: "index_topics_on_creative_id_and_system_kind", unique: true
     t.index ["creative_id"], name: "index_topics_on_creative_id"
     t.index ["primary_agent_id", "session_id"], name: "index_topics_on_primary_agent_and_session"
     t.index ["primary_agent_id"], name: "index_topics_on_primary_agent_id"

--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -1623,6 +1623,87 @@ body.chat-fullscreen {
     margin-right: -1px;
 }
 
+.creative-history-list {
+  display: grid;
+  gap: 12px;
+  padding: 12px;
+}
+
+.creative-history-item {
+  border: 1px solid var(--border-color, #ddd);
+  border-radius: 8px;
+  padding: 12px;
+}
+
+.creative-history-header,
+.creative-history-stats {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.creative-history-summary {
+  margin: 8px 0 4px;
+}
+
+.creative-history-stats {
+  color: var(--text-secondary, #666);
+  font-size: 0.85rem;
+}
+
+.creative-history-stats ins {
+  color: #16803a;
+  text-decoration: none;
+}
+
+.creative-history-stats del {
+  color: #b42318;
+  text-decoration: none;
+}
+
+.creative-history-diff {
+  margin-top: 8px;
+}
+
+.creative-history-inline {
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
+.creative-history-inline ins {
+  background: #dcfce7;
+  text-decoration: none;
+}
+
+.creative-history-inline del {
+  background: #fee2e2;
+}
+
+.creative-history-split {
+  table-layout: fixed;
+  width: 100%;
+}
+
+.creative-history-split td {
+  overflow-wrap: anywhere;
+  padding: 2px 6px;
+  vertical-align: top;
+  white-space: pre-wrap;
+  width: 50%;
+}
+
+.creative-history-split .diff-changed td:first-child {
+  background: #fee2e2;
+}
+
+.creative-history-split .diff-changed td:last-child {
+  background: #dcfce7;
+}
+
+.creative-history-revert {
+  margin-top: 10px;
+}
+
 .comment-item[draggable="true"] {
     cursor: grab;
 }

--- a/engines/collavre/app/controllers/collavre/comments_controller.rb
+++ b/engines/collavre/app/controllers/collavre/comments_controller.rb
@@ -9,6 +9,8 @@ module Collavre
     before_action :set_creative
     before_action :set_comment, only: [ :destroy, :show, :update, :convert, :approve, :deny, :update_action, :download_images, :remove_image ]
 
+    include Collavre::Comments::HistoryTopicGuard
+
     def fullscreen
       # Render the creative index page with comments popup auto-opened in fullscreen.
       # This way the creative list loads behind the popup, so exiting fullscreen

--- a/engines/collavre/app/controllers/collavre/comments_controller.rb
+++ b/engines/collavre/app/controllers/collavre/comments_controller.rb
@@ -28,7 +28,11 @@ module Collavre
     end
 
     def index
-      Collavre::Comments::ListResponse.new(controller: self, creative: @creative).render
+      Collavre::Comments::ListResponse.new(
+        controller: self,
+        creative: @creative,
+        history_scope_creative: @requested_creative
+      ).render
     end
 
     def create

--- a/engines/collavre/app/controllers/collavre/creative_change_sets_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creative_change_sets_controller.rb
@@ -5,7 +5,7 @@ module Collavre
     before_action :set_creative
 
     def apply
-      change_set = CreativeChangeSet.for_creative_scope(@creative).find(params[:id])
+      change_set = CreativeChangeSet.for_creative_scope(@requested_creative).find(params[:id])
       result = apply_service(change_set).call
 
       render json: payload_for(result), status: response_status(result)
@@ -30,8 +30,9 @@ module Collavre
     end
 
     def set_creative
-      @creative = Creative.find(params[:creative_id]).effective_origin
-      head :forbidden unless @creative.has_permission?(Current.user, :read)
+      @requested_creative = Creative.find(params[:creative_id])
+      readable_ids = Creatives::PermissionFilter.new(user: Current.user).readable_ids([ @requested_creative.id ])
+      head :forbidden unless readable_ids.include?(@requested_creative.id)
     end
 
     def payload_for(result)
@@ -46,7 +47,7 @@ module Collavre
 
     def response_status(result)
       return :conflict if result.status == :conflict
-      return :unprocessable_entity unless result.status == :applied
+      return :unprocessable_entity unless result.status.in?(%i[applied partial])
 
       :ok
     end

--- a/engines/collavre/app/controllers/collavre/creative_change_sets_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creative_change_sets_controller.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module Collavre
+  class CreativeChangeSetsController < ApplicationController
+    before_action :set_creative
+
+    def apply
+      change_set = CreativeChangeSet.for_creative_scope(@creative).find(params[:id])
+      result = apply_service(change_set).call
+
+      render json: payload_for(result), status: response_status(result)
+    end
+
+    private
+
+    def apply_service(change_set)
+      return Creatives::ChangeSetRestoreService.new(change_set: change_set, user: Current.user) if params[:mode] == "restore"
+
+      Creatives::ChangeSetRevertService.new(
+        change_set: change_set,
+        user: Current.user,
+        resolutions: resolutions
+      )
+    end
+
+    def resolutions
+      params.fetch(:resolutions, {}).each_pair.filter_map do |creative_id, decision|
+        [ creative_id.to_s, decision ] if creative_id.to_s.match?(/\A\d+\z/) && decision.in?(%w[force skip])
+      end.to_h
+    end
+
+    def set_creative
+      @creative = Creative.find(params[:creative_id]).effective_origin
+      head :forbidden unless @creative.has_permission?(Current.user, :read)
+    end
+
+    def payload_for(result)
+      {
+        status: result.status,
+        change_set_id: result.change_set&.id,
+        conflicts: result.conflicts,
+        skipped: result.skipped,
+        message: I18n.t("collavre.creative_history.results.#{result.status}")
+      }
+    end
+
+    def response_status(result)
+      return :conflict if result.status == :conflict
+      return :unprocessable_entity unless result.status == :applied
+
+      :ok
+    end
+  end
+end

--- a/engines/collavre/app/controllers/collavre/topics_controller.rb
+++ b/engines/collavre/app/controllers/collavre/topics_controller.rb
@@ -10,6 +10,8 @@ module Collavre
     before_action :require_creative_admin!, only: %i[update destroy move reorder]
     before_action :require_creative_write!, only: %i[create archive unarchive set_primary_agent]
 
+    include Collavre::Topics::ReservedTopicGuard
+
     def index
       is_owner = @creative.user == Current.user
       can_manage = @creative.has_permission?(Current.user, :admin) || is_owner
@@ -115,10 +117,6 @@ module Collavre
 
     def destroy
       topic = @creative.topics.find(params[:id])
-
-      if topic.name == Creative::MAIN_TOPIC_NAME
-        render json: { error: I18n.t("collavre.topics.cannot_delete_main") }, status: :unprocessable_entity and return
-      end
 
       topic_id, topic_name = Topics::TopicDestroy.new(
         topic: topic, source_creative: @creative

--- a/engines/collavre/app/controllers/concerns/collavre/comments/comment_scoping.rb
+++ b/engines/collavre/app/controllers/concerns/collavre/comments/comment_scoping.rb
@@ -8,8 +8,10 @@ module Collavre
       private
 
       def set_creative
-        @creative = Creative.find(params[:creative_id]).effective_origin
-        unless @creative.has_permission?(Current.user, :read)
+        @requested_creative = Creative.find(params[:creative_id])
+        @creative = @requested_creative.effective_origin
+        readable_ids = Creatives::PermissionFilter.new(user: Current.user).readable_ids([ @requested_creative.id ])
+        unless readable_ids.include?(@requested_creative.id)
           render json: { error: I18n.t("collavre.creatives.errors.no_permission") }, status: :forbidden
         end
       end

--- a/engines/collavre/app/controllers/concerns/collavre/comments/history_topic_guard.rb
+++ b/engines/collavre/app/controllers/concerns/collavre/comments/history_topic_guard.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Collavre
+  module Comments
+    module HistoryTopicGuard
+      extend ActiveSupport::Concern
+
+      included do
+        before_action :reject_history_topic_comment!, only: :create
+      end
+
+      private
+
+      def reject_history_topic_comment!
+        topic_id = params.dig(:comment, :topic_id).presence
+        return unless topic_id && @creative.topics.where(id: topic_id, name: Creative::HISTORY_TOPIC_NAME).exists?
+
+        render json: { error: I18n.t("collavre.creative_history.read_only") }, status: :forbidden
+      end
+    end
+  end
+end

--- a/engines/collavre/app/controllers/concerns/collavre/comments/history_topic_guard.rb
+++ b/engines/collavre/app/controllers/concerns/collavre/comments/history_topic_guard.rb
@@ -13,7 +13,7 @@ module Collavre
 
       def reject_history_topic_comment!
         topic_id = params.dig(:comment, :topic_id).presence
-        return unless topic_id && @creative.topics.where(id: topic_id, name: Creative::HISTORY_TOPIC_NAME).exists?
+        return unless topic_id && @creative.topics.history.exists?(id: topic_id)
 
         render json: { error: I18n.t("collavre.creative_history.read_only") }, status: :forbidden
       end

--- a/engines/collavre/app/controllers/concerns/collavre/topics/reserved_topic_guard.rb
+++ b/engines/collavre/app/controllers/concerns/collavre/topics/reserved_topic_guard.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Collavre
+  module Topics
+    module ReservedTopicGuard
+      extend ActiveSupport::Concern
+
+      included do
+        before_action :reject_reserved_topic_name!, only: :create
+        before_action :reject_reserved_topic_mutation!,
+                      only: %i[update destroy move archive unarchive set_primary_agent]
+        before_action :pin_history_topic_last!, only: :reorder
+      end
+
+      private
+
+      def reject_reserved_topic_name!
+        reject_reserved_topic! if ReservedName.reserved?(@creative, topic_params[:name])
+      end
+
+      def reject_reserved_topic_mutation!
+        topic = @creative.topics.find(params[:id])
+        new_name = topic_params[:name] if action_name == "update"
+        reject_reserved_topic! if ReservedName.reserved?(@creative, topic.name) ||
+                                  ReservedName.reserved?(@creative, new_name)
+      end
+
+      def reject_reserved_topic!
+        render json: { error: I18n.t("collavre.topics.reserved_name") }, status: :unprocessable_entity
+      end
+
+      def pin_history_topic_last!
+        return unless params[:topic_ids].is_a?(Array)
+
+        history_id = @creative.topics.find_by(name: Creative::HISTORY_TOPIC_NAME)&.id
+        params[:topic_ids] = [ *(params[:topic_ids].map(&:to_s) - [ history_id&.to_s ]), history_id ].compact
+      end
+    end
+  end
+end

--- a/engines/collavre/app/controllers/concerns/collavre/topics/reserved_topic_guard.rb
+++ b/engines/collavre/app/controllers/concerns/collavre/topics/reserved_topic_guard.rb
@@ -21,7 +21,7 @@ module Collavre
       def reject_reserved_topic_mutation!
         topic = @creative.topics.find(params[:id])
         new_name = topic_params[:name] if action_name == "update"
-        reject_reserved_topic! if ReservedName.reserved?(@creative, topic.name) ||
+        reject_reserved_topic! if ReservedName.reserved_topic?(@creative, topic) ||
                                   ReservedName.reserved?(@creative, new_name)
       end
 
@@ -32,7 +32,7 @@ module Collavre
       def pin_history_topic_last!
         return unless params[:topic_ids].is_a?(Array)
 
-        history_id = @creative.topics.find_by(name: Creative::HISTORY_TOPIC_NAME)&.id
+        history_id = @creative.topics.history.pick(:id)
         params[:topic_ids] = [ *(params[:topic_ids].map(&:to_s) - [ history_id&.to_s ]), history_id ].compact
       end
     end

--- a/engines/collavre/app/javascript/controllers/__tests__/creative_history_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/creative_history_controller.test.js
@@ -1,0 +1,88 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { jest } from '@jest/globals'
+
+const csrfFetch = jest.fn()
+const confirmDialog = jest.fn()
+const alertDialog = jest.fn()
+
+jest.unstable_mockModule('../../lib/api/csrf_fetch', () => ({ default: csrfFetch }))
+jest.unstable_mockModule('../../lib/utils/dialog', () => ({ confirmDialog, alertDialog }))
+
+const { Application } = await import('@hotwired/stimulus')
+const CreativeHistoryController = (await import('../creative_history_controller')).default
+
+describe('CreativeHistoryController', () => {
+  let application
+  let controller
+  let button
+
+  beforeEach(async () => {
+    document.body.innerHTML = `
+      <div data-controller="creative-history">
+        <button data-action="creative-history#revert"
+                data-url="/creatives/1/history/2/revert"
+                data-confirm="Revert?"
+                data-conflict="Creative #%{id} changed"
+                data-force="Force"
+                data-skip="Skip">Revert</button>
+      </div>`
+    application = Application.start()
+    application.register('creative-history', CreativeHistoryController)
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    const element = document.querySelector('[data-controller="creative-history"]')
+    controller = application.getControllerForElementAndIdentifier(element, 'creative-history')
+    button = document.querySelector('button')
+  })
+
+  afterEach(() => {
+    application.stop()
+    jest.clearAllMocks()
+    document.body.innerHTML = ''
+  })
+
+  test('collects a force or skip resolution for every conflict', async () => {
+    confirmDialog.mockResolvedValueOnce(true).mockResolvedValueOnce(true).mockResolvedValueOnce(false)
+    csrfFetch
+      .mockResolvedValueOnce({ ok: false, status: 409, json: async () => ({ conflicts: [
+        { creative_id: 11 }, { creative_id: 12 },
+      ] }) })
+      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ status: 'applied' }) })
+    const reload = jest.fn()
+    jest.spyOn(controller, 'listController', 'get').mockReturnValue({ loadInitialComments: reload })
+
+    await controller.revert({ currentTarget: button })
+
+    expect(JSON.parse(csrfFetch.mock.calls[1][1].body).resolutions).toEqual({
+      11: 'force',
+      12: 'skip',
+    })
+    expect(reload).toHaveBeenCalled()
+    expect(alertDialog).not.toHaveBeenCalled()
+  })
+
+  test('leaves the button enabled when the user cancels', async () => {
+    confirmDialog.mockResolvedValue(false)
+
+    await controller.revert({ currentTarget: button })
+
+    expect(csrfFetch).not.toHaveBeenCalled()
+    expect(button.disabled).toBe(false)
+  })
+
+  test('shows an error and re-enables the button when the request fails', async () => {
+    confirmDialog.mockResolvedValue(true)
+    csrfFetch.mockResolvedValue({ ok: false, status: 422, json: async () => ({ message: 'Not allowed' }) })
+
+    await controller.revert({ currentTarget: button })
+
+    expect(alertDialog).toHaveBeenCalledWith('Not allowed')
+    expect(button.disabled).toBe(false)
+  })
+
+  test('returns no list controller outside a comments list', () => {
+    expect(controller.listController).toBeNull()
+  })
+})

--- a/engines/collavre/app/javascript/controllers/__tests__/creative_history_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/creative_history_controller.test.js
@@ -82,6 +82,22 @@ describe('CreativeHistoryController', () => {
     expect(button.disabled).toBe(false)
   })
 
+  test('reports a partial revert and reloads the remaining changes', async () => {
+    confirmDialog.mockResolvedValue(true)
+    csrfFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ status: 'partial', message: 'Some changes remain' }),
+    })
+    const reload = jest.fn()
+    jest.spyOn(controller, 'listController', 'get').mockReturnValue({ loadInitialComments: reload })
+
+    await controller.revert({ currentTarget: button })
+
+    expect(alertDialog).toHaveBeenCalledWith('Some changes remain')
+    expect(reload).toHaveBeenCalled()
+  })
+
   test('returns no list controller outside a comments list', () => {
     expect(controller.listController).toBeNull()
   })

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_double_submit.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_double_submit.test.js
@@ -156,4 +156,18 @@ describe('FormController - double submit on slow API', () => {
     pressEnter(controller.textareaTarget)
     expect(fetchSpy).toHaveBeenCalledTimes(2)
   })
+
+  test('hides the composer while a read-only History topic is selected', () => {
+    controller.canComment = true
+    controller.readOnlyTopic = false
+    controller.updateFormVisibility()
+    expect(controller.formTarget.style.display).toBe('')
+
+    controller.handleTopicChange({
+      detail: { topicId: '99', readOnly: true, isInbox: false },
+    })
+
+    expect(controller.formTarget.style.display).toBe('none')
+    expect(controller.shouldAutoFocusOnOpen()).toBe(false)
+  })
 })

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/list_controller_read_pointer.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/list_controller_read_pointer.test.js
@@ -94,6 +94,17 @@ describe('CommentsListController read pointer updates', () => {
     })
   })
 
+  test('uses History change set IDs when the read-only topic has no comment rows', () => {
+    controller.listTarget = document.createElement('div')
+    controller.listTarget.innerHTML = `
+      <article class="creative-history-item" data-change-set-id="7"></article>
+      <article class="creative-history-item" data-change-set-id="9"></article>
+    `
+
+    expect(controller.getMinId()).toBe(7)
+    expect(controller.getMaxId()).toBe(9)
+  })
+
   test('extends the All Messages read bound when pagination renders a legacy comment', async () => {
     controller.currentTopicId = null
     controller.renderedAllTopicIds = ['1']

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_creation_container.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_creation_container.test.js
@@ -128,6 +128,21 @@ describe('TopicsController create-button placement', () => {
     expect(document.querySelector('.add-topic-btn')).not.toBeNull()
   })
 
+  test('publishes the read-only state with History topic selection', () => {
+    const history = { id: 99, name: 'History', read_only: true }
+    controller.topics = [history]
+    controller.renderTopics([history], true, true)
+    const listener = jest.fn()
+    controller.element.addEventListener('comments--topics:change', listener)
+
+    controller.selectTopic(history.id)
+
+    expect(listener.mock.calls[0][0].detail).toMatchObject({
+      topicId: history.id,
+      readOnly: true,
+    })
+  })
+
   // Alt+Left/Right chat navigation switches creatives without blurring the input,
   // so a preserved draft would otherwise be posted to the wrong creative.
   test('drops an in-progress topic name when the creative changes', () => {

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -293,9 +293,11 @@ export default class extends Controller {
       this._awaitingEffectiveDraftKeyFor = null
     }
     this.currentTopicId = event.detail.topicId
+    this.readOnlyTopic = event.detail.readOnly || false
     this._isInbox = event.detail.isInbox || false
     this._systemTopicId = event.detail.systemTopicId || null
     this._mainTopicId = event.detail.mainTopicId || null
+    this.updateFormVisibility()
     this._updateInboxReplyMode()
   }
 
@@ -351,7 +353,8 @@ export default class extends Controller {
     // controller BEFORE topics loadTopics() dispatches comments--topics:change,
     // so by the time we get here, currentTopicId already reflects the new
     // creative's restored topic. Do not re-clear it.
-    this.formTarget.style.display = canComment ? '' : 'none'
+    this.canComment = canComment
+    this.updateFormVisibility()
     // Capture input entered while topics were loading before reset clears it.
     // Without a pending input timer, a blank textarea must not erase a draft
     // that is waiting in storage to be restored below.
@@ -414,7 +417,8 @@ export default class extends Controller {
   }
 
   setCommentPermission(canComment) {
-    this.formTarget.style.display = canComment ? '' : 'none'
+    this.canComment = canComment
+    this.updateFormVisibility()
 
     if (!canComment) {
       this._flushDraftSave()
@@ -436,8 +440,13 @@ export default class extends Controller {
   }
 
   shouldAutoFocusOnOpen() {
+    if (this.readOnlyTopic) return false
     if (window.innerWidth <= 768) return false
     return this.element.dataset.autoFocusOnOpen !== 'false'
+  }
+
+  updateFormVisibility() {
+    this.formTarget.style.display = this.canComment && !this.readOnlyTopic ? '' : 'none'
   }
 
   focusTextarea() {

--- a/engines/collavre/app/javascript/controllers/comments/list_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/list_controller.js
@@ -460,18 +460,23 @@ export default class extends Controller {
 
   getMinId() {
     // Standard: First element is oldest
-    const items = this.listTarget.querySelectorAll('.comment-item')
+    const items = this.paginationItems()
     if (items.length === 0) return null
     const first = items[0]
-    return parseInt(first.dataset.commentId)
+    return parseInt(first.dataset.commentId || first.dataset.changeSetId)
   }
 
   getMaxId() {
     // Standard: Last element is newest
-    const items = this.listTarget.querySelectorAll('.comment-item')
+    const items = this.paginationItems()
     if (items.length === 0) return null
     const last = items[items.length - 1]
-    return parseInt(last.dataset.commentId)
+    return parseInt(last.dataset.commentId || last.dataset.changeSetId)
+  }
+
+  paginationItems() {
+    const comments = this.listTarget.querySelectorAll('.comment-item')
+    return comments.length > 0 ? comments : this.listTarget.querySelectorAll('.creative-history-item')
   }
 
   // Public seam for sibling controllers that scroll the list on their own

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -475,7 +475,7 @@ export default class extends Controller {
 
         const renderTopic = (topic) => {
             const isActive = String(this.currentTopicId) === String(topic.id) ? 'active' : ''
-            const draggable = canManage ? 'draggable="true"' : ''
+            const draggable = canManage && !topic.read_only ? 'draggable="true"' : ''
             // agent_locked marks a live agent session topic, whose primary agent is
             // session identity rather than a routing pin — the server refuses to
             // change it, so the avatar must not offer to release it.
@@ -488,11 +488,12 @@ export default class extends Controller {
                 ? `<span class="topic-unread-badge">${topic.unread_count}</span>`
                 : ''
             const isMainTopic = this.mainTopicId && String(topic.id) === String(this.mainTopicId)
+            const interactionActions = topic.read_only ? '' : `${dropActions} ${dragActions} ${topicDropActions}`
             let s = `<span class="topic-tag topic-drop-target ${isActive}" ${draggable}
-                          data-action="click->comments--topics#select ${dropActions} ${dragActions} ${topicDropActions}"
+                          data-action="click->comments--topics#select ${interactionActions}"
                           data-id="${topic.id}"${topic.source_topic_id ? ` data-source-topic-id="${topic.source_topic_id}"` : ''}>
-                        ${agentAvatar}${branchIcon}#${topic.name}${unreadBadge}`
-            if (canManage && !isMainTopic) {
+                        ${agentAvatar}${branchIcon}#${topic.display_name || topic.name}${unreadBadge}`
+            if (canManage && !isMainTopic && !topic.read_only) {
                 s += `<button class="archive-topic-btn" data-action="click->comments--topics#archiveTopic" data-id="${topic.id}" title="Archive">${ICON_ARCHIVE}</button>`
                 s += `<button class="delete-topic-btn" data-action="click->comments--topics#deleteTopic" data-id="${topic.id}">&times;</button>`
             }
@@ -1124,7 +1125,9 @@ export default class extends Controller {
         const id = event.currentTarget.dataset.id
 
         // If clicking on already active topic (not Main), show edit mode
-        if (id && String(this.currentTopicId) === String(id) && this.canManageTopics) {
+        const selectedTopic = [ ...(this.topics || []), ...(this.archivedTopics || []) ]
+            .find(topic => String(topic.id) === String(id))
+        if (id && String(this.currentTopicId) === String(id) && this.canManageTopics && !selectedTopic?.read_only) {
             this.showEditInput(event.currentTarget, id)
             return
         }
@@ -1145,7 +1148,17 @@ export default class extends Controller {
             this.clearNewMessageBadge(id)
         }
         // Dispatch event
-        this.dispatch("change", { detail: { topicId: id, isInbox: this.isInbox, systemTopicId: this.systemTopicId, mainTopicId: this.mainTopicId } })
+        const topic = [ ...(this.topics || []), ...(this.archivedTopics || []) ]
+            .find(candidate => String(candidate.id) === String(id))
+        this.dispatch("change", {
+            detail: {
+                topicId: id,
+                isInbox: this.isInbox,
+                systemTopicId: this.systemTopicId,
+                mainTopicId: this.mainTopicId,
+                readOnly: topic?.read_only || false,
+            },
+        })
     }
 
     showEditInput(topicEl, topicId) {

--- a/engines/collavre/app/javascript/controllers/creative_history_controller.js
+++ b/engines/collavre/app/javascript/controllers/creative_history_controller.js
@@ -16,6 +16,7 @@ export default class extends Controller {
         body = await response.json()
       }
       if (!response.ok) throw new Error(body.message)
+      if (body.status === 'partial') await alertDialog(body.message)
 
       this.listController?.loadInitialComments()
       window.dispatchEvent(new CustomEvent('collavre:creative-drop-complete'))

--- a/engines/collavre/app/javascript/controllers/creative_history_controller.js
+++ b/engines/collavre/app/javascript/controllers/creative_history_controller.js
@@ -1,0 +1,54 @@
+import { Controller } from '@hotwired/stimulus'
+import csrfFetch from '../lib/api/csrf_fetch'
+import { alertDialog, confirmDialog } from '../lib/utils/dialog'
+
+export default class extends Controller {
+  async revert(event) {
+    const button = event.currentTarget
+    if (!await confirmDialog(button.dataset.confirm, { danger: true })) return
+
+    button.disabled = true
+    try {
+      let response = await this.request(button.dataset.url, {}, button.dataset.mode)
+      let body = await response.json()
+      if (response.status === 409) {
+        response = await this.resolveConflicts(button, body.conflicts)
+        body = await response.json()
+      }
+      if (!response.ok) throw new Error(body.message)
+
+      this.listController?.loadInitialComments()
+      window.dispatchEvent(new CustomEvent('collavre:creative-drop-complete'))
+    } catch (error) {
+      await alertDialog(error.message)
+      button.disabled = false
+    }
+  }
+
+  async resolveConflicts(button, conflicts) {
+    const resolutions = {}
+    for (const conflict of conflicts) {
+      const force = await confirmDialog(
+        button.dataset.conflict.replace('%{id}', conflict.creative_id),
+        { danger: true, confirmText: button.dataset.force, cancelText: button.dataset.skip },
+      )
+      resolutions[conflict.creative_id] = force ? 'force' : 'skip'
+    }
+    return this.request(button.dataset.url, resolutions, button.dataset.mode)
+  }
+
+  request(url, resolutions = {}, mode = 'revert') {
+    return csrfFetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+      body: JSON.stringify({ resolutions, mode }),
+    })
+  }
+
+  get listController() {
+    return this.application.getControllerForElementAndIdentifier(
+      this.element.closest('[data-controller~="comments--list"]'),
+      'comments--list',
+    )
+  }
+}

--- a/engines/collavre/app/javascript/controllers/index.js
+++ b/engines/collavre/app/javascript/controllers/index.js
@@ -46,6 +46,7 @@ import GatewayCheckController from "./gateway_check_controller"
 import AgentConnectionController from "./agent_connection_controller"
 import AgentVendorController from "./agent_vendor_controller"
 import DesktopProxySetupController from "./desktop_proxy_setup_controller"
+import CreativeHistoryController from "./creative_history_controller"
 
 // Export all controllers
 export {
@@ -90,7 +91,8 @@ export {
   GatewayCheckController,
   AgentConnectionController,
   AgentVendorController,
-  DesktopProxySetupController
+  DesktopProxySetupController,
+  CreativeHistoryController
 }
 
 // Registration function for use with a Stimulus application
@@ -141,4 +143,5 @@ export function registerControllers(application) {
   application.register("agent-connection", AgentConnectionController)
   application.register("agent-vendor", AgentVendorController)
   application.register("desktop-proxy-setup", DesktopProxySetupController)
+  application.register("creative-history", CreativeHistoryController)
 }

--- a/engines/collavre/app/jobs/collavre/cron_action_job.rb
+++ b/engines/collavre/app/jobs/collavre/cron_action_job.rb
@@ -22,10 +22,7 @@ module Collavre
       end
 
       topic = topic_id.present? ? Topic.find_by(id: topic_id) : creative.main_topic(fallback_user: agent)
-      unless topic
-        Rails.logger.warn("[CronActionJob] Skipping: topic=#{topic_id} not found")
-        return
-      end
+      return unless usable_topic?(topic, topic_id)
 
       comment = create_comment(creative, topic, agent, message)
       return unless comment
@@ -65,6 +62,14 @@ module Collavre
     end
 
     private
+
+    def usable_topic?(topic, topic_id)
+      reason = topic ? "is read-only History" : "not found"
+      return true if topic && !topic.history?
+
+      Rails.logger.warn("[CronActionJob] Skipping: topic=#{topic&.id || topic_id} #{reason}")
+      false
+    end
 
     def create_comment(creative, topic, agent, message)
       comment = nil

--- a/engines/collavre/app/jobs/collavre/purge_unreferenced_blob_job.rb
+++ b/engines/collavre/app/jobs/collavre/purge_unreferenced_blob_job.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Collavre
+  class PurgeUnreferencedBlobJob < ApplicationJob
+    queue_as :default
+
+    def perform(blob_id)
+      blob = ActiveStorage::Blob.find_by(id: blob_id)
+      return unless blob
+      return if ActiveStorage::Attachment.where(blob_id: blob.id).exists?
+
+      signed_id = blob.signed_id
+      pattern = "%#{ActiveRecord::Base.sanitize_sql_like(signed_id)}%"
+      return if Creative.where("description LIKE ?", pattern).exists?
+
+      blob.purge
+    end
+  end
+end

--- a/engines/collavre/app/models/collavre/creative.rb
+++ b/engines/collavre/app/models/collavre/creative.rb
@@ -71,7 +71,7 @@ module Collavre
     include Permissible
     include Describable
     include RealtimeBroadcastable
-    include HistoryTrackable
+    include HistoryTrackable, CreativeHistoryTopic
 
     has_many :comments, class_name: "Collavre::Comment", dependent: :destroy
     has_many :comment_read_pointers, class_name: "Collavre::CommentReadPointer", dependent: :delete_all

--- a/engines/collavre/app/models/collavre/creative/describable.rb
+++ b/engines/collavre/app/models/collavre/creative/describable.rb
@@ -115,7 +115,7 @@ module Collavre
           self.content_type_input = "html" if data&.dig("content_type") == "markdown"
           update!(description: stripped)
         else
-          detach_and_maybe_purge(attachment)
+          detach_and_maybe_purge(attachment, schedule_during_history: true)
         end
         true
       end
@@ -302,7 +302,7 @@ module Collavre
       # references it — a shared blob (description copied between creatives)
       # would otherwise be deleted out from under the others, 404-ing their
       # descriptions.
-      def detach_and_maybe_purge(attachment)
+      def detach_and_maybe_purge(attachment, schedule_during_history: false)
         blob = attachment.blob
         attachment.delete
         return if blob.nil?
@@ -313,9 +313,9 @@ module Collavre
                                    .exists?
         return if still_referenced
         return if ActiveStorage::Attachment.where(blob_id: blob.id).exists?
-        return if Creatives::History.recordable?
+        return if Creatives::History.recordable? && !schedule_during_history
 
-        PurgeUnreferencedBlobJob.perform_later(blob.id)
+        Creatives::History.schedule_blob_purge_rechecks([ blob.id ])
       end
 
       def purge_description_attachments

--- a/engines/collavre/app/models/collavre/creative/describable.rb
+++ b/engines/collavre/app/models/collavre/creative/describable.rb
@@ -313,8 +313,9 @@ module Collavre
                                    .exists?
         return if still_referenced
         return if ActiveStorage::Attachment.where(blob_id: blob.id).exists?
+        return if Creatives::History.recordable?
 
-        blob.purge_later
+        PurgeUnreferencedBlobJob.perform_later(blob.id)
       end
 
       def purge_description_attachments
@@ -332,7 +333,7 @@ module Collavre
                             .where("description LIKE ?", "%#{ActiveRecord::Base.sanitize_sql_like(signed_id)}%")
                             .exists?
 
-            blob.purge
+            PurgeUnreferencedBlobJob.perform_later(blob.id)
           rescue ActiveRecord::RecordNotFound, ActiveSupport::MessageVerifier::InvalidSignature
             Rails.logger.warn("Creative##{id}: could not find blob for signed_id=#{signed_id}")
           rescue StandardError => e

--- a/engines/collavre/app/models/collavre/creative_change.rb
+++ b/engines/collavre/app/models/collavre/creative_change.rb
@@ -13,5 +13,18 @@ module Collavre
 
     validates :operation, inclusion: { in: OPERATIONS }
     validates :creative_id, uniqueness: { scope: :creative_change_set_id }
+
+    after_create_commit :ensure_history_topic
+
+    private
+
+    def ensure_history_topic
+      return if change_set.origin == "sync"
+
+      anchor = change_set.anchor_creative || Creative.unscoped.find_by(id: creative_id)
+      return unless anchor
+
+      anchor.history_topic(fallback_user: change_set.user || anchor.user)
+    end
   end
 end

--- a/engines/collavre/app/models/collavre/creative_change.rb
+++ b/engines/collavre/app/models/collavre/creative_change.rb
@@ -10,6 +10,12 @@ module Collavre
                             foreign_key: :creative_change_set_id,
                             inverse_of: :creative_changes
     belongs_to :creative, class_name: "Collavre::Creative"
+    has_many :history_file_attachments,
+             -> { where(name: "history_files") },
+             as: :record,
+             class_name: "ActiveStorage::Attachment",
+             inverse_of: :record,
+             dependent: :delete_all
 
     validates :operation, inclusion: { in: OPERATIONS }
     validates :creative_id, uniqueness: { scope: :creative_change_set_id }

--- a/engines/collavre/app/models/collavre/topic.rb
+++ b/engines/collavre/app/models/collavre/topic.rb
@@ -26,8 +26,10 @@ module Collavre
     # --- Archive scopes ---
     scope :active, -> { where(archived_at: nil) }
     scope :archived, -> { where.not(archived_at: nil) }
+    scope :history, -> { where(system_kind: "history") }
 
     validates :name, presence: true, uniqueness: { scope: :creative_id }
+    validates :system_kind, inclusion: { in: %w[history] }, allow_nil: true
 
     before_create :set_default_position
     after_create :keep_history_topic_last
@@ -93,6 +95,10 @@ module Collavre
       update!(archived_at: nil)
     end
 
+    def history?
+      system_kind == "history"
+    end
+
     private
 
     def advance_last_topic_preference_revisions
@@ -106,9 +112,9 @@ module Collavre
     end
 
     def keep_history_topic_last
-      return if name == Creative::HISTORY_TOPIC_NAME
+      return if history?
 
-      history = Topic.unscoped.find_by(creative_id: creative_id, name: Creative::HISTORY_TOPIC_NAME)
+      history = Topic.unscoped.find_by(creative_id: creative_id, system_kind: "history")
       history&.update_column(:position, position + 1) if history&.position.to_i <= position
     end
   end

--- a/engines/collavre/app/models/collavre/topic.rb
+++ b/engines/collavre/app/models/collavre/topic.rb
@@ -30,6 +30,7 @@ module Collavre
     validates :name, presence: true, uniqueness: { scope: :creative_id }
 
     before_create :set_default_position
+    after_create :keep_history_topic_last
 
     default_scope { order(:position) }
 
@@ -102,6 +103,13 @@ module Collavre
       return if position_changed? && position != 0
 
       self.position = (Topic.unscoped.where(creative_id: creative_id).maximum(:position) || -1) + 1
+    end
+
+    def keep_history_topic_last
+      return if name == Creative::HISTORY_TOPIC_NAME
+
+      history = Topic.unscoped.find_by(creative_id: creative_id, name: Creative::HISTORY_TOPIC_NAME)
+      history&.update_column(:position, position + 1) if history&.position.to_i <= position
     end
   end
 end

--- a/engines/collavre/app/models/concerns/collavre/creative_history_topic.rb
+++ b/engines/collavre/app/models/concerns/collavre/creative_history_topic.rb
@@ -8,8 +8,9 @@ module Collavre
       HISTORY_TOPIC_NAME = "History"
     end
 
-    def history_topic(fallback_user: user)
-      topics.find_or_create_by!(name: HISTORY_TOPIC_NAME) do |topic|
+    def history_topic(fallback_user: effective_origin.user)
+      target = effective_origin
+      target.topics.find_or_create_by!(name: HISTORY_TOPIC_NAME) do |topic|
         topic.user = fallback_user
       end
     end

--- a/engines/collavre/app/models/concerns/collavre/creative_history_topic.rb
+++ b/engines/collavre/app/models/concerns/collavre/creative_history_topic.rb
@@ -6,13 +6,29 @@ module Collavre
 
     included do
       HISTORY_TOPIC_NAME = "History"
+      HISTORY_TOPIC_INTERNAL_NAME = "__collavre_history__"
     end
 
     def history_topic(fallback_user: effective_origin.user)
       target = effective_origin
-      target.topics.find_or_create_by!(name: HISTORY_TOPIC_NAME) do |topic|
+      target.topics.find_or_create_by!(system_kind: "history") do |topic|
+        topic.name = available_history_topic_name(target)
         topic.user = fallback_user
       end
+    end
+
+    private
+
+    def available_history_topic_name(target)
+      return HISTORY_TOPIC_NAME unless target.topics.exists?(name: HISTORY_TOPIC_NAME)
+
+      candidate = HISTORY_TOPIC_INTERNAL_NAME
+      suffix = 1
+      while target.topics.exists?(name: candidate)
+        suffix += 1
+        candidate = "#{HISTORY_TOPIC_INTERNAL_NAME}_#{suffix}"
+      end
+      candidate
     end
   end
 end

--- a/engines/collavre/app/models/concerns/collavre/creative_history_topic.rb
+++ b/engines/collavre/app/models/concerns/collavre/creative_history_topic.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Collavre
+  module CreativeHistoryTopic
+    extend ActiveSupport::Concern
+
+    included do
+      HISTORY_TOPIC_NAME = "History"
+    end
+
+    def history_topic(fallback_user: user)
+      topics.find_or_create_by!(name: HISTORY_TOPIC_NAME) do |topic|
+        topic.user = fallback_user
+      end
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/comment_move_service.rb
+++ b/engines/collavre/app/services/collavre/comment_move_service.rb
@@ -106,7 +106,7 @@ module Collavre
 
     def validate_destination_topic!(locked_topics, topic_id, target_origin)
       topic = locked_topics[topic_id]
-      if topic&.name == Creative::HISTORY_TOPIC_NAME
+      if topic&.history?
         raise MoveError, I18n.t("collavre.creative_history.read_only")
       end
       return if topic&.creative_id == target_origin.id

--- a/engines/collavre/app/services/collavre/comment_move_service.rb
+++ b/engines/collavre/app/services/collavre/comment_move_service.rb
@@ -105,7 +105,11 @@ module Collavre
     end
 
     def validate_destination_topic!(locked_topics, topic_id, target_origin)
-      return if locked_topics[topic_id]&.creative_id == target_origin.id
+      topic = locked_topics[topic_id]
+      if topic&.name == Creative::HISTORY_TOPIC_NAME
+        raise MoveError, I18n.t("collavre.creative_history.read_only")
+      end
+      return if topic&.creative_id == target_origin.id
 
       raise MoveError, I18n.t("collavre.comments.move_invalid_topic", default: "Invalid topic")
     end

--- a/engines/collavre/app/services/collavre/comments/list_response.rb
+++ b/engines/collavre/app/services/collavre/comments/list_response.rb
@@ -28,7 +28,7 @@ module Collavre
 
       def history_topic?
         params[:topic_id].present? &&
-          creative.topics.where(id: params[:topic_id], name: Creative::HISTORY_TOPIC_NAME).exists?
+          creative.topics.history.exists?(id: params[:topic_id])
       end
 
       def render_history

--- a/engines/collavre/app/services/collavre/comments/list_response.rb
+++ b/engines/collavre/app/services/collavre/comments/list_response.rb
@@ -34,7 +34,13 @@ module Collavre
       def render_history
         change_sets = CreativeChangeSet.for_creative_scope(@history_scope_creative)
           .visible_by_default.includes(:creative_changes, :user)
-        change_sets = history_page(change_sets)
+        change_sets = Creatives::HistoryPage.new(
+          scope: change_sets,
+          user: Current.user,
+          before_id: params[:before_id],
+          after_id: params[:after_id],
+          limit: LIMIT
+        ).call
         response.headers["X-Topic-Id"] = params[:topic_id].to_s
         controller.render partial: "collavre/creative_change_sets/list",
                           locals: {
@@ -42,17 +48,6 @@ module Collavre
                             change_sets: change_sets,
                             pagination: params[:before_id].present? || params[:after_id].present?
                           }
-      end
-
-      def history_page(scope)
-        if params[:before_id].present?
-          scope.where("creative_change_sets.id < ?", params[:before_id].to_i).limit(LIMIT).to_a.reverse
-        elsif params[:after_id].present?
-          scope.where("creative_change_sets.id > ?", params[:after_id].to_i)
-            .reorder("creative_change_sets.id ASC").limit(LIMIT).to_a
-        else
-          scope.limit(LIMIT).to_a.reverse
-        end
       end
 
       def load_comments

--- a/engines/collavre/app/services/collavre/comments/list_response.rb
+++ b/engines/collavre/app/services/collavre/comments/list_response.rb
@@ -6,9 +6,10 @@ module Collavre
       LIMIT = 20
       LEGACY_TOPIC_WATERMARK_KEY = "_legacy"
 
-      def initialize(controller:, creative:)
+      def initialize(controller:, creative:, history_scope_creative: creative)
         @controller = controller
         @creative = creative
+        @history_scope_creative = history_scope_creative
       end
 
       def render
@@ -31,10 +32,27 @@ module Collavre
       end
 
       def render_history
-        change_sets = CreativeChangeSet.for_creative_scope(creative).visible_by_default.limit(LIMIT)
+        change_sets = CreativeChangeSet.for_creative_scope(@history_scope_creative)
+          .visible_by_default.includes(:creative_changes, :user)
+        change_sets = history_page(change_sets)
         response.headers["X-Topic-Id"] = params[:topic_id].to_s
         controller.render partial: "collavre/creative_change_sets/list",
-                          locals: { creative: creative, change_sets: change_sets }
+                          locals: {
+                            creative: @history_scope_creative,
+                            change_sets: change_sets,
+                            pagination: params[:before_id].present? || params[:after_id].present?
+                          }
+      end
+
+      def history_page(scope)
+        if params[:before_id].present?
+          scope.where("creative_change_sets.id < ?", params[:before_id].to_i).limit(LIMIT).to_a.reverse
+        elsif params[:after_id].present?
+          scope.where("creative_change_sets.id > ?", params[:after_id].to_i)
+            .reorder("creative_change_sets.id ASC").limit(LIMIT).to_a
+        else
+          scope.limit(LIMIT).to_a.reverse
+        end
       end
 
       def load_comments

--- a/engines/collavre/app/services/collavre/comments/list_response.rb
+++ b/engines/collavre/app/services/collavre/comments/list_response.rb
@@ -12,6 +12,8 @@ module Collavre
       end
 
       def render
+        return render_history if history_topic?
+
         comments, topic_id, all_messages = load_comments
         write_rendered_topic_headers(comments) if all_messages
         controller.render(**render_options(comments, topic_id))
@@ -22,6 +24,18 @@ module Collavre
       attr_reader :controller, :creative
 
       delegate :params, :response, to: :controller
+
+      def history_topic?
+        params[:topic_id].present? &&
+          creative.topics.where(id: params[:topic_id], name: Creative::HISTORY_TOPIC_NAME).exists?
+      end
+
+      def render_history
+        change_sets = CreativeChangeSet.for_creative_scope(creative).visible_by_default.limit(LIMIT)
+        response.headers["X-Topic-Id"] = params[:topic_id].to_s
+        controller.render partial: "collavre/creative_change_sets/list",
+                          locals: { creative: creative, change_sets: change_sets }
+      end
 
       def load_comments
         visible_scope = creative.comments.visible_to(Current.user)

--- a/engines/collavre/app/services/collavre/creatives/change_set_apply_service.rb
+++ b/engines/collavre/app/services/collavre/creatives/change_set_apply_service.rb
@@ -118,7 +118,6 @@ module Collavre
           origin: "revert",
           status: "applied",
           reverts: @mode == :revert ? source : nil,
-          summary: source.summary,
           applied_at: Time.current
         )
       end

--- a/engines/collavre/app/services/collavre/creatives/change_set_apply_service.rb
+++ b/engines/collavre/app/services/collavre/creatives/change_set_apply_service.rb
@@ -5,12 +5,13 @@ module Collavre
     class ChangeSetApplyService
       Result = Struct.new(:status, :change_set, :conflicts, :skipped, keyword_init: true)
 
-      def initialize(source:, user:, targets:, resolutions: {}, mode: :revert)
+      def initialize(source:, user:, targets:, resolutions: {}, mode: :revert, complete: true)
         @source = source
         @user = user
         @targets = targets
         @resolutions = resolutions.stringify_keys
         @mode = mode.to_sym
+        @complete = complete
       end
 
       def call
@@ -32,29 +33,51 @@ module Collavre
       private
 
       def build_plan
-        plan = []
-        conflicts = []
-        skipped = []
-        creatives = Creative.unscoped.where(id: @targets.keys.map(&:creative_id)).order(:id).lock.index_by(&:id)
-        @targets.each do |change, snapshot|
-          creative = creatives[change.creative_id]
-          if creative.nil? || !creative.has_permission?(@user, :write)
-            skipped << change.creative_id
-          elsif History.snapshot(creative) == snapshot
-            next
-          elsif current_conflict?(creative, change) && resolution(change) != "force"
-            resolution(change) == "skip" ? skipped << change.creative_id : conflicts << conflict_for(creative, change)
-          else
-            plan << [ creative, snapshot ]
-          end
+        records = locked_records
+        writable_ids = writable_ids_for(records.keys)
+        @targets.each_with_object([ [], [], [] ]) do |(change, snapshot), buckets|
+          classify_target(change, snapshot, records, writable_ids, buckets)
         end
-        [ plan, conflicts, skipped ]
+      end
+
+      def locked_records
+        target_ids = @targets.keys.map(&:creative_id)
+        parent_ids = @targets.values.filter_map { |snapshot| snapshot["parent_id"] }
+        Creative.unscoped.where(id: [ *target_ids, *parent_ids ]).order(:id).lock.index_by(&:id)
+      end
+
+      def classify_target(change, snapshot, records, writable_ids, buckets)
+        plan, conflicts, skipped = buckets
+        creative = records[change.creative_id]
+        return skipped << change.creative_id unless target_writable?(creative, snapshot, records, writable_ids)
+        return if History.snapshot(creative) == snapshot
+
+        if current_conflict?(creative, change) && resolution(change) != "force"
+          resolution(change) == "skip" ? skipped << change.creative_id : conflicts << conflict_for(creative, change)
+        else
+          plan << [ creative, snapshot ]
+        end
+      end
+
+      def target_writable?(creative, snapshot, records, writable_ids)
+        creative && writable_ids.include?(creative.id) && target_parent_writable?(creative, snapshot, records, writable_ids)
       end
 
       def revertible?(source)
-        return false if source.origin == "sync"
+        return false if source.origin == "sync" || @targets.keys.any? { |change| change.operation == "destroy" }
 
         @mode == :restore ? source.status.in?(%w[applied reverted]) : source.status == "applied"
+      end
+
+      def writable_ids_for(ids)
+        PermissionFilter.new(user: @user)
+          .readable_ids(ids, min_permission: :write).to_set
+      end
+
+      def target_parent_writable?(creative, snapshot, records, writable_ids)
+        parent_id = snapshot["parent_id"]
+        parent_id.nil? || parent_id == creative.parent_id ||
+          (records.key?(parent_id) && writable_ids.include?(parent_id))
       end
 
       def current_conflict?(creative, change)
@@ -81,8 +104,9 @@ module Collavre
           Current.change_set = reverse
           plan.each { |creative, snapshot| apply_snapshot(creative, snapshot) }
         end
-        source.update!(status: "reverted", reverted_by: reverse) if @mode == :revert
-        result(:applied, change_set: reverse, skipped: skipped)
+        source.update!(status: "reverted", reverted_by: reverse) if @mode == :revert && skipped.empty? && @complete
+        status = skipped.empty? && @complete ? :applied : :partial
+        result(status, change_set: reverse, skipped: skipped)
       end
 
       def create_reverse_set(source)
@@ -93,7 +117,7 @@ module Collavre
           actor_kind: @user&.ai_user? ? "agent" : "human",
           origin: "revert",
           status: "applied",
-          reverts: source,
+          reverts: @mode == :revert ? source : nil,
           summary: source.summary,
           applied_at: Time.current
         )

--- a/engines/collavre/app/services/collavre/creatives/change_set_apply_service.rb
+++ b/engines/collavre/app/services/collavre/creatives/change_set_apply_service.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+module Collavre
+  module Creatives
+    class ChangeSetApplyService
+      Result = Struct.new(:status, :change_set, :conflicts, :skipped, keyword_init: true)
+
+      def initialize(source:, user:, targets:, resolutions: {}, mode: :revert)
+        @source = source
+        @user = user
+        @targets = targets
+        @resolutions = resolutions.stringify_keys
+        @mode = mode.to_sym
+      end
+
+      def call
+        CreativeChangeSet.transaction do
+          source = CreativeChangeSet.lock.find(@source.id)
+          next result(:not_revertible) unless revertible?(source)
+
+          plan, conflicts, skipped = build_plan
+          if conflicts.any?
+            result(:conflict, conflicts: conflicts, skipped: skipped)
+          elsif plan.empty?
+            result(:skipped, skipped: skipped)
+          else
+            apply(source, plan, skipped)
+          end
+        end
+      end
+
+      private
+
+      def build_plan
+        plan = []
+        conflicts = []
+        skipped = []
+        creatives = Creative.unscoped.where(id: @targets.keys.map(&:creative_id)).order(:id).lock.index_by(&:id)
+        @targets.each do |change, snapshot|
+          creative = creatives[change.creative_id]
+          if creative.nil? || !creative.has_permission?(@user, :write)
+            skipped << change.creative_id
+          elsif History.snapshot(creative) == snapshot
+            next
+          elsif current_conflict?(creative, change) && resolution(change) != "force"
+            resolution(change) == "skip" ? skipped << change.creative_id : conflicts << conflict_for(creative, change)
+          else
+            plan << [ creative, snapshot ]
+          end
+        end
+        [ plan, conflicts, skipped ]
+      end
+
+      def revertible?(source)
+        return false if source.origin == "sync"
+
+        @mode == :restore ? source.status.in?(%w[applied reverted]) : source.status == "applied"
+      end
+
+      def current_conflict?(creative, change)
+        return false if @mode == :restore
+
+        History.snapshot(creative) != change.after
+      end
+
+      def resolution(change)
+        @resolutions[change.creative_id.to_s]
+      end
+
+      def conflict_for(creative, change)
+        {
+          creative_id: creative.id,
+          expected_revision: change.after,
+          current_revision: History.snapshot(creative)
+        }
+      end
+
+      def apply(source, plan, skipped)
+        reverse = create_reverse_set(source)
+        History.track(actor: @user, origin: :revert, anchor: source.anchor_creative, anchor_source: :explicit) do
+          Current.change_set = reverse
+          plan.each { |creative, snapshot| apply_snapshot(creative, snapshot) }
+        end
+        source.update!(status: "reverted", reverted_by: reverse) if @mode == :revert
+        result(:applied, change_set: reverse, skipped: skipped)
+      end
+
+      def create_reverse_set(source)
+        CreativeChangeSet.create!(
+          anchor_creative: source.anchor_creative,
+          anchor_source: source.anchor_source || "explicit",
+          user: @user,
+          actor_kind: @user&.ai_user? ? "agent" : "human",
+          origin: "revert",
+          status: "applied",
+          reverts: source,
+          summary: source.summary,
+          applied_at: Time.current
+        )
+      end
+
+      def apply_snapshot(creative, snapshot)
+        return creative.update!(archived_at: Time.current) if snapshot.empty?
+
+        creative.skip_read_only_source_validation = true
+        creative.assign_attributes(snapshot_attributes(creative, snapshot))
+        creative.save!
+      end
+
+      def snapshot_attributes(creative, snapshot)
+        data = (creative.data || {}).deep_dup
+        data["content_type"] = snapshot["content_type"]
+        data["editor"] = snapshot["editor"]
+        data["markdown_source"] = snapshot["markdown_source"]
+        {
+          data: data,
+          description: snapshot["content_type"] == "markdown" ?
+            MarkdownConverter.markdown_to_html(snapshot["markdown_source"].to_s) : snapshot["description"],
+          parent_id: snapshot["parent_id"],
+          sequence: snapshot["sequence"],
+          progress: snapshot["progress"],
+          archived_at: snapshot["archived_at"]
+        }
+      end
+
+      def result(status, change_set: nil, conflicts: [], skipped: [])
+        Result.new(status: status, change_set: change_set, conflicts: conflicts, skipped: skipped)
+      end
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/creatives/change_set_apply_service.rb
+++ b/engines/collavre/app/services/collavre/creatives/change_set_apply_service.rb
@@ -83,8 +83,10 @@ module Collavre
 
       def target_parent_writable?(creative, snapshot, records, writable_ids)
         parent_id = snapshot["parent_id"]
-        parent_id.nil? || parent_id == creative.parent_id ||
-          writable_parent?(records[parent_id], writable_ids)
+        return true if parent_id.nil? || parent_id == creative.parent_id
+
+        parent = records[parent_id]
+        writable_parent?(parent, writable_ids) && !parent.self_and_ancestors.exists?(id: creative.id)
       end
 
       def writable_parent?(parent, writable_ids)

--- a/engines/collavre/app/services/collavre/creatives/change_set_apply_service.rb
+++ b/engines/collavre/app/services/collavre/creatives/change_set_apply_service.rb
@@ -5,18 +5,17 @@ module Collavre
     class ChangeSetApplyService
       Result = Struct.new(:status, :change_set, :conflicts, :skipped, keyword_init: true)
 
-      def initialize(source:, user:, targets:, resolutions: {}, mode: :revert, complete: true)
+      def initialize(source:, user:, resolutions: {}, mode: :revert)
         @source = source
         @user = user
-        @targets = targets
         @resolutions = resolutions.stringify_keys
         @mode = mode.to_sym
-        @complete = complete
       end
 
       def call
         CreativeChangeSet.transaction do
           source = CreativeChangeSet.lock.find(@source.id)
+          build_targets(source)
           next result(:not_revertible) unless revertible?(source)
 
           plan, conflicts, skipped = build_plan
@@ -31,6 +30,13 @@ module Collavre
       end
 
       private
+
+      def build_targets(source)
+        all_changes = source.creative_changes.order(@mode == :revert ? { position: :desc } : { position: :asc })
+        changes = ChangeSetVisibility.new(user: @user).changes(all_changes)
+        @targets = changes.to_h { |change| [ change, @mode == :revert ? change.before : change.after ] }
+        @complete = changes.size == all_changes.size
+      end
 
       def build_plan
         records = locked_records
@@ -60,7 +66,8 @@ module Collavre
       end
 
       def target_writable?(creative, snapshot, records, writable_ids)
-        creative && writable_ids.include?(creative.id) && target_parent_writable?(creative, snapshot, records, writable_ids)
+        creative && !creative.read_only_source? && writable_ids.include?(creative.id) &&
+          target_parent_writable?(creative, snapshot, records, writable_ids)
       end
 
       def revertible?(source)
@@ -77,7 +84,11 @@ module Collavre
       def target_parent_writable?(creative, snapshot, records, writable_ids)
         parent_id = snapshot["parent_id"]
         parent_id.nil? || parent_id == creative.parent_id ||
-          (records.key?(parent_id) && writable_ids.include?(parent_id))
+          writable_parent?(records[parent_id], writable_ids)
+      end
+
+      def writable_parent?(parent, writable_ids)
+        parent && !parent.read_only_source? && writable_ids.include?(parent.id)
       end
 
       def current_conflict?(creative, change)
@@ -125,7 +136,6 @@ module Collavre
       def apply_snapshot(creative, snapshot)
         return creative.update!(archived_at: Time.current) if snapshot.empty?
 
-        creative.skip_read_only_source_validation = true
         creative.assign_attributes(snapshot_attributes(creative, snapshot))
         creative.save!
       end

--- a/engines/collavre/app/services/collavre/creatives/change_set_diff.rb
+++ b/engines/collavre/app/services/collavre/creatives/change_set_diff.rb
@@ -1,0 +1,150 @@
+# frozen_string_literal: true
+
+require "diff/lcs"
+
+module Collavre
+  module Creatives
+    class ChangeSetDiff
+      BLOCK_SEPARATOR = "\n\n---\n\n"
+
+      def initialize(change_set)
+        @change_set = change_set
+        @changes = change_set.creative_changes.order(:position).to_a
+        @changes_by_id = @changes.index_by(&:creative_id)
+      end
+
+      def groups
+        group_root_ids.map { |root_id| build_group(root_id) }
+      end
+
+      private
+
+      def group_root_ids
+        tops = touched_top_ids
+        anchor_id = @change_set.anchor_creative_id
+        return [ anchor_id ] if anchor_id && tops.all? { |id| descendant_of?(id, anchor_id) }
+
+        tops
+      end
+
+      def touched_top_ids
+        touched = @changes_by_id.keys.to_set
+        @changes.filter_map do |change|
+          change.creative_id unless ancestor_ids(change.creative_id).any? { |id| touched.include?(id) }
+        end
+      end
+
+      def descendant_of?(creative_id, ancestor_id)
+        creative_id == ancestor_id || ancestor_ids(creative_id).include?(ancestor_id)
+      end
+
+      def ancestor_ids(creative_id)
+        ids = []
+        parent_id = parent_id_for(creative_id)
+        while parent_id && !ids.include?(parent_id)
+          ids << parent_id
+          parent_id = parent_id_for(parent_id)
+        end
+        ids
+      end
+
+      def parent_id_for(creative_id)
+        change = @changes_by_id[creative_id]
+        return (change.after.presence || change.before)["parent_id"] if change
+
+        Creative.unscoped.where(id: creative_id).pick(:parent_id)
+      end
+
+      def build_group(root_id)
+        before = document(root_id, :before)
+        after = document(root_id, :after)
+        additions, deletions = line_counts(before, after)
+        {
+          root_id: root_id,
+          label: label_for(root_id),
+          before: before,
+          after: after,
+          additions: additions,
+          deletions: deletions,
+          moved: moved_in_group?(root_id),
+          inline_html: inline_html(before, after),
+          split_rows: split_rows(before, after)
+        }
+      end
+
+      def moved_in_group?(root_id)
+        @changes.any? do |change|
+          change.operation.in?(%w[move reorder]) && descendant_of?(change.creative_id, root_id)
+        end
+      end
+
+      def document(root_id, state)
+        nodes = candidate_nodes(root_id).to_h { |creative| [ creative.id, History.snapshot(creative) ] }
+        @changes.each do |change|
+          snapshot = change.public_send(state)
+          snapshot.empty? ? nodes.delete(change.creative_id) : nodes[change.creative_id] = snapshot
+        end
+        ordered_node_ids(root_id, nodes).filter_map { |id| markdown_for(nodes[id]) }.join(BLOCK_SEPARATOR)
+      end
+
+      def candidate_nodes(root_id)
+        roots = Creative.unscoped.where(id: [ root_id, *@changes_by_id.keys ])
+        roots.flat_map { |creative| creative.self_and_descendants.to_a }.uniq(&:id)
+      end
+
+      def ordered_node_ids(root_id, nodes)
+        children = nodes.keys.group_by { |id| nodes[id]["parent_id"] }
+        walk = lambda do |id|
+          return [] unless nodes.key?(id)
+
+          descendants = Array(children[id]).sort_by { |child_id| [ nodes[child_id]["sequence"] || 0, child_id ] }
+          [ id, *descendants.flat_map { |child_id| walk.call(child_id) } ]
+        end
+        walk.call(root_id)
+      end
+
+      def markdown_for(snapshot)
+        return snapshot["markdown_source"].to_s if snapshot["content_type"] == "markdown"
+
+        MarkdownConverter.html_to_markdown(snapshot["description"].to_s)
+      end
+
+      def label_for(root_id)
+        snapshot = @changes_by_id[root_id]&.after.presence ||
+                   @changes_by_id[root_id]&.before.presence ||
+                   Creative.unscoped.find_by(id: root_id)&.then { |creative| History.snapshot(creative) }
+        markdown_for(snapshot || {}).lines.first.to_s.sub(/\A#+\s*/, "").strip.presence || "##{root_id}"
+      end
+
+      def inline_html(before, after)
+        Diff::LCS.sdiff(tokens(before), tokens(after)).map do |change|
+          old_value = ERB::Util.html_escape(change.old_element.to_s)
+          new_value = ERB::Util.html_escape(change.new_element.to_s)
+          case change.action
+          when "=" then old_value
+          when "-" then "<del>#{old_value}</del>"
+          when "+" then "<ins>#{new_value}</ins>"
+          else "<del>#{old_value}</del><ins>#{new_value}</ins>"
+          end
+        end.join
+      end
+
+      def split_rows(before, after)
+        Diff::LCS.sdiff(before.lines, after.lines).map do |change|
+          { action: change.action, before: change.old_element.to_s, after: change.new_element.to_s }
+        end
+      end
+
+      def line_counts(before, after)
+        changes = Diff::LCS.sdiff(before.lines, after.lines)
+        additions = changes.count { |change| %w[+ !].include?(change.action) }
+        deletions = changes.count { |change| %w[- !].include?(change.action) }
+        [ additions, deletions ]
+      end
+
+      def tokens(markdown)
+        markdown.split(/(\s+|[[:punct:]])/).reject(&:empty?)
+      end
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/creatives/change_set_diff.rb
+++ b/engines/collavre/app/services/collavre/creatives/change_set_diff.rb
@@ -7,9 +7,10 @@ module Collavre
     class ChangeSetDiff
       BLOCK_SEPARATOR = "\n\n---\n\n"
 
-      def initialize(change_set)
+      def initialize(change_set, user:)
         @change_set = change_set
-        @changes = change_set.creative_changes.order(:position).to_a
+        @visibility = ChangeSetVisibility.new(user: user)
+        @changes = @visibility.changes(change_set.creative_changes.order(:position))
         @changes_by_id = @changes.index_by(&:creative_id)
       end
 
@@ -17,12 +18,21 @@ module Collavre
         group_root_ids.map { |root_id| build_group(root_id) }
       end
 
+      def change_count = @changes.size
+
+      def fully_visible? = change_count == @change_set.creative_changes.size
+
+      def revertible? = @change_set.origin != "sync" && @changes.none? { |change| change.operation == "destroy" }
+
       private
 
       def group_root_ids
         tops = touched_top_ids
+        return [] if tops.empty?
+
         anchor_id = @change_set.anchor_creative_id
-        return [ anchor_id ] if anchor_id && tops.all? { |id| descendant_of?(id, anchor_id) }
+        anchor_visible = @changes_by_id.key?(anchor_id) || @visibility.visible_id?(anchor_id)
+        return [ anchor_id ] if anchor_visible && tops.all? { |id| descendant_of?(id, anchor_id) }
 
         tops
       end
@@ -89,7 +99,8 @@ module Collavre
 
       def candidate_nodes(root_id)
         roots = Creative.unscoped.where(id: [ root_id, *@changes_by_id.keys ])
-        roots.flat_map { |creative| creative.self_and_descendants.to_a }.uniq(&:id)
+        candidates = roots.flat_map { |creative| creative.self_and_descendants.to_a }.uniq(&:id)
+        @visibility.nodes(candidates)
       end
 
       def ordered_node_ids(root_id, nodes)

--- a/engines/collavre/app/services/collavre/creatives/change_set_restore_service.rb
+++ b/engines/collavre/app/services/collavre/creatives/change_set_restore_service.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Collavre
+  module Creatives
+    class ChangeSetRestoreService
+      def initialize(change_set:, user:)
+        @change_set = change_set
+        @user = user
+      end
+
+      def call
+        targets = @change_set.creative_changes.order(:position).to_h { |change| [ change, change.after ] }
+        ChangeSetApplyService.new(
+          source: @change_set,
+          user: @user,
+          targets: targets,
+          mode: :restore
+        ).call
+      end
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/creatives/change_set_restore_service.rb
+++ b/engines/collavre/app/services/collavre/creatives/change_set_restore_service.rb
@@ -9,12 +9,15 @@ module Collavre
       end
 
       def call
-        targets = @change_set.creative_changes.order(:position).to_h { |change| [ change, change.after ] }
+        all_changes = @change_set.creative_changes.order(:position)
+        changes = ChangeSetVisibility.new(user: @user).changes(all_changes)
+        targets = changes.to_h { |change| [ change, change.after ] }
         ChangeSetApplyService.new(
           source: @change_set,
           user: @user,
           targets: targets,
-          mode: :restore
+          mode: :restore,
+          complete: changes.size == all_changes.size
         ).call
       end
     end

--- a/engines/collavre/app/services/collavre/creatives/change_set_restore_service.rb
+++ b/engines/collavre/app/services/collavre/creatives/change_set_restore_service.rb
@@ -9,15 +9,10 @@ module Collavre
       end
 
       def call
-        all_changes = @change_set.creative_changes.order(:position)
-        changes = ChangeSetVisibility.new(user: @user).changes(all_changes)
-        targets = changes.to_h { |change| [ change, change.after ] }
         ChangeSetApplyService.new(
           source: @change_set,
           user: @user,
-          targets: targets,
-          mode: :restore,
-          complete: changes.size == all_changes.size
+          mode: :restore
         ).call
       end
     end

--- a/engines/collavre/app/services/collavre/creatives/change_set_revert_service.rb
+++ b/engines/collavre/app/services/collavre/creatives/change_set_revert_service.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Collavre
+  module Creatives
+    class ChangeSetRevertService
+      def initialize(change_set:, user:, resolutions: {})
+        @change_set = change_set
+        @user = user
+        @resolutions = resolutions
+      end
+
+      def call
+        targets = @change_set.creative_changes.order(position: :desc).to_h { |change| [ change, change.before ] }
+        ChangeSetApplyService.new(
+          source: @change_set,
+          user: @user,
+          targets: targets,
+          resolutions: @resolutions
+        ).call
+      end
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/creatives/change_set_revert_service.rb
+++ b/engines/collavre/app/services/collavre/creatives/change_set_revert_service.rb
@@ -10,15 +10,10 @@ module Collavre
       end
 
       def call
-        all_changes = @change_set.creative_changes.order(position: :desc)
-        changes = ChangeSetVisibility.new(user: @user).changes(all_changes)
-        targets = changes.to_h { |change| [ change, change.before ] }
         ChangeSetApplyService.new(
           source: @change_set,
           user: @user,
-          targets: targets,
-          resolutions: @resolutions,
-          complete: changes.size == all_changes.size
+          resolutions: @resolutions
         ).call
       end
     end

--- a/engines/collavre/app/services/collavre/creatives/change_set_revert_service.rb
+++ b/engines/collavre/app/services/collavre/creatives/change_set_revert_service.rb
@@ -10,12 +10,15 @@ module Collavre
       end
 
       def call
-        targets = @change_set.creative_changes.order(position: :desc).to_h { |change| [ change, change.before ] }
+        all_changes = @change_set.creative_changes.order(position: :desc)
+        changes = ChangeSetVisibility.new(user: @user).changes(all_changes)
+        targets = changes.to_h { |change| [ change, change.before ] }
         ChangeSetApplyService.new(
           source: @change_set,
           user: @user,
           targets: targets,
-          resolutions: @resolutions
+          resolutions: @resolutions,
+          complete: changes.size == all_changes.size
         ).call
       end
     end

--- a/engines/collavre/app/services/collavre/creatives/change_set_visibility.rb
+++ b/engines/collavre/app/services/collavre/creatives/change_set_visibility.rb
@@ -4,6 +4,7 @@ module Collavre
   module Creatives
     class ChangeSetVisibility
       def initialize(user:)
+        @user_id = user&.id
         @permission_filter = PermissionFilter.new(user: user)
       end
 
@@ -12,6 +13,7 @@ module Collavre
         existing_ids = Creative.unscoped.where(id: changes.map(&:creative_id)).pluck(:id).to_set
         visible_ids = readable_ids(existing_ids)
         missing = changes.reject { |change| existing_ids.include?(change.creative_id) }
+          .select { |change| historical_snapshot_visible?(change) }
         readable_parents = readable_ids(missing.filter_map { |change| historical_parent_id(change) })
 
         append_visible_descendants(missing, visible_ids, readable_parents)
@@ -45,6 +47,15 @@ module Collavre
 
       def historical_parent_id(change)
         change.previous_parent_id || change.before["parent_id"] || change.after["parent_id"]
+      end
+
+      # A hard delete removes the Creative and its direct permission boundary.
+      # The former parent alone cannot prove that another viewer could read the
+      # deleted child (a closer no_access share may have overridden it), so only
+      # the actor who performed that explicit deletion may inspect its snapshot.
+      # AI deletes are archival and keep their live permission rows.
+      def historical_snapshot_visible?(change)
+        @user_id && change.change_set.user_id == @user_id
       end
 
       def readable_ids(ids)

--- a/engines/collavre/app/services/collavre/creatives/change_set_visibility.rb
+++ b/engines/collavre/app/services/collavre/creatives/change_set_visibility.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module Collavre
+  module Creatives
+    class ChangeSetVisibility
+      def initialize(user:)
+        @permission_filter = PermissionFilter.new(user: user)
+      end
+
+      def changes(changes)
+        changes = changes.to_a
+        existing_ids = Creative.unscoped.where(id: changes.map(&:creative_id)).pluck(:id).to_set
+        visible_ids = readable_ids(existing_ids)
+        missing = changes.reject { |change| existing_ids.include?(change.creative_id) }
+        readable_parents = readable_ids(missing.filter_map { |change| historical_parent_id(change) })
+
+        append_visible_descendants(missing, visible_ids, readable_parents)
+        changes.select { |change| visible_ids.include?(change.creative_id) }
+      end
+
+      def nodes(creatives)
+        creatives = creatives.to_a.uniq(&:id)
+        visible_ids = readable_ids(creatives.map(&:id))
+        creatives.select { |creative| visible_ids.include?(creative.id) }
+      end
+
+      def visible_id?(id)
+        readable_ids([ id ]).include?(id)
+      end
+
+      private
+
+      def append_visible_descendants(missing, visible_ids, readable_parents)
+        loop do
+          additions = missing.select do |change|
+            parent_id = historical_parent_id(change)
+            !visible_ids.include?(change.creative_id) && parent_id &&
+              (visible_ids.include?(parent_id) || readable_parents.include?(parent_id))
+          end
+          break if additions.empty?
+
+          visible_ids.merge(additions.map(&:creative_id))
+        end
+      end
+
+      def historical_parent_id(change)
+        change.previous_parent_id || change.before["parent_id"] || change.after["parent_id"]
+      end
+
+      def readable_ids(ids)
+        @permission_filter.readable_ids(ids).to_set
+      end
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/creatives/history.rb
+++ b/engines/collavre/app/services/collavre/creatives/history.rb
@@ -87,8 +87,38 @@ module Collavre
         change.operation = merged_operation(change.operation, operation.to_s)
         change.conflict ||= {}
         change.save!
+        retain_snapshot_files!(change)
         change_set.touch
         change
+      end
+
+      def retain_snapshot_files!(change)
+        blobs = snapshot_signed_ids(change).filter_map do |signed_id|
+          ActiveStorage::Blob.find_signed(signed_id)
+        rescue ActiveSupport::MessageVerifier::InvalidSignature, ActiveRecord::RecordNotFound
+          nil
+        end.uniq(&:id)
+        retained_ids = change.history_file_attachments.pluck(:blob_id)
+        change.history_file_attachments.where.not(blob_id: blobs.map(&:id)).delete_all
+        blobs.reject { |blob| retained_ids.include?(blob.id) }.each do |blob|
+          change.history_file_attachments.create!(name: "history_files", blob: blob)
+        end
+      end
+
+      def snapshot_signed_ids(change)
+        [ change.before, change.after ].flat_map do |snapshot|
+          [ snapshot["description"], snapshot["markdown_source"] ].flat_map do |markup|
+            extract_signed_ids(markup)
+          end
+        end.uniq
+      end
+
+      def extract_signed_ids(markup)
+        return [] if markup.blank?
+
+        markup.to_s.scan(%r{/rails/active_storage/blobs/(?:redirect|proxy)/([^/?#]+)}).flatten +
+          markup.to_s.scan(%r{/rails/active_storage/blobs/([^/?#]+)}).flatten +
+          markup.to_s.scan(%r{/public-assets/blobs/([^/?#]+)}).flatten
       end
 
       def snapshot(creative, persisted: false)

--- a/engines/collavre/app/services/collavre/creatives/history.rb
+++ b/engines/collavre/app/services/collavre/creatives/history.rb
@@ -46,14 +46,16 @@ module Collavre
       end
 
       def record_bulk(creatives, operation:)
-        records = creatives.to_a
-        before = records.to_h { |creative| [ creative.id, locked_snapshot(creative) ] }
-        result = yield
-        records.each do |creative|
-          creative.reload
-          record(creative, operation: operation, before: before.fetch(creative.id), after: snapshot(creative))
+        records = creatives.to_a.sort_by(&:id)
+        Creative.transaction do
+          before = records.to_h { |creative| [ creative.id, locked_snapshot(creative) ] }
+          result = yield
+          records.each do |creative|
+            creative.reload
+            record(creative, operation: operation, before: before.fetch(creative.id), after: snapshot(creative))
+          end
+          result
         end
-        result
       end
 
       def record(creative, operation:, before:, after:)
@@ -72,7 +74,9 @@ module Collavre
         if change.new_record?
           change.before = before
           change.position = next_position(change_set)
-          change.previous_parent_id = before["parent_id"] if operation.to_s == "destroy"
+        end
+        if operation.to_s.in?(%w[destroy move])
+          change.previous_parent_id ||= change.before["parent_id"] || before["parent_id"]
         end
         change.after = after
         if change.persisted? && change.before == after

--- a/engines/collavre/app/services/collavre/creatives/history.rb
+++ b/engines/collavre/app/services/collavre/creatives/history.rb
@@ -80,7 +80,9 @@ module Collavre
         end
         change.after = after
         if change.persisted? && change.before == after
+          stale_blob_ids = change.history_file_attachments.pluck(:blob_id)
           change.destroy!
+          schedule_blob_purge_rechecks(stale_blob_ids)
           change_set.touch
           return
         end

--- a/engines/collavre/app/services/collavre/creatives/history.rb
+++ b/engines/collavre/app/services/collavre/creatives/history.rb
@@ -99,9 +99,20 @@ module Collavre
           nil
         end.uniq(&:id)
         retained_ids = change.history_file_attachments.pluck(:blob_id)
-        change.history_file_attachments.where.not(blob_id: blobs.map(&:id)).delete_all
+        stale_attachments = change.history_file_attachments.where.not(blob_id: blobs.map(&:id))
+        stale_blob_ids = stale_attachments.pluck(:blob_id)
+        stale_attachments.delete_all
+        schedule_blob_purge_rechecks(stale_blob_ids)
         blobs.reject { |blob| retained_ids.include?(blob.id) }.each do |blob|
           change.history_file_attachments.create!(name: "history_files", blob: blob)
+        end
+      end
+
+      def schedule_blob_purge_rechecks(blob_ids)
+        return if blob_ids.empty?
+
+        ActiveRecord.after_all_transactions_commit do
+          blob_ids.each { |blob_id| PurgeUnreferencedBlobJob.perform_later(blob_id) }
         end
       end
 

--- a/engines/collavre/app/services/collavre/creatives/history_page.rb
+++ b/engines/collavre/app/services/collavre/creatives/history_page.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module Collavre
+  module Creatives
+    class HistoryPage
+      def initialize(scope:, user:, before_id:, after_id:, limit:)
+        @scope = scope
+        @visibility = ChangeSetVisibility.new(user: user)
+        @before_id = before_id.presence&.to_i
+        @after_id = after_id.presence&.to_i
+        @limit = limit
+      end
+
+      def call
+        visible = []
+        cursor = boundary
+
+        loop do
+          batch = next_batch(cursor)
+          break if batch.empty?
+
+          visible.concat(batch.select { |change_set| visible?(change_set) })
+          break if visible.size >= @limit
+
+          cursor = batch.last.id
+        end
+
+        page = visible.first(@limit)
+        descending? ? page.reverse : page
+      end
+
+      private
+
+      def next_batch(cursor)
+        relation = @scope.reorder(id: descending? ? :desc : :asc)
+        relation = constrained(relation, cursor) if cursor
+        relation.limit(@limit).to_a
+      end
+
+      def constrained(relation, cursor)
+        if descending?
+          relation.where("creative_change_sets.id < ?", cursor)
+        else
+          relation.where("creative_change_sets.id > ?", cursor)
+        end
+      end
+
+      def visible?(change_set)
+        @visibility.changes(change_set.creative_changes).any?
+      end
+
+      def descending?
+        @after_id.nil?
+      end
+
+      def boundary
+        @after_id || @before_id
+      end
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/tools/cron_create_service.rb
+++ b/engines/collavre/app/services/collavre/tools/cron_create_service.rb
@@ -65,6 +65,7 @@ module Tools
 
     def create_task(topic:, creative:, creative_id:, key:, schedule:, message:, description:)
       topic.with_lock do
+        return { error: I18n.t("collavre.creative_history.read_only") } if topic.history?
         unless topic.creative_id == creative.effective_origin.id
           return { error: I18n.t("collavre.comments.invalid_topic") }
         end
@@ -93,6 +94,7 @@ module Tools
       else
         topic = Topic.find_by(name: topic_name, creative_id: origin.id)
         return { error: "Topic '#{topic_name}' not found for this creative" } unless topic
+        return { error: I18n.t("collavre.creative_history.read_only") } if topic.history?
 
         topic
       end

--- a/engines/collavre/app/services/collavre/tools/topic_message_create_service.rb
+++ b/engines/collavre/app/services/collavre/tools/topic_message_create_service.rb
@@ -81,7 +81,7 @@ module Tools
       if topic.archived?
         raise ArgumentError, I18n.t("collavre.tools.topic_message_create.errors.archived_topic")
       end
-      if topic.name == Creative::HISTORY_TOPIC_NAME
+      if topic.history?
         raise ArgumentError, I18n.t("collavre.tools.topic_message_create.errors.history_topic")
       end
       return unless topic.creative.inbox? && topic.name == Creative::SYSTEM_TOPIC_NAME

--- a/engines/collavre/app/services/collavre/tools/topic_message_create_service.rb
+++ b/engines/collavre/app/services/collavre/tools/topic_message_create_service.rb
@@ -27,8 +27,8 @@ module Tools
       it is currently handling; continue that work in the current turn instead.
 
       Requires feedback permission or better on the topic's creative. Archived
-      creatives, archived topics, and an inbox's reserved System topic do not
-      accept messages through this tool.
+      creatives, archived topics, History topics, and an inbox's reserved System
+      topic do not accept messages through this tool.
     DESC
 
     tool_param :topic_id, description: "The topic to post the message to."
@@ -80,6 +80,9 @@ module Tools
       end
       if topic.archived?
         raise ArgumentError, I18n.t("collavre.tools.topic_message_create.errors.archived_topic")
+      end
+      if topic.name == Creative::HISTORY_TOPIC_NAME
+        raise ArgumentError, I18n.t("collavre.tools.topic_message_create.errors.history_topic")
       end
       return unless topic.creative.inbox? && topic.name == Creative::SYSTEM_TOPIC_NAME
 

--- a/engines/collavre/app/services/collavre/tools/topic_move_service.rb
+++ b/engines/collavre/app/services/collavre/tools/topic_move_service.rb
@@ -83,8 +83,8 @@ module Tools
     end
 
     def reserved?(topic, target)
-      Topics::ReservedName.reserved?(topic.creative, topic.name) ||
-        Topics::ReservedName.reserved?(target, topic.name)
+      Topics::ReservedName.reserved_topic?(topic.creative, topic) ||
+        (target.inbox? && topic.name == Creative::SYSTEM_TOPIC_NAME)
     end
 
     def released_agent_payload(agent, reason, target)

--- a/engines/collavre/app/services/collavre/tools/topic_update_service.rb
+++ b/engines/collavre/app/services/collavre/tools/topic_update_service.rb
@@ -122,7 +122,7 @@ module Tools
     end
 
     def reserved_topic?(topic)
-      Topics::ReservedName.reserved?(topic.creative, topic.name)
+      Topics::ReservedName.reserved_topic?(topic.creative, topic)
     end
 
     def set_archived(topic, archived)

--- a/engines/collavre/app/services/collavre/topics/reserved_name.rb
+++ b/engines/collavre/app/services/collavre/topics/reserved_name.rb
@@ -5,6 +5,7 @@ module Collavre
 
       def reserved?(creative, name)
         name == Creative::MAIN_TOPIC_NAME ||
+          name == Creative::HISTORY_TOPIC_NAME ||
           (creative.inbox? && name == Creative::SYSTEM_TOPIC_NAME)
       end
 

--- a/engines/collavre/app/services/collavre/topics/reserved_name.rb
+++ b/engines/collavre/app/services/collavre/topics/reserved_name.rb
@@ -14,6 +14,11 @@ module Collavre
 
         raise error_class, I18n.t("collavre.topics.reserved_name")
       end
+
+      def reserved_topic?(creative, topic)
+        topic.history? || topic.name == Creative::MAIN_TOPIC_NAME ||
+          (creative.inbox? && topic.name == Creative::SYSTEM_TOPIC_NAME)
+      end
     end
   end
 end

--- a/engines/collavre/app/services/collavre/topics/serializer.rb
+++ b/engines/collavre/app/services/collavre/topics/serializer.rb
@@ -16,6 +16,8 @@ module Collavre
         data = topic.slice(:id, :name, :source_topic_id)
         data[:primary_agent] = agent_json(topic.primary_agent) if topic.primary_agent
         data[:agent_locked] = topic.session_id.present?
+        data[:read_only] = topic.name == Creative::HISTORY_TOPIC_NAME
+        data[:display_name] = I18n.t("collavre.topics.history_name") if data[:read_only]
         data[:archived_at] = topic.archived_at if topic.archived_at
         data[:unread_count] = unread_count unless unread_count.nil?
         data
@@ -25,6 +27,8 @@ module Collavre
         data = topic.slice(:id, :name, :source_topic_id)
         data[:primary_agent] = agent ? agent_json(agent) : nil
         data[:agent_locked] = topic.session_id.present?
+        data[:read_only] = topic.name == Creative::HISTORY_TOPIC_NAME
+        data[:display_name] = I18n.t("collavre.topics.history_name") if data[:read_only]
         data
       end
 
@@ -68,6 +72,7 @@ module Collavre
           creative_id: topic.creative_id,
           archived: topic.archived?,
           main: topic.name == Creative::MAIN_TOPIC_NAME,
+          read_only: topic.name == Creative::HISTORY_TOPIC_NAME,
           system: topic.creative.inbox? && topic.name == Creative::SYSTEM_TOPIC_NAME,
           source_topic_id: topic.source_topic_id,
           primary_agent: primary_agent_for_tool(topic),

--- a/engines/collavre/app/services/collavre/topics/serializer.rb
+++ b/engines/collavre/app/services/collavre/topics/serializer.rb
@@ -16,7 +16,7 @@ module Collavre
         data = topic.slice(:id, :name, :source_topic_id)
         data[:primary_agent] = agent_json(topic.primary_agent) if topic.primary_agent
         data[:agent_locked] = topic.session_id.present?
-        data[:read_only] = topic.name == Creative::HISTORY_TOPIC_NAME
+        data[:read_only] = topic.history?
         data[:display_name] = I18n.t("collavre.topics.history_name") if data[:read_only]
         data[:archived_at] = topic.archived_at if topic.archived_at
         data[:unread_count] = unread_count unless unread_count.nil?
@@ -27,7 +27,7 @@ module Collavre
         data = topic.slice(:id, :name, :source_topic_id)
         data[:primary_agent] = agent ? agent_json(agent) : nil
         data[:agent_locked] = topic.session_id.present?
-        data[:read_only] = topic.name == Creative::HISTORY_TOPIC_NAME
+        data[:read_only] = topic.history?
         data[:display_name] = I18n.t("collavre.topics.history_name") if data[:read_only]
         data
       end
@@ -68,11 +68,11 @@ module Collavre
       def for_tool(topic, message_count: nil, message_chars: nil, last_message_at: nil)
         {
           id: topic.id,
-          name: topic.name,
+          name: topic.history? ? Creative::HISTORY_TOPIC_NAME : topic.name,
           creative_id: topic.creative_id,
           archived: topic.archived?,
           main: topic.name == Creative::MAIN_TOPIC_NAME,
-          read_only: topic.name == Creative::HISTORY_TOPIC_NAME,
+          read_only: topic.history?,
           system: topic.creative.inbox? && topic.name == Creative::SYSTEM_TOPIC_NAME,
           source_topic_id: topic.source_topic_id,
           primary_agent: primary_agent_for_tool(topic),

--- a/engines/collavre/app/views/collavre/creative_change_sets/_list.html.erb
+++ b/engines/collavre/app/views/collavre/creative_change_sets/_list.html.erb
@@ -1,14 +1,15 @@
-<div class="creative-history-list" data-controller="creative-history">
-  <% if change_sets.empty? %>
+<% unless pagination %><div class="creative-history-list" data-controller="creative-history"><% end %>
+  <% if change_sets.empty? && !pagination %>
     <p class="creative-history-empty"><%= t("collavre.creative_history.empty") %></p>
   <% end %>
 
   <% change_sets.each do |change_set| %>
-    <% diff = Collavre::Creatives::ChangeSetDiff.new(change_set) %>
+    <% diff = Collavre::Creatives::ChangeSetDiff.new(change_set, user: Current.user) %>
     <% groups = diff.groups %>
+    <% next if groups.empty? %>
     <% additions = groups.sum { |group| group[:additions] } %>
     <% deletions = groups.sum { |group| group[:deletions] } %>
-    <article class="creative-history-item" data-change-set-id="<%= change_set.id %>">
+    <article class="creative-history-item" data-change-set-id="<%= change_set.id %>" data-controller="creative-history">
       <header class="creative-history-header">
         <%= render Collavre::AvatarComponent.new(user: change_set.user, size: 20, classes: "avatar") %>
         <strong><%= change_set.user&.display_name || t("collavre.comments.system_user") %></strong>
@@ -18,9 +19,11 @@
         </time>
       </header>
 
-      <p class="creative-history-summary"><%= change_set.summary.presence || t("collavre.creative_history.default_summary") %></p>
+      <p class="creative-history-summary">
+        <%= (diff.fully_visible? ? change_set.summary : nil).presence || t("collavre.creative_history.default_summary") %>
+      </p>
       <p class="creative-history-stats">
-        <%= t("collavre.creative_history.changed_count", count: change_set.creative_changes.size) %>
+        <%= t("collavre.creative_history.changed_count", count: diff.change_count) %>
         · <ins>+<%= additions %></ins> <del>−<%= deletions %></del>
       </p>
 
@@ -53,7 +56,7 @@
         </details>
       <% end %>
 
-      <% if change_set.status == "applied" && change_set.origin != "sync" %>
+      <% if change_set.status == "applied" && diff.revertible? %>
         <button type="button"
                 class="creative-history-revert"
                 data-action="creative-history#revert"
@@ -67,8 +70,10 @@
         </button>
       <% elsif change_set.status == "reverted" %>
         <span class="creative-history-state"><%= t("collavre.creative_history.reverted") %></span>
+      <% elsif !diff.revertible? %>
+        <span class="creative-history-state"><%= t("collavre.creative_history.irreversible") %></span>
       <% end %>
-      <% if change_set.origin != "sync" && change_set.status.in?(%w[applied reverted]) %>
+      <% if diff.revertible? && change_set.status.in?(%w[applied reverted]) %>
         <button type="button"
                 class="creative-history-restore"
                 data-action="creative-history#revert"
@@ -80,4 +85,4 @@
       <% end %>
     </article>
   <% end %>
-</div>
+<% unless pagination %></div><% end %>

--- a/engines/collavre/app/views/collavre/creative_change_sets/_list.html.erb
+++ b/engines/collavre/app/views/collavre/creative_change_sets/_list.html.erb
@@ -1,0 +1,83 @@
+<div class="creative-history-list" data-controller="creative-history">
+  <% if change_sets.empty? %>
+    <p class="creative-history-empty"><%= t("collavre.creative_history.empty") %></p>
+  <% end %>
+
+  <% change_sets.each do |change_set| %>
+    <% diff = Collavre::Creatives::ChangeSetDiff.new(change_set) %>
+    <% groups = diff.groups %>
+    <% additions = groups.sum { |group| group[:additions] } %>
+    <% deletions = groups.sum { |group| group[:deletions] } %>
+    <article class="creative-history-item" data-change-set-id="<%= change_set.id %>">
+      <header class="creative-history-header">
+        <%= render Collavre::AvatarComponent.new(user: change_set.user, size: 20, classes: "avatar") %>
+        <strong><%= change_set.user&.display_name || t("collavre.comments.system_user") %></strong>
+        <time title="<%= l(change_set.created_at.in_time_zone, format: :chat_timestamp) %>"
+              datetime="<%= change_set.created_at.iso8601 %>">
+          · <%= t("datetime.ago", time: time_ago_in_words(change_set.created_at)) %>
+        </time>
+      </header>
+
+      <p class="creative-history-summary"><%= change_set.summary.presence || t("collavre.creative_history.default_summary") %></p>
+      <p class="creative-history-stats">
+        <%= t("collavre.creative_history.changed_count", count: change_set.creative_changes.size) %>
+        · <ins>+<%= additions %></ins> <del>−<%= deletions %></del>
+      </p>
+
+      <% groups.each do |group| %>
+        <details class="creative-history-diff">
+          <summary>
+            <%= group[:label] %>
+            <% if group[:moved] %><span class="creative-history-moved"><%= t("collavre.creative_history.moved") %></span><% end %>
+            <span>+<%= group[:additions] %> −<%= group[:deletions] %></span>
+          </summary>
+          <div class="creative-history-diff-modes">
+            <details open>
+              <summary><%= t("collavre.creative_history.inline") %></summary>
+              <pre class="creative-history-inline"><%= sanitize(group[:inline_html], tags: %w[ins del]) %></pre>
+            </details>
+            <details>
+              <summary><%= t("collavre.creative_history.split") %></summary>
+              <table class="creative-history-split">
+                <tbody>
+                  <% group[:split_rows].each do |row| %>
+                    <tr class="diff-<%= row[:action] == "=" ? "same" : "changed" %>">
+                      <td><%= row[:before] %></td>
+                      <td><%= row[:after] %></td>
+                    </tr>
+                  <% end %>
+                </tbody>
+              </table>
+            </details>
+          </div>
+        </details>
+      <% end %>
+
+      <% if change_set.status == "applied" && change_set.origin != "sync" %>
+        <button type="button"
+                class="creative-history-revert"
+                data-action="creative-history#revert"
+                data-url="<%= creative_apply_change_set_path(creative, change_set) %>"
+                data-mode="revert"
+                data-confirm="<%= t("collavre.creative_history.revert_confirm") %>"
+                data-conflict="<%= t("collavre.creative_history.conflict_choice") %>"
+                data-force="<%= t("collavre.creative_history.force") %>"
+                data-skip="<%= t("collavre.creative_history.skip") %>">
+          <%= t("collavre.creative_history.revert") %>
+        </button>
+      <% elsif change_set.status == "reverted" %>
+        <span class="creative-history-state"><%= t("collavre.creative_history.reverted") %></span>
+      <% end %>
+      <% if change_set.origin != "sync" && change_set.status.in?(%w[applied reverted]) %>
+        <button type="button"
+                class="creative-history-restore"
+                data-action="creative-history#revert"
+                data-url="<%= creative_apply_change_set_path(creative, change_set) %>"
+                data-mode="restore"
+                data-confirm="<%= t("collavre.creative_history.restore_confirm") %>">
+          <%= t("collavre.creative_history.restore") %>
+        </button>
+      <% end %>
+    </article>
+  <% end %>
+</div>

--- a/engines/collavre/collavre.gemspec
+++ b/engines/collavre/collavre.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
 
   # Markdown rendering
   spec.add_dependency "commonmarker"           # GitHub-flavored Markdown to HTML
+  spec.add_dependency "diff-lcs"               # Word and line diffs for Creative history
 
   # Integrations
   spec.add_dependency "httparty"               # HTTP client for link previews and APIs

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -15,6 +15,7 @@ en:
       default_name_prefix: "Topic"
       branch_prefix: "Branch"
       main_name: "Main"
+      history_name: "History"
       cannot_delete_main: "Cannot delete the Main topic."
       reserved_name: "This topic name is reserved and cannot be assigned."
       orphaned_cron_notice: "[System] The topic '%{topic_name}' was deleted, but a recurring cron job (%{cron_key}) still targets it and will silently do nothing on each run. Original message: \"%{message}\". Re-point it to another topic or cancel it with cron_cancel."

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -15,6 +15,7 @@ ko:
       default_name_prefix: "토픽"
       branch_prefix: "분기"
       main_name: "메인"
+      history_name: "이력"
       cannot_delete_main: "메인 토픽은 삭제할 수 없습니다."
       reserved_name: "예약된 토픽 이름은 지정할 수 없습니다."
       orphaned_cron_notice: "[시스템] '%{topic_name}' 토픽이 삭제되었지만, 이 토픽을 대상으로 하는 반복 크론 작업(%{cron_key})이 아직 남아 있어 실행될 때마다 아무 동작도 하지 않고 조용히 종료됩니다. 원래 메시지: \"%{message}\". 다른 토픽으로 다시 지정하거나 cron_cancel로 취소하세요."

--- a/engines/collavre/config/locales/creative_history.en.yml
+++ b/engines/collavre/config/locales/creative_history.en.yml
@@ -14,6 +14,7 @@ en:
       revert: Revert change
       restore: Restore this version
       reverted: Reverted
+      irreversible: Cannot be restored
       revert_confirm: Revert this entire change set?
       restore_confirm: Make this version the current version?
       conflict_choice: "Creative #%{id} changed afterward. Force revert it, or skip it?"
@@ -21,6 +22,7 @@ en:
       skip: Skip
       results:
         applied: The change was reverted.
+        partial: The writable changes were applied. You can retry the remaining changes after permissions change.
         conflict: Resolve each conflict before reverting.
         skipped: No writable creatives remained to revert.
         not_revertible: This change cannot be reverted.

--- a/engines/collavre/config/locales/creative_history.en.yml
+++ b/engines/collavre/config/locales/creative_history.en.yml
@@ -1,0 +1,26 @@
+---
+en:
+  collavre:
+    creative_history:
+      read_only: History topics are read-only.
+      empty: No changes have been recorded here yet.
+      default_summary: Creative updated
+      changed_count:
+        one: 1 creative
+        other: "%{count} creatives"
+      inline: Inline diff
+      split: Split diff
+      moved: Moved
+      revert: Revert change
+      restore: Restore this version
+      reverted: Reverted
+      revert_confirm: Revert this entire change set?
+      restore_confirm: Make this version the current version?
+      conflict_choice: "Creative #%{id} changed afterward. Force revert it, or skip it?"
+      force: Force revert
+      skip: Skip
+      results:
+        applied: The change was reverted.
+        conflict: Resolve each conflict before reverting.
+        skipped: No writable creatives remained to revert.
+        not_revertible: This change cannot be reverted.

--- a/engines/collavre/config/locales/creative_history.ko.yml
+++ b/engines/collavre/config/locales/creative_history.ko.yml
@@ -12,6 +12,7 @@ ko:
       revert: 변경 되돌리기
       restore: 이 버전으로 복원
       reverted: 되돌림 완료
+      irreversible: 복원할 수 없음
       revert_confirm: 이 변경 셋 전체를 되돌릴까요?
       restore_confirm: 이 버전을 현재 버전으로 적용할까요?
       conflict_choice: "크리에이티브 #%{id}이(가) 이후에 변경되었습니다. 강제로 되돌리거나 건너뛰세요."
@@ -19,6 +20,7 @@ ko:
       skip: 건너뛰기
       results:
         applied: 변경을 되돌렸습니다.
+        partial: 쓰기 가능한 변경을 적용했습니다. 권한이 변경되면 남은 변경을 다시 시도할 수 있습니다.
         conflict: 되돌리기 전에 각 충돌을 처리하세요.
         skipped: 되돌릴 수 있는 쓰기 가능 크리에이티브가 없습니다.
         not_revertible: 이 변경은 되돌릴 수 없습니다.

--- a/engines/collavre/config/locales/creative_history.ko.yml
+++ b/engines/collavre/config/locales/creative_history.ko.yml
@@ -1,0 +1,24 @@
+---
+ko:
+  collavre:
+    creative_history:
+      read_only: 이력 토픽은 읽기 전용입니다.
+      empty: 아직 기록된 변경이 없습니다.
+      default_summary: 크리에이티브 수정
+      changed_count: "크리에이티브 %{count}개"
+      inline: 인라인 diff
+      split: 분할 diff
+      moved: 이동됨
+      revert: 변경 되돌리기
+      restore: 이 버전으로 복원
+      reverted: 되돌림 완료
+      revert_confirm: 이 변경 셋 전체를 되돌릴까요?
+      restore_confirm: 이 버전을 현재 버전으로 적용할까요?
+      conflict_choice: "크리에이티브 #%{id}이(가) 이후에 변경되었습니다. 강제로 되돌리거나 건너뛰세요."
+      force: 강제 되돌리기
+      skip: 건너뛰기
+      results:
+        applied: 변경을 되돌렸습니다.
+        conflict: 되돌리기 전에 각 충돌을 처리하세요.
+        skipped: 되돌릴 수 있는 쓰기 가능 크리에이티브가 없습니다.
+        not_revertible: 이 변경은 되돌릴 수 없습니다.

--- a/engines/collavre/config/locales/tools.en.yml
+++ b/engines/collavre/config/locales/tools.en.yml
@@ -7,6 +7,7 @@ en:
           archived_creative: Archived creatives do not accept topic messages.
           archived_topic: Archived topics do not accept messages.
           system_topic: The inbox System topic does not accept user-authored messages.
+          history_topic: History topics are read-only.
           current_topic: An agent cannot dispatch a topic message to its own current topic.
           self_route: An agent cannot route an unpinned topic message back to itself.
       topic_move:

--- a/engines/collavre/config/locales/tools.ko.yml
+++ b/engines/collavre/config/locales/tools.ko.yml
@@ -7,6 +7,7 @@ ko:
           archived_creative: 보관된 크리에이티브에는 토픽 메시지를 작성할 수 없습니다.
           archived_topic: 보관된 토픽에는 메시지를 작성할 수 없습니다.
           system_topic: 받은 편지함의 System 토픽에는 사용자가 메시지를 작성할 수 없습니다.
+          history_topic: History 토픽은 읽기 전용입니다.
           current_topic: 에이전트는 현재 처리 중인 토픽에 토픽 메시지를 전달할 수 없습니다.
           self_route: 에이전트는 고정되지 않은 토픽 메시지를 자신에게 다시 라우팅할 수 없습니다.
       topic_move:

--- a/engines/collavre/config/routes.rb
+++ b/engines/collavre/config/routes.rb
@@ -95,6 +95,7 @@ Collavre::Engine.routes.draw do
     end
   end
   resources :creatives do
+    post "history/:id/apply", to: "creative_change_sets#apply", as: :apply_change_set
     resources :attachments, only: [ :create ], module: :creatives
     resources :creative_shares, only: [ :index, :create, :update, :destroy ]
     resources :invitations, only: [ :update, :destroy ], controller: "creative_invitations"
@@ -114,8 +115,7 @@ Collavre::Engine.routes.draw do
     resources :comments, only: [ :index, :create, :destroy, :show, :update ] do
       member do
         post :convert
-        post :approve
-        post :deny
+        %i[approve deny].each { |action| post action }
         patch :update_action
         delete :reactions, to: "comments/reactions#destroy"
         get :download_images

--- a/engines/collavre/db/migrate/20260903190000_add_system_kind_to_topics.rb
+++ b/engines/collavre/db/migrate/20260903190000_add_system_kind_to_topics.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddSystemKindToTopics < ActiveRecord::Migration[8.1]
+  def change
+    add_column :topics, :system_kind, :string
+    add_index :topics, %i[creative_id system_kind], unique: true
+  end
+end

--- a/engines/collavre/test/controllers/comments_controller_test.rb
+++ b/engines/collavre/test/controllers/comments_controller_test.rb
@@ -24,6 +24,26 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
 
   public
 
+  test "History topic renders change sets and rejects comments" do
+    Collavre::Creatives::History.track(actor: @user, origin: :tool, anchor: @creative, anchor_source: :explicit) do
+      @creative.update!(progress: 0.75)
+    end
+    history_topic = @creative.reload.history_topic
+
+    get creative_comments_path(@creative), params: { topic_id: history_topic.id }
+
+    assert_response :success
+    assert_select ".creative-history-item", count: 1
+    assert_select ".creative-history-revert", count: 1
+
+    assert_no_difference("Comment.count") do
+      post creative_comments_path(@creative),
+           params: { comment: { topic_id: history_topic.id, content: "not allowed" } }, as: :json
+    end
+    assert_response :forbidden
+    assert_equal I18n.t("collavre.creative_history.read_only"), response.parsed_body["error"]
+  end
+
   test "merge rejects comments from different topics" do
     first_topic = @creative.topics.create!(name: "First merge topic", user: @user)
     second_topic = @creative.topics.create!(name: "Second merge topic", user: @user)

--- a/engines/collavre/test/controllers/comments_controller_test.rb
+++ b/engines/collavre/test/controllers/comments_controller_test.rb
@@ -44,6 +44,72 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
     assert_equal I18n.t("collavre.creative_history.read_only"), response.parsed_body["error"]
   end
 
+  test "linked Creatives use the origin History topic while preserving the linked history scope" do
+    linked = Collavre::Creative.create!(user: @user, origin: @creative)
+    Collavre::Creatives::History.track(actor: @user, origin: :tool, anchor: linked, anchor_source: :explicit) do
+      @creative.update!(progress: 0.75)
+    end
+    history_topic = @creative.reload.history_topic
+
+    assert_equal history_topic, linked.history_topic
+    assert_nil linked.topics.find_by(name: Collavre::Creative::HISTORY_TOPIC_NAME)
+
+    get creative_comments_path(linked), params: { topic_id: history_topic.id }
+
+    assert_response :success
+    assert_select ".creative-history-item", count: 1
+  end
+
+  test "History rejects a foreign private linked placement whose origin is readable" do
+    foreign_parent = Collavre::Creative.create!(description: "Private", user: users(:two))
+    linked = Collavre::Creative.create!(user: users(:two), parent: foreign_parent, origin: @creative)
+    history_topic = @creative.history_topic
+
+    get creative_comments_path(linked), params: { topic_id: history_topic.id }
+
+    assert_response :forbidden
+  end
+
+  test "hard deletion is recorded without offering a lossy restore" do
+    child = Collavre::Creative.create!(description: "Disposable", user: @user, parent: @creative)
+    Collavre::Creatives::History.track(actor: @user, origin: :editor, anchor: @creative) { child.destroy! }
+    history_topic = @creative.reload.history_topic
+
+    get creative_comments_path(@creative), params: { topic_id: history_topic.id }
+
+    assert_response :success
+    assert_select ".creative-history-item", count: 1
+    assert_select ".creative-history-revert", count: 0
+    assert_select ".creative-history-state", text: I18n.t("collavre.creative_history.irreversible")
+  end
+
+  test "History topic paginates beyond the newest twenty change sets" do
+    snapshot = Collavre::Creatives::History.snapshot(@creative)
+    sets = 21.times.map do |index|
+      change_set = Collavre::CreativeChangeSet.create!(
+        anchor_creative: @creative, anchor_source: "explicit", user: @user,
+        actor_kind: "human", origin: "editor", status: "applied", applied_at: Time.current
+      )
+      change_set.creative_changes.create!(
+        creative: @creative, operation: "update", before: snapshot,
+        after: snapshot.merge("description" => "Version #{index}"), position: 0
+      )
+      change_set
+    end
+    history_topic = @creative.reload.history_topic
+
+    get creative_comments_path(@creative), params: { topic_id: history_topic.id }
+    assert_response :success
+    assert_select ".creative-history-item", count: 20
+    oldest_visible_id = sets.second.id
+
+    get creative_comments_path(@creative), params: { topic_id: history_topic.id, before_id: oldest_visible_id }
+    assert_response :success
+    assert_select ".creative-history-item", count: 1
+    assert_select ".creative-history-list", count: 0
+    assert_select ".creative-history-item[data-change-set-id='#{sets.first.id}']", count: 1
+  end
+
   test "merge rejects comments from different topics" do
     first_topic = @creative.topics.create!(name: "First merge topic", user: @user)
     second_topic = @creative.topics.create!(name: "Second merge topic", user: @user)

--- a/engines/collavre/test/controllers/comments_controller_test.rb
+++ b/engines/collavre/test/controllers/comments_controller_test.rb
@@ -108,6 +108,42 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
     assert_select ".creative-history-item", count: 1
     assert_select ".creative-history-list", count: 0
     assert_select ".creative-history-item[data-change-set-id='#{sets.first.id}']", count: 1
+
+    get creative_comments_path(@creative), params: { topic_id: history_topic.id, after_id: sets.last.id }
+    assert_response :success
+    assert_select ".creative-history-item", count: 0
+  end
+
+  test "History pagination scans past an invisible page" do
+    snapshot = Collavre::Creatives::History.snapshot(@creative)
+    visible = Collavre::CreativeChangeSet.create!(
+      anchor_creative: @creative, anchor_source: "explicit", user: @user,
+      actor_kind: "human", origin: "editor", status: "applied", applied_at: Time.current
+    )
+    visible.creative_changes.create!(
+      creative: @creative, operation: "update", before: snapshot,
+      after: snapshot.merge("description" => "Visible history"), position: 0
+    )
+    foreign = Collavre::Creative.create!(description: "Foreign", user: users(:two))
+    foreign_snapshot = Collavre::Creatives::History.snapshot(foreign)
+    20.times do |index|
+      hidden = Collavre::CreativeChangeSet.create!(
+        anchor_creative: @creative, anchor_source: "explicit", user: users(:two),
+        actor_kind: "human", origin: "editor", status: "applied", applied_at: Time.current
+      )
+      hidden.creative_changes.create!(
+        creative: @creative, operation: "update", before: snapshot,
+        after: snapshot, position: 0
+      ).update_columns(creative_id: foreign.id, previous_parent_id: @creative.id)
+      hidden.update_column(:summary, "Hidden #{index}")
+    end
+    history_topic = @creative.reload.history_topic
+
+    get creative_comments_path(@creative), params: { topic_id: history_topic.id }
+
+    assert_response :success
+    assert_select ".creative-history-item", count: 1
+    assert_select ".creative-history-item[data-change-set-id='#{visible.id}']", count: 1
   end
 
   test "merge rejects comments from different topics" do

--- a/engines/collavre/test/controllers/creative_change_sets_controller_test.rb
+++ b/engines/collavre/test/controllers/creative_change_sets_controller_test.rb
@@ -64,6 +64,27 @@ module Collavre
       assert_equal [ @creative.id ], response.parsed_body["skipped"]
     end
 
+    test "a partial revert stays successful and retryable" do
+      foreign = Creative.create!(description: "Foreign after", user: users(:two))
+      perform_enqueued_jobs do
+        CreativeShare.create!(creative: foreign, user: @user, shared_by: users(:two), permission: :read)
+      end
+      @change_set.creative_changes.create!(
+        creative: foreign,
+        operation: "update",
+        before: Creatives::History.snapshot(foreign).merge("description" => "Foreign before"),
+        after: Creatives::History.snapshot(foreign),
+        position: 1
+      )
+
+      post creative_apply_change_set_path(@creative, @change_set), params: { mode: "revert" }, as: :json
+
+      assert_response :success
+      assert_equal "partial", response.parsed_body["status"]
+      assert_equal [ foreign.id ], response.parsed_body["skipped"]
+      assert_equal "applied", @change_set.reload.status
+    end
+
     test "restore makes the selected snapshot current without a conflict" do
       @creative.update!(progress: 0.9)
 
@@ -72,6 +93,29 @@ module Collavre
       assert_response :success
       assert_equal 0.75, @creative.reload.progress
       assert_equal "applied", @change_set.reload.status
+    end
+
+    test "revert resolves a change set through a linked Creative scope" do
+      linked = nil
+      creation = nil
+      Creatives::History.track(actor: @user, origin: :tool, anchor: @creative) do
+        linked = Creative.create!(user: @user, origin: @creative)
+        creation = Current.change_set
+      end
+
+      post creative_apply_change_set_path(linked, creation), params: { mode: "revert" }, as: :json
+
+      assert_response :success
+      assert linked.reload.archived?
+    end
+
+    test "rejects a foreign private linked placement even when its origin is readable" do
+      foreign_parent = Creative.create!(description: "Private", user: users(:two))
+      linked = Creative.create!(user: users(:two), parent: foreign_parent, origin: @creative)
+
+      post creative_apply_change_set_path(linked, @change_set), params: { mode: "revert" }, as: :json
+
+      assert_response :forbidden
     end
   end
 end

--- a/engines/collavre/test/controllers/creative_change_sets_controller_test.rb
+++ b/engines/collavre/test/controllers/creative_change_sets_controller_test.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  class CreativeChangeSetsControllerTest < ActionDispatch::IntegrationTest
+    setup do
+      @user = users(:one)
+      @creative = creatives(:tshirt)
+      @user.update!(email_verified_at: Time.current)
+      post session_path, params: { email: @user.email, password: "password" }
+      @before = Creatives::History.snapshot(@creative)
+      Creatives::History.track(actor: @user, origin: :tool, anchor: @creative, anchor_source: :explicit) do
+        @creative.update!(progress: 0.75)
+        @change_set = CreativeChangeSet.order(:id).last
+      end
+    end
+
+    test "revert creates an append-only reverse change set" do
+      assert_difference("CreativeChangeSet.count", 1) do
+        post creative_apply_change_set_path(@creative, @change_set), params: { mode: "revert" }, as: :json
+      end
+
+      assert_response :success
+      assert_equal "applied", response.parsed_body["status"]
+      assert_equal @before, Creatives::History.snapshot(@creative.reload)
+      assert_equal "reverted", @change_set.reload.status
+    end
+
+    test "revert returns conflict details after a later edit" do
+      Creatives::History.track(actor: @user, origin: :editor, anchor: @creative, anchor_source: :view_root) do
+        @creative.update!(progress: 0.9)
+      end
+
+      post creative_apply_change_set_path(@creative, @change_set), params: { mode: "revert" }, as: :json
+
+      assert_response :conflict
+      assert_equal "conflict", response.parsed_body["status"]
+      assert_equal @creative.id, response.parsed_body.dig("conflicts", 0, "creative_id")
+    end
+
+    test "revert ignores invalid conflict resolutions" do
+      @creative.update!(progress: 0.9)
+
+      post creative_apply_change_set_path(@creative, @change_set),
+           params: { mode: "revert", resolutions: { @creative.id => "invalid", bad: "force" } }, as: :json
+
+      assert_response :conflict
+      assert_equal "conflict", response.parsed_body["status"]
+    end
+
+    test "read-only users cannot force a revert" do
+      other = users(:two)
+      other.update!(email_verified_at: Time.current)
+      CreativeShare.create!(creative: @creative, user: other, shared_by: @user, permission: :read)
+      delete session_path
+      post session_path, params: { email: other.email, password: "password" }
+
+      post creative_apply_change_set_path(@creative, @change_set),
+           params: { mode: "revert", resolutions: { @creative.id => "force" } }, as: :json
+
+      assert_response :unprocessable_entity
+      assert_equal "skipped", response.parsed_body["status"]
+      assert_equal [ @creative.id ], response.parsed_body["skipped"]
+    end
+
+    test "restore makes the selected snapshot current without a conflict" do
+      @creative.update!(progress: 0.9)
+
+      post creative_apply_change_set_path(@creative, @change_set), params: { mode: "restore" }, as: :json
+
+      assert_response :success
+      assert_equal 0.75, @creative.reload.progress
+      assert_equal "applied", @change_set.reload.status
+    end
+  end
+end

--- a/engines/collavre/test/controllers/topics_controller_test.rb
+++ b/engines/collavre/test/controllers/topics_controller_test.rb
@@ -41,6 +41,31 @@ class TopicsControllerTest < ActionDispatch::IntegrationTest
     assert_operator history.position, :>, @topic.reload.position
   end
 
+  test "an existing ordinary History topic remains a normal conversation" do
+    legacy = @creative.topics.create!(name: "History", user: @user)
+    @creative.topics.create!(name: Collavre::Creative::HISTORY_TOPIC_INTERNAL_NAME, user: @user)
+    comment = @creative.comments.create!(topic: legacy, user: @user, content: "Existing history discussion")
+    history = @creative.history_topic
+
+    assert_not_equal legacy, history
+    assert legacy.reload.system_kind.nil?
+    assert history.history?
+    assert_equal "#{Collavre::Creative::HISTORY_TOPIC_INTERNAL_NAME}_2", history.name
+
+    get collavre.creative_topics_url(@creative), as: :json
+    topics = response.parsed_body["topics"].index_by { |topic| topic["id"] }
+    assert_not topics.fetch(legacy.id)["read_only"]
+    assert topics.fetch(history.id)["read_only"]
+
+    get collavre.creative_comments_url(@creative), params: { topic_id: legacy.id }
+    assert_response :success
+    assert_includes response.body, comment.content
+
+    patch collavre.creative_topic_url(@creative, legacy), params: { topic: { name: "History notes" } }, as: :json
+    assert_response :success
+    assert_equal "History notes", legacy.reload.name
+  end
+
   test "index returns the last topic revision" do
     preference = Collavre::UserCreativePreference.create!(
       creative: @creative,

--- a/engines/collavre/test/controllers/topics_controller_test.rb
+++ b/engines/collavre/test/controllers/topics_controller_test.rb
@@ -15,6 +15,32 @@ class TopicsControllerTest < ActionDispatch::IntegrationTest
     assert_equal @creative.id, json["effective_creative_id"]
   end
 
+  test "History topic is read-only, reserved, and kept last" do
+    history = @creative.history_topic
+    other = @creative.topics.create!(name: "Later", user: @user)
+    assert_equal history, @creative.topics.active.last
+
+    get collavre.creative_topics_url(@creative), as: :json
+    assert response.parsed_body["topics"].find { |topic| topic["id"] == history.id }["read_only"]
+
+    post collavre.creative_topics_url(@creative), params: { topic: { name: "History" } }, as: :json
+    assert_response :unprocessable_entity
+
+    patch collavre.creative_topic_url(@creative, history), params: { topic: { name: "Renamed" } }, as: :json
+    assert_response :unprocessable_entity
+    assert_equal "History", history.reload.name
+
+    delete collavre.creative_topic_url(@creative, history), as: :json
+    assert_response :unprocessable_entity
+    assert history.reload.persisted?
+
+    post collavre.reorder_creative_topics_url(@creative),
+         params: { topic_ids: [ history.id, other.id, @topic.id ] }, as: :json
+    assert_response :success
+    assert_operator history.reload.position, :>, other.reload.position
+    assert_operator history.position, :>, @topic.reload.position
+  end
+
   test "index returns the last topic revision" do
     preference = Collavre::UserCreativePreference.create!(
       creative: @creative,

--- a/engines/collavre/test/controllers/topics_controller_test.rb
+++ b/engines/collavre/test/controllers/topics_controller_test.rb
@@ -92,10 +92,13 @@ class TopicsControllerTest < ActionDispatch::IntegrationTest
 
   test "index returns effective_creative_id for linked creative (origin id)" do
     linked = Collavre::Creative.create!(user: @user, description: "linked wrapper", origin: @creative)
+    history = linked.history_topic
     get collavre.creative_topics_url(linked), as: :json
     assert_response :success
     json = JSON.parse(response.body)
     assert_equal @creative.id, json["effective_creative_id"]
+    assert_includes json["topics"].pluck("id"), history.id
+    assert_equal @creative, history.creative
   end
 
   # set_primary_agent is guarded by require_creative_write!, so the client needs a

--- a/engines/collavre/test/jobs/collavre/cron_action_job_test.rb
+++ b/engines/collavre/test/jobs/collavre/cron_action_job_test.rb
@@ -69,6 +69,19 @@ module Collavre
       end
     end
 
+    test "drops a persisted cron action targeting the read-only History topic" do
+      history = @creative.history_topic
+
+      assert_no_difference("Comment.count") do
+        CronActionJob.perform_now(
+          creative_id: @creative.id,
+          topic_id: history.id,
+          agent_id: @agent.id,
+          message: "Hidden scheduled message"
+        )
+      end
+    end
+
     test "drops an enqueued cron action whose topic moved" do
       destination = Creative.create!(description: "Cron destination", user: @user)
       Collavre::Topics::TopicMove.new(topic: @topic, target_creative: destination).call

--- a/engines/collavre/test/jobs/collavre/purge_unreferenced_blob_job_test.rb
+++ b/engines/collavre/test/jobs/collavre/purge_unreferenced_blob_job_test.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  class PurgeUnreferencedBlobJobTest < ActiveJob::TestCase
+    test "purges an unreferenced blob" do
+      blob = ActiveStorage::Blob.create_and_upload!(
+        io: StringIO.new("orphan"), filename: "orphan.txt", content_type: "text/plain"
+      )
+
+      PurgeUnreferencedBlobJob.perform_now(blob.id)
+
+      assert_not ActiveStorage::Blob.exists?(blob.id)
+    end
+
+    test "keeps blobs retained by history" do
+      user = users(:one)
+      creative = Creative.create!(description: "Current", user: user)
+      blob = ActiveStorage::Blob.create_and_upload!(
+        io: StringIO.new("history"), filename: "history.txt", content_type: "text/plain"
+      )
+      change_set = CreativeChangeSet.create!(
+        user: user, actor_kind: "human", origin: "editor", status: "applied", applied_at: Time.current
+      )
+      change = change_set.creative_changes.create!(
+        creative: creative, operation: "update", before: {}, after: {}, position: 0
+      )
+      change.history_file_attachments.create!(name: "history_files", blob: blob)
+
+      PurgeUnreferencedBlobJob.perform_now(blob.id)
+
+      assert ActiveStorage::Blob.exists?(blob.id)
+    end
+  end
+end

--- a/engines/collavre/test/services/collavre/creatives/change_set_diff_test.rb
+++ b/engines/collavre/test/services/collavre/creatives/change_set_diff_test.rb
@@ -28,7 +28,7 @@ module Collavre
       end
 
       test "renders changes under the observed anchor as one document diff" do
-        group = ChangeSetDiff.new(@change_set).groups.sole
+        group = ChangeSetDiff.new(@change_set, user: @user).groups.sole
 
         assert_equal @root.id, group.fetch(:root_id)
         assert_equal "Root", group.fetch(:label)
@@ -51,7 +51,7 @@ module Collavre
         )
 
         assert_equal [ @child.id, outside.id ].sort,
-                     ChangeSetDiff.new(@change_set).groups.pluck(:root_id).sort
+                     ChangeSetDiff.new(@change_set, user: @user).groups.pluck(:root_id).sort
       end
 
       test "treats a Creative moved to the tree root as outside the anchor" do
@@ -63,7 +63,7 @@ module Collavre
         )
         @child.update!(parent: nil)
 
-        group = ChangeSetDiff.new(@change_set).groups.sole
+        group = ChangeSetDiff.new(@change_set, user: @user).groups.sole
         assert_equal @child.id, group.fetch(:root_id)
         assert group.fetch(:moved)
       end
@@ -78,10 +78,41 @@ module Collavre
           position: 1
         )
 
-        group = ChangeSetDiff.new(@change_set).groups.sole
+        group = ChangeSetDiff.new(@change_set, user: @user).groups.sole
         assert_not_includes group.fetch(:before), "Created"
         assert_includes group.fetch(:after), "Created"
         assert group.fetch(:split_rows).any? { |row| row.fetch(:action) != "=" }
+      end
+
+      test "filters changes outside the viewer's permission boundary" do
+        foreign = Creative.create!(description: "Foreign secret", user: users(:two))
+        @change_set.creative_changes.create!(
+          creative: foreign,
+          operation: "update",
+          before: History.snapshot(foreign).merge("description" => "Earlier secret"),
+          after: History.snapshot(foreign),
+          position: 1
+        )
+
+        diff = ChangeSetDiff.new(@change_set, user: @user)
+        rendered = diff.groups.to_json
+
+        assert_not_includes rendered, "Foreign secret"
+        assert_not_includes rendered, "Earlier secret"
+        assert_equal 1, diff.change_count
+        assert_not diff.fully_visible?
+      end
+
+      test "keeps a destroyed descendant visible through its readable former parent" do
+        change = @change_set.creative_changes.sole
+        before = change.before.merge("parent_id" => @root.id, "description" => "Removed child")
+        change.update!(operation: "destroy", before: before, after: {}, previous_parent_id: @root.id)
+        @child.destroy!
+
+        group = ChangeSetDiff.new(@change_set, user: @user).groups.sole
+
+        assert_includes group.fetch(:before), "Removed child"
+        assert_not_includes group.fetch(:after), "Removed child"
       end
     end
   end

--- a/engines/collavre/test/services/collavre/creatives/change_set_diff_test.rb
+++ b/engines/collavre/test/services/collavre/creatives/change_set_diff_test.rb
@@ -114,6 +114,31 @@ module Collavre
         assert_includes group.fetch(:before), "Removed child"
         assert_not_includes group.fetch(:after), "Removed child"
       end
+
+      test "does not infer permission to a deleted snapshot from its former parent" do
+        reader = users(:two)
+        root_share = CreativeShare.create!(
+          creative: @root, user: reader, shared_by: @user, permission: :read
+        )
+        deny = CreativeShare.create!(
+          creative: @child, user: reader, shared_by: @user, permission: :no_access
+        )
+        PermissionCacheBuilder.propagate_share(root_share)
+        PermissionCacheBuilder.propagate_share(deny)
+        change = @change_set.creative_changes.sole
+        change.update!(
+          operation: "destroy",
+          before: change.before.merge("parent_id" => @root.id, "description" => "Removed secret"),
+          after: {},
+          previous_parent_id: @root.id
+        )
+        @child.destroy!
+
+        diff = ChangeSetDiff.new(@change_set, user: reader)
+
+        assert_empty diff.groups
+        assert_equal 0, diff.change_count
+      end
     end
   end
 end

--- a/engines/collavre/test/services/collavre/creatives/change_set_diff_test.rb
+++ b/engines/collavre/test/services/collavre/creatives/change_set_diff_test.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  module Creatives
+    class ChangeSetDiffTest < ActiveSupport::TestCase
+      setup do
+        @user = users(:one)
+        @root = Creative.create!(description: "Root", user: @user)
+        @child = Creative.create!(description: "<p>New &lt;value&gt;</p>", user: @user, parent: @root)
+        @change_set = CreativeChangeSet.create!(
+          anchor_creative: @root,
+          anchor_source: "view_root",
+          user: @user,
+          actor_kind: "human",
+          origin: "editor",
+          status: "applied",
+          applied_at: Time.current
+        )
+        @change_set.creative_changes.create!(
+          creative: @child,
+          operation: "update",
+          before: History.snapshot(@child).merge("description" => "<p>Old &lt;value&gt;</p>"),
+          after: History.snapshot(@child),
+          position: 0
+        )
+      end
+
+      test "renders changes under the observed anchor as one document diff" do
+        group = ChangeSetDiff.new(@change_set).groups.sole
+
+        assert_equal @root.id, group.fetch(:root_id)
+        assert_equal "Root", group.fetch(:label)
+        assert_includes group.fetch(:before), "Old &lt;value&gt;"
+        assert_includes group.fetch(:after), "New &lt;value&gt;"
+        assert_includes group.fetch(:inline_html), "<del>Old</del>"
+        assert_includes group.fetch(:inline_html), "&amp;lt;"
+        assert_equal 1, group.fetch(:additions)
+        assert_equal 1, group.fetch(:deletions)
+      end
+
+      test "renders touched roots outside the anchor as separate groups" do
+        outside = Creative.create!(description: "Outside", user: @user)
+        @change_set.creative_changes.create!(
+          creative: outside,
+          operation: "update",
+          before: History.snapshot(outside).merge("description" => "Before"),
+          after: History.snapshot(outside),
+          position: 1
+        )
+
+        assert_equal [ @child.id, outside.id ].sort,
+                     ChangeSetDiff.new(@change_set).groups.pluck(:root_id).sort
+      end
+
+      test "treats a Creative moved to the tree root as outside the anchor" do
+        change = @change_set.creative_changes.sole
+        change.update!(
+          operation: "move",
+          before: change.before.merge("parent_id" => @root.id),
+          after: change.after.merge("parent_id" => nil)
+        )
+        @child.update!(parent: nil)
+
+        group = ChangeSetDiff.new(@change_set).groups.sole
+        assert_equal @child.id, group.fetch(:root_id)
+        assert group.fetch(:moved)
+      end
+
+      test "reconstructs created and removed nodes from snapshots" do
+        created = Creative.create!(description: "Created", user: @user, parent: @root)
+        @change_set.creative_changes.create!(
+          creative: created,
+          operation: "create",
+          before: {},
+          after: History.snapshot(created),
+          position: 1
+        )
+
+        group = ChangeSetDiff.new(@change_set).groups.sole
+        assert_not_includes group.fetch(:before), "Created"
+        assert_includes group.fetch(:after), "Created"
+        assert group.fetch(:split_rows).any? { |row| row.fetch(:action) != "=" }
+      end
+    end
+  end
+end

--- a/engines/collavre/test/services/collavre/creatives/change_set_revert_service_test.rb
+++ b/engines/collavre/test/services/collavre/creatives/change_set_revert_service_test.rb
@@ -56,12 +56,73 @@ module Collavre
         assert_equal "Before", @child.reload.description
       end
 
-      test "skips Creatives without write permission" do
+      test "skips unreadable Creatives without exposing their ids" do
         result = ChangeSetRevertService.new(change_set: @change_set, user: users(:two)).call
 
         assert_equal :skipped, result.status
-        assert_equal [ @child.id ], result.skipped
+        assert_empty result.skipped
         assert_equal "After", @child.reload.description
+      end
+
+      test "does not move a Creative under a parent the user cannot write" do
+        foreign_parent = Creative.create!(description: "Private", user: users(:two))
+        change = @change_set.creative_changes.sole
+        change.update!(before: change.before.merge("parent_id" => foreign_parent.id))
+
+        result = ChangeSetRevertService.new(change_set: @change_set, user: @user).call
+
+        assert_equal :skipped, result.status
+        assert_equal [ @child.id ], result.skipped
+        assert_equal @root, @child.reload.parent
+      end
+
+      test "keeps a partial revert retryable and skips already reverted Creatives" do
+        foreign = Creative.create!(description: "Foreign after", user: users(:two))
+        perform_enqueued_jobs do
+          CreativeShare.create!(creative: foreign, user: @user, shared_by: users(:two), permission: :read)
+        end
+        @change_set.creative_changes.create!(
+          creative: foreign,
+          operation: "update",
+          before: History.snapshot(foreign).merge("description" => "Foreign before"),
+          after: History.snapshot(foreign),
+          position: 1
+        )
+
+        partial = ChangeSetRevertService.new(change_set: @change_set, user: @user).call
+        assert_equal :partial, partial.status
+        assert_equal [ foreign.id ], partial.skipped
+        assert_equal "Before", @child.reload.description
+        assert_equal "applied", @change_set.reload.status
+
+        perform_enqueued_jobs do
+          CreativeShare.find_by!(creative: foreign, user: @user).update!(permission: :write)
+        end
+        retried = ChangeSetRevertService.new(change_set: @change_set, user: @user).call
+
+        assert_equal :applied, retried.status
+        assert_equal "Foreign before", foreign.reload.description
+        assert_equal "Before", @child.reload.description
+        assert_equal "reverted", @change_set.reload.status
+        assert_equal [ foreign.id ], retried.change_set.creative_changes.pluck(:creative_id)
+      end
+
+      test "does not expose or mark unreadable changes as reverted" do
+        foreign = Creative.create!(description: "Foreign after", user: users(:two))
+        @change_set.creative_changes.create!(
+          creative: foreign,
+          operation: "update",
+          before: History.snapshot(foreign).merge("description" => "Foreign before"),
+          after: History.snapshot(foreign),
+          position: 1
+        )
+
+        result = ChangeSetRevertService.new(change_set: @change_set, user: @user).call
+
+        assert_equal :partial, result.status
+        assert_empty result.skipped
+        assert_equal "Foreign after", foreign.reload.description
+        assert_equal "applied", @change_set.reload.status
       end
 
       test "does not revert synchronized or already reverted sets" do
@@ -70,6 +131,15 @@ module Collavre
                      ChangeSetRevertService.new(change_set: @change_set, user: @user).call.status
 
         @change_set.update!(origin: "editor", status: "reverted")
+        assert_equal :not_revertible,
+                     ChangeSetRevertService.new(change_set: @change_set, user: @user).call.status
+      end
+
+      test "does not offer a lossy reconstruction for hard-deleted Creatives" do
+        change = @change_set.creative_changes.sole
+        change.update!(operation: "destroy", after: {})
+        @child.destroy!
+
         assert_equal :not_revertible,
                      ChangeSetRevertService.new(change_set: @change_set, user: @user).call.status
       end
@@ -113,7 +183,11 @@ module Collavre
         assert_equal :applied, result.status
         assert_equal "After", @child.reload.description
         assert_equal "applied", @change_set.reload.status
-        assert_equal @change_set, result.change_set.reverts
+        assert_nil result.change_set.reverts
+
+        reverted = ChangeSetRevertService.new(change_set: @change_set, user: @user).call
+        assert_equal :applied, reverted.status
+        assert_equal "Before", @child.reload.description
       end
 
       private

--- a/engines/collavre/test/services/collavre/creatives/change_set_revert_service_test.rb
+++ b/engines/collavre/test/services/collavre/creatives/change_set_revert_service_test.rb
@@ -76,6 +76,59 @@ module Collavre
         assert_equal @root, @child.reload.parent
       end
 
+      test "does not move a Creative under a read only parent" do
+        read_only_parent = Creative.create!(
+          description: "Synced",
+          user: @user,
+          data: { "source" => { "type" => "github_markdown" } }
+        )
+        change = @change_set.creative_changes.sole
+        change.update!(before: change.before.merge("parent_id" => read_only_parent.id))
+
+        result = ChangeSetRevertService.new(change_set: @change_set, user: @user).call
+
+        assert_equal :skipped, result.status
+        assert_equal [ @child.id ], result.skipped
+        assert_equal @root, @child.reload.parent
+      end
+
+      test "skips a Creative that became read only after the recorded edit" do
+        data = @child.data.deep_dup
+        data["source"] = { "type" => "github_markdown" }
+        @child.update_column(:data, data)
+
+        result = ChangeSetRevertService.new(change_set: @change_set, user: @user).call
+
+        assert_equal :skipped, result.status
+        assert_equal [ @child.id ], result.skipped
+        assert_equal "After", @child.reload.description
+      end
+
+      test "loads merged targets while holding the source lock" do
+        sibling = Creative.create!(description: "Sibling after", user: @user, parent: @root)
+        source = @change_set
+        lock_relation = Object.new
+        lock_relation.define_singleton_method(:find) do |id|
+          source.creative_changes.create!(
+            creative: sibling,
+            operation: "update",
+            before: History.snapshot(sibling).merge("description" => "Sibling before"),
+            after: History.snapshot(sibling),
+            position: 1
+          )
+          CreativeChangeSet.find(id)
+        end
+
+        result = CreativeChangeSet.stub(:lock, lock_relation) do
+          ChangeSetRevertService.new(change_set: @change_set, user: @user).call
+        end
+
+        assert_equal :applied, result.status
+        assert_equal "Before", @child.reload.description
+        assert_equal "Sibling before", sibling.reload.description
+        assert_equal "reverted", @change_set.reload.status
+      end
+
       test "keeps a partial revert retryable and skips already reverted Creatives" do
         foreign = Creative.create!(description: "Foreign after", user: users(:two))
         perform_enqueued_jobs do

--- a/engines/collavre/test/services/collavre/creatives/change_set_revert_service_test.rb
+++ b/engines/collavre/test/services/collavre/creatives/change_set_revert_service_test.rb
@@ -92,6 +92,24 @@ module Collavre
         assert_equal @root, @child.reload.parent
       end
 
+      test "does not restore a move that would create a hierarchy cycle" do
+        destination = Creative.create!(description: "Destination", user: @user)
+        moved = nil
+        History.track(actor: @user, origin: :editor, anchor: @root) do
+          @child.update!(parent: destination)
+          moved = Current.change_set
+        end
+        Current.reset
+        @root.update!(parent: @child)
+
+        result = ChangeSetRevertService.new(change_set: moved, user: @user).call
+
+        assert_equal :skipped, result.status
+        assert_equal [ @child.id ], result.skipped
+        assert_equal destination, @child.reload.parent
+        assert_equal @child, @root.reload.parent
+      end
+
       test "skips a Creative that became read only after the recorded edit" do
         data = @child.data.deep_dup
         data["source"] = { "type" => "github_markdown" }

--- a/engines/collavre/test/services/collavre/creatives/change_set_revert_service_test.rb
+++ b/engines/collavre/test/services/collavre/creatives/change_set_revert_service_test.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  module Creatives
+    class ChangeSetRevertServiceTest < ActiveSupport::TestCase
+      setup do
+        @user = users(:one)
+        @root = Creative.create!(description: "Root", user: @user)
+        @child = Creative.create!(description: "Before", user: @user, parent: @root)
+        @change_set = recorded_update
+        Current.reset
+      end
+
+      test "applies the inverse as a linked append-only change set" do
+        result = ChangeSetRevertService.new(change_set: @change_set, user: @user).call
+
+        assert_equal :applied, result.status
+        assert_equal "Before", @child.reload.description
+        assert_equal "reverted", @change_set.reload.status
+        assert_equal result.change_set, @change_set.reverted_by
+        assert_equal @change_set, result.change_set.reverts
+        assert_equal "revert", result.change_set.origin
+        assert_equal "After", result.change_set.creative_changes.sole.before.fetch("description")
+        assert_equal "Before", result.change_set.creative_changes.sole.after.fetch("description")
+      end
+
+      test "reports a conflict without changing the Creative" do
+        @child.update!(description: "Human follow-up")
+
+        result = ChangeSetRevertService.new(change_set: @change_set, user: @user).call
+
+        assert_equal :conflict, result.status
+        assert_equal [ @child.id ], result.conflicts.pluck(:creative_id)
+        assert_equal "Human follow-up", @child.reload.description
+        assert_equal "applied", @change_set.reload.status
+      end
+
+      test "supports force and skip resolutions per Creative" do
+        @child.update!(description: "Human follow-up")
+        skipped = ChangeSetRevertService.new(
+          change_set: @change_set,
+          user: @user,
+          resolutions: { @child.id => "skip" }
+        ).call
+        assert_equal :skipped, skipped.status
+        assert_equal [ @child.id ], skipped.skipped
+
+        forced = ChangeSetRevertService.new(
+          change_set: @change_set,
+          user: @user,
+          resolutions: { @child.id => "force" }
+        ).call
+        assert_equal :applied, forced.status
+        assert_equal "Before", @child.reload.description
+      end
+
+      test "skips Creatives without write permission" do
+        result = ChangeSetRevertService.new(change_set: @change_set, user: users(:two)).call
+
+        assert_equal :skipped, result.status
+        assert_equal [ @child.id ], result.skipped
+        assert_equal "After", @child.reload.description
+      end
+
+      test "does not revert synchronized or already reverted sets" do
+        @change_set.update!(origin: "sync")
+        assert_equal :not_revertible,
+                     ChangeSetRevertService.new(change_set: @change_set, user: @user).call.status
+
+        @change_set.update!(origin: "editor", status: "reverted")
+        assert_equal :not_revertible,
+                     ChangeSetRevertService.new(change_set: @change_set, user: @user).call.status
+      end
+
+      test "archives a Creative when reverting its creation" do
+        created = nil
+        creation = nil
+        History.track(actor: @user, origin: :tool, anchor: @root) do
+          created = Creative.create!(description: "Created", user: @user, parent: @root)
+          creation = Current.change_set
+        end
+        Current.reset
+
+        result = ChangeSetRevertService.new(change_set: creation, user: @user).call
+
+        assert_equal :applied, result.status
+        assert created.reload.archived?
+      end
+
+      test "reverting creation of a linked shell does not archive its existing origin" do
+        linked = nil
+        creation = nil
+        History.track(actor: @user, origin: :tool, anchor: @root) do
+          linked = Creative.create!(user: @user, origin: @child)
+          creation = Current.change_set
+        end
+        Current.reset
+
+        result = ChangeSetRevertService.new(change_set: creation, user: @user).call
+
+        assert_equal :applied, result.status
+        assert linked.reload.archived?
+        assert_not @child.reload.archived?
+      end
+
+      test "restores a selected version without marking its source reverted" do
+        @child.update!(description: "Newest")
+
+        result = ChangeSetRestoreService.new(change_set: @change_set, user: @user).call
+
+        assert_equal :applied, result.status
+        assert_equal "After", @child.reload.description
+        assert_equal "applied", @change_set.reload.status
+        assert_equal @change_set, result.change_set.reverts
+      end
+
+      private
+
+      def recorded_update
+        change_set = nil
+        History.track(actor: @user, origin: :editor, anchor: @root, anchor_source: :view_root) do
+          @child.update!(description: "After")
+          change_set = Current.change_set
+        end
+        change_set
+      end
+    end
+  end
+end

--- a/engines/collavre/test/services/collavre/creatives/change_set_revert_service_test.rb
+++ b/engines/collavre/test/services/collavre/creatives/change_set_revert_service_test.rb
@@ -109,6 +109,7 @@ module Collavre
 
       test "does not expose or mark unreadable changes as reverted" do
         foreign = Creative.create!(description: "Foreign after", user: users(:two))
+        @change_set.update!(summary: "Foreign secret summary")
         @change_set.creative_changes.create!(
           creative: foreign,
           operation: "update",
@@ -123,6 +124,7 @@ module Collavre
         assert_empty result.skipped
         assert_equal "Foreign after", foreign.reload.description
         assert_equal "applied", @change_set.reload.status
+        assert_nil result.change_set.summary
       end
 
       test "does not revert synchronized or already reverted sets" do

--- a/engines/collavre/test/services/collavre/creatives/history_test.rb
+++ b/engines/collavre/test/services/collavre/creatives/history_test.rb
@@ -5,6 +5,7 @@ require "test_helper"
 module Collavre
   module Creatives
     class HistoryTest < ActiveSupport::TestCase
+      include ActiveJob::TestHelper
       include ActiveSupport::Testing::TimeHelpers
 
       setup do
@@ -187,6 +188,40 @@ module Collavre
         assert_equal "destroy", change.operation
         assert_equal "Child", change.before.fetch("description")
         assert_equal({}, change.after)
+      end
+
+      test "retains blobs referenced by a historical snapshot" do
+        blob = ActiveStorage::Blob.create_and_upload!(
+          io: StringIO.new("historical file"),
+          filename: "history.txt",
+          content_type: "text/plain"
+        )
+        path = Rails.application.routes.url_helpers.rails_blob_path(blob, only_path: true)
+        @child.update!(description: %(<a href="#{path}">History file</a>))
+        CreativeChangeSet.delete_all
+
+        perform_enqueued_jobs do
+          History.track(actor: @user, origin: :editor, anchor: @root) do
+            @child.update!(description: "Removed attachment")
+          end
+        end
+
+        change = CreativeChange.sole
+        assert ActiveStorage::Blob.exists?(blob.id)
+        assert_equal [ blob.id ], change.history_file_attachments.pluck(:blob_id)
+
+        result = ChangeSetRevertService.new(change_set: change.change_set, user: @user).call
+        assert_equal :applied, result.status
+        assert_includes @child.reload.description, blob.signed_id
+        assert_includes @child.files.blobs, blob
+      end
+
+      test "ignores invalid signed blob references in snapshots" do
+        History.track(actor: @user, origin: :editor, anchor: @root) do
+          @child.update!(description: '<a href="/public-assets/blobs/invalid/file.txt">Invalid</a>')
+        end
+
+        assert_empty CreativeChange.sole.history_file_attachments
       end
 
       test "keeps bulk snapshots and writes in one transaction" do

--- a/engines/collavre/test/services/collavre/creatives/history_test.rb
+++ b/engines/collavre/test/services/collavre/creatives/history_test.rb
@@ -216,6 +216,28 @@ module Collavre
         assert_includes @child.files.blobs, blob
       end
 
+      test "rechecks blobs dropped from merged snapshot retention after commit" do
+        first_blob = create_blob("first.txt")
+        second_blob = create_blob("second.txt")
+        callbacks = []
+        capture_callback = ->(&callback) { callbacks << callback }
+
+        ActiveRecord.stub(:after_all_transactions_commit, capture_callback) do
+          History.track(actor: @user, origin: :editor, anchor: @root) do
+            @child.update!(description: blob_link(first_blob))
+            @child.update!(description: blob_link(second_blob))
+          end
+        end
+
+        assert_equal [ second_blob.id ], CreativeChange.sole.history_file_attachments.pluck(:blob_id)
+        assert_equal 1, callbacks.size
+        scheduled_blob_ids = []
+        PurgeUnreferencedBlobJob.stub(:perform_later, ->(blob_id) { scheduled_blob_ids << blob_id }) do
+          callbacks.sole.call
+        end
+        assert_equal [ first_blob.id ], scheduled_blob_ids
+      end
+
       test "ignores invalid signed blob references in snapshots" do
         History.track(actor: @user, origin: :editor, anchor: @root) do
           @child.update!(description: '<a href="/public-assets/blobs/invalid/file.txt">Invalid</a>')
@@ -450,6 +472,17 @@ module Collavre
       end
 
       private
+
+      def create_blob(filename)
+        ActiveStorage::Blob.create_and_upload!(
+          io: StringIO.new(filename), filename: filename, content_type: "text/plain"
+        )
+      end
+
+      def blob_link(blob)
+        path = Rails.application.routes.url_helpers.rails_blob_path(blob, only_path: true)
+        %(<a href="#{path}">#{blob.filename}</a>)
+      end
 
       def track_editor_change(token, &block)
         History.track(

--- a/engines/collavre/test/services/collavre/creatives/history_test.rb
+++ b/engines/collavre/test/services/collavre/creatives/history_test.rb
@@ -189,6 +189,44 @@ module Collavre
         assert_equal({}, change.after)
       end
 
+      test "keeps bulk snapshots and writes in one transaction" do
+        History.track(actor: @user, origin: :editor, anchor: @root) do
+          History.record_bulk([ @child ], operation: "reorder") do
+            assert Creative.connection.transaction_open?
+            @child.update_column(:sequence, 7)
+            raise ActiveRecord::Rollback
+          end
+        end
+
+        assert_not_equal 7, @child.reload.sequence
+        assert_empty CreativeChangeSet.all
+      end
+
+      test "retains the former parent when an existing change becomes a destroy" do
+        History.track(actor: @user, origin: :editor, anchor: @root) do
+          @child.update!(description: "Updated before deletion")
+          @child.destroy!
+        end
+
+        change = CreativeChange.sole
+        assert_equal "destroy", change.operation
+        assert_equal @root.id, change.previous_parent_id
+        assert_equal [ change.change_set ], CreativeChangeSet.for_creative_scope(@root).to_a
+      end
+
+      test "retains the former parent when a Creative moves to another tree" do
+        destination = Creative.create!(description: "Destination", user: @user)
+
+        History.track(actor: @user, origin: :editor, anchor: @root) do
+          @child.update!(parent: destination)
+        end
+
+        change = CreativeChange.find_by!(creative_id: @child.id)
+        assert_equal "move", change.operation
+        assert_equal @root.id, change.previous_parent_id
+        assert_includes CreativeChangeSet.for_creative_scope(@root), change.change_set
+      end
+
       test "does not create a History topic when the deleted Creative was its own anchor" do
         root = Creative.create!(description: "Deleted root", user: @user)
 

--- a/engines/collavre/test/services/collavre/creatives/history_test.rb
+++ b/engines/collavre/test/services/collavre/creatives/history_test.rb
@@ -238,6 +238,27 @@ module Collavre
         assert_equal [ first_blob.id ], scheduled_blob_ids
       end
 
+      test "rechecks retained blobs when a merged change returns to its initial state" do
+        blob = create_blob("cancelled.txt")
+        callbacks = []
+        capture_callback = ->(&callback) { callbacks << callback }
+
+        ActiveRecord.stub(:after_all_transactions_commit, capture_callback) do
+          History.track(actor: @user, origin: :editor, anchor: @root) do
+            @child.update!(description: blob_link(blob))
+            @child.update!(description: "Child")
+          end
+        end
+
+        assert_empty CreativeChangeSet.all
+        assert_equal 1, callbacks.size
+        scheduled_blob_ids = []
+        PurgeUnreferencedBlobJob.stub(:perform_later, ->(blob_id) { scheduled_blob_ids << blob_id }) do
+          callbacks.sole.call
+        end
+        assert_equal [ blob.id ], scheduled_blob_ids
+      end
+
       test "ignores invalid signed blob references in snapshots" do
         History.track(actor: @user, origin: :editor, anchor: @root) do
           @child.update!(description: '<a href="/public-assets/blobs/invalid/file.txt">Invalid</a>')

--- a/engines/collavre/test/services/collavre/creatives/history_test.rb
+++ b/engines/collavre/test/services/collavre/creatives/history_test.rb
@@ -189,6 +189,14 @@ module Collavre
         assert_equal({}, change.after)
       end
 
+      test "does not create a History topic when the deleted Creative was its own anchor" do
+        root = Creative.create!(description: "Deleted root", user: @user)
+
+        History.track(actor: @user, origin: :editor, anchor: root) { root.destroy! }
+
+        assert_nil Topic.find_by(creative_id: root.id, name: Creative::HISTORY_TOPIC_NAME)
+      end
+
       test "discards a change that returns to its initial state" do
         History.track(actor: @user, origin: :editor, anchor: @root) do
           @child.update!(description: "Temporary")

--- a/engines/collavre/test/services/collavre/tools/creative_remove_attachment_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/creative_remove_attachment_service_test.rb
@@ -17,12 +17,14 @@ module Collavre
       teardown { Current.user = nil }
 
       test "removes the attachment by signed_id" do
+        blob_id = @attachment.blob_id
         result = CreativeRemoveAttachmentService.new.call(
           creative_id: @creative.id,
           signed_id: @signed_id
         )
         assert result[:success]
         assert_equal 0, @creative.reload.files.count
+        assert_not ActiveStorage::Blob.exists?(blob_id)
       end
 
       test "strips the embedded node from the description and detaches" do

--- a/engines/collavre/test/services/collavre/tools/cron_create_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/cron_create_service_test.rb
@@ -127,6 +127,37 @@ module Collavre
         assert_match(/Topic 'Nonexistent Topic' not found/, result[:error])
       end
 
+      test "rejects the read-only History topic" do
+        history = @creative.history_topic
+
+        result = CronCreateService.new.call(
+          creative_id: @creative.id,
+          topic_name: history.name,
+          schedule: "0 9 * * *",
+          message: "Hidden history message"
+        )
+
+        assert_equal I18n.t("collavre.creative_history.read_only"), result[:error]
+        assert_empty SolidQueue::RecurringTask.where(static: false)
+      end
+
+      test "rechecks History status while creating the recurring task" do
+        history = @creative.history_topic
+        service = CronCreateService.new
+
+        result = service.stub(:resolve_topic, history) do
+          service.call(
+            creative_id: @creative.id,
+            topic_name: history.name,
+            schedule: "0 9 * * *",
+            message: "Racing history message"
+          )
+        end
+
+        assert_equal I18n.t("collavre.creative_history.read_only"), result[:error]
+        assert_empty SolidQueue::RecurringTask.where(static: false)
+      end
+
       test "generates unique keys" do
         result1 = CronCreateService.new.call(
           creative_id: @creative.id,

--- a/engines/collavre/test/services/collavre/tools/topic_message_create_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/topic_message_create_service_test.rb
@@ -27,6 +27,17 @@ module Collavre
         assert_not comment.private?
       end
 
+      test "rejects messages in the read-only History topic" do
+        history = @creative.history_topic
+
+        error = assert_raises(ArgumentError) do
+          service.call(topic_id: history.id, content: "Rewrite the audit trail")
+        end
+
+        assert_equal I18n.t("collavre.tools.topic_message_create.errors.history_topic"), error.message
+        assert_not Comment.exists?(topic: history)
+      end
+
       test "uses normal comment dispatch exactly once for a human author" do
         events = []
 

--- a/engines/collavre/test/services/collavre/tools/topic_move_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/topic_move_service_test.rb
@@ -229,6 +229,22 @@ module Collavre
         assert_equal @source.id, ordinary_system.reload.creative_id
       end
 
+      test "protects the system History topic while an ordinary History topic remains movable" do
+        ordinary = @source.topics.create!(name: Creative::HISTORY_TOPIC_NAME, user: @owner)
+        history = @source.history_topic
+
+        error = assert_raises(ArgumentError) do
+          TopicMoveService.new.call(topic_id: history.id, creative_id: @target.id)
+        end
+        assert_equal I18n.t("collavre.tools.topic_move.errors.reserved_topic"), error.message
+
+        result = TopicMoveService.new.call(topic_id: ordinary.id, creative_id: @target.id)
+
+        assert_equal @target.id, result[:creative_id]
+        assert_equal @target.id, ordinary.reload.creative_id
+        assert_equal @source.id, history.reload.creative_id
+      end
+
       test "rejects a live agent session topic" do
         @topic.update!(session_id: "session-1")
 

--- a/engines/collavre/test/services/collavre/tools/topic_update_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/topic_update_service_test.rb
@@ -106,6 +106,22 @@ module Collavre
         assert system_named.archived?
       end
 
+      test "protects the system History topic while an ordinary History topic remains mutable" do
+        ordinary = @creative.topics.create!(name: Creative::HISTORY_TOPIC_NAME, user: @user)
+        history = @creative.history_topic
+
+        assert_raises(ArgumentError) do
+          TopicUpdateService.new.call(topic_id: history.id, archived: true)
+        end
+
+        result = TopicUpdateService.new.call(topic_id: ordinary.id, name: "Project history", archived: true)
+
+        assert_equal %w[name archived], result[:changed]
+        assert_equal "Project history", ordinary.reload.name
+        assert ordinary.archived?
+        assert_not history.reload.archived?
+      end
+
       test "an archived topic keeps its messages and stays readable" do
         Comment.create!(creative: @creative, topic: @topic, user: @user, content: "kept",
                         skip_default_user: true, skip_dispatch: true)

--- a/engines/collavre/test/services/collavre/topics/serializer_test.rb
+++ b/engines/collavre/test/services/collavre/topics/serializer_test.rb
@@ -86,6 +86,18 @@ module Collavre
         assert_equal({ id: @agent.id, name: "Pinned" }, Serializer.for_tool(@topic)[:primary_agent])
       end
 
+      test "History payloads expose the localized display contract instead of an internal collision name" do
+        @creative.topics.create!(name: Creative::HISTORY_TOPIC_NAME, user: @user)
+        history = @creative.history_topic
+
+        assert_equal Creative::HISTORY_TOPIC_INTERNAL_NAME, history.name
+        assert Serializer.call(history)[:read_only]
+        assert_equal I18n.t("collavre.topics.history_name"), Serializer.call(history)[:display_name]
+        assert Serializer.with_agent(history, nil)[:read_only]
+        assert_equal Creative::HISTORY_TOPIC_NAME, Serializer.for_tool(history)[:name]
+        assert Serializer.for_tool(history)[:read_only]
+      end
+
       test "the tool payload flags System only on an inbox creative" do
         ordinary_system = @creative.topics.create!(name: Creative::SYSTEM_TOPIC_NAME, user: @user)
         inbox = Creative.create!(description: "Inbox", user: @user, data: { "kind" => "inbox" })

--- a/engines/collavre/test/services/comment_move_service_test.rb
+++ b/engines/collavre/test/services/comment_move_service_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 module Collavre
   class CommentMoveServiceTest < ActiveSupport::TestCase
-    setup do
+  setup do
       @user = users(:one)
       @creative = creatives(:tshirt)
       Current.user = @user
@@ -170,6 +170,21 @@ module Collavre
       assert_equal source_topic.id, comment.topic_id
       assert_equal destination_creative.id, source_topic.reload.creative_id
       assert_equal @creative.id, target_topic.reload.creative_id
+    end
+
+    test "rejects moving comments into the read-only History topic" do
+      comment = @creative.comments.create!(content: "keep", user: @user)
+      original_topic_id = comment.topic_id
+      history = @creative.history_topic
+
+      error = assert_raises(CommentMoveService::MoveError) do
+        CommentMoveService.new(creative: @creative, user: @user).call(
+          comment_ids: [ comment.id ], target_topic_id: history.id
+        )
+      end
+
+      assert_equal I18n.t("collavre.creative_history.read_only"), error.message
+      assert_equal original_topic_id, comment.reload.topic_id
     end
   end
 end


### PR DESCRIPTION
## Summary
- add a dedicated read-only History topic with lazy creation and scoped change-set listings
- render anchor-aware inline or split Markdown diffs, including multi-root and move presentation
- add append-only revert and restore flows with conflict choices and permission-aware partial application
- protect the reserved History topic and keep it last in topic ordering

## Validation
- 198 focused Ruby tests, 825 assertions
- 13 focused JavaScript tests
- 8 related system tests, 71 assertions
- RuboCop for changed Ruby files
- bin/complexity_check