### PR TITLE
feat: archive AI deletes with undo notice

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -2301,3 +2301,38 @@ li:hover .topic-create-option {
     background: var(--surface-hover);
     color: var(--text-primary);
 }
+
+.creative-history-toast-container {
+    position: fixed;
+    right: 20px;
+    bottom: 20px;
+    z-index: 1200;
+    display: grid;
+    gap: 8px;
+}
+
+.creative-history-undo-toast {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    max-width: min(420px, calc(100vw - 40px));
+    padding: 12px 14px;
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-3);
+    background: var(--surface-raised);
+    box-shadow: var(--shadow-lg);
+    color: var(--text-primary);
+}
+
+.creative-history-undo-toast .creative-history-revert {
+    margin-top: 0;
+    white-space: nowrap;
+}
+
+.creative-history-undo-dismiss {
+    border: 0;
+    background: transparent;
+    color: var(--text-muted);
+    cursor: pointer;
+    font-size: 1.2rem;
+}

--- a/engines/collavre/app/javascript/controllers/__tests__/creative_history_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/creative_history_controller.test.js
@@ -78,11 +78,17 @@ describe('CreativeHistoryController', () => {
   test('applies a toast undo immediately when confirmation is omitted', async () => {
     delete button.dataset.confirm
     csrfFetch.mockResolvedValue({ ok: true, status: 200, json: async () => ({ status: 'applied' }) })
+    const legacyRefresh = jest.fn()
+    const workspaceRefresh = jest.fn()
+    document.addEventListener('creative-sync:refetch', legacyRefresh, { once: true })
+    document.addEventListener('workspace-tree:invalidate', workspaceRefresh, { once: true })
 
     await controller.revert({ currentTarget: button })
 
     expect(confirmDialog).not.toHaveBeenCalled()
     expect(csrfFetch).toHaveBeenCalled()
+    expect(legacyRefresh).toHaveBeenCalled()
+    expect(workspaceRefresh).toHaveBeenCalled()
   })
 
   test('shows an error and re-enables the button when the request fails', async () => {

--- a/engines/collavre/app/javascript/controllers/__tests__/creative_history_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/creative_history_controller.test.js
@@ -75,6 +75,16 @@ describe('CreativeHistoryController', () => {
     expect(button.disabled).toBe(false)
   })
 
+  test('applies a toast undo immediately when confirmation is omitted', async () => {
+    delete button.dataset.confirm
+    csrfFetch.mockResolvedValue({ ok: true, status: 200, json: async () => ({ status: 'applied' }) })
+
+    await controller.revert({ currentTarget: button })
+
+    expect(confirmDialog).not.toHaveBeenCalled()
+    expect(csrfFetch).toHaveBeenCalled()
+  })
+
   test('shows an error and re-enables the button when the request fails', async () => {
     confirmDialog.mockResolvedValue(true)
     csrfFetch.mockResolvedValue({ ok: false, status: 422, json: async () => ({ message: 'Not allowed' }) })

--- a/engines/collavre/app/javascript/controllers/__tests__/creative_history_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/creative_history_controller.test.js
@@ -52,6 +52,8 @@ describe('CreativeHistoryController', () => {
       .mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ status: 'applied' }) })
     const reload = jest.fn()
     jest.spyOn(controller, 'listController', 'get').mockReturnValue({ loadInitialComments: reload })
+    const applied = jest.fn()
+    controller.element.addEventListener('creative-history:applied', applied)
 
     await controller.revert({ currentTarget: button })
 
@@ -60,6 +62,7 @@ describe('CreativeHistoryController', () => {
       12: 'skip',
     })
     expect(reload).toHaveBeenCalled()
+    expect(applied).toHaveBeenCalled()
     expect(alertDialog).not.toHaveBeenCalled()
   })
 

--- a/engines/collavre/app/javascript/controllers/__tests__/creative_history_undo_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/creative_history_undo_controller.test.js
@@ -8,12 +8,15 @@ import CreativeHistoryUndoController from '../creative_history_undo_controller'
 
 describe('CreativeHistoryUndoController', () => {
   let application
-  let treeRefresh
+  let legacyTreeRefresh
+  let workspaceTreeRefresh
 
   beforeEach(async () => {
     jest.useFakeTimers()
-    treeRefresh = jest.fn()
-    window.addEventListener('collavre:creative-drop-complete', treeRefresh)
+    legacyTreeRefresh = jest.fn()
+    workspaceTreeRefresh = jest.fn()
+    document.addEventListener('creative-sync:refetch', legacyTreeRefresh)
+    document.addEventListener('workspace-tree:invalidate', workspaceTreeRefresh)
     document.body.innerHTML = `
       <aside data-controller="creative-history-undo"
              data-creative-history-undo-timeout-value="30000">
@@ -26,13 +29,15 @@ describe('CreativeHistoryUndoController', () => {
 
   afterEach(() => {
     application.stop()
-    window.removeEventListener('collavre:creative-drop-complete', treeRefresh)
+    document.removeEventListener('creative-sync:refetch', legacyTreeRefresh)
+    document.removeEventListener('workspace-tree:invalidate', workspaceTreeRefresh)
     jest.useRealTimers()
     document.body.innerHTML = ''
   })
 
   test('dismisses itself after thirty seconds', () => {
-    expect(treeRefresh).toHaveBeenCalledTimes(1)
+    expect(legacyTreeRefresh).toHaveBeenCalledTimes(1)
+    expect(workspaceTreeRefresh).toHaveBeenCalledTimes(1)
     jest.advanceTimersByTime(30000)
 
     expect(document.querySelector('aside')).toBeNull()

--- a/engines/collavre/app/javascript/controllers/__tests__/creative_history_undo_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/creative_history_undo_controller.test.js
@@ -1,0 +1,50 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { jest } from '@jest/globals'
+import { Application } from '@hotwired/stimulus'
+import CreativeHistoryUndoController from '../creative_history_undo_controller'
+
+describe('CreativeHistoryUndoController', () => {
+  let application
+  let treeRefresh
+
+  beforeEach(async () => {
+    jest.useFakeTimers()
+    treeRefresh = jest.fn()
+    window.addEventListener('collavre:creative-drop-complete', treeRefresh)
+    document.body.innerHTML = `
+      <aside data-controller="creative-history-undo"
+             data-creative-history-undo-timeout-value="30000">
+        <button data-action="creative-history-undo#dismiss">Dismiss</button>
+      </aside>`
+    application = Application.start()
+    application.register('creative-history-undo', CreativeHistoryUndoController)
+    await Promise.resolve()
+  })
+
+  afterEach(() => {
+    application.stop()
+    window.removeEventListener('collavre:creative-drop-complete', treeRefresh)
+    jest.useRealTimers()
+    document.body.innerHTML = ''
+  })
+
+  test('dismisses itself after thirty seconds', () => {
+    expect(treeRefresh).toHaveBeenCalledTimes(1)
+    jest.advanceTimersByTime(30000)
+
+    expect(document.querySelector('aside')).toBeNull()
+  })
+
+  test('dismisses immediately and clears its timer', async () => {
+    const clearTimeout = jest.spyOn(window, 'clearTimeout')
+
+    document.querySelector('button').click()
+    await Promise.resolve()
+
+    expect(document.querySelector('aside')).toBeNull()
+    expect(clearTimeout).toHaveBeenCalled()
+  })
+})

--- a/engines/collavre/app/javascript/controllers/creative_history_controller.js
+++ b/engines/collavre/app/javascript/controllers/creative_history_controller.js
@@ -18,6 +18,7 @@ export default class extends Controller {
       if (!response.ok) throw new Error(body.message)
       if (body.status === 'partial') await alertDialog(body.message)
 
+      this.dispatch('applied', { detail: body })
       this.listController?.loadInitialComments()
       window.dispatchEvent(new CustomEvent('collavre:creative-drop-complete'))
     } catch (error) {

--- a/engines/collavre/app/javascript/controllers/creative_history_controller.js
+++ b/engines/collavre/app/javascript/controllers/creative_history_controller.js
@@ -5,7 +5,7 @@ import { alertDialog, confirmDialog } from '../lib/utils/dialog'
 export default class extends Controller {
   async revert(event) {
     const button = event.currentTarget
-    if (!await confirmDialog(button.dataset.confirm, { danger: true })) return
+    if (button.dataset.confirm && !await confirmDialog(button.dataset.confirm, { danger: true })) return
 
     button.disabled = true
     try {

--- a/engines/collavre/app/javascript/controllers/creative_history_controller.js
+++ b/engines/collavre/app/javascript/controllers/creative_history_controller.js
@@ -1,6 +1,7 @@
 import { Controller } from '@hotwired/stimulus'
 import csrfFetch from '../lib/api/csrf_fetch'
 import { alertDialog, confirmDialog } from '../lib/utils/dialog'
+import { invalidateCreativeTree } from '../lib/creative_tree_invalidation'
 
 export default class extends Controller {
   async revert(event) {
@@ -20,7 +21,7 @@ export default class extends Controller {
 
       this.dispatch('applied', { detail: body })
       this.listController?.loadInitialComments()
-      window.dispatchEvent(new CustomEvent('collavre:creative-drop-complete'))
+      invalidateCreativeTree()
     } catch (error) {
       await alertDialog(error.message)
       button.disabled = false

--- a/engines/collavre/app/javascript/controllers/creative_history_undo_controller.js
+++ b/engines/collavre/app/javascript/controllers/creative_history_undo_controller.js
@@ -1,10 +1,11 @@
 import { Controller } from '@hotwired/stimulus'
+import { invalidateCreativeTree } from '../lib/creative_tree_invalidation'
 
 export default class extends Controller {
   static values = { timeout: { type: Number, default: 30000 } }
 
   connect() {
-    window.dispatchEvent(new CustomEvent('collavre:creative-drop-complete'))
+    invalidateCreativeTree()
     this.timer = window.setTimeout(() => this.dismiss(), this.timeoutValue)
   }
 

--- a/engines/collavre/app/javascript/controllers/creative_history_undo_controller.js
+++ b/engines/collavre/app/javascript/controllers/creative_history_undo_controller.js
@@ -1,0 +1,18 @@
+import { Controller } from '@hotwired/stimulus'
+
+export default class extends Controller {
+  static values = { timeout: { type: Number, default: 30000 } }
+
+  connect() {
+    window.dispatchEvent(new CustomEvent('collavre:creative-drop-complete'))
+    this.timer = window.setTimeout(() => this.dismiss(), this.timeoutValue)
+  }
+
+  disconnect() {
+    window.clearTimeout(this.timer)
+  }
+
+  dismiss() {
+    this.element.remove()
+  }
+}

--- a/engines/collavre/app/javascript/controllers/index.js
+++ b/engines/collavre/app/javascript/controllers/index.js
@@ -47,6 +47,7 @@ import AgentConnectionController from "./agent_connection_controller"
 import AgentVendorController from "./agent_vendor_controller"
 import DesktopProxySetupController from "./desktop_proxy_setup_controller"
 import CreativeHistoryController from "./creative_history_controller"
+import CreativeHistoryUndoController from "./creative_history_undo_controller"
 
 // Export all controllers
 export {
@@ -92,7 +93,8 @@ export {
   AgentConnectionController,
   AgentVendorController,
   DesktopProxySetupController,
-  CreativeHistoryController
+  CreativeHistoryController,
+  CreativeHistoryUndoController
 }
 
 // Registration function for use with a Stimulus application
@@ -144,4 +146,5 @@ export function registerControllers(application) {
   application.register("agent-vendor", AgentVendorController)
   application.register("desktop-proxy-setup", DesktopProxySetupController)
   application.register("creative-history", CreativeHistoryController)
+  application.register("creative-history-undo", CreativeHistoryUndoController)
 }

--- a/engines/collavre/app/javascript/lib/__tests__/turbo_stream_actions.test.js
+++ b/engines/collavre/app/javascript/lib/__tests__/turbo_stream_actions.test.js
@@ -46,6 +46,18 @@ function dispatchCreativeTreeStream(payload) {
   })
 }
 
+test('generic tree invalidation refreshes both tree implementations', () => {
+  const legacyRefresh = jest.fn()
+  const workspaceRefresh = jest.fn()
+  document.addEventListener('creative-sync:refetch', legacyRefresh, { once: true })
+  document.addEventListener('workspace-tree:invalidate', workspaceRefresh, { once: true })
+
+  fakeTurbo.StreamActions.invalidate_creative_tree.call({})
+
+  expect(legacyRefresh).toHaveBeenCalled()
+  expect(workspaceRefresh).toHaveBeenCalled()
+})
+
 afterEach(() => {
   document.body.innerHTML = ''
   jest.restoreAllMocks()

--- a/engines/collavre/app/javascript/lib/creative_tree_invalidation.js
+++ b/engines/collavre/app/javascript/lib/creative_tree_invalidation.js
@@ -1,0 +1,4 @@
+export function invalidateCreativeTree() {
+  document.dispatchEvent(new CustomEvent('creative-sync:refetch'))
+  document.dispatchEvent(new CustomEvent('workspace-tree:invalidate'))
+}

--- a/engines/collavre/app/javascript/lib/turbo_stream_actions.js
+++ b/engines/collavre/app/javascript/lib/turbo_stream_actions.js
@@ -1,6 +1,7 @@
 import { Turbo } from "@hotwired/turbo-rails"
 import { createRow, applyRowProperties, replaceProgressControl, updateProgressHtml } from "../creatives/tree_renderer"
 import { hideTreeEmptyState, restoreTreeEmptyState } from "../modules/creative_tree_empty_state"
+import { invalidateCreativeTree } from "./creative_tree_invalidation"
 
 // Register custom actions on both the imported Turbo and the global window.Turbo
 function registerStreamAction(name, handler) {
@@ -50,6 +51,10 @@ registerStreamAction("refresh_creative_tree", function () {
     // Update ancestor progress for all actions
     updateAncestorProgress(creative.ancestors)
     document.dispatchEvent(new CustomEvent('workspace-tree:invalidate'))
+})
+
+registerStreamAction("invalidate_creative_tree", function () {
+    invalidateCreativeTree()
 })
 
 function handleCreated(creative) {

--- a/engines/collavre/app/jobs/collavre/creative_history_notice_job.rb
+++ b/engines/collavre/app/jobs/collavre/creative_history_notice_job.rb
@@ -11,7 +11,7 @@ module Collavre
 
       diff = Creatives::ChangeSetDiff.new(change_set, user: user)
       creative = notice_creative(diff)
-      return unless creative && diff.revertible?
+      return unless creative && diff.revertible? && writable_change?(change_set, user)
 
       I18n.with_locale(user.locale.presence || I18n.default_locale) do
         apply_url = Engine.routes.url_helpers.creative_apply_change_set_path(creative, change_set)
@@ -29,6 +29,12 @@ module Collavre
     def notice_creative(diff)
       root_id = diff.groups.first&.fetch(:root_id)
       Creative.find_by(id: root_id) if root_id
+    end
+
+    def writable_change?(change_set, user)
+      ids = change_set.creative_changes.pluck(:creative_id)
+      writable_ids = Creatives::PermissionFilter.new(user: user).readable_ids(ids, min_permission: :write)
+      Creative.where(id: writable_ids).any? { |creative| !creative.read_only_source? }
     end
   end
 end

--- a/engines/collavre/app/jobs/collavre/creative_history_notice_job.rb
+++ b/engines/collavre/app/jobs/collavre/creative_history_notice_job.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Collavre
+  class CreativeHistoryNoticeJob < ApplicationJob
+    queue_as :default
+
+    def perform(change_set_id, user_id)
+      change_set = CreativeChangeSet.includes(:creative_changes).find_by(id: change_set_id)
+      user = User.find_by(id: user_id)
+      return unless change_set&.status == "applied" && change_set.actor_kind == "agent" && user
+
+      diff = Creatives::ChangeSetDiff.new(change_set, user: user)
+      creative = notice_creative(diff)
+      return unless creative && diff.revertible?
+
+      I18n.with_locale(user.locale.presence || I18n.default_locale) do
+        apply_url = Engine.routes.url_helpers.creative_apply_change_set_path(creative, change_set)
+        Turbo::StreamsChannel.broadcast_append_to(
+          [ user, :creative_tree ],
+          target: "creative-history-toast-container",
+          partial: "collavre/creative_change_sets/undo_toast",
+          locals: { change_set: change_set, apply_url: apply_url, change_count: diff.change_count }
+        )
+      end
+    end
+
+    private
+
+    def notice_creative(diff)
+      root_id = diff.groups.first&.fetch(:root_id)
+      Creative.find_by(id: root_id) if root_id
+    end
+  end
+end

--- a/engines/collavre/app/jobs/collavre/creative_tree_invalidation_job.rb
+++ b/engines/collavre/app/jobs/collavre/creative_tree_invalidation_job.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Collavre
+  class CreativeTreeInvalidationJob < ApplicationJob
+    queue_as :default
+
+    def perform(creative_ids)
+      ids = Array(creative_ids).filter_map { |id| Integer(id, exception: false) }.uniq
+      return if ids.empty?
+
+      candidate_users(ids).find_each do |user|
+        next if Creatives::PermissionFilter.new(user: user).readable_ids(ids).empty?
+
+        Turbo::StreamsChannel.broadcast_action_to(
+          [ user, :creative_tree ],
+          action: :invalidate_creative_tree,
+          target: "creatives"
+        )
+      end
+    end
+
+    private
+
+    def candidate_users(ids)
+      cache_scope = CreativeSharesCache.where(creative_id: ids)
+      return User.all if cache_scope.where(user_id: nil).where.not(permission: :no_access).exists?
+
+      user_ids = Creative.unscoped.where(id: ids).pluck(:user_id)
+      user_ids.concat(cache_scope.where.not(user_id: nil).pluck(:user_id))
+      User.where(id: user_ids.compact.uniq)
+    end
+  end
+end

--- a/engines/collavre/app/models/collavre/creative.rb
+++ b/engines/collavre/app/models/collavre/creative.rb
@@ -303,8 +303,10 @@ module Collavre
 
     def archive!
       now = Time.current
+      affected_ids = []
       self.class.transaction do
         targets = self.class.where(id: archive_family_ids).where(archived_at: nil)
+        affected_ids = targets.pluck(:id)
         Creatives::History.record_bulk(targets, operation: "archive") do
           targets.update_all(archived_at: now)
         end
@@ -313,11 +315,14 @@ module Collavre
         parent&.reload
         Collavre::Creatives::ProgressService.new(parent).update_progress_from_children! if parent
       end
+      CreativeTreeInvalidationJob.perform_later(affected_ids) if affected_ids.any?
     end
 
     def unarchive!
+      affected_ids = []
       self.class.transaction do
         targets = self.class.where(id: archive_family_ids).where.not(archived_at: nil)
+        affected_ids = targets.pluck(:id)
         Creatives::History.record_bulk(targets, operation: "unarchive") do
           targets.update_all(archived_at: nil)
         end
@@ -326,6 +331,7 @@ module Collavre
         parent&.reload
         Collavre::Creatives::ProgressService.new(parent).update_progress_from_children! if parent
       end
+      CreativeTreeInvalidationJob.perform_later(affected_ids) if affected_ids.any?
     end
 
 

--- a/engines/collavre/app/models/collavre/creative.rb
+++ b/engines/collavre/app/models/collavre/creative.rb
@@ -296,45 +296,6 @@ module Collavre
       end
     end
 
-    # --- Archive ---
-    def archived?
-      archived_at.present?
-    end
-
-    def archive!
-      now = Time.current
-      affected_ids = []
-      self.class.transaction do
-        targets = self.class.where(id: archive_family_ids).where(archived_at: nil)
-        affected_ids = targets.pluck(:id)
-        Creatives::History.record_bulk(targets, operation: "archive") do
-          targets.update_all(archived_at: now)
-        end
-
-        reload
-        parent&.reload
-        Collavre::Creatives::ProgressService.new(parent).update_progress_from_children! if parent
-      end
-      CreativeTreeInvalidationJob.perform_later(affected_ids) if affected_ids.any?
-    end
-
-    def unarchive!
-      affected_ids = []
-      self.class.transaction do
-        targets = self.class.where(id: archive_family_ids).where.not(archived_at: nil)
-        affected_ids = targets.pluck(:id)
-        Creatives::History.record_bulk(targets, operation: "unarchive") do
-          targets.update_all(archived_at: nil)
-        end
-
-        reload
-        parent&.reload
-        Collavre::Creatives::ProgressService.new(parent).update_progress_from_children! if parent
-      end
-      CreativeTreeInvalidationJob.perform_later(affected_ids) if affected_ids.any?
-    end
-
-
     private
 
     def assign_default_user

--- a/engines/collavre/app/models/collavre/creative/history_trackable.rb
+++ b/engines/collavre/app/models/collavre/creative/history_trackable.rb
@@ -38,10 +38,11 @@ module Collavre
         self.class.transaction do
           targets = archive_targets(archived_at)
           affected_ids = targets.pluck(:id)
+          parent_ids = targets.where.not(parent_id: nil).distinct.pluck(:parent_id)
           Creatives::History.record_bulk(targets, operation: operation) do
             targets.update_all(archived_at: archived_at)
           end
-          refresh_archive_parent_progress
+          refresh_archive_parent_progress(parent_ids)
         end
         CreativeTreeInvalidationJob.perform_later(affected_ids) if affected_ids.any?
       end
@@ -51,10 +52,11 @@ module Collavre
         archived_at ? scope.where(archived_at: nil) : scope.where.not(archived_at: nil)
       end
 
-      def refresh_archive_parent_progress
+      def refresh_archive_parent_progress(parent_ids)
         reload
-        parent&.reload
-        Creatives::ProgressService.new(parent).update_progress_from_children! if parent
+        self.class.where(id: parent_ids).find_each do |affected_parent|
+          Creatives::ProgressService.new(affected_parent).update_progress_from_children!
+        end
       end
 
       def record_change_history(&block)

--- a/engines/collavre/app/models/collavre/creative/history_trackable.rb
+++ b/engines/collavre/app/models/collavre/creative/history_trackable.rb
@@ -19,7 +19,43 @@ module Collavre
         end
       end
 
+      def archived?
+        archived_at.present?
+      end
+
+      def archive!
+        mutate_archive_family(archived_at: Time.current, operation: "archive")
+      end
+
+      def unarchive!
+        mutate_archive_family(archived_at: nil, operation: "unarchive")
+      end
+
       private
+
+      def mutate_archive_family(archived_at:, operation:)
+        affected_ids = []
+        self.class.transaction do
+          targets = archive_targets(archived_at)
+          affected_ids = targets.pluck(:id)
+          Creatives::History.record_bulk(targets, operation: operation) do
+            targets.update_all(archived_at: archived_at)
+          end
+          refresh_archive_parent_progress
+        end
+        CreativeTreeInvalidationJob.perform_later(affected_ids) if affected_ids.any?
+      end
+
+      def archive_targets(archived_at)
+        scope = self.class.where(id: archive_family_ids)
+        archived_at ? scope.where(archived_at: nil) : scope.where.not(archived_at: nil)
+      end
+
+      def refresh_archive_parent_progress
+        reload
+        parent&.reload
+        Creatives::ProgressService.new(parent).update_progress_from_children! if parent
+      end
 
       def record_change_history(&block)
         Creatives::History.capture(self, &block)

--- a/engines/collavre/app/services/collavre/ai_agent_service.rb
+++ b/engines/collavre/app/services/collavre/ai_agent_service.rb
@@ -18,7 +18,7 @@ module Collavre
 
     def call
       begin
-        Current.set(user: @agent, agent_turn: { user: workspace_user, task: @task }) do
+        Creatives::AgentTurnHistory.call(@agent, workspace_user, @task) do
           if @agent.claude_channel_agent?
             delegate_to_claude_channel
           else

--- a/engines/collavre/app/services/collavre/creatives/agent_turn_history.rb
+++ b/engines/collavre/app/services/collavre/creatives/agent_turn_history.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Collavre
+  module Creatives
+    class AgentTurnHistory
+      def self.call(agent, workspace_user, task)
+        Current.set(user: agent, agent_turn: { user: workspace_user, task: task }) do
+          yield
+        ensure
+          History.finish_agent_turn
+        end
+      end
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/creatives/change_set_apply_service.rb
+++ b/engines/collavre/app/services/collavre/creatives/change_set_apply_service.rb
@@ -32,15 +32,17 @@ module Collavre
       private
 
       def build_targets(source)
-        all_changes = source.creative_changes.order(@mode == :revert ? { position: :desc } : { position: :asc })
-        changes = ChangeSetVisibility.new(user: @user).changes(all_changes)
-        @targets = changes.to_h { |change| [ change, @mode == :revert ? change.before : change.after ] }
-        @complete = changes.size == all_changes.size
+        @all_changes = source.creative_changes.order(@mode == :revert ? { position: :desc } : { position: :asc }).to_a
+        visible_changes = ChangeSetVisibility.new(user: @user).changes(@all_changes)
+        @visible_change_ids = visible_changes.map(&:id).to_set
+        candidates = (visible_changes + @all_changes.select { |change| archival_transition?(change) }).uniq
+        @targets = candidates.to_h { |change| [ change, @mode == :revert ? change.before : change.after ] }
       end
 
       def build_plan
         records = locked_records
         writable_ids = writable_ids_for(records.keys)
+        retain_authorized_targets(records, writable_ids)
         @targets.each_with_object([ [], [], [] ]) do |(change, snapshot), buckets|
           classify_target(change, snapshot, records, writable_ids, buckets)
         end
@@ -55,6 +57,7 @@ module Collavre
       def classify_target(change, snapshot, records, writable_ids, buckets)
         plan, conflicts, skipped = buckets
         creative = records[change.creative_id]
+        return classify_propagated_target(change, creative, snapshot, plan) if propagated_target?(change)
         return skipped << change.creative_id unless target_writable?(creative, snapshot, records, writable_ids)
         return if History.snapshot(creative) == snapshot
 
@@ -63,6 +66,32 @@ module Collavre
         else
           plan << [ creative, snapshot ]
         end
+      end
+
+      def retain_authorized_targets(records, writable_ids)
+        visible_origins = @targets.keys.filter_map do |change|
+          next unless @visible_change_ids.include?(change.id) && change.operation.in?(%w[archive unarchive])
+
+          creative = records[change.creative_id]
+          creative&.id if target_writable?(creative, @targets.fetch(change), records, writable_ids)
+        end.to_set
+        @propagated_change_ids = @targets.keys.filter_map do |change|
+          creative = records[change.creative_id]
+          change.id if !@visible_change_ids.include?(change.id) && creative&.origin_id.in?(visible_origins) &&
+            archival_transition_only?(change)
+        end.to_set
+        @targets.select! { |change, _snapshot| @visible_change_ids.include?(change.id) || propagated_target?(change) }
+        @complete = @targets.size == @all_changes.size
+      end
+
+      def classify_propagated_target(change, creative, snapshot, plan)
+        unless creative && History.snapshot(creative)["archived_at"] == change.public_send(source_snapshot_side)["archived_at"]
+          @complete = false
+          return
+        end
+        return if History.snapshot(creative)["archived_at"] == snapshot["archived_at"]
+
+        plan << [ creative, snapshot, true ]
       end
 
       def target_writable?(creative, snapshot, records, writable_ids)
@@ -115,7 +144,7 @@ module Collavre
         reverse = create_reverse_set(source)
         History.track(actor: @user, origin: :revert, anchor: source.anchor_creative, anchor_source: :explicit) do
           Current.change_set = reverse
-          plan.each { |creative, snapshot| apply_snapshot(creative, snapshot) }
+          plan.each { |creative, snapshot, archive_only| apply_snapshot(creative, snapshot, archive_only: archive_only) }
         end
         source.update!(status: "reverted", reverted_by: reverse) if @mode == :revert && skipped.empty? && @complete
         status = skipped.empty? && @complete ? :applied : :partial
@@ -135,11 +164,30 @@ module Collavre
         )
       end
 
-      def apply_snapshot(creative, snapshot)
+      def apply_snapshot(creative, snapshot, archive_only: false)
         return creative.update!(archived_at: Time.current) if snapshot.empty?
+        return creative.update!(archived_at: snapshot["archived_at"]) if archive_only
 
         creative.assign_attributes(snapshot_attributes(creative, snapshot))
         creative.save!
+      end
+
+      def propagated_target?(change)
+        @propagated_change_ids&.include?(change.id)
+      end
+
+      def archival_transition?(change)
+        change.operation.in?(%w[archive unarchive]) &&
+          change.before["archived_at"] != change.after["archived_at"]
+      end
+
+      def archival_transition_only?(change)
+        archival_transition?(change) &&
+          change.before.except("archived_at") == change.after.except("archived_at")
+      end
+
+      def source_snapshot_side
+        @mode == :revert ? :after : :before
       end
 
       def snapshot_attributes(creative, snapshot)

--- a/engines/collavre/app/services/collavre/creatives/change_set_apply_service.rb
+++ b/engines/collavre/app/services/collavre/creatives/change_set_apply_service.rb
@@ -85,11 +85,12 @@ module Collavre
       end
 
       def classify_propagated_target(change, creative, snapshot, plan)
-        unless creative && History.snapshot(creative)["archived_at"] == change.public_send(source_snapshot_side)["archived_at"]
+        current_archived_at = History.snapshot(creative)["archived_at"] if creative
+        return if current_archived_at == snapshot["archived_at"]
+        unless creative && current_archived_at == change.public_send(source_snapshot_side)["archived_at"]
           @complete = false
           return
         end
-        return if History.snapshot(creative)["archived_at"] == snapshot["archived_at"]
 
         plan << [ creative, snapshot, true ]
       end

--- a/engines/collavre/app/services/collavre/creatives/change_set_apply_service.rb
+++ b/engines/collavre/app/services/collavre/creatives/change_set_apply_service.rb
@@ -77,7 +77,6 @@ module Collavre
         end.to_set
         @propagated_attributes = PropagatedChangeAuthorization.new(
           changes: @targets.keys,
-          visible_change_ids: @visible_change_ids,
           records: records,
           writable_origin_ids: visible_origins
         ).call

--- a/engines/collavre/app/services/collavre/creatives/change_set_apply_service.rb
+++ b/engines/collavre/app/services/collavre/creatives/change_set_apply_service.rb
@@ -35,7 +35,7 @@ module Collavre
         @all_changes = source.creative_changes.order(@mode == :revert ? { position: :desc } : { position: :asc }).to_a
         visible_changes = ChangeSetVisibility.new(user: @user).changes(@all_changes)
         @visible_change_ids = visible_changes.map(&:id).to_set
-        candidates = (visible_changes + @all_changes.select { |change| archival_transition?(change) }).uniq
+        candidates = (visible_changes + @all_changes.select { |change| propagated_candidate?(change) }).uniq
         @targets = candidates.to_h { |change| [ change, @mode == :revert ? change.before : change.after ] }
       end
 
@@ -75,24 +75,26 @@ module Collavre
           creative = records[change.creative_id]
           creative&.id if target_writable?(creative, @targets.fetch(change), records, writable_ids)
         end.to_set
-        @propagated_change_ids = @targets.keys.filter_map do |change|
-          creative = records[change.creative_id]
-          change.id if !@visible_change_ids.include?(change.id) && creative&.origin_id.in?(visible_origins) &&
-            archival_transition_only?(change)
-        end.to_set
+        @propagated_attributes = PropagatedChangeAuthorization.new(
+          changes: @targets.keys,
+          visible_change_ids: @visible_change_ids,
+          records: records,
+          writable_origin_ids: visible_origins
+        ).call
         @targets.select! { |change, _snapshot| @visible_change_ids.include?(change.id) || propagated_target?(change) }
         @complete = @targets.size == @all_changes.size
       end
 
       def classify_propagated_target(change, creative, snapshot, plan)
-        current_archived_at = History.snapshot(creative)["archived_at"] if creative
-        return if current_archived_at == snapshot["archived_at"]
-        unless creative && current_archived_at == change.public_send(source_snapshot_side)["archived_at"]
+        attribute = @propagated_attributes.fetch(change.id)
+        current_value = History.snapshot(creative)[attribute] if creative
+        return if current_value == snapshot[attribute]
+        unless creative && current_value == change.public_send(source_snapshot_side)[attribute]
           @complete = false
           return
         end
 
-        plan << [ creative, snapshot, true ]
+        plan << [ creative, snapshot, attribute ]
       end
 
       def target_writable?(creative, snapshot, records, writable_ids)
@@ -145,7 +147,7 @@ module Collavre
         reverse = create_reverse_set(source)
         History.track(actor: @user, origin: :revert, anchor: source.anchor_creative, anchor_source: :explicit) do
           Current.change_set = reverse
-          plan.each { |creative, snapshot, archive_only| apply_snapshot(creative, snapshot, archive_only: archive_only) }
+          plan.each { |creative, snapshot, propagated_attribute| apply_snapshot(creative, snapshot, propagated_attribute:) }
         end
         source.update!(status: "reverted", reverted_by: reverse) if @mode == :revert && skipped.empty? && @complete
         status = skipped.empty? && @complete ? :applied : :partial
@@ -172,16 +174,16 @@ module Collavre
         result(:applied)
       end
 
-      def apply_snapshot(creative, snapshot, archive_only: false)
+      def apply_snapshot(creative, snapshot, propagated_attribute: nil)
         return creative.update!(archived_at: Time.current) if snapshot.empty?
-        return creative.update!(archived_at: snapshot["archived_at"]) if archive_only
+        return creative.update!(propagated_attribute => snapshot[propagated_attribute]) if propagated_attribute
 
         creative.assign_attributes(snapshot_attributes(creative, snapshot))
         creative.save!
       end
 
       def propagated_target?(change)
-        @propagated_change_ids&.include?(change.id)
+        @propagated_attributes&.key?(change.id)
       end
 
       def archival_transition?(change)
@@ -189,9 +191,8 @@ module Collavre
           change.before["archived_at"] != change.after["archived_at"]
       end
 
-      def archival_transition_only?(change)
-        archival_transition?(change) &&
-          change.before.except("archived_at") == change.after.except("archived_at")
+      def propagated_candidate?(change)
+        archival_transition?(change) || change.operation == "update"
       end
 
       def source_snapshot_side

--- a/engines/collavre/app/services/collavre/creatives/change_set_apply_service.rb
+++ b/engines/collavre/app/services/collavre/creatives/change_set_apply_service.rb
@@ -22,7 +22,7 @@ module Collavre
           if conflicts.any?
             result(:conflict, conflicts: conflicts, skipped: skipped)
           elsif plan.empty?
-            result(:skipped, skipped: skipped)
+            complete_noop(source, skipped)
           else
             apply(source, plan, skipped)
           end
@@ -163,6 +163,13 @@ module Collavre
           reverts: @mode == :revert ? source : nil,
           applied_at: Time.current
         )
+      end
+
+      def complete_noop(source, skipped)
+        return result(:skipped, skipped: skipped) unless skipped.empty? && @complete
+
+        source.update!(status: "reverted") if @mode == :revert
+        result(:applied)
       end
 
       def apply_snapshot(creative, snapshot, archive_only: false)

--- a/engines/collavre/app/services/collavre/creatives/history.rb
+++ b/engines/collavre/app/services/collavre/creatives/history.rb
@@ -169,6 +169,22 @@ module Collavre
         Current.creative_history_context.present? || Current.user.present?
       end
 
+      def finish_agent_turn
+        change_set = Current.change_set
+        return unless change_set&.persisted? && Current.agent_turn&.dig(:task)
+
+        if change_set.creative_changes.exists?
+          workspace_user = Current.agent_turn[:user]
+          if workspace_user && change_set.status == "applied" && change_set.actor_kind == "agent"
+            CreativeHistoryNoticeJob.perform_later(change_set.id, workspace_user.id)
+          end
+        else
+          change_set.destroy!
+        end
+      ensure
+        Current.change_set = nil
+      end
+
       def current_change_set(creative)
         Current.creative_history_context ||= inferred_context(creative)
         Current.change_set ||= find_or_create_change_set(Current.creative_history_context)

--- a/engines/collavre/app/services/collavre/creatives/propagated_change_authorization.rb
+++ b/engines/collavre/app/services/collavre/creatives/propagated_change_authorization.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module Collavre
+  module Creatives
+    class PropagatedChangeAuthorization
+      def initialize(changes:, visible_change_ids:, records:, writable_origin_ids:)
+        @changes = changes
+        @visible_change_ids = visible_change_ids
+        @records = records
+        @writable_origin_ids = writable_origin_ids
+      end
+
+      def call
+        attributes = linked_archive_attributes
+        add_parent_progress_attributes(attributes)
+        attributes
+      end
+
+      private
+
+      def linked_archive_attributes
+        changes.each_with_object({}) do |change, attributes|
+          creative = records[change.creative_id]
+          next if visible_change_ids.include?(change.id) || !creative&.origin_id.in?(writable_origin_ids)
+          next unless transition_only?(change, "archived_at", %w[archive unarchive])
+
+          attributes[change.id] = "archived_at"
+        end
+      end
+
+      def add_parent_progress_attributes(attributes)
+        parent_ids = attributes.keys.filter_map { |id| records[change_by_id.fetch(id).creative_id]&.parent_id }.to_set
+        loop do
+          additions = parent_progress_additions(parent_ids, attributes)
+          break if additions.empty?
+
+          register_parent_progress(additions, attributes, parent_ids)
+        end
+      end
+
+      def parent_progress_additions(parent_ids, attributes)
+        changes.filter_map do |change|
+          creative = records[change.creative_id]
+          change if !visible_change_ids.include?(change.id) && !attributes.key?(change.id) &&
+            parent_ids.include?(creative&.id) && transition_only?(change, "progress", %w[update])
+        end
+      end
+
+      def register_parent_progress(additions, attributes, parent_ids)
+        additions.each do |change|
+          attributes[change.id] = "progress"
+          parent_ids << records.fetch(change.creative_id).parent_id
+        end
+      end
+
+      def transition_only?(change, attribute, operations)
+        operations.include?(change.operation) && change.before[attribute] != change.after[attribute] &&
+          change.before.except(attribute) == change.after.except(attribute)
+      end
+
+      def change_by_id
+        @change_by_id ||= changes.index_by(&:id)
+      end
+
+      attr_reader :changes, :visible_change_ids, :records, :writable_origin_ids
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/creatives/propagated_change_authorization.rb
+++ b/engines/collavre/app/services/collavre/creatives/propagated_change_authorization.rb
@@ -3,9 +3,8 @@
 module Collavre
   module Creatives
     class PropagatedChangeAuthorization
-      def initialize(changes:, visible_change_ids:, records:, writable_origin_ids:)
+      def initialize(changes:, records:, writable_origin_ids:)
         @changes = changes
-        @visible_change_ids = visible_change_ids
         @records = records
         @writable_origin_ids = writable_origin_ids
       end
@@ -21,7 +20,7 @@ module Collavre
       def linked_archive_attributes
         changes.each_with_object({}) do |change, attributes|
           creative = records[change.creative_id]
-          next if visible_change_ids.include?(change.id) || !creative&.origin_id.in?(writable_origin_ids)
+          next unless creative&.origin_id.in?(writable_origin_ids)
           next unless transition_only?(change, "archived_at", %w[archive unarchive])
 
           attributes[change.id] = "archived_at"
@@ -41,8 +40,8 @@ module Collavre
       def parent_progress_additions(parent_ids, attributes)
         changes.filter_map do |change|
           creative = records[change.creative_id]
-          change if !visible_change_ids.include?(change.id) && !attributes.key?(change.id) &&
-            parent_ids.include?(creative&.id) && transition_only?(change, "progress", %w[update])
+          change if !attributes.key?(change.id) && parent_ids.include?(creative&.id) &&
+            transition_only?(change, "progress", %w[update])
         end
       end
 
@@ -62,7 +61,7 @@ module Collavre
         @change_by_id ||= changes.index_by(&:id)
       end
 
-      attr_reader :changes, :visible_change_ids, :records, :writable_origin_ids
+      attr_reader :changes, :records, :writable_origin_ids
     end
   end
 end

--- a/engines/collavre/app/services/collavre/tools/creative_batch_service.rb
+++ b/engines/collavre/app/services/collavre/tools/creative_batch_service.rb
@@ -10,6 +10,7 @@ module Collavre
       tool_name "creative_batch_service"
       tool_description "Execute multiple Creative operations (create, update, delete) in a single batch call. " \
                        "All operations run inside a transaction — if any operation fails, the entire batch is rolled back.\n\n" \
+                       "Delete operations archive Creatives so they remain recoverable from History.\n\n" \
                        "This tool requires approval before execution.\n\n" \
                        "Each operation is a hash with an 'action' key ('create', 'update', or 'delete') plus action-specific fields."
 
@@ -20,7 +21,7 @@ module Collavre
       tool_param :operations, description: "Array of operation objects. Each object must have an 'action' key.\n\n" \
                  "For 'create': { action: 'create', parent_id: <int>, description: <markdown string>, progress: <float>, after_id: <int>, before_id: <int> }\n" \
                  "For 'update': { action: 'update', id: <int>, description: <markdown string>, progress: 1.0, parent_id: <int> } — progress only accepts 1.0 (complete) and only on leaf Creatives\n" \
-                 "For 'delete': { action: 'delete', id: <int> }\n\n" \
+                 "For 'delete': { action: 'delete', id: <int> } — archives the Creative and its propagated family\n\n" \
                  "The 'description' field is written as Markdown (GitHub-Flavored).\n" \
                  "Fields other than 'action' and 'id'/'parent_id' are optional.", required: true
 
@@ -100,12 +101,8 @@ module Collavre
         return { error: "Creative not found", id: id } unless creative
         return { error: "No write permission on this Creative", id: id } unless creative.has_permission?(Current.user, :write)
 
-        result = Creatives::DestroyService.new(
-          creative: creative,
-          user: Current.user
-        ).call
-        return { error: "Failed to destroy creative", id: id } unless result
-        { success: true, id: id, deleted: true }
+        creative.archive!
+        { success: true, id: id, archived: true }
       end
     end
   end

--- a/engines/collavre/app/views/collavre/creative_change_sets/_undo_toast.html.erb
+++ b/engines/collavre/app/views/collavre/creative_change_sets/_undo_toast.html.erb
@@ -1,0 +1,23 @@
+<aside id="creative-history-undo-<%= change_set.id %>"
+       class="creative-history-undo-toast"
+       role="status"
+       data-controller="creative-history creative-history-undo"
+       data-creative-history-undo-timeout-value="30000"
+       data-action="creative-history:applied->creative-history-undo#dismiss">
+  <span><%= t("collavre.creative_history.undo_notice", count: change_count) %></span>
+  <button type="button"
+          class="creative-history-revert"
+          data-action="creative-history#revert"
+          data-url="<%= apply_url %>"
+          data-mode="revert"
+          data-confirm="<%= t("collavre.creative_history.revert_confirm") %>"
+          data-conflict="<%= t("collavre.creative_history.conflict_choice") %>"
+          data-force="<%= t("collavre.creative_history.force") %>"
+          data-skip="<%= t("collavre.creative_history.skip") %>">
+    <%= t("collavre.creative_history.undo") %>
+  </button>
+  <button type="button"
+          class="creative-history-undo-dismiss"
+          aria-label="<%= t("collavre.creative_history.dismiss") %>"
+          data-action="creative-history-undo#dismiss">×</button>
+</aside>

--- a/engines/collavre/app/views/collavre/creative_change_sets/_undo_toast.html.erb
+++ b/engines/collavre/app/views/collavre/creative_change_sets/_undo_toast.html.erb
@@ -10,7 +10,6 @@
           data-action="creative-history#revert"
           data-url="<%= apply_url %>"
           data-mode="revert"
-          data-confirm="<%= t("collavre.creative_history.revert_confirm") %>"
           data-conflict="<%= t("collavre.creative_history.conflict_choice") %>"
           data-force="<%= t("collavre.creative_history.force") %>"
           data-skip="<%= t("collavre.creative_history.skip") %>">

--- a/engines/collavre/app/views/collavre/creatives/_workspace_tree.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/_workspace_tree.html.erb
@@ -12,6 +12,7 @@
       grid shell it would become a grid item with its own implicit row and
       push all three columns down. %>
   <%= turbo_stream_from Current.user, :creative_tree %>
+  <div id="creative-history-toast-container" class="creative-history-toast-container"></div>
   <button type="button"
           class="creative-workspace-tree-toggle"
           data-workspace-tree-target="panelToggle"

--- a/engines/collavre/app/views/collavre/creatives/index.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/index.html.erb
@@ -17,6 +17,7 @@
     shell (_workspace_tree) so center-frame swaps never drop the subscription %>
 <% if authenticated? && !creative_workspace? %>
   <%= turbo_stream_from Current.user, :creative_tree %>
+  <div id="creative-history-toast-container" class="creative-history-toast-container"></div>
 <% end %>
 <% if @auto_fullscreen %>
   <% content_for :comments_popup_auto_fullscreen, "true" %>

--- a/engines/collavre/config/locales/creative_history.en.yml
+++ b/engines/collavre/config/locales/creative_history.en.yml
@@ -15,6 +15,11 @@ en:
       restore: Restore this version
       reverted: Reverted
       irreversible: Cannot be restored
+      undo_notice:
+        one: AI updated 1 creative.
+        other: "AI updated %{count} creatives."
+      undo: Undo
+      dismiss: Dismiss
       revert_confirm: Revert this entire change set?
       restore_confirm: Make this version the current version?
       conflict_choice: "Creative #%{id} changed afterward. Force revert it, or skip it?"

--- a/engines/collavre/config/locales/creative_history.ko.yml
+++ b/engines/collavre/config/locales/creative_history.ko.yml
@@ -13,6 +13,9 @@ ko:
       restore: 이 버전으로 복원
       reverted: 되돌림 완료
       irreversible: 복원할 수 없음
+      undo_notice: "AI가 크리에이티브 %{count}개를 수정했습니다."
+      undo: 되돌리기
+      dismiss: 닫기
       revert_confirm: 이 변경 셋 전체를 되돌릴까요?
       restore_confirm: 이 버전을 현재 버전으로 적용할까요?
       conflict_choice: "크리에이티브 #%{id}이(가) 이후에 변경되었습니다. 강제로 되돌리거나 건너뛰세요."

--- a/engines/collavre/test/jobs/collavre/creative_history_notice_job_test.rb
+++ b/engines/collavre/test/jobs/collavre/creative_history_notice_job_test.rb
@@ -37,6 +37,20 @@ module Collavre
       assert true
     end
 
+    test "does not offer undo to a read-only viewer" do
+      owner = users(:one)
+      reader = users(:two)
+      agent = users(:ai_bot)
+      creative = Creative.create!(description: "Before", user: owner)
+      CreativeShare.create!(creative: creative, user: reader, shared_by: owner, permission: :read)
+      Current.set(user: agent) { creative.update!(description: "After") }
+
+      Turbo::StreamsChannel.stub(:broadcast_append_to, ->(*) { flunk "read-only viewers must not receive undo" }) do
+        CreativeHistoryNoticeJob.perform_now(CreativeChangeSet.sole.id, reader.id)
+      end
+      assert true
+    end
+
     test "renders an actionable undo toast" do
       user = users(:one)
       agent = users(:ai_bot)

--- a/engines/collavre/test/jobs/collavre/creative_history_notice_job_test.rb
+++ b/engines/collavre/test/jobs/collavre/creative_history_notice_job_test.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  class CreativeHistoryNoticeJobTest < ActiveJob::TestCase
+    test "broadcasts a localized undo notice for a visible agent change" do
+      user = users(:one)
+      agent = users(:ai_bot)
+      creative = Creative.create!(description: "Before", user: user)
+      before = Creatives::History.snapshot(creative)
+      Current.set(user: agent) { creative.update!(description: "After") }
+      change_set = CreativeChangeSet.sole
+      broadcasts = []
+
+      Turbo::StreamsChannel.stub(:broadcast_append_to, ->(*stream, **options) { broadcasts << [ stream, options ] }) do
+        CreativeHistoryNoticeJob.perform_now(change_set.id, user.id)
+      end
+
+      stream, options = broadcasts.sole
+      assert_equal [ [ user, :creative_tree ] ], stream
+      assert_equal "creative-history-toast-container", options[:target]
+      assert_equal "collavre/creative_change_sets/undo_toast", options[:partial]
+      assert_equal "/creatives/#{creative.id}/history/#{change_set.id}/apply", options.dig(:locals, :apply_url)
+      assert_equal 1, options.dig(:locals, :change_count)
+      assert_equal before, change_set.creative_changes.sole.before
+    end
+
+    test "does not broadcast a human change" do
+      user = users(:one)
+      creative = Creative.create!(description: "Before", user: user)
+      Current.set(user: user) { creative.update!(description: "After") }
+
+      Turbo::StreamsChannel.stub(:broadcast_append_to, ->(*) { flunk "human changes must not produce AI undo notices" }) do
+        CreativeHistoryNoticeJob.perform_now(CreativeChangeSet.sole.id, user.id)
+      end
+      assert true
+    end
+
+    test "renders an actionable undo toast" do
+      user = users(:one)
+      agent = users(:ai_bot)
+      creative = Creative.create!(description: "Before", user: user)
+      Current.set(user: agent) { creative.update!(description: "After") }
+      change_set = CreativeChangeSet.sole
+      payloads = []
+
+      ActionCable.server.stub(:broadcast, ->(_stream, payload) { payloads << payload }) do
+        CreativeHistoryNoticeJob.perform_now(change_set.id, user.id)
+      end
+
+      payload = payloads.sole
+      assert_includes payload, %(id="creative-history-undo-#{change_set.id}")
+      assert_includes payload, %(/creatives/#{creative.id}/history/#{change_set.id}/apply)
+      assert_includes payload, "AI updated 1 creative."
+    end
+  end
+end

--- a/engines/collavre/test/jobs/collavre/creative_tree_invalidation_job_test.rb
+++ b/engines/collavre/test/jobs/collavre/creative_tree_invalidation_job_test.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  class CreativeTreeInvalidationJobTest < ActiveJob::TestCase
+    test "ignores an empty creative list" do
+      Turbo::StreamsChannel.stub(:broadcast_action_to, ->(*) { flunk "empty invalidations must not broadcast" }) do
+        CreativeTreeInvalidationJob.perform_now([])
+      end
+      assert true
+    end
+
+    test "broadcasts a generic invalidation to every readable user" do
+      owner = users(:one)
+      reader = users(:two)
+      creative = Creative.create!(description: "Shared", user: owner)
+      CreativeSharesCache.create!(creative: creative, user: reader, permission: :read)
+      broadcasts = []
+
+      Turbo::StreamsChannel.stub(:broadcast_action_to, ->(*stream, **options) { broadcasts << [ stream, options ] }) do
+        CreativeTreeInvalidationJob.perform_now([ creative.id ])
+      end
+
+      assert_equal [ owner.id, reader.id ].sort, broadcasts.map { |stream, _options| stream.first.first.id }.sort
+      assert broadcasts.all? { |_stream, options| options[:action] == :invalidate_creative_tree }
+      assert broadcasts.all? { |_stream, options| options[:target] == "creatives" }
+    end
+
+    test "does not broadcast to an explicitly denied user of a public creative" do
+      owner = users(:one)
+      denied = users(:two)
+      creative = Creative.create!(description: "Public", user: owner)
+      CreativeSharesCache.create!(creative: creative, user: nil, permission: :read)
+      CreativeSharesCache.create!(creative: creative, user: denied, permission: :no_access)
+      recipients = []
+
+      Turbo::StreamsChannel.stub(:broadcast_action_to, ->(stream, **) { recipients << stream.first.id }) do
+        CreativeTreeInvalidationJob.perform_now([ creative.id ])
+      end
+
+      assert_includes recipients, owner.id
+      assert_not_includes recipients, denied.id
+    end
+  end
+end

--- a/engines/collavre/test/models/collavre/creative_archive_test.rb
+++ b/engines/collavre/test/models/collavre/creative_archive_test.rb
@@ -84,6 +84,24 @@ module Collavre
       assert linked.archived?, "Linked creative should be archived when origin is archived"
     end
 
+    test "archive! recalculates every linked placement parent" do
+      foreign_parent = Creative.create!(description: "Foreign parent", user: users(:two), progress: 0)
+      Creative.create!(description: "Incomplete", user: users(:two), parent: foreign_parent, progress: 0)
+      linked = Creative.create!(user: users(:two), parent: foreign_parent, origin: @child1)
+      foreign_parent.reload
+      assert_in_delta 0.5, foreign_parent.progress, 0.01
+
+      @child1.archive!
+
+      assert linked.reload.archived?
+      assert_in_delta 0, foreign_parent.reload.progress, 0.01
+
+      @child1.unarchive!
+
+      assert_not linked.reload.archived?
+      assert_in_delta 0.5, foreign_parent.reload.progress, 0.01
+    end
+
     test "unarchive! on linked creative also unarchives origin" do
       origin = Creative.create!(description: "Origin", user: @user)
       linked = Creative.create!(description: "Linked", user: @user, parent: @parent, origin_id: origin.id)

--- a/engines/collavre/test/services/collavre/creatives/history_test.rb
+++ b/engines/collavre/test/services/collavre/creatives/history_test.rb
@@ -378,6 +378,39 @@ module Collavre
         assert_equal [ @child.id, sibling.id ].sort, change_set.creative_changes.pluck(:creative_id).sort
       end
 
+      test "finishes an agent turn with one undo notice" do
+        agent = users(:ai_bot)
+        topic = Topic.create!(creative: @root, user: @user, name: "Agent notice")
+        task = Task.create!(agent: agent, creative: @root, topic_id: topic.id, name: "Edit", status: "running")
+
+        Current.set(user: agent, agent_turn: { user: @user, task: task }) do
+          @child.update!(description: "Notify once")
+          change_set = Current.change_set
+          notices = []
+
+          CreativeHistoryNoticeJob.stub(:perform_later, ->(*args) { notices << args }) do
+            History.finish_agent_turn
+          end
+          assert_equal [ [ change_set.id, @user.id ] ], notices
+          assert_nil Current.change_set
+        end
+      end
+
+      test "finishing an empty agent turn removes its empty change set" do
+        agent = users(:ai_bot)
+        topic = Topic.create!(creative: @root, user: @user, name: "Empty agent turn")
+        task = Task.create!(agent: agent, creative: @root, topic_id: topic.id, name: "Edit", status: "running")
+        empty_set = CreativeChangeSet.create!(
+          user: agent, actor_kind: "agent", origin: "tool", status: "applied", task: task, applied_at: Time.current
+        )
+
+        Current.set(user: agent, agent_turn: { user: @user, task: task }, change_set: empty_set) do
+          History.finish_agent_turn
+          assert_not CreativeChangeSet.exists?(empty_set.id)
+          assert_nil Current.change_set
+        end
+      end
+
       test "keeps nested import tracking in the enclosing agent turn" do
         agent = users(:ai_bot)
         topic = Topic.create!(creative: @root, user: @user, name: "Agent import")

--- a/engines/collavre/test/services/tools/creative_batch_service_test.rb
+++ b/engines/collavre/test/services/tools/creative_batch_service_test.rb
@@ -111,6 +111,23 @@ module Collavre
         assert_not linked.reload.archived?
       end
 
+      test "undo succeeds when the entire propagated family was already restored" do
+        child, linked = create_private_linked_pair
+
+        CreativeBatchService.new.call(operations: [ { "action" => "delete", "id" => child.id } ])
+        change_set = CreativeChangeSet.newest_first.first
+        Current.change_set = nil
+        child.unarchive!
+
+        revert = Creatives::ChangeSetRevertService.new(change_set: change_set, user: @user).call
+
+        assert_equal :applied, revert.status
+        assert_nil revert.change_set
+        assert_equal "reverted", change_set.reload.status
+        assert_not child.reload.archived?
+        assert_not linked.reload.archived?
+      end
+
       test "undo does not overwrite or expose an independently rearchived hidden shell" do
         child, linked = create_private_linked_pair
 

--- a/engines/collavre/test/services/tools/creative_batch_service_test.rb
+++ b/engines/collavre/test/services/tools/creative_batch_service_test.rb
@@ -67,6 +67,35 @@ module Collavre
         assert_not grandchild.reload.archived?
       end
 
+      test "undo restores linked shells propagated into a private tree" do
+        child = Creative.create!(description: "<p>Shared source</p>", user: @user, parent: @root)
+        foreign_user = users(:two)
+        foreign_root = Creative.create!(description: "<p>Private tree</p>", user: foreign_user)
+        linked = Creative.create!(origin: child, user: foreign_user, parent: foreign_root)
+        Current.change_set = nil
+
+        result = CreativeBatchService.new.call(operations: [ { "action" => "delete", "id" => child.id } ])
+        change_set = CreativeChangeSet.newest_first.first
+
+        assert result[:success]
+        assert linked.reload.archived?
+        assert_not_includes Creatives::PermissionFilter.new(user: @user).readable_ids([ linked.id ]), linked.id
+
+        revert = Creatives::ChangeSetRevertService.new(change_set: change_set, user: @user).call
+
+        assert_equal :applied, revert.status
+        assert_equal "reverted", change_set.reload.status
+        assert_not child.reload.archived?
+        assert_not linked.reload.archived?
+        assert_includes revert.change_set.creative_changes.pluck(:creative_id), linked.id
+
+        restore = Creatives::ChangeSetRestoreService.new(change_set: change_set, user: @user).call
+
+        assert_equal :applied, restore.status
+        assert child.reload.archived?
+        assert linked.reload.archived?
+      end
+
       test "mixed operations in a single batch" do
         child = Creative.create!(description: "<p>Child</p>", user: @user, parent: @root)
         service = CreativeBatchService.new

--- a/engines/collavre/test/services/tools/creative_batch_service_test.rb
+++ b/engines/collavre/test/services/tools/creative_batch_service_test.rb
@@ -94,6 +94,24 @@ module Collavre
         assert linked.reload.archived?
       end
 
+      test "undo restores a linked placement the actor can read but not write" do
+        child, linked = create_private_linked_pair
+        CreativeSharesCache.create!(creative: linked, user: @user, permission: :read)
+
+        CreativeBatchService.new.call(operations: [ { "action" => "delete", "id" => child.id } ])
+        change_set = CreativeChangeSet.newest_first.first
+        filter = Creatives::PermissionFilter.new(user: @user)
+        assert_includes filter.readable_ids([ linked.id ]), linked.id
+        assert_not_includes filter.readable_ids([ linked.id ], min_permission: :write), linked.id
+
+        revert = Creatives::ChangeSetRevertService.new(change_set: change_set, user: @user).call
+
+        assert_equal :applied, revert.status
+        assert_not child.reload.archived?
+        assert_not linked.reload.archived?
+        assert_in_delta 0.5, linked.parent.reload.progress, 0.01
+      end
+
       test "undo treats an independently restored hidden shell as complete" do
         child, linked = create_private_linked_pair
 

--- a/engines/collavre/test/services/tools/creative_batch_service_test.rb
+++ b/engines/collavre/test/services/tools/creative_batch_service_test.rb
@@ -58,7 +58,13 @@ module Collavre
         assert result[:results][0][:archived]
         assert child.reload.archived?
         assert grandchild.reload.archived?
-        assert_equal %w[archive archive], CreativeChangeSet.newest_first.first.creative_changes.order(:creative_id).pluck(:operation)
+        change_set = CreativeChangeSet.newest_first.first
+        assert_equal %w[archive archive], change_set.creative_changes.order(:creative_id).pluck(:operation)
+
+        revert = Creatives::ChangeSetRevertService.new(change_set: change_set, user: @user).call
+        assert_equal :applied, revert.status
+        assert_not child.reload.archived?
+        assert_not grandchild.reload.archived?
       end
 
       test "mixed operations in a single batch" do

--- a/engines/collavre/test/services/tools/creative_batch_service_test.rb
+++ b/engines/collavre/test/services/tools/creative_batch_service_test.rb
@@ -44,8 +44,10 @@ module Collavre
         assert_equal 1.0, result[:results][0][:progress]
       end
 
-      test "deletes a creative via batch" do
-        child = Creative.create!(description: "<p>To delete</p>", user: @user, parent: @root)
+      test "archives a creative subtree via batch" do
+        child = Creative.create!(description: "<p>To archive</p>", user: @user, parent: @root)
+        grandchild = Creative.create!(description: "<p>Nested</p>", user: @user, parent: child)
+        Current.change_set = nil
 
         service = CreativeBatchService.new
         result = service.call(operations: [
@@ -53,8 +55,10 @@ module Collavre
         ])
 
         assert result[:success]
-        assert result[:results][0][:deleted]
-        assert_nil Creative.find_by(id: child.id)
+        assert result[:results][0][:archived]
+        assert child.reload.archived?
+        assert grandchild.reload.archived?
+        assert_equal %w[archive archive], CreativeChangeSet.newest_first.first.creative_changes.order(:creative_id).pluck(:operation)
       end
 
       test "mixed operations in a single batch" do

--- a/engines/collavre/test/services/tools/creative_batch_service_test.rb
+++ b/engines/collavre/test/services/tools/creative_batch_service_test.rb
@@ -96,6 +96,38 @@ module Collavre
         assert linked.reload.archived?
       end
 
+      test "undo treats an independently restored hidden shell as complete" do
+        child, linked = create_private_linked_pair
+
+        CreativeBatchService.new.call(operations: [ { "action" => "delete", "id" => child.id } ])
+        change_set = CreativeChangeSet.newest_first.first
+        linked.update_column(:archived_at, nil)
+
+        revert = Creatives::ChangeSetRevertService.new(change_set: change_set, user: @user).call
+
+        assert_equal :applied, revert.status
+        assert_equal "reverted", change_set.reload.status
+        assert_not child.reload.archived?
+        assert_not linked.reload.archived?
+      end
+
+      test "undo does not overwrite or expose an independently rearchived hidden shell" do
+        child, linked = create_private_linked_pair
+
+        CreativeBatchService.new.call(operations: [ { "action" => "delete", "id" => child.id } ])
+        change_set = CreativeChangeSet.newest_first.first
+        later_archive = 1.hour.from_now
+        linked.update_column(:archived_at, later_archive)
+
+        revert = Creatives::ChangeSetRevertService.new(change_set: change_set, user: @user).call
+
+        assert_equal :partial, revert.status
+        assert_equal "applied", change_set.reload.status
+        assert_not child.reload.archived?
+        assert_in_delta later_archive, linked.reload.archived_at, 0.001
+        assert_not_includes revert.skipped, linked.id
+      end
+
       test "mixed operations in a single batch" do
         child = Creative.create!(description: "<p>Child</p>", user: @user, parent: @root)
         service = CreativeBatchService.new
@@ -176,6 +208,17 @@ module Collavre
 
         assert_not result[:success]
         assert_equal initial_count, Creative.count
+      end
+
+      private
+
+      def create_private_linked_pair
+        child = Creative.create!(description: "<p>Shared source</p>", user: @user, parent: @root)
+        foreign_user = users(:two)
+        foreign_root = Creative.create!(description: "<p>Private tree</p>", user: foreign_user)
+        linked = Creative.create!(origin: child, user: foreign_user, parent: foreign_root)
+        Current.change_set = nil
+        [ child, linked ]
       end
     end
   end

--- a/engines/collavre/test/services/tools/creative_batch_service_test.rb
+++ b/engines/collavre/test/services/tools/creative_batch_service_test.rb
@@ -68,17 +68,14 @@ module Collavre
       end
 
       test "undo restores linked shells propagated into a private tree" do
-        child = Creative.create!(description: "<p>Shared source</p>", user: @user, parent: @root)
-        foreign_user = users(:two)
-        foreign_root = Creative.create!(description: "<p>Private tree</p>", user: foreign_user)
-        linked = Creative.create!(origin: child, user: foreign_user, parent: foreign_root)
-        Current.change_set = nil
+        child, linked = create_private_linked_pair
 
         result = CreativeBatchService.new.call(operations: [ { "action" => "delete", "id" => child.id } ])
         change_set = CreativeChangeSet.newest_first.first
 
         assert result[:success]
         assert linked.reload.archived?
+        assert_in_delta 0, linked.parent.reload.progress, 0.01
         assert_not_includes Creatives::PermissionFilter.new(user: @user).readable_ids([ linked.id ]), linked.id
 
         revert = Creatives::ChangeSetRevertService.new(change_set: change_set, user: @user).call
@@ -87,6 +84,7 @@ module Collavre
         assert_equal "reverted", change_set.reload.status
         assert_not child.reload.archived?
         assert_not linked.reload.archived?
+        assert_in_delta 0.5, linked.parent.reload.progress, 0.01
         assert_includes revert.change_set.creative_changes.pluck(:creative_id), linked.id
 
         restore = Creatives::ChangeSetRestoreService.new(change_set: change_set, user: @user).call
@@ -230,9 +228,10 @@ module Collavre
       private
 
       def create_private_linked_pair
-        child = Creative.create!(description: "<p>Shared source</p>", user: @user, parent: @root)
+        child = Creative.create!(description: "<p>Shared source</p>", user: @user, parent: @root, progress: 1)
         foreign_user = users(:two)
         foreign_root = Creative.create!(description: "<p>Private tree</p>", user: foreign_user)
+        Creative.create!(description: "<p>Incomplete</p>", user: foreign_user, parent: foreign_root, progress: 0)
         linked = Creative.create!(origin: child, user: foreign_user, parent: foreign_root)
         Current.change_set = nil
         [ child, linked ]


### PR DESCRIPTION
## Summary
- archive AI batch delete targets instead of hard-deleting them
- finalize each AI turn with one user-scoped History undo notification
- provide a 30-second undo toast that reuses the permission- and conflict-aware ChangeSet revert flow
- refresh the creative tree when AI changes or undo results arrive

## Validation
- `bundle exec rails test engines/collavre/test/services/tools/creative_batch_service_test.rb engines/collavre/test/services/collavre/creatives/history_test.rb engines/collavre/test/jobs/collavre/creative_history_notice_job_test.rb engines/collavre/test/services/ai_agent_service_test.rb` (71 tests, 234 assertions)
- `npm test -- --runInBand engines/collavre/app/javascript/controllers/__tests__/creative_history_controller.test.js engines/collavre/app/javascript/controllers/__tests__/creative_history_undo_controller.test.js engines/collavre/app/javascript/controllers/__tests__/index.test.js` (8 tests)
- `./bin/rubocop -a`
- `bin/complexity_check`
- `npm run build`