### PR TITLE
feat: add review policy for AI creative writes

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -1624,13 +1624,18 @@ body.chat-fullscreen {
 }
 
 .creative-history-list {
+  --creative-history-addition-bg: color-mix(in srgb, var(--color-success) 18%, var(--surface-section));
+  --creative-history-addition-text: color-mix(in srgb, var(--color-success) 65%, var(--text-primary));
+  --creative-history-deletion-bg: color-mix(in srgb, var(--color-danger) 18%, var(--surface-section));
+  --creative-history-deletion-text: color-mix(in srgb, var(--color-danger) 65%, var(--text-primary));
+
   display: grid;
   gap: 12px;
   padding: 12px;
 }
 
 .creative-history-item {
-  border: 1px solid var(--border-color, #ddd);
+  border: 1px solid var(--border-color);
   border-radius: 8px;
   padding: 12px;
 }
@@ -1647,17 +1652,17 @@ body.chat-fullscreen {
 }
 
 .creative-history-stats {
-  color: var(--text-secondary, #666);
+  color: var(--text-muted);
   font-size: 0.85rem;
 }
 
 .creative-history-stats ins {
-  color: #16803a;
+  color: var(--creative-history-addition-text);
   text-decoration: none;
 }
 
 .creative-history-stats del {
-  color: #b42318;
+  color: var(--creative-history-deletion-text);
   text-decoration: none;
 }
 
@@ -1671,12 +1676,14 @@ body.chat-fullscreen {
 }
 
 .creative-history-inline ins {
-  background: #dcfce7;
+  background: var(--creative-history-addition-bg);
+  color: var(--text-primary);
   text-decoration: none;
 }
 
 .creative-history-inline del {
-  background: #fee2e2;
+  background: var(--creative-history-deletion-bg);
+  color: var(--text-primary);
 }
 
 .creative-history-split {
@@ -1693,11 +1700,13 @@ body.chat-fullscreen {
 }
 
 .creative-history-split .diff-changed td:first-child {
-  background: #fee2e2;
+  background: var(--creative-history-deletion-bg);
+  color: var(--text-primary);
 }
 
 .creative-history-split .diff-changed td:last-child {
-  background: #dcfce7;
+  background: var(--creative-history-addition-bg);
+  color: var(--text-primary);
 }
 
 .creative-history-revert {

--- a/engines/collavre/app/controllers/collavre/creative_change_sets_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creative_change_sets_controller.rb
@@ -55,8 +55,14 @@ module Collavre
         change_set_id: result.change_set&.id,
         conflicts: result.conflicts,
         skipped: result.skipped,
-        message: I18n.t("collavre.creative_history.results.#{result.status}")
+        message: I18n.t("collavre.creative_history.results.#{result_message_key(result)}")
       }
+    end
+
+    def result_message_key(result)
+      return :approved if result.status == :applied && params[:mode] == "approve"
+
+      result.status
     end
 
     def response_status(result)

--- a/engines/collavre/app/controllers/collavre/creative_change_sets_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creative_change_sets_controller.rb
@@ -14,6 +14,20 @@ module Collavre
     private
 
     def apply_service(change_set)
+      if change_set.status == "draft"
+        return Creatives::DraftChangeSetRejectService.new(
+          change_set: change_set, user: Current.user, scope_creative: @requested_creative
+        ) if params[:mode] == "reject"
+
+        mode = params[:mode] == "approve" ? :draft : :invalid
+        return Creatives::ChangeSetApplyService.new(
+          source: change_set,
+          user: Current.user,
+          resolutions: resolutions,
+          mode: mode
+        )
+      end
+
       return Creatives::ChangeSetRestoreService.new(change_set: change_set, user: Current.user) if params[:mode] == "restore"
 
       Creatives::ChangeSetRevertService.new(
@@ -47,7 +61,7 @@ module Collavre
 
     def response_status(result)
       return :conflict if result.status == :conflict
-      return :unprocessable_entity unless result.status.in?(%i[applied partial])
+      return :unprocessable_entity unless result.status.in?(%i[applied partial rejected])
 
       :ok
     end

--- a/engines/collavre/app/controllers/collavre/creatives/attachments_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creatives/attachments_controller.rb
@@ -26,6 +26,15 @@ module Collavre
         file = params[:file]
         return render(json: { error: "No file provided" }, status: :unprocessable_entity) unless file.respond_to?(:read)
 
+        result = Collavre::Creatives::AiWritePolicy.capture(
+          creatives: [ creative, creative.effective_origin ], anchor: creative, external_request: true
+        ) { attach_file(creative, file) }
+        render json: result
+      end
+
+      private
+
+      def attach_file(creative, file)
         io = file.to_io
         content_type = resolved_content_type(file, io)
         io.rewind
@@ -37,7 +46,8 @@ module Collavre
 
         creative.embed_attachment_blob!(blob)
 
-        render json: {
+        {
+          success: true,
           signed_id: blob.signed_id,
           filename: blob.filename.to_s,
           content_type: blob.content_type,
@@ -45,8 +55,6 @@ module Collavre
           url: public_asset_url(blob)
         }
       end
-
-      private
 
       # The bundled `collavre` CLI sends application/octet-stream for every part,
       # so treat octet-stream (and blank) as "unknown" and sniff via Marcel —

--- a/engines/collavre/app/models/collavre/creative.rb
+++ b/engines/collavre/app/models/collavre/creative.rb
@@ -71,7 +71,7 @@ module Collavre
     include Permissible
     include Describable
     include RealtimeBroadcastable
-    include HistoryTrackable, CreativeHistoryTopic
+    include HistoryTrackable, CreativeHistoryTopic, AiWritePolicy
 
     has_many :comments, class_name: "Collavre::Comment", dependent: :destroy
     has_many :comment_read_pointers, class_name: "Collavre::CommentReadPointer", dependent: :delete_all

--- a/engines/collavre/app/models/collavre/creative/ai_write_policy.rb
+++ b/engines/collavre/app/models/collavre/creative/ai_write_policy.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Collavre
+  class Creative < ApplicationRecord
+    module AiWritePolicy
+      extend ActiveSupport::Concern
+
+      POLICIES = %w[auto review].freeze
+      DEFAULT_POLICY = "auto"
+
+      def effective_ai_write_policy(visited_ids = Set.new)
+        return DEFAULT_POLICY if visited_ids.include?(id)
+
+        visited_ids.add(id)
+        own_policy = data&.dig("ai_write_policy").to_s
+        return own_policy if own_policy.in?(POLICIES)
+
+        parent&.effective_ai_write_policy(visited_ids) || DEFAULT_POLICY
+      end
+
+      def ai_write_review?
+        effective_ai_write_policy == "review"
+      end
+    end
+  end
+end

--- a/engines/collavre/app/models/collavre/creative/history_trackable.rb
+++ b/engines/collavre/app/models/collavre/creative/history_trackable.rb
@@ -31,6 +31,10 @@ module Collavre
         mutate_archive_family(archived_at: nil, operation: "unarchive")
       end
 
+      def archive_family
+        self.class.where(id: archive_family_ids)
+      end
+
       private
 
       def mutate_archive_family(archived_at:, operation:)
@@ -48,7 +52,7 @@ module Collavre
       end
 
       def archive_targets(archived_at)
-        scope = self.class.where(id: archive_family_ids)
+        scope = archive_family
         archived_at ? scope.where(archived_at: nil) : scope.where.not(archived_at: nil)
       end
 

--- a/engines/collavre/app/models/collavre/creative_change.rb
+++ b/engines/collavre/app/models/collavre/creative_change.rb
@@ -23,6 +23,11 @@ module Collavre
     validates :operation, inclusion: { in: OPERATIONS }
     validates :creative_id, uniqueness: { scope: :creative_change_set_id }
 
+    def archival_only?
+      operation.in?(%w[archive unarchive]) && before["archived_at"] != after["archived_at"] &&
+        before.except("archived_at") == after.except("archived_at")
+    end
+
     after_create_commit :ensure_history_topic
 
     private

--- a/engines/collavre/app/models/collavre/creative_change.rb
+++ b/engines/collavre/app/models/collavre/creative_change.rb
@@ -5,6 +5,7 @@ module Collavre
     self.table_name = "creative_changes"
 
     OPERATIONS = %w[create update move reorder archive unarchive destroy].freeze
+    ARCHIVE_PROPAGATION_KEYS = %w[archived_at progress].freeze
 
     belongs_to :change_set, class_name: "Collavre::CreativeChangeSet",
                             foreign_key: :creative_change_set_id,
@@ -23,9 +24,9 @@ module Collavre
     validates :operation, inclusion: { in: OPERATIONS }
     validates :creative_id, uniqueness: { scope: :creative_change_set_id }
 
-    def archival_only?
+    def archive_propagation_only?
       operation.in?(%w[archive unarchive]) && before["archived_at"] != after["archived_at"] &&
-        before.except("archived_at") == after.except("archived_at")
+        before.except(*ARCHIVE_PROPAGATION_KEYS) == after.except(*ARCHIVE_PROPAGATION_KEYS)
     end
 
     after_create_commit :ensure_history_topic

--- a/engines/collavre/app/models/collavre/creative_change.rb
+++ b/engines/collavre/app/models/collavre/creative_change.rb
@@ -9,7 +9,10 @@ module Collavre
     belongs_to :change_set, class_name: "Collavre::CreativeChangeSet",
                             foreign_key: :creative_change_set_id,
                             inverse_of: :creative_changes
-    belongs_to :creative, class_name: "Collavre::Creative"
+    # Draft create operations use a negative temporary id until approval creates
+    # the real row and remaps the change. Applied history still points at a live
+    # Creative, while the optional association lets the draft diff exist first.
+    belongs_to :creative, class_name: "Collavre::Creative", optional: true
     has_many :history_file_attachments,
              -> { where(name: "history_files") },
              as: :record,

--- a/engines/collavre/app/services/collavre/creatives/ai_write_policy.rb
+++ b/engines/collavre/app/services/collavre/creatives/ai_write_policy.rb
@@ -3,8 +3,8 @@
 module Collavre
   module Creatives
     class AiWritePolicy
-      def self.review_required?(creatives)
-        return false unless Current.agent_turn&.dig(:task) || Current.mcp_request
+      def self.review_required?(creatives, external_request: false)
+        return false unless external_request || Current.agent_turn&.dig(:task) || Current.mcp_request
 
         Array(creatives).compact.uniq(&:id).any?(&:ai_write_review?)
       end
@@ -14,10 +14,10 @@ module Collavre
         task&.topic_id ? Topic.find_by(id: task.topic_id)&.creative : nil
       end
 
-      def self.capture(creatives:, anchor:, origin: :tool)
-        return yield unless review_required?(creatives)
+      def self.capture(creatives:, anchor:, origin: :tool, external_request: false)
+        return yield unless review_required?(creatives, external_request: external_request)
 
-        effective_origin = Current.mcp_request ? :mcp : origin
+        effective_origin = Current.mcp_request || external_request ? :mcp : origin
         DraftChangeSetCapture.new(
           anchor: anchor || agent_anchor || Array(creatives).compact.first,
           origin: effective_origin

--- a/engines/collavre/app/services/collavre/creatives/ai_write_policy.rb
+++ b/engines/collavre/app/services/collavre/creatives/ai_write_policy.rb
@@ -4,7 +4,7 @@ module Collavre
   module Creatives
     class AiWritePolicy
       def self.review_required?(creatives)
-        return false unless Current.agent_turn&.dig(:task)
+        return false unless Current.agent_turn&.dig(:task) || Current.mcp_request
 
         Array(creatives).compact.uniq(&:id).any?(&:ai_write_review?)
       end
@@ -17,7 +17,11 @@ module Collavre
       def self.capture(creatives:, anchor:, origin: :tool)
         return yield unless review_required?(creatives)
 
-        DraftChangeSetCapture.new(anchor: anchor || agent_anchor, origin: origin).call { yield }
+        effective_origin = Current.mcp_request ? :mcp : origin
+        DraftChangeSetCapture.new(
+          anchor: anchor || agent_anchor || Array(creatives).compact.first,
+          origin: effective_origin
+        ).call { yield }
       end
     end
   end

--- a/engines/collavre/app/services/collavre/creatives/ai_write_policy.rb
+++ b/engines/collavre/app/services/collavre/creatives/ai_write_policy.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Collavre
+  module Creatives
+    class AiWritePolicy
+      def self.review_required?(creatives)
+        return false unless Current.agent_turn&.dig(:task)
+
+        Array(creatives).compact.uniq(&:id).any?(&:ai_write_review?)
+      end
+
+      def self.agent_anchor
+        task = Current.agent_turn&.dig(:task)
+        task&.topic_id ? Topic.find_by(id: task.topic_id)&.creative : nil
+      end
+
+      def self.capture(creatives:, anchor:, origin: :tool)
+        return yield unless review_required?(creatives)
+
+        DraftChangeSetCapture.new(anchor: anchor || agent_anchor, origin: origin).call { yield }
+      end
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/creatives/change_set_apply_service.rb
+++ b/engines/collavre/app/services/collavre/creatives/change_set_apply_service.rb
@@ -127,19 +127,19 @@ module Collavre
       end
 
       def classify_propagated_target(change, creative, snapshot, plan)
-        attribute = @propagated_attributes.fetch(change.id)
-        current_value = History.snapshot(creative)[attribute] if creative
-        return @resolved_change_ids << change.id if current_value == snapshot[attribute]
-        unless creative && current_value == change.public_send(source_snapshot_side)[attribute]
+        attributes = Array(@propagated_attributes.fetch(change.id))
+        current_values = History.snapshot(creative).slice(*attributes) if creative
+        return @resolved_change_ids << change.id if current_values == snapshot.slice(*attributes)
+        unless creative && current_values == change.public_send(source_snapshot_side).slice(*attributes)
           @complete = false unless @authorization_only
           return
         end
 
-        plan << [ creative, snapshot, attribute, change ]
+        plan << [ creative, snapshot, attributes, change ]
       end
 
       def target_writable?(creative, snapshot, records, writable_ids, change)
-        creative && (!creative.read_only_source? || change.archival_only?) && writable_ids.include?(creative.id) &&
+        creative && (!creative.read_only_source? || change.archive_propagation_only?) && writable_ids.include?(creative.id) &&
           (@authorization_only || target_parent_writable?(creative, snapshot, records, writable_ids))
       end
 
@@ -238,7 +238,7 @@ module Collavre
 
       def apply_snapshot(creative, snapshot, propagated_attribute: nil)
         return creative.update!(archived_at: Time.current) if snapshot.empty?
-        return creative.update!(propagated_attribute => snapshot[propagated_attribute]) if propagated_attribute
+        return creative.update!(snapshot.slice(*Array(propagated_attribute))) if propagated_attribute
 
         SnapshotAssignment.call(creative, snapshot)
         creative.save!

--- a/engines/collavre/app/services/collavre/creatives/change_set_apply_service.rb
+++ b/engines/collavre/app/services/collavre/creatives/change_set_apply_service.rb
@@ -140,7 +140,7 @@ module Collavre
 
       def target_writable?(creative, snapshot, records, writable_ids)
         creative && !creative.read_only_source? && writable_ids.include?(creative.id) &&
-          target_parent_writable?(creative, snapshot, records, writable_ids)
+          (@authorization_only || target_parent_writable?(creative, snapshot, records, writable_ids))
       end
 
       def revertible?(source)

--- a/engines/collavre/app/services/collavre/creatives/change_set_apply_service.rb
+++ b/engines/collavre/app/services/collavre/creatives/change_set_apply_service.rb
@@ -75,7 +75,9 @@ module Collavre
         plan, conflicts, skipped = buckets
         creative = records[change.creative_id]
         return classify_draft_creation(change, snapshot, records, writable_ids, plan, skipped) if draft_creation?(change, creative)
-        return classify_propagated_target(change, creative, snapshot, plan) if propagated_target?(change)
+        if propagated_target?(change) && !target_writable?(creative, snapshot, records, writable_ids)
+          return classify_propagated_target(change, creative, snapshot, plan)
+        end
         return skipped << change.creative_id unless target_writable?(creative, snapshot, records, writable_ids)
         return @resolved_change_ids << change.id if History.snapshot(creative) == snapshot
 

--- a/engines/collavre/app/services/collavre/creatives/change_set_apply_service.rb
+++ b/engines/collavre/app/services/collavre/creatives/change_set_apply_service.rb
@@ -57,6 +57,7 @@ module Collavre
       def classify_target(change, snapshot, records, writable_ids, buckets)
         plan, conflicts, skipped = buckets
         creative = records[change.creative_id]
+        return classify_draft_creation(change, snapshot, records, writable_ids, plan, skipped) if draft_creation?(change, creative)
         return classify_propagated_target(change, creative, snapshot, plan) if propagated_target?(change)
         return skipped << change.creative_id unless target_writable?(creative, snapshot, records, writable_ids)
         return if History.snapshot(creative) == snapshot
@@ -64,8 +65,19 @@ module Collavre
         if current_conflict?(creative, change) && resolution(change) != "force"
           resolution(change) == "skip" ? skipped << change.creative_id : conflicts << conflict_for(creative, change)
         else
-          plan << [ creative, snapshot ]
+          plan << [ creative, snapshot, nil, change ]
         end
+      end
+
+      def classify_draft_creation(change, snapshot, records, writable_ids, plan, skipped)
+        parent_id = snapshot["parent_id"]
+        writable = if parent_id&.negative?
+                     virtual_creation_ids.include?(parent_id)
+        else
+                     parent = records[parent_id]
+                     parent && writable_parent?(parent, writable_ids)
+        end
+        writable ? plan << [ nil, snapshot, nil, change ] : skipped << change.creative_id
       end
 
       def retain_authorized_targets(records, writable_ids)
@@ -93,7 +105,7 @@ module Collavre
           return
         end
 
-        plan << [ creative, snapshot, attribute ]
+        plan << [ creative, snapshot, attribute, change ]
       end
 
       def target_writable?(creative, snapshot, records, writable_ids)
@@ -103,6 +115,8 @@ module Collavre
 
       def revertible?(source)
         return false if source.origin == "sync" || @targets.keys.any? { |change| change.operation == "destroy" }
+
+        return source.status == "draft" if @mode == :draft
 
         @mode == :restore ? source.status.in?(%w[applied reverted]) : source.status == "applied"
       end
@@ -125,6 +139,7 @@ module Collavre
       end
 
       def current_conflict?(creative, change)
+        return History.snapshot(creative) != change.before if @mode == :draft
         return false if @mode == :restore
 
         History.snapshot(creative) != change.after
@@ -143,10 +158,12 @@ module Collavre
       end
 
       def apply(source, plan, skipped)
+        return apply_draft(source, plan, skipped) if @mode == :draft
+
         reverse = create_reverse_set(source)
         History.track(actor: @user, origin: :revert, anchor: source.anchor_creative, anchor_source: :explicit) do
           Current.change_set = reverse
-          plan.each { |creative, snapshot, propagated_attribute| apply_snapshot(creative, snapshot, propagated_attribute:) }
+          plan.each { |creative, snapshot, propagated_attribute, _change| apply_snapshot(creative, snapshot, propagated_attribute:) }
         end
         source.update!(status: "reverted", reverted_by: reverse) if @mode == :revert && skipped.empty? && @complete
         status = skipped.empty? && @complete ? :applied : :partial
@@ -169,15 +186,26 @@ module Collavre
       def complete_noop(source, skipped)
         return result(:skipped, skipped: skipped) unless skipped.empty? && @complete
 
-        source.update!(status: "reverted") if @mode == :revert
+        if @mode == :revert
+          source.update!(status: "reverted")
+        elsif @mode == :draft
+          source.update!(status: "applied", applied_at: Time.current)
+        end
         result(:applied)
+      end
+
+      def apply_draft(source, plan, skipped)
+        return result(:skipped, skipped: skipped) unless skipped.empty? && @complete
+
+        DraftChangeSetApplicator.new(change_set: source, user: @user, plan: plan).call
+        result(:applied, change_set: source)
       end
 
       def apply_snapshot(creative, snapshot, propagated_attribute: nil)
         return creative.update!(archived_at: Time.current) if snapshot.empty?
         return creative.update!(propagated_attribute => snapshot[propagated_attribute]) if propagated_attribute
 
-        creative.assign_attributes(snapshot_attributes(creative, snapshot))
+        SnapshotAssignment.call(creative, snapshot)
         creative.save!
       end
 
@@ -198,20 +226,12 @@ module Collavre
         @mode == :revert ? :after : :before
       end
 
-      def snapshot_attributes(creative, snapshot)
-        data = (creative.data || {}).deep_dup
-        data["content_type"] = snapshot["content_type"]
-        data["editor"] = snapshot["editor"]
-        data["markdown_source"] = snapshot["markdown_source"]
-        {
-          data: data,
-          description: snapshot["content_type"] == "markdown" ?
-            MarkdownConverter.markdown_to_html(snapshot["markdown_source"].to_s) : snapshot["description"],
-          parent_id: snapshot["parent_id"],
-          sequence: snapshot["sequence"],
-          progress: snapshot["progress"],
-          archived_at: snapshot["archived_at"]
-        }
+      def draft_creation?(change, creative)
+        @mode == :draft && creative.nil? && change.before.empty?
+      end
+
+      def virtual_creation_ids
+        @virtual_creation_ids ||= @targets.keys.select { |change| change.before.empty? }.map(&:creative_id).to_set
       end
 
       def result(status, change_set: nil, conflicts: [], skipped: [])

--- a/engines/collavre/app/services/collavre/creatives/change_set_apply_service.rb
+++ b/engines/collavre/app/services/collavre/creatives/change_set_apply_service.rb
@@ -32,6 +32,7 @@ module Collavre
       private
 
       def build_targets(source)
+        @source_record = source
         @all_changes = source.creative_changes.order(@mode == :revert ? { position: :desc } : { position: :asc }).to_a
         visible_changes = ChangeSetVisibility.new(user: @user).changes(@all_changes)
         @visible_change_ids = visible_changes.map(&:id).to_set
@@ -51,7 +52,8 @@ module Collavre
       def locked_records
         target_ids = @targets.keys.map(&:creative_id)
         parent_ids = @targets.values.filter_map { |snapshot| snapshot["parent_id"] }
-        Creative.unscoped.where(id: [ *target_ids, *parent_ids ]).order(:id).lock.index_by(&:id)
+        anchor_ids = @mode == :draft ? [ @source_record.anchor_creative_id ] : []
+        Creative.unscoped.where(id: [ *target_ids, *parent_ids, *anchor_ids ]).order(:id).lock.index_by(&:id)
       end
 
       def classify_target(change, snapshot, records, writable_ids, buckets)
@@ -71,7 +73,9 @@ module Collavre
 
       def classify_draft_creation(change, snapshot, records, writable_ids, plan, skipped)
         parent_id = snapshot["parent_id"]
-        writable = if parent_id&.negative?
+        writable = if parent_id.nil?
+                     writable_parent?(records[@source_record.anchor_creative_id], writable_ids)
+        elsif parent_id.negative?
                      virtual_creation_ids.include?(parent_id)
         else
                      parent = records[parent_id]
@@ -195,10 +199,11 @@ module Collavre
       end
 
       def apply_draft(source, plan, skipped)
-        return result(:skipped, skipped: skipped) unless skipped.empty? && @complete
+        return result(:skipped, skipped: skipped) unless @complete && explicitly_skipped?(skipped)
 
-        DraftChangeSetApplicator.new(change_set: source, user: @user, plan: plan).call
-        result(:applied, change_set: source)
+        DraftChangeSetApplicator.new(change_set: source, user: @user, plan: plan, skipped_ids: skipped).call
+        status = skipped.empty? ? :applied : :partial
+        result(status, change_set: source, skipped: skipped)
       end
 
       def apply_snapshot(creative, snapshot, propagated_attribute: nil)
@@ -232,6 +237,10 @@ module Collavre
 
       def virtual_creation_ids
         @virtual_creation_ids ||= @targets.keys.select { |change| change.before.empty? }.map(&:creative_id).to_set
+      end
+
+      def explicitly_skipped?(ids)
+        ids.all? { |id| @resolutions[id.to_s] == "skip" }
       end
 
       def result(status, change_set: nil, conflicts: [], skipped: [])

--- a/engines/collavre/app/services/collavre/creatives/change_set_apply_service.rb
+++ b/engines/collavre/app/services/collavre/creatives/change_set_apply_service.rb
@@ -29,6 +29,17 @@ module Collavre
         end
       end
 
+      def fully_authorized?
+        CreativeChangeSet.transaction do
+          source = CreativeChangeSet.lock.find(@source.id)
+          build_targets(source)
+          next false unless revertible?(source)
+
+          _plan, _conflicts, skipped = build_plan
+          skipped.empty? && @complete
+        end
+      end
+
       private
 
       def build_targets(source)
@@ -44,9 +55,12 @@ module Collavre
         records = locked_records
         writable_ids = writable_ids_for(records.keys)
         retain_authorized_targets(records, writable_ids)
-        @targets.each_with_object([ [], [], [] ]) do |(change, snapshot), buckets|
-          classify_target(change, snapshot, records, writable_ids, buckets)
+        @conflict_skipped_change_ids = Set.new
+        buckets = @targets.each_with_object([ [], [], [] ]) do |(change, snapshot), result|
+          classify_target(change, snapshot, records, writable_ids, result)
         end
+        prune_skipped_dependencies(buckets.first, records) if @mode == :draft
+        buckets
       end
 
       def locked_records
@@ -65,7 +79,12 @@ module Collavre
         return if History.snapshot(creative) == snapshot
 
         if current_conflict?(creative, change) && resolution(change) != "force"
-          resolution(change) == "skip" ? skipped << change.creative_id : conflicts << conflict_for(creative, change)
+          if resolution(change) == "skip"
+            @conflict_skipped_change_ids << change.id
+            skipped << change.creative_id
+          else
+            conflicts << conflict_for(creative, change)
+          end
         else
           plan << [ creative, snapshot, nil, change ]
         end
@@ -188,6 +207,7 @@ module Collavre
       end
 
       def complete_noop(source, skipped)
+        return reject_fully_skipped_draft(source, skipped) if fully_skipped_draft?(skipped)
         return result(:skipped, skipped: skipped) unless skipped.empty? && @complete
 
         if @mode == :revert
@@ -199,9 +219,11 @@ module Collavre
       end
 
       def apply_draft(source, plan, skipped)
-        return result(:skipped, skipped: skipped) unless @complete && explicitly_skipped?(skipped)
+        return result(:skipped, skipped: skipped) unless @complete && only_conflicts_skipped?(skipped)
 
-        DraftChangeSetApplicator.new(change_set: source, user: @user, plan: plan, skipped_ids: skipped).call
+        DraftChangeSetApplicator.new(
+          change_set: source, user: @user, plan: plan, skipped_change_ids: @draft_discard_change_ids
+        ).call
         status = skipped.empty? ? :applied : :partial
         result(status, change_set: source, skipped: skipped)
       end
@@ -239,8 +261,26 @@ module Collavre
         @virtual_creation_ids ||= @targets.keys.select { |change| change.before.empty? }.map(&:creative_id).to_set
       end
 
-      def explicitly_skipped?(ids)
-        ids.all? { |id| @resolutions[id.to_s] == "skip" }
+      def only_conflicts_skipped?(ids)
+        conflict_ids = @all_changes.select { |change| @conflict_skipped_change_ids.include?(change.id) }
+          .map(&:creative_id).to_set
+        ids.to_set == conflict_ids
+      end
+
+      def fully_skipped_draft?(skipped)
+        @mode == :draft && @complete && skipped.present? && only_conflicts_skipped?(skipped) &&
+          @draft_discard_change_ids.size == @all_changes.size
+      end
+
+      def reject_fully_skipped_draft(source, skipped)
+        source.update!(status: "rejected")
+        result(:rejected, change_set: source, skipped: skipped)
+      end
+
+      def prune_skipped_dependencies(plan, records)
+        @draft_discard_change_ids = DraftConflictDependencyPruner.new(
+          changes: @all_changes, records: records, skipped_change_ids: @conflict_skipped_change_ids
+        ).call(plan)
       end
 
       def result(status, change_set: nil, conflicts: [], skipped: [])

--- a/engines/collavre/app/services/collavre/creatives/change_set_apply_service.rb
+++ b/engines/collavre/app/services/collavre/creatives/change_set_apply_service.rb
@@ -56,6 +56,7 @@ module Collavre
         writable_ids = writable_ids_for(records.keys)
         retain_authorized_targets(records, writable_ids)
         @conflict_skipped_change_ids = Set.new
+        @resolved_change_ids = Set.new
         buckets = @targets.each_with_object([ [], [], [] ]) do |(change, snapshot), result|
           classify_target(change, snapshot, records, writable_ids, result)
         end
@@ -76,7 +77,7 @@ module Collavre
         return classify_draft_creation(change, snapshot, records, writable_ids, plan, skipped) if draft_creation?(change, creative)
         return classify_propagated_target(change, creative, snapshot, plan) if propagated_target?(change)
         return skipped << change.creative_id unless target_writable?(creative, snapshot, records, writable_ids)
-        return if History.snapshot(creative) == snapshot
+        return @resolved_change_ids << change.id if History.snapshot(creative) == snapshot
 
         if current_conflict?(creative, change) && resolution(change) != "force"
           if resolution(change) == "skip"
@@ -104,8 +105,9 @@ module Collavre
       end
 
       def retain_authorized_targets(records, writable_ids)
-        visible_origins = @targets.keys.filter_map do |change|
-          next unless @visible_change_ids.include?(change.id) && change.operation.in?(%w[archive unarchive])
+        writable_sources = @targets.keys.filter_map do |change|
+          next unless @visible_change_ids.include?(change.id)
+          next unless archival_transition?(change) || progress_transition?(change)
 
           creative = records[change.creative_id]
           creative&.id if target_writable?(creative, @targets.fetch(change), records, writable_ids)
@@ -113,7 +115,7 @@ module Collavre
         @propagated_attributes = PropagatedChangeAuthorization.new(
           changes: @targets.keys,
           records: records,
-          writable_origin_ids: visible_origins
+          writable_source_ids: writable_sources
         ).call
         @targets.select! { |change, _snapshot| @visible_change_ids.include?(change.id) || propagated_target?(change) }
         @complete = @targets.size == @all_changes.size
@@ -122,7 +124,7 @@ module Collavre
       def classify_propagated_target(change, creative, snapshot, plan)
         attribute = @propagated_attributes.fetch(change.id)
         current_value = History.snapshot(creative)[attribute] if creative
-        return if current_value == snapshot[attribute]
+        return @resolved_change_ids << change.id if current_value == snapshot[attribute]
         unless creative && current_value == change.public_send(source_snapshot_side)[attribute]
           @complete = false
           return
@@ -208,6 +210,7 @@ module Collavre
 
       def complete_noop(source, skipped)
         return reject_fully_skipped_draft(source, skipped) if fully_skipped_draft?(skipped)
+        return apply_draft(source, [], skipped) if resolved_skipped_draft?(skipped)
         return result(:skipped, skipped: skipped) unless skipped.empty? && @complete
 
         if @mode == :revert
@@ -245,6 +248,10 @@ module Collavre
           change.before["archived_at"] != change.after["archived_at"]
       end
 
+      def progress_transition?(change)
+        change.before["progress"] != change.after["progress"]
+      end
+
       def propagated_candidate?(change)
         archival_transition?(change) || change.operation == "update"
       end
@@ -270,6 +277,12 @@ module Collavre
       def fully_skipped_draft?(skipped)
         @mode == :draft && @complete && skipped.present? && only_conflicts_skipped?(skipped) &&
           @draft_discard_change_ids.size == @all_changes.size
+      end
+
+      def resolved_skipped_draft?(skipped)
+        return false unless @mode == :draft && @complete && skipped.present? && only_conflicts_skipped?(skipped)
+
+        (@draft_discard_change_ids | @resolved_change_ids).size == @all_changes.size
       end
 
       def reject_fully_skipped_draft(source, skipped)

--- a/engines/collavre/app/services/collavre/creatives/change_set_apply_service.rb
+++ b/engines/collavre/app/services/collavre/creatives/change_set_apply_service.rb
@@ -30,6 +30,7 @@ module Collavre
       end
 
       def fully_authorized?
+        @authorization_only = true
         CreativeChangeSet.transaction do
           source = CreativeChangeSet.lock.find(@source.id)
           build_targets(source)
@@ -38,6 +39,8 @@ module Collavre
           _plan, _conflicts, skipped = build_plan
           skipped.empty? && @complete
         end
+      ensure
+        @authorization_only = false
       end
 
       private
@@ -89,7 +92,7 @@ module Collavre
             conflicts << conflict_for(creative, change)
           end
         else
-          plan << [ creative, snapshot, nil, change ]
+          plan << [ creative, snapshot, @propagated_attributes[change.id], change ]
         end
       end
 
@@ -128,7 +131,7 @@ module Collavre
         current_value = History.snapshot(creative)[attribute] if creative
         return @resolved_change_ids << change.id if current_value == snapshot[attribute]
         unless creative && current_value == change.public_send(source_snapshot_side)[attribute]
-          @complete = false
+          @complete = false unless @authorization_only
           return
         end
 

--- a/engines/collavre/app/services/collavre/creatives/change_set_apply_service.rb
+++ b/engines/collavre/app/services/collavre/creatives/change_set_apply_service.rb
@@ -78,10 +78,10 @@ module Collavre
         plan, conflicts, skipped = buckets
         creative = records[change.creative_id]
         return classify_draft_creation(change, snapshot, records, writable_ids, plan, skipped) if draft_creation?(change, creative)
-        if propagated_target?(change) && !target_writable?(creative, snapshot, records, writable_ids)
+        if propagated_target?(change) && !target_writable?(creative, snapshot, records, writable_ids, change)
           return classify_propagated_target(change, creative, snapshot, plan)
         end
-        return skipped << change.creative_id unless target_writable?(creative, snapshot, records, writable_ids)
+        return skipped << change.creative_id unless target_writable?(creative, snapshot, records, writable_ids, change)
         return @resolved_change_ids << change.id if History.snapshot(creative) == snapshot
 
         if current_conflict?(creative, change) && resolution(change) != "force"
@@ -115,7 +115,7 @@ module Collavre
           next unless archival_transition?(change) || progress_transition?(change)
 
           creative = records[change.creative_id]
-          creative&.id if target_writable?(creative, @targets.fetch(change), records, writable_ids)
+          creative&.id if target_writable?(creative, @targets.fetch(change), records, writable_ids, change)
         end.to_set
         @propagated_attributes = PropagatedChangeAuthorization.new(
           changes: @targets.keys,
@@ -138,8 +138,8 @@ module Collavre
         plan << [ creative, snapshot, attribute, change ]
       end
 
-      def target_writable?(creative, snapshot, records, writable_ids)
-        creative && !creative.read_only_source? && writable_ids.include?(creative.id) &&
+      def target_writable?(creative, snapshot, records, writable_ids, change)
+        creative && (!creative.read_only_source? || change.archival_only?) && writable_ids.include?(creative.id) &&
           (@authorization_only || target_parent_writable?(creative, snapshot, records, writable_ids))
       end
 

--- a/engines/collavre/app/services/collavre/creatives/change_set_visibility.rb
+++ b/engines/collavre/app/services/collavre/creatives/change_set_visibility.rb
@@ -55,7 +55,9 @@ module Collavre
       # the actor who performed that explicit deletion may inspect its snapshot.
       # AI deletes are archival and keep their live permission rows.
       def historical_snapshot_visible?(change)
-        return true if change.change_set.status == "draft" && historical_parent_id(change)
+        if change.change_set.status == "draft" && change.creative_id.negative? && change.before.empty?
+          return historical_parent_id(change).present?
+        end
 
         @user_id && change.change_set.user_id == @user_id
       end

--- a/engines/collavre/app/services/collavre/creatives/change_set_visibility.rb
+++ b/engines/collavre/app/services/collavre/creatives/change_set_visibility.rb
@@ -55,6 +55,8 @@ module Collavre
       # the actor who performed that explicit deletion may inspect its snapshot.
       # AI deletes are archival and keep their live permission rows.
       def historical_snapshot_visible?(change)
+        return true if change.change_set.status == "draft" && historical_parent_id(change)
+
         @user_id && change.change_set.user_id == @user_id
       end
 

--- a/engines/collavre/app/services/collavre/creatives/draft_change_set_applicator.rb
+++ b/engines/collavre/app/services/collavre/creatives/draft_change_set_applicator.rb
@@ -54,7 +54,7 @@ module Collavre
 
       def apply_creation(snapshot, virtual_change)
         parent = Creative.find_by(id: snapshot["parent_id"])
-        creative = Creative.new(user: parent&.user || @user, parent: parent)
+        creative = Creative.new(user: parent&.user || @change_set.user || @user, parent: parent)
         SnapshotAssignment.call(creative, snapshot)
         creative.save!
         remap_virtual_change!(virtual_change, creative)

--- a/engines/collavre/app/services/collavre/creatives/draft_change_set_applicator.rb
+++ b/engines/collavre/app/services/collavre/creatives/draft_change_set_applicator.rb
@@ -3,14 +3,16 @@
 module Collavre
   module Creatives
     class DraftChangeSetApplicator
-      def initialize(change_set:, user:, plan:)
+      def initialize(change_set:, user:, plan:, skipped_ids: [])
         @change_set = change_set
         @user = user
         @plan = plan
+        @skipped_ids = skipped_ids
         @id_map = {}
       end
 
       def call
+        discard_skipped_changes
         History.track(**history_context) do
           Current.change_set = @change_set
           @plan.each { |creative, snapshot, attribute, change| apply(creative, snapshot, attribute, change) }
@@ -20,6 +22,13 @@ module Collavre
       end
 
       private
+
+      def discard_skipped_changes
+        changes = @change_set.creative_changes.where(creative_id: @skipped_ids)
+        stale_blob_ids = ActiveStorage::Attachment.where(record: changes, name: "history_files").pluck(:blob_id)
+        changes.destroy_all
+        History.schedule_blob_purge_rechecks(stale_blob_ids)
+      end
 
       def history_context
         {

--- a/engines/collavre/app/services/collavre/creatives/draft_change_set_applicator.rb
+++ b/engines/collavre/app/services/collavre/creatives/draft_change_set_applicator.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+module Collavre
+  module Creatives
+    class DraftChangeSetApplicator
+      def initialize(change_set:, user:, plan:)
+        @change_set = change_set
+        @user = user
+        @plan = plan
+        @id_map = {}
+      end
+
+      def call
+        History.track(**history_context) do
+          Current.change_set = @change_set
+          @plan.each { |creative, snapshot, attribute, change| apply(creative, snapshot, attribute, change) }
+        end
+        @change_set.update!(status: "applied", applied_at: Time.current)
+        CreativeTreeInvalidationJob.perform_later(@change_set.creative_changes.pluck(:creative_id))
+      end
+
+      private
+
+      def history_context
+        {
+          actor: @change_set.user,
+          origin: @change_set.origin,
+          anchor: @change_set.anchor_creative,
+          anchor_source: @change_set.anchor_source || :explicit,
+          task: @change_set.task,
+          topic: @change_set.topic,
+          summary: @change_set.summary,
+          status: "draft"
+        }
+      end
+
+      def apply(creative, snapshot, attribute, change)
+        remapped = remap_snapshot(snapshot)
+        return apply_creation(remapped, change) unless creative
+        return creative.update!(attribute => remapped[attribute]) if attribute
+
+        SnapshotAssignment.call(creative, remapped)
+        creative.save!
+      end
+
+      def apply_creation(snapshot, virtual_change)
+        parent = Creative.find_by(id: snapshot["parent_id"])
+        creative = Creative.new(user: parent&.user || @user, parent: parent)
+        SnapshotAssignment.call(creative, snapshot)
+        creative.save!
+        remap_virtual_change!(virtual_change, creative)
+      end
+
+      def remap_snapshot(snapshot)
+        result = snapshot.deep_dup
+        parent_id = result["parent_id"]
+        result["parent_id"] = @id_map.fetch(parent_id, parent_id) if parent_id
+        result
+      end
+
+      def remap_virtual_change!(virtual_change, creative)
+        virtual_id = virtual_change.creative_id
+        @id_map[virtual_id] = creative.id
+        actual_change = @change_set.creative_changes.find_by!(creative_id: creative.id)
+        actual_change.update!(position: virtual_change.position, conflict: virtual_change.conflict)
+        virtual_change.destroy!
+        remap_pending_references!(virtual_id, creative.id)
+      end
+
+      def remap_pending_references!(virtual_id, creative_id)
+        @change_set.creative_changes.where.not(creative_id: creative_id).find_each do |change|
+          attributes = {}
+          %w[before after].each do |side|
+            snapshot = change.public_send(side).deep_dup
+            next unless snapshot["parent_id"] == virtual_id
+
+            snapshot["parent_id"] = creative_id
+            attributes[side] = snapshot
+          end
+          if change.previous_parent_id == virtual_id
+            attributes[:previous_parent_id] = creative_id
+          end
+          change.update!(attributes) if attributes.any?
+        end
+      end
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/creatives/draft_change_set_applicator.rb
+++ b/engines/collavre/app/services/collavre/creatives/draft_change_set_applicator.rb
@@ -3,11 +3,11 @@
 module Collavre
   module Creatives
     class DraftChangeSetApplicator
-      def initialize(change_set:, user:, plan:, skipped_ids: [])
+      def initialize(change_set:, user:, plan:, skipped_change_ids: [])
         @change_set = change_set
         @user = user
         @plan = plan
-        @skipped_ids = skipped_ids
+        @skipped_change_ids = skipped_change_ids
         @id_map = {}
       end
 
@@ -24,7 +24,7 @@ module Collavre
       private
 
       def discard_skipped_changes
-        changes = @change_set.creative_changes.where(creative_id: @skipped_ids)
+        changes = @change_set.creative_changes.where(id: @skipped_change_ids)
         stale_blob_ids = ActiveStorage::Attachment.where(record: changes, name: "history_files").pluck(:blob_id)
         changes.destroy_all
         History.schedule_blob_purge_rechecks(stale_blob_ids)

--- a/engines/collavre/app/services/collavre/creatives/draft_change_set_applicator.rb
+++ b/engines/collavre/app/services/collavre/creatives/draft_change_set_applicator.rb
@@ -46,7 +46,7 @@ module Collavre
       def apply(creative, snapshot, attribute, change)
         remapped = remap_snapshot(snapshot)
         return apply_creation(remapped, change) unless creative
-        return creative.update!(attribute => remapped[attribute]) if attribute
+        return creative.update!(remapped.slice(*Array(attribute))) if attribute
 
         SnapshotAssignment.call(creative, remapped)
         creative.save!

--- a/engines/collavre/app/services/collavre/creatives/draft_change_set_capture.rb
+++ b/engines/collavre/app/services/collavre/creatives/draft_change_set_capture.rb
@@ -125,7 +125,9 @@ module Collavre
         changes.map do |attributes|
           attributes = attributes.deep_dup
           attributes["creative_id"] = id_map.fetch(attributes["creative_id"], attributes["creative_id"])
-          attributes["previous_parent_id"] ||= attributes.dig("after", "parent_id") if attributes["before"].empty?
+          if attributes["before"].empty?
+            attributes["previous_parent_id"] ||= attributes.dig("after", "parent_id") || @anchor&.id
+          end
           rewrite_parent_ids!(attributes, id_map)
           attributes
         end

--- a/engines/collavre/app/services/collavre/creatives/draft_change_set_capture.rb
+++ b/engines/collavre/app/services/collavre/creatives/draft_change_set_capture.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+
+module Collavre
+  module Creatives
+    class DraftChangeSetCapture
+      CHANGE_SET_KEYS = %w[anchor_creative_id anchor_source user_id actor_kind origin task_id topic_id
+                           change_group_token summary].freeze
+      CHANGE_KEYS = %w[creative_id previous_parent_id operation before after position conflict].freeze
+
+      def initialize(anchor:, origin:, summary: nil)
+        @anchor = anchor
+        @origin = origin.to_s
+        @summary = summary
+        @actor = Current.user
+        @agent_turn = Current.agent_turn
+      end
+
+      def call(&operation)
+        task = current_task
+        return capture_and_persist(&operation) unless task
+
+        task.with_lock { capture_and_persist(&operation) }
+      end
+
+      private
+
+      def capture_and_persist
+        return pending_result(existing_draft) if existing_draft
+
+        payload = capture { yield }
+        return payload.fetch(:result) unless payload[:change_set]
+
+        draft = persist(payload)
+        pending_result(draft)
+      end
+
+      def existing_draft
+        CreativeChangeSet.find_by(task_id: current_task&.id, status: "draft") if current_task
+      end
+
+      def current_task = @agent_turn&.dig(:task)
+
+      def capture
+        payload = { result: nil, change_set: nil, changes: nil, blobs: [] }
+        ApplicationRecord.transaction(requires_new: true) do
+          Current.set(user: @actor, agent_turn: nil, change_set: nil, creative_history_context: nil) do
+            History.track(**history_context) do
+              payload[:result] = yield
+              serialize_capture(payload) if payload[:result]&.dig(:success)
+            end
+          end
+          raise ActiveRecord::Rollback
+        end
+        payload
+      end
+
+      def history_context
+        {
+          actor: @actor,
+          origin: @origin,
+          anchor: @anchor,
+          anchor_source: @origin == "import" ? :import_target : :agent_topic,
+          task: current_task,
+          topic: current_task&.topic_id ? Topic.find_by(id: current_task.topic_id) : nil,
+          summary: @summary,
+          status: "draft"
+        }
+      end
+
+      def serialize_capture(payload)
+        change_set = Current.change_set
+        return unless change_set&.creative_changes&.exists?
+
+        changes = change_set.creative_changes.order(:position).to_a
+        payload[:change_set] = change_set.attributes.slice(*CHANGE_SET_KEYS)
+        payload[:changes] = changes.map { |change| change.attributes.slice(*CHANGE_KEYS) }
+        payload[:blobs] = added_snapshot_blobs(changes)
+      end
+
+      def added_snapshot_blobs(changes)
+        signed_ids = changes.flat_map do |change|
+          History.extract_signed_ids(change.after["description"]) +
+            History.extract_signed_ids(change.after["markdown_source"])
+        end.uniq
+        before_ids = changes.flat_map do |change|
+          History.extract_signed_ids(change.before["description"]) +
+            History.extract_signed_ids(change.before["markdown_source"])
+        end.uniq
+
+        (signed_ids - before_ids).filter_map do |signed_id|
+          blob = ActiveStorage::Blob.find_signed(signed_id)
+          next unless blob
+
+          { old_signed_id: signed_id, attributes: blob.attributes.except("id", "created_at", "updated_at") }
+        end
+      end
+
+      def persist(payload)
+        replacements = restore_blob_rows(payload[:blobs])
+        changes = virtualize_creations(payload.fetch(:changes))
+        rewrite_snapshot_strings!(changes, replacements)
+
+        CreativeChangeSet.transaction do
+          draft = CreativeChangeSet.create!(payload.fetch(:change_set).merge(status: "draft", applied_at: nil))
+          changes.each do |attributes|
+            change = draft.creative_changes.create!(attributes)
+            History.retain_snapshot_files!(change)
+          end
+          draft
+        end
+      end
+
+      def restore_blob_rows(blobs)
+        blobs.to_h do |blob_data|
+          blob = ActiveStorage::Blob.create!(blob_data.fetch(:attributes))
+          [ blob_data.fetch(:old_signed_id), blob.signed_id ]
+        end
+      end
+
+      def virtualize_creations(changes)
+        created_ids = changes.select { |change| change.fetch("before").empty? }
+          .map { |change| change.fetch("creative_id") }
+        id_map = created_ids.each_with_index.to_h { |id, index| [ id, -(index + 1) ] }
+
+        changes.map do |attributes|
+          attributes = attributes.deep_dup
+          attributes["creative_id"] = id_map.fetch(attributes["creative_id"], attributes["creative_id"])
+          attributes["previous_parent_id"] ||= attributes.dig("after", "parent_id") if attributes["before"].empty?
+          rewrite_parent_ids!(attributes, id_map)
+          attributes
+        end
+      end
+
+      def rewrite_parent_ids!(attributes, id_map)
+        %w[before after].each do |side|
+          parent_id = attributes.dig(side, "parent_id")
+          attributes[side]["parent_id"] = id_map.fetch(parent_id, parent_id) if parent_id
+        end
+        previous_parent_id = attributes["previous_parent_id"]
+        attributes["previous_parent_id"] = id_map.fetch(previous_parent_id, previous_parent_id) if previous_parent_id
+      end
+
+      def rewrite_snapshot_strings!(changes, replacements)
+        return if replacements.empty?
+
+        changes.each do |attributes|
+          %w[before after].each do |side|
+            %w[description markdown_source].each do |key|
+              next unless attributes[side].key?(key)
+
+              value = attributes.dig(side, key)
+              attributes[side][key] = replacements.reduce(value) { |text, (old_id, new_id)| text&.gsub(old_id, new_id) }
+            end
+          end
+        end
+      end
+
+      def pending_result(draft)
+        {
+          success: true,
+          status: "pending_review",
+          pending_review: true,
+          change_set_id: draft.id
+        }
+      end
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/creatives/draft_change_set_capture.rb
+++ b/engines/collavre/app/services/collavre/creatives/draft_change_set_capture.rb
@@ -79,8 +79,20 @@ module Collavre
 
         changes = change_set.creative_changes.order(:position).to_a
         payload[:change_set] = change_set.attributes.slice(*CHANGE_SET_KEYS)
-        payload[:changes] = changes.map { |change| change.attributes.slice(*CHANGE_KEYS) }
+        payload[:changes] = changes.map { |change| serialized_change(change) }
         payload[:blobs] = added_snapshot_blobs(changes)
+      end
+
+      def serialized_change(change)
+        attributes = change.attributes.slice(*CHANGE_KEYS)
+        return attributes if change.before.empty? || change.before["progress"] == change.after["progress"]
+
+        creative = Creative.unscoped.find_by(id: change.creative_id)
+        return attributes unless creative
+
+        target_ids = ProgressPropagationTargets.new(creative.effective_origin).call.map(&:id)
+        attributes["conflict"] = attributes.fetch("conflict", {}).merge("progress_target_ids" => target_ids)
+        attributes
       end
 
       def added_snapshot_blobs(changes)
@@ -146,6 +158,8 @@ module Collavre
         end
         previous_parent_id = attributes["previous_parent_id"]
         attributes["previous_parent_id"] = id_map.fetch(previous_parent_id, previous_parent_id) if previous_parent_id
+        target_ids = attributes.dig("conflict", "progress_target_ids")
+        attributes["conflict"]["progress_target_ids"] = target_ids.map { |id| id_map.fetch(id, id) } if target_ids
       end
 
       def rewrite_snapshot_strings!(changes, replacements)

--- a/engines/collavre/app/services/collavre/creatives/draft_change_set_capture.rb
+++ b/engines/collavre/app/services/collavre/creatives/draft_change_set_capture.rb
@@ -43,7 +43,7 @@ module Collavre
       def capture
         payload = { result: nil, change_set: nil, changes: nil, blobs: [] }
         ApplicationRecord.transaction(requires_new: true) do
-          Current.set(user: @actor, agent_turn: nil, change_set: nil, creative_history_context: nil) do
+          Current.set(user: @actor, agent_turn: nil, mcp_request: nil, change_set: nil, creative_history_context: nil) do
             History.track(**history_context) do
               payload[:result] = yield
               serialize_capture(payload) if payload[:result]&.dig(:success)
@@ -59,12 +59,18 @@ module Collavre
           actor: @actor,
           origin: @origin,
           anchor: @anchor,
-          anchor_source: @origin == "import" ? :import_target : :agent_topic,
+          anchor_source: anchor_source,
           task: current_task,
           topic: current_task&.topic_id ? Topic.find_by(id: current_task.topic_id) : nil,
           summary: @summary,
           status: "draft"
         }
+      end
+
+      def anchor_source
+        return :import_target if @origin == "import"
+
+        current_task ? :agent_topic : :explicit
       end
 
       def serialize_capture(payload)

--- a/engines/collavre/app/services/collavre/creatives/draft_change_set_reject_service.rb
+++ b/engines/collavre/app/services/collavre/creatives/draft_change_set_reject_service.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Collavre
+  module Creatives
+    class DraftChangeSetRejectService
+      def initialize(change_set:, user:, scope_creative:)
+        @change_set = change_set
+        @user = user
+        @scope_creative = scope_creative
+      end
+
+      def call
+        CreativeChangeSet.transaction do
+          source = CreativeChangeSet.lock.find(@change_set.id)
+          next result(:not_revertible) unless source.status == "draft"
+          unless @scope_creative.has_permission?(@user, :write)
+            next result(:skipped, skipped: [ @scope_creative.id ])
+          end
+
+          source.update!(status: "rejected")
+          result(:rejected, change_set: source)
+        end
+      end
+
+      private
+
+      def result(status, change_set: nil, skipped: [])
+        ChangeSetApplyService::Result.new(
+          status: status,
+          change_set: change_set,
+          conflicts: [],
+          skipped: skipped
+        )
+      end
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/creatives/draft_change_set_reject_service.rb
+++ b/engines/collavre/app/services/collavre/creatives/draft_change_set_reject_service.rb
@@ -16,6 +16,9 @@ module Collavre
           unless @scope_creative.has_permission?(@user, :write)
             next result(:skipped, skipped: [ @scope_creative.id ])
           end
+          unless ChangeSetApplyService.new(source: source, user: @user, mode: :draft).fully_authorized?
+            next result(:skipped, skipped: [ @scope_creative.id ])
+          end
 
           source.update!(status: "rejected")
           result(:rejected, change_set: source)

--- a/engines/collavre/app/services/collavre/creatives/draft_conflict_dependency_pruner.rb
+++ b/engines/collavre/app/services/collavre/creatives/draft_conflict_dependency_pruner.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+module Collavre
+  module Creatives
+    class DraftConflictDependencyPruner
+      def initialize(changes:, records:, skipped_change_ids:)
+        @changes = changes
+        @records = records
+        @discard_change_ids = skipped_change_ids.dup
+      end
+
+      def call(plan)
+        source_ids = skipped_archive_changes.map(&:creative_id).to_set
+        return discard_change_ids if source_ids.empty?
+
+        collect_archive_family(source_ids)
+        collect_progress_chain
+        plan.reject! { |_creative, _snapshot, _attribute, change| discard_change_ids.include?(change.id) }
+        discard_change_ids
+      end
+
+      private
+
+      attr_reader :changes, :records, :discard_change_ids
+
+      def skipped_archive_changes
+        changes.select { |change| discard_change_ids.include?(change.id) && archival_transition?(change) }
+      end
+
+      def collect_archive_family(family_ids)
+        loop do
+          additions = changes.select do |change|
+            archive_family_addition?(change, family_ids)
+          end
+          break if additions.empty?
+
+          additions.each do |change|
+            family_ids << change.creative_id
+            discard_change_ids << change.id
+          end
+        end
+      end
+
+      def archive_family_addition?(change, family_ids)
+        return false unless archival_transition?(change) && !family_ids.include?(change.creative_id)
+
+        creative = records[change.creative_id]
+        parent_id = change.before["parent_id"] || change.after["parent_id"]
+        family_ids.include?(parent_id) || family_ids.include?(creative&.origin_id)
+      end
+
+      def collect_progress_chain
+        parent_ids = discard_change_ids.filter_map do |change_id|
+          change = changes_by_id[change_id]
+          records[change&.creative_id]&.parent_id
+        end.to_set
+        loop do
+          additions = changes.select do |change|
+            !discard_change_ids.include?(change.id) && parent_ids.include?(change.creative_id) && progress_only?(change)
+          end
+          break if additions.empty?
+
+          additions.each do |change|
+            discard_change_ids << change.id
+            parent_ids << records[change.creative_id]&.parent_id
+          end
+        end
+      end
+
+      def archival_transition?(change)
+        change.operation.in?(%w[archive unarchive]) &&
+          change.before["archived_at"] != change.after["archived_at"]
+      end
+
+      def progress_only?(change)
+        change.operation == "update" && change.before["progress"] != change.after["progress"] &&
+          change.before.except("progress") == change.after.except("progress")
+      end
+
+      def changes_by_id
+        @changes_by_id ||= changes.index_by(&:id)
+      end
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/creatives/draft_conflict_dependency_pruner.rb
+++ b/engines/collavre/app/services/collavre/creatives/draft_conflict_dependency_pruner.rb
@@ -50,10 +50,8 @@ module Collavre
       end
 
       def collect_progress_chain
-        parent_ids = discard_change_ids.filter_map do |change_id|
-          change = changes_by_id[change_id]
-          records[change&.creative_id]&.parent_id
-        end.to_set
+        source_ids = discard_change_ids.filter_map { |change_id| changes_by_id[change_id]&.creative_id }.to_set
+        parent_ids = propagation_parent_ids(source_ids)
         loop do
           additions = changes.select do |change|
             !discard_change_ids.include?(change.id) && parent_ids.include?(change.creative_id) && progress_only?(change)
@@ -62,9 +60,15 @@ module Collavre
 
           additions.each do |change|
             discard_change_ids << change.id
-            parent_ids << records[change.creative_id]&.parent_id
           end
+          parent_ids.merge(propagation_parent_ids(additions.map(&:creative_id)))
         end
+      end
+
+      def propagation_parent_ids(source_ids)
+        direct_ids = source_ids.filter_map { |id| records[id]&.parent_id }
+        linked_ids = Creative.where(origin_id: source_ids).where.not(parent_id: nil).distinct.pluck(:parent_id)
+        [ *direct_ids, *linked_ids ].to_set
       end
 
       def archival_transition?(change)

--- a/engines/collavre/app/services/collavre/creatives/draft_conflict_dependency_pruner.rb
+++ b/engines/collavre/app/services/collavre/creatives/draft_conflict_dependency_pruner.rb
@@ -10,10 +10,7 @@ module Collavre
       end
 
       def call(plan)
-        source_ids = skipped_archive_changes.map(&:creative_id).to_set
-        return discard_change_ids if source_ids.empty?
-
-        collect_archive_family(source_ids)
+        collect_archive_family(skipped_archive_family_ids)
         collect_progress_chain
         plan.reject! { |_creative, _snapshot, _attribute, change| discard_change_ids.include?(change.id) }
         discard_change_ids
@@ -27,7 +24,16 @@ module Collavre
         changes.select { |change| discard_change_ids.include?(change.id) && archival_transition?(change) }
       end
 
+      def skipped_archive_family_ids
+        skipped_archive_changes.flat_map do |change|
+          creative = records[change.creative_id]
+          [ change.creative_id, creative&.origin_id ]
+        end.compact.to_set
+      end
+
       def collect_archive_family(family_ids)
+        return if family_ids.empty?
+
         loop do
           additions = changes.select do |change|
             archive_family_addition?(change, family_ids)
@@ -42,11 +48,11 @@ module Collavre
       end
 
       def archive_family_addition?(change, family_ids)
-        return false unless archival_transition?(change) && !family_ids.include?(change.creative_id)
+        return false unless archival_transition?(change) && !discard_change_ids.include?(change.id)
 
         creative = records[change.creative_id]
         parent_id = change.before["parent_id"] || change.after["parent_id"]
-        family_ids.include?(parent_id) || family_ids.include?(creative&.origin_id)
+        family_ids.include?(change.creative_id) || family_ids.include?(parent_id) || family_ids.include?(creative&.origin_id)
       end
 
       def collect_progress_chain

--- a/engines/collavre/app/services/collavre/creatives/draft_conflict_dependency_pruner.rb
+++ b/engines/collavre/app/services/collavre/creatives/draft_conflict_dependency_pruner.rb
@@ -72,9 +72,20 @@ module Collavre
       end
 
       def propagation_parent_ids(source_ids)
-        direct_ids = source_ids.filter_map { |id| records[id]&.parent_id }
+        direct_ids = source_ids.flat_map { |id| snapshot_parent_ids(changes_by_creative_id[id]) }
         linked_ids = Creative.where(origin_id: source_ids).where.not(parent_id: nil).distinct.pluck(:parent_id)
-        [ *direct_ids, *linked_ids ].to_set
+        captured_ids = source_ids.flat_map { |id| captured_progress_target_ids(changes_by_creative_id[id]) }
+        [ *direct_ids, *linked_ids, *captured_ids ].to_set
+      end
+
+      def snapshot_parent_ids(change)
+        return [] unless change
+
+        [ change.before["parent_id"], change.after["parent_id"] ].compact
+      end
+
+      def captured_progress_target_ids(change)
+        Array(change&.conflict&.fetch("progress_target_ids", nil))
       end
 
       def archival_transition?(change)
@@ -89,6 +100,10 @@ module Collavre
 
       def changes_by_id
         @changes_by_id ||= changes.index_by(&:id)
+      end
+
+      def changes_by_creative_id
+        @changes_by_creative_id ||= changes.index_by(&:creative_id)
       end
     end
   end

--- a/engines/collavre/app/services/collavre/creatives/progress_propagation_targets.rb
+++ b/engines/collavre/app/services/collavre/creatives/progress_propagation_targets.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Collavre
+  module Creatives
+    class ProgressPropagationTargets
+      def initialize(creative)
+        @creative = creative
+      end
+
+      def call
+        targets = []
+        queue = [ @creative ]
+        visited_ids = Set.new
+        until queue.empty?
+          source = queue.shift
+          next if visited_ids.include?(source.id)
+
+          visited_ids << source.id
+          parents_for(source).each do |parent|
+            next if visited_ids.include?(parent.id) || targets.any? { |target| target.id == parent.id }
+
+            targets << parent
+            queue << parent
+          end
+        end
+        targets
+      end
+
+      private
+
+      def parents_for(source)
+        [ source.parent, *source.linked_creatives.includes(:parent).filter_map(&:parent) ].compact
+      end
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/creatives/propagated_change_authorization.rb
+++ b/engines/collavre/app/services/collavre/creatives/propagated_change_authorization.rb
@@ -43,7 +43,8 @@ module Collavre
           change.creative_id if writable_source_ids.include?(change.creative_id) &&
             change.before["progress"] != change.after["progress"]
         end.to_set
-        parent_ids = direct_parent_ids(source_ids) | linked_parent_ids(source_ids)
+        parent_ids = direct_parent_ids(source_ids) | linked_parent_ids(source_ids) |
+          captured_progress_target_ids(source_ids)
         loop do
           additions = parent_progress_additions(parent_ids, attributes)
           break if additions.empty?
@@ -63,6 +64,14 @@ module Collavre
 
           snapshot_parent_ids(change)
         end.compact.to_set
+      end
+
+      def captured_progress_target_ids(source_ids)
+        changes.flat_map do |change|
+          next [] unless source_ids.include?(change.creative_id)
+
+          Array(change.conflict&.fetch("progress_target_ids", nil))
+        end.to_set
       end
 
       def parent_progress_additions(parent_ids, attributes)

--- a/engines/collavre/app/services/collavre/creatives/propagated_change_authorization.rb
+++ b/engines/collavre/app/services/collavre/creatives/propagated_change_authorization.rb
@@ -22,7 +22,7 @@ module Collavre
         attributes = {}
         source_ids = changes.filter_map do |change|
           change.creative_id if writable_source_ids.include?(change.creative_id) &&
-            transition_only?(change, "archived_at", %w[archive unarchive])
+            archive_transition?(change)
         end.to_set
         family_ids = source_ids | source_ids.filter_map { |id| records[id]&.origin_id }.to_set
         loop do
@@ -45,6 +45,10 @@ module Collavre
         creative = records[change.creative_id]
         family_ids.include?(change.creative_id) || family_ids.include?(creative&.origin_id) ||
           snapshot_parent_ids(change).any? { |parent_id| family_ids.include?(parent_id) }
+      end
+
+      def archive_transition?(change)
+        change.operation.in?(%w[archive unarchive]) && change.before["archived_at"] != change.after["archived_at"]
       end
 
       def add_parent_progress_attributes(attributes)

--- a/engines/collavre/app/services/collavre/creatives/propagated_change_authorization.rb
+++ b/engines/collavre/app/services/collavre/creatives/propagated_change_authorization.rb
@@ -3,6 +3,8 @@
 module Collavre
   module Creatives
     class PropagatedChangeAuthorization
+      ARCHIVE_ATTRIBUTES = %w[archived_at progress].freeze
+
       def initialize(changes:, records:, writable_source_ids:)
         @changes = changes
         @records = records
@@ -20,6 +22,7 @@ module Collavre
 
       def archive_attributes
         attributes = {}
+        visited_change_ids = Set.new
         source_ids = changes.filter_map do |change|
           change.creative_id if writable_source_ids.include?(change.creative_id) &&
             archive_transition?(change)
@@ -27,24 +30,32 @@ module Collavre
         family_ids = source_ids | source_ids.filter_map { |id| records[id]&.origin_id }.to_set
         loop do
           additions = changes.select do |change|
-            !attributes.key?(change.id) && archive_family_addition?(change, family_ids)
+            !visited_change_ids.include?(change.id) && archive_family_addition?(change, family_ids)
           end
           break if additions.empty?
 
           additions.each do |change|
-            attributes[change.id] = "archived_at"
+            visited_change_ids << change.id
             family_ids << change.creative_id
+            apply_attributes = archive_apply_attributes(change, source_ids)
+            attributes[change.id] = apply_attributes if apply_attributes
           end
         end
         attributes
       end
 
       def archive_family_addition?(change, family_ids)
-        return false unless transition_only?(change, "archived_at", %w[archive unarchive])
+        return false unless archive_transition?(change)
 
         creative = records[change.creative_id]
         family_ids.include?(change.creative_id) || family_ids.include?(creative&.origin_id) ||
           snapshot_parent_ids(change).any? { |parent_id| family_ids.include?(parent_id) }
+      end
+
+      def archive_apply_attributes(change, source_ids)
+        return if source_ids.include?(change.creative_id) && !change.archive_propagation_only?
+
+        ARCHIVE_ATTRIBUTES.select { |attribute| change.before[attribute] != change.after[attribute] }
       end
 
       def archive_transition?(change)

--- a/engines/collavre/app/services/collavre/creatives/propagated_change_authorization.rb
+++ b/engines/collavre/app/services/collavre/creatives/propagated_change_authorization.rb
@@ -10,7 +10,7 @@ module Collavre
       end
 
       def call
-        attributes = linked_archive_attributes
+        attributes = archive_attributes
         add_parent_progress_attributes(attributes)
         add_linked_progress_attributes(attributes)
         attributes
@@ -18,14 +18,33 @@ module Collavre
 
       private
 
-      def linked_archive_attributes
-        changes.each_with_object({}) do |change, attributes|
-          creative = records[change.creative_id]
-          next unless creative&.origin_id.in?(writable_source_ids)
-          next unless transition_only?(change, "archived_at", %w[archive unarchive])
+      def archive_attributes
+        attributes = {}
+        source_ids = changes.filter_map do |change|
+          change.creative_id if writable_source_ids.include?(change.creative_id) &&
+            transition_only?(change, "archived_at", %w[archive unarchive])
+        end.to_set
+        family_ids = source_ids | source_ids.filter_map { |id| records[id]&.origin_id }.to_set
+        loop do
+          additions = changes.select do |change|
+            !attributes.key?(change.id) && archive_family_addition?(change, family_ids)
+          end
+          break if additions.empty?
 
-          attributes[change.id] = "archived_at"
+          additions.each do |change|
+            attributes[change.id] = "archived_at"
+            family_ids << change.creative_id
+          end
         end
+        attributes
+      end
+
+      def archive_family_addition?(change, family_ids)
+        return false unless transition_only?(change, "archived_at", %w[archive unarchive])
+
+        creative = records[change.creative_id]
+        family_ids.include?(change.creative_id) || family_ids.include?(creative&.origin_id) ||
+          snapshot_parent_ids(change).any? { |parent_id| family_ids.include?(parent_id) }
       end
 
       def add_parent_progress_attributes(attributes)

--- a/engines/collavre/app/services/collavre/creatives/propagated_change_authorization.rb
+++ b/engines/collavre/app/services/collavre/creatives/propagated_change_authorization.rb
@@ -29,7 +29,7 @@ module Collavre
       end
 
       def add_parent_progress_attributes(attributes)
-        parent_ids = attributes.keys.filter_map { |id| records[change_by_id.fetch(id).creative_id]&.parent_id }.to_set
+        parent_ids = attributes.keys.flat_map { |id| snapshot_parent_ids(change_by_id.fetch(id)) }.to_set
         loop do
           additions = parent_progress_additions(parent_ids, attributes)
           break if additions.empty?
@@ -58,7 +58,11 @@ module Collavre
       end
 
       def direct_parent_ids(source_ids)
-        source_ids.filter_map { |source_id| records[source_id]&.parent_id }.to_set
+        changes.flat_map do |change|
+          next unless source_ids.include?(change.creative_id)
+
+          snapshot_parent_ids(change)
+        end.compact.to_set
       end
 
       def parent_progress_additions(parent_ids, attributes)
@@ -72,8 +76,12 @@ module Collavre
       def register_parent_progress(additions, attributes, parent_ids)
         additions.each do |change|
           attributes[change.id] = "progress"
-          parent_ids << records.fetch(change.creative_id).parent_id
+          parent_ids.merge(snapshot_parent_ids(change))
         end
+      end
+
+      def snapshot_parent_ids(change)
+        [ change.before["parent_id"], change.after["parent_id"] ].compact
       end
 
       def transition_only?(change, attribute, operations)

--- a/engines/collavre/app/services/collavre/creatives/propagated_change_authorization.rb
+++ b/engines/collavre/app/services/collavre/creatives/propagated_change_authorization.rb
@@ -3,15 +3,16 @@
 module Collavre
   module Creatives
     class PropagatedChangeAuthorization
-      def initialize(changes:, records:, writable_origin_ids:)
+      def initialize(changes:, records:, writable_source_ids:)
         @changes = changes
         @records = records
-        @writable_origin_ids = writable_origin_ids
+        @writable_source_ids = writable_source_ids
       end
 
       def call
         attributes = linked_archive_attributes
         add_parent_progress_attributes(attributes)
+        add_linked_progress_attributes(attributes)
         attributes
       end
 
@@ -20,7 +21,7 @@ module Collavre
       def linked_archive_attributes
         changes.each_with_object({}) do |change, attributes|
           creative = records[change.creative_id]
-          next unless creative&.origin_id.in?(writable_origin_ids)
+          next unless creative&.origin_id.in?(writable_source_ids)
           next unless transition_only?(change, "archived_at", %w[archive unarchive])
 
           attributes[change.id] = "archived_at"
@@ -35,6 +36,25 @@ module Collavre
 
           register_parent_progress(additions, attributes, parent_ids)
         end
+      end
+
+      def add_linked_progress_attributes(attributes)
+        source_ids = changes.filter_map do |change|
+          change.creative_id if writable_source_ids.include?(change.creative_id) &&
+            change.before["progress"] != change.after["progress"]
+        end.to_set
+        parent_ids = linked_parent_ids(source_ids)
+        loop do
+          additions = parent_progress_additions(parent_ids, attributes)
+          break if additions.empty?
+
+          register_parent_progress(additions, attributes, parent_ids)
+          parent_ids.merge(linked_parent_ids(additions.map(&:creative_id)))
+        end
+      end
+
+      def linked_parent_ids(source_ids)
+        Creative.where(origin_id: source_ids).where.not(parent_id: nil).distinct.pluck(:parent_id).to_set
       end
 
       def parent_progress_additions(parent_ids, attributes)
@@ -61,7 +81,7 @@ module Collavre
         @change_by_id ||= changes.index_by(&:id)
       end
 
-      attr_reader :changes, :records, :writable_origin_ids
+      attr_reader :changes, :records, :writable_source_ids
     end
   end
 end

--- a/engines/collavre/app/services/collavre/creatives/propagated_change_authorization.rb
+++ b/engines/collavre/app/services/collavre/creatives/propagated_change_authorization.rb
@@ -43,7 +43,7 @@ module Collavre
           change.creative_id if writable_source_ids.include?(change.creative_id) &&
             change.before["progress"] != change.after["progress"]
         end.to_set
-        parent_ids = linked_parent_ids(source_ids)
+        parent_ids = direct_parent_ids(source_ids) | linked_parent_ids(source_ids)
         loop do
           additions = parent_progress_additions(parent_ids, attributes)
           break if additions.empty?
@@ -55,6 +55,10 @@ module Collavre
 
       def linked_parent_ids(source_ids)
         Creative.where(origin_id: source_ids).where.not(parent_id: nil).distinct.pluck(:parent_id).to_set
+      end
+
+      def direct_parent_ids(source_ids)
+        source_ids.filter_map { |source_id| records[source_id]&.parent_id }.to_set
       end
 
       def parent_progress_additions(parent_ids, attributes)

--- a/engines/collavre/app/services/collavre/creatives/snapshot_assignment.rb
+++ b/engines/collavre/app/services/collavre/creatives/snapshot_assignment.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Collavre
+  module Creatives
+    class SnapshotAssignment
+      def self.call(creative, snapshot)
+        if snapshot["content_type"] == "markdown"
+          creative.content_type_input = "markdown"
+          creative.markdown_source = snapshot["markdown_source"].to_s
+          creative.markdown_editor = snapshot["editor"]
+        else
+          creative.content_type_input = "html"
+          creative.description = snapshot["description"]
+        end
+        creative.assign_attributes(
+          parent_id: snapshot["parent_id"],
+          sequence: snapshot["sequence"],
+          progress: snapshot["progress"],
+          archived_at: snapshot["archived_at"]
+        )
+      end
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/tools/creative_attach_files_service.rb
+++ b/engines/collavre/app/services/collavre/tools/creative_attach_files_service.rb
@@ -8,7 +8,7 @@ module Tools
     include Collavre::PublicAssetsHelper
 
     tool_name "creative_attach_files_service"
-    tool_description "Attach inline, agent-generated TEXT content (markdown, html, svg, plain text) to a Creative. The content is stored as an ActiveStorage blob, embedded into the Creative's description, and served via CloudFront-cached /public-assets URLs.\n\nUse this for content the agent produced as text (notes, generated markdown/html/svg).\n\nFor BINARY files already on disk (png, mp4, pdf), use the CLI `collavre attach --creative <id> --file <path>` instead — it uploads the raw bytes over a bearer multipart HTTP endpoint without base64 bloat.\n\nRequires :write permission on the target Creative."
+    tool_description "Attach inline, agent-generated TEXT content (markdown, html, svg, plain text) to a Creative. The content is stored as an ActiveStorage blob, embedded into the Creative's description, and served via CloudFront-cached /public-assets URLs.\n\nUse this for content the agent produced as text (notes, generated markdown/html/svg).\n\nFor BINARY files already on disk (png, mp4, pdf), use the CLI `collavre attach --creative <id> --file <path>` instead — it uploads the raw bytes over a bearer multipart HTTP endpoint without base64 bloat.\n\nRequires :write permission on the target Creative. A Creative with inherited ai_write_policy=review stores a draft in History for approval."
 
     tool_param :creative_id, description: "ID of the Creative to attach content to.", required: true
     tool_param :files, description: "Array of objects: { filename, content, content_type? }. `content` is the literal UTF-8 text to store (e.g. markdown/html/svg source). `content_type` is inferred from the filename when omitted.", required: true
@@ -30,6 +30,14 @@ module Tools
       # later in the array never leaves an orphaned blob from an earlier one.
       return { error: "Each file requires a filename" } if files.any? { |f| f["filename"].to_s.blank? }
 
+      Creatives::AiWritePolicy.capture(
+        creatives: [ creative, creative.effective_origin ], anchor: Creatives::AiWritePolicy.agent_anchor || creative
+      ) { attach_files(creative, files) }
+    end
+
+    private
+
+    def attach_files(creative, files)
       blobs = files.map do |f|
         name = f["filename"].to_s
         content = f["content"].to_s

--- a/engines/collavre/app/services/collavre/tools/creative_batch_service.rb
+++ b/engines/collavre/app/services/collavre/tools/creative_batch_service.rb
@@ -88,7 +88,17 @@ module Collavre
         end.to_set
         archive_targets = creatives.select { |creative| delete_ids.include?(creative.id) }
           .flat_map { |creative| creative.archive_family.to_a }
-        [ *creatives, *archive_targets ]
+        progress_targets = progress_sources(operations, creatives)
+          .flat_map { |creative| Creatives::ProgressPropagationTargets.new(creative.effective_origin).call }
+        [ *creatives, *archive_targets, *progress_targets ]
+      end
+
+      def progress_sources(operations, creatives)
+        progress_ids = operations.filter_map do |operation|
+          operation = operation.stringify_keys
+          operation["id"].to_i if operation["action"] == "update" && operation["progress"].present?
+        end.to_set
+        creatives.select { |creative| progress_ids.include?(creative.id) }
       end
 
       def execute_create(op)

--- a/engines/collavre/app/services/collavre/tools/creative_batch_service.rb
+++ b/engines/collavre/app/services/collavre/tools/creative_batch_service.rb
@@ -79,7 +79,7 @@ module Collavre
       def review_targets(operations)
         ids = operations.flat_map do |operation|
           operation = operation.stringify_keys
-          [ operation["id"], operation["parent_id"] ]
+          [ operation["id"], operation["parent_id"], operation["before_id"], operation["after_id"] ]
         end.compact.map(&:to_i).select(&:positive?)
         creatives = Creative.where(id: ids).to_a
         delete_ids = operations.filter_map do |operation|
@@ -88,9 +88,9 @@ module Collavre
         end.to_set
         archive_targets = creatives.select { |creative| delete_ids.include?(creative.id) }
           .flat_map { |creative| creative.archive_family.to_a }
-        progress_targets = progress_sources(operations, creatives)
-          .flat_map { |creative| Creatives::ProgressPropagationTargets.new(creative.effective_origin).call }
-        [ *creatives, *archive_targets, *progress_targets ]
+        progress_targets = propagation_targets(progress_sources(operations, creatives))
+        archive_progress_targets = propagation_targets(archive_targets)
+        [ *creatives, *archive_targets, *progress_targets, *archive_progress_targets, *reorder_targets(operations) ]
       end
 
       def progress_sources(operations, creatives)
@@ -99,6 +99,20 @@ module Collavre
           operation["id"].to_i if operation["action"] == "update" && operation["progress"].present?
         end.to_set
         creatives.select { |creative| progress_ids.include?(creative.id) }
+      end
+
+      def propagation_targets(creatives)
+        creatives.flat_map { |creative| Creatives::ProgressPropagationTargets.new(creative.effective_origin).call }
+      end
+
+      def reorder_targets(operations)
+        operations.flat_map do |operation|
+          operation = operation.stringify_keys
+          next [] unless operation["action"] == "create" && (operation["before_id"].present? || operation["after_id"].present?)
+
+          parent_id = operation["parent_id"].to_i
+          parent_id.positive? ? Creative.where(parent_id: parent_id).to_a : Creative.roots.to_a
+        end
       end
 
       def execute_create(op)

--- a/engines/collavre/app/services/collavre/tools/creative_batch_service.rb
+++ b/engines/collavre/app/services/collavre/tools/creative_batch_service.rb
@@ -11,11 +11,11 @@ module Collavre
       tool_description "Execute multiple Creative operations (create, update, delete) in a single batch call. " \
                        "All operations run inside a transaction — if any operation fails, the entire batch is rolled back.\n\n" \
                        "Delete operations archive Creatives so they remain recoverable from History.\n\n" \
-                       "This tool requires approval before execution.\n\n" \
+                       "A Creative with inherited ai_write_policy=review stores a draft in History for approval instead of applying immediately.\n\n" \
                        "Each operation is a hash with an 'action' key ('create', 'update', or 'delete') plus action-specific fields."
 
       def self.requires_approval?
-        true
+        false
       end
 
       tool_param :operations, description: "Array of operation objects. Each object must have an 'action' key.\n\n" \
@@ -38,6 +38,15 @@ module Collavre
       def call(operations:)
         raise "Current.user is required" unless Current.user
 
+        Creatives::AiWritePolicy.capture(
+          creatives: review_targets(operations),
+          anchor: Creatives::AiWritePolicy.agent_anchor
+        ) { perform_operations(operations) }
+      end
+
+      private
+
+      def perform_operations(operations)
         results = []
 
         ApplicationRecord.transaction do
@@ -67,7 +76,14 @@ module Collavre
         { success: false, error: "Operation #{failed[:index]} (#{failed[:action]}) failed: #{failed[:error]}", results: e.results }
       end
 
-      private
+      def review_targets(operations)
+        ids = operations.flat_map do |operation|
+          operation = operation.stringify_keys
+          [ operation["id"], operation["parent_id"] ]
+        end.compact.map(&:to_i).select(&:positive?)
+        creatives = Creative.where(id: ids).to_a
+        [ *creatives, *creatives.map(&:effective_origin) ]
+      end
 
       def execute_create(op)
         service = CreativeCreateService.new

--- a/engines/collavre/app/services/collavre/tools/creative_batch_service.rb
+++ b/engines/collavre/app/services/collavre/tools/creative_batch_service.rb
@@ -82,7 +82,13 @@ module Collavre
           [ operation["id"], operation["parent_id"] ]
         end.compact.map(&:to_i).select(&:positive?)
         creatives = Creative.where(id: ids).to_a
-        [ *creatives, *creatives.map(&:effective_origin) ]
+        delete_ids = operations.filter_map do |operation|
+          operation = operation.stringify_keys
+          operation["id"].to_i if operation["action"] == "delete"
+        end.to_set
+        archive_targets = creatives.select { |creative| delete_ids.include?(creative.id) }
+          .flat_map { |creative| creative.archive_family.to_a }
+        [ *creatives, *archive_targets ]
       end
 
       def execute_create(op)

--- a/engines/collavre/app/services/collavre/tools/creative_batch_service.rb
+++ b/engines/collavre/app/services/collavre/tools/creative_batch_service.rb
@@ -88,6 +88,7 @@ module Collavre
         end.to_set
         archive_targets = creatives.select { |creative| delete_ids.include?(creative.id) }
           .flat_map { |creative| creative.archive_family.to_a }
+        archive_targets.concat(moved_families_before_delete(operations, creatives))
         progress_targets = propagation_targets(progress_sources(operations, creatives))
         archive_progress_targets = propagation_targets(archive_targets)
         structural_progress_sources = structural_progress_sources(operations, creatives)
@@ -127,6 +128,18 @@ module Collavre
         return [] unless operation["parent_id"].present? && operation["parent_id"].to_i.positive?
 
         [ records[operation["id"].to_i]&.parent, records[operation["parent_id"].to_i] ].compact
+      end
+
+      def moved_families_before_delete(operations, creatives)
+        records = creatives.index_by(&:id)
+        delete_indexes = operations.each_index.select { |index| operations[index].stringify_keys["action"] == "delete" }
+        operations.each_with_index.flat_map do |operation, index|
+          operation = operation.stringify_keys
+          next [] unless operation["action"] == "update" && delete_indexes.any? { |delete_index| delete_index > index }
+          next [] unless operation["parent_id"].present? && operation["parent_id"].to_i.positive?
+
+          records[operation["id"].to_i]&.archive_family&.to_a || []
+        end
       end
 
       def reorder_targets(operations)

--- a/engines/collavre/app/services/collavre/tools/creative_batch_service.rb
+++ b/engines/collavre/app/services/collavre/tools/creative_batch_service.rb
@@ -90,7 +90,12 @@ module Collavre
           .flat_map { |creative| creative.archive_family.to_a }
         progress_targets = propagation_targets(progress_sources(operations, creatives))
         archive_progress_targets = propagation_targets(archive_targets)
-        [ *creatives, *archive_targets, *progress_targets, *archive_progress_targets, *reorder_targets(operations) ]
+        structural_progress_sources = structural_progress_sources(operations, creatives)
+        structural_progress_targets = propagation_targets(structural_progress_sources)
+        [
+          *creatives, *archive_targets, *progress_targets, *archive_progress_targets,
+          *structural_progress_sources, *structural_progress_targets, *reorder_targets(operations)
+        ]
       end
 
       def progress_sources(operations, creatives)
@@ -103,6 +108,25 @@ module Collavre
 
       def propagation_targets(creatives)
         creatives.flat_map { |creative| Creatives::ProgressPropagationTargets.new(creative.effective_origin).call }
+      end
+
+      def structural_progress_sources(operations, creatives)
+        records = creatives.index_by(&:id)
+        operations.flat_map do |operation|
+          operation = operation.stringify_keys
+          case operation["action"]
+          when "create"
+            records[operation["parent_id"].to_i]
+          when "update"
+            move_progress_sources(operation, records)
+          end
+        end.compact
+      end
+
+      def move_progress_sources(operation, records)
+        return [] unless operation["parent_id"].present? && operation["parent_id"].to_i.positive?
+
+        [ records[operation["id"].to_i]&.parent, records[operation["parent_id"].to_i] ].compact
       end
 
       def reorder_targets(operations)

--- a/engines/collavre/app/services/collavre/tools/creative_create_service.rb
+++ b/engines/collavre/app/services/collavre/tools/creative_create_service.rb
@@ -32,7 +32,7 @@ module Tools
       end
 
       Creatives::AiWritePolicy.capture(
-        creatives: [ parent, parent&.effective_origin ], anchor: parent
+        creatives: review_targets(parent, before_id, after_id), anchor: parent
       ) do
         perform_create(
           description: description, parent: parent, progress: progress,
@@ -42,6 +42,13 @@ module Tools
     end
 
     private
+
+    def review_targets(parent, before_id, after_id)
+      targets = [ parent, parent&.effective_origin ]
+      return targets unless before_id.present? || after_id.present?
+
+      targets.concat(parent ? parent.children.to_a : Creative.roots.to_a)
+    end
 
     def perform_create(description:, parent:, progress:, after_id:, before_id:)
       # Build the creative. The description is authored as Markdown: store it as

--- a/engines/collavre/app/services/collavre/tools/creative_create_service.rb
+++ b/engines/collavre/app/services/collavre/tools/creative_create_service.rb
@@ -7,7 +7,7 @@ module Tools
     extend ToolMeta
 
     tool_name "creative_create_service"
-    tool_description "Create a new Creative (task/content block) in the hierarchical structure. Creatives function like tasks in a tree structure, with automatic progress calculation.\n\nUse this to:\n- Create new tasks under a parent Creative\n- Add sub-items to organize work\n- Build hierarchical project structures\n\nNote: The description field is written as Markdown."
+    tool_description "Create a new Creative (task/content block) in the hierarchical structure. Creatives function like tasks in a tree structure, with automatic progress calculation.\n\nUse this to:\n- Create new tasks under a parent Creative\n- Add sub-items to organize work\n- Build hierarchical project structures\n\nNote: The description field is written as Markdown. A parent with inherited ai_write_policy=review stores a draft in History for approval."
 
     tool_param :description, description: "The content/title of the Creative, written in Markdown (GitHub-Flavored: headings, bold/italic, lists, links, tables, code blocks, task lists). A single newline is a line break. Plain text is stored as-is. Example: '# Title\\n\\n- item one\\n- item two'.", required: true
     tool_param :parent_id, description: "ID of the parent Creative. Required to create under a specific parent. If omitted, creates a root Creative.", required: false
@@ -31,6 +31,19 @@ module Tools
         end
       end
 
+      Creatives::AiWritePolicy.capture(
+        creatives: [ parent, parent&.effective_origin ], anchor: parent
+      ) do
+        perform_create(
+          description: description, parent: parent, progress: progress,
+          after_id: after_id, before_id: before_id
+        )
+      end
+    end
+
+    private
+
+    def perform_create(description:, parent:, progress:, after_id:, before_id:)
       # Build the creative. The description is authored as Markdown: store it as
       # the canonical markdown_source and let Describable#convert_markdown_to_html
       # render it to the HTML description (markdown_editor defaults to the
@@ -64,8 +77,6 @@ module Tools
         progress: creative.progress
       }
     end
-
-    private
 
     def handle_ordering(creative, before_id:, after_id:)
       return unless before_id.present? || after_id.present?

--- a/engines/collavre/app/services/collavre/tools/creative_create_service.rb
+++ b/engines/collavre/app/services/collavre/tools/creative_create_service.rb
@@ -45,6 +45,7 @@ module Tools
 
     def review_targets(parent, before_id, after_id)
       targets = [ parent, parent&.effective_origin ]
+      targets.concat(Creatives::ProgressPropagationTargets.new(parent.effective_origin).call) if parent
       return targets unless before_id.present? || after_id.present?
 
       targets.concat(parent ? parent.children.to_a : Creative.roots.to_a)

--- a/engines/collavre/app/services/collavre/tools/creative_import_service.rb
+++ b/engines/collavre/app/services/collavre/tools/creative_import_service.rb
@@ -33,11 +33,19 @@ module Collavre
         return { error: "No write permission on parent Creative", id: parent_id } unless parent.has_permission?(Current.user, :write)
 
         Creatives::AiWritePolicy.capture(
-          creatives: [ parent, parent.effective_origin ], anchor: parent, origin: :import
+          creatives: review_targets(parent), anchor: parent, origin: :import
         ) { perform_import(markdown, parent, parent_id) }
       end
 
       private
+
+      def review_targets(parent)
+        [
+          parent,
+          parent.effective_origin,
+          *Creatives::ProgressPropagationTargets.new(parent.effective_origin).call
+        ]
+      end
 
       def perform_import(markdown, parent, parent_id)
         created = Creatives::History.track(

--- a/engines/collavre/app/services/collavre/tools/creative_import_service.rb
+++ b/engines/collavre/app/services/collavre/tools/creative_import_service.rb
@@ -15,10 +15,10 @@ module Collavre
                        "Example input:\n" \
                        "```\n# Project Plan\n## Phase 1\n- Setup infrastructure\n- Configure CI\n## Phase 2\n- Build features\n```\n\n" \
                        "This creates a tree under the specified parent Creative.\n\n" \
-                       "This tool requires approval before execution."
+                       "A parent with inherited ai_write_policy=review stores a draft in History for approval instead of applying immediately."
 
       def self.requires_approval?
-        true
+        false
       end
 
       tool_param :markdown, description: "The markdown text to import. Headings and bullet lists define the tree structure.", required: true
@@ -32,6 +32,14 @@ module Collavre
         return { error: "Parent Creative not found", id: parent_id } unless parent
         return { error: "No write permission on parent Creative", id: parent_id } unless parent.has_permission?(Current.user, :write)
 
+        Creatives::AiWritePolicy.capture(
+          creatives: [ parent, parent.effective_origin ], anchor: parent, origin: :import
+        ) { perform_import(markdown, parent, parent_id) }
+      end
+
+      private
+
+      def perform_import(markdown, parent, parent_id)
         created = Creatives::History.track(
           actor: Current.user,
           origin: :import,

--- a/engines/collavre/app/services/collavre/tools/creative_remove_attachment_service.rb
+++ b/engines/collavre/app/services/collavre/tools/creative_remove_attachment_service.rb
@@ -7,7 +7,7 @@ module Tools
     extend ToolMeta
 
     tool_name "creative_remove_attachment_service"
-    tool_description "Remove a single attachment from a Creative by its signed_id. Requires :write permission. Strips the attachment's node from the description and purges the underlying blob asynchronously when nothing else references it."
+    tool_description "Remove a single attachment from a Creative by its signed_id. Requires :write permission. Strips the attachment's node from the description and purges the underlying blob asynchronously when nothing else references it. A Creative with inherited ai_write_policy=review stores a draft in History for approval."
 
     tool_param :creative_id, description: "ID of the Creative.", required: true
     tool_param :signed_id, description: "signed_id of the blob (from creative_list_attachments_service or creative_attach_files_service response).", required: true
@@ -23,6 +23,27 @@ module Tools
         return { error: "No write permission on Creative", id: creative_id }
       end
 
+      targets = [ creative, creative.effective_origin ]
+      if Creatives::AiWritePolicy.review_required?(targets) && unembedded_attachment?(creative, signed_id)
+        return { error: "An unembedded legacy attachment cannot be proposed for review" }
+      end
+
+      Creatives::AiWritePolicy.capture(
+        creatives: targets, anchor: Creatives::AiWritePolicy.agent_anchor || creative
+      ) { remove_attachment(creative, signed_id) }
+    end
+
+    private
+
+    def unembedded_attachment?(creative, signed_id)
+      target = creative.effective_origin
+      blob = ActiveStorage::Blob.find_signed(signed_id)
+      return false unless blob && target.files.attachments.exists?(blob_id: blob.id)
+
+      !Creatives::History.extract_signed_ids(target.description).include?(signed_id)
+    end
+
+    def remove_attachment(creative, signed_id)
       # HTML is the source of truth: strip the node from the description and let
       # after_save reconcile detach + safe-purge the blob. Removing only the
       # ActiveStorage attachment would leave a dangling node in the description

--- a/engines/collavre/app/services/collavre/tools/creative_update_service.rb
+++ b/engines/collavre/app/services/collavre/tools/creative_update_service.rb
@@ -32,7 +32,7 @@ module Tools
       destination = Creative.find_by(id: parent_id) if parent_id.present? && parent_id != 0
 
       Creatives::AiWritePolicy.capture(
-        creatives: review_targets(creative, base, destination, progress),
+        creatives: review_targets(creative, base, destination, progress, parent_id),
         anchor: Creatives::AiWritePolicy.agent_anchor || creative
       ) do
         perform_update(
@@ -44,10 +44,16 @@ module Tools
 
     private
 
-    def review_targets(creative, base, destination, progress)
+    def review_targets(creative, base, destination, progress, parent_id)
       targets = [ creative, base, destination ]
       targets.concat(Creatives::ProgressPropagationTargets.new(base).call) if progress.present?
+      targets.concat(move_progress_targets(creative, destination)) if parent_id.present? && parent_id != 0
       targets
+    end
+
+    def move_progress_targets(creative, destination)
+      sources = [ creative.parent, destination ].compact
+      [ *sources, *sources.flat_map { |source| Creatives::ProgressPropagationTargets.new(source.effective_origin).call } ]
     end
 
     def perform_update(creative:, base:, description:, progress:, parent_id:)

--- a/engines/collavre/app/services/collavre/tools/creative_update_service.rb
+++ b/engines/collavre/app/services/collavre/tools/creative_update_service.rb
@@ -7,7 +7,7 @@ module Tools
     extend ToolMeta
 
     tool_name "creative_update_service"
-    tool_description "Update an existing Creative's content, progress, or parent. Use this to:\n- Modify the description/title of a Creative\n- Mark a leaf Creative as complete (progress = 1.0)\n- Move a Creative to a different parent\n\nProgress constraints:\n- Only 1.0 (100%) is allowed — partial progress updates are not supported\n- Only leaf Creatives (with no children) can have their progress updated\n- Parent Creative progress is automatically calculated from children\n\nUse creative_retrieval_service to find the correct Creative before updating."
+    tool_description "Update an existing Creative's content, progress, or parent. Use this to:\n- Modify the description/title of a Creative\n- Mark a leaf Creative as complete (progress = 1.0)\n- Move a Creative to a different parent\n\nProgress constraints:\n- Only 1.0 (100%) is allowed — partial progress updates are not supported\n- Only leaf Creatives (with no children) can have their progress updated\n- Parent Creative progress is automatically calculated from children\n\nUse creative_retrieval_service to find the correct Creative before updating. A Creative with inherited ai_write_policy=review stores a draft in History for approval."
 
     tool_param :id, description: "The ID of the Creative to update.", required: true
     tool_param :description, description: "New content/title for the Creative, written in Markdown (GitHub-Flavored: headings, bold/italic, lists, links, tables, code blocks, task lists). A single newline is a line break. Replaces the whole body. If omitted, the description remains unchanged.", required: false
@@ -29,105 +29,97 @@ module Tools
 
       # Get the effective origin for updating content
       base = creative.effective_origin
+      destination = Creative.find_by(id: parent_id) if parent_id.present? && parent_id != 0
 
-      updates = {}
-      parent_updates = {}
-
-      # Handle description update. The description is authored as Markdown: set it
-      # as the canonical markdown_source on the base/origin and let
-      # Describable#convert_markdown_to_html render the HTML description on save.
-      #
-      # Force the "source" editing surface (like create does) rather than letting
-      # convert_markdown_to_html preserve a prior "rich" preference: this update
-      # replaces the whole body with fresh tool/MCP-authored GFM, so the old
-      # rich-authored content the preference belonged to is gone. Tool writes can
-      # contain tables/raw HTML the Lexical nodes don't fully model; reopening in
-      # the source textarea preserves that structure, whereas a rich-editor
-      # round-trip could silently rewrite it.
-      description_provided = description.present?
-      if description_provided
-        base.content_type_input = "markdown"
-        base.markdown_source = description
-        base.markdown_editor = "source"
-      end
-
-      # Handle progress update
-      if progress.present?
-        progress_value = progress.to_f.clamp(0.0, 1.0)
-
-        # Only 100% (1.0) progress updates are allowed via tools
-        unless progress_value == 1.0
-          return { error: "Only progress of 1.0 (100%) is allowed. Partial progress updates are not supported.", id: id }
-        end
-
-        # Only leaf creatives (no children) can have progress updated directly
-        if base.children.exists?
-          return { error: "Cannot update progress on a parent Creative. Only leaf Creatives (with no children) can be marked complete.", id: id }
-        end
-
-        updates[:progress] = progress_value
-      end
-
-      # Handle parent change (on the creative itself, not base)
-      # Skip if parent_id is nil or 0 — these mean "don't change parent"
-      if parent_id.present? && parent_id != 0
-        new_parent_id = parent_id
-
-        # Prevent self-reference
-        if new_parent_id == creative.id
-          return { error: "Cannot set a Creative as its own parent", id: id }
-        end
-
-        new_parent = Creative.find_by(id: new_parent_id)
-        unless new_parent
-          return { error: "New parent Creative not found", parent_id: new_parent_id }
-        end
-        unless new_parent.has_permission?(Current.user, :write)
-          return { error: "No write permission on new parent Creative", parent_id: new_parent_id }
-        end
-        # Prevent circular reference
-        if new_parent.self_and_ancestors.include?(creative)
-          return { error: "Cannot move Creative under its own descendant", parent_id: new_parent_id }
-        end
-
-        parent_updates[:parent_id] = new_parent_id
-      end
-
-      # Apply updates
-      success = true
-
-      # Update parent on the creative (for linked creatives, parent is on the link, not origin)
-      if parent_updates.present?
-        success &&= creative.update(parent_updates)
-      end
-
-      # Update content on the base/origin. markdown_source is set on `base`
-      # directly (above), so save it whenever a description was provided even if
-      # `updates` (progress) is empty.
-      if updates.present? || description_provided
-        base.assign_attributes(updates) if updates.present?
-        success &&= base.save
-
-        # Note: progress updates are only allowed on leaf Creatives (validated above).
-        # Parent progress is automatically calculated from children.
-      end
-
-      if success
-        creative.reload
-        base.reload
-        {
-          success: true,
-          id: creative.id,
-          description: base.description,
-          parent_id: creative.parent_id,
-          progress: base.progress
-        }
-      else
-        { error: "Failed to update Creative", details: creative.errors.full_messages + base.errors.full_messages }
+      Creatives::AiWritePolicy.capture(
+        creatives: [ creative, base, destination ], anchor: Creatives::AiWritePolicy.agent_anchor || creative
+      ) do
+        perform_update(
+          creative: creative, base: base, description: description,
+          progress: progress, parent_id: parent_id
+        )
       end
     end
 
     private
+
+    def perform_update(creative:, base:, description:, progress:, parent_id:)
+      description_provided = prepare_description(base, description)
+      updates, error = progress_updates(base, progress, creative.id)
+      return error if error
+
+      parent_updates, error = parent_updates(creative, parent_id)
+      return error if error
+
+      apply_updates(creative, base, updates, parent_updates, description_provided)
+    end
+
+    def prepare_description(base, description)
+      return false unless description.present?
+
+      # Tool-authored GFM is canonical and must reopen in the source editor so
+      # structures that the rich editor cannot represent are not rewritten.
+      base.content_type_input = "markdown"
+      base.markdown_source = description
+      base.markdown_editor = "source"
+      true
+    end
+
+    def progress_updates(base, progress, creative_id)
+      return [ {}, nil ] unless progress.present?
+
+      progress_value = progress.to_f.clamp(0.0, 1.0)
+      unless progress_value == 1.0
+        return [ {}, { error: "Only progress of 1.0 (100%) is allowed. Partial progress updates are not supported.", id: creative_id } ]
+      end
+      if base.children.exists?
+        return [ {}, { error: "Cannot update progress on a parent Creative. Only leaf Creatives (with no children) can be marked complete.", id: creative_id } ]
+      end
+
+      [ { progress: progress_value }, nil ]
+    end
+
+    def parent_updates(creative, parent_id)
+      return [ {}, nil ] unless parent_id.present? && parent_id != 0
+      return [ {}, { error: "Cannot set a Creative as its own parent", id: creative.id } ] if parent_id == creative.id
+
+      new_parent = Creative.find_by(id: parent_id)
+      return [ {}, { error: "New parent Creative not found", parent_id: parent_id } ] unless new_parent
+      unless new_parent.has_permission?(Current.user, :write)
+        return [ {}, { error: "No write permission on new parent Creative", parent_id: parent_id } ]
+      end
+      if new_parent.self_and_ancestors.include?(creative)
+        return [ {}, { error: "Cannot move Creative under its own descendant", parent_id: parent_id } ]
+      end
+
+      [ { parent_id: parent_id }, nil ]
+    end
+
+    def apply_updates(creative, base, updates, parent_updates, description_provided)
+      success = parent_updates.blank? || creative.update(parent_updates)
+      if success && (updates.present? || description_provided)
+        base.assign_attributes(updates) if updates.present?
+        success = base.save
+      end
+
+      success ? success_result(creative, base) : failure_result(creative, base)
+    end
+
+    def success_result(creative, base)
+      creative.reload
+      base.reload
+      {
+        success: true,
+        id: creative.id,
+        description: base.description,
+        parent_id: creative.parent_id,
+        progress: base.progress
+      }
+    end
+
+    def failure_result(creative, base)
+      { error: "Failed to update Creative", details: creative.errors.full_messages + base.errors.full_messages }
+    end
   end
 end
 end

--- a/engines/collavre/app/services/collavre/tools/creative_update_service.rb
+++ b/engines/collavre/app/services/collavre/tools/creative_update_service.rb
@@ -32,7 +32,8 @@ module Tools
       destination = Creative.find_by(id: parent_id) if parent_id.present? && parent_id != 0
 
       Creatives::AiWritePolicy.capture(
-        creatives: [ creative, base, destination ], anchor: Creatives::AiWritePolicy.agent_anchor || creative
+        creatives: review_targets(creative, base, destination, progress),
+        anchor: Creatives::AiWritePolicy.agent_anchor || creative
       ) do
         perform_update(
           creative: creative, base: base, description: description,
@@ -42,6 +43,12 @@ module Tools
     end
 
     private
+
+    def review_targets(creative, base, destination, progress)
+      targets = [ creative, base, destination ]
+      targets.concat(Creatives::ProgressPropagationTargets.new(base).call) if progress.present?
+      targets
+    end
 
     def perform_update(creative:, base:, description:, progress:, parent_id:)
       description_provided = prepare_description(base, description)

--- a/engines/collavre/app/views/collavre/creative_change_sets/_list.html.erb
+++ b/engines/collavre/app/views/collavre/creative_change_sets/_list.html.erb
@@ -56,7 +56,29 @@
         </details>
       <% end %>
 
-      <% if change_set.status == "applied" && diff.revertible? %>
+      <% if change_set.status == "draft" && creative.has_permission?(Current.user, :write) %>
+        <button type="button"
+                class="approve-comment-btn"
+                data-action="creative-history#revert"
+                data-url="<%= creative_apply_change_set_path(creative, change_set) %>"
+                data-mode="approve"
+                data-confirm="<%= t("collavre.creative_history.approve_confirm") %>"
+                data-conflict="<%= t("collavre.creative_history.approve_conflict_choice") %>"
+                data-force="<%= t("collavre.creative_history.force_apply") %>"
+                data-skip="<%= t("collavre.creative_history.skip") %>">
+          <%= t("collavre.creative_history.approve") %>
+        </button>
+        <button type="button"
+                class="deny-comment-btn"
+                data-action="creative-history#revert"
+                data-url="<%= creative_apply_change_set_path(creative, change_set) %>"
+                data-mode="reject"
+                data-confirm="<%= t("collavre.creative_history.reject_confirm") %>">
+          <%= t("collavre.creative_history.reject") %>
+        </button>
+      <% elsif change_set.status == "draft" %>
+        <span class="creative-history-state"><%= t("collavre.creative_history.pending_review") %></span>
+      <% elsif change_set.status == "applied" && diff.revertible? %>
         <button type="button"
                 class="creative-history-revert"
                 data-action="creative-history#revert"
@@ -70,6 +92,8 @@
         </button>
       <% elsif change_set.status == "reverted" %>
         <span class="creative-history-state"><%= t("collavre.creative_history.reverted") %></span>
+      <% elsif change_set.status == "rejected" %>
+        <span class="creative-history-state"><%= t("collavre.creative_history.rejected") %></span>
       <% elsif !diff.revertible? %>
         <span class="creative-history-state"><%= t("collavre.creative_history.irreversible") %></span>
       <% end %>

--- a/engines/collavre/config/locales/creative_history.en.yml
+++ b/engines/collavre/config/locales/creative_history.en.yml
@@ -14,6 +14,14 @@ en:
       revert: Revert change
       restore: Restore this version
       reverted: Reverted
+      approve: Approve
+      approve_confirm: Apply this proposed change?
+      approve_conflict_choice: "Creative #%{id} changed after this proposal. Force apply it, or skip it?"
+      force_apply: Force apply
+      reject: Reject
+      reject_confirm: Reject this proposed change?
+      rejected: Rejected
+      pending_review: Awaiting approval
       irreversible: Cannot be restored
       undo_notice:
         one: AI updated 1 creative.
@@ -26,7 +34,8 @@ en:
       force: Force revert
       skip: Skip
       results:
-        applied: The change was reverted.
+        applied: The change was applied.
+        rejected: The proposed change was rejected.
         partial: The writable changes were applied. You can retry the remaining changes after permissions change.
         conflict: Resolve each conflict before reverting.
         skipped: No writable creatives remained to revert.

--- a/engines/collavre/config/locales/creative_history.en.yml
+++ b/engines/collavre/config/locales/creative_history.en.yml
@@ -34,7 +34,8 @@ en:
       force: Force revert
       skip: Skip
       results:
-        applied: The change was applied.
+        applied: The change was reverted.
+        approved: The proposed change was applied.
         rejected: The proposed change was rejected.
         partial: The writable changes were applied. You can retry the remaining changes after permissions change.
         conflict: Resolve each conflict before reverting.

--- a/engines/collavre/config/locales/creative_history.ko.yml
+++ b/engines/collavre/config/locales/creative_history.ko.yml
@@ -30,7 +30,8 @@ ko:
       force: 강제 되돌리기
       skip: 건너뛰기
       results:
-        applied: 변경을 적용했습니다.
+        applied: 변경을 되돌렸습니다.
+        approved: 변경안을 적용했습니다.
         rejected: 변경안을 거절했습니다.
         partial: 쓰기 가능한 변경을 적용했습니다. 권한이 변경되면 남은 변경을 다시 시도할 수 있습니다.
         conflict: 되돌리기 전에 각 충돌을 처리하세요.

--- a/engines/collavre/config/locales/creative_history.ko.yml
+++ b/engines/collavre/config/locales/creative_history.ko.yml
@@ -12,6 +12,14 @@ ko:
       revert: 변경 되돌리기
       restore: 이 버전으로 복원
       reverted: 되돌림 완료
+      approve: 승인
+      approve_confirm: 이 변경안을 적용할까요?
+      approve_conflict_choice: "변경안 작성 후 크리에이티브 #%{id}이(가) 변경되었습니다. 강제로 적용하거나 건너뛰세요."
+      force_apply: 강제 적용
+      reject: 거절
+      reject_confirm: 이 변경안을 거절할까요?
+      rejected: 거절됨
+      pending_review: 승인 대기 중
       irreversible: 복원할 수 없음
       undo_notice: "AI가 크리에이티브 %{count}개를 수정했습니다."
       undo: 되돌리기
@@ -22,7 +30,8 @@ ko:
       force: 강제 되돌리기
       skip: 건너뛰기
       results:
-        applied: 변경을 되돌렸습니다.
+        applied: 변경을 적용했습니다.
+        rejected: 변경안을 거절했습니다.
         partial: 쓰기 가능한 변경을 적용했습니다. 권한이 변경되면 남은 변경을 다시 시도할 수 있습니다.
         conflict: 되돌리기 전에 각 충돌을 처리하세요.
         skipped: 되돌릴 수 있는 쓰기 가능 크리에이티브가 없습니다.

--- a/engines/collavre/test/controllers/collavre/creatives/attachments_controller_test.rb
+++ b/engines/collavre/test/controllers/collavre/creatives/attachments_controller_test.rb
@@ -52,6 +52,33 @@ module Collavre
         assert_includes creative.files.map { |f| f.blob.signed_id }, body["signed_id"]
       end
 
+      test "stores a bearer upload as a draft under review policy" do
+        creative = Collavre::Creative.create!(
+          description: "<p>x</p>", user: @owner,
+          data: { "ai_write_policy" => "review" }
+        )
+        assert creative.ai_write_review?
+
+        post path_for(creative),
+             params: { file: upload(content_type: "image/png", filename: "proposal.png") },
+             headers: { "Authorization" => "Bearer #{token_for(@owner)}" }
+
+        assert_response :success
+        body = JSON.parse(response.body)
+        assert body["pending_review"], body.inspect
+        assert_equal "<p>x</p>", creative.reload.description
+        assert_empty creative.files
+        draft = CreativeChangeSet.find(body.fetch("change_set_id"))
+        assert_equal "mcp", draft.origin
+        retained_blob = draft.creative_changes.sole.history_file_attachments.sole.blob
+
+        applied = Creatives::ChangeSetApplyService.new(source: draft, user: @owner, mode: :draft).call
+
+        assert_equal :applied, applied.status
+        assert_equal retained_blob.id, creative.reload.files.blobs.sole.id
+        assert_includes creative.description, retained_blob.signed_id
+      end
+
       test "uploads an mp4 and embeds <video controls>" do
         creative = Collavre::Creative.create!(description: "<p>x</p>", user: @owner)
         post path_for(creative),

--- a/engines/collavre/test/controllers/comments_controller_test.rb
+++ b/engines/collavre/test/controllers/comments_controller_test.rb
@@ -44,6 +44,50 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
     assert_equal I18n.t("collavre.creative_history.read_only"), response.parsed_body["error"]
   end
 
+  test "History renders approval and rejection controls for a draft" do
+    snapshot = Collavre::Creatives::History.snapshot(@creative)
+    draft = Collavre::CreativeChangeSet.create!(
+      anchor_creative: @creative, anchor_source: "agent_topic", user: users(:ai_bot),
+      actor_kind: "agent", origin: "tool", status: "draft"
+    )
+    draft.creative_changes.create!(
+      creative: @creative, operation: "update", before: snapshot,
+      after: snapshot.merge("description" => "Proposed"), position: 0
+    )
+    history_topic = @creative.reload.history_topic
+
+    get creative_comments_path(@creative), params: { topic_id: history_topic.id }
+
+    assert_response :success
+    assert_select ".approve-comment-btn[data-mode='approve']", text: I18n.t("collavre.creative_history.approve")
+    assert_select ".deny-comment-btn[data-mode='reject']", text: I18n.t("collavre.creative_history.reject")
+    assert_select ".creative-history-revert", count: 0
+  end
+
+  test "History hides draft actions from a read-only viewer" do
+    snapshot = Collavre::Creatives::History.snapshot(@creative)
+    draft = Collavre::CreativeChangeSet.create!(
+      anchor_creative: @creative, anchor_source: "agent_topic", user: users(:ai_bot),
+      actor_kind: "agent", origin: "tool", status: "draft"
+    )
+    draft.creative_changes.create!(
+      creative: @creative, operation: "update", before: snapshot,
+      after: snapshot.merge("description" => "Proposed"), position: 0
+    )
+    history_topic = @creative.reload.history_topic
+    viewer = users(:two)
+    grant_read_access_to_other_user(@creative, user: viewer)
+    delete session_path
+    post session_path, params: { email: viewer.email, password: "password" }
+
+    get creative_comments_path(@creative), params: { topic_id: history_topic.id }
+
+    assert_response :success
+    assert_select ".approve-comment-btn", count: 0
+    assert_select ".deny-comment-btn", count: 0
+    assert_select ".creative-history-state", text: I18n.t("collavre.creative_history.pending_review")
+  end
+
   test "linked Creatives use the origin History topic while preserving the linked history scope" do
     linked = Collavre::Creative.create!(user: @user, origin: @creative)
     Collavre::Creatives::History.track(actor: @user, origin: :tool, anchor: linked, anchor_source: :explicit) do

--- a/engines/collavre/test/controllers/creative_change_sets_controller_test.rb
+++ b/engines/collavre/test/controllers/creative_change_sets_controller_test.rb
@@ -117,5 +117,146 @@ module Collavre
 
       assert_response :forbidden
     end
+
+    test "approves a draft create and remaps its temporary id" do
+      draft = build_review_draft([
+        { "action" => "create", "parent_id" => @creative.id, "description" => "Proposed child" }
+      ])
+      temporary_id = draft.creative_changes.find_by!(operation: "create").creative_id
+
+      assert_difference("Creative.count", 1) do
+        post creative_apply_change_set_path(@creative, draft), params: { mode: "approve" }, as: :json
+      end
+
+      assert_response :success
+      assert_equal "applied", response.parsed_body["status"]
+      assert_equal "applied", draft.reload.status
+      assert draft.applied_at
+      refute draft.creative_changes.exists?(creative_id: temporary_id)
+      created = @creative.children.where("description LIKE ?", "%Proposed child%").sole
+      assert draft.creative_changes.exists?(creative_id: created.id)
+    end
+
+    test "approves a nested draft import with remapped parent ids" do
+      draft = build_review_import("# Project\n## Child")
+
+      post creative_apply_change_set_path(@creative, draft), params: { mode: "approve" }, as: :json
+
+      assert_response :success
+      project = @creative.children.where("description LIKE ?", "%Project%").sole
+      assert project.children.where("description LIKE ?", "%Child%").exists?
+      assert_equal "applied", draft.reload.status
+      assert draft.creative_changes.pluck(:creative_id).all?(&:positive?)
+    end
+
+    test "rejects a draft without applying it" do
+      draft = build_review_draft([
+        { "action" => "update", "id" => @creative.id, "description" => "Do not apply" }
+      ])
+
+      post creative_apply_change_set_path(@creative, draft), params: { mode: "reject" }, as: :json
+
+      assert_response :success
+      assert_equal "rejected", response.parsed_body["status"]
+      assert_equal "rejected", draft.reload.status
+      refute_includes @creative.reload.description, "Do not apply"
+    end
+
+    test "reports a conflict when a draft target changed after capture" do
+      draft = build_review_draft([
+        { "action" => "update", "id" => @creative.id, "description" => "Proposed" }
+      ])
+      @creative.update!(description: "Later human edit")
+
+      post creative_apply_change_set_path(@creative, draft), params: { mode: "approve" }, as: :json
+
+      assert_response :conflict
+      assert_equal "draft", draft.reload.status
+      assert_includes @creative.reload.description, "Later human edit"
+    end
+
+    test "does not approve a draft without an explicit mode" do
+      draft = build_review_draft([
+        { "action" => "update", "id" => @creative.id, "description" => "Proposed" }
+      ])
+
+      post creative_apply_change_set_path(@creative, draft), as: :json
+
+      assert_response :unprocessable_entity
+      assert_equal "not_revertible", response.parsed_body["status"]
+      assert_equal "draft", draft.reload.status
+      refute_includes @creative.reload.description, "Proposed"
+    end
+
+    test "finalizes a draft when its proposed state is already current" do
+      snapshot = Creatives::History.snapshot(@creative)
+      draft = CreativeChangeSet.create!(
+        anchor_creative: @creative, anchor_source: "agent_topic", user: users(:ai_bot),
+        actor_kind: "agent", origin: "tool", status: "draft"
+      )
+      draft.creative_changes.create!(
+        creative: @creative, operation: "update",
+        before: snapshot.merge("description" => "Earlier"), after: snapshot, position: 0
+      )
+
+      post creative_apply_change_set_path(@creative, draft), params: { mode: "approve" }, as: :json
+
+      assert_response :success
+      assert_equal "applied", response.parsed_body["status"]
+      assert_equal "applied", draft.reload.status
+      assert draft.applied_at
+    end
+
+    test "does not let a read-only viewer approve or reject a draft" do
+      draft = build_review_draft([
+        { "action" => "update", "id" => @creative.id, "description" => "Proposed" }
+      ])
+      viewer = users(:two)
+      viewer.update!(email_verified_at: Time.current)
+      share = CreativeShare.find_or_initialize_by(creative: @creative, user: viewer)
+      share.update!(shared_by: @user, permission: :read)
+      delete session_path
+      post session_path, params: { email: viewer.email, password: "password" }
+
+      post creative_apply_change_set_path(@creative, draft), params: { mode: "approve" }, as: :json
+      assert_response :unprocessable_entity
+      assert_equal "draft", draft.reload.status
+
+      post creative_apply_change_set_path(@creative, draft), params: { mode: "reject" }, as: :json
+      assert_response :unprocessable_entity
+      assert_equal "draft", draft.reload.status
+      refute_includes @creative.reload.description, "Proposed"
+    end
+
+    private
+
+    def build_review_draft(operations)
+      @creative.update!(data: @creative.data.merge("ai_write_policy" => "review"))
+      agent, task = review_agent_and_task
+      result = Current.set(user: agent, agent_turn: { user: @user, task: task }) do
+        Tools::CreativeBatchService.new.call(operations: operations)
+      end
+      CreativeChangeSet.find(result.fetch(:change_set_id))
+    end
+
+    def build_review_import(markdown)
+      @creative.update!(data: @creative.data.merge("ai_write_policy" => "review"))
+      agent, task = review_agent_and_task
+      result = Current.set(user: agent, agent_turn: { user: @user, task: task }) do
+        Tools::CreativeImportService.new.call(markdown: markdown, parent_id: @creative.id)
+      end
+      CreativeChangeSet.find(result.fetch(:change_set_id))
+    end
+
+    def review_agent_and_task
+      agent = users(:ai_bot)
+      CreativeShare.find_or_create_by!(creative: @creative, user: agent) do |share|
+        share.shared_by = @user
+        share.permission = :write
+      end
+      topic = Topic.create!(creative: @creative, user: @user, name: "Draft #{SecureRandom.hex(3)}")
+      task = Task.create!(agent: agent, creative: @creative, topic_id: topic.id, name: "Draft", status: "running")
+      [ agent, task ]
+    end
   end
 end

--- a/engines/collavre/test/controllers/creative_change_sets_controller_test.rb
+++ b/engines/collavre/test/controllers/creative_change_sets_controller_test.rb
@@ -23,6 +23,7 @@ module Collavre
 
       assert_response :success
       assert_equal "applied", response.parsed_body["status"]
+      assert_equal "The change was reverted.", response.parsed_body["message"]
       assert_equal @before, Creatives::History.snapshot(@creative.reload)
       assert_equal "reverted", @change_set.reload.status
     end
@@ -130,6 +131,7 @@ module Collavre
 
       assert_response :success
       assert_equal "applied", response.parsed_body["status"]
+      assert_equal "The proposed change was applied.", response.parsed_body["message"]
       assert_equal "applied", draft.reload.status
       assert draft.applied_at
       refute draft.creative_changes.exists?(creative_id: temporary_id)

--- a/engines/collavre/test/controllers/creative_change_sets_controller_test.rb
+++ b/engines/collavre/test/controllers/creative_change_sets_controller_test.rb
@@ -195,6 +195,52 @@ module Collavre
       assert_equal "applied", draft.reload.status
     end
 
+    test "does not treat a requested skip as authority over an unwritable draft target" do
+      draft = build_review_draft([
+        { "action" => "update", "id" => @creative.id, "description" => "Authorized proposal" }
+      ])
+      foreign = append_unwritable_draft_change(draft)
+
+      post creative_apply_change_set_path(@creative, draft),
+           params: { mode: "approve", resolutions: { foreign.id => "skip" } }, as: :json
+
+      assert_response :unprocessable_entity
+      assert_equal "skipped", response.parsed_body["status"]
+      assert_equal "draft", draft.reload.status
+      assert draft.creative_changes.exists?(creative_id: foreign.id)
+      refute_includes @creative.reload.description, "Authorized proposal"
+    end
+
+    test "rejects only when the reviewer can write every draft target" do
+      draft = build_review_draft([
+        { "action" => "update", "id" => @creative.id, "description" => "Authorized proposal" }
+      ])
+      foreign = append_unwritable_draft_change(draft)
+
+      post creative_apply_change_set_path(@creative, draft), params: { mode: "reject" }, as: :json
+
+      assert_response :unprocessable_entity
+      assert_equal "skipped", response.parsed_body["status"]
+      assert_equal "draft", draft.reload.status
+      assert draft.creative_changes.exists?(creative_id: foreign.id)
+    end
+
+    test "rejects a draft when every actual conflict is skipped" do
+      draft = build_review_draft([
+        { "action" => "update", "id" => @creative.id, "description" => "Proposed" }
+      ])
+      @creative.update!(description: "Later human edit")
+
+      post creative_apply_change_set_path(@creative, draft),
+           params: { mode: "approve", resolutions: { @creative.id => "skip" } }, as: :json
+
+      assert_response :success
+      assert_equal "rejected", response.parsed_body["status"]
+      assert_equal "rejected", draft.reload.status
+      assert draft.creative_changes.exists?(creative_id: @creative.id)
+      assert_includes @creative.reload.description, "Later human edit"
+    end
+
     test "does not approve a draft without an explicit mode" do
       draft = build_review_draft([
         { "action" => "update", "id" => @creative.id, "description" => "Proposed" }
@@ -277,6 +323,19 @@ module Collavre
       topic = Topic.create!(creative: @creative, user: @user, name: "Draft #{SecureRandom.hex(3)}")
       task = Task.create!(agent: agent, creative: @creative, topic_id: topic.id, name: "Draft", status: "running")
       [ agent, task ]
+    end
+
+    def append_unwritable_draft_change(draft)
+      foreign = Creative.create!(description: "Foreign", user: users(:two))
+      perform_enqueued_jobs do
+        CreativeShare.create!(creative: foreign, user: @user, shared_by: users(:two), permission: :read)
+      end
+      snapshot = Creatives::History.snapshot(foreign)
+      draft.creative_changes.create!(
+        creative: foreign, operation: "update", before: snapshot,
+        after: snapshot.merge("description" => "Unauthorized proposal"), position: 1
+      )
+      foreign
     end
   end
 end

--- a/engines/collavre/test/controllers/creative_change_sets_controller_test.rb
+++ b/engines/collavre/test/controllers/creative_change_sets_controller_test.rb
@@ -175,6 +175,26 @@ module Collavre
       assert_includes @creative.reload.description, "Later human edit"
     end
 
+    test "applies nonconflicting draft changes when a conflict is skipped" do
+      child = Creative.create!(description: "Child", user: @user, parent: @creative)
+      draft = build_review_draft([
+        { "action" => "update", "id" => @creative.id, "description" => "Proposed parent" },
+        { "action" => "update", "id" => child.id, "description" => "Proposed child" }
+      ])
+      @creative.update!(description: "Later human edit")
+
+      post creative_apply_change_set_path(@creative, draft),
+           params: { mode: "approve", resolutions: { @creative.id => "skip" } }, as: :json
+
+      assert_response :success
+      assert_equal "partial", response.parsed_body["status"]
+      assert_equal [ @creative.id ], response.parsed_body["skipped"]
+      assert_includes @creative.reload.description, "Later human edit"
+      assert_includes child.reload.description, "Proposed child"
+      refute draft.creative_changes.exists?(creative_id: @creative.id)
+      assert_equal "applied", draft.reload.status
+    end
+
     test "does not approve a draft without an explicit mode" do
       draft = build_review_draft([
         { "action" => "update", "id" => @creative.id, "description" => "Proposed" }

--- a/engines/collavre/test/controllers/creative_change_sets_controller_test.rb
+++ b/engines/collavre/test/controllers/creative_change_sets_controller_test.rb
@@ -241,6 +241,28 @@ module Collavre
       assert_includes @creative.reload.description, "Later human edit"
     end
 
+    test "finalizes a draft with skipped conflicts and already-current proposals" do
+      child = Creative.create!(description: "Child", user: @user, parent: @creative)
+      draft = build_review_draft([
+        { "action" => "update", "id" => @creative.id, "description" => "Proposed parent" },
+        { "action" => "update", "id" => child.id, "description" => "Proposed child" }
+      ])
+      @creative.update!(description: "Later human edit")
+      child_change = draft.creative_changes.find_by!(creative_id: child.id)
+      Creatives::SnapshotAssignment.call(child, child_change.after)
+      child.save!
+
+      post creative_apply_change_set_path(@creative, draft),
+           params: { mode: "approve", resolutions: { @creative.id => "skip" } }, as: :json
+
+      assert_response :success
+      assert_equal "partial", response.parsed_body["status"]
+      assert_equal "applied", draft.reload.status
+      refute draft.creative_changes.exists?(creative_id: @creative.id)
+      assert draft.creative_changes.exists?(creative_id: child.id)
+      assert_includes child.reload.description, "Proposed child"
+    end
+
     test "does not approve a draft without an explicit mode" do
       draft = build_review_draft([
         { "action" => "update", "id" => @creative.id, "description" => "Proposed" }

--- a/engines/collavre/test/models/collavre/creative_ai_write_policy_test.rb
+++ b/engines/collavre/test/models/collavre/creative_ai_write_policy_test.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  class CreativeAiWritePolicyTest < ActiveSupport::TestCase
+    setup do
+      @user = users(:one)
+      @root = Creative.create!(description: "Root", user: @user)
+      @child = Creative.create!(description: "Child", user: @user, parent: @root)
+    end
+
+    test "defaults to auto" do
+      assert_equal "auto", @child.effective_ai_write_policy
+      assert_not @child.ai_write_review?
+    end
+
+    test "inherits the nearest valid policy from ancestors" do
+      @root.update!(data: @root.data.merge("ai_write_policy" => "review"))
+      assert_equal "review", @child.effective_ai_write_policy
+
+      @child.update!(data: @child.data.merge("ai_write_policy" => "auto"))
+      assert_equal "auto", @child.effective_ai_write_policy
+    end
+
+    test "ignores invalid policy values" do
+      @root.update!(data: @root.data.merge("ai_write_policy" => "sometimes"))
+
+      assert_equal "auto", @child.effective_ai_write_policy
+    end
+  end
+end

--- a/engines/collavre/test/services/collavre/creatives/change_set_diff_test.rb
+++ b/engines/collavre/test/services/collavre/creatives/change_set_diff_test.rb
@@ -139,6 +139,27 @@ module Collavre
         assert_empty diff.groups
         assert_equal 0, diff.change_count
       end
+
+      test "does not expose a deleted existing draft target through its former parent" do
+        reader = users(:two)
+        root_share = CreativeShare.create!(
+          creative: @root, user: reader, shared_by: @user, permission: :read
+        )
+        deny = CreativeShare.create!(
+          creative: @child, user: reader, shared_by: @user, permission: :no_access
+        )
+        PermissionCacheBuilder.propagate_share(root_share)
+        PermissionCacheBuilder.propagate_share(deny)
+        @change_set.update!(status: "draft", user: users(:ai_bot), actor_kind: "agent", origin: "tool")
+        change = @change_set.creative_changes.sole
+        change.update!(previous_parent_id: @root.id)
+        @child.destroy!
+
+        diff = ChangeSetDiff.new(@change_set, user: reader)
+
+        assert_empty diff.groups
+        assert_equal 0, diff.change_count
+      end
     end
   end
 end

--- a/engines/collavre/test/services/collavre/tools/creative_attach_files_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/creative_attach_files_service_test.rb
@@ -36,6 +36,29 @@ module Collavre
         end
       end
 
+      test "stores a direct agent attachment as a draft under review policy" do
+        task, agent = review_agent_turn(@creative)
+
+        result = Current.set(user: agent, agent_turn: { user: @user, task: task }) do
+          CreativeAttachFilesService.new.call(
+            creative_id: @creative.id,
+            files: [ { "filename" => "proposal.txt", "content" => "draft" } ]
+          )
+        end
+
+        assert result[:pending_review]
+        assert_equal 0, @creative.reload.files.count
+        draft = CreativeChangeSet.find(result[:change_set_id])
+        change = draft.creative_changes.sole
+        retained_blob = change.history_file_attachments.sole.blob
+
+        applied = Creatives::ChangeSetApplyService.new(source: draft, user: @user, mode: :draft).call
+
+        assert_equal :applied, applied.status
+        assert_equal retained_blob.id, @creative.reload.files.blobs.sole.id
+        assert_includes @creative.description, retained_blob.signed_id
+      end
+
       test "rejects when user lacks write permission" do
         Current.user = users(:two)
         # creative owned by users(:one); users(:two) is non-admin with no share
@@ -128,6 +151,18 @@ module Collavre
           assert_match(/filename/i, result[:error])
         end
         assert_not_includes @creative.reload.description.to_s, "notes.md"
+      end
+
+      private
+
+      def review_agent_turn(creative)
+        creative.update!(data: creative.data.merge("ai_write_policy" => "review"))
+        agent = users(:ai_bot)
+        share = CreativeShare.find_or_initialize_by(creative: creative, user: agent)
+        share.update!(shared_by: @user, permission: :write)
+        topic = Topic.create!(creative: creative, user: @user, name: "Review attachment")
+        task = Task.create!(agent: agent, creative: creative, topic_id: topic.id, name: "Review", status: "running")
+        [ task, agent ]
       end
     end
   end

--- a/engines/collavre/test/services/collavre/tools/creative_remove_attachment_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/creative_remove_attachment_service_test.rb
@@ -27,6 +27,39 @@ module Collavre
         assert_not ActiveStorage::Blob.exists?(blob_id)
       end
 
+      test "stores a direct agent attachment removal as a draft under review policy" do
+        @creative.embed_attachment_blob!(@attachment.blob)
+        task, agent = review_agent_turn(@creative)
+
+        result = Current.set(user: agent, agent_turn: { user: @user, task: task }) do
+          CreativeRemoveAttachmentService.new.call(creative_id: @creative.id, signed_id: @signed_id)
+        end
+
+        assert result[:pending_review]
+        assert_equal 1, @creative.reload.files.count
+        draft = CreativeChangeSet.find(result[:change_set_id])
+        assert_equal "draft", draft.status
+        assert_equal 1, draft.creative_changes.sole.history_file_attachments.count
+
+        applied = Creatives::ChangeSetApplyService.new(source: draft, user: @user, mode: :draft).call
+
+        assert_equal :applied, applied.status
+        assert_equal 0, @creative.reload.files.count
+        assert ActiveStorage::Blob.exists?(@attachment.blob_id)
+      end
+
+      test "blocks an unembedded legacy removal that cannot be represented as a draft" do
+        task, agent = review_agent_turn(@creative)
+
+        result = Current.set(user: agent, agent_turn: { user: @user, task: task }) do
+          CreativeRemoveAttachmentService.new.call(creative_id: @creative.id, signed_id: @signed_id)
+        end
+
+        assert_match(/cannot be proposed/i, result[:error])
+        assert_equal 1, @creative.reload.files.count
+        assert_not CreativeChangeSet.where(task_id: task.id, status: "draft").exists?
+      end
+
       test "strips the embedded node from the description and detaches" do
         # HTML is the source of truth: an attachment embedded in the description
         # must have its node removed, otherwise the next save reconciles the
@@ -73,6 +106,18 @@ module Collavre
         )
         assert_match(/not found/i, result[:error])
         assert_equal 1, @creative.reload.files.count
+      end
+
+      private
+
+      def review_agent_turn(creative)
+        creative.update_column(:data, creative.data.merge("ai_write_policy" => "review"))
+        agent = users(:ai_bot)
+        share = CreativeShare.find_or_initialize_by(creative: creative, user: agent)
+        share.update!(shared_by: @user, permission: :write)
+        topic = Topic.create!(creative: creative, user: @user, name: "Review removal")
+        task = Task.create!(agent: agent, creative: creative, topic_id: topic.id, name: "Review", status: "running")
+        [ task, agent ]
       end
     end
   end

--- a/engines/collavre/test/services/tools/creative_batch_service_test.rb
+++ b/engines/collavre/test/services/tools/creative_batch_service_test.rb
@@ -175,6 +175,31 @@ module Collavre
         assert_equal "applied", draft.reload.status
       end
 
+      test "skipping an archive conflict also skips its propagated family" do
+        child, linked = create_private_linked_pair
+        task, agent = review_agent_turn
+        result = Current.set(user: agent, agent_turn: { user: @user, task: task }) do
+          CreativeBatchService.new.call(operations: [ { "action" => "delete", "id" => child.id } ])
+        end
+        draft = CreativeChangeSet.find(result[:change_set_id])
+        expected_root_progress = @root.reload.progress
+        expected_foreign_progress = linked.parent.reload.progress
+        child.update!(description: "Later human edit")
+
+        applied = Creatives::ChangeSetApplyService.new(
+          source: draft, user: @user, mode: :draft, resolutions: { child.id => "skip" }
+        ).call
+
+        assert_equal :rejected, applied.status
+        assert_equal "rejected", draft.reload.status
+        assert_not child.reload.archived?
+        assert_not linked.reload.archived?
+        assert_includes child.description, "Later human edit"
+        assert_in_delta expected_root_progress, @root.reload.progress, 0.01
+        assert_in_delta expected_foreign_progress, linked.parent.reload.progress, 0.01
+        assert_operator draft.creative_changes.count, :>, 1
+      end
+
       test "creates a creative via batch" do
         service = CreativeBatchService.new
         result = service.call(operations: [

--- a/engines/collavre/test/services/tools/creative_batch_service_test.rb
+++ b/engines/collavre/test/services/tools/creative_batch_service_test.rb
@@ -527,6 +527,50 @@ module Collavre
         assert hidden.reload.archived?
       end
 
+      test "merged archive and progress parent traverses to hidden descendants" do
+        source, hidden_parent, draft = hidden_descendant_archive_draft(nested_hidden: true)
+        hidden_child = hidden_parent.children.sole
+        parent_change = draft.creative_changes.find_by!(creative_id: hidden_parent.id)
+
+        assert_not_equal parent_change.before["progress"], parent_change.after["progress"]
+        applied = Creatives::ChangeSetApplyService.new(source: draft, user: @user, mode: :draft).call
+
+        assert_equal :applied, applied.status, applied.skipped.inspect
+        assert source.reload.archived?
+        assert hidden_parent.reload.archived?
+        assert_equal 0.0, hidden_parent.progress
+        assert hidden_child.reload.archived?
+      end
+
+      test "force approval applies merged progress and archive to a changed read-only source" do
+        source_type = "review_archive_progress_test"
+        Creative.register_read_only_source(source_type)
+        child = Creative.create!(
+          description: "Synced child", user: @user, parent: @root, progress: 0,
+          data: { "source" => { "type" => source_type }, "ai_write_policy" => "review" }
+        )
+        task, agent = agent_turn
+        result = Current.set(user: agent, agent_turn: { user: @user, task: task }) do
+          CreativeBatchService.new.call(operations: [
+            { "action" => "update", "id" => child.id, "progress" => 1.0 },
+            { "action" => "delete", "id" => child.id }
+          ])
+        end
+        draft = CreativeChangeSet.find(result[:change_set_id])
+        child.update_column(:description, "Newly synced content")
+
+        applied = Creatives::ChangeSetApplyService.new(
+          source: draft, user: @user, mode: :draft, resolutions: { child.id => "force" }
+        ).call
+
+        assert_equal :applied, applied.status, applied.skipped.inspect
+        assert child.reload.archived?
+        assert_equal 1.0, child.progress
+        assert_equal "Newly synced content", child.description
+      ensure
+        Creative.read_only_source_types.delete(source_type) if source_type
+      end
+
       test "skipping a progress conflict also skips linked parent rollups" do
         child, linked = create_private_linked_pair(progress: 0)
         task, agent = review_agent_turn
@@ -859,13 +903,16 @@ module Collavre
         [ child, linked ]
       end
 
-      def hidden_descendant_archive_draft(update_before_delete: false)
+      def hidden_descendant_archive_draft(update_before_delete: false, nested_hidden: false)
         owner = users(:two)
         source = Creative.create!(
           description: "Shared source", user: owner,
           data: { "ai_write_policy" => "review" }
         )
-        hidden = Creative.create!(description: "Hidden descendant", user: owner, parent: source)
+        hidden = Creative.create!(
+          description: "Hidden descendant", user: owner, parent: source, progress: nested_hidden ? 1 : 0
+        )
+        Creative.create!(description: "Hidden leaf", user: owner, parent: hidden, progress: 1) if nested_hidden
         CreativeShare.create!(creative: source, user: @user, shared_by: owner, permission: :write)
         CreativeShare.create!(creative: hidden, user: @user, shared_by: owner, permission: :no_access)
         agent = users(:ai_bot)

--- a/engines/collavre/test/services/tools/creative_batch_service_test.rb
+++ b/engines/collavre/test/services/tools/creative_batch_service_test.rb
@@ -94,6 +94,39 @@ module Collavre
         assert_not child.reload.archived?
       end
 
+      test "reviews an archive when its progress parent requires review" do
+        @root.update!(data: @root.data.merge("ai_write_policy" => "review"))
+        child = Creative.create!(
+          description: "Explicit auto child", user: @user, parent: @root,
+          data: { "ai_write_policy" => "auto" }
+        )
+        task, agent = agent_turn
+
+        result = Current.set(user: agent, agent_turn: { user: @user, task: task }) do
+          CreativeBatchService.new.call(operations: [ { "action" => "delete", "id" => child.id } ])
+        end
+
+        assert result[:pending_review], result.inspect
+        assert_not child.reload.archived?
+      end
+
+      test "reviews batch create resequencing when a sibling requires review" do
+        sibling = Creative.create!(
+          description: "Protected sibling", user: @user, parent: @root,
+          data: { "ai_write_policy" => "review" }
+        )
+        task, agent = agent_turn
+
+        result = Current.set(user: agent, agent_turn: { user: @user, task: task }) do
+          CreativeBatchService.new.call(operations: [
+            { "action" => "create", "parent_id" => @root.id, "description" => "Before", "before_id" => sibling.id }
+          ])
+        end
+
+        assert result[:pending_review], result.inspect
+        assert_not @root.children.where("description LIKE ?", "%Before%").exists?
+      end
+
       test "keeps a parentless create on the default auto policy" do
         task, agent = review_agent_turn
 
@@ -262,6 +295,31 @@ module Collavre
         assert result[:pending_review]
         assert_equal 0.0, child.reload.progress
         assert_in_delta 0.0, linked.parent.reload.progress, 0.01
+      end
+
+      test "draft approval authorizes a hidden direct parent progress rollup" do
+        foreign_parent = Creative.create!(description: "Private parent", user: users(:two), progress: 0)
+        Creative.create!(description: "Incomplete", user: users(:two), parent: foreign_parent, progress: 0)
+        child = Creative.create!(
+          description: "Owned child", user: @user, parent: foreign_parent, progress: 0,
+          data: { "ai_write_policy" => "review" }
+        )
+        agent = users(:ai_bot)
+        CreativeShare.create!(creative: child, user: agent, shared_by: @user, permission: :write)
+        topic = Topic.create!(creative: child, user: @user, name: "Hidden parent review")
+        task = Task.create!(agent: agent, creative: child, topic_id: topic.id, name: "Review", status: "running")
+        result = Current.set(user: agent, agent_turn: { user: @user, task: task }) do
+          CreativeBatchService.new.call(operations: [
+            { "action" => "update", "id" => child.id, "progress" => 1.0 }
+          ])
+        end
+        draft = CreativeChangeSet.find(result[:change_set_id])
+
+        assert_not_includes Creatives::PermissionFilter.new(user: @user).readable_ids([ foreign_parent.id ]), foreign_parent.id
+        applied = Creatives::ChangeSetApplyService.new(source: draft, user: @user, mode: :draft).call
+        assert_equal :applied, applied.status, applied.skipped.inspect
+        assert_equal 1.0, child.reload.progress
+        assert_in_delta 0.5, foreign_parent.reload.progress, 0.01
       end
 
       test "skipping a progress conflict also skips linked parent rollups" do

--- a/engines/collavre/test/services/tools/creative_batch_service_test.rb
+++ b/engines/collavre/test/services/tools/creative_batch_service_test.rb
@@ -71,6 +71,25 @@ module Collavre
         assert Creative.where(parent_id: nil).where("description LIKE ?", "%Independent root%").exists?
       end
 
+      test "approves a parentless create captured with a review-policy batch" do
+        task, agent = review_agent_turn
+
+        result = Current.set(user: agent, agent_turn: { user: @user, task: task }) do
+          CreativeBatchService.new.call(operations: [
+            { "action" => "create", "parent_id" => @root.id, "description" => "Reviewed child" },
+            { "action" => "create", "description" => "Reviewed root" }
+          ])
+        end
+        draft = CreativeChangeSet.find(result[:change_set_id])
+        root_change = draft.creative_changes.find { |change| change.after["parent_id"].nil? }
+
+        assert_equal @root.id, root_change.previous_parent_id
+        applied = Creatives::ChangeSetApplyService.new(source: draft, user: @user, mode: :draft).call
+        assert_equal :applied, applied.status, applied.skipped.inspect
+        assert @root.children.where("description LIKE ?", "%Reviewed child%").exists?
+        assert Creative.roots.where("description LIKE ?", "%Reviewed root%").exists?
+      end
+
       test "returns the existing pending draft for another write in the same turn" do
         task, agent = review_agent_turn
 

--- a/engines/collavre/test/services/tools/creative_batch_service_test.rb
+++ b/engines/collavre/test/services/tools/creative_batch_service_test.rb
@@ -464,6 +464,55 @@ module Collavre
         Creative.read_only_source_types.delete(source_type) if source_type
       end
 
+      test "force approval archives a changed read-only source without overwriting synced content" do
+        source_type = "review_archive_force_test"
+        Creative.register_read_only_source(source_type)
+        child = Creative.create!(
+          description: "Synced child", user: @user, parent: @root,
+          data: { "source" => { "type" => source_type }, "ai_write_policy" => "review" }
+        )
+        task, agent = agent_turn
+        result = Current.set(user: agent, agent_turn: { user: @user, task: task }) do
+          CreativeBatchService.new.call(operations: [ { "action" => "delete", "id" => child.id } ])
+        end
+        draft = CreativeChangeSet.find(result[:change_set_id])
+        child.update_column(:description, "Newly synced content")
+
+        applied = Creatives::ChangeSetApplyService.new(
+          source: draft, user: @user, mode: :draft, resolutions: { child.id => "force" }
+        ).call
+
+        assert_equal :applied, applied.status, applied.skipped.inspect
+        assert child.reload.archived?
+        assert_equal "Newly synced content", child.description
+      ensure
+        Creative.read_only_source_types.delete(source_type) if source_type
+      end
+
+      test "draft approval archives a hidden descendant in the captured family" do
+        source, hidden, draft = hidden_descendant_archive_draft
+
+        assert_not_includes Creatives::PermissionFilter.new(user: @user).readable_ids([ hidden.id ]), hidden.id
+        applied = Creatives::ChangeSetApplyService.new(source: draft, user: @user, mode: :draft).call
+
+        assert_equal :applied, applied.status, applied.skipped.inspect
+        assert source.reload.archived?
+        assert hidden.reload.archived?
+      end
+
+      test "draft rejection accepts a hidden descendant in the captured family" do
+        source, hidden, draft = hidden_descendant_archive_draft
+
+        rejected = Creatives::DraftChangeSetRejectService.new(
+          change_set: draft, user: @user, scope_creative: source
+        ).call
+
+        assert_equal :rejected, rejected.status, rejected.skipped.inspect
+        assert_equal "rejected", draft.reload.status
+        assert_not source.reload.archived?
+        assert_not hidden.reload.archived?
+      end
+
       test "skipping a progress conflict also skips linked parent rollups" do
         child, linked = create_private_linked_pair(progress: 0)
         task, agent = review_agent_turn
@@ -794,6 +843,25 @@ module Collavre
         linked = Creative.create!(origin: child, user: foreign_user, parent: foreign_root)
         Current.change_set = nil
         [ child, linked ]
+      end
+
+      def hidden_descendant_archive_draft
+        owner = users(:two)
+        source = Creative.create!(
+          description: "Shared source", user: owner,
+          data: { "ai_write_policy" => "review" }
+        )
+        hidden = Creative.create!(description: "Hidden descendant", user: owner, parent: source)
+        CreativeShare.create!(creative: source, user: @user, shared_by: owner, permission: :write)
+        CreativeShare.create!(creative: hidden, user: @user, shared_by: owner, permission: :no_access)
+        agent = users(:ai_bot)
+        CreativeShare.create!(creative: source, user: agent, shared_by: owner, permission: :write)
+        topic = Topic.create!(creative: source, user: @user, name: "Hidden descendant #{SecureRandom.hex(3)}")
+        task = Task.create!(agent: agent, creative: source, topic_id: topic.id, name: "Review", status: "running")
+        result = Current.set(user: agent, agent_turn: { user: @user, task: task }) do
+          CreativeBatchService.new.call(operations: [ { "action" => "delete", "id" => source.id } ])
+        end
+        [ source, hidden, CreativeChangeSet.find(result[:change_set_id]) ]
       end
     end
   end

--- a/engines/collavre/test/services/tools/creative_batch_service_test.rb
+++ b/engines/collavre/test/services/tools/creative_batch_service_test.rb
@@ -127,6 +127,29 @@ module Collavre
         assert_not @root.children.where("description LIKE ?", "%Before%").exists?
       end
 
+      test "reviews batch move progress propagation when an ancestor requires review" do
+        @root.update!(data: @root.data.merge("ai_write_policy" => "review"))
+        source = Creative.create!(
+          description: "Auto source", user: @user, parent: @root,
+          data: { "ai_write_policy" => "auto" }
+        )
+        destination = Creative.create!(
+          description: "Auto destination", user: @user, parent: @root,
+          data: { "ai_write_policy" => "auto" }
+        )
+        moved = Creative.create!(description: "Moved", user: @user, parent: source)
+        task, agent = agent_turn
+
+        result = Current.set(user: agent, agent_turn: { user: @user, task: task }) do
+          CreativeBatchService.new.call(operations: [
+            { "action" => "update", "id" => moved.id, "parent_id" => destination.id }
+          ])
+        end
+
+        assert result[:pending_review], result.inspect
+        assert_equal source.id, moved.reload.parent_id
+      end
+
       test "keeps a parentless create on the default auto policy" do
         task, agent = review_agent_turn
 

--- a/engines/collavre/test/services/tools/creative_batch_service_test.rb
+++ b/engines/collavre/test/services/tools/creative_batch_service_test.rb
@@ -57,6 +57,43 @@ module Collavre
         assert @root.children.where("description LIKE ?", "%Immediate%").exists?
       end
 
+      test "stores a taskless MCP write as a draft under review policy" do
+        @root.update!(data: @root.data.merge("ai_write_policy" => "review"))
+
+        result = Current.set(user: @user, mcp_request: true) do
+          CreativeBatchService.new.call(operations: [
+            { "action" => "update", "id" => @root.id, "description" => "MCP proposal" }
+          ])
+        end
+
+        assert result[:pending_review]
+        refute_includes @root.reload.description, "MCP proposal"
+        draft = CreativeChangeSet.find(result[:change_set_id])
+        assert_equal "mcp", draft.origin
+        assert_equal @root.id, draft.anchor_creative_id
+        assert_equal "explicit", draft.anchor_source
+      end
+
+      test "reviews an archive when a descendant locally requires review" do
+        task, agent = agent_turn
+        parent = Creative.create!(
+          description: "Auto parent", user: @user, parent: @root,
+          data: { "ai_write_policy" => "auto" }
+        )
+        child = Creative.create!(
+          description: "Protected child", user: @user, parent: parent,
+          data: { "ai_write_policy" => "review" }
+        )
+
+        result = Current.set(user: agent, agent_turn: { user: @user, task: task }) do
+          CreativeBatchService.new.call(operations: [ { "action" => "delete", "id" => parent.id } ])
+        end
+
+        assert result[:pending_review]
+        assert_not parent.reload.archived?
+        assert_not child.reload.archived?
+      end
+
       test "keeps a parentless create on the default auto policy" do
         task, agent = review_agent_turn
 
@@ -172,6 +209,24 @@ module Collavre
         assert_equal :applied, applied.status
         assert child.reload.archived?
         assert linked.reload.archived?
+        assert_equal "applied", draft.reload.status
+      end
+
+      test "draft approval applies linked parent progress rollups" do
+        child, linked = create_private_linked_pair(progress: 0)
+        task, agent = review_agent_turn
+        result = Current.set(user: agent, agent_turn: { user: @user, task: task }) do
+          CreativeBatchService.new.call(operations: [
+            { "action" => "update", "id" => child.id, "progress" => 1.0 }
+          ])
+        end
+        draft = CreativeChangeSet.find(result[:change_set_id])
+
+        applied = Creatives::ChangeSetApplyService.new(source: draft, user: @user, mode: :draft).call
+
+        assert_equal :applied, applied.status, applied.skipped.inspect
+        assert_equal 1.0, child.reload.progress
+        assert_in_delta 0.5, linked.parent.reload.progress, 0.01
         assert_equal "applied", draft.reload.status
       end
 
@@ -435,8 +490,8 @@ module Collavre
         [ task, agent ]
       end
 
-      def create_private_linked_pair
-        child = Creative.create!(description: "<p>Shared source</p>", user: @user, parent: @root, progress: 1)
+      def create_private_linked_pair(progress: 1)
+        child = Creative.create!(description: "<p>Shared source</p>", user: @user, parent: @root, progress: progress)
         foreign_user = users(:two)
         foreign_root = Creative.create!(description: "<p>Private tree</p>", user: foreign_user)
         Creative.create!(description: "<p>Incomplete</p>", user: foreign_user, parent: foreign_root, progress: 0)

--- a/engines/collavre/test/services/tools/creative_batch_service_test.rb
+++ b/engines/collavre/test/services/tools/creative_batch_service_test.rb
@@ -513,6 +513,20 @@ module Collavre
         assert_not hidden.reload.archived?
       end
 
+      test "merged update and archive seeds the hidden descendant family" do
+        source, hidden, draft = hidden_descendant_archive_draft(update_before_delete: true)
+        source_change = draft.creative_changes.find_by!(creative_id: source.id)
+
+        assert_equal "archive", source_change.operation
+        assert_not_equal source_change.before["markdown_source"], source_change.after["markdown_source"]
+        applied = Creatives::ChangeSetApplyService.new(source: draft, user: @user, mode: :draft).call
+
+        assert_equal :applied, applied.status, applied.skipped.inspect
+        assert source.reload.archived?
+        assert_includes source.description, "Updated before archive"
+        assert hidden.reload.archived?
+      end
+
       test "skipping a progress conflict also skips linked parent rollups" do
         child, linked = create_private_linked_pair(progress: 0)
         task, agent = review_agent_turn
@@ -845,7 +859,7 @@ module Collavre
         [ child, linked ]
       end
 
-      def hidden_descendant_archive_draft
+      def hidden_descendant_archive_draft(update_before_delete: false)
         owner = users(:two)
         source = Creative.create!(
           description: "Shared source", user: owner,
@@ -858,8 +872,13 @@ module Collavre
         CreativeShare.create!(creative: source, user: agent, shared_by: owner, permission: :write)
         topic = Topic.create!(creative: source, user: @user, name: "Hidden descendant #{SecureRandom.hex(3)}")
         task = Task.create!(agent: agent, creative: source, topic_id: topic.id, name: "Review", status: "running")
+        operations = []
+        if update_before_delete
+          operations << { "action" => "update", "id" => source.id, "description" => "Updated before archive" }
+        end
+        operations << { "action" => "delete", "id" => source.id }
         result = Current.set(user: agent, agent_turn: { user: @user, task: task }) do
-          CreativeBatchService.new.call(operations: [ { "action" => "delete", "id" => source.id } ])
+          CreativeBatchService.new.call(operations: operations)
         end
         [ source, hidden, CreativeChangeSet.find(result[:change_set_id]) ]
       end

--- a/engines/collavre/test/services/tools/creative_batch_service_test.rb
+++ b/engines/collavre/test/services/tools/creative_batch_service_test.rb
@@ -124,7 +124,8 @@ module Collavre
         applied = Creatives::ChangeSetApplyService.new(source: draft, user: @user, mode: :draft).call
         assert_equal :applied, applied.status, applied.skipped.inspect
         assert @root.children.where("description LIKE ?", "%Reviewed child%").exists?
-        assert Creative.roots.where("description LIKE ?", "%Reviewed root%").exists?
+        reviewed_root = Creative.roots.where("description LIKE ?", "%Reviewed root%").sole
+        assert_equal agent, reviewed_root.user
       end
 
       test "returns the existing pending draft for another write in the same turn" do
@@ -230,6 +231,27 @@ module Collavre
         assert_equal "applied", draft.reload.status
       end
 
+      test "skipping a progress conflict also skips linked parent rollups" do
+        child, linked = create_private_linked_pair(progress: 0)
+        task, agent = review_agent_turn
+        result = Current.set(user: agent, agent_turn: { user: @user, task: task }) do
+          CreativeBatchService.new.call(operations: [
+            { "action" => "update", "id" => child.id, "progress" => 1.0 }
+          ])
+        end
+        draft = CreativeChangeSet.find(result[:change_set_id])
+        child.update!(description: "Later human edit")
+
+        applied = Creatives::ChangeSetApplyService.new(
+          source: draft, user: @user, mode: :draft, resolutions: { child.id => "skip" }
+        ).call
+
+        assert_equal :rejected, applied.status
+        assert_equal "rejected", draft.reload.status
+        assert_equal 0.0, child.reload.progress
+        assert_in_delta 0.0, linked.parent.reload.progress, 0.01
+      end
+
       test "skipping an archive conflict also skips its propagated family" do
         child, linked = create_private_linked_pair
         task, agent = review_agent_turn
@@ -253,6 +275,29 @@ module Collavre
         assert_in_delta expected_root_progress, @root.reload.progress, 0.01
         assert_in_delta expected_foreign_progress, linked.parent.reload.progress, 0.01
         assert_operator draft.creative_changes.count, :>, 1
+      end
+
+      test "skipping a linked archive conflict also skips its origin family" do
+        child = Creative.create!(description: "Source", user: @user, parent: @root)
+        linked_parent = Creative.create!(description: "Placement", user: @user)
+        linked = Creative.create!(origin: child, user: @user, parent: linked_parent)
+        task, agent = review_agent_turn
+        result = Current.set(user: agent, agent_turn: { user: @user, task: task }) do
+          CreativeBatchService.new.call(operations: [ { "action" => "delete", "id" => linked.id } ])
+        end
+        draft = CreativeChangeSet.find(result[:change_set_id])
+        linked.update!(sequence: linked.sequence + 1)
+        linked_change = draft.creative_changes.find_by!(creative_id: linked.id)
+        assert_not_equal linked_change.before, Creatives::History.snapshot(linked)
+
+        applied = Creatives::ChangeSetApplyService.new(
+          source: draft, user: @user, mode: :draft, resolutions: { linked.id => "skip" }
+        ).call
+
+        assert_equal :rejected, applied.status
+        assert_equal "rejected", draft.reload.status
+        assert_not child.reload.archived?
+        assert_not linked.reload.archived?
       end
 
       test "creates a creative via batch" do

--- a/engines/collavre/test/services/tools/creative_batch_service_test.rb
+++ b/engines/collavre/test/services/tools/creative_batch_service_test.rb
@@ -400,6 +400,70 @@ module Collavre
         assert_equal "rejected", draft.reload.status
       end
 
+      test "draft rejection preserves captured linked parents after a placement moves" do
+        child, linked = create_private_linked_pair(progress: 0)
+        task, agent = review_agent_turn
+        result = Current.set(user: agent, agent_turn: { user: @user, task: task }) do
+          CreativeBatchService.new.call(operations: [
+            { "action" => "update", "id" => child.id, "progress" => 1.0 }
+          ])
+        end
+        draft = CreativeChangeSet.find(result[:change_set_id])
+        new_parent = Creative.create!(description: "New private parent", user: users(:two))
+        linked.update_column(:parent_id, new_parent.id)
+
+        rejected = Creatives::DraftChangeSetRejectService.new(
+          change_set: draft, user: @user, scope_creative: @root
+        ).call
+
+        assert_equal :rejected, rejected.status, rejected.skipped.inspect
+        assert_equal "rejected", draft.reload.status
+      end
+
+      test "skipping a conflicted move also skips both parent progress chains" do
+        @root.update!(data: @root.data.merge("ai_write_policy" => "review"))
+        source = Creative.create!(description: "Source", user: @user, parent: @root)
+        destination = Creative.create!(description: "Destination", user: @user, parent: @root)
+        moved = Creative.create!(description: "Moved", user: @user, parent: source, progress: 1)
+        task, agent = agent_turn
+        result = Current.set(user: agent, agent_turn: { user: @user, task: task }) do
+          CreativeBatchService.new.call(operations: [
+            { "action" => "update", "id" => moved.id, "parent_id" => destination.id }
+          ])
+        end
+        draft = CreativeChangeSet.find(result[:change_set_id])
+        moved.update!(description: "Later human edit")
+
+        applied = Creatives::ChangeSetApplyService.new(
+          source: draft, user: @user, mode: :draft, resolutions: { moved.id => "skip" }
+        ).call
+
+        assert_equal :rejected, applied.status, applied.skipped.inspect
+        assert_equal 1.0, source.reload.progress
+        assert_equal 0.0, destination.reload.progress
+      end
+
+      test "approves archive-only changes for a read-only source" do
+        source_type = "review_archive_test"
+        Creative.register_read_only_source(source_type)
+        child = Creative.create!(
+          description: "Synced child", user: @user, parent: @root,
+          data: { "source" => { "type" => source_type }, "ai_write_policy" => "review" }
+        )
+        task, agent = agent_turn
+        result = Current.set(user: agent, agent_turn: { user: @user, task: task }) do
+          CreativeBatchService.new.call(operations: [ { "action" => "delete", "id" => child.id } ])
+        end
+        draft = CreativeChangeSet.find(result[:change_set_id])
+
+        applied = Creatives::ChangeSetApplyService.new(source: draft, user: @user, mode: :draft).call
+
+        assert_equal :applied, applied.status, applied.skipped.inspect
+        assert child.reload.archived?
+      ensure
+        Creative.read_only_source_types.delete(source_type) if source_type
+      end
+
       test "skipping a progress conflict also skips linked parent rollups" do
         child, linked = create_private_linked_pair(progress: 0)
         task, agent = review_agent_turn

--- a/engines/collavre/test/services/tools/creative_batch_service_test.rb
+++ b/engines/collavre/test/services/tools/creative_batch_service_test.rb
@@ -19,8 +19,141 @@ module Collavre
         Current.user = nil
       end
 
-      test "requires_approval? returns true" do
-        assert CreativeBatchService.requires_approval?
+      test "does not use the opaque pre-execution approval gate" do
+        assert_not CreativeBatchService.requires_approval?
+      end
+
+      test "stores an agent batch as a draft under the inherited review policy" do
+        task, agent = review_agent_turn
+        initial_count = Creative.count
+
+        result = Current.set(user: agent, agent_turn: { user: @user, task: task }) do
+          CreativeBatchService.new.call(operations: [
+            { "action" => "create", "parent_id" => @root.id, "description" => "Review me" },
+            { "action" => "update", "id" => @root.id, "description" => "Reviewed root" }
+          ])
+        end
+
+        assert result[:pending_review]
+        assert_equal initial_count, Creative.count
+        assert_equal "<p>Root</p>", @root.reload.description
+        draft = CreativeChangeSet.find(result[:change_set_id])
+        assert_equal "draft", draft.status
+        assert_equal task.id, draft.task_id
+        assert draft.creative_changes.where("creative_id < 0").exists?
+      end
+
+      test "keeps auto policy agent batches immediate" do
+        task, agent = agent_turn
+
+        result = Current.set(user: agent, agent_turn: { user: @user, task: task }) do
+          CreativeBatchService.new.call(operations: [
+            { "action" => "create", "parent_id" => @root.id, "description" => "Immediate" }
+          ])
+        end
+
+        assert result[:success]
+        assert_not result[:pending_review]
+        assert @root.children.where("description LIKE ?", "%Immediate%").exists?
+      end
+
+      test "keeps a parentless create on the default auto policy" do
+        task, agent = review_agent_turn
+
+        result = Current.set(user: agent, agent_turn: { user: @user, task: task }) do
+          CreativeBatchService.new.call(operations: [
+            { "action" => "create", "description" => "Independent root" }
+          ])
+        end
+
+        assert result[:success]
+        assert_not result[:pending_review]
+        assert Creative.where(parent_id: nil).where("description LIKE ?", "%Independent root%").exists?
+      end
+
+      test "returns the existing pending draft for another write in the same turn" do
+        task, agent = review_agent_turn
+
+        results = Current.set(user: agent, agent_turn: { user: @user, task: task }) do
+          first = CreativeBatchService.new.call(operations: [
+            { "action" => "update", "id" => @root.id, "description" => "First" }
+          ])
+          second = CreativeBatchService.new.call(operations: [
+            { "action" => "update", "id" => @root.id, "description" => "Second" }
+          ])
+          [ first, second ]
+        end
+
+        assert_equal results.first[:change_set_id], results.second[:change_set_id]
+        assert_equal 1, CreativeChangeSet.where(task_id: task.id, status: "draft").count
+        assert_equal "<p>Root</p>", @root.reload.description
+      end
+
+      test "retains a newly uploaded draft image and applies it without re-uploading" do
+        task, agent = review_agent_turn
+        data_uri = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
+
+        result = Current.set(user: agent, agent_turn: { user: @user, task: task }) do
+          CreativeBatchService.new.call(operations: [
+            { "action" => "create", "parent_id" => @root.id, "description" => "![pixel](#{data_uri})" }
+          ])
+        end
+        draft = CreativeChangeSet.find(result[:change_set_id])
+        change = draft.creative_changes.find_by!(operation: "create")
+        signed_id = Creatives::History.extract_signed_ids(change.after["markdown_source"]).find do |candidate|
+          ActiveStorage::Blob.find_signed(candidate)
+        end
+        retained_blob = ActiveStorage::Blob.find_signed!(signed_id)
+
+        assert_equal 1, change.history_file_attachments.count
+        assert_no_difference("ActiveStorage::Blob.count") do
+          applied = Creatives::ChangeSetApplyService.new(source: draft, user: @user, mode: :draft).call
+          assert_equal :applied, applied.status, applied.skipped.inspect
+        end
+        created = @root.children.where("description LIKE ?", "%pixel%").sole
+        assert_includes created.data["markdown_source"], signed_id
+        assert_equal retained_blob.id, created.files.blobs.sole.id
+      end
+
+      test "approves a draft update using its canonical markdown snapshot" do
+        @root.update!(
+          data: @root.data.merge(
+            "ai_write_policy" => "review",
+            "content_type" => "markdown",
+            "markdown_source" => "Original"
+          )
+        )
+        task, agent = agent_turn
+        result = Current.set(user: agent, agent_turn: { user: @user, task: task }) do
+          CreativeBatchService.new.call(operations: [
+            { "action" => "update", "id" => @root.id, "description" => "**Approved**" }
+          ])
+        end
+        draft = CreativeChangeSet.find(result[:change_set_id])
+
+        applied = Creatives::ChangeSetApplyService.new(source: draft, user: @user, mode: :draft).call
+
+        assert_equal :applied, applied.status
+        assert_equal "**Approved**", @root.reload.data["markdown_source"]
+        assert_includes @root.description, "<strong>Approved</strong>"
+      end
+
+      test "draft approval applies the propagated linked archive family" do
+        child, linked = create_private_linked_pair
+        task, agent = review_agent_turn
+
+        result = Current.set(user: agent, agent_turn: { user: @user, task: task }) do
+          CreativeBatchService.new.call(operations: [ { "action" => "delete", "id" => child.id } ])
+        end
+        draft = CreativeChangeSet.find(result[:change_set_id])
+
+        assert_not child.reload.archived?
+        assert_not linked.reload.archived?
+        applied = Creatives::ChangeSetApplyService.new(source: draft, user: @user, mode: :draft).call
+        assert_equal :applied, applied.status
+        assert child.reload.archived?
+        assert linked.reload.archived?
+        assert_equal "applied", draft.reload.status
       end
 
       test "creates a creative via batch" do
@@ -244,6 +377,19 @@ module Collavre
       end
 
       private
+
+      def review_agent_turn
+        @root.update!(data: @root.data.merge("ai_write_policy" => "review"))
+        agent_turn
+      end
+
+      def agent_turn
+        agent = users(:ai_bot)
+        CreativeShare.create!(creative: @root, user: agent, shared_by: @user, permission: :write)
+        topic = Topic.create!(creative: @root, user: @user, name: "Review #{SecureRandom.hex(3)}")
+        task = Task.create!(agent: agent, creative: @root, topic_id: topic.id, name: "Review", status: "running")
+        [ task, agent ]
+      end
 
       def create_private_linked_pair
         child = Creative.create!(description: "<p>Shared source</p>", user: @user, parent: @root, progress: 1)

--- a/engines/collavre/test/services/tools/creative_batch_service_test.rb
+++ b/engines/collavre/test/services/tools/creative_batch_service_test.rb
@@ -213,6 +213,23 @@ module Collavre
         assert_equal "applied", draft.reload.status
       end
 
+      test "draft approval archives a writable linked shell with nonzero origin progress" do
+        child = Creative.create!(description: "Source", user: @user, parent: @root, progress: 1)
+        linked_parent = Creative.create!(description: "Placement", user: @user)
+        linked = Creative.create!(origin: child, user: @user, parent: linked_parent)
+        task, agent = review_agent_turn
+        result = Current.set(user: agent, agent_turn: { user: @user, task: task }) do
+          CreativeBatchService.new.call(operations: [ { "action" => "delete", "id" => linked.id } ])
+        end
+        draft = CreativeChangeSet.find(result[:change_set_id])
+
+        applied = Creatives::ChangeSetApplyService.new(source: draft, user: @user, mode: :draft).call
+
+        assert_equal :applied, applied.status, applied.skipped.inspect
+        assert child.reload.archived?
+        assert linked.reload.archived?
+      end
+
       test "draft approval applies linked parent progress rollups" do
         child, linked = create_private_linked_pair(progress: 0)
         task, agent = review_agent_turn
@@ -229,6 +246,22 @@ module Collavre
         assert_equal 1.0, child.reload.progress
         assert_in_delta 0.5, linked.parent.reload.progress, 0.01
         assert_equal "applied", draft.reload.status
+      end
+
+      test "review policy includes linked parent progress targets" do
+        child, linked = create_private_linked_pair(progress: 0)
+        linked.parent.update!(data: linked.parent.data.merge("ai_write_policy" => "review"))
+        task, agent = agent_turn
+
+        result = Current.set(user: agent, agent_turn: { user: @user, task: task }) do
+          CreativeBatchService.new.call(operations: [
+            { "action" => "update", "id" => child.id, "progress" => 1.0 }
+          ])
+        end
+
+        assert result[:pending_review]
+        assert_equal 0.0, child.reload.progress
+        assert_in_delta 0.0, linked.parent.reload.progress, 0.01
       end
 
       test "skipping a progress conflict also skips linked parent rollups" do
@@ -298,6 +331,24 @@ module Collavre
         assert_equal "rejected", draft.reload.status
         assert_not child.reload.archived?
         assert_not linked.reload.archived?
+      end
+
+      test "rejects an archive draft despite hidden propagated state drift" do
+        child, linked = create_private_linked_pair
+        task, agent = review_agent_turn
+        result = Current.set(user: agent, agent_turn: { user: @user, task: task }) do
+          CreativeBatchService.new.call(operations: [ { "action" => "delete", "id" => child.id } ])
+        end
+        draft = CreativeChangeSet.find(result[:change_set_id])
+        linked.update_column(:archived_at, 1.day.from_now)
+
+        rejected = Creatives::DraftChangeSetRejectService.new(
+          change_set: draft, user: @user, scope_creative: @root
+        ).call
+
+        assert_equal :rejected, rejected.status
+        assert_equal "rejected", draft.reload.status
+        assert_not child.reload.archived?
       end
 
       test "creates a creative via batch" do

--- a/engines/collavre/test/services/tools/creative_batch_service_test.rb
+++ b/engines/collavre/test/services/tools/creative_batch_service_test.rb
@@ -150,6 +150,34 @@ module Collavre
         assert_equal source.id, moved.reload.parent_id
       end
 
+      test "reviews a moved subtree before a later delete archives it" do
+        target = Creative.create!(
+          description: "Delete target", user: @user, parent: @root,
+          data: { "ai_write_policy" => "auto" }
+        )
+        moved = Creative.create!(
+          description: "Moved subtree", user: @user, parent: @root,
+          data: { "ai_write_policy" => "auto" }
+        )
+        protected_child = Creative.create!(
+          description: "Protected child", user: @user, parent: moved,
+          data: { "ai_write_policy" => "review" }
+        )
+        task, agent = agent_turn
+
+        result = Current.set(user: agent, agent_turn: { user: @user, task: task }) do
+          CreativeBatchService.new.call(operations: [
+            { "action" => "update", "id" => moved.id, "parent_id" => target.id },
+            { "action" => "delete", "id" => target.id }
+          ])
+        end
+
+        assert result[:pending_review], result.inspect
+        assert_equal @root.id, moved.reload.parent_id
+        assert_not target.reload.archived?
+        assert_not protected_child.reload.archived?
+      end
+
       test "keeps a parentless create on the default auto policy" do
         task, agent = review_agent_turn
 
@@ -343,6 +371,33 @@ module Collavre
         assert_equal :applied, applied.status, applied.skipped.inspect
         assert_equal 1.0, child.reload.progress
         assert_in_delta 0.5, foreign_parent.reload.progress, 0.01
+      end
+
+      test "draft rejection uses the captured parent when the source moves later" do
+        foreign_parent = Creative.create!(description: "Captured private parent", user: users(:two), progress: 0)
+        Creative.create!(description: "Incomplete", user: users(:two), parent: foreign_parent, progress: 0)
+        child = Creative.create!(
+          description: "Owned child", user: @user, parent: foreign_parent, progress: 0,
+          data: { "ai_write_policy" => "review" }
+        )
+        agent = users(:ai_bot)
+        CreativeShare.create!(creative: child, user: agent, shared_by: @user, permission: :write)
+        topic = Topic.create!(creative: child, user: @user, name: "Captured parent review")
+        task = Task.create!(agent: agent, creative: child, topic_id: topic.id, name: "Review", status: "running")
+        result = Current.set(user: agent, agent_turn: { user: @user, task: task }) do
+          CreativeBatchService.new.call(operations: [
+            { "action" => "update", "id" => child.id, "progress" => 1.0 }
+          ])
+        end
+        draft = CreativeChangeSet.find(result[:change_set_id])
+        child.update_column(:parent_id, @root.id)
+
+        rejected = Creatives::DraftChangeSetRejectService.new(
+          change_set: draft, user: @user, scope_creative: child
+        ).call
+
+        assert_equal :rejected, rejected.status, rejected.skipped.inspect
+        assert_equal "rejected", draft.reload.status
       end
 
       test "skipping a progress conflict also skips linked parent rollups" do

--- a/engines/collavre/test/services/tools/creative_create_service_test.rb
+++ b/engines/collavre/test/services/tools/creative_create_service_test.rb
@@ -38,6 +38,18 @@ module Collavre
         assert_equal 0, creative.progress
       end
 
+      test "stores a direct agent create as a draft under review policy" do
+        task, agent = review_agent_turn(@parent_creative)
+
+        result = Current.set(user: agent, agent_turn: { user: @user, task: task }) do
+          CreativeCreateService.new.call(parent_id: @parent_creative.id, description: "Proposed")
+        end
+
+        assert result[:pending_review], result.inspect
+        assert_not @parent_creative.children.where("description LIKE ?", "%Proposed%").exists?
+        assert CreativeChangeSet.find(result[:change_set_id]).creative_changes.where("creative_id < 0").exists?
+      end
+
       test "stores the description as Markdown-canonical" do
         service = CreativeCreateService.new
 
@@ -220,6 +232,19 @@ module Collavre
         assert_raises(RuntimeError) do
           service.call(description: "No user task")
         end
+      end
+
+      private
+
+      def review_agent_turn(creative)
+        creative.update!(data: creative.data.merge("ai_write_policy" => "review"))
+        agent = users(:ai_bot)
+        perform_enqueued_jobs(only: PermissionCacheJob) do
+          CreativeShare.create!(creative: creative, user: agent, shared_by: @user, permission: :write)
+        end
+        topic = Topic.create!(creative: creative, user: @user, name: "Review create")
+        task = Task.create!(agent: agent, creative: creative, topic_id: topic.id, name: "Review", status: "running")
+        [ task, agent ]
       end
     end
   end

--- a/engines/collavre/test/services/tools/creative_create_service_test.rb
+++ b/engines/collavre/test/services/tools/creative_create_service_test.rb
@@ -68,6 +68,25 @@ module Collavre
         assert_equal 0, sibling.reload.sequence
       end
 
+      test "stores parent progress propagation as a draft when an ancestor requires review" do
+        review_root = Creative.create!(
+          description: "Review root", user: @user,
+          data: { "ai_write_policy" => "review" }
+        )
+        @parent_creative.update!(
+          parent: review_root,
+          data: @parent_creative.data.merge("ai_write_policy" => "auto")
+        )
+        task, agent = agent_turn(review_root)
+
+        result = Current.set(user: agent, agent_turn: { user: @user, task: task }) do
+          CreativeCreateService.new.call(parent_id: @parent_creative.id, description: "Proposed child")
+        end
+
+        assert result[:pending_review], result.inspect
+        assert_not @parent_creative.children.where("description LIKE ?", "%Proposed child%").exists?
+      end
+
       test "stores the description as Markdown-canonical" do
         service = CreativeCreateService.new
 

--- a/engines/collavre/test/services/tools/creative_create_service_test.rb
+++ b/engines/collavre/test/services/tools/creative_create_service_test.rb
@@ -50,6 +50,24 @@ module Collavre
         assert CreativeChangeSet.find(result[:change_set_id]).creative_changes.where("creative_id < 0").exists?
       end
 
+      test "stores sibling resequencing as a draft when the sibling requires review" do
+        sibling = Creative.create!(
+          description: "Protected sibling", user: @user, parent: @parent_creative,
+          data: { "ai_write_policy" => "review" }
+        )
+        task, agent = agent_turn(@parent_creative)
+
+        result = Current.set(user: agent, agent_turn: { user: @user, task: task }) do
+          CreativeCreateService.new.call(
+            parent_id: @parent_creative.id, description: "Before sibling", before_id: sibling.id
+          )
+        end
+
+        assert result[:pending_review], result.inspect
+        assert_not @parent_creative.children.where("description LIKE ?", "%Before sibling%").exists?
+        assert_equal 0, sibling.reload.sequence
+      end
+
       test "stores the description as Markdown-canonical" do
         service = CreativeCreateService.new
 
@@ -238,6 +256,10 @@ module Collavre
 
       def review_agent_turn(creative)
         creative.update!(data: creative.data.merge("ai_write_policy" => "review"))
+        agent_turn(creative)
+      end
+
+      def agent_turn(creative)
         agent = users(:ai_bot)
         perform_enqueued_jobs(only: PermissionCacheJob) do
           CreativeShare.create!(creative: creative, user: agent, shared_by: @user, permission: :write)

--- a/engines/collavre/test/services/tools/creative_import_service_test.rb
+++ b/engines/collavre/test/services/tools/creative_import_service_test.rb
@@ -95,8 +95,29 @@ module Collavre
         assert_equal @parent.id, result[:tree].first[:parent_id]
       end
 
-      test "requires approval" do
-        assert CreativeImportService.requires_approval?
+      test "does not use the opaque pre-execution approval gate" do
+        assert_not CreativeImportService.requires_approval?
+      end
+
+      test "stores an inherited review-policy import as a draft without creating rows" do
+        @parent.update!(data: @parent.data.merge("ai_write_policy" => "review"))
+        agent = users(:ai_bot)
+        CreativeShare.create!(creative: @parent, user: agent, shared_by: @user, permission: :write)
+        topic = Topic.create!(creative: @parent, user: @user, name: "Review import")
+        task = Task.create!(agent: agent, creative: @parent, topic_id: topic.id, name: "Import", status: "running")
+        initial_count = Creative.count
+
+        result = Current.set(user: agent, agent_turn: { user: @user, task: task }) do
+          @service.call(markdown: "# Project\n## Child", parent_id: @parent.id)
+        end
+
+        assert result[:pending_review]
+        assert_equal initial_count, Creative.count
+        draft = CreativeChangeSet.find(result[:change_set_id])
+        assert_equal "draft", draft.status
+        assert_equal 2, draft.creative_changes.where("creative_id < 0").count
+        root, child = draft.creative_changes.order(:position).to_a
+        assert_equal root.creative_id, child.after["parent_id"]
       end
     end
   end

--- a/engines/collavre/test/services/tools/creative_import_service_test.rb
+++ b/engines/collavre/test/services/tools/creative_import_service_test.rb
@@ -119,6 +119,26 @@ module Collavre
         root, child = draft.creative_changes.order(:position).to_a
         assert_equal root.creative_id, child.after["parent_id"]
       end
+
+      test "stores import progress propagation as a draft when an ancestor requires review" do
+        review_root = Creative.create!(
+          description: "Review root", user: @user,
+          data: { "ai_write_policy" => "review" }
+        )
+        @parent.update!(parent: review_root, data: @parent.data.merge("ai_write_policy" => "auto"))
+        agent = users(:ai_bot)
+        CreativeShare.create!(creative: review_root, user: agent, shared_by: @user, permission: :write)
+        topic = Topic.create!(creative: review_root, user: @user, name: "Review import propagation")
+        task = Task.create!(agent: agent, creative: review_root, topic_id: topic.id, name: "Import", status: "running")
+        initial_count = Creative.count
+
+        result = Current.set(user: agent, agent_turn: { user: @user, task: task }) do
+          @service.call(markdown: "# Proposed", parent_id: @parent.id)
+        end
+
+        assert result[:pending_review], result.inspect
+        assert_equal initial_count, Creative.count
+      end
     end
   end
 end

--- a/engines/collavre/test/services/tools/creative_update_service_test.rb
+++ b/engines/collavre/test/services/tools/creative_update_service_test.rb
@@ -30,6 +30,33 @@ module Collavre
         assert_equal "<p>Updated <em>content</em></p>", @creative.description
       end
 
+      test "stores a direct agent update as a draft under review policy" do
+        task, agent = review_agent_turn(@creative)
+
+        result = Current.set(user: agent, agent_turn: { user: @user, task: task }) do
+          CreativeUpdateService.new.call(id: @creative.id, description: "Proposed")
+        end
+
+        assert result[:pending_review]
+        assert_equal "<p>Original</p>", @creative.reload.description
+        assert_equal "draft", CreativeChangeSet.find(result[:change_set_id]).status
+      end
+
+      test "stores a move into a review-policy parent as a draft" do
+        destination = Creative.create!(description: "Destination", user: @user)
+        task, agent = review_agent_turn(destination)
+        CreativeShare.create!(creative: @creative, user: agent, shared_by: @user, permission: :write)
+
+        result = Current.set(user: agent, agent_turn: { user: @user, task: task }) do
+          CreativeUpdateService.new.call(id: @creative.id, parent_id: destination.id)
+        end
+
+        assert result[:pending_review]
+        assert_nil @creative.reload.parent_id
+        draft = CreativeChangeSet.find(result[:change_set_id])
+        assert_equal destination.id, draft.creative_changes.find_by!(creative_id: @creative.id).after["parent_id"]
+      end
+
       test "updates description with plain text" do
         service = CreativeUpdateService.new
 
@@ -149,6 +176,28 @@ module Collavre
         assert result[:success]
         @creative.reload
         assert_equal new_parent.id, @creative.parent_id
+      end
+
+      test "rejects a destination parent without write permission" do
+        other_user = User.create!(name: "Other Parent", email: "other_parent@example.com", password: "password123")
+        new_parent = Creative.create!(description: "<p>Private parent</p>", user: other_user)
+
+        result = CreativeUpdateService.new.call(id: @creative.id, parent_id: new_parent.id)
+
+        assert_match(/permission/i, result[:error])
+        assert_nil @creative.reload.parent_id
+      end
+
+      test "returns validation failures from the update" do
+        service = CreativeUpdateService.new
+
+        result = Creative.stub(:find_by, @creative) do
+          @creative.stub(:save, false) do
+            service.call(id: @creative.id, description: "Rejected by model")
+          end
+        end
+
+        assert_match(/failed to update/i, result[:error])
       end
 
       test "returns error when creative not found" do
@@ -277,6 +326,17 @@ module Collavre
         assert_raises(RuntimeError) do
           service.call(id: @creative.id, description: "No user")
         end
+      end
+
+      private
+
+      def review_agent_turn(creative)
+        creative.update!(data: creative.data.merge("ai_write_policy" => "review"))
+        agent = users(:ai_bot)
+        CreativeShare.create!(creative: creative, user: agent, shared_by: @user, permission: :write)
+        topic = Topic.create!(creative: creative, user: @user, name: "Review update")
+        task = Task.create!(agent: agent, creative: creative, topic_id: topic.id, name: "Review", status: "running")
+        [ task, agent ]
       end
     end
   end

--- a/engines/collavre/test/services/tools/creative_update_service_test.rb
+++ b/engines/collavre/test/services/tools/creative_update_service_test.rb
@@ -57,6 +57,26 @@ module Collavre
         assert_equal destination.id, draft.creative_changes.find_by!(creative_id: @creative.id).after["parent_id"]
       end
 
+      test "stores move progress propagation as a draft when a destination ancestor requires review" do
+        review_root = Creative.create!(
+          description: "Review root", user: @user,
+          data: { "ai_write_policy" => "review" }
+        )
+        destination = Creative.create!(
+          description: "Auto destination", user: @user, parent: review_root,
+          data: { "ai_write_policy" => "auto" }
+        )
+        task, agent = review_agent_turn(review_root)
+        CreativeShare.create!(creative: @creative, user: agent, shared_by: @user, permission: :write)
+
+        result = Current.set(user: agent, agent_turn: { user: @user, task: task }) do
+          CreativeUpdateService.new.call(id: @creative.id, parent_id: destination.id)
+        end
+
+        assert result[:pending_review], result.inspect
+        assert_nil @creative.reload.parent_id
+      end
+
       test "updates description with plain text" do
         service = CreativeUpdateService.new
 


### PR DESCRIPTION
## Summary
- add inherited `ai_write_policy` with `auto` as the default and `review` as an opt-in
- capture agent creative mutations as draft ChangeSets without applying them, including create/import/batch and attachment paths
- add diff-based approve/reject actions with conflict, permission, linked-archive, and temporary-ID handling
- replace opaque pre-execution approval for batch/import with the persisted History review flow

## Validation
- 322 focused Ruby tests / 1,313 assertions
- 100% Ruby patch coverage (323/323 instrumented changed lines)
- RuboCop on all changed Ruby files
- Brakeman
- `bin/complexity_check --base origin/feature-revision`