### PR TITLE
feat: add cron management filter to creative search

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/creatives.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/creatives.css
@@ -1034,6 +1034,19 @@ creative-tree-row.is-being-edited .creative-tree {
     display: contents;
 }
 
+.creative-cron-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1);
+    margin-left: var(--space-1);
+    padding: 0 var(--space-2);
+    border-radius: var(--radius-round, 9999px);
+    background: var(--surface-input, var(--color-bg));
+    color: var(--text-secondary);
+    font-size: var(--text-0);
+    white-space: nowrap;
+}
+
 /* ─── Bundle drag image (shared by creatives + comments) ─── */
 
 .drag-bundle-image {

--- a/engines/collavre/app/controllers/collavre/creatives_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creatives_controller.rb
@@ -691,7 +691,7 @@ module Collavre
       # query layer while preserving every filter the index endpoint supports.
       def index_query_params
         params.permit(
-          :id, :simple, :search, :search_mode, :comment, :has_comments,
+          :id, :simple, :search, :search_mode, :comment, :has_comments, :has_cron,
           :min_progress, :max_progress, :due_before, :due_after, :has_due_date,
           :assignee_id, :unassigned, :show_archived, :page, :per_page,
           tags: []
@@ -708,18 +708,7 @@ module Collavre
       helper_method :any_filter_active?
 
       def any_filter_active?
-        params[:tags].present? ||
-          params[:min_progress].present? ||
-          params[:max_progress].present? ||
-          params[:search].present? ||
-          params[:comment] == "true" ||
-          params[:has_comments].present? ||
-          params[:due_before].present? ||
-          params[:due_after].present? ||
-          params[:has_due_date].present? ||
-          params[:assignee_id].present? ||
-          params[:unassigned].present? ||
-          params[:show_archived].present?
+        Creatives::FilterState.new(params, include_archived: true).active?
       end
 
       # Thin delegator to Creatives::CreativeTreeSerializer. Kept as a controller

--- a/engines/collavre/app/helpers/collavre/creatives_helper.rb
+++ b/engines/collavre/app/helpers/collavre/creatives_helper.rb
@@ -36,7 +36,7 @@ module Collavre
     # creatives at once (the browse tree) resolve them in batch and hand them in.
     # Left nil, each is resolved for this creative alone — correct, but a query
     # per node. Single-creative call sites take that path.
-    def render_creative_progress(creative, select_mode: false, has_children: nil, can_write: nil, can_feedback: nil, unread_count: nil)
+    def render_creative_progress(creative, select_mode: false, has_children: nil, can_write: nil, can_feedback: nil, unread_count: nil, cron_tasks: [])
       progress_value = if params[:tags].present?
         tag_ids = Array(params[:tags]).map(&:to_s)
         creative.filtered_progress || creative.progress_for_tags(tag_ids) || 0
@@ -47,43 +47,7 @@ module Collavre
       can_feedback = creative.has_permission?(Current.user, :feedback) if can_feedback.nil?
 
       content_tag(:div, class: "creative-row-end") do
-        comment_part = if creative.archived?
-          safe_join([])
-        elsif can_feedback
-          origin = creative.effective_origin
-          comments_count = origin.comments_count
-          # A batched count already has presence suppression applied by
-          # CommentBadgeIndex; re-checking here would be one cache read per node,
-          # which is exactly what the batch exists to avoid.
-          if unread_count.nil?
-            badge_index = Creatives::CommentBadgeIndex.new(user: Current.user)
-            badge_index.index([ origin ])
-            unread_count = badge_index.unread_count_for(origin)
-          end
-          classes = [ "comments-btn", "creative-action-btn" ]
-          classes << "no-comments" if comments_count.zero?
-          comment_icon = svg_tag(
-            "comment.svg",
-            class: "comment-icon"
-          )
-          badge_id = "comment-badge-#{origin.id}"
-          stream = turbo_stream_from [ Current.user, origin, :comment_badge ]
-          badge = render(
-            Inbox::BadgeComponent.new(
-              count: unread_count,
-              badge_id: badge_id,
-              show_zero: comments_count.positive?
-            )
-          )
-          stream + button_tag(
-            comment_icon + badge,
-            name: "show-comments-btn",
-            data: { creative_id: creative.id, can_comment: true, creative_snippet: creative.creative_snippet },
-            class: classes.join(" ")
-          )
-        else
-          safe_join([])
-        end
+        comment_part = render_creative_comment_action(creative, can_feedback, unread_count)
         is_leaf = has_children.nil? ? !creative.children.exists? : !has_children
         can_write = creative.has_permission?(Current.user, :write) if can_write.nil?
         progress_part = render_progress_control(
@@ -93,14 +57,69 @@ module Collavre
           can_write: can_write,
           select_mode: select_mode
         )
+        cron_part = cron_tasks.any? ? render_cron_badge(cron_tasks) : safe_join([])
 
         safe_join([
           progress_part,
+          cron_part,
           comment_part,
           tag.br,
           (creative.tags ? render_creative_tags(creative) : safe_join([]))
         ])
       end
+    end
+
+    def render_creative_comment_action(creative, can_feedback, unread_count)
+      return safe_join([]) if creative.archived? || !can_feedback
+
+      origin = creative.effective_origin
+      comments_count = origin.comments_count
+      if unread_count.nil?
+        badge_index = Creatives::CommentBadgeIndex.new(user: Current.user)
+        badge_index.index([ origin ])
+        unread_count = badge_index.unread_count_for(origin)
+      end
+      classes = [ "comments-btn", "creative-action-btn" ]
+      classes << "no-comments" if comments_count.zero?
+      comment_icon = svg_tag("comment.svg", class: "comment-icon")
+      badge_id = "comment-badge-#{origin.id}"
+      stream = turbo_stream_from [ Current.user, origin, :comment_badge ]
+      badge = render_comment_badge(unread_count, badge_id, comments_count)
+      stream + button_tag(
+        comment_icon + badge,
+        name: "show-comments-btn",
+        data: { creative_id: creative.id, can_comment: true, creative_snippet: creative.creative_snippet },
+        class: classes.join(" ")
+      )
+    end
+
+    def render_comment_badge(unread_count, badge_id, comments_count)
+      render(
+        Inbox::BadgeComponent.new(
+          count: unread_count,
+          badge_id: badge_id,
+          show_zero: comments_count.positive?
+        )
+      )
+    end
+
+    def render_cron_badge(tasks)
+      details = tasks.map do |task|
+        t(
+          "collavre.creatives.index.cron_schedule",
+          schedule: task.schedule,
+          next_run: l(task.next_time, format: :short)
+        )
+      end
+      label = t("collavre.creatives.index.cron_count", count: tasks.size)
+
+      content_tag(
+        :span,
+        safe_join([ tag.span("⏰", aria: { hidden: true }), tag.span(tasks.size) ], " "),
+        class: "creative-cron-badge",
+        title: details.join("\n"),
+        aria: { label: "#{label}. #{details.join('. ')}" }
+      )
     end
 
     def render_progress_control(creative, value, has_children:, can_write:, select_mode: false)

--- a/engines/collavre/app/javascript/controllers/__tests__/search_popup_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/search_popup_controller.test.js
@@ -131,6 +131,8 @@ describe('SearchPopupController filter navigation', () => {
                 data-action="click->search-popup#applyProgressFilter"></button>
         <button data-filter-state="comment"
                 data-action="click->search-popup#applyCommentFilter"></button>
+        <button data-filter-state="cron"
+                data-action="click->search-popup#applyCronFilter"></button>
         <button data-filter-state="archived"
                 data-label-on="Hide archived" data-label-off="Show archived"
                 data-action="click->search-popup#toggleArchive">Show archived</button>
@@ -181,6 +183,17 @@ describe('SearchPopupController filter navigation', () => {
     click('[data-filter-state="comment"]')
 
     expect(visit).toHaveBeenCalledWith('/creatives?comment=true', {
+      action: 'advance',
+      frame: WORKSPACE_FRAME_ID
+    })
+  })
+
+  test('toggles the cron filter through the workspace frame', async () => {
+    await mount()
+
+    click('[data-filter-state="cron"]')
+
+    expect(visit).toHaveBeenCalledWith('/creatives?has_cron=true', {
       action: 'advance',
       frame: WORKSPACE_FRAME_ID
     })

--- a/engines/collavre/app/javascript/controllers/search_popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/search_popup_controller.js
@@ -112,6 +112,12 @@ export default class extends Controller {
     this._navigate((params) => applyFilterParam(params, 'comment'))
   }
 
+  // Apply recurring cron filter
+  applyCronFilter(event) {
+    event.preventDefault()
+    this._navigate((params) => applyFilterParam(params, 'cron'))
+  }
+
   // Toggle search mode (flat/tree)
   applySearchMode(event) {
     event.preventDefault()

--- a/engines/collavre/app/javascript/lib/utils/__tests__/filter_navigation.test.js
+++ b/engines/collavre/app/javascript/lib/utils/__tests__/filter_navigation.test.js
@@ -75,6 +75,15 @@ describe('applyFilterParam', () => {
     expect(params.has('comment')).toBe(false)
   })
 
+  test('toggles the cron filter', () => {
+    const params = new URLSearchParams()
+    applyFilterParam(params, 'cron')
+    expect(params.get('has_cron')).toBe('true')
+
+    applyFilterParam(params, 'cron')
+    expect(params.has('has_cron')).toBe(false)
+  })
+
   test('sets the complete progress range', () => {
     const params = new URLSearchParams()
     applyFilterParam(params, 'complete')
@@ -147,6 +156,7 @@ describe('syncFilterButtons', () => {
       <button data-filter-state="progress:incomplete" class="active"></button>
       <button data-filter-state="progress:complete"></button>
       <button data-filter-state="comment"></button>
+      <button data-filter-state="cron"></button>
       <button data-filter-state="archived" data-label-on="Hide archived" data-label-off="Show archived">Show archived</button>
     `
   })
@@ -184,6 +194,12 @@ describe('syncFilterButtons', () => {
 
     syncFilterButtons(new URL('http://localhost/creatives?search=abc'))
     expect(activeStates()).toContain('any-filter')
+  })
+
+  test('activates cron management filtering and the search trigger', () => {
+    syncFilterButtons(new URL('http://localhost/creatives?has_cron=true'))
+
+    expect(activeStates().sort()).toEqual(['any-filter', 'cron', 'progress:all'])
   })
 
   test('ignores blank and whitespace-only filter values, matching server-side .present?', () => {

--- a/engines/collavre/app/javascript/lib/utils/filter_navigation.js
+++ b/engines/collavre/app/javascript/lib/utils/filter_navigation.js
@@ -27,8 +27,17 @@ export function buildFilterUrl({ indexPath, onIndex }, mutate) {
   return url
 }
 
-// Shared by the GNB component and the search popup's progress/comment buttons.
+// Shared by the GNB component and the search popup's filter buttons.
 export function applyFilterParam(params, filter) {
+  if (filter === 'cron') {
+    if (params.get('has_cron') === 'true') {
+      params.delete('has_cron')
+    } else {
+      params.set('has_cron', 'true')
+    }
+    return
+  }
+
   if (filter === 'comment') {
     if (params.get('comment') === 'true') {
       params.delete('comment')
@@ -80,12 +89,14 @@ export function syncFilterButtons(url) {
   const params = url.searchParams
   const hasProgress = Boolean(params.get('min_progress') || params.get('max_progress'))
   const hasArchived = params.get('show_archived') === 'true'
+  const hasCron = params.get('has_cron') === 'true'
   const hasSearch = Boolean(params.get('search')?.trim())
   const active = {
     [`progress:${progressState(params)}`]: true,
     comment: params.get('comment') === 'true',
+    cron: hasCron,
     archived: hasArchived,
-    'any-filter': hasProgress || hasArchived || hasSearch
+    'any-filter': hasProgress || hasArchived || hasCron || hasSearch
   }
 
   document.querySelectorAll('[data-filter-state]').forEach((element) => {

--- a/engines/collavre/app/services/collavre/creatives/filter_pipeline.rb
+++ b/engines/collavre/app/services/collavre/creatives/filter_pipeline.rb
@@ -15,6 +15,7 @@ module Creatives
       Filters::TagFilter,
       Filters::SearchFilter,
       Filters::CommentFilter,
+      Filters::CronFilter,
       Filters::DateFilter,
       Filters::AssigneeFilter
     ].freeze

--- a/engines/collavre/app/services/collavre/creatives/filter_state.rb
+++ b/engines/collavre/app/services/collavre/creatives/filter_state.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Collavre
+module Creatives
+  class FilterState
+    FILTER_KEYS = %i[
+      tags min_progress max_progress search has_comments has_cron due_before
+      due_after has_due_date assignee_id unassigned
+    ].freeze
+
+    def initialize(params, include_archived: false)
+      @params = params
+      @keys = include_archived ? FILTER_KEYS + [ :show_archived ] : FILTER_KEYS
+    end
+
+    def active?
+      params[:comment] == "true" || keys.any? { |key| params[key].present? }
+    end
+
+    private
+
+    attr_reader :params, :keys
+  end
+end
+end

--- a/engines/collavre/app/services/collavre/creatives/filters/cron_filter.rb
+++ b/engines/collavre/app/services/collavre/creatives/filters/cron_filter.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Collavre
+module Creatives
+  module Filters
+    class CronFilter < BaseFilter
+      def active?
+        params[:has_cron].present?
+      end
+
+      def match
+        creative_ids = Collavre::Crons::RecurringTaskIndex.new.creative_ids
+        relation = params[:has_cron] == "true" ? scope.where(id: creative_ids) : scope.where.not(id: creative_ids)
+        relation.pluck(:id)
+      end
+    end
+  end
+end
+end

--- a/engines/collavre/app/services/collavre/creatives/index_query.rb
+++ b/engines/collavre/app/services/collavre/creatives/index_query.rb
@@ -64,17 +64,7 @@ module Creatives
     end
 
     def any_filter_active?
-      params[:tags].present? ||
-        params[:min_progress].present? ||
-        params[:max_progress].present? ||
-        params[:search].present? ||
-        params[:comment] == "true" ||
-        params[:has_comments].present? ||
-        params[:due_before].present? ||
-        params[:due_after].present? ||
-        params[:has_due_date].present? ||
-        params[:assignee_id].present? ||
-        params[:unassigned].present?
+      FilterState.new(params).active?
     end
 
     def handle_filtered_query

--- a/engines/collavre/app/services/collavre/creatives/tree_builder.rb
+++ b/engines/collavre/app/services/collavre/creatives/tree_builder.rb
@@ -205,7 +205,7 @@ module Creatives
     def template_payload_for(creative, has_children: nil, can_write: nil)
       description_html = view_context.embed_youtube_iframe(creative.effective_description(raw_params["tags"]&.first))
       can_feedback = can_feedback?(creative)
-      cron_tasks = cron_filter_active? ? cron_task_index.tasks_for(creative.id) : []
+      cron_tasks = cron_filter_active? ? cron_task_index.tasks_for(creative.effective_origin.id) : []
       progress_options = {
         select_mode: !!select_mode,
         has_children: has_children,

--- a/engines/collavre/app/services/collavre/creatives/tree_builder.rb
+++ b/engines/collavre/app/services/collavre/creatives/tree_builder.rb
@@ -100,6 +100,14 @@ module Creatives
       comment_badge_index.index(visible.map(&:effective_origin), include_visible_counts: false)
     end
 
+    def cron_task_index
+      @cron_task_index ||= Collavre::Crons::RecurringTaskIndex.new
+    end
+
+    def cron_filter_active?
+      raw_params["has_cron"].present?
+    end
+
     def build_nodes(creatives, level:)
       return [] if level > max_level
       return [] if creatives.empty?
@@ -197,14 +205,16 @@ module Creatives
     def template_payload_for(creative, has_children: nil, can_write: nil)
       description_html = view_context.embed_youtube_iframe(creative.effective_description(raw_params["tags"]&.first))
       can_feedback = can_feedback?(creative)
-      progress_html = view_context.render_creative_progress(
-        creative,
+      cron_tasks = cron_filter_active? ? cron_task_index.tasks_for(creative.id) : []
+      progress_options = {
         select_mode: !!select_mode,
         has_children: has_children,
         can_write: can_write,
         can_feedback: can_feedback,
         unread_count: can_feedback ? comment_badge_index.unread_count_for(creative.effective_origin) : nil
-      )
+      }
+      progress_options[:cron_tasks] = cron_tasks if cron_tasks.any?
+      progress_html = view_context.render_creative_progress(creative, **progress_options)
 
       {
         description_html: description_html,

--- a/engines/collavre/app/services/collavre/crons/recurring_task_index.rb
+++ b/engines/collavre/app/services/collavre/crons/recurring_task_index.rb
@@ -23,9 +23,20 @@ module Collavre
       attr_reader :scope
 
       def tasks_by_creative_id
-        @tasks_by_creative_id ||= scope.select(:key, :schedule).order(:key).each_with_object(Hash.new { |hash, key| hash[key] = [] }) do |task, index|
+        @tasks_by_creative_id ||= begin
+          tasks = parsed_tasks
+          effective_ids = Creatives::EffectiveCreativeResolution.effective_creative_ids(tasks.map(&:last))
+
+          tasks.each_with_object(Hash.new { |hash, key| hash[key] = [] }) do |(task, creative_id), index|
+            index[effective_ids.fetch(creative_id)] << task
+          end
+        end
+      end
+
+      def parsed_tasks
+        scope.select(:key, :schedule).order(:key).filter_map do |task|
           creative_id = task.key.match(KEY_PATTERN)&.[](1)&.to_i
-          index[creative_id] << task if creative_id
+          [ task, creative_id ] if creative_id
         end
       end
     end

--- a/engines/collavre/app/services/collavre/crons/recurring_task_index.rb
+++ b/engines/collavre/app/services/collavre/crons/recurring_task_index.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Collavre
+  module Crons
+    class RecurringTaskIndex
+      KEY_PATTERN = /\Acron_(\d+)_/.freeze
+      EMPTY_TASKS = [].freeze
+
+      def initialize(scope: SolidQueue::RecurringTask.dynamic)
+        @scope = scope
+      end
+
+      def creative_ids
+        tasks_by_creative_id.keys
+      end
+
+      def tasks_for(creative_id)
+        tasks_by_creative_id.fetch(creative_id.to_i, EMPTY_TASKS)
+      end
+
+      private
+
+      attr_reader :scope
+
+      def tasks_by_creative_id
+        @tasks_by_creative_id ||= scope.select(:key, :schedule).order(:key).each_with_object(Hash.new { |hash, key| hash[key] = [] }) do |task, index|
+          creative_id = task.key.match(KEY_PATTERN)&.[](1)&.to_i
+          index[creative_id] << task if creative_id
+        end
+      end
+    end
+  end
+end

--- a/engines/collavre/app/views/collavre/creatives/index.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/index.html.erb
@@ -269,7 +269,7 @@
   # Only pass filter parameters to avoid unnecessary params in URL
   tree_params = params.to_unsafe_h.slice(
     "id", "tags", "min_progress", "max_progress", "search", "comment",
-    "has_comments", "due_before", "due_after", "has_due_date",
+    "has_comments", "has_cron", "due_before", "due_after", "has_due_date",
     "assignee_id", "unassigned", "show_archived", "search_mode"
   ).merge(format: :json)
   tree_url = creatives_path(tree_params)

--- a/engines/collavre/app/views/collavre/shared/navigation/_search_form.html.erb
+++ b/engines/collavre/app/views/collavre/shared/navigation/_search_form.html.erb
@@ -9,9 +9,10 @@
     has_progress = url_params['min_progress'].present? || url_params['max_progress'].present?
     has_comment = url_params['comment'] == 'true'
     has_archived = url_params['show_archived'] == 'true'
+    has_cron = url_params['has_cron'] == 'true'
     has_search = url_params['search'].present?
     search_mode = url_params['search_mode'] || 'flat'
-    has_any_filter = has_progress || has_archived || has_search
+    has_any_filter = has_progress || has_archived || has_cron || has_search
 
     progress_state = if url_params['min_progress'] == '1' && url_params['max_progress'] == '1'
                        :complete
@@ -79,6 +80,10 @@
                   class="search-popup-filter-btn<%= ' active' if has_comment %>"
                   data-filter-state="comment"
                   data-action="click->search-popup#applyCommentFilter"><%= t('app.filter_comments') %></button>
+          <button type="button"
+                  class="search-popup-filter-btn<%= ' active' if has_cron %>"
+                  data-filter-state="cron"
+                  data-action="click->search-popup#applyCronFilter"><%= t('collavre.search_popup.has_cron') %></button>
           <% if authenticated? %>
             <%# Both labels ship up front so a frame-only navigation can swap them without a round trip. %>
             <button type="button"

--- a/engines/collavre/config/locales/creatives.en.yml
+++ b/engines/collavre/config/locales/creatives.en.yml
@@ -26,6 +26,10 @@ en:
         unarchive: Restore
         show_archived: Show archived
         hide_archived: Hide archived
+        cron_count:
+          one: "%{count} scheduled job"
+          other: "%{count} scheduled jobs"
+        cron_schedule: "%{schedule} · next %{next_run}"
         delete_only_this: Delete only this Creative
         delete_with_children: Delete this Creative and all its children
         are_you_sure: Are you sure?

--- a/engines/collavre/config/locales/creatives.ko.yml
+++ b/engines/collavre/config/locales/creatives.ko.yml
@@ -26,6 +26,8 @@ ko:
         unarchive: 복원
         show_archived: 아카이브 표시
         hide_archived: 아카이브 숨기기
+        cron_count: "예약 작업 %{count}개"
+        cron_schedule: "%{schedule} · 다음 실행 %{next_run}"
         delete_only_this: 이 항목만 삭제
         delete_with_children: 이 항목과 모든 하위 항목 삭제
         are_you_sure: 정말 삭제하시겠습니까?

--- a/engines/collavre/config/locales/search_popup.en.yml
+++ b/engines/collavre/config/locales/search_popup.en.yml
@@ -8,5 +8,6 @@ en:
       flat_view: "Flat"
       tree_view: "Tree"
       other_filters: "Filters"
+      has_cron: "Scheduled"
       to_search: "to search"
       to_close: "to close"

--- a/engines/collavre/config/locales/search_popup.ko.yml
+++ b/engines/collavre/config/locales/search_popup.ko.yml
@@ -8,5 +8,6 @@ ko:
       flat_view: "플랫"
       tree_view: "트리"
       other_filters: "필터"
+      has_cron: "예약 작업"
       to_search: "검색"
       to_close: "닫기"

--- a/engines/collavre/test/helpers/creatives_helper_test.rb
+++ b/engines/collavre/test/helpers/creatives_helper_test.rb
@@ -2,6 +2,23 @@ require "test_helper"
 
 class CreativesHelperTest < ActionView::TestCase
   include Collavre::CreativesHelper
+
+  test "render_cron_badge shows the count, schedules, and next run times" do
+    first = Struct.new(:schedule, :next_time).new("0 9 * * *", Time.zone.parse("2026-09-05 09:00"))
+    second = Struct.new(:schedule, :next_time).new("0 18 * * *", Time.zone.parse("2026-09-05 18:00"))
+
+    I18n.with_locale(:en) do
+      html = render_cron_badge([ first, second ])
+
+      assert_includes html, "creative-cron-badge"
+      assert_includes html, "⏰"
+      assert_includes html, ">2</span>"
+      assert_includes html, "2 scheduled jobs"
+      assert_includes html, "0 9 * * *"
+      assert_includes html, I18n.l(first.next_time, format: :short)
+    end
+  end
+
   test "markdown_links_to_html converts markdown link to HTML" do
     input = "Check [link](https://example.com)"
     result = markdown_links_to_html(input)

--- a/engines/collavre/test/integration/creative_cron_filter_test.rb
+++ b/engines/collavre/test/integration/creative_cron_filter_test.rb
@@ -45,6 +45,31 @@ class CreativeCronFilterTest < ActionDispatch::IntegrationTest
     assert_select "[data-creatives--tree-url-value*='has_cron=true']"
   end
 
+  test "cron filter resolves a linked creative task to its origin and linked placement" do
+    origin = Creative.create!(user: @user, description: "Shared automation")
+    linked = Creative.create!(user: @user, parent: @root, origin: origin)
+    @task.destroy!
+    @task = SolidQueue::RecurringTask.create!(
+      key: "cron_#{linked.id}_#{SecureRandom.hex(4)}",
+      class_name: "Collavre::CronActionJob",
+      schedule: "30 10 * * *",
+      static: false,
+      arguments: []
+    )
+
+    get creatives_path(format: :json, has_cron: "true")
+
+    assert_response :success
+    nodes = flatten_nodes(JSON.parse(response.body).fetch("creatives"))
+    assert_includes nodes.pluck("id"), origin.id
+    assert_includes nodes.pluck("id"), linked.id
+    [ origin.id, linked.id ].each do |creative_id|
+      badge_html = nodes.find { |node| node.fetch("id") == creative_id }.dig("templates", "progress_html")
+      assert_includes badge_html, "creative-cron-badge"
+      assert_includes badge_html, @task.schedule
+    end
+  end
+
   private
 
   def flatten_nodes(nodes)

--- a/engines/collavre/test/integration/creative_cron_filter_test.rb
+++ b/engines/collavre/test/integration/creative_cron_filter_test.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class CreativeCronFilterTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = User.create!(email: "cron-filter@example.com", password: TEST_PASSWORD, name: "Cron Filter")
+    @root = Creative.create!(user: @user, description: "Automation root")
+    @scheduled = Creative.create!(user: @user, parent: @root, description: "Scheduled child")
+    @unscheduled = Creative.create!(user: @user, parent: @root, description: "Regular child")
+    @task = SolidQueue::RecurringTask.create!(
+      key: "cron_#{@scheduled.id}_#{SecureRandom.hex(4)}",
+      class_name: "Collavre::CronActionJob",
+      schedule: "0 9 * * *",
+      static: false,
+      arguments: []
+    )
+    sign_in_as(@user)
+  end
+
+  teardown do
+    @task.destroy! if @task.persisted?
+  end
+
+  test "cron filter returns the scheduled creative with its ancestor and management badge" do
+    get creatives_path(format: :json, has_cron: "true")
+
+    assert_response :success
+    nodes = flatten_nodes(JSON.parse(response.body).fetch("creatives"))
+    assert_equal [ @root.id, @scheduled.id ].sort, nodes.pluck("id").sort
+    refute_includes nodes.pluck("id"), @unscheduled.id
+
+    scheduled_node = nodes.find { |node| node.fetch("id") == @scheduled.id }
+    badge_html = scheduled_node.dig("templates", "progress_html")
+    assert_includes badge_html, "creative-cron-badge"
+    assert_includes badge_html, @task.schedule
+  end
+
+  test "html index preserves the cron filter for the client tree request" do
+    get creatives_path(has_cron: "true")
+
+    assert_response :success
+    assert_select "[data-filter-state='cron'].active"
+    assert_select "[data-filter-state='any-filter'].active"
+    assert_select "[data-creatives--tree-url-value*='has_cron=true']"
+  end
+
+  private
+
+  def flatten_nodes(nodes)
+    nodes.flat_map do |node|
+      [ node ] + flatten_nodes(node.dig("children_container", "nodes") || [])
+    end
+  end
+end

--- a/engines/collavre/test/integration/creative_filter_navigation_test.rb
+++ b/engines/collavre/test/integration/creative_filter_navigation_test.rb
@@ -65,6 +65,7 @@ class CreativeFilterNavigationTest < ActionDispatch::IntegrationTest
     assert_select "[data-filter-state='progress:incomplete']"
     assert_select "[data-filter-state='progress:complete']"
     assert_select "[data-filter-state='comment']"
+    assert_select "[data-filter-state='cron']"
     assert_select "[data-filter-state='archived'][data-label-on][data-label-off]"
   end
 

--- a/engines/collavre/test/services/collavre/crons/recurring_task_index_test.rb
+++ b/engines/collavre/test/services/collavre/crons/recurring_task_index_test.rb
@@ -34,16 +34,30 @@ module Collavre
         assert_empty RecurringTaskIndex.new.creative_ids
       end
 
+      test "groups a linked creative cron under its effective origin" do
+        linked = Creative.create!(user: users(:two), origin: @creative)
+        task = create_task(key: "cron_#{linked.id}_#{SecureRandom.hex(4)}")
+
+        index = RecurringTaskIndex.new
+
+        assert_includes index.creative_ids, @creative.id
+        refute_includes index.creative_ids, linked.id
+        assert_equal [ task.key ], index.tasks_for(@creative.id).map(&:key)
+        assert_empty index.tasks_for(linked.id)
+      end
+
       private
 
       def create_task(key:, static: false)
-        @tasks << SolidQueue::RecurringTask.create!(
+        task = SolidQueue::RecurringTask.create!(
           key: key,
           class_name: "Collavre::CronActionJob",
           schedule: "0 9 * * *",
           static: static,
           arguments: []
         )
+        @tasks << task
+        task
       end
     end
   end

--- a/engines/collavre/test/services/collavre/crons/recurring_task_index_test.rb
+++ b/engines/collavre/test/services/collavre/crons/recurring_task_index_test.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  module Crons
+    class RecurringTaskIndexTest < ActiveSupport::TestCase
+      setup do
+        @tasks = []
+        @creative = creatives(:tshirt)
+      end
+
+      teardown do
+        @tasks.each { |task| task.destroy! if task.persisted? }
+      end
+
+      test "groups cron tasks by creative id in key order" do
+        later_key = "cron_#{@creative.id}_z_#{SecureRandom.hex(4)}"
+        earlier_key = "cron_#{@creative.id}_a_#{SecureRandom.hex(4)}"
+        create_task(key: later_key)
+        create_task(key: earlier_key)
+        create_task(key: "other_#{@creative.id}_#{SecureRandom.hex(4)}")
+
+        index = RecurringTaskIndex.new
+
+        assert_includes index.creative_ids, @creative.id
+        assert_equal [ earlier_key, later_key ], index.tasks_for(@creative.id).map(&:key)
+        assert_empty index.tasks_for(-1)
+      end
+
+      test "ignores static cron tasks" do
+        create_task(key: "cron_#{@creative.id}_#{SecureRandom.hex(4)}", static: true)
+
+        assert_empty RecurringTaskIndex.new.creative_ids
+      end
+
+      private
+
+      def create_task(key:, static: false)
+        @tasks << SolidQueue::RecurringTask.create!(
+          key: key,
+          class_name: "Collavre::CronActionJob",
+          schedule: "0 9 * * *",
+          static: static,
+          arguments: []
+        )
+      end
+    end
+  end
+end

--- a/engines/collavre/test/services/creatives/filter_state_test.rb
+++ b/engines/collavre/test/services/creatives/filter_state_test.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  module Creatives
+    class FilterStateTest < ActiveSupport::TestCase
+      test "is active for supported filters" do
+        FilterState::FILTER_KEYS.each do |key|
+          assert FilterState.new({ key => "true" }).active?, "Expected #{key} to activate filters"
+        end
+      end
+
+      test "only treats the true comment feed as active" do
+        assert FilterState.new({ comment: "true" }).active?
+        refute FilterState.new({ comment: "false" }).active?
+      end
+
+      test "optionally includes archived visibility" do
+        refute FilterState.new({ show_archived: "true" }).active?
+        assert FilterState.new({ show_archived: "true" }, include_archived: true).active?
+      end
+
+      test "is inactive without filter parameters" do
+        refute FilterState.new({}).active?
+      end
+    end
+  end
+end

--- a/engines/collavre/test/services/creatives/filters/cron_filter_test.rb
+++ b/engines/collavre/test/services/creatives/filters/cron_filter_test.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  module Creatives
+    module Filters
+      class CronFilterTest < ActiveSupport::TestCase
+        setup do
+          @tasks = []
+          @user = users(:one)
+          @with_cron = Creative.create!(user: @user, description: "Scheduled")
+          @without_cron = Creative.create!(user: @user, description: "Not scheduled")
+          @scope = Creative.where(id: [ @with_cron.id, @without_cron.id ])
+          create_task(key: "cron_#{@with_cron.id}_#{SecureRandom.hex(4)}")
+        end
+
+        teardown do
+          @tasks.each { |task| task.destroy! if task.persisted? }
+        end
+
+        test "is active when has_cron is present" do
+          assert CronFilter.new(params: { has_cron: "true" }, scope: @scope).active?
+          refute CronFilter.new(params: {}, scope: @scope).active?
+        end
+
+        test "matches creatives with dynamic cron tasks" do
+          result = CronFilter.new(params: { has_cron: "true" }, scope: @scope).match
+
+          assert_equal [ @with_cron.id ], result
+        end
+
+        test "matches creatives without dynamic cron tasks when false" do
+          result = CronFilter.new(params: { has_cron: "false" }, scope: @scope).match
+
+          assert_equal [ @without_cron.id ], result
+        end
+
+        test "ignores static and unrelated dynamic recurring tasks" do
+          create_task(key: "cron_#{@without_cron.id}_static", static: true)
+          create_task(key: "unrelated_#{@without_cron.id}")
+
+          result = CronFilter.new(params: { has_cron: "true" }, scope: @scope).match
+
+          assert_equal [ @with_cron.id ], result
+        end
+
+        private
+
+        def create_task(key:, static: false)
+          @tasks << SolidQueue::RecurringTask.create!(
+            key: key,
+            class_name: "Collavre::CronActionJob",
+            schedule: "0 9 * * *",
+            static: static,
+            arguments: []
+          )
+        end
+      end
+    end
+  end
+end

--- a/engines/collavre/test/services/creatives/filters/cron_filter_test.rb
+++ b/engines/collavre/test/services/creatives/filters/cron_filter_test.rb
@@ -45,6 +45,16 @@ module Collavre
           assert_equal [ @with_cron.id ], result
         end
 
+        test "matches the effective origin when a cron key references a linked creative" do
+          origin = Creative.create!(user: @user, description: "Shared scheduled creative")
+          linked = Creative.create!(user: @user, origin: origin)
+          create_task(key: "cron_#{linked.id}_#{SecureRandom.hex(4)}")
+
+          result = CronFilter.new(params: { has_cron: "true" }, scope: Creative.where(id: origin.id)).match
+
+          assert_equal [ origin.id ], result
+        end
+
         private
 
         def create_task(key:, static: false)

--- a/engines/collavre/test/services/creatives/tree_builder_test.rb
+++ b/engines/collavre/test/services/creatives/tree_builder_test.rb
@@ -9,8 +9,8 @@ module Creatives
         "<iframe></iframe>"
       end
 
-      def render_creative_progress(_creative, select_mode: false, has_children: nil, can_write: nil, can_feedback: nil, unread_count: nil)
-        "<progress data-select='#{select_mode}'></progress>"
+      def render_creative_progress(_creative, select_mode: false, has_children: nil, can_write: nil, can_feedback: nil, unread_count: nil, cron_tasks: [])
+        "<progress data-select='#{select_mode}'></progress><cron-badge count='#{cron_tasks.size}'></cron-badge>"
       end
 
       def svg_tag(name, className: nil, width: nil, height: nil)
@@ -89,6 +89,23 @@ module Creatives
       assert_equal creative.effective_description, payload[:description_raw_html]
       assert_in_delta creative.progress, payload[:progress]
       assert_nil payload[:origin_id]
+    end
+
+    test "includes cron badge details when the cron filter is active" do
+      creative = Creative.create!(user: @user, progress: 0, description: "Scheduled")
+      task = SolidQueue::RecurringTask.create!(
+        key: "cron_#{creative.id}_#{SecureRandom.hex(4)}",
+        class_name: "Collavre::CronActionJob",
+        schedule: "0 9 * * *",
+        static: false,
+        arguments: []
+      )
+
+      nodes = build_tree_builder(params: { has_cron: "true" }).build([ creative ])
+
+      assert_includes nodes.first.dig(:templates, :progress_html), "<cron-badge count='1'>"
+    ensure
+      task&.destroy!
     end
 
     private


### PR DESCRIPTION
## Summary

- add a scheduled-job filter to creative search while keeping Solid Queue as the source of truth
- preserve tree context and show cron counts with schedule and next-run details
- support filter navigation state and localized English/Korean labels
- cover cron indexing, filtering, tree rendering, helper output, integration behavior, and frontend navigation

## Verification

- `PARALLEL_WORKERS=1 bundle exec rake test` (4,769 runs, 16,531 assertions)
- `bundle exec rake test:system` (113 runs, 729 assertions; 2 existing skips)
- `npm test -- --runInBand` (1,708 tests)
- `./bin/rubocop` (1,332 files)
- `bin/complexity_check`

## Notes

- Full-file Stylelint still reports the existing hardcoded-color violations in `creatives.css`; the added badge styles introduce no new violations.