### PR TITLE
fix(collavre): delete crons with removed topics

### DIFF
--- a/engines/collavre/app/controllers/collavre/topics_controller.rb
+++ b/engines/collavre/app/controllers/collavre/topics_controller.rb
@@ -122,8 +122,8 @@ module Collavre
         topic: topic, source_creative: @creative
       ).call
 
-      # Best-effort orphaned-cron notice. Must never break the core deletion:
-      # if it raises, swallow + log so broadcast/head still run.
+      # Best-effort recurring-cron cleanup and notice. Must never break the
+      # core deletion: if it raises, swallow + log so broadcast/head still run.
       begin
         Collavre::Topics::OrphanedCronNotifier.new(
           topic_id: topic_id,

--- a/engines/collavre/app/services/collavre/topics/orphaned_cron_notifier.rb
+++ b/engines/collavre/app/services/collavre/topics/orphaned_cron_notifier.rb
@@ -1,14 +1,12 @@
 # frozen_string_literal: true
 
+require "json"
+
 module Collavre
   module Topics
-    # When a Topic is deleted, find every non-static recurring cron task that
-    # targets that topic (topic_id stored inside the task's arguments JSON) and
-    # post a system message into the affected creative's Main topic so the user
-    # knows the cron is now orphaned.
-    #
-    # Decision: notify only. The recurring task is intentionally left in place
-    # so the user can decide whether to re-point or cancel it.
+    # When a Topic is deleted, remove every non-static recurring cron task that
+    # targets it and post a system message with a command that recreates the
+    # original cron configuration.
     class OrphanedCronNotifier
       include Collavre::Crons::RecurringTaskArguments
 
@@ -20,7 +18,9 @@ module Collavre
       def call
         return if @topic_id.blank?
 
-        matching_tasks.each do |task, args|
+        tasks = matching_tasks
+        tasks.each { |task, _args| task.destroy! }
+        tasks.each do |task, args|
           notify_for(task, args)
         end
       end
@@ -59,9 +59,21 @@ module Collavre
             "collavre.topics.orphaned_cron_notice",
             topic_name: @topic_name,
             cron_key: task.key,
-            message: args["message"]
+            cron_create_command: cron_create_command(task, creative, args)
           )
         )
+      end
+
+      def cron_create_command(task, creative, args)
+        payload = {
+          creative_id: creative.id,
+          topic_name: @topic_name,
+          schedule: task.schedule,
+          message: args["message"],
+          description: task.description
+        }
+
+        "/cron_create #{JSON.generate(payload)}"
       end
     end
   end

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -18,7 +18,7 @@ en:
       history_name: "History"
       cannot_delete_main: "Cannot delete the Main topic."
       reserved_name: "This topic name is reserved and cannot be assigned."
-      orphaned_cron_notice: "[System] The topic '%{topic_name}' was deleted, but a recurring cron job (%{cron_key}) still targets it and will silently do nothing on each run. Original message: \"%{message}\". Re-point it to another topic or cancel it with cron_cancel."
+      orphaned_cron_notice: "[System] The topic '%{topic_name}' and its recurring cron job (%{cron_key}) were deleted. To recreate the cron job, run:\n\n```\n%{cron_create_command}\n```"
       create_and_move: 'Create "%{name}" and move'
       move:
         no_target_permission: You don't have write permission on the target creative.

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -18,7 +18,7 @@ ko:
       history_name: "이력"
       cannot_delete_main: "메인 토픽은 삭제할 수 없습니다."
       reserved_name: "예약된 토픽 이름은 지정할 수 없습니다."
-      orphaned_cron_notice: "[시스템] '%{topic_name}' 토픽이 삭제되었지만, 이 토픽을 대상으로 하는 반복 크론 작업(%{cron_key})이 아직 남아 있어 실행될 때마다 아무 동작도 하지 않고 조용히 종료됩니다. 원래 메시지: \"%{message}\". 다른 토픽으로 다시 지정하거나 cron_cancel로 취소하세요."
+      orphaned_cron_notice: "[시스템] '%{topic_name}' 토픽과 이 토픽을 대상으로 하던 반복 크론 작업(%{cron_key})이 함께 삭제되었습니다. 크론 작업을 다시 생성하려면 다음 명령을 실행하세요:\n\n```\n%{cron_create_command}\n```"
       create_and_move: '"%{name}" 생성후 이동'
       move:
         no_target_permission: 대상 크리에이티브에 대한 쓰기 권한이 없습니다.

--- a/engines/collavre/test/services/collavre/topics/orphaned_cron_notifier_test.rb
+++ b/engines/collavre/test/services/collavre/topics/orphaned_cron_notifier_test.rb
@@ -19,14 +19,14 @@ module Collavre
         @topic = @creative.topics.create!(name: "Counseling", user: @user)
       end
 
-      def create_cron(creative_id:, topic_id:, message: "@Ming: do the thing")
+      def create_cron(creative_id:, topic_id:, message: "@Ming: do the thing", description: nil)
         SolidQueue::RecurringTask.create!(
           key: "cron_#{creative_id}_#{SecureRandom.hex(4)}",
           class_name: "Collavre::CronActionJob",
           schedule: "0 10 * * *",
           queue_name: "default",
           static: false,
-          description: "Cron job for creative #{creative_id}",
+          description: description || "Cron job for creative #{creative_id}",
           arguments: [ {
             creative_id: creative_id,
             topic_id: topic_id,
@@ -36,8 +36,14 @@ module Collavre
         )
       end
 
-      test "posts a system comment to the creative's main topic when a cron targets the deleted topic" do
-        cron = create_cron(creative_id: @creative.id, topic_id: @topic.id)
+      test "deletes a matching cron and posts a recreation command to the creative's main topic" do
+        message = "Ask \"Ming\" to do the thing\nand follow up"
+        cron = create_cron(
+          creative_id: @creative.id,
+          topic_id: @topic.id,
+          message: message,
+          description: "Daily follow-up"
+        )
         deleted_name = @topic.name
         deleted_id = @topic.id
         @topic.destroy!
@@ -50,27 +56,47 @@ module Collavre
         assert_equal @creative.main_topic.id, notice.topic_id
         assert_includes notice.content, cron.key
         assert_includes notice.content, "Counseling"
-      end
+        assert_not SolidQueue::RecurringTask.exists?(key: cron.key)
 
-      test "leaves the recurring task in place (notify only)" do
-        cron = create_cron(creative_id: @creative.id, topic_id: @topic.id)
-        deleted_id = @topic.id
-        @topic.destroy!
-
-        OrphanedCronNotifier.new(topic_id: deleted_id, topic_name: "Counseling").call
-
-        assert SolidQueue::RecurringTask.exists?(key: cron.key), "cron must NOT be cancelled"
+        command = notice.content.lines.find { |line| line.start_with?("/cron_create ") }
+        assert_not_nil command
+        payload = JSON.parse(command.delete_prefix("/cron_create "))
+        assert_equal(
+          {
+            "creative_id" => @creative.id,
+            "topic_name" => "Counseling",
+            "schedule" => "0 10 * * *",
+            "message" => message,
+            "description" => "Daily follow-up"
+          },
+          payload
+        )
       end
 
       test "does nothing for crons targeting a different topic" do
         other = @creative.topics.create!(name: "Other", user: @user)
-        create_cron(creative_id: @creative.id, topic_id: other.id)
+        cron = create_cron(creative_id: @creative.id, topic_id: other.id)
         deleted_id = @topic.id
         @topic.destroy!
 
         assert_no_difference -> { Collavre::Comment.where(user_id: nil).count } do
           OrphanedCronNotifier.new(topic_id: deleted_id, topic_name: "Counseling").call
         end
+        assert SolidQueue::RecurringTask.exists?(key: cron.key)
+      end
+
+      test "deletes every matching cron before posting notices" do
+        crons = 2.times.map { create_cron(creative_id: @creative.id, topic_id: @topic.id) }
+        deleted_id = @topic.id
+        @topic.destroy!
+
+        Collavre::Comment.stub(:create!, ->(*) { raise "notice failed" }) do
+          assert_raises(RuntimeError) do
+            OrphanedCronNotifier.new(topic_id: deleted_id, topic_name: "Counseling").call
+          end
+        end
+
+        assert_empty SolidQueue::RecurringTask.where(key: crons.map(&:key))
       end
 
       test "keeps the notice as a system message even when a deleter is Current.user" do
@@ -103,7 +129,7 @@ module Collavre
         )
         linked = Collavre::Creative.create!(origin_id: @creative.id, user: other_user)
 
-        create_cron(creative_id: linked.id, topic_id: @topic.id)
+        cron = create_cron(creative_id: linked.id, topic_id: @topic.id)
         deleted_id = @topic.id
         @topic.destroy!
 
@@ -114,16 +140,22 @@ module Collavre
         assert_equal @creative.main_topic.id, notice.topic_id
         # Topic and (origin-rewritten) creative must be consistent — no orphaned topic.
         assert_equal notice.creative_id, notice.topic.creative_id
+        assert_not SolidQueue::RecurringTask.exists?(key: cron.key)
+
+        command = notice.content.lines.find { |line| line.start_with?("/cron_create ") }
+        payload = JSON.parse(command.delete_prefix("/cron_create "))
+        assert_equal linked.id, payload.fetch("creative_id")
       end
 
       test "ignores crons whose topic_id is nil (main-topic crons)" do
-        create_cron(creative_id: @creative.id, topic_id: nil)
+        cron = create_cron(creative_id: @creative.id, topic_id: nil)
         deleted_id = @topic.id
         @topic.destroy!
 
         assert_no_difference -> { Collavre::Comment.where(user_id: nil).count } do
           OrphanedCronNotifier.new(topic_id: deleted_id, topic_name: "Counseling").call
         end
+        assert SolidQueue::RecurringTask.exists?(key: cron.key)
       end
     end
   end


### PR DESCRIPTION
## Summary

- delete recurring cron jobs that target a deleted topic
- post a localized system notice confirming deletion with a copyable `/cron_create` JSON command
- preserve the original creative, topic name, schedule, message, and description for recreation
- remove all matching jobs before posting notices so a notification failure cannot leave later jobs orphaned

## Dependency

- [#1621](https://github.com/sh1nj1/plan42/pull/1621) has been merged. This branch is rebased onto that change, so `cron_create` recreates both the missing named topic and its cron configuration in one step.

## Testing

- `mise exec -- bin/rails test engines/collavre/test/services/collavre/topics/orphaned_cron_notifier_test.rb engines/collavre/test/services/collavre/tools/cron_create_service_test.rb` (24 runs, 85 assertions)
- `mise exec -- bundle exec rubocop engines/collavre/app/services/collavre/topics/orphaned_cron_notifier.rb engines/collavre/test/services/collavre/topics/orphaned_cron_notifier_test.rb`
- `mise exec -- bin/complexity_check --base main`
