### PR TITLE
fix: create missing topics when scheduling crons

### DIFF
--- a/engines/collavre/app/services/collavre/tools/cron_create_service.rb
+++ b/engines/collavre/app/services/collavre/tools/cron_create_service.rb
@@ -44,7 +44,7 @@ module Tools
       key = "cron_#{creative_id}_#{suffix}"
 
       task = create_task(
-        topic: topic, creative: creative, creative_id: creative_id,
+        topic: topic, creative: creative, creative_id: creative_id, topic_created: topic_created,
         key: key, schedule: schedule, message: message, description: description
       )
       return task if task.is_a?(Hash) && task[:error]
@@ -64,28 +64,43 @@ module Tools
 
     private
 
-    def create_task(topic:, creative:, creative_id:, key:, schedule:, message:, description:)
-      topic.with_lock do
+    def create_task(topic:, creative:, creative_id:, key:, schedule:, message:, description:, topic_created:)
+      creation_error = nil
+      task = topic.with_lock do
         return { error: I18n.t("collavre.creative_history.read_only") } if topic.history?
         unless topic.creative_id == creative.effective_origin.id
           return { error: I18n.t("collavre.comments.invalid_topic") }
         end
 
-        SolidQueue::RecurringTask.create!(
-          key: key,
-          class_name: "Collavre::CronActionJob",
-          schedule: schedule,
-          queue_name: "default",
-          static: false,
-          description: description || "Cron job for creative #{creative_id}",
-          arguments: [ {
-            creative_id: creative_id,
-            topic_id: topic.id,
-            agent_id: Current.user.id,
-            message: message
-          } ]
+        persist_task(
+          topic: topic, creative_id: creative_id, key: key, schedule: schedule,
+          message: message, description: description
         )
+      rescue StandardError => e
+        topic.destroy! if topic_created
+        creation_error = e
+        nil
       end
+      raise creation_error if creation_error
+
+      task
+    end
+
+    def persist_task(topic:, creative_id:, key:, schedule:, message:, description:)
+      SolidQueue::RecurringTask.create!(
+        key: key,
+        class_name: "Collavre::CronActionJob",
+        schedule: schedule,
+        queue_name: "default",
+        static: false,
+        description: description || "Cron job for creative #{creative_id}",
+        arguments: [ {
+          creative_id: creative_id,
+          topic_id: topic.id,
+          agent_id: Current.user.id,
+          message: message
+        } ]
+      )
     end
 
     def resolve_topic(creative, topic_name)

--- a/engines/collavre/app/services/collavre/tools/cron_create_service.rb
+++ b/engines/collavre/app/services/collavre/tools/cron_create_service.rb
@@ -66,6 +66,7 @@ module Tools
 
     def create_task(topic:, creative:, creative_id:, key:, schedule:, message:, description:, topic_created:)
       creation_error = nil
+      retained_created_topic = false
       task = topic.with_lock do
         return { error: I18n.t("collavre.creative_history.read_only") } if topic.history?
         unless topic.creative_id == creative.effective_origin.id
@@ -77,13 +78,21 @@ module Tools
           message: message, description: description
         )
       rescue StandardError => e
-        topic.destroy! if topic_created && !recurring_topic_adopted?(topic)
+        retained_created_topic = clean_up_failed_topic_creation(topic) if topic_created
         creation_error = e
         nil
       end
+      broadcast_topic_created(topic) if retained_created_topic
       raise creation_error if creation_error
 
       task
+    end
+
+    def clean_up_failed_topic_creation(topic)
+      return true if recurring_topic_adopted?(topic)
+
+      topic.destroy!
+      false
     end
 
     def recurring_topic_adopted?(topic)

--- a/engines/collavre/app/services/collavre/tools/cron_create_service.rb
+++ b/engines/collavre/app/services/collavre/tools/cron_create_service.rb
@@ -7,10 +7,10 @@ module Tools
     extend ToolMeta
 
     tool_name "cron_create"
-    tool_description "Create a new recurring scheduled job. The job will periodically post a message to a creative's topic, triggering agent orchestration. Schedule uses cron syntax (e.g., '*/5 * * * *' for every 5 minutes, '0 9 * * *' for daily at 9am)."
+    tool_description "Create a new recurring scheduled job. The job will periodically post a message to a creative's topic, creating the named topic when it does not exist, and triggering agent orchestration. Schedule uses cron syntax (e.g., '*/5 * * * *' for every 5 minutes, '0 9 * * *' for daily at 9am)."
 
     tool_param :creative_id, description: "The creative ID to post recurring messages to.", required: true
-    tool_param :topic_name, description: "The topic name within the creative to post to. Use 'Main' for the default main topic.", required: true
+    tool_param :topic_name, description: "The topic name within the creative to post to. Missing topics are created automatically. Use 'Main' for the default main topic.", required: true
     tool_param :schedule, description: "Cron schedule expression (e.g., '0 9 * * *' for daily at 9am, '*/30 * * * *' for every 30 minutes).", required: true
     tool_param :message, description: "The message content to post on each execution. This triggers the agent orchestration pipeline.", required: true
     tool_param :description, description: "Human-readable description of what this cron job does.", required: false
@@ -33,13 +33,12 @@ module Tools
         return { error: "No write permission on this Creative", id: creative_id }
       end
 
-      topic = resolve_topic(creative, topic_name)
-      return topic if topic.is_a?(Hash) && topic[:error]
-
-      parsed = Fugit.parse(schedule)
-      unless parsed.is_a?(Fugit::Cron)
+      unless Fugit.parse(schedule).is_a?(Fugit::Cron)
         return { error: "Invalid cron schedule: #{schedule}. Use cron syntax like '0 9 * * *'." }
       end
+
+      topic, topic_created = resolve_topic(creative, topic_name)
+      return topic if topic.is_a?(Hash) && topic[:error]
 
       suffix = SecureRandom.hex(4)
       key = "cron_#{creative_id}_#{suffix}"
@@ -49,6 +48,8 @@ module Tools
         key: key, schedule: schedule, message: message, description: description
       )
       return task if task.is_a?(Hash) && task[:error]
+
+      broadcast_topic_created(topic) if topic_created
 
       {
         success: true,
@@ -90,14 +91,23 @@ module Tools
     def resolve_topic(creative, topic_name)
       origin = creative.effective_origin
       if topic_name.casecmp(Creative::MAIN_TOPIC_NAME).zero?
-        origin.main_topic(fallback_user: Current.user)
-      else
-        topic = Topic.find_by(name: topic_name, creative_id: origin.id)
-        return { error: "Topic '#{topic_name}' not found for this creative" } unless topic
-        return { error: I18n.t("collavre.creative_history.read_only") } if topic.history?
-
-        topic
+        return [ origin.main_topic(fallback_user: Current.user), false ]
       end
+
+      topic = origin.topics.find_by(name: topic_name)
+      return [ { error: I18n.t("collavre.creative_history.read_only") }, false ] if topic&.history?
+      return [ topic, false ] if topic
+      return [ { error: I18n.t("collavre.topics.reserved_name") }, false ] if Topics::ReservedName.reserved?(origin, topic_name)
+
+      topic = origin.topics.find_or_create_by!(name: topic_name) { |created| created.user = Current.user }
+      [ topic, topic.previously_new_record? ]
+    end
+
+    def broadcast_topic_created(topic)
+      TopicsChannel.broadcast_to(
+        topic.creative,
+        { action: "created", topic: topic.slice(:id, :name), user_id: Current.user.id }
+      )
     end
   end
 end

--- a/engines/collavre/app/services/collavre/tools/cron_create_service.rb
+++ b/engines/collavre/app/services/collavre/tools/cron_create_service.rb
@@ -77,7 +77,7 @@ module Tools
           message: message, description: description
         )
       rescue StandardError => e
-        topic.destroy! if topic_created
+        topic.destroy! if topic_created && !Crons::RecurringTopicTasks.new(topic.id).any?
         creation_error = e
         nil
       end

--- a/engines/collavre/app/services/collavre/tools/cron_create_service.rb
+++ b/engines/collavre/app/services/collavre/tools/cron_create_service.rb
@@ -108,6 +108,8 @@ module Tools
         topic.creative,
         { action: "created", topic: topic.slice(:id, :name), user_id: Current.user.id }
       )
+    rescue StandardError => e
+      Rails.logger.warn("[CronCreateService] Failed to broadcast created topic #{topic.id}: #{e.message}")
     end
   end
 end

--- a/engines/collavre/app/services/collavre/tools/cron_create_service.rb
+++ b/engines/collavre/app/services/collavre/tools/cron_create_service.rb
@@ -77,13 +77,20 @@ module Tools
           message: message, description: description
         )
       rescue StandardError => e
-        topic.destroy! if topic_created && !Crons::RecurringTopicTasks.new(topic.id).any?
+        topic.destroy! if topic_created && !recurring_topic_adopted?(topic)
         creation_error = e
         nil
       end
       raise creation_error if creation_error
 
       task
+    end
+
+    def recurring_topic_adopted?(topic)
+      Crons::RecurringTopicTasks.new(topic.id).any?
+    rescue StandardError => e
+      Rails.logger.warn("[CronCreateService] Failed to check topic #{topic.id} adoption: #{e.message}")
+      false
     end
 
     def persist_task(topic:, creative_id:, key:, schedule:, message:, description:)

--- a/engines/collavre/test/services/collavre/tools/cron_create_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/cron_create_service_test.rb
@@ -200,6 +200,30 @@ module Collavre
         assert @topic.reload
       end
 
+      test "keeps a newly created topic adopted by a concurrent recurring task" do
+        original_create = SolidQueue::RecurringTask.method(:create!)
+        adopted_task = nil
+        failing_create = lambda do |**attributes|
+          adopted_task = original_create.call(**attributes.merge(key: "#{attributes[:key]}_adopted"))
+          raise "queue unavailable"
+        end
+
+        error = SolidQueue::RecurringTask.stub(:create!, failing_create) do
+          assert_raises(RuntimeError) do
+            CronCreateService.new.call(
+              creative_id: @creative.id,
+              topic_name: "Adopted Topic",
+              schedule: "0 9 * * *",
+              message: "test"
+            )
+          end
+        end
+
+        topic = @creative.topics.find_by!(name: "Adopted Topic")
+        assert_equal "queue unavailable", error.message
+        assert_equal topic.id, adopted_task.arguments.first[:topic_id]
+      end
+
       test "rejects a missing reserved topic name" do
         result = CronCreateService.new.call(
           creative_id: @creative.id,

--- a/engines/collavre/test/services/collavre/tools/cron_create_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/cron_create_service_test.rb
@@ -148,6 +148,26 @@ module Collavre
         end
       end
 
+      test "keeps the cron successful when broadcasting a created topic fails" do
+        warning = nil
+        result = Rails.logger.stub(:warn, ->(message) { warning = message }) do
+          TopicsChannel.stub(:broadcast_to, ->(*) { raise "cable unavailable" }) do
+            CronCreateService.new.call(
+              creative_id: @creative.id,
+              topic_name: "Broadcast Failure Topic",
+              schedule: "0 9 * * *",
+              message: "test"
+            )
+          end
+        end
+
+        assert result[:success]
+        topic = @creative.topics.find_by!(name: "Broadcast Failure Topic")
+        task = SolidQueue::RecurringTask.find_by!(key: result[:key])
+        assert_equal topic.id, task.arguments.first[:topic_id]
+        assert_match(/Failed to broadcast created topic #{topic.id}: cable unavailable/, warning)
+      end
+
       test "rejects a missing reserved topic name" do
         result = CronCreateService.new.call(
           creative_id: @creative.id,

--- a/engines/collavre/test/services/collavre/tools/cron_create_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/cron_create_service_test.rb
@@ -115,16 +115,49 @@ module Collavre
         assert_equal "Creative not found", result[:error]
       end
 
-      test "rejects when topic_name not found" do
+      test "creates a missing topic and targets it" do
+        broadcast = nil
+
+        TopicsChannel.stub(:broadcast_to, ->(*args) { broadcast = args }) do
+          result = CronCreateService.new.call(
+            creative_id: @creative.id,
+            topic_name: "New Cron Topic",
+            schedule: "0 9 * * *",
+            message: "test"
+          )
+
+          assert result[:success]
+          task = SolidQueue::RecurringTask.find_by!(key: result[:key])
+          topic = @creative.topics.find_by!(name: "New Cron Topic")
+          assert_equal @user, topic.user
+          assert_equal topic.id, task.arguments.first[:topic_id]
+          assert_equal [ @creative, { action: "created", topic: topic.slice(:id, :name), user_id: @user.id } ], broadcast
+        end
+      end
+
+      test "does not create a missing topic for an invalid schedule" do
+        assert_no_difference -> { @creative.topics.count } do
+          result = CronCreateService.new.call(
+            creative_id: @creative.id,
+            topic_name: "Invalid Schedule Topic",
+            schedule: "not a valid schedule",
+            message: "test"
+          )
+
+          assert_match(/Invalid cron schedule/, result[:error])
+        end
+      end
+
+      test "rejects a missing reserved topic name" do
         result = CronCreateService.new.call(
           creative_id: @creative.id,
-          topic_name: "Nonexistent Topic",
+          topic_name: Creative::HISTORY_TOPIC_NAME,
           schedule: "0 9 * * *",
           message: "test"
         )
 
-        assert result[:error]
-        assert_match(/Topic 'Nonexistent Topic' not found/, result[:error])
+        assert_equal I18n.t("collavre.topics.reserved_name"), result[:error]
+        assert_nil @creative.topics.find_by(name: Creative::HISTORY_TOPIC_NAME)
       end
 
       test "rejects the read-only History topic" do

--- a/engines/collavre/test/services/collavre/tools/cron_create_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/cron_create_service_test.rb
@@ -224,6 +224,31 @@ module Collavre
         assert_equal topic.id, adopted_task.arguments.first[:topic_id]
       end
 
+      test "removes a new topic and preserves the original error when the adoption check fails" do
+        checker = Object.new
+        checker.define_singleton_method(:any?) { raise "queue still unavailable" }
+        warning = nil
+
+        error = Rails.logger.stub(:warn, ->(message) { warning = message }) do
+          Crons::RecurringTopicTasks.stub(:new, checker) do
+            SolidQueue::RecurringTask.stub(:create!, ->(**) { raise "queue unavailable" }) do
+              assert_raises(RuntimeError) do
+                CronCreateService.new.call(
+                  creative_id: @creative.id,
+                  topic_name: "Unavailable Queue Topic",
+                  schedule: "0 9 * * *",
+                  message: "test"
+                )
+              end
+            end
+          end
+        end
+
+        assert_equal "queue unavailable", error.message
+        assert_nil @creative.topics.find_by(name: "Unavailable Queue Topic")
+        assert_match(/Failed to check topic .* adoption: queue still unavailable/, warning)
+      end
+
       test "rejects a missing reserved topic name" do
         result = CronCreateService.new.call(
           creative_id: @creative.id,

--- a/engines/collavre/test/services/collavre/tools/cron_create_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/cron_create_service_test.rb
@@ -168,6 +168,38 @@ module Collavre
         assert_match(/Failed to broadcast created topic #{topic.id}: cable unavailable/, warning)
       end
 
+      test "removes a newly created topic when recurring task creation fails" do
+        error = SolidQueue::RecurringTask.stub(:create!, ->(**) { raise "queue unavailable" }) do
+          assert_raises(RuntimeError) do
+            CronCreateService.new.call(
+              creative_id: @creative.id,
+              topic_name: "Task Failure Topic",
+              schedule: "0 9 * * *",
+              message: "test"
+            )
+          end
+        end
+
+        assert_equal "queue unavailable", error.message
+        assert_nil @creative.topics.find_by(name: "Task Failure Topic")
+      end
+
+      test "keeps an existing topic when recurring task creation fails" do
+        error = SolidQueue::RecurringTask.stub(:create!, ->(**) { raise "queue unavailable" }) do
+          assert_raises(RuntimeError) do
+            CronCreateService.new.call(
+              creative_id: @creative.id,
+              topic_name: @topic.name,
+              schedule: "0 9 * * *",
+              message: "test"
+            )
+          end
+        end
+
+        assert_equal "queue unavailable", error.message
+        assert @topic.reload
+      end
+
       test "rejects a missing reserved topic name" do
         result = CronCreateService.new.call(
           creative_id: @creative.id,

--- a/engines/collavre/test/services/collavre/tools/cron_create_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/cron_create_service_test.rb
@@ -203,25 +203,29 @@ module Collavre
       test "keeps a newly created topic adopted by a concurrent recurring task" do
         original_create = SolidQueue::RecurringTask.method(:create!)
         adopted_task = nil
+        broadcast = nil
         failing_create = lambda do |**attributes|
           adopted_task = original_create.call(**attributes.merge(key: "#{attributes[:key]}_adopted"))
           raise "queue unavailable"
         end
 
-        error = SolidQueue::RecurringTask.stub(:create!, failing_create) do
-          assert_raises(RuntimeError) do
-            CronCreateService.new.call(
-              creative_id: @creative.id,
-              topic_name: "Adopted Topic",
-              schedule: "0 9 * * *",
-              message: "test"
-            )
+        error = TopicsChannel.stub(:broadcast_to, ->(*args) { broadcast = args }) do
+          SolidQueue::RecurringTask.stub(:create!, failing_create) do
+            assert_raises(RuntimeError) do
+              CronCreateService.new.call(
+                creative_id: @creative.id,
+                topic_name: "Adopted Topic",
+                schedule: "0 9 * * *",
+                message: "test"
+              )
+            end
           end
         end
 
         topic = @creative.topics.find_by!(name: "Adopted Topic")
         assert_equal "queue unavailable", error.message
         assert_equal topic.id, adopted_task.arguments.first[:topic_id]
+        assert_equal [ @creative, { action: "created", topic: topic.slice(:id, :name), user_id: @user.id } ], broadcast
       end
 
       test "removes a new topic and preserves the original error when the adoption check fails" do


### PR DESCRIPTION
## Summary

- create a named topic automatically when `cron_create` cannot find it
- broadcast the new topic so connected clients update immediately
- validate the cron schedule before creating a topic and preserve reserved-topic protections

## Testing

- `./bin/rubocop -a`
- `bundle exec rake test` (4,774 tests, 16,560 assertions)
- `bundle exec rake test:system` (113 tests, 729 assertions, 2 skips)
- `bin/complexity_check`
- `bin/rails test engines/collavre/test/services/collavre/tools/cron_create_service_test.rb`