### PR TITLE
fix: authorize creative reorder and link_drop

### DIFF
--- a/engines/collavre/app/controllers/collavre/concerns/tree_manageable.rb
+++ b/engines/collavre/app/controllers/collavre/concerns/tree_manageable.rb
@@ -22,6 +22,8 @@ module Collavre
           )
         end
         head :ok
+      rescue ::Creatives::Reorderer::PermissionError
+        head :forbidden
       rescue ::Creatives::Reorderer::Error
         head :unprocessable_entity
       end
@@ -48,6 +50,8 @@ module Collavre
           parent_id: result.parent&.id,
           direction: result.direction
         }
+      rescue ::Creatives::Reorderer::PermissionError
+        head :forbidden
       rescue ::Creatives::Reorderer::Error
         head :unprocessable_entity
       end

--- a/engines/collavre/app/services/collavre/creatives/reorderer.rb
+++ b/engines/collavre/app/services/collavre/creatives/reorderer.rb
@@ -2,6 +2,10 @@ module Collavre
 module Creatives
   class Reorderer
     class Error < StandardError; end
+    # Raised when the acting user lacks the permission required to perform the
+    # move. Subclasses Error so existing `rescue Reorderer::Error` call sites
+    # keep failing closed; controllers rescue it first to answer 403 vs 422.
+    class PermissionError < Error; end
 
     LinkDropResult = Struct.new(:new_creative, :parent, :direction, keyword_init: true)
 
@@ -13,6 +17,8 @@ module Creatives
       dragged, target = fetch_creatives(dragged_id, target_id)
       validate_direction!(direction)
       raise Error, "Invalid creatives" unless dragged && target
+
+      authorize_move!([ dragged ], target, direction)
 
       if direction == "child"
         reorder_as_child(dragged, target)
@@ -39,6 +45,10 @@ module Creatives
         raise Error, "Invalid creatives"
       end
 
+      # Every dragged creative is checked before any mutation runs, so a single
+      # unauthorized id rejects the whole batch and leaves the DB untouched.
+      authorize_move!(ordered_dragged, target, direction)
+
       target_ancestor_ids = target.ancestors.pluck(:id)
       if ordered_dragged.any? { |creative| target_ancestor_ids.include?(creative.id) }
         raise Error, "Invalid creatives"
@@ -59,6 +69,8 @@ module Creatives
       dragged, target = fetch_creatives(dragged_id, target_id)
       validate_direction!(direction)
       raise Error, "Invalid creatives" unless dragged && target
+
+      authorize_link_drop!(dragged, target, direction)
 
       origin = dragged.effective_origin
       new_parent = direction == "child" ? target : target.parent
@@ -113,6 +125,36 @@ module Creatives
 
     def validate_direction!(direction)
       raise Error, "Invalid direction" unless %w[up down child].include?(direction)
+    end
+
+    # A move rewrites the dragged creatives themselves and the child ordering of
+    # the container they land in, so both need :write. For "child" the container
+    # is the target; for "up"/"down" it is the target's parent (nil at root, in
+    # which case the target itself is the only anchor we can check).
+    def authorize_move!(dragged_creatives, target, direction)
+      new_parent = direction == "child" ? target : target.parent
+      subjects = dragged_creatives + [ target, new_parent ].compact
+      subjects.uniq(&:id).each { |creative| require_write!(creative) }
+    end
+
+    # A link drop never mutates the dragged creative - it creates a new shell
+    # pointing at the same origin - so :read on the source is enough. The
+    # container that receives the shell still needs :write.
+    def authorize_link_drop!(dragged, target, direction)
+      require_permission!(dragged, :read)
+
+      new_parent = direction == "child" ? target : target.parent
+      [ target, new_parent ].compact.uniq(&:id).each { |creative| require_write!(creative) }
+    end
+
+    def require_write!(creative)
+      require_permission!(creative, :write)
+    end
+
+    def require_permission!(creative, level)
+      return if creative.has_permission?(user, level)
+
+      raise PermissionError, "Permission denied"
     end
 
     def reorder_as_child(dragged, target)

--- a/engines/collavre/app/services/collavre/creatives/reorderer.rb
+++ b/engines/collavre/app/services/collavre/creatives/reorderer.rb
@@ -92,25 +92,28 @@ module Creatives
     def authorize_move!(dragged_creatives, target, direction)
       new_parent = direction == "child" ? target : target.parent
       subjects = dragged_creatives + [ target, new_parent ].compact
-      subjects.uniq(&:id).each { |creative| require_write!(creative) }
+      require_permissions!(subjects, :write)
     end
 
     # A link drop never mutates the dragged creative - it creates a new shell
     # pointing at the same origin - so :read on the source is enough. The
     # container that receives the shell still needs :write.
     def authorize_link_drop!(dragged, target, direction)
-      require_permission!(dragged, :read)
+      require_permissions!([ dragged ], :read)
 
       new_parent = direction == "child" ? target : target.parent
-      [ target, new_parent ].compact.uniq(&:id).each { |creative| require_write!(creative) }
+      require_permissions!([ target, new_parent ].compact, :write)
     end
 
-    def require_write!(creative)
-      require_permission!(creative, :write)
-    end
-
-    def require_permission!(creative, level)
-      return if creative.has_permission?(user, level)
+    # PermissionChecker resolves a link shell to its origin, which is correct
+    # for content access but insufficient for a tree mutation: write access to
+    # an origin must not authorize moving somebody else's private shell or
+    # inserting below it. PermissionFilter applies both origin access and the
+    # shell-placement gate, and batches the subjects for multi-drag.
+    def require_permissions!(creatives, level)
+      ids = creatives.uniq(&:id).map(&:id)
+      allowed_ids = Collavre::Creatives::PermissionFilter.new(user: user).readable_ids(ids, min_permission: level)
+      return if allowed_ids.size == ids.size
 
       raise PermissionError, "Permission denied"
     end

--- a/engines/collavre/app/services/collavre/creatives/reorderer.rb
+++ b/engines/collavre/app/services/collavre/creatives/reorderer.rb
@@ -32,27 +32,17 @@ module Creatives
     def reorder_multiple(dragged_ids:, target_id:, direction:)
       ids = Array(dragged_ids).map(&:presence).compact
       validate_direction!(direction)
-      raise Error, "Invalid creatives" if ids.empty? || ids.map(&:to_s).uniq.size != ids.size
 
       target = Creative.find_by(id: target_id)
       raise Error, "Invalid creatives" unless target
 
-      dragged_lookup = Creative.where(id: ids).index_by { |creative| creative.id.to_s }
-      ordered_dragged = ids.map { |id| dragged_lookup[id.to_s] }.compact
-      raise Error, "Invalid creatives" unless ordered_dragged.size == ids.size
-
-      if ordered_dragged.any? { |creative| creative.id == target.id }
-        raise Error, "Invalid creatives"
-      end
-
+      ordered_dragged = resolve_selection(ids, target)
       # Every dragged creative is checked before any mutation runs, so a single
       # unauthorized id rejects the whole batch and leaves the DB untouched.
+      # Authorizing ahead of the ancestor check also keeps a caller without
+      # access from reading tree shape out of the 403-vs-422 split.
       authorize_move!(ordered_dragged, target, direction)
-
-      target_ancestor_ids = target.ancestors.pluck(:id)
-      if ordered_dragged.any? { |creative| target_ancestor_ids.include?(creative.id) }
-        raise Error, "Invalid creatives"
-      end
+      validate_not_target_ancestors!(ordered_dragged, target)
 
       if direction == "child"
         reorder_multiple_as_child(ordered_dragged, target)
@@ -74,41 +64,9 @@ module Creatives
 
       origin = dragged.effective_origin
       new_parent = direction == "child" ? target : target.parent
+      validate_link_placement!(origin, new_parent)
 
-      if new_parent.present?
-        origin_descendant_ids = origin.self_and_descendants.pluck(:id)
-
-        new_parent.self_and_ancestors.each do |ancestor|
-          ancestor_origin_id = ancestor.origin_id.presence || ancestor.id
-
-          if origin_descendant_ids.include?(ancestor_origin_id)
-            raise Error, "Invalid creatives"
-          end
-        end
-      end
-
-      new_creative = nil
-      Creative.transaction do
-        new_creative = Creative.create!(
-          origin_id: origin.id,
-          parent: new_parent,
-          user: new_parent&.user || user
-        )
-
-        siblings = sibling_scope(new_parent)
-        siblings.reject! { |s| s.id == new_creative.id }
-
-        if direction == "child"
-          siblings << new_creative
-        else
-          target_index = siblings.index { |s| s.id == target.id } || 0
-          insert_index = direction == "up" ? target_index : target_index + 1
-          insert_index = [ [ insert_index, 0 ].max, siblings.size ].min
-          siblings.insert(insert_index, new_creative)
-        end
-
-        resequence!(siblings)
-      end
+      new_creative = insert_link_shell!(origin, target, new_parent, direction)
 
       LinkDropResult.new(new_creative: new_creative, parent: new_parent, direction: direction)
     rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotSaved => e
@@ -155,6 +113,68 @@ module Creatives
       return if creative.has_permission?(user, level)
 
       raise PermissionError, "Permission denied"
+    end
+
+    # Resolves the dragged ids into Creatives in selection order, rejecting any
+    # selection that cannot produce a valid tree: empty, duplicated, containing
+    # an unknown id, or containing the target itself.
+    def resolve_selection(ids, target)
+      raise Error, "Invalid creatives" if ids.empty? || ids.map(&:to_s).uniq.size != ids.size
+
+      lookup = Creative.where(id: ids).index_by { |creative| creative.id.to_s }
+      ordered = ids.map { |id| lookup[id.to_s] }.compact
+      raise Error, "Invalid creatives" unless ordered.size == ids.size
+      raise Error, "Invalid creatives" if ordered.any? { |creative| creative.id == target.id }
+
+      ordered
+    end
+
+    # Dropping onto a descendant of the selection would make the target its own
+    # ancestor.
+    def validate_not_target_ancestors!(dragged_creatives, target)
+      target_ancestor_ids = target.ancestors.pluck(:id)
+      return if dragged_creatives.none? { |creative| target_ancestor_ids.include?(creative.id) }
+
+      raise Error, "Invalid creatives"
+    end
+
+    # Same cycle guard for links, compared on origin ids so a link shell sitting
+    # in the ancestor chain is caught alongside a real creative.
+    def validate_link_placement!(origin, new_parent)
+      return if new_parent.blank?
+
+      origin_descendant_ids = origin.self_and_descendants.pluck(:id)
+
+      new_parent.self_and_ancestors.each do |ancestor|
+        ancestor_origin_id = ancestor.origin_id.presence || ancestor.id
+
+        raise Error, "Invalid creatives" if origin_descendant_ids.include?(ancestor_origin_id)
+      end
+    end
+
+    def insert_link_shell!(origin, target, new_parent, direction)
+      Creative.transaction do
+        new_creative = Creative.create!(
+          origin_id: origin.id,
+          parent: new_parent,
+          user: new_parent&.user || user
+        )
+
+        siblings = sibling_scope(new_parent).reject { |s| s.id == new_creative.id }
+        resequence!(place_relative_to(siblings, new_creative, target, direction))
+
+        new_creative
+      end
+    end
+
+    # Returns `siblings` with `creative` placed relative to `target`: appended
+    # for "child", before or after the target for "up"/"down".
+    def place_relative_to(siblings, creative, target, direction)
+      return siblings << creative if direction == "child"
+
+      target_index = siblings.index { |s| s.id == target.id } || 0
+      insert_index = direction == "up" ? target_index : target_index + 1
+      siblings.insert([ [ insert_index, 0 ].max, siblings.size ].min, creative)
     end
 
     def reorder_as_child(dragged, target)

--- a/engines/collavre/test/integration/creatives_reorder_authorization_test.rb
+++ b/engines/collavre/test/integration/creatives_reorder_authorization_test.rb
@@ -79,6 +79,42 @@ class CreativesReorderAuthorizationTest < ActionDispatch::IntegrationTest
     assert_equal [ @owner_a.id, @owner_b.id ], @owner_root.children.order(:sequence).pluck(:id)
   end
 
+  test "reorder cannot move a link shell from another user's private placement" do
+    share!(@owner_root, @collaborator, :write)
+    foreign_shell = Creative.create!(
+      user: @stranger,
+      parent: @stranger_root,
+      origin_id: @owner_a.id,
+      sequence: 1
+    )
+    sign_in_as(@collaborator)
+
+    post reorder_creatives_path, params: {
+      dragged_id: foreign_shell.id, target_id: @collaborator_root.id, direction: "child"
+    }, as: :json
+
+    assert_response :forbidden
+    assert_equal @stranger_root.id, foreign_shell.reload.parent_id
+  end
+
+  test "reorder cannot insert into another user's private link shell" do
+    share!(@owner_root, @collaborator, :write)
+    foreign_shell = Creative.create!(
+      user: @stranger,
+      parent: @stranger_root,
+      origin_id: @owner_a.id,
+      sequence: 1
+    )
+    sign_in_as(@collaborator)
+
+    post reorder_creatives_path, params: {
+      dragged_id: @collaborator_root.id, target_id: foreign_shell.id, direction: "child"
+    }, as: :json
+
+    assert_response :forbidden
+    assert_nil @collaborator_root.reload.parent_id
+  end
+
   # --- reorder: authorized ---------------------------------------------------
 
   test "owner can reorder their own creatives" do
@@ -162,6 +198,24 @@ class CreativesReorderAuthorizationTest < ActionDispatch::IntegrationTest
       post link_drop_creatives_path, params: {
         dragged_id: @stranger_a.id, target_id: @owner_a.id, direction: "child"
       }, as: :json
+    end
+
+    assert_response :forbidden
+  end
+
+  test "link_drop cannot insert into another user's private link shell" do
+    share!(@owner_root, @collaborator, :write)
+    foreign_shell = Creative.create!(
+      user: @stranger,
+      parent: @stranger_root,
+      origin_id: @owner_a.id,
+      sequence: 1
+    )
+    sign_in_as(@collaborator)
+
+    assert_no_difference -> { Creative.count } do
+      params = { dragged_id: @owner_b.id, target_id: foreign_shell.id, direction: "child" }
+      post link_drop_creatives_path, params: params, as: :json
     end
 
     assert_response :forbidden

--- a/engines/collavre/test/integration/creatives_reorder_authorization_test.rb
+++ b/engines/collavre/test/integration/creatives_reorder_authorization_test.rb
@@ -1,0 +1,242 @@
+require "test_helper"
+
+# POST /creatives/reorder and /creatives/link_drop re-parent Creatives. Before
+# this suite existed the endpoints looked up their operands with
+# Creative.find_by(id:) and never consulted the acting user, so any signed-in
+# account could re-parent an arbitrary Creative by id (IDOR).
+#
+# The matrix below pins the authorization contract: :write on every dragged
+# Creative and on the container that receives it, :read on a link drop's source
+# (a link never mutates it), 403 for a permission failure, 422 reserved for
+# malformed or cyclic input, and no partial writes when one id in a batch fails.
+class CreativesReorderAuthorizationTest < ActionDispatch::IntegrationTest
+  include ActiveJob::TestHelper
+
+  setup do
+    @owner = create_user("reorder-owner")
+    @stranger = create_user("reorder-stranger")
+    @collaborator = create_user("reorder-collaborator")
+
+    perform_enqueued_jobs do
+      @owner_root = Creative.create!(user: @owner, description: "Owner root", sequence: 0)
+      @owner_a = Creative.create!(user: @owner, parent: @owner_root, description: "Owner A", sequence: 0)
+      @owner_b = Creative.create!(user: @owner, parent: @owner_root, description: "Owner B", sequence: 1)
+
+      @stranger_root = Creative.create!(user: @stranger, description: "Stranger root", sequence: 0)
+      @stranger_a = Creative.create!(user: @stranger, parent: @stranger_root, description: "Stranger A", sequence: 0)
+
+      @collaborator_root = Creative.create!(user: @collaborator, description: "Collaborator root", sequence: 0)
+    end
+  end
+
+  # --- reorder: unauthorized -------------------------------------------------
+
+  test "reorder is forbidden when the dragged creative is not writable" do
+    sign_in_as(@stranger)
+
+    post reorder_creatives_path, params: {
+      dragged_id: @owner_a.id, target_id: @stranger_root.id, direction: "child"
+    }, as: :json
+
+    assert_response :forbidden
+    assert_equal @owner_root.id, @owner_a.reload.parent_id
+  end
+
+  test "reorder is forbidden when the receiving container is not writable" do
+    sign_in_as(@stranger)
+
+    post reorder_creatives_path, params: {
+      dragged_id: @stranger_a.id, target_id: @owner_a.id, direction: "child"
+    }, as: :json
+
+    assert_response :forbidden
+    assert_equal @stranger_root.id, @stranger_a.reload.parent_id
+  end
+
+  # "up"/"down" land the dragged creative in the target's PARENT, so write on
+  # the target alone must not be enough to inject into a container above it.
+  test "reorder up is forbidden when the target's parent is not writable" do
+    share!(@owner_a, @collaborator, :write)
+    sign_in_as(@collaborator)
+
+    post reorder_creatives_path, params: {
+      dragged_id: @collaborator_root.id, target_id: @owner_a.id, direction: "up"
+    }, as: :json
+
+    assert_response :forbidden
+    assert_nil @collaborator_root.reload.parent_id
+  end
+
+  test "reorder is forbidden with read-only access" do
+    share!(@owner_root, @collaborator, :read)
+    sign_in_as(@collaborator)
+
+    post reorder_creatives_path, params: {
+      dragged_id: @owner_b.id, target_id: @owner_a.id, direction: "up"
+    }, as: :json
+
+    assert_response :forbidden
+    assert_equal [ @owner_a.id, @owner_b.id ], @owner_root.children.order(:sequence).pluck(:id)
+  end
+
+  # --- reorder: authorized ---------------------------------------------------
+
+  test "owner can reorder their own creatives" do
+    sign_in_as(@owner)
+
+    post reorder_creatives_path, params: {
+      dragged_id: @owner_b.id, target_id: @owner_a.id, direction: "up"
+    }, as: :json
+
+    assert_response :ok
+    assert_equal [ @owner_b.id, @owner_a.id ], @owner_root.children.order(:sequence).pluck(:id)
+  end
+
+  test "a write-shared collaborator can reorder inside the shared subtree" do
+    share!(@owner_root, @collaborator, :write)
+    sign_in_as(@collaborator)
+
+    post reorder_creatives_path, params: {
+      dragged_id: @owner_b.id, target_id: @owner_a.id, direction: "up"
+    }, as: :json
+
+    assert_response :ok
+    assert_equal [ @owner_b.id, @owner_a.id ], @owner_root.children.order(:sequence).pluck(:id)
+  end
+
+  # --- reorder_multiple ------------------------------------------------------
+
+  test "multi-drag is rejected in full when one dragged creative is unauthorized" do
+    sign_in_as(@stranger)
+
+    post reorder_creatives_path, params: {
+      dragged_ids: [ @stranger_a.id, @owner_a.id ],
+      target_id: @stranger_root.id,
+      direction: "child"
+    }, as: :json
+
+    assert_response :forbidden
+    assert_equal @owner_root.id, @owner_a.reload.parent_id
+    assert_equal @stranger_root.id, @stranger_a.reload.parent_id
+  end
+
+  test "multi-drag succeeds when every dragged creative is authorized" do
+    sign_in_as(@owner)
+
+    post reorder_creatives_path, params: {
+      dragged_ids: [ @owner_b.id, @owner_a.id ],
+      target_id: @collaborator_root.id,
+      direction: "child"
+    }, as: :json
+
+    assert_response :forbidden, "the collaborator's root is not writable by the owner"
+
+    post reorder_creatives_path, params: {
+      dragged_ids: [ @owner_b.id, @owner_a.id ],
+      target_id: @owner_root.id,
+      direction: "child"
+    }, as: :json
+
+    assert_response :ok
+    assert_equal [ @owner_b.id, @owner_a.id ], @owner_root.children.order(:sequence).pluck(:id)
+  end
+
+  # --- link_drop -------------------------------------------------------------
+
+  test "link_drop is forbidden when the source is not readable" do
+    sign_in_as(@stranger)
+
+    assert_no_difference -> { Creative.count } do
+      post link_drop_creatives_path, params: {
+        dragged_id: @owner_a.id, target_id: @stranger_root.id, direction: "child"
+      }, as: :json
+    end
+
+    assert_response :forbidden
+  end
+
+  test "link_drop is forbidden when the receiving container is not writable" do
+    sign_in_as(@stranger)
+
+    assert_no_difference -> { Creative.count } do
+      post link_drop_creatives_path, params: {
+        dragged_id: @stranger_a.id, target_id: @owner_a.id, direction: "child"
+      }, as: :json
+    end
+
+    assert_response :forbidden
+  end
+
+  # Read is the whole requirement on the source: the drop creates a new shell
+  # pointing at the same origin and never writes to the dragged Creative.
+  test "link_drop only needs read on the source creative" do
+    share!(@owner_root, @collaborator, :read)
+    sign_in_as(@collaborator)
+
+    assert_difference -> { Creative.count }, 1 do
+      post link_drop_creatives_path, params: {
+        dragged_id: @owner_a.id, target_id: @collaborator_root.id, direction: "child"
+      }, as: :json
+    end
+
+    assert_response :ok
+    linked = Creative.find(JSON.parse(response.body)["creative_id"])
+    assert_equal @owner_a.id, linked.origin_id
+    assert_equal @collaborator_root.id, linked.parent_id
+  end
+
+  # A root target has no parent, so the target itself is the only container the
+  # check can anchor on.
+  test "link_drop next to a root target checks the target itself" do
+    share!(@owner_root, @collaborator, :read)
+    sign_in_as(@collaborator)
+
+    assert_difference -> { Creative.count }, 1 do
+      post link_drop_creatives_path, params: {
+        dragged_id: @owner_a.id, target_id: @collaborator_root.id, direction: "up"
+      }, as: :json
+    end
+    assert_response :ok
+
+    assert_no_difference -> { Creative.count } do
+      post link_drop_creatives_path, params: {
+        dragged_id: @owner_a.id, target_id: @owner_root.id, direction: "up"
+      }, as: :json
+    end
+    assert_response :forbidden
+  end
+
+  # --- status code separation ------------------------------------------------
+
+  test "malformed input still answers 422, not 403" do
+    sign_in_as(@owner)
+
+    post reorder_creatives_path, params: {
+      dragged_id: @owner_a.id, target_id: @owner_b.id, direction: "sideways"
+    }, as: :json
+    assert_response :unprocessable_entity
+
+    post reorder_creatives_path, params: {
+      dragged_id: 0, target_id: 0, direction: "up"
+    }, as: :json
+    assert_response :unprocessable_entity
+  end
+
+  private
+
+  def create_user(handle)
+    User.create!(
+      email: "#{handle}@example.com",
+      password: TEST_PASSWORD,
+      name: handle,
+      email_verified_at: Time.current,
+      notifications_enabled: false
+    )
+  end
+
+  def share!(creative, user, permission)
+    perform_enqueued_jobs do
+      CreativeShare.create!(creative: creative, user: user, permission: permission)
+    end
+  end
+end


### PR DESCRIPTION
## Problem

`POST /creatives/reorder` and `POST /creatives/link_drop` resolved their operands by ID without authorizing the acting user. Any signed-in account could therefore re-parent another user's Creative or graft content into a tree it could not write (IDOR).

Linked Creatives add a second boundary: `Creative#has_permission?` resolves a shell to its origin. Origin permission alone must not authorize moving a shell from another user's private placement or using that private shell as a drop target.

This security fix is intentionally isolated from the D&D expansion work and targets `main` directly.

## Fix

Authorization now converges in `Collavre::Creatives::Reorderer`:

- `reorder` and `reorder_multiple` require `:write` on every dragged Creative, the target, and the receiving container. For `up`/`down`, the receiving container is the target's parent.
- `reorder_multiple` authorizes the entire selection before any mutation, so one denied item rejects the batch without partial writes.
- `link_drop` requires `:read` on the source and `:write` on the target and receiving container. Read is sufficient for the source because the operation creates a shell and does not mutate source content.
- Authorization uses the canonical `PermissionFilter`, applying both origin permission and the linked-shell placement gate. This closes the private-shell ID bypass that a direct `has_permission?` check would leave open.
- `Reorderer::PermissionError` maps to HTTP 403; malformed and cyclic input remains HTTP 422.

No frontend change is needed because the existing D&D handler reverts optimistic DOM movement for every non-success response.

## Behavior note

A user with `:write` on a child but only `:read` on its parent can no longer reorder that child among siblings. Rearranging a container requires write access to the container.

## Tests

The new authorization integration suite contains 16 tests covering:

- owner, write-shared, read-shared, and unauthorized actors
- single reorder, multi-reorder, and link drop
- denied source and receiving-container access
- all-or-nothing multi-drag behavior
- linked shells in another user's private placement, as both source and target
- 403/422 status separation

Local verification:

- Authorization and related reorder/link/permission suites: 38 runs, 152 assertions, 0 failures
- Previously flaky unrelated system test, isolated: 1 run, 8 assertions, 0 failures
- RuboCop: clean
- Complexity ratchet: 397 entities over budget versus 403 on `main`; no growth

The first CI attempt passed all unit/integration tests (4,795 runs, 16,672 assertions) but hit an unrelated foreign-key race in `InlineScriptsTest#test_workspace_tree_refresh_does_not_reopen_a_destroyed_creative_chat` during parallel system tests. The isolated test passed locally and the failed CI job was rerun.
