### PR TITLE
feat: show cron job details from topic badges

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/creatives.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/creatives.css
@@ -1060,7 +1060,7 @@ creative-tree-row.is-being-edited .creative-tree {
     background: var(--surface-hover);
 }
 
-.cron-badge-popup {
+.popup-menu.cron-badge-popup {
     width: min(360px, calc(100vw - 8px));
     max-height: min(480px, calc(100vh - 8px));
     padding: var(--space-3);

--- a/engines/collavre/app/assets/stylesheets/collavre/creatives.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/creatives.css
@@ -1034,6 +1034,11 @@ creative-tree-row.is-being-edited .creative-tree {
     display: contents;
 }
 
+.cron-badge-wrapper {
+    display: inline-flex;
+    position: relative;
+}
+
 .creative-cron-badge {
     display: inline-flex;
     align-items: center;
@@ -1045,6 +1050,87 @@ creative-tree-row.is-being-edited .creative-tree {
     color: var(--text-secondary);
     font-size: var(--text-0);
     white-space: nowrap;
+    border: 0;
+    cursor: pointer;
+    line-height: 1.5;
+}
+
+.creative-cron-badge:hover,
+.creative-cron-badge:focus-visible {
+    background: var(--surface-hover);
+}
+
+.cron-badge-popup {
+    width: min(360px, calc(100vw - 8px));
+    max-height: min(480px, calc(100vh - 8px));
+    padding: var(--space-3);
+    overflow-y: auto;
+    cursor: default;
+    color: var(--text-primary);
+    white-space: normal;
+}
+
+.cron-badge-popup-title,
+.cron-task,
+.cron-task-field,
+.cron-task-label,
+.cron-task-message {
+    display: block;
+}
+
+.cron-badge-popup-title {
+    margin-bottom: var(--space-2);
+    font-size: var(--text-1);
+}
+
+.cron-task {
+    padding: var(--space-2) 0;
+    border-top: var(--border-1) solid var(--border-muted);
+}
+
+.cron-task:first-of-type {
+    border-top: 0;
+}
+
+.cron-task-field {
+    margin-bottom: var(--space-2);
+}
+
+.cron-task-label {
+    margin-bottom: var(--space-1);
+    color: var(--text-muted);
+    font-size: var(--text-0);
+    font-weight: var(--weight-semibold);
+}
+
+.cron-task code,
+.cron-task time,
+.cron-task-message {
+    font-size: var(--text-0);
+}
+
+.cron-task-message {
+    max-height: 8em;
+    overflow-y: auto;
+    overflow-wrap: anywhere;
+    white-space: pre-wrap;
+}
+
+.cron-task-delete {
+    display: inline-flex;
+    justify-content: center;
+    width: 100%;
+    padding: var(--space-2);
+    border: var(--border-1) solid var(--color-danger);
+    border-radius: var(--radius-2);
+    background: transparent;
+    color: var(--color-danger);
+    cursor: pointer;
+}
+
+.cron-task-delete:hover,
+.cron-task-delete:focus-visible {
+    background: color-mix(in srgb, var(--color-danger) 12%, transparent);
 }
 
 /* ─── Bundle drag image (shared by creatives + comments) ─── */

--- a/engines/collavre/app/assets/stylesheets/collavre/creatives.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/creatives.css
@@ -1046,7 +1046,7 @@ creative-tree-row.is-being-edited .creative-tree {
     margin-left: var(--space-1);
     padding: 0 var(--space-2);
     border-radius: var(--radius-round, 9999px);
-    background: var(--surface-input, var(--color-bg));
+    background: transparent;
     color: var(--text-secondary);
     font-size: var(--text-0);
     white-space: nowrap;

--- a/engines/collavre/app/assets/stylesheets/collavre/creatives.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/creatives.css
@@ -344,7 +344,6 @@ creative-tree-row.show-edit .creative-row {
     align-items: center;
     justify-items: center;
     min-width: 1.5em;
-    padding-top: var(--space-1);
 }
 
 .progress-toggle-wrap > * {
@@ -1039,8 +1038,9 @@ creative-tree-row.is-being-edited .creative-tree {
     position: relative;
 }
 
+.creative-row-end > .progress-toggle-wrap,
 .creative-row-end > .cron-badge-wrapper {
-    margin-top: var(--space-1);
+    align-self: center;
 }
 
 .creative-cron-badge {

--- a/engines/collavre/app/assets/stylesheets/collavre/creatives.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/creatives.css
@@ -1047,17 +1047,12 @@ creative-tree-row.is-being-edited .creative-tree {
     padding: 0 var(--space-2);
     border-radius: var(--radius-round, 9999px);
     background: transparent;
-    color: var(--text-secondary);
+    color: var(--text-muted);
     font-size: var(--text-0);
     white-space: nowrap;
     border: 0;
     cursor: pointer;
     line-height: 1.5;
-}
-
-.creative-cron-badge:hover,
-.creative-cron-badge:focus-visible {
-    background: var(--surface-hover);
 }
 
 .popup-menu.cron-badge-popup {

--- a/engines/collavre/app/assets/stylesheets/collavre/creatives.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/creatives.css
@@ -344,7 +344,7 @@ creative-tree-row.show-edit .creative-row {
     align-items: center;
     justify-items: center;
     min-width: 1.5em;
-    padding-top: 4px;
+    padding-top: var(--space-1);
 }
 
 .progress-toggle-wrap > * {
@@ -1037,6 +1037,10 @@ creative-tree-row.is-being-edited .creative-tree {
 .cron-badge-wrapper {
     display: inline-flex;
     position: relative;
+}
+
+.creative-row-end > .cron-badge-wrapper {
+    margin-top: var(--space-1);
 }
 
 .creative-cron-badge {

--- a/engines/collavre/app/components/collavre/cron_badge_component.html.erb
+++ b/engines/collavre/app/components/collavre/cron_badge_component.html.erb
@@ -1,0 +1,56 @@
+<span class="cron-badge-wrapper"
+      data-controller="popup-menu cron-badge"
+      data-cron-badge-delete-confirm-value="<%= t('collavre.crons.delete_confirm') %>"
+      data-cron-badge-delete-error-value="<%= t('collavre.crons.delete_error') %>"
+      data-cron-badge-count-one-value="<%= t('collavre.crons.count_one') %>"
+      data-cron-badge-count-other-value="<%= t('collavre.crons.count_other') %>">
+  <button type="button"
+          class="creative-cron-badge popup-menu-toggle"
+          title="<%= count_label %>"
+          aria-label="<%= count_label %>"
+          aria-haspopup="dialog"
+          aria-expanded="false"
+          data-popup-menu-target="button"
+          data-cron-badge-target="badge"
+          data-action="click->popup-menu#toggle">
+    <span aria-hidden="true">⏰</span>
+    <span data-cron-badge-target="count"><%= tasks.size %></span>
+  </button>
+  <span id="<%= menu_id %>"
+        class="popup-menu cron-badge-popup"
+        role="dialog"
+        aria-label="<%= t('collavre.crons.title') %>"
+        data-popup-menu-target="menu"
+        data-action="click->popup-menu#menuClick click->cron-badge#stopPropagation">
+    <strong class="cron-badge-popup-title"><%= t('collavre.crons.title') %></strong>
+    <% tasks.each do |task| %>
+      <% task_next_run = next_run(task) %>
+      <span class="cron-task" data-cron-badge-target="task" data-cron-key="<%= task.key %>">
+        <span class="cron-task-field">
+          <span class="cron-task-label"><%= t('collavre.crons.schedule') %></span>
+          <code><%= task.schedule %></code>
+        </span>
+        <span class="cron-task-field">
+          <span class="cron-task-label"><%= t('collavre.crons.message') %></span>
+          <span class="cron-task-message"><%= task_message(task) %></span>
+        </span>
+        <span class="cron-task-field">
+          <span class="cron-task-label"><%= t('collavre.crons.next_run') %></span>
+          <% if task_next_run %>
+            <time datetime="<%= task_next_run.iso8601 %>"><%= next_run_label(task_next_run) %></time>
+          <% else %>
+            <span><%= next_run_label(task_next_run) %></span>
+          <% end %>
+        </span>
+        <% if can_delete? %>
+          <button type="button"
+                  class="cron-task-delete"
+                  data-action="click->cron-badge#destroy"
+                  data-cron-delete-url="<%= destroy_path(task) %>">
+            <%= t('collavre.crons.delete') %>
+          </button>
+        <% end %>
+      </span>
+    <% end %>
+  </span>
+</span>

--- a/engines/collavre/app/components/collavre/cron_badge_component.rb
+++ b/engines/collavre/app/components/collavre/cron_badge_component.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Collavre
+  class CronBadgeComponent < ViewComponent::Base
+    include Crons::RecurringTaskArguments
+
+    def initialize(tasks:, creative_id:, can_delete: false)
+      @tasks = tasks
+      @creative_id = creative_id
+      @can_delete = can_delete
+      @menu_id = "cron-badge-menu-#{SecureRandom.hex(4)}"
+    end
+
+    attr_reader :tasks, :creative_id, :menu_id
+
+    def can_delete? = @can_delete
+
+    def count_label
+      t("collavre.creatives.index.cron_count", count: tasks.size)
+    end
+
+    def task_message(task)
+      parse_arguments(task)["message"].presence || t("collavre.crons.not_available")
+    end
+
+    def next_run(task)
+      task.next_time
+    end
+
+    def next_run_label(time)
+      time ? helpers.l(time, format: :short) : t("collavre.crons.not_available")
+    end
+
+    def destroy_path(task)
+      helpers.collavre.creative_cron_path(creative_id, task.key)
+    end
+  end
+end

--- a/engines/collavre/app/controllers/collavre/crons_controller.rb
+++ b/engines/collavre/app/controllers/collavre/crons_controller.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Collavre
+  class CronsController < ApplicationController
+    include Collavre::CreativePermissionGuard
+
+    before_action :set_creative
+    before_action :require_creative_write!
+
+    def destroy
+      task = recurring_tasks.find { |candidate| candidate.key == params[:key] }
+      return head :not_found unless task
+
+      task.destroy!
+      Crons::ChangeBroadcaster.call(@creative)
+      head :no_content
+    end
+
+    private
+
+    def set_creative
+      @creative = Creative.find(params[:creative_id]).effective_origin
+    end
+
+    def recurring_tasks
+      Crons::RecurringTaskIndex.new.tasks_for(@creative.id)
+    end
+  end
+end

--- a/engines/collavre/app/controllers/collavre/crons_controller.rb
+++ b/engines/collavre/app/controllers/collavre/crons_controller.rb
@@ -23,7 +23,7 @@ module Collavre
     end
 
     def recurring_tasks
-      Crons::RecurringTaskIndex.new.tasks_for(@creative.id)
+      Crons::RecurringTaskIndex.for_creative_family(@creative).tasks_for(@creative.id)
     end
   end
 end

--- a/engines/collavre/app/controllers/collavre/topics_controller.rb
+++ b/engines/collavre/app/controllers/collavre/topics_controller.rb
@@ -6,7 +6,7 @@ module Collavre
     include Collavre::CreativePermissionGuard
 
     before_action :set_creative
-    before_action :require_creative_read!, only: %i[next_name channel_chips]
+    before_action :require_creative_read!, only: %i[index next_name channel_chips]
     before_action :require_creative_admin!, only: %i[update destroy move reorder]
     before_action :require_creative_write!, only: %i[create archive unarchive set_primary_agent]
 

--- a/engines/collavre/app/controllers/collavre/topics_controller.rb
+++ b/engines/collavre/app/controllers/collavre/topics_controller.rb
@@ -29,13 +29,13 @@ module Collavre
       main_topic = @creative.main_topic(fallback_user: Current.user)
       system_topic = @creative.inbox? ? @creative.system_topic(fallback_user: Current.user) : nil
 
-      active_topics = @creative.topics.active.includes(primary_agent: { avatar_attachment: :blob }).order(:created_at).to_a
-      archived_topics = @creative.topics.archived.includes(primary_agent: { avatar_attachment: :blob }).order(:created_at).to_a
+      active_topics = @creative.topics.active.includes(primary_agent: { avatar_attachment: :blob }).order(:created_at)
+      archived_topics = @creative.topics.archived.includes(primary_agent: { avatar_attachment: :blob }).order(:created_at)
       unread_counts_by_topic = Creatives::CommentBadgeIndex.new(user: Current.user)
         .unread_counts_by_topic(@creative)
 
-      system_topic_id = system_topic&.id
       main_topic_id = main_topic.id
+      @cron_badge_decorator = Topics::CronBadgeDecorator.new(@creative, main_topic_id, can_write, view_context)
 
       render json: {
         topics: active_topics.map { |t| topic_json(t, unread_count: unread_counts_by_topic.fetch(t.id, 0)) },
@@ -45,7 +45,7 @@ module Collavre
         can_set_primary_agent: can_write,
         **Topics::LastTopicPreferencePayload.new(creative: @creative, user: Current.user).call,
         is_inbox: @creative.inbox?,
-        system_topic_id: system_topic_id,
+        system_topic_id: system_topic&.id,
         main_topic_id: main_topic_id,
         effective_creative_id: @creative.id
       }
@@ -354,7 +354,8 @@ module Collavre
     # same events from outside a request, cannot describe a topic differently
     # from this controller.
     def topic_json(topic, unread_count: nil)
-      Topics::Serializer.call(topic, unread_count: unread_count)
+      data = Topics::Serializer.call(topic, unread_count: unread_count)
+      @cron_badge_decorator ? @cron_badge_decorator.call(data, topic) : data
     end
 
     # Always carries a :primary_agent key, explicitly nil when cleared. The client

--- a/engines/collavre/app/helpers/collavre/creatives_helper.rb
+++ b/engines/collavre/app/helpers/collavre/creatives_helper.rb
@@ -36,7 +36,7 @@ module Collavre
     # creatives at once (the browse tree) resolve them in batch and hand them in.
     # Left nil, each is resolved for this creative alone — correct, but a query
     # per node. Single-creative call sites take that path.
-    def render_creative_progress(creative, select_mode: false, has_children: nil, can_write: nil, can_feedback: nil, unread_count: nil, cron_tasks: [])
+    def render_creative_progress(creative, select_mode: false, has_children: nil, can_write: nil, can_feedback: nil, unread_count: nil, cron_tasks: [], can_delete_cron: nil)
       progress_value = if params[:tags].present?
         tag_ids = Array(params[:tags]).map(&:to_s)
         creative.filtered_progress || creative.progress_for_tags(tag_ids) || 0
@@ -57,7 +57,7 @@ module Collavre
           can_write: can_write,
           select_mode: select_mode
         )
-        cron_part = render_cron_badge_for_creative(creative, cron_tasks, can_delete: can_write)
+        cron_part = render_cron_badge_for_creative(creative, cron_tasks, can_delete: can_delete_cron)
 
         safe_join([
           progress_part,
@@ -116,6 +116,7 @@ module Collavre
     def render_cron_badge_for_creative(creative, tasks, can_delete: false)
       return safe_join([]) if tasks.empty?
 
+      can_delete = creative.has_permission?(Current.user, :write) if can_delete.nil?
       render_cron_badge(tasks, creative_id: creative.effective_origin.id, can_delete: can_delete)
     end
 

--- a/engines/collavre/app/helpers/collavre/creatives_helper.rb
+++ b/engines/collavre/app/helpers/collavre/creatives_helper.rb
@@ -57,7 +57,7 @@ module Collavre
           can_write: can_write,
           select_mode: select_mode
         )
-        cron_part = cron_tasks.any? ? render_cron_badge(cron_tasks) : safe_join([])
+        cron_part = render_cron_badge_for_creative(creative, cron_tasks, can_delete: can_write)
 
         safe_join([
           progress_part,
@@ -103,23 +103,20 @@ module Collavre
       )
     end
 
-    def render_cron_badge(tasks)
-      details = tasks.map do |task|
-        t(
-          "collavre.creatives.index.cron_schedule",
-          schedule: task.schedule,
-          next_run: l(task.next_time, format: :short)
+    def render_cron_badge(tasks, creative_id:, can_delete: false)
+      render(
+        Collavre::CronBadgeComponent.new(
+          tasks: tasks,
+          creative_id: creative_id,
+          can_delete: can_delete
         )
-      end
-      label = t("collavre.creatives.index.cron_count", count: tasks.size)
-
-      content_tag(
-        :span,
-        safe_join([ tag.span("⏰", aria: { hidden: true }), tag.span(tasks.size) ], " "),
-        class: "creative-cron-badge",
-        title: details.join("\n"),
-        aria: { label: "#{label}. #{details.join('. ')}" }
       )
+    end
+
+    def render_cron_badge_for_creative(creative, tasks, can_delete: false)
+      return safe_join([]) if tasks.empty?
+
+      render_cron_badge(tasks, creative_id: creative.effective_origin.id, can_delete: can_delete)
     end
 
     def render_progress_control(creative, value, has_children:, can_write:, select_mode: false)

--- a/engines/collavre/app/javascript/controllers/__tests__/cron_badge_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/cron_badge_controller.test.js
@@ -85,6 +85,23 @@ describe('CronBadgeController', () => {
     expect(document.body.contains(element)).toBe(false)
   })
 
+  test('refreshes creative trees after deleting a task', async () => {
+    const refetch = jest.fn()
+    const invalidate = jest.fn()
+    document.addEventListener('creative-sync:refetch', refetch)
+    document.addEventListener('workspace-tree:invalidate', invalidate)
+    confirmDialog.mockResolvedValue(true)
+    fetch.mockResolvedValue({ ok: true, status: 204 })
+
+    element.querySelector('[data-cron-delete-url$="/one"]').click()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(refetch).toHaveBeenCalledTimes(1)
+    expect(invalidate).toHaveBeenCalledTimes(1)
+    document.removeEventListener('creative-sync:refetch', refetch)
+    document.removeEventListener('workspace-tree:invalidate', invalidate)
+  })
+
   test('does not request deletion when confirmation is cancelled', async () => {
     confirmDialog.mockResolvedValue(false)
 

--- a/engines/collavre/app/javascript/controllers/__tests__/cron_badge_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/cron_badge_controller.test.js
@@ -1,0 +1,120 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { jest } from '@jest/globals'
+import { Application } from '@hotwired/stimulus'
+
+const confirmDialog = jest.fn()
+const alertDialog = jest.fn()
+
+jest.unstable_mockModule('../../lib/utils/dialog', () => ({
+  confirmDialog,
+  alertDialog,
+}))
+
+const { default: CronBadgeController } = await import('../cron_badge_controller')
+
+describe('CronBadgeController', () => {
+  let application
+  let element
+  let controller
+
+  beforeEach(async () => {
+    document.head.innerHTML = '<meta name="csrf-token" content="token">'
+    document.body.innerHTML = `
+      <span data-controller="cron-badge"
+            data-cron-badge-delete-confirm-value="Delete it?"
+            data-cron-badge-delete-error-value="Delete failed"
+            data-cron-badge-count-one-value="__count__ scheduled job"
+            data-cron-badge-count-other-value="__count__ scheduled jobs">
+        <button data-cron-badge-target="badge" title="2 scheduled jobs" aria-label="2 scheduled jobs">
+          <span data-cron-badge-target="count">2</span>
+        </button>
+        <span data-cron-badge-target="task">
+          <button data-action="click->cron-badge#destroy" data-cron-delete-url="/creatives/42/crons/one">Delete</button>
+        </span>
+        <span data-cron-badge-target="task">
+          <button data-action="click->cron-badge#destroy" data-cron-delete-url="/creatives/42/crons/two">Delete</button>
+        </span>
+      </span>
+    `
+    element = document.querySelector('[data-controller="cron-badge"]')
+    application = Application.start()
+    application.register('cron-badge', CronBadgeController)
+    await new Promise(resolve => setTimeout(resolve, 0))
+    controller = application.getControllerForElementAndIdentifier(element, 'cron-badge')
+    confirmDialog.mockReset()
+    alertDialog.mockReset()
+    global.fetch = jest.fn()
+  })
+
+  afterEach(() => {
+    application.stop()
+    document.head.innerHTML = ''
+    document.body.innerHTML = ''
+    jest.restoreAllMocks()
+  })
+
+  test('deletes a task and updates the count', async () => {
+    confirmDialog.mockResolvedValue(true)
+    fetch.mockResolvedValue({ ok: true, status: 204 })
+
+    element.querySelector('[data-cron-delete-url$="/one"]').click()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(confirmDialog).toHaveBeenCalledWith('Delete it?', { danger: true })
+    expect(fetch).toHaveBeenCalledWith('/creatives/42/crons/one', {
+      method: 'DELETE',
+      headers: { 'X-CSRF-Token': 'token' },
+    })
+    expect(controller.taskTargets).toHaveLength(1)
+    expect(controller.countTarget.textContent).toBe('1')
+    expect(controller.badgeTarget.title).toBe('1 scheduled job')
+    expect(controller.badgeTarget.getAttribute('aria-label')).toBe('1 scheduled job')
+  })
+
+  test('removes the badge after deleting its last task', async () => {
+    element.querySelectorAll('[data-cron-badge-target="task"]')[1].remove()
+    confirmDialog.mockResolvedValue(true)
+    fetch.mockResolvedValue({ ok: true, status: 204 })
+
+    element.querySelector('[data-cron-delete-url$="/one"]').click()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(document.body.contains(element)).toBe(false)
+  })
+
+  test('does not request deletion when confirmation is cancelled', async () => {
+    confirmDialog.mockResolvedValue(false)
+
+    element.querySelector('[data-cron-delete-url$="/one"]').click()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(fetch).not.toHaveBeenCalled()
+    expect(controller.taskTargets).toHaveLength(2)
+  })
+
+  test('reports a failed deletion and restores the button', async () => {
+    confirmDialog.mockResolvedValue(true)
+    fetch.mockResolvedValue({ ok: false, status: 500 })
+    alertDialog.mockResolvedValue(undefined)
+    const button = element.querySelector('[data-cron-delete-url$="/one"]')
+
+    button.click()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(alertDialog).toHaveBeenCalledWith('Delete failed')
+    expect(button.disabled).toBe(false)
+    expect(controller.taskTargets).toHaveLength(2)
+  })
+
+  test('stops popup clicks from selecting the parent topic', () => {
+    const event = { stopPropagation: jest.fn() }
+
+    controller.stopPropagation(event)
+
+    expect(event.stopPropagation).toHaveBeenCalled()
+  })
+
+})

--- a/engines/collavre/app/javascript/controllers/__tests__/cron_badge_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/cron_badge_controller.test.js
@@ -7,10 +7,16 @@ import { Application } from '@hotwired/stimulus'
 
 const confirmDialog = jest.fn()
 const alertDialog = jest.fn()
+const csrfFetch = jest.fn()
+const refreshCsrfToken = jest.fn()
 
 jest.unstable_mockModule('../../lib/utils/dialog', () => ({
   confirmDialog,
   alertDialog,
+}))
+jest.unstable_mockModule('../../lib/api/csrf_fetch', () => ({
+  default: csrfFetch,
+  refreshCsrfToken,
 }))
 
 const { default: CronBadgeController } = await import('../cron_badge_controller')
@@ -46,7 +52,8 @@ describe('CronBadgeController', () => {
     controller = application.getControllerForElementAndIdentifier(element, 'cron-badge')
     confirmDialog.mockReset()
     alertDialog.mockReset()
-    global.fetch = jest.fn()
+    csrfFetch.mockReset()
+    refreshCsrfToken.mockReset()
   })
 
   afterEach(() => {
@@ -58,16 +65,13 @@ describe('CronBadgeController', () => {
 
   test('deletes a task and updates the count', async () => {
     confirmDialog.mockResolvedValue(true)
-    fetch.mockResolvedValue({ ok: true, status: 204 })
+    csrfFetch.mockResolvedValue({ ok: true, status: 204 })
 
     element.querySelector('[data-cron-delete-url$="/one"]').click()
     await new Promise(resolve => setTimeout(resolve, 0))
 
     expect(confirmDialog).toHaveBeenCalledWith('Delete it?', { danger: true })
-    expect(fetch).toHaveBeenCalledWith('/creatives/42/crons/one', {
-      method: 'DELETE',
-      headers: { 'X-CSRF-Token': 'token' },
-    })
+    expect(csrfFetch).toHaveBeenCalledWith('/creatives/42/crons/one', { method: 'DELETE' })
     expect(controller.taskTargets).toHaveLength(1)
     expect(controller.countTarget.textContent).toBe('1')
     expect(controller.badgeTarget.title).toBe('1 scheduled job')
@@ -77,7 +81,7 @@ describe('CronBadgeController', () => {
   test('removes the badge after deleting its last task', async () => {
     element.querySelectorAll('[data-cron-badge-target="task"]')[1].remove()
     confirmDialog.mockResolvedValue(true)
-    fetch.mockResolvedValue({ ok: true, status: 204 })
+    csrfFetch.mockResolvedValue({ ok: true, status: 204 })
 
     element.querySelector('[data-cron-delete-url$="/one"]').click()
     await new Promise(resolve => setTimeout(resolve, 0))
@@ -91,7 +95,7 @@ describe('CronBadgeController', () => {
     document.addEventListener('creative-sync:refetch', refetch)
     document.addEventListener('workspace-tree:invalidate', invalidate)
     confirmDialog.mockResolvedValue(true)
-    fetch.mockResolvedValue({ ok: true, status: 204 })
+    csrfFetch.mockResolvedValue({ ok: true, status: 204 })
 
     element.querySelector('[data-cron-delete-url$="/one"]').click()
     await new Promise(resolve => setTimeout(resolve, 0))
@@ -108,13 +112,13 @@ describe('CronBadgeController', () => {
     element.querySelector('[data-cron-delete-url$="/one"]').click()
     await new Promise(resolve => setTimeout(resolve, 0))
 
-    expect(fetch).not.toHaveBeenCalled()
+    expect(csrfFetch).not.toHaveBeenCalled()
     expect(controller.taskTargets).toHaveLength(2)
   })
 
   test('reports a failed deletion and restores the button', async () => {
     confirmDialog.mockResolvedValue(true)
-    fetch.mockResolvedValue({ ok: false, status: 500 })
+    csrfFetch.mockResolvedValue({ ok: false, status: 500 })
     alertDialog.mockResolvedValue(undefined)
     const button = element.querySelector('[data-cron-delete-url$="/one"]')
 
@@ -124,6 +128,21 @@ describe('CronBadgeController', () => {
     expect(alertDialog).toHaveBeenCalledWith('Delete failed')
     expect(button.disabled).toBe(false)
     expect(controller.taskTargets).toHaveLength(2)
+  })
+
+  test('refreshes the CSRF token and retries once after a 422 response', async () => {
+    confirmDialog.mockResolvedValue(true)
+    csrfFetch
+      .mockResolvedValueOnce({ ok: false, status: 422 })
+      .mockResolvedValueOnce({ ok: true, status: 204 })
+
+    element.querySelector('[data-cron-delete-url$="/one"]').click()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(refreshCsrfToken).toHaveBeenCalledTimes(1)
+    expect(csrfFetch).toHaveBeenCalledTimes(2)
+    expect(csrfFetch).toHaveBeenNthCalledWith(2, '/creatives/42/crons/one', { method: 'DELETE' })
+    expect(controller.taskTargets).toHaveLength(1)
   })
 
   test('stops popup clicks from selecting the parent topic', () => {

--- a/engines/collavre/app/javascript/controllers/__tests__/index.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/index.test.js
@@ -38,5 +38,9 @@ describe('registerControllers', () => {
       'last-visited-creative',
       LastVisitedCreativeController,
     )
+    expect(application.register).toHaveBeenCalledWith(
+      'cron-badge',
+      expect.any(Function),
+    )
   })
 })

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_archived.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_archived.test.js
@@ -82,6 +82,19 @@ describe('TopicsController archived topic messages', () => {
       expect(controller.listTarget.querySelector('.topic-archived[data-id="3"] .topic-unread-badge').textContent).toBe('4')
     })
 
+    test('renders the shared cron badge on an archived topic', () => {
+      controller.archivedTopics = [{
+        id: 3,
+        name: 'Zeta',
+        cron_badge_html: '<span class="cron-badge-wrapper"><button class="creative-cron-badge">1</button></span>',
+      }]
+      controller.showingArchived = true
+
+      render()
+
+      expect(controller.listTarget.querySelector('.topic-archived[data-id="3"] .creative-cron-badge')).not.toBeNull()
+    })
+
     test('archived chips carry the select action so clicking one opens it', () => {
       controller.showingArchived = true
       render()

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_creation_container.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_creation_container.test.js
@@ -157,7 +157,9 @@ describe('TopicsController create-button placement', () => {
     expect(controller.loadTopics).toHaveBeenCalled()
   })
 
-  test('reloads a newly created cron topic to render its badge', () => {
+  test('reloads a cached newly created cron topic to render its badge', () => {
+    controller.topics = [{ id: 2, name: 'Scheduled topic' }]
+
     controller.handleTopicMessage({
       action: 'created',
       topic: { id: 2, name: 'Scheduled topic' },

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_creation_container.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_creation_container.test.js
@@ -143,6 +143,43 @@ describe('TopicsController create-button placement', () => {
     })
   })
 
+  test('renders the server-provided shared cron badge inside a topic', () => {
+    const cronBadge = '<span class="cron-badge-wrapper"><button class="creative-cron-badge">1</button></span>'
+
+    controller.renderTopics([{ id: 1, name: 'Main', cron_badge_html: cronBadge }], true, true)
+
+    expect(controller.listTarget.querySelector('.topic-tag[data-id="1"] .creative-cron-badge')).not.toBeNull()
+  })
+
+  test('reloads topics when a cron change is broadcast', () => {
+    controller.handleTopicMessage({ action: 'cron_changed' })
+
+    expect(controller.loadTopics).toHaveBeenCalled()
+  })
+
+  test('reloads a newly created cron topic to render its badge', () => {
+    controller.handleTopicMessage({
+      action: 'created',
+      topic: { id: 2, name: 'Scheduled topic' },
+      cron_changed: true,
+    })
+
+    expect(controller.loadTopics).toHaveBeenCalled()
+  })
+
+  test('does not select or edit a topic when its cron badge is clicked', () => {
+    controller.currentTopicId = '1'
+    const selectTopic = jest.spyOn(controller, 'selectTopic')
+    const wrapper = document.createElement('span')
+    wrapper.className = 'cron-badge-wrapper'
+    const button = document.createElement('button')
+    wrapper.appendChild(button)
+
+    controller.select({ target: button, currentTarget: { dataset: { id: '1' } } })
+
+    expect(selectTopic).not.toHaveBeenCalled()
+  })
+
   // Alt+Left/Right chat navigation switches creatives without blurring the input,
   // so a preserved draft would otherwise be posted to the wrong creative.
   test('drops an in-progress topic name when the creative changes', () => {

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_creation_container.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_creation_container.test.js
@@ -152,9 +152,18 @@ describe('TopicsController create-button placement', () => {
   })
 
   test('reloads topics when a cron change is broadcast', () => {
+    const refetch = jest.fn()
+    const invalidate = jest.fn()
+    document.addEventListener('creative-sync:refetch', refetch)
+    document.addEventListener('workspace-tree:invalidate', invalidate)
+
     controller.handleTopicMessage({ action: 'cron_changed' })
 
     expect(controller.loadTopics).toHaveBeenCalled()
+    expect(refetch).toHaveBeenCalledTimes(1)
+    expect(invalidate).toHaveBeenCalledTimes(1)
+    document.removeEventListener('creative-sync:refetch', refetch)
+    document.removeEventListener('workspace-tree:invalidate', invalidate)
   })
 
   test('reloads a cached newly created cron topic to render its badge', () => {

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_creation_container.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_creation_container.test.js
@@ -159,6 +159,8 @@ describe('TopicsController create-button placement', () => {
 
   test('reloads a cached newly created cron topic to render its badge', () => {
     controller.topics = [{ id: 2, name: 'Scheduled topic' }]
+    controller.loadTopics.mockImplementation(() => { controller.topics = [] })
+    const renderTopics = jest.spyOn(controller, 'renderTopics')
 
     controller.handleTopicMessage({
       action: 'created',
@@ -167,6 +169,7 @@ describe('TopicsController create-button placement', () => {
     })
 
     expect(controller.loadTopics).toHaveBeenCalled()
+    expect(renderTopics).not.toHaveBeenCalled()
   })
 
   test('does not select or edit a topic when its cron badge is clicked', () => {

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -2467,9 +2467,9 @@ export default class extends Controller {
 
 	// A topic can already be cached when cron creation broadcasts its
 	// `created` event: the topic row commits before the recurring task.
-	// Refresh before the duplicate guards so that cached topic still gets
-	// its newly persisted cron badge.
-	if (data.cron_changed) this.loadTopics()
+	// Keep the current DOM until this authoritative reload completes instead
+	// of rendering the sparse broadcast payload after loadTopics clears state.
+	if (data.cron_changed) return this.loadTopics()
 
         const topics = this.topics || []
         const existsById = topics.some((topic) => String(topic.id) === String(data.topic.id))

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -2465,11 +2465,11 @@ export default class extends Controller {
 
         if (!data.topic) return
 
-		// A topic can already be cached when cron creation broadcasts its
-		// `created` event: the topic row commits before the recurring task.
-		// Refresh before the duplicate guards so that cached topic still gets
-		// its newly persisted cron badge.
-		if (data.cron_changed) this.loadTopics()
+	// A topic can already be cached when cron creation broadcasts its
+	// `created` event: the topic row commits before the recurring task.
+	// Refresh before the duplicate guards so that cached topic still gets
+	// its newly persisted cron badge.
+	if (data.cron_changed) this.loadTopics()
 
         const topics = this.topics || []
         const existsById = topics.some((topic) => String(topic.id) === String(data.topic.id))

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -2,6 +2,7 @@ import { Controller } from "@hotwired/stimulus"
 import { createSubscription } from "../../services/cable"
 import { fetchNextTopicName, createTopicWithComments, saveLastTopic } from "../../lib/api/topics"
 import { alertDialog, confirmDialog } from "../../lib/utils/dialog"
+import { invalidateCreativeTree } from '../../lib/creative_tree_invalidation'
 import PopupToggleGuard from '../../lib/popup_toggle_guard'
 
 const ICON_ARCHIVE = `<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="5" rx="1"/><path d="M4 8v11a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8"/><path d="M10 12h4"/></svg>`
@@ -2363,7 +2364,8 @@ export default class extends Controller {
 
         const action = data.action || "created"
 
-        if (action === "cron_changed") {
+	if (action === "cron_changed" || data.cron_changed) {
+	    invalidateCreativeTree()
             this.loadTopics()
             return
         }
@@ -2464,12 +2466,6 @@ export default class extends Controller {
         }
 
         if (!data.topic) return
-
-	// A topic can already be cached when cron creation broadcasts its
-	// `created` event: the topic row commits before the recurring task.
-	// Keep the current DOM until this authoritative reload completes instead
-	// of rendering the sparse broadcast payload after loadTopics clears state.
-	if (data.cron_changed) return this.loadTopics()
 
         const topics = this.topics || []
         const existsById = topics.some((topic) => String(topic.id) === String(data.topic.id))

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -2465,6 +2465,12 @@ export default class extends Controller {
 
         if (!data.topic) return
 
+		// A topic can already be cached when cron creation broadcasts its
+		// `created` event: the topic row commits before the recurring task.
+		// Refresh before the duplicate guards so that cached topic still gets
+		// its newly persisted cron badge.
+		if (data.cron_changed) this.loadTopics()
+
         const topics = this.topics || []
         const existsById = topics.some((topic) => String(topic.id) === String(data.topic.id))
         if (existsById) return
@@ -2492,7 +2498,6 @@ export default class extends Controller {
         } else {
             this.restoreSelection()
         }
-        if (data.cron_changed) this.loadTopics()
     }
 
     reorderTopicsFromServer(topicIds) {

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -487,12 +487,13 @@ export default class extends Controller {
             const unreadBadge = topic.unread_count > 0
                 ? `<span class="topic-unread-badge">${topic.unread_count}</span>`
                 : ''
+            const cronBadge = topic.cron_badge_html || ''
             const isMainTopic = this.mainTopicId && String(topic.id) === String(this.mainTopicId)
             const interactionActions = topic.read_only ? '' : `${dropActions} ${dragActions} ${topicDropActions}`
             let s = `<span class="topic-tag topic-drop-target ${isActive}" ${draggable}
                           data-action="click->comments--topics#select ${interactionActions}"
                           data-id="${topic.id}"${topic.source_topic_id ? ` data-source-topic-id="${topic.source_topic_id}"` : ''}>
-                        ${agentAvatar}${branchIcon}#${topic.display_name || topic.name}${unreadBadge}`
+                        ${agentAvatar}${branchIcon}#${topic.display_name || topic.name}${cronBadge}${unreadBadge}`
             if (canManage && !isMainTopic && !topic.read_only) {
                 s += `<button class="archive-topic-btn" data-action="click->comments--topics#archiveTopic" data-id="${topic.id}" title="Archive">${ICON_ARCHIVE}</button>`
                 s += `<button class="delete-topic-btn" data-action="click->comments--topics#deleteTopic" data-id="${topic.id}">&times;</button>`
@@ -523,10 +524,11 @@ export default class extends Controller {
                     const unreadBadge = topic.unread_count > 0
                         ? `<span class="topic-unread-badge">${topic.unread_count}</span>`
                         : ''
+                    const cronBadge = topic.cron_badge_html || ''
                     html += `<span class="topic-tag topic-archived${isActive}${hasNew}"
                                    data-action="click->comments--topics#select"
                                    data-id="${topic.id}">
-                              #${topic.name}${unreadBadge}
+                              #${topic.name}${cronBadge}${unreadBadge}
                               ${canManage ? `<button class="unarchive-topic-btn" data-action="click->comments--topics#unarchiveTopic" data-id="${topic.id}" title="Restore">${ICON_RESTORE}</button>` : ''}
                              </span>`
                 })
@@ -1110,6 +1112,7 @@ export default class extends Controller {
     select(event) {
         // Ignore if clicking on delete button (though stopPropagation should handle it)
         if (event.target.closest('.delete-topic-btn')) return
+        if (event.target.closest('.cron-badge-wrapper')) return
         // Ignore if clicking on edit input
         if (event.target.closest('.topic-edit-input')) return
 
@@ -2360,6 +2363,11 @@ export default class extends Controller {
 
         const action = data.action || "created"
 
+        if (action === "cron_changed") {
+            this.loadTopics()
+            return
+        }
+
         if (action === "last_topic_changed") {
             // Broadcast is already scoped to the current user via user-specific channel
             const newTopicId = data.last_topic_id ? String(data.last_topic_id) : ""
@@ -2484,6 +2492,7 @@ export default class extends Controller {
         } else {
             this.restoreSelection()
         }
+        if (data.cron_changed) this.loadTopics()
     }
 
     reorderTopicsFromServer(topicIds) {

--- a/engines/collavre/app/javascript/controllers/cron_badge_controller.js
+++ b/engines/collavre/app/javascript/controllers/cron_badge_controller.js
@@ -1,5 +1,6 @@
 import { Controller } from '@hotwired/stimulus'
 import { alertDialog, confirmDialog } from '../lib/utils/dialog'
+import { invalidateCreativeTree } from '../lib/creative_tree_invalidation'
 
 export default class extends Controller {
   static targets = ['badge', 'count', 'task']
@@ -32,6 +33,7 @@ export default class extends Controller {
 
       button.closest('[data-cron-badge-target="task"]')?.remove()
       this.refreshCount()
+      invalidateCreativeTree()
     } catch (error) {
       console.error(error)
       button.disabled = false

--- a/engines/collavre/app/javascript/controllers/cron_badge_controller.js
+++ b/engines/collavre/app/javascript/controllers/cron_badge_controller.js
@@ -1,0 +1,55 @@
+import { Controller } from '@hotwired/stimulus'
+import { alertDialog, confirmDialog } from '../lib/utils/dialog'
+
+export default class extends Controller {
+  static targets = ['badge', 'count', 'task']
+  static values = {
+    countOne: String,
+    countOther: String,
+    deleteConfirm: String,
+    deleteError: String,
+  }
+
+  stopPropagation(event) {
+    event.stopPropagation()
+  }
+
+  async destroy(event) {
+    event.preventDefault()
+    event.stopPropagation()
+    const button = event.currentTarget
+
+    if (!(await confirmDialog(this.deleteConfirmValue, { danger: true }))) return
+
+    button.disabled = true
+
+    try {
+      const response = await fetch(button.dataset.cronDeleteUrl, {
+        method: 'DELETE',
+        headers: { 'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]')?.content || '' },
+      })
+      if (!response.ok) throw new Error(`Cron delete failed (${response.status})`)
+
+      button.closest('[data-cron-badge-target="task"]')?.remove()
+      this.refreshCount()
+    } catch (error) {
+      console.error(error)
+      button.disabled = false
+      await alertDialog(this.deleteErrorValue)
+    }
+  }
+
+  refreshCount() {
+    const count = this.taskTargets.length
+    if (count === 0) {
+      this.element.remove()
+      return
+    }
+
+    this.countTarget.textContent = String(count)
+    const template = count === 1 ? this.countOneValue : this.countOtherValue
+    const label = template.replace('__count__', String(count))
+    this.badgeTarget.title = label
+    this.badgeTarget.setAttribute('aria-label', label)
+  }
+}

--- a/engines/collavre/app/javascript/controllers/cron_badge_controller.js
+++ b/engines/collavre/app/javascript/controllers/cron_badge_controller.js
@@ -1,6 +1,7 @@
 import { Controller } from '@hotwired/stimulus'
 import { alertDialog, confirmDialog } from '../lib/utils/dialog'
 import { invalidateCreativeTree } from '../lib/creative_tree_invalidation'
+import csrfFetch, { refreshCsrfToken } from '../lib/api/csrf_fetch'
 
 export default class extends Controller {
   static targets = ['badge', 'count', 'task']
@@ -25,10 +26,7 @@ export default class extends Controller {
     button.disabled = true
 
     try {
-      const response = await fetch(button.dataset.cronDeleteUrl, {
-        method: 'DELETE',
-        headers: { 'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]')?.content || '' },
-      })
+      const response = await this.deleteCron(button.dataset.cronDeleteUrl)
       if (!response.ok) throw new Error(`Cron delete failed (${response.status})`)
 
       button.closest('[data-cron-badge-target="task"]')?.remove()
@@ -39,6 +37,16 @@ export default class extends Controller {
       button.disabled = false
       await alertDialog(this.deleteErrorValue)
     }
+  }
+
+  async deleteCron(url) {
+    const options = { method: 'DELETE' }
+    let response = await csrfFetch(url, options)
+    if (response.status !== 422) return response
+
+    await refreshCsrfToken()
+    response = await csrfFetch(url, options)
+    return response
   }
 
   refreshCount() {

--- a/engines/collavre/app/javascript/controllers/index.js
+++ b/engines/collavre/app/javascript/controllers/index.js
@@ -48,6 +48,7 @@ import AgentVendorController from "./agent_vendor_controller"
 import DesktopProxySetupController from "./desktop_proxy_setup_controller"
 import CreativeHistoryController from "./creative_history_controller"
 import CreativeHistoryUndoController from "./creative_history_undo_controller"
+import CronBadgeController from "./cron_badge_controller"
 
 // Export all controllers
 export {
@@ -94,7 +95,8 @@ export {
   AgentVendorController,
   DesktopProxySetupController,
   CreativeHistoryController,
-  CreativeHistoryUndoController
+  CreativeHistoryUndoController,
+  CronBadgeController
 }
 
 // Registration function for use with a Stimulus application
@@ -147,4 +149,5 @@ export function registerControllers(application) {
   application.register("desktop-proxy-setup", DesktopProxySetupController)
   application.register("creative-history", CreativeHistoryController)
   application.register("creative-history-undo", CreativeHistoryUndoController)
+  application.register("cron-badge", CronBadgeController)
 }

--- a/engines/collavre/app/services/collavre/creatives/tree_builder.rb
+++ b/engines/collavre/app/services/collavre/creatives/tree_builder.rb
@@ -48,6 +48,7 @@ module Creatives
 
       preload_permissions(creatives)
       preload_comment_badges(creatives)
+      preload_cron_tasks(creatives)
 
       return if children_suppressed?
 
@@ -100,12 +101,22 @@ module Creatives
       comment_badge_index.index(visible.map(&:effective_origin), include_visible_counts: false)
     end
 
-    def cron_task_index
-      @cron_task_index ||= Collavre::Crons::RecurringTaskIndex.new
-    end
-
     def cron_filter_active?
       raw_params["has_cron"].present?
+    end
+
+    def preload_cron_tasks(creatives)
+      return unless cron_filter_active?
+
+      index = Collavre::Crons::RecurringTaskIndex.for_creatives(creatives)
+      creatives.each do |creative|
+        origin_id = creative.effective_origin.id
+        cron_tasks_by_creative_id[origin_id] = index.tasks_for(origin_id)
+      end
+    end
+
+    def cron_tasks_by_creative_id
+      @cron_tasks_by_creative_id ||= {}
     end
 
     def build_nodes(creatives, level:)
@@ -205,7 +216,7 @@ module Creatives
     def template_payload_for(creative, has_children: nil, can_write: nil)
       description_html = view_context.embed_youtube_iframe(creative.effective_description(raw_params["tags"]&.first))
       can_feedback = can_feedback?(creative)
-      cron_tasks = cron_filter_active? ? cron_task_index.tasks_for(creative.effective_origin.id) : []
+      cron_tasks = cron_filter_active? ? cron_tasks_by_creative_id.fetch(creative.effective_origin.id, []) : []
       progress_options = {
         select_mode: !!select_mode,
         has_children: has_children,

--- a/engines/collavre/app/services/collavre/creatives/tree_builder.rb
+++ b/engines/collavre/app/services/collavre/creatives/tree_builder.rb
@@ -213,7 +213,10 @@ module Creatives
         can_feedback: can_feedback,
         unread_count: can_feedback ? comment_badge_index.unread_count_for(creative.effective_origin) : nil
       }
-      progress_options[:cron_tasks] = cron_tasks if cron_tasks.any?
+      if cron_tasks.any?
+        progress_options[:cron_tasks] = cron_tasks
+        progress_options[:can_delete_cron] = allowed?(creative, :write)
+      end
       progress_html = view_context.render_creative_progress(creative, **progress_options)
 
       {

--- a/engines/collavre/app/services/collavre/crons/change_broadcaster.rb
+++ b/engines/collavre/app/services/collavre/crons/change_broadcaster.rb
@@ -9,6 +9,10 @@ module Collavre
         broadcast_tree_change(origin)
       end
 
+      def self.tree_only(creative)
+        broadcast_tree_change(creative.effective_origin)
+      end
+
       def self.broadcast_topic_change(origin)
         TopicsChannel.broadcast_to(origin, action: "cron_changed")
       rescue StandardError => e

--- a/engines/collavre/app/services/collavre/crons/change_broadcaster.rb
+++ b/engines/collavre/app/services/collavre/crons/change_broadcaster.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Collavre
+  module Crons
+    class ChangeBroadcaster
+      def self.call(creative)
+        TopicsChannel.broadcast_to(creative.effective_origin, action: "cron_changed")
+      rescue StandardError => e
+        Rails.logger.warn("[CronChangeBroadcaster] Broadcast failed for creative #{creative.id}: #{e.message}")
+      end
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/crons/change_broadcaster.rb
+++ b/engines/collavre/app/services/collavre/crons/change_broadcaster.rb
@@ -4,10 +4,28 @@ module Collavre
   module Crons
     class ChangeBroadcaster
       def self.call(creative)
-        TopicsChannel.broadcast_to(creative.effective_origin, action: "cron_changed")
-      rescue StandardError => e
-        Rails.logger.warn("[CronChangeBroadcaster] Broadcast failed for creative #{creative.id}: #{e.message}")
+        origin = creative.effective_origin
+        broadcast_topic_change(origin)
+        broadcast_tree_change(origin)
       end
+
+      def self.broadcast_topic_change(origin)
+        TopicsChannel.broadcast_to(origin, action: "cron_changed")
+      rescue StandardError => e
+        warn_failure(origin, e)
+      end
+
+      def self.broadcast_tree_change(origin)
+        CreativeTreeInvalidationJob.perform_later([ origin.id ])
+      rescue StandardError => e
+        warn_failure(origin, e)
+      end
+
+      def self.warn_failure(creative, error)
+        Rails.logger.warn("[CronChangeBroadcaster] Broadcast failed for creative #{creative.id}: #{error.message}")
+      end
+
+      private_class_method :broadcast_topic_change, :broadcast_tree_change, :warn_failure
     end
   end
 end

--- a/engines/collavre/app/services/collavre/crons/recurring_task_index.rb
+++ b/engines/collavre/app/services/collavre/crons/recurring_task_index.rb
@@ -9,7 +9,14 @@ module Collavre
       EMPTY_TASKS = [].freeze
 
       def self.for_creative_family(creative)
-        creative_ids = [ creative.id, *creative.linked_creative_ids ]
+        for_creatives([ creative ])
+      end
+
+      def self.for_creatives(creatives)
+        origin_ids = creatives.map { |creative| creative.origin_id || creative.id }.uniq
+        return new(scope: SolidQueue::RecurringTask.none) if origin_ids.empty?
+
+        creative_ids = origin_ids + Creative.where(origin_id: origin_ids).pluck(:id)
         patterns = creative_ids.map do |creative_id|
           "#{SolidQueue::RecurringTask.sanitize_sql_like("cron_#{creative_id}_")}%"
         end
@@ -23,7 +30,10 @@ module Collavre
       end
 
       def creative_ids
-        tasks_by_creative_id.keys
+        @creative_ids ||= begin
+          ids = scope.pluck(:key).filter_map { |key| key.match(KEY_PATTERN)&.[](1)&.to_i }
+          Creatives::EffectiveCreativeResolution.effective_creative_ids(ids).values.uniq
+        end
       end
 
       def tasks_for(creative_id)
@@ -44,7 +54,7 @@ module Collavre
 
       def tasks_by_creative_id
         @tasks_by_creative_id ||= begin
-          tasks = parsed_tasks
+          tasks = detailed_tasks
           effective_ids = Creatives::EffectiveCreativeResolution.effective_creative_ids(tasks.map(&:last))
 
           tasks.each_with_object(Hash.new { |hash, key| hash[key] = [] }) do |(task, creative_id), index|
@@ -53,7 +63,7 @@ module Collavre
         end
       end
 
-      def parsed_tasks
+      def detailed_tasks
         scope.select(:id, :key, :schedule, :arguments).order(:key).filter_map do |task|
           creative_id = task.key.match(KEY_PATTERN)&.[](1)&.to_i
           [ task, creative_id ] if creative_id

--- a/engines/collavre/app/services/collavre/crons/recurring_task_index.rb
+++ b/engines/collavre/app/services/collavre/crons/recurring_task_index.rb
@@ -3,6 +3,8 @@
 module Collavre
   module Crons
     class RecurringTaskIndex
+      include RecurringTaskArguments
+
       KEY_PATTERN = /\Acron_(\d+)_/.freeze
       EMPTY_TASKS = [].freeze
 
@@ -16,6 +18,14 @@ module Collavre
 
       def tasks_for(creative_id)
         tasks_by_creative_id.fetch(creative_id.to_i, EMPTY_TASKS)
+      end
+
+      def tasks_for_topic(creative_id, topic_id, main_topic_id: nil)
+        tasks_for(creative_id).select do |task|
+          scheduled_topic_id = parse_arguments(task)["topic_id"]&.to_i
+          scheduled_topic_id == topic_id.to_i ||
+            (scheduled_topic_id.nil? && main_topic_id.to_i == topic_id.to_i)
+        end
       end
 
       private
@@ -34,7 +44,7 @@ module Collavre
       end
 
       def parsed_tasks
-        scope.select(:key, :schedule).order(:key).filter_map do |task|
+        scope.select(:id, :key, :schedule, :arguments).order(:key).filter_map do |task|
           creative_id = task.key.match(KEY_PATTERN)&.[](1)&.to_i
           [ task, creative_id ] if creative_id
         end

--- a/engines/collavre/app/services/collavre/crons/recurring_task_index.rb
+++ b/engines/collavre/app/services/collavre/crons/recurring_task_index.rb
@@ -8,6 +8,16 @@ module Collavre
       KEY_PATTERN = /\Acron_(\d+)_/.freeze
       EMPTY_TASKS = [].freeze
 
+      def self.for_creative_family(creative)
+        creative_ids = [ creative.id, *creative.linked_creative_ids ]
+        patterns = creative_ids.map do |creative_id|
+          "#{SolidQueue::RecurringTask.sanitize_sql_like("cron_#{creative_id}_")}%"
+        end
+        key_matches = SolidQueue::RecurringTask.arel_table[:key].matches_any(patterns, "\\")
+
+        new(scope: SolidQueue::RecurringTask.dynamic.where(key_matches))
+      end
+
       def initialize(scope: SolidQueue::RecurringTask.dynamic)
         @scope = scope
       end

--- a/engines/collavre/app/services/collavre/crons/recurring_task_index.rb
+++ b/engines/collavre/app/services/collavre/crons/recurring_task_index.rb
@@ -41,11 +41,7 @@ module Collavre
       end
 
       def tasks_for_topic(creative_id, topic_id, main_topic_id: nil)
-        tasks_for(creative_id).select do |task|
-          scheduled_topic_id = parse_arguments(task)["topic_id"]&.to_i
-          scheduled_topic_id == topic_id.to_i ||
-            (scheduled_topic_id.nil? && main_topic_id.to_i == topic_id.to_i)
-        end
+        tasks_by_topic_id(creative_id, main_topic_id).fetch(topic_id.to_i, EMPTY_TASKS)
       end
 
       private
@@ -67,6 +63,14 @@ module Collavre
         scope.select(:id, :key, :schedule, :arguments).order(:key).filter_map do |task|
           creative_id = task.key.match(KEY_PATTERN)&.[](1)&.to_i
           [ task, creative_id ] if creative_id
+        end
+      end
+
+      def tasks_by_topic_id(creative_id, main_topic_id)
+        @tasks_by_topic_id ||= {}
+        cache_key = [ creative_id.to_i, main_topic_id.to_i ]
+        @tasks_by_topic_id[cache_key] ||= tasks_for(creative_id).group_by do |task|
+          parse_arguments(task)["topic_id"]&.to_i || main_topic_id.to_i
         end
       end
     end

--- a/engines/collavre/app/services/collavre/tools/cron_cancel_service.rb
+++ b/engines/collavre/app/services/collavre/tools/cron_cancel_service.rb
@@ -27,6 +27,7 @@ module Tools
       end
 
       task.destroy!
+      Crons::ChangeBroadcaster.call(creative)
 
       { success: true, key: key, message: "Cron job cancelled successfully" }
     end

--- a/engines/collavre/app/services/collavre/tools/cron_create_service.rb
+++ b/engines/collavre/app/services/collavre/tools/cron_create_service.rb
@@ -140,6 +140,8 @@ module Tools
       )
     rescue StandardError => e
       Rails.logger.warn("[CronCreateService] Failed to broadcast created topic #{topic.id}: #{e.message}")
+    ensure
+      Crons::ChangeBroadcaster.tree_only(topic.creative)
     end
   end
 end

--- a/engines/collavre/app/services/collavre/tools/cron_create_service.rb
+++ b/engines/collavre/app/services/collavre/tools/cron_create_service.rb
@@ -40,8 +40,7 @@ module Tools
       topic, topic_created = resolve_topic(creative, topic_name)
       return topic if topic.is_a?(Hash) && topic[:error]
 
-      suffix = SecureRandom.hex(4)
-      key = "cron_#{creative_id}_#{suffix}"
+      key = "cron_#{creative_id}_#{SecureRandom.hex(4)}"
 
       task = create_task(
         topic: topic, creative: creative, creative_id: creative_id, topic_created: topic_created,
@@ -49,7 +48,7 @@ module Tools
       )
       return task if task.is_a?(Hash) && task[:error]
 
-      broadcast_topic_created(topic) if topic_created
+      topic_created ? broadcast_topic_created(topic) : Crons::ChangeBroadcaster.call(creative)
 
       {
         success: true,
@@ -137,7 +136,7 @@ module Tools
     def broadcast_topic_created(topic)
       TopicsChannel.broadcast_to(
         topic.creative,
-        { action: "created", topic: topic.slice(:id, :name), user_id: Current.user.id }
+        { action: "created", topic: topic.slice(:id, :name), user_id: Current.user.id, cron_changed: true }
       )
     rescue StandardError => e
       Rails.logger.warn("[CronCreateService] Failed to broadcast created topic #{topic.id}: #{e.message}")

--- a/engines/collavre/app/services/collavre/tools/cron_update_service.rb
+++ b/engines/collavre/app/services/collavre/tools/cron_update_service.rb
@@ -51,9 +51,9 @@ module Tools
 
       task.description = description if description.present?
 
-      unless task.save
-        return { error: "Failed to update cron job", details: task.errors.full_messages }
-      end
+      return { error: "Failed to update cron job", details: task.errors.full_messages } unless task.save
+
+      Crons::ChangeBroadcaster.call(creative)
 
       {
         success: true,

--- a/engines/collavre/app/services/collavre/topics/cron_badge_decorator.rb
+++ b/engines/collavre/app/services/collavre/topics/cron_badge_decorator.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Collavre
+  module Topics
+    class CronBadgeDecorator
+      def initialize(creative, main_topic_id, can_delete, view_context)
+        @creative = creative
+        @main_topic_id = main_topic_id
+        @can_delete = can_delete
+        @view_context = view_context
+        @task_index = Crons::RecurringTaskIndex.new
+      end
+
+      def call(payload, topic)
+        tasks = @task_index.tasks_for_topic(
+          @creative.id,
+          topic.id,
+          main_topic_id: @main_topic_id
+        )
+        return payload if tasks.empty?
+
+        payload.merge(
+          cron_badge_html: @view_context.render_cron_badge(
+            tasks,
+            creative_id: @creative.id,
+            can_delete: @can_delete
+          )
+        )
+      end
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/topics/cron_badge_decorator.rb
+++ b/engines/collavre/app/services/collavre/topics/cron_badge_decorator.rb
@@ -8,7 +8,7 @@ module Collavre
         @main_topic_id = main_topic_id
         @can_delete = can_delete
         @view_context = view_context
-        @task_index = Crons::RecurringTaskIndex.new
+        @task_index = Crons::RecurringTaskIndex.for_creative_family(creative)
       end
 
       def call(payload, topic)

--- a/engines/collavre/config/locales/crons.en.yml
+++ b/engines/collavre/config/locales/crons.en.yml
@@ -1,0 +1,14 @@
+---
+en:
+  collavre:
+    crons:
+      title: Scheduled jobs
+      count_one: "__count__ scheduled job"
+      count_other: "__count__ scheduled jobs"
+      schedule: Schedule
+      message: Message
+      next_run: Next run
+      delete: Delete scheduled job
+      delete_confirm: Delete this scheduled job?
+      delete_error: Could not delete the scheduled job. Please try again.
+      not_available: Not available

--- a/engines/collavre/config/locales/crons.ko.yml
+++ b/engines/collavre/config/locales/crons.ko.yml
@@ -1,0 +1,14 @@
+---
+ko:
+  collavre:
+    crons:
+      title: 예약 작업
+      count_one: "예약 작업 __count__개"
+      count_other: "예약 작업 __count__개"
+      schedule: 스케줄 수식
+      message: 메시지
+      next_run: 다음 스케줄 시간
+      delete: 예약 작업 삭제
+      delete_confirm: 이 예약 작업을 삭제하시겠습니까?
+      delete_error: 예약 작업을 삭제하지 못했습니다. 다시 시도해 주세요.
+      not_available: 정보 없음

--- a/engines/collavre/config/routes.rb
+++ b/engines/collavre/config/routes.rb
@@ -6,8 +6,7 @@ Collavre::Engine.routes.draw do
   # cards. Keys come from Collavre::FeatureCardRegistry, which rejects a key this
   # constraint could not route, so the two cannot drift apart.
   get "features", to: "features#index", as: :features
-  get "features/:key", to: "features#show", as: :feature,
-      constraints: { key: Collavre::FeatureCard::GUIDE_KEY_FORMAT }
+  get "features/:key", to: "features#show", as: :feature, constraints: { key: Collavre::FeatureCard::GUIDE_KEY_FORMAT }
 
   # Authentication routes
   resource :session, only: [ :new, :create, :destroy ]
@@ -95,6 +94,7 @@ Collavre::Engine.routes.draw do
     end
   end
   resources :creatives do
+    resources :crons, only: [ :destroy ], param: :key
     post "history/:id/apply", to: "creative_change_sets#apply", as: :apply_change_set
     resources :attachments, only: [ :create ], module: :creatives
     resources :creative_shares, only: [ :index, :create, :update, :destroy ]

--- a/engines/collavre/test/components/cron_badge_component_test.rb
+++ b/engines/collavre/test/components/cron_badge_component_test.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class CronBadgeComponentTest < ViewComponent::TestCase
+  Task = Struct.new(:key, :schedule, :next_time, :arguments)
+
+  test "renders schedule, message, next run, and a deletion action" do
+    time = Time.zone.parse("2026-09-05 09:00")
+    task = Task.new("cron_42_daily", "0 9 * * *", time, [ { message: "Daily summary" } ])
+
+    render_inline(
+      Collavre::CronBadgeComponent.new(
+        tasks: [ task ],
+        creative_id: 42,
+        can_delete: true
+      )
+    )
+
+    assert_selector "[data-controller='popup-menu cron-badge']"
+    assert_selector "[data-cron-badge-count-one-value='__count__ scheduled job']"
+    assert_selector "button.creative-cron-badge[data-cron-badge-target='badge']", text: "1"
+    assert_selector ".cron-task code", text: "0 9 * * *"
+    assert_selector ".cron-task-message", text: "Daily summary"
+    assert_selector "time[datetime='#{time.iso8601}']"
+    assert_selector "button.cron-task-delete[data-cron-delete-url='/creatives/42/crons/cron_42_daily']"
+  end
+
+  test "renders unavailable values and omits deletion without write access" do
+    task = Task.new("cron_42_daily", "0 9 * * *", nil, [])
+
+    render_inline(
+      Collavre::CronBadgeComponent.new(tasks: [ task ], creative_id: 42)
+    )
+
+    assert_text "Not available", count: 2
+    assert_no_selector ".cron-task-delete"
+  end
+end

--- a/engines/collavre/test/controllers/crons_controller_test.rb
+++ b/engines/collavre/test/controllers/crons_controller_test.rb
@@ -43,6 +43,22 @@ class CronsControllerTest < ActionDispatch::IntegrationTest
     assert @task.class.exists?(@task.id)
   end
 
+  test "scopes recurring task lookup to the writable creative family" do
+    index = Minitest::Mock.new
+    index.expect(:tasks_for, [ @task ], [ @creative.id ])
+    scope = lambda do |creative|
+      assert_equal @creative, creative
+      index
+    end
+
+    Collavre::Crons::RecurringTaskIndex.stub(:for_creative_family, scope) do
+      delete collavre.creative_cron_url(@creative, @task.key), as: :json
+    end
+
+    assert_response :no_content
+    assert_mock index
+  end
+
   private
 
   def create_task(creative, topic)

--- a/engines/collavre/test/controllers/crons_controller_test.rb
+++ b/engines/collavre/test/controllers/crons_controller_test.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class CronsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:one)
+    @creative = Collavre::Creative.create!(user: @user, description: "Scheduled work")
+    @topic = @creative.main_topic(fallback_user: @user)
+    @task = create_task(@creative, @topic)
+    sign_in_as @user, password: "password"
+  end
+
+  teardown do
+    @task.destroy! if @task&.persisted?
+  end
+
+  test "destroys a cron belonging to the writable creative and broadcasts the change" do
+    assert_broadcast_on(Collavre::TopicsChannel.broadcasting_for(@creative), action: "cron_changed") do
+      delete collavre.creative_cron_url(@creative, @task.key), as: :json
+    end
+
+    assert_response :no_content
+    assert_not @task.class.exists?(@task.id)
+  end
+
+  test "rejects deletion without write permission" do
+    other_user = users(:two)
+    sign_in_as other_user, password: "password"
+
+    delete collavre.creative_cron_url(@creative, @task.key), as: :json
+
+    assert_response :forbidden
+    assert @task.class.exists?(@task.id)
+  end
+
+  test "does not delete a cron belonging to another creative" do
+    other_creative = Collavre::Creative.create!(user: @user, description: "Other work")
+
+    delete collavre.creative_cron_url(other_creative, @task.key), as: :json
+
+    assert_response :not_found
+    assert @task.class.exists?(@task.id)
+  end
+
+  private
+
+  def create_task(creative, topic)
+    SolidQueue::RecurringTask.create!(
+      key: "cron_#{creative.id}_#{SecureRandom.hex(4)}",
+      class_name: "Collavre::CronActionJob",
+      schedule: "0 9 * * *",
+      static: false,
+      arguments: [ { creative_id: creative.id, topic_id: topic.id, message: "Daily summary" } ]
+    )
+  end
+end

--- a/engines/collavre/test/controllers/topics_controller_test.rb
+++ b/engines/collavre/test/controllers/topics_controller_test.rb
@@ -64,6 +64,24 @@ class TopicsControllerTest < ActionDispatch::IntegrationTest
     task&.destroy! if task&.persisted?
   end
 
+  test "index rejects users without read access before exposing cron details" do
+    task = SolidQueue::RecurringTask.create!(
+      key: "cron_#{@creative.id}_#{SecureRandom.hex(4)}",
+      class_name: "Collavre::CronActionJob",
+      schedule: "0 9 * * *",
+      static: false,
+      arguments: [ { creative_id: @creative.id, topic_id: @topic.id, message: "Private schedule details" } ]
+    )
+    sign_in_as users(:two), password: "password"
+
+    get collavre.creative_topics_url(@creative), as: :json
+
+    assert_response :forbidden
+    assert_not_includes response.body, "Private schedule details"
+  ensure
+    task&.destroy! if task&.persisted?
+  end
+
   test "History topic is read-only, reserved, and kept last" do
     history = @creative.history_topic
     other = @creative.topics.create!(name: "Later", user: @user)

--- a/engines/collavre/test/controllers/topics_controller_test.rb
+++ b/engines/collavre/test/controllers/topics_controller_test.rb
@@ -15,6 +15,55 @@ class TopicsControllerTest < ActionDispatch::IntegrationTest
     assert_equal @creative.id, json["effective_creative_id"]
   end
 
+  test "index adds the shared cron popup badge to the scheduled topic" do
+    task = SolidQueue::RecurringTask.create!(
+      key: "cron_#{@creative.id}_#{SecureRandom.hex(4)}",
+      class_name: "Collavre::CronActionJob",
+      schedule: "0 9 * * *",
+      static: false,
+      arguments: [ { creative_id: @creative.id, topic_id: @topic.id, message: "Daily summary" } ]
+    )
+
+    get collavre.creative_topics_url(@creative), as: :json
+
+    assert_response :success
+    topic = response.parsed_body["topics"].find { |candidate| candidate["id"] == @topic.id }
+    badge = topic.fetch("cron_badge_html")
+    assert_includes badge, "creative-cron-badge"
+    assert_includes badge, "Daily summary"
+    assert_includes badge, "cron-task-delete"
+  ensure
+    task&.destroy! if task&.persisted?
+  end
+
+  test "index hides cron deletion from a read-only collaborator" do
+    collaborator = users(:two)
+    Collavre::CreativeShare.create!(
+      creative: @creative,
+      user: collaborator,
+      shared_by: @user,
+      permission: :read
+    )
+    task = SolidQueue::RecurringTask.create!(
+      key: "cron_#{@creative.id}_#{SecureRandom.hex(4)}",
+      class_name: "Collavre::CronActionJob",
+      schedule: "0 9 * * *",
+      static: false,
+      arguments: [ { creative_id: @creative.id, topic_id: @topic.id, message: "Daily summary" } ]
+    )
+    sign_in_as collaborator, password: "password"
+
+    get collavre.creative_topics_url(@creative), as: :json
+
+    assert_response :success
+    topic = response.parsed_body["topics"].find { |candidate| candidate["id"] == @topic.id }
+    badge = topic.fetch("cron_badge_html")
+    assert_includes badge, "Daily summary"
+    assert_not_includes badge, "cron-task-delete"
+  ensure
+    task&.destroy! if task&.persisted?
+  end
+
   test "History topic is read-only, reserved, and kept last" do
     history = @creative.history_topic
     other = @creative.topics.create!(name: "Later", user: @user)

--- a/engines/collavre/test/helpers/creatives_helper_test.rb
+++ b/engines/collavre/test/helpers/creatives_helper_test.rb
@@ -4,11 +4,22 @@ class CreativesHelperTest < ActionView::TestCase
   include Collavre::CreativesHelper
 
   test "render_cron_badge shows the count, schedules, and next run times" do
-    first = Struct.new(:schedule, :next_time).new("0 9 * * *", Time.zone.parse("2026-09-05 09:00"))
-    second = Struct.new(:schedule, :next_time).new("0 18 * * *", Time.zone.parse("2026-09-05 18:00"))
+    task = Struct.new(:key, :schedule, :next_time, :arguments)
+    first = task.new(
+      "cron_1_first",
+      "0 9 * * *",
+      Time.zone.parse("2026-09-05 09:00"),
+      [ { message: "Morning check-in" } ]
+    )
+    second = task.new(
+      "cron_1_second",
+      "0 18 * * *",
+      Time.zone.parse("2026-09-05 18:00"),
+      [ { message: "Evening check-in" } ]
+    )
 
     I18n.with_locale(:en) do
-      html = render_cron_badge([ first, second ])
+      html = render_cron_badge([ first, second ], creative_id: 1)
 
       assert_includes html, "creative-cron-badge"
       assert_includes html, "⏰"
@@ -16,6 +27,8 @@ class CreativesHelperTest < ActionView::TestCase
       assert_includes html, "2 scheduled jobs"
       assert_includes html, "0 9 * * *"
       assert_includes html, I18n.l(first.next_time, format: :short)
+      assert_includes html, "Morning check-in"
+      assert_includes html, "click->popup-menu#toggle"
     end
   end
 

--- a/engines/collavre/test/services/collavre/crons/change_broadcaster_test.rb
+++ b/engines/collavre/test/services/collavre/crons/change_broadcaster_test.rb
@@ -5,28 +5,36 @@ require "test_helper"
 module Collavre
   module Crons
     class ChangeBroadcasterTest < ActiveSupport::TestCase
-      test "broadcasts a cron change to the creative" do
+      test "broadcasts a cron change to the creative and its readable tree streams" do
         creative = creatives(:tshirt)
         broadcast = nil
+        invalidations = []
 
-        TopicsChannel.stub(:broadcast_to, ->(*args) { broadcast = args }) do
-          ChangeBroadcaster.call(creative)
+        CreativeTreeInvalidationJob.stub(:perform_later, ->(ids) { invalidations << ids }) do
+          TopicsChannel.stub(:broadcast_to, ->(*args) { broadcast = args }) do
+            ChangeBroadcaster.call(creative)
+          end
         end
 
         assert_equal [ creative, { action: "cron_changed" } ], broadcast
+        assert_equal [ [ creative.id ] ], invalidations
       end
 
       test "does not fail the completed mutation when broadcasting fails" do
         creative = creatives(:tshirt)
         warning = nil
+        invalidations = []
 
         Rails.logger.stub(:warn, ->(message) { warning = message }) do
-          TopicsChannel.stub(:broadcast_to, ->(*) { raise "cable unavailable" }) do
-            ChangeBroadcaster.call(creative)
+          CreativeTreeInvalidationJob.stub(:perform_later, ->(ids) { invalidations << ids }) do
+            TopicsChannel.stub(:broadcast_to, ->(*) { raise "cable unavailable" }) do
+              ChangeBroadcaster.call(creative)
+            end
           end
         end
 
         assert_match(/Broadcast failed for creative #{creative.id}: cable unavailable/, warning)
+        assert_equal [ [ creative.id ] ], invalidations
       end
     end
   end

--- a/engines/collavre/test/services/collavre/crons/change_broadcaster_test.rb
+++ b/engines/collavre/test/services/collavre/crons/change_broadcaster_test.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  module Crons
+    class ChangeBroadcasterTest < ActiveSupport::TestCase
+      test "broadcasts a cron change to the creative" do
+        creative = creatives(:tshirt)
+        broadcast = nil
+
+        TopicsChannel.stub(:broadcast_to, ->(*args) { broadcast = args }) do
+          ChangeBroadcaster.call(creative)
+        end
+
+        assert_equal [ creative, { action: "cron_changed" } ], broadcast
+      end
+
+      test "does not fail the completed mutation when broadcasting fails" do
+        creative = creatives(:tshirt)
+        warning = nil
+
+        Rails.logger.stub(:warn, ->(message) { warning = message }) do
+          TopicsChannel.stub(:broadcast_to, ->(*) { raise "cable unavailable" }) do
+            ChangeBroadcaster.call(creative)
+          end
+        end
+
+        assert_match(/Broadcast failed for creative #{creative.id}: cable unavailable/, warning)
+      end
+    end
+  end
+end

--- a/engines/collavre/test/services/collavre/crons/change_broadcaster_test.rb
+++ b/engines/collavre/test/services/collavre/crons/change_broadcaster_test.rb
@@ -36,6 +36,19 @@ module Collavre
         assert_match(/Broadcast failed for creative #{creative.id}: cable unavailable/, warning)
         assert_equal [ [ creative.id ] ], invalidations
       end
+
+      test "broadcasts only the tree change when requested" do
+        creative = creatives(:tshirt)
+        invalidations = []
+
+        TopicsChannel.stub(:broadcast_to, ->(*) { flunk "tree-only changes must not broadcast a topic event" }) do
+          CreativeTreeInvalidationJob.stub(:perform_later, ->(ids) { invalidations << ids }) do
+            ChangeBroadcaster.tree_only(creative)
+          end
+        end
+
+        assert_equal [ [ creative.id ] ], invalidations
+      end
     end
   end
 end

--- a/engines/collavre/test/services/collavre/crons/recurring_task_index_test.rb
+++ b/engines/collavre/test/services/collavre/crons/recurring_task_index_test.rb
@@ -46,15 +46,41 @@ module Collavre
         assert_empty index.tasks_for(linked.id)
       end
 
+      test "groups cron tasks by topic and treats a missing topic as Main" do
+        main_topic = @creative.main_topic(fallback_user: users(:one))
+        other_topic = @creative.topics.create!(name: "Scheduled topic", user: users(:one))
+        main_task = create_task(
+          key: "cron_#{@creative.id}_main_#{SecureRandom.hex(4)}",
+          arguments: [ { creative_id: @creative.id } ]
+        )
+        other_task = create_task(
+          key: "cron_#{@creative.id}_topic_#{SecureRandom.hex(4)}",
+          arguments: [ { creative_id: @creative.id, topic_id: other_topic.id } ]
+        )
+
+        index = RecurringTaskIndex.new
+
+        assert_equal [ main_task.key ], index.tasks_for_topic(
+          @creative.id,
+          main_topic.id,
+          main_topic_id: main_topic.id
+        ).map(&:key)
+        assert_equal [ other_task.key ], index.tasks_for_topic(
+          @creative.id,
+          other_topic.id,
+          main_topic_id: main_topic.id
+        ).map(&:key)
+      end
+
       private
 
-      def create_task(key:, static: false)
+      def create_task(key:, static: false, arguments: [])
         task = SolidQueue::RecurringTask.create!(
           key: key,
           class_name: "Collavre::CronActionJob",
           schedule: "0 9 * * *",
           static: static,
-          arguments: []
+          arguments: arguments
         )
         @tasks << task
         task

--- a/engines/collavre/test/services/collavre/crons/recurring_task_index_test.rb
+++ b/engines/collavre/test/services/collavre/crons/recurring_task_index_test.rb
@@ -46,6 +46,19 @@ module Collavre
         assert_empty index.tasks_for(linked.id)
       end
 
+      test "scopes a creative family index to the origin and its linked creatives" do
+        linked = Creative.create!(user: users(:two), origin: @creative)
+        unrelated = creatives(:root_parent)
+        origin_task = create_task(key: "cron_#{@creative.id}_#{SecureRandom.hex(4)}")
+        linked_task = create_task(key: "cron_#{linked.id}_#{SecureRandom.hex(4)}")
+        create_task(key: "cron_#{unrelated.id}_#{SecureRandom.hex(4)}")
+
+        index = RecurringTaskIndex.for_creative_family(@creative)
+
+        assert_equal [ @creative.id ], index.creative_ids
+        assert_equal [ origin_task.key, linked_task.key ].sort, index.tasks_for(@creative.id).map(&:key)
+      end
+
       test "groups cron tasks by topic and treats a missing topic as Main" do
         main_topic = @creative.main_topic(fallback_user: users(:one))
         other_topic = @creative.topics.create!(name: "Scheduled topic", user: users(:one))

--- a/engines/collavre/test/services/collavre/crons/recurring_task_index_test.rb
+++ b/engines/collavre/test/services/collavre/crons/recurring_task_index_test.rb
@@ -59,6 +59,45 @@ module Collavre
         assert_equal [ origin_task.key, linked_task.key ].sort, index.tasks_for(@creative.id).map(&:key)
       end
 
+      test "scopes details for multiple visible creative families" do
+        other = creatives(:root_parent)
+        unrelated = Creative.create!(user: @creative.user, description: "Unrelated")
+        included_task = create_task(key: "cron_#{@creative.id}_#{SecureRandom.hex(4)}")
+        other_task = create_task(key: "cron_#{other.id}_#{SecureRandom.hex(4)}")
+        create_task(key: "cron_#{unrelated.id}_#{SecureRandom.hex(4)}")
+
+        index = RecurringTaskIndex.for_creatives([ @creative, other ])
+
+        assert_equal [ included_task.key ], index.tasks_for(@creative.id).map(&:key)
+        assert_equal [ other_task.key ], index.tasks_for(other.id).map(&:key)
+      end
+
+      test "returns an empty index for no visible creatives" do
+        index = RecurringTaskIndex.for_creatives([])
+
+        assert_empty index.creative_ids
+        assert_empty index.tasks_for(@creative.id)
+      end
+
+      test "loads only keys for creative id filtering and defers task details" do
+        create_task(
+          key: "cron_#{@creative.id}_#{SecureRandom.hex(4)}",
+          arguments: [ { message: "large payload" } ]
+        )
+        queries = []
+        subscriber = lambda do |_name, _started, _finished, _unique_id, payload|
+          queries << payload[:sql] if payload[:sql].include?("solid_queue_recurring_tasks")
+        end
+        index = RecurringTaskIndex.new
+
+        ActiveSupport::Notifications.subscribed(subscriber, "sql.active_record") do
+          assert_includes index.creative_ids, @creative.id
+        end
+
+        assert queries.any?
+        assert queries.none? { |sql| sql.include?("arguments") }
+      end
+
       test "groups cron tasks by topic and treats a missing topic as Main" do
         main_topic = @creative.main_topic(fallback_user: users(:one))
         other_topic = @creative.topics.create!(name: "Scheduled topic", user: users(:one))

--- a/engines/collavre/test/services/collavre/crons/recurring_task_index_test.rb
+++ b/engines/collavre/test/services/collavre/crons/recurring_task_index_test.rb
@@ -124,6 +124,31 @@ module Collavre
         ).map(&:key)
       end
 
+      test "indexes task arguments once across topic lookups" do
+        main_topic = @creative.main_topic(fallback_user: users(:one))
+        other_topic = @creative.topics.create!(name: "Indexed topic", user: users(:one))
+        create_task(
+          key: "cron_#{@creative.id}_main_#{SecureRandom.hex(4)}",
+          arguments: [ { creative_id: @creative.id } ]
+        )
+        create_task(
+          key: "cron_#{@creative.id}_topic_#{SecureRandom.hex(4)}",
+          arguments: [ { creative_id: @creative.id, topic_id: other_topic.id } ]
+        )
+        index = RecurringTaskIndex.new
+        parse_count = 0
+        original_parser = index.method(:parse_arguments)
+        index.define_singleton_method(:parse_arguments) do |task|
+          parse_count += 1
+          original_parser.call(task)
+        end
+
+        index.tasks_for_topic(@creative.id, main_topic.id, main_topic_id: main_topic.id)
+        index.tasks_for_topic(@creative.id, other_topic.id, main_topic_id: main_topic.id)
+
+        assert_equal 2, parse_count
+      end
+
       private
 
       def create_task(key:, static: false, arguments: [])

--- a/engines/collavre/test/services/collavre/tools/cron_create_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/cron_create_service_test.rb
@@ -131,7 +131,10 @@ module Collavre
           topic = @creative.topics.find_by!(name: "New Cron Topic")
           assert_equal @user, topic.user
           assert_equal topic.id, task.arguments.first[:topic_id]
-          assert_equal [ @creative, { action: "created", topic: topic.slice(:id, :name), user_id: @user.id } ], broadcast
+          assert_equal [
+            @creative,
+            { action: "created", topic: topic.slice(:id, :name), user_id: @user.id, cron_changed: true }
+          ], broadcast
         end
       end
 
@@ -225,7 +228,10 @@ module Collavre
         topic = @creative.topics.find_by!(name: "Adopted Topic")
         assert_equal "queue unavailable", error.message
         assert_equal topic.id, adopted_task.arguments.first[:topic_id]
-        assert_equal [ @creative, { action: "created", topic: topic.slice(:id, :name), user_id: @user.id } ], broadcast
+        assert_equal [
+          @creative,
+          { action: "created", topic: topic.slice(:id, :name), user_id: @user.id, cron_changed: true }
+        ], broadcast
       end
 
       test "removes a new topic and preserves the original error when the adoption check fails" do

--- a/engines/collavre/test/services/collavre/tools/cron_create_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/cron_create_service_test.rb
@@ -117,25 +117,30 @@ module Collavre
 
       test "creates a missing topic and targets it" do
         broadcast = nil
+        invalidated = nil
 
-        TopicsChannel.stub(:broadcast_to, ->(*args) { broadcast = args }) do
-          result = CronCreateService.new.call(
-            creative_id: @creative.id,
-            topic_name: "New Cron Topic",
-            schedule: "0 9 * * *",
-            message: "test"
-          )
+        Crons::ChangeBroadcaster.stub(:tree_only, ->(creative) { invalidated = creative }) do
+          TopicsChannel.stub(:broadcast_to, ->(*args) { broadcast = args }) do
+            result = CronCreateService.new.call(
+              creative_id: @creative.id,
+              topic_name: "New Cron Topic",
+              schedule: "0 9 * * *",
+              message: "test"
+            )
 
-          assert result[:success]
-          task = SolidQueue::RecurringTask.find_by!(key: result[:key])
-          topic = @creative.topics.find_by!(name: "New Cron Topic")
-          assert_equal @user, topic.user
-          assert_equal topic.id, task.arguments.first[:topic_id]
-          assert_equal [
-            @creative,
-            { action: "created", topic: topic.slice(:id, :name), user_id: @user.id, cron_changed: true }
-          ], broadcast
+            assert result[:success]
+            task = SolidQueue::RecurringTask.find_by!(key: result[:key])
+            topic = @creative.topics.find_by!(name: "New Cron Topic")
+            assert_equal @user, topic.user
+            assert_equal topic.id, task.arguments.first[:topic_id]
+            assert_equal [
+              @creative,
+              { action: "created", topic: topic.slice(:id, :name), user_id: @user.id, cron_changed: true }
+            ], broadcast
+          end
         end
+
+        assert_equal @creative, invalidated
       end
 
       test "does not create a missing topic for an invalid schedule" do
@@ -153,14 +158,17 @@ module Collavre
 
       test "keeps the cron successful when broadcasting a created topic fails" do
         warning = nil
-        result = Rails.logger.stub(:warn, ->(message) { warning = message }) do
-          TopicsChannel.stub(:broadcast_to, ->(*) { raise "cable unavailable" }) do
-            CronCreateService.new.call(
-              creative_id: @creative.id,
-              topic_name: "Broadcast Failure Topic",
-              schedule: "0 9 * * *",
-              message: "test"
-            )
+        invalidated = nil
+        result = Crons::ChangeBroadcaster.stub(:tree_only, ->(creative) { invalidated = creative }) do
+          Rails.logger.stub(:warn, ->(message) { warning = message }) do
+            TopicsChannel.stub(:broadcast_to, ->(*) { raise "cable unavailable" }) do
+              CronCreateService.new.call(
+                creative_id: @creative.id,
+                topic_name: "Broadcast Failure Topic",
+                schedule: "0 9 * * *",
+                message: "test"
+              )
+            end
           end
         end
 
@@ -169,6 +177,7 @@ module Collavre
         task = SolidQueue::RecurringTask.find_by!(key: result[:key])
         assert_equal topic.id, task.arguments.first[:topic_id]
         assert_match(/Failed to broadcast created topic #{topic.id}: cable unavailable/, warning)
+        assert_equal @creative, invalidated
       end
 
       test "removes a newly created topic when recurring task creation fails" do

--- a/engines/collavre/test/services/creatives/tree_builder_test.rb
+++ b/engines/collavre/test/services/creatives/tree_builder_test.rb
@@ -9,8 +9,8 @@ module Creatives
         "<iframe></iframe>"
       end
 
-      def render_creative_progress(_creative, select_mode: false, has_children: nil, can_write: nil, can_feedback: nil, unread_count: nil, cron_tasks: [])
-        "<progress data-select='#{select_mode}'></progress><cron-badge count='#{cron_tasks.size}'></cron-badge>"
+      def render_creative_progress(_creative, select_mode: false, has_children: nil, can_write: nil, can_feedback: nil, unread_count: nil, cron_tasks: [], can_delete_cron: nil)
+        "<progress data-select='#{select_mode}'></progress><cron-badge count='#{cron_tasks.size}' can-delete='#{can_delete_cron}'></cron-badge>"
       end
 
       def svg_tag(name, className: nil, width: nil, height: nil)
@@ -103,9 +103,37 @@ module Creatives
 
       nodes = build_tree_builder(params: { has_cron: "true" }).build([ creative ])
 
-      assert_includes nodes.first.dig(:templates, :progress_html), "<cron-badge count='1'>"
+      assert_includes nodes.first.dig(:templates, :progress_html), "<cron-badge count='1'"
     ensure
       task&.destroy!
+    end
+
+    test "allows cron deletion for a writer when source content is read-only" do
+      source_type = "tree_builder_read_only_source"
+      Creative.register_read_only_source(source_type)
+      owner = users(:two)
+      creative = Creative.create!(
+        user: owner,
+        progress: 0,
+        description: "Read-only scheduled",
+        data: { "source" => { "type" => source_type } }
+      )
+      CreativeShare.create!(creative: creative, user: @user, shared_by: owner, permission: :write)
+      task = SolidQueue::RecurringTask.create!(
+        key: "cron_#{creative.id}_#{SecureRandom.hex(4)}",
+        class_name: "Collavre::CronActionJob",
+        schedule: "0 9 * * *",
+        static: false,
+        arguments: []
+      )
+
+      node = build_tree_builder(params: { has_cron: "true" }).build([ creative ]).first
+
+      assert_equal false, node[:can_write]
+      assert_includes node.dig(:templates, :progress_html), "can-delete='true'"
+    ensure
+      task&.destroy!
+      Creative.read_only_source_types.delete(source_type) if source_type
     end
 
     private

--- a/engines/collavre/test/system/creative_cron_badge_alignment_test.rb
+++ b/engines/collavre/test/system/creative_cron_badge_alignment_test.rb
@@ -1,0 +1,50 @@
+require_relative "../application_system_test_case"
+
+class CreativeCronBadgeAlignmentTest < ApplicationSystemTestCase
+  setup do
+    @user = User.create!(
+      email: "cron-badge-alignment@example.com",
+      password: SystemHelpers::PASSWORD,
+      name: "CronBadgeAlignmentUser",
+      email_verified_at: Time.current,
+      notifications_enabled: false
+    )
+    @creative = Creative.create!(description: "Scheduled creative", user: @user)
+    @task = SolidQueue::RecurringTask.create!(
+      key: "cron_#{@creative.id}_alignment",
+      class_name: "Collavre::CronActionJob",
+      schedule: "0 9 * * *",
+      static: false,
+      arguments: []
+    )
+
+    resize_window_to
+    sign_in_via_ui(@user)
+  end
+
+  teardown do
+    @task.destroy! if @task&.persisted?
+  end
+
+  test "cron badge aligns vertically with the progress checkbox" do
+    visit collavre.creatives_path(has_cron: "true")
+    row_selector = "#creative-#{@creative.id}"
+    assert_selector "#{row_selector} .progress-toggle-checkbox", visible: :all
+    assert_selector "#{row_selector} .creative-cron-badge", visible: :all
+
+    positions = page.evaluate_script(<<~JS)
+      (() => {
+        const centerY = (selector) => {
+          const rect = document.querySelector(selector).getBoundingClientRect()
+          return rect.top + rect.height / 2
+        }
+        return {
+          checkbox: centerY('#{row_selector} .progress-toggle-checkbox'),
+          badge: centerY('#{row_selector} .creative-cron-badge')
+        }
+      })()
+    JS
+
+    assert_in_delta positions.fetch("checkbox"), positions.fetch("badge"), 1
+  end
+end


### PR DESCRIPTION
## Summary

- render one shared cron badge component in creative results and topic tabs
- show schedule, message, next run time, and a permission-gated delete action in the popup
- refresh topic badges after cron mutations and preserve successful mutations when realtime broadcasting is unavailable
- provide English and Korean UI strings and update count accessibility labels after deletion

## Testing

- `mise exec -- ./bin/rubocop -a`
- `mise exec -- bin/complexity_check`
- `mise exec -- bundle exec rake test` (4,805 tests)
- `npm test -- --runInBand` (1,718 tests)
- `mise exec -- bundle exec rake test:system` (113 tests, 2 environment skips)
- targeted cron badge/controller/service/i18n tests (134 tests)