### PR TITLE
fix: preserve persisted All Messages selection

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_09_03_190000) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_08_000000) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -983,6 +983,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_03_190000) do
     t.datetime "created_at", null: false
     t.integer "creative_id"
     t.json "expanded_status", default: {}, null: false
+    t.boolean "last_topic_all_messages", default: false, null: false
     t.integer "last_topic_id"
     t.integer "last_topic_revision", default: 0, null: false
     t.bigint "last_topic_save_fence_applied", default: 0, null: false

--- a/engines/collavre/app/controllers/collavre/user_creative_preferences_controller.rb
+++ b/engines/collavre/app/controllers/collavre/user_creative_preferences_controller.rb
@@ -46,7 +46,8 @@ module Collavre
       render json: {
         success: saved,
         stale_last_topic_save: !saved,
-        last_topic_revision: [ record.id, record.last_topic_revision ]
+        last_topic_revision: [ record.id, record.last_topic_revision ],
+        last_topic_all_messages: record.last_topic_all_messages?
       }
     end
 
@@ -78,7 +79,8 @@ module Collavre
     end
 
     def empty_preference?(record, state)
-      state.empty? && record.last_topic_id.nil? && record.last_topic_revision.to_i.zero? &&
+      state.empty? && record.last_topic_id.nil? && !record.last_topic_all_messages? &&
+        record.last_topic_revision.to_i.zero? &&
         record.last_topic_save_fence_issued.to_i.zero? && record.last_topic_save_fence_applied.to_i.zero?
     end
 
@@ -102,11 +104,11 @@ module Collavre
 
         record.expanded_status ||= {}
         record.last_topic_id = params[:last_topic_id].presence
+        record.last_topic_all_messages = params[:last_topic_id].blank?
         record.last_topic_revision = record.last_topic_revision.to_i + 1
         assign_last_topic_save_order(record)
-        # Retain a cleared preference after it has participated in last-topic
-        # ordering. Its revision lets a reopened client distinguish a newer
-        # Main selection from the empty snapshot that preceded an in-flight save.
+        # Retain All Messages as an explicit preference even though it has no
+        # topic id. The marker distinguishes it from deletion and move tombstones.
         if empty_preference?(record, record.expanded_status)
           record.destroy!
         else
@@ -227,6 +229,7 @@ module Collavre
       payload = {
         action: "last_topic_changed",
         last_topic_id: record.last_topic_id,
+        last_topic_all_messages: record.last_topic_all_messages?,
         last_topic_revision: [ record.id, record.last_topic_revision ],
         client_id: params[:client_id].presence
       }

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_archived.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_archived.test.js
@@ -752,6 +752,16 @@ describe('TopicsController archived topic messages', () => {
         expect(controller.currentTopicId).toBe('1')
       })
 
+      test('does not expose a saved preference naming the same deleted topic', () => {
+        controller.serverLastTopicId = '3'
+        controller.setOverrideTopicId('3')
+
+        deleteBroadcast(3)
+
+        expect(controller.currentTopicId).toBe('1')
+        expect(controller.serverLastTopicId).toBe('1')
+      })
+
       test('drops a ?topic_id= naming it', () => {
         window.history.replaceState({}, '', '/?topic_id=3')
 

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_delete.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_delete.test.js
@@ -97,6 +97,7 @@ describe('TopicsController#deleteTopic', () => {
   test('allows All Messages to scroll into view after deleting the selected topic', async () => {
     controller.serverLastTopicId = '99'
     controller._topicScrollInterrupted = true
+    const saveLastTopic = jest.spyOn(controller, 'debounceSaveLastTopic')
     const interruptionStatesAtLoad = []
     controller.loadTopics = jest.fn(() => {
       interruptionStatesAtLoad.push(controller._topicScrollInterrupted)
@@ -109,6 +110,8 @@ describe('TopicsController#deleteTopic', () => {
     await controller.deleteTopic({ stopPropagation: jest.fn(), currentTarget: button })
 
     expect(interruptionStatesAtLoad).toEqual([false])
+    expect(saveLastTopic).not.toHaveBeenCalled()
+    expect(controller._explicitAllMessagesSelection).toBe(false)
   })
 
   test('allows All Messages to scroll into view when the deleted broadcast arrives before the response', async () => {

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_scroll.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_scroll.test.js
@@ -156,6 +156,7 @@ describe('TopicsController topic strip scrolling', () => {
         controller.creativeIdValue = '42'
         controller.serverLastTopicId = '1'
         controller._topicScrollInterrupted = true
+        const saveLastTopic = jest.spyOn(controller, 'debounceSaveLastTopic')
         const interruptionStatesAtLoad = []
         controller.loadTopics = jest.fn(() => {
             interruptionStatesAtLoad.push(controller._topicScrollInterrupted)
@@ -164,6 +165,8 @@ describe('TopicsController topic strip scrolling', () => {
         controller.handleTopicMoved({ detail: { sourceCreativeId: '42', topicId: '1' } })
 
         expect(interruptionStatesAtLoad).toEqual([false])
+        expect(saveLastTopic).not.toHaveBeenCalled()
+        expect(controller._explicitAllMessagesSelection).toBe(false)
     })
 
     test('preserves the user scroll lock when moving an inactive topic away', () => {

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_scroll.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_scroll.test.js
@@ -169,6 +169,20 @@ describe('TopicsController topic strip scrolling', () => {
         expect(controller._explicitAllMessagesSelection).toBe(false)
     })
 
+    test('clears a moved preference hidden behind a deep link to the same topic', () => {
+        controller.creativeIdValue = '42'
+        controller.serverLastTopicId = '1'
+        controller.setOverrideTopicId('1')
+        controller.loadTopics = jest.fn()
+        const saveLastTopic = jest.spyOn(controller, 'debounceSaveLastTopic')
+
+        controller.handleTopicMoved({ detail: { sourceCreativeId: '42', topicId: '1' } })
+
+        expect(controller.currentTopicId).toBe('')
+        expect(controller.serverLastTopicId).toBe('')
+        expect(saveLastTopic).not.toHaveBeenCalled()
+    })
+
     test('preserves the user scroll lock when moving an inactive topic away', () => {
         controller.creativeIdValue = '42'
         controller.serverLastTopicId = '1'

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_selection_race.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_selection_race.test.js
@@ -308,7 +308,7 @@ describe('TopicsController selection vs. in-flight loadTopics', () => {
   })
 
   describe('a persisted All Messages selection', () => {
-    const loadEmptyPreference = (revision) => {
+    const loadEmptyPreference = ({ revision = 2, allMessages = true } = {}) => {
       global.fetch = jest.fn().mockResolvedValue({
         ok: true,
         status: 200,
@@ -318,6 +318,7 @@ describe('TopicsController selection vs. in-flight loadTopics', () => {
           can_manage: true,
           main_topic_id: 1,
           last_topic_id: null,
+          last_topic_all_messages: allMessages,
           last_topic_revision: [5, revision],
         }),
       })
@@ -338,8 +339,8 @@ describe('TopicsController selection vs. in-flight loadTopics', () => {
       expect(changeEvents.at(-1).topicId).toBe('')
     })
 
-    test('is restored from a cleared preference revision', async () => {
-      await loadEmptyPreference(2)
+    test('is restored from an explicit server preference', async () => {
+      await loadEmptyPreference()
 
       expect(controller.currentTopicId).toBe('')
       expect(controller.listTarget.querySelector('.topic-all-messages').classList)
@@ -349,19 +350,41 @@ describe('TopicsController selection vs. in-flight loadTopics', () => {
 
     test('outranks the legacy localStorage migration', async () => {
       localStorage.setItem('collavre_creative_42_last_topic', '2')
-      await loadEmptyPreference(2)
+      await loadEmptyPreference()
 
       expect(controller.currentTopicId).toBe('')
       expect(saveLastTopic).not.toHaveBeenCalledWith('42', '2', expect.any(String), expect.anything())
       expect(localStorage.getItem('collavre_creative_42_last_topic')).toBeNull()
     })
 
-    test('an untouched preference still defaults to Main', async () => {
-      await loadEmptyPreference(0)
+    test('a deletion or move tombstone still defaults to Main', async () => {
+      await loadEmptyPreference({ allMessages: false })
 
       expect(controller.currentTopicId).toBe('1')
       expect(controller.listTarget.querySelector('.topic-tag[data-id="1"]').classList)
         .toContain('active')
+    })
+
+    test('does not write a deep link over the stored All Messages preference', async () => {
+      window.history.replaceState({}, '', '/creatives/42?topic_id=3')
+      const saveSpy = jest.spyOn(controller, 'debounceSaveLastTopic')
+
+      await loadEmptyPreference()
+
+      expect(controller.currentTopicId).toBe('3')
+      expect(saveSpy).not.toHaveBeenCalled()
+      expect(controller._explicitAllMessagesSelection).toBe(true)
+    })
+
+    test('does not rewrite the preference for an empty deep-link override', async () => {
+      controller.setOverrideTopicId('')
+      const saveSpy = jest.spyOn(controller, 'debounceSaveLastTopic')
+
+      await loadEmptyPreference()
+
+      expect(controller.currentTopicId).toBe('')
+      expect(saveSpy).not.toHaveBeenCalled()
+      expect(controller._explicitAllMessagesSelection).toBe(true)
     })
   })
 

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_selection_race.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_selection_race.test.js
@@ -257,6 +257,51 @@ describe('TopicsController selection vs. in-flight loadTopics', () => {
     expect(controller.topics.map((topic) => topic.id)).toEqual([1, 3])
   })
 
+  test('a deleted deep link does not replace its distinct saved preference with Main', async () => {
+    let resolveStaleFetch
+    let resolveReloadFetch
+    global.fetch = jest.fn()
+      .mockImplementationOnce(() => new Promise((resolve) => { resolveStaleFetch = resolve }))
+      .mockImplementationOnce(() => new Promise((resolve) => { resolveReloadFetch = resolve }))
+    controller.serverLastTopicId = '3'
+    controller.setOverrideTopicId('2')
+    const saveSpy = jest.spyOn(controller, 'debounceSaveLastTopic')
+
+    const loading = controller.loadTopics()
+    controller.handleTopicMessage({ action: 'deleted', topic_id: 2 })
+
+    expect(controller.currentTopicId).toBe('3')
+    expect(saveSpy).not.toHaveBeenCalled()
+
+    resolveStaleFetch({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        topics: TOPICS,
+        archived_topics: [],
+        can_manage: true,
+        main_topic_id: 1,
+        last_topic_id: 3,
+      }),
+    })
+    await loading
+    resolveReloadFetch({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        topics: [TOPICS[0], TOPICS[2]],
+        archived_topics: [],
+        can_manage: true,
+        main_topic_id: 1,
+        last_topic_id: 3,
+      }),
+    })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(controller.currentTopicId).toBe('3')
+    expect(saveSpy).not.toHaveBeenCalledWith('1')
+  })
+
   // The strip can also be stale about its own creative: another member deletes
   // a topic while the chip for it is still on screen. The pick is about this
   // creative, but it names a topic that no longer exists, so keeping it would

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_selection_race.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_selection_race.test.js
@@ -307,6 +307,64 @@ describe('TopicsController selection vs. in-flight loadTopics', () => {
     })
   })
 
+  describe('a persisted All Messages selection', () => {
+    const loadEmptyPreference = (revision) => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          topics: TOPICS,
+          archived_topics: [],
+          can_manage: true,
+          main_topic_id: 1,
+          last_topic_id: null,
+          last_topic_revision: [5, revision],
+        }),
+      })
+      return controller.loadTopics()
+    }
+
+    afterEach(() => localStorage.clear())
+
+    test('survives a later topic re-render', () => {
+      controller.selectTopic('')
+      controller._pendingPick = null
+
+      controller.handleTopicMessage({ action: 'updated', topic: { id: 1, name: 'Renamed Main' } })
+
+      expect(controller.currentTopicId).toBe('')
+      expect(controller.listTarget.querySelector('.topic-all-messages').classList)
+        .toContain('active')
+      expect(changeEvents.at(-1).topicId).toBe('')
+    })
+
+    test('is restored from a cleared preference revision', async () => {
+      await loadEmptyPreference(2)
+
+      expect(controller.currentTopicId).toBe('')
+      expect(controller.listTarget.querySelector('.topic-all-messages').classList)
+        .toContain('active')
+      expect(changeEvents.at(-1).topicId).toBe('')
+    })
+
+    test('outranks the legacy localStorage migration', async () => {
+      localStorage.setItem('collavre_creative_42_last_topic', '2')
+      await loadEmptyPreference(2)
+
+      expect(controller.currentTopicId).toBe('')
+      expect(saveLastTopic).not.toHaveBeenCalledWith('42', '2', expect.any(String), expect.anything())
+      expect(localStorage.getItem('collavre_creative_42_last_topic')).toBeNull()
+    })
+
+    test('an untouched preference still defaults to Main', async () => {
+      await loadEmptyPreference(0)
+
+      expect(controller.currentTopicId).toBe('1')
+      expect(controller.listTarget.querySelector('.topic-tag[data-id="1"]').classList)
+        .toContain('active')
+    })
+  })
+
   // A pick can only outrank the response if it was made against the strip of
   // the creative the response describes. Switching creatives leaves the
   // previous creative's chips on screen until the new strip lands, so a click
@@ -499,14 +557,14 @@ describe('TopicsController selection vs. in-flight loadTopics', () => {
       expect(saveLastTopic).toHaveBeenLastCalledWith('42', '3', expect.any(String), expect.anything())
     })
 
-    test('re-dispatches a picked All Messages after an interim restore', async () => {
+    test('keeps a picked All Messages through an interim restore', async () => {
       let resolveFetch
       global.fetch = jest.fn(() => new Promise((resolve) => { resolveFetch = resolve }))
 
       const loading = controller.loadTopics()
       controller.selectTopic('')
       broadcastCreate()
-      expect(changeEvents.at(-1).topicId).toBe('1')
+      expect(changeEvents.at(-1).topicId).toBe('')
 
       respond(resolveFetch)
       await loading

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_selection_race.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_selection_race.test.js
@@ -412,6 +412,17 @@ describe('TopicsController selection vs. in-flight loadTopics', () => {
       expect(saveSpy).not.toHaveBeenCalled()
       expect(controller._explicitAllMessagesSelection).toBe(true)
     })
+
+    test('keeps All Messages behind a deleted deep-linked topic', () => {
+      controller.serverLastTopicId = ''
+      controller._explicitAllMessagesSelection = true
+      controller.setOverrideTopicId('2')
+
+      controller.handleTopicMessage({ action: 'deleted', topic_id: 2 })
+
+      expect(controller.currentTopicId).toBe('')
+      expect(controller._explicitAllMessagesSelection).toBe(true)
+    })
   })
 
   // A pick can only outrank the response if it was made against the strip of

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_selection_race.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_selection_race.test.js
@@ -122,6 +122,32 @@ describe('TopicsController selection vs. in-flight loadTopics', () => {
     expect(controller.serverLastTopicId).toBe('3')
   })
 
+  test('a deletion broadcast invalidates an older topic-list response', async () => {
+    let resolveFetch
+    global.fetch = jest.fn(() => new Promise((resolve) => { resolveFetch = resolve }))
+    controller.serverLastTopicId = '2'
+
+    const loading = controller.loadTopics()
+    controller.handleTopicMessage({ action: 'deleted', topic_id: 2 })
+
+    resolveFetch({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        topics: TOPICS,
+        archived_topics: [],
+        can_manage: true,
+        main_topic_id: 1,
+        last_topic_id: 2,
+      }),
+    })
+    await loading
+
+    expect(controller.currentTopicId).toBe('1')
+    expect(controller.topics).not.toContainEqual(expect.objectContaining({ id: 2 }))
+    expect(saveLastTopic).not.toHaveBeenCalledWith('42', '2', expect.any(String), expect.anything())
+  })
+
   // The strip can also be stale about its own creative: another member deletes
   // a topic while the chip for it is still on screen. The pick is about this
   // creative, but it names a topic that no longer exists, so keeping it would

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_selection_race.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_selection_race.test.js
@@ -148,6 +148,33 @@ describe('TopicsController selection vs. in-flight loadTopics', () => {
     expect(saveLastTopic).not.toHaveBeenCalledWith('42', '2', expect.any(String), expect.anything())
   })
 
+  test('a deletion broadcast invalidates a response already being decoded', async () => {
+    let resolveFetch
+    let resolveJson
+    global.fetch = jest.fn(() => new Promise((resolve) => { resolveFetch = resolve }))
+    controller.serverLastTopicId = '2'
+
+    const loading = controller.loadTopics()
+    resolveFetch({
+      ok: true,
+      status: 200,
+      json: () => new Promise((resolve) => { resolveJson = resolve }),
+    })
+    await Promise.resolve()
+    controller.handleTopicMessage({ action: 'deleted', topic_id: 2 })
+    resolveJson({
+      topics: TOPICS,
+      archived_topics: [],
+      can_manage: true,
+      main_topic_id: 1,
+      last_topic_id: 2,
+    })
+    await loading
+
+    expect(controller.currentTopicId).toBe('1')
+    expect(controller.topics).not.toContainEqual(expect.objectContaining({ id: 2 }))
+  })
+
   // The strip can also be stale about its own creative: another member deletes
   // a topic while the chip for it is still on screen. The pick is about this
   // creative, but it names a topic that no longer exists, so keeping it would

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_selection_race.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_selection_race.test.js
@@ -122,15 +122,29 @@ describe('TopicsController selection vs. in-flight loadTopics', () => {
     expect(controller.serverLastTopicId).toBe('3')
   })
 
+  test('an unresolved Main fallback is not saved as All Messages', () => {
+    controller.mainTopicId = null
+    controller.serverLastTopicId = ''
+    const saveSpy = jest.spyOn(controller, 'debounceSaveLastTopic')
+
+    controller.restoreSelection()
+
+    expect(controller.currentTopicId).toBe('')
+    expect(saveSpy).not.toHaveBeenCalled()
+  })
+
   test('a deletion broadcast invalidates an older topic-list response', async () => {
-    let resolveFetch
-    global.fetch = jest.fn(() => new Promise((resolve) => { resolveFetch = resolve }))
+    let resolveStaleFetch
+    let resolveReloadFetch
+    global.fetch = jest.fn()
+      .mockImplementationOnce(() => new Promise((resolve) => { resolveStaleFetch = resolve }))
+      .mockImplementationOnce(() => new Promise((resolve) => { resolveReloadFetch = resolve }))
     controller.serverLastTopicId = '2'
 
     const loading = controller.loadTopics()
     controller.handleTopicMessage({ action: 'deleted', topic_id: 2 })
 
-    resolveFetch({
+    resolveStaleFetch({
       ok: true,
       status: 200,
       json: async () => ({
@@ -142,20 +156,36 @@ describe('TopicsController selection vs. in-flight loadTopics', () => {
       }),
     })
     await loading
+    resolveReloadFetch({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        topics: [TOPICS[0], TOPICS[2]],
+        archived_topics: [],
+        can_manage: true,
+        main_topic_id: 1,
+        last_topic_id: null,
+        last_topic_all_messages: false,
+      }),
+    })
+    await new Promise((resolve) => setTimeout(resolve, 0))
 
     expect(controller.currentTopicId).toBe('1')
-    expect(controller.topics).not.toContainEqual(expect.objectContaining({ id: 2 }))
+    expect(controller.topics.map((topic) => topic.id)).toEqual([1, 3])
     expect(saveLastTopic).not.toHaveBeenCalledWith('42', '2', expect.any(String), expect.anything())
   })
 
   test('a deletion broadcast invalidates a response already being decoded', async () => {
-    let resolveFetch
+    let resolveStaleFetch
     let resolveJson
-    global.fetch = jest.fn(() => new Promise((resolve) => { resolveFetch = resolve }))
+    let resolveReloadFetch
+    global.fetch = jest.fn()
+      .mockImplementationOnce(() => new Promise((resolve) => { resolveStaleFetch = resolve }))
+      .mockImplementationOnce(() => new Promise((resolve) => { resolveReloadFetch = resolve }))
     controller.serverLastTopicId = '2'
 
     const loading = controller.loadTopics()
-    resolveFetch({
+    resolveStaleFetch({
       ok: true,
       status: 200,
       json: () => new Promise((resolve) => { resolveJson = resolve }),
@@ -170,9 +200,61 @@ describe('TopicsController selection vs. in-flight loadTopics', () => {
       last_topic_id: 2,
     })
     await loading
+    resolveReloadFetch({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        topics: [TOPICS[0], TOPICS[2]],
+        archived_topics: [],
+        can_manage: true,
+        main_topic_id: 1,
+        last_topic_id: null,
+        last_topic_all_messages: false,
+      }),
+    })
+    await new Promise((resolve) => setTimeout(resolve, 0))
 
     expect(controller.currentTopicId).toBe('1')
-    expect(controller.topics).not.toContainEqual(expect.objectContaining({ id: 2 }))
+    expect(controller.topics.map((topic) => topic.id)).toEqual([1, 3])
+  })
+
+  test('an inactive deletion also replaces an in-flight stale topic list', async () => {
+    let resolveStaleFetch
+    let resolveReloadFetch
+    global.fetch = jest.fn()
+      .mockImplementationOnce(() => new Promise((resolve) => { resolveStaleFetch = resolve }))
+      .mockImplementationOnce(() => new Promise((resolve) => { resolveReloadFetch = resolve }))
+    controller.serverLastTopicId = '1'
+
+    const loading = controller.loadTopics()
+    controller.handleTopicMessage({ action: 'deleted', topic_id: 2 })
+    resolveStaleFetch({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        topics: TOPICS,
+        archived_topics: [],
+        can_manage: true,
+        main_topic_id: 1,
+        last_topic_id: 1,
+      }),
+    })
+    await loading
+    resolveReloadFetch({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        topics: [TOPICS[0], TOPICS[2]],
+        archived_topics: [],
+        can_manage: true,
+        main_topic_id: 1,
+        last_topic_id: 1,
+      }),
+    })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(controller.currentTopicId).toBe('1')
+    expect(controller.topics.map((topic) => topic.id)).toEqual([1, 3])
   })
 
   // The strip can also be stale about its own creative: another member deletes

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -252,6 +252,9 @@ export default class extends Controller {
             }
             if (response.ok) {
                 const data = await response.json()
+                // A removal or newer load can arrive while a large response is
+                // being decoded, after the pre-parse version check above.
+                if (version !== this._loadTopicsVersion) return
                 const unreadCounts = this._unreadCountsOverlay?.loadVersion === version
                     ? this._unreadCountsOverlay.counts
                     : null

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -1452,6 +1452,10 @@ export default class extends Controller {
     // reload is still pending, because the server records blank saves as an
     // explicit All Messages choice.
     fallbackFromRemovedTopic(topicId) {
+        // A removal broadcast does not start a replacement load. Invalidate any
+        // older response so it cannot reintroduce the removed topic and restore
+        // its stale preference after this fallback.
+        this._loadTopicsVersion += 1
         this.cancelPendingSaveLastTopic()
         if (String(this._pendingPick?.topicId) === String(topicId)) this._pendingPick = null
         this.releaseDeepLinkSelection(topicId)
@@ -2567,12 +2571,14 @@ export default class extends Controller {
         // from here would keep an openable chip and, through pruneArchivedBadges
         // never running, a lit toggle for a conversation that no longer exists.
         const nextArchivedTopics = archivedTopics.filter((topic) => String(topic.id) !== String(topicId))
-        if (nextTopics.length === topics.length && nextArchivedTopics.length === archivedTopics.length) return
+        const removedCurrentSelection = String(this.currentTopicId) === String(topicId)
+        if (nextTopics.length === topics.length && nextArchivedTopics.length === archivedTopics.length &&
+            !removedCurrentSelection) return
 
         this.topics = nextTopics
         this.archivedTopics = nextArchivedTopics
         this.pruneArchivedBadges()
-        if (String(this.currentTopicId) === String(topicId)) {
+        if (removedCurrentSelection) {
             this.fallbackFromRemovedTopic(topicId)
             this.dispatch("change", { detail: { topicId: "", mainTopicId: this.mainTopicId } })
         }

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -1458,9 +1458,12 @@ export default class extends Controller {
         this._loadTopicsVersion += 1
         this.cancelPendingSaveLastTopic()
         if (String(this._pendingPick?.topicId) === String(topicId)) this._pendingPick = null
+        const preservePreference = this.hasDeepLinkSelection
         this.releaseDeepLinkSelection(topicId)
-        this.serverLastTopicId = ""
-        this._explicitAllMessagesSelection = false
+        if (!preservePreference) {
+            this.serverLastTopicId = ""
+            this._explicitAllMessagesSelection = false
+        }
     }
 
     // Drop ?topic_id= when it names the topic being archived. It is a selection

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -800,8 +800,7 @@ export default class extends Controller {
                     // Same deep-link hazard as the "deleted" broadcast: this
                     // path reaches restoreSelection through loadTopics instead
                     // of removeTopic, but the getter is the same one.
-                    this.releaseDeepLinkSelection(topicId)
-                    this.currentTopicId = "" // Switch to Main
+                    this.fallbackFromRemovedTopic(topicId)
                     this.dispatch("change", { detail: { topicId: "", mainTopicId: this.mainTopicId } })
                 }
                 this.loadTopics()
@@ -1333,7 +1332,7 @@ export default class extends Controller {
             // If we were viewing the moved topic, switch to Main
             if (String(this.currentTopicId) === String(topicId)) {
                 this._topicScrollInterrupted = false
-                this.currentTopicId = ""
+                this.fallbackFromRemovedTopic(topicId)
                 this.dispatch("change", { detail: { topicId: "", mainTopicId: this.mainTopicId } })
             }
             this.loadTopics()
@@ -1446,6 +1445,18 @@ export default class extends Controller {
     releaseDeepLinkSelection(topicId) {
         this.clearOverrideTopicId()
         this.clearUrlTopicId(topicId)
+    }
+
+    // Deletion and move tombstones mean "fall back to Main", not that the user
+    // picked All Messages. Do not queue a blank preference save while the topic
+    // reload is still pending, because the server records blank saves as an
+    // explicit All Messages choice.
+    fallbackFromRemovedTopic(topicId) {
+        this.cancelPendingSaveLastTopic()
+        if (String(this._pendingPick?.topicId) === String(topicId)) this._pendingPick = null
+        this.releaseDeepLinkSelection(topicId)
+        this.serverLastTopicId = ""
+        this._explicitAllMessagesSelection = false
     }
 
     // Drop ?topic_id= when it names the topic being archived. It is a selection
@@ -2562,8 +2573,7 @@ export default class extends Controller {
         this.archivedTopics = nextArchivedTopics
         this.pruneArchivedBadges()
         if (String(this.currentTopicId) === String(topicId)) {
-            this.releaseDeepLinkSelection(topicId)
-            this.currentTopicId = ""
+            this.fallbackFromRemovedTopic(topicId)
             this.dispatch("change", { detail: { topicId: "", mainTopicId: this.mainTopicId } })
         }
 

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -45,6 +45,7 @@ export default class extends Controller {
         this._topicScrollFrame = null
         this._topicScrollInterrupted = false
         this._topicScrollInterruptionVersion ||= 0
+        this._explicitAllMessagesSelection ??= false
         // Initial load if creativeId is available (e.g. from dataset if set server-side)
         if (this.creativeId && this.element.dataset.docked !== 'true') {
             this.loadTopics()
@@ -274,6 +275,7 @@ export default class extends Controller {
                     : String(this.creativeId)
                 this.knownEffectiveCreativeIds.set(String(creativeId), effectiveCreativeId)
                 const snapshotTopicId = data.last_topic_id ? String(data.last_topic_id) : ""
+                const snapshotAllMessages = data.last_topic_all_messages === true
                 const snapshotTopicRevision = this.normalizeLastTopicRevision(data.last_topic_revision)
                 this.element.dataset.effectiveCreativeId = effectiveCreativeId
                 this.remapPendingSelfEchoesForCreative(creativeId, effectiveCreativeId)
@@ -346,14 +348,12 @@ export default class extends Controller {
                     )
                     if (pendingTopicId === undefined) {
                         this.serverLastTopicId = snapshotTopicId
-                        // A positive revision with no topic is not a missing
-                        // preference: it is the ordering tombstone written when
-                        // All Messages was selected. Revision zero belongs to a
-                        // row created only for expansion state, so it keeps the
-                        // first-visit Main fallback.
+                        // An empty id is also written when a selected topic is
+                        // deleted or moved. Only the explicit server flag can
+                        // distinguish that tombstone from All Messages.
                         keepEmptySelection = this.isPersistedAllMessagesSelection(
                             snapshotTopicId,
-                            snapshotTopicRevision
+                            snapshotAllMessages
                         )
                         // A retained claim proves this response was an older view of
                         // the preference. Do not let that stale snapshot roll back
@@ -407,7 +407,7 @@ export default class extends Controller {
 
     // keepEmptySelection: the caller established that All Messages is an
     // intentional selection, either from a pick that outran this load or from
-    // a cleared server preference with a positive revision. It names no topic,
+    // the explicit All Messages server preference. It names no topic,
     // so it cannot be restored from a topic list and must be reapplied. Without
     // this the Main fallback below treats it as "nothing selected", navigates
     // away from it and persists Main. A prior interim restore may also have
@@ -419,7 +419,7 @@ export default class extends Controller {
         // for the saved preference. Replaying the linked selection after a
         // preference broadcast must therefore update the UI without writing the
         // link back over that newer server value.
-        const preservePreference = this.hasDeepLinkSelection && !keepEmptySelection
+        const preservePreference = this.hasDeepLinkSelection
         // archiveTopic() switched away from this topic on purpose. The server
         // preference still names it until the debounced save lands, so accept
         // the local intent over the stale server answer for that window.
@@ -443,7 +443,7 @@ export default class extends Controller {
         }
 
         if (keepEmptySelection && !lastTopicId) {
-            this.selectTopic("", { pick: false })
+            this.selectTopic("", { pick: false, persist: !preservePreference })
             return
         }
 
@@ -2033,8 +2033,8 @@ export default class extends Controller {
         return revision.every(Number.isSafeInteger) ? revision : null
     }
 
-    isPersistedAllMessagesSelection(topicId, revision) {
-        return !topicId && Boolean(revision && revision[1] > 0)
+    isPersistedAllMessagesSelection(topicId, allMessages) {
+        return !topicId && allMessages === true
     }
 
     compareLastTopicRevisions(left, right) {
@@ -2387,6 +2387,7 @@ export default class extends Controller {
         if (action === "last_topic_changed") {
             // Broadcast is already scoped to the current user via user-specific channel
             const newTopicId = data.last_topic_id ? String(data.last_topic_id) : ""
+            const allMessages = data.last_topic_all_messages === true
             const lastTopicRevision = this.normalizeLastTopicRevision(data.last_topic_revision)
             // A retired ambiguous save remains non-actionable, but it can still have
             // committed after the request failed. Its revision must advance this
@@ -2422,7 +2423,9 @@ export default class extends Controller {
             // session still established that preference, so the queued one-shot link
             // must not write itself back over it.
             if (this.hasDeepLinkSelection) this.cancelPendingSaveLastTopic()
-            if (newTopicId !== this.serverLastTopicId) {
+            const explicitSelectionChanged = allMessages !== this._explicitAllMessagesSelection
+            this._explicitAllMessagesSelection = allMessages
+            if (newTopicId !== this.serverLastTopicId || explicitSelectionChanged) {
                 this.serverLastTopicId = newTopicId
                 // Another session moved the preference; nobody clicked in this
                 // popup. A deep link outranks the preference in the getter, so

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -1461,7 +1461,11 @@ export default class extends Controller {
         this._loadTopicsVersion += 1
         this.cancelPendingSaveLastTopic()
         if (String(this._pendingPick?.topicId) === String(topicId)) this._pendingPick = null
-        const preservePreference = this.hasDeepLinkSelection
+        // A link only protects a distinct saved preference behind it. If both
+        // sources name the removed topic, releasing the link would otherwise
+        // expose that same dead preference and select it again.
+        const preservePreference = this.hasDeepLinkSelection &&
+            String(this.serverLastTopicId) !== String(topicId)
         this.releaseDeepLinkSelection(topicId)
         if (!preservePreference) {
             this.serverLastTopicId = ""

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -2579,6 +2579,19 @@ export default class extends Controller {
         const topicLoadInFlight = this.activeLoadAcknowledgementVersions.has(this._loadTopicsVersion)
         const topics = this.topics || []
         const archivedTopics = this.archivedTopics || []
+        const removedCurrentSelection = String(this.currentTopicId) === String(topicId)
+        if (topicLoadInFlight) {
+            if (removedCurrentSelection) {
+                this.fallbackFromRemovedTopic(topicId)
+                this.dispatch("change", { detail: { topicId: "", mainTopicId: this.mainTopicId } })
+            }
+            // The cache is intentionally incomplete while loadTopics awaits.
+            // Restoring against it can replace a distinct preference hidden
+            // behind the removed deep link with Main. Let the replacement
+            // response provide the authoritative list before restoring.
+            this.loadTopics()
+            return
+        }
         const nextTopics = topics.filter((topic) => String(topic.id) !== String(topicId))
         // An archived topic is deletable and now selectable, so the "deleted"
         // broadcast has to reach this cache too — nothing else does. It is the
@@ -2586,12 +2599,8 @@ export default class extends Controller {
         // from here would keep an openable chip and, through pruneArchivedBadges
         // never running, a lit toggle for a conversation that no longer exists.
         const nextArchivedTopics = archivedTopics.filter((topic) => String(topic.id) !== String(topicId))
-        const removedCurrentSelection = String(this.currentTopicId) === String(topicId)
         if (nextTopics.length === topics.length && nextArchivedTopics.length === archivedTopics.length &&
-            !removedCurrentSelection) {
-            if (topicLoadInFlight) this.loadTopics()
-            return
-        }
+            !removedCurrentSelection) return
 
         this.topics = nextTopics
         this.archivedTopics = nextArchivedTopics
@@ -2603,7 +2612,6 @@ export default class extends Controller {
 
         this.renderTopics(this.topics, this.canManageTopics, this.canCreateTopic, this.canSetPrimaryAgent)
         this.restoreSelection()
-        if (topicLoadInFlight) this.loadTopics()
     }
 
     handleAddButtonDragOver(event) {

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -460,7 +460,11 @@ export default class extends Controller {
         // re-render landing in that window resolves to Main whatever the user
         // has selected. Counting it as intent would let it outrank the answer
         // it was derived from — and drop the deep link on the way.
-        this.selectTopic(this.mainTopicId || "", { pick: false, persist: !preservePreference })
+        // Before the first topic response there is no Main id yet. The empty
+        // placeholder is not an All Messages choice, so it must not be saved as
+        // the explicit empty preference introduced for that user action.
+        const persistFallback = Boolean(this.mainTopicId) && !preservePreference
+        this.selectTopic(this.mainTopicId || "", { pick: false, persist: persistFallback })
     }
 
     // An archived topic can be opened from the topic strip, the topic-list popup,
@@ -1455,10 +1459,6 @@ export default class extends Controller {
     // reload is still pending, because the server records blank saves as an
     // explicit All Messages choice.
     fallbackFromRemovedTopic(topicId) {
-        // A removal broadcast does not start a replacement load. Invalidate any
-        // older response so it cannot reintroduce the removed topic and restore
-        // its stale preference after this fallback.
-        this._loadTopicsVersion += 1
         this.cancelPendingSaveLastTopic()
         if (String(this._pendingPick?.topicId) === String(topicId)) this._pendingPick = null
         // A link only protects a distinct saved preference behind it. If both
@@ -2572,6 +2572,11 @@ export default class extends Controller {
     removeTopic(topicId) {
         if (!topicId) return
 
+        // loadTopics clears its cache before awaiting the response. If a
+        // deletion arrives in that window, the local filter has nothing to
+        // retain and the old response must not rebuild the deleted chip. A
+        // replacement load both invalidates that response and refills the strip.
+        const topicLoadInFlight = this.activeLoadAcknowledgementVersions.has(this._loadTopicsVersion)
         const topics = this.topics || []
         const archivedTopics = this.archivedTopics || []
         const nextTopics = topics.filter((topic) => String(topic.id) !== String(topicId))
@@ -2583,7 +2588,10 @@ export default class extends Controller {
         const nextArchivedTopics = archivedTopics.filter((topic) => String(topic.id) !== String(topicId))
         const removedCurrentSelection = String(this.currentTopicId) === String(topicId)
         if (nextTopics.length === topics.length && nextArchivedTopics.length === archivedTopics.length &&
-            !removedCurrentSelection) return
+            !removedCurrentSelection) {
+            if (topicLoadInFlight) this.loadTopics()
+            return
+        }
 
         this.topics = nextTopics
         this.archivedTopics = nextArchivedTopics
@@ -2595,6 +2603,7 @@ export default class extends Controller {
 
         this.renderTopics(this.topics, this.canManageTopics, this.canCreateTopic, this.canSetPrimaryAgent)
         this.restoreSelection()
+        if (topicLoadInFlight) this.loadTopics()
     }
 
     handleAddButtonDragOver(event) {

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -98,6 +98,7 @@ export default class extends Controller {
         // transient — loadTopics() cannot rebuild them.
         if (String(previousCreativeId || '') !== String(creativeId || '')) {
             this.archivedWithNewMessages.clear()
+            this._explicitAllMessagesSelection = false
             // Scoped to the creative it was archived in; a topic id from another
             // creative must not veto this one's restored selection.
             this.archivedAwayTopicId = null
@@ -128,6 +129,7 @@ export default class extends Controller {
         this.creativeIdValue = null
         this.topics = []
         this.mainTopicId = null
+        this._explicitAllMessagesSelection = false
         this.archivedWithNewMessages.clear()
         this.archivedAwayTopicId = null
         delete this.element.dataset.effectiveCreativeId
@@ -312,6 +314,7 @@ export default class extends Controller {
                     snapshotTopicId,
                     snapshotTopicRevision
                 ) && this.pickOutranks(selectionEpoch, creativeId, topics, this.archivedTopics)
+                let keepEmptySelection = false
                 if (skipLastTopicReconciliation) {
                     // The GET has a server ordering token, but this save has neither
                     // its response revision nor its echo yet. Its predecessor topic is
@@ -325,6 +328,7 @@ export default class extends Controller {
                     // belongs to the actual pick, so restore that picked value
                     // rather than treating the derived fallback as its value.
                     this.serverLastTopicId = this._pickTopicId
+                    keepEmptySelection = !this._pickTopicId
                     // The picked value has not necessarily reached the server yet.
                     // Keep the snapshot as the first known remote baseline so a
                     // claim created after this load records what its pending save
@@ -342,13 +346,26 @@ export default class extends Controller {
                     )
                     if (pendingTopicId === undefined) {
                         this.serverLastTopicId = snapshotTopicId
+                        // A positive revision with no topic is not a missing
+                        // preference: it is the ordering tombstone written when
+                        // All Messages was selected. Revision zero belongs to a
+                        // row created only for expansion state, so it keeps the
+                        // first-visit Main fallback.
+                        keepEmptySelection = this.isPersistedAllMessagesSelection(
+                            snapshotTopicId,
+                            snapshotTopicRevision
+                        )
                         // A retained claim proves this response was an older view of
                         // the preference. Do not let that stale snapshot roll back
                         // the baseline used by the next save's closed-reopen check.
                         this.setLastKnownRemoteTopicId(effectiveCreativeId, snapshotTopicId)
                     } else {
                         this.serverLastTopicId = pendingTopicId
+                        keepEmptySelection = !pendingTopicId
                     }
+                }
+                if (!skipLastTopicReconciliation) {
+                    this._explicitAllMessagesSelection = keepEmptySelection
                 }
                 // The archive guard only has to outlive the sources that still
                 // name the topic. Test the effective selection, not just the
@@ -369,13 +386,13 @@ export default class extends Controller {
                 // unresolved revisioned save must not turn its retained local
                 // selection into another PATCH while reconciliation is deferred.
                 if (!skipLastTopicReconciliation) {
-                    this.migrateLocalStorage({ keepEmptyPick: pickWon })
+                    this.migrateLocalStorage({ keepEmptySelection })
                 }
 
                 this.renderTopics(this.topics, this.canManageTopics, this.canCreateTopic, this.canSetPrimaryAgent, creativeId)
                 if (this.currentTopicId) this.clearNewMessageBadge(this.currentTopicId)
                 if (!skipLastTopicReconciliation) {
-                    this.restoreSelection({ keepEmptyPick: pickWon })
+                    this.restoreSelection({ keepEmptySelection })
                 }
                 this.refreshOpenTopicListPopup()
             }
@@ -388,21 +405,21 @@ export default class extends Controller {
         }
     }
 
-    // keepEmptyPick: the caller established that the user picked All Messages
-    // after this render was set in motion. That pick names no topic, so it
-    // cannot be restored from a topic list — it must be reapplied. Without
-    // this the Main fallback below would treat it as "nothing selected",
-    // navigate away from it and persist Main, which is the same revert a chip
-    // click suffers. A prior interim restore may also have dispatched Main, so
-    // reapplying sends the authoritative empty selection to downstream
-    // controllers again.
-    restoreSelection({ keepEmptyPick = false } = {}) {
+    // keepEmptySelection: the caller established that All Messages is an
+    // intentional selection, either from a pick that outran this load or from
+    // a cleared server preference with a positive revision. It names no topic,
+    // so it cannot be restored from a topic list and must be reapplied. Without
+    // this the Main fallback below treats it as "nothing selected", navigates
+    // away from it and persists Main. A prior interim restore may also have
+    // dispatched Main, so reapplying sends the authoritative empty selection
+    // to downstream controllers again.
+    restoreSelection({ keepEmptySelection = this._explicitAllMessagesSelection } = {}) {
         const lastTopicId = this.currentTopicId
         // A deep link controls this popup's view, but it is not a replacement
         // for the saved preference. Replaying the linked selection after a
         // preference broadcast must therefore update the UI without writing the
         // link back over that newer server value.
-        const preservePreference = this.hasDeepLinkSelection && !keepEmptyPick
+        const preservePreference = this.hasDeepLinkSelection && !keepEmptySelection
         // archiveTopic() switched away from this topic on purpose. The server
         // preference still names it until the debounced save lands, so accept
         // the local intent over the stale server answer for that window.
@@ -425,7 +442,7 @@ export default class extends Controller {
             }
         }
 
-        if (keepEmptyPick && !lastTopicId) {
+        if (keepEmptySelection && !lastTopicId) {
             this.selectTopic("", { pick: false })
             return
         }
@@ -1464,6 +1481,10 @@ export default class extends Controller {
     applySelection(id, { pick = true, persist = true, pending = false } = {}) {
         if (persist) this.serverLastTopicId = id ? String(id) : ""
         if (pick) {
+            // selectTopic marks picks as pending; a blank direct setter is a
+            // programmatic fallback after deletion/archive and should retain
+            // the established Main fallback instead of becoming All Messages.
+            if (id || pending) this._explicitAllMessagesSelection = !id
             // Writing only the preference leaves the two sources that outrank it
             // in the getter still naming the topic being left, so the getter
             // keeps answering with it: the next renderTopics() lights the old
@@ -2012,6 +2033,10 @@ export default class extends Controller {
         return revision.every(Number.isSafeInteger) ? revision : null
     }
 
+    isPersistedAllMessagesSelection(topicId, revision) {
+        return !topicId && Boolean(revision && revision[1] > 0)
+    }
+
     compareLastTopicRevisions(left, right) {
         if (!left || !right) return null
         return left[0] === right[0] ? left[1] - right[1] : left[0] - right[0]
@@ -2237,18 +2262,17 @@ export default class extends Controller {
     }
 
     // The legacy key is adopted only as a stand-in for a preference the server
-    // does not hold yet. A winning empty pick is a preference — it just names no
-    // topic, so it is indistinguishable here from "server holds nothing", and
-    // adopting the legacy value would hand the user back a topic they did not
-    // ask for and persist it. The caller knows which of the two it is.
+    // does not hold yet. A winning empty pick or a revisioned cleared preference
+    // is an All Messages selection — it just names no topic, so adopting the
+    // legacy value would hand the user back a topic they did not ask for and
+    // persist it. The caller knows whether the empty value is intentional.
     //
-    // The key still goes, either way: the pick supersedes it, and its own save
-    // is already on the way, so leaving it behind would only re-apply a value
-    // the user has moved off on the next load.
-    migrateLocalStorage({ keepEmptyPick = false } = {}) {
+    // The key still goes either way: an intentional empty selection supersedes
+    // it, so leaving it behind would only re-apply a value the user moved off.
+    migrateLocalStorage({ keepEmptySelection = false } = {}) {
         const key = `collavre_creative_${this.creativeId}_last_topic`
         const localValue = localStorage.getItem(key)
-        if (localValue && !this.serverLastTopicId && !keepEmptyPick) {
+        if (localValue && !this.serverLastTopicId && !keepEmptySelection) {
             this.serverLastTopicId = localValue
             // The migration is a save like any other. Giving it a client id
             // prevents its broadcast from being mistaken for another session's

--- a/engines/collavre/app/models/collavre/topic.rb
+++ b/engines/collavre/app/models/collavre/topic.rb
@@ -102,7 +102,9 @@ module Collavre
     private
 
     def advance_last_topic_preference_revisions
-      user_creative_preferences_as_last_topic.update_all("last_topic_revision = last_topic_revision + 1")
+      user_creative_preferences_as_last_topic.update_all(
+        "last_topic_all_messages = FALSE, last_topic_revision = last_topic_revision + 1"
+      )
     end
 
     def set_default_position

--- a/engines/collavre/app/models/collavre/user_creative_preference.rb
+++ b/engines/collavre/app/models/collavre/user_creative_preference.rb
@@ -7,7 +7,8 @@ module Collavre
     belongs_to :last_topic, class_name: "Collavre::Topic", optional: true
 
     validates :expanded_status, presence: true, unless: -> {
-      last_topic_id? || last_topic_revision.to_i.positive? || last_topic_save_fence_issued.to_i.positive?
+      last_topic_id? || last_topic_all_messages? || last_topic_revision.to_i.positive? ||
+        last_topic_save_fence_issued.to_i.positive?
     }
     validates :creative_id, uniqueness: { scope: :user_id }, allow_nil: true
   end

--- a/engines/collavre/app/services/collavre/topics/last_topic_preference_payload.rb
+++ b/engines/collavre/app/services/collavre/topics/last_topic_preference_payload.rb
@@ -10,6 +10,7 @@ module Collavre
         preference = UserCreativePreference.find_by(user_id: @user&.id, creative_id: @creative.id)
         {
           last_topic_id: preference&.last_topic_id,
+          last_topic_all_messages: preference&.last_topic_all_messages? || false,
           last_topic_revision: preference && [ preference.id, preference.last_topic_revision ]
         }
       end

--- a/engines/collavre/app/services/collavre/topics/topic_move.rb
+++ b/engines/collavre/app/services/collavre/topics/topic_move.rb
@@ -64,7 +64,10 @@ module Collavre
       def clear_source_last_topic_preferences
         topic.user_creative_preferences_as_last_topic
              .where(creative_id: source_creative_id)
-             .update_all("last_topic_id = NULL, last_topic_revision = last_topic_revision + 1")
+             .update_all(
+               "last_topic_id = NULL, last_topic_all_messages = FALSE, " \
+                 "last_topic_revision = last_topic_revision + 1"
+             )
       end
 
       def release_unroutable_primary_agent

--- a/engines/collavre/db/migrate/20260908000000_add_last_topic_all_messages_to_user_creative_preferences.rb
+++ b/engines/collavre/db/migrate/20260908000000_add_last_topic_all_messages_to_user_creative_preferences.rb
@@ -1,0 +1,5 @@
+class AddLastTopicAllMessagesToUserCreativePreferences < ActiveRecord::Migration[8.0]
+  def change
+    add_column :user_creative_preferences, :last_topic_all_messages, :boolean, null: false, default: false
+  end
+end

--- a/engines/collavre/test/controllers/topics_controller_test.rb
+++ b/engines/collavre/test/controllers/topics_controller_test.rb
@@ -13,6 +13,7 @@ class TopicsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     json = JSON.parse(response.body)
     assert_equal @creative.id, json["effective_creative_id"]
+    assert_equal false, json["last_topic_all_messages"]
   end
 
   test "History topic is read-only, reserved, and kept last" do
@@ -80,6 +81,7 @@ class TopicsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     json = JSON.parse(response.body)
     assert_equal @topic.id, json["last_topic_id"]
+    assert_equal false, json["last_topic_all_messages"]
     assert_equal [ preference.id, 7 ], json["last_topic_revision"]
   end
 
@@ -88,6 +90,7 @@ class TopicsControllerTest < ActionDispatch::IntegrationTest
       creative: @creative,
       user: @user,
       expanded_status: {},
+      last_topic_all_messages: true,
       last_topic_revision: 2
     )
 
@@ -96,6 +99,7 @@ class TopicsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     json = JSON.parse(response.body)
     assert_nil json["last_topic_id"]
+    assert_equal true, json["last_topic_all_messages"]
     assert_equal [ preference.id, 2 ], json["last_topic_revision"]
   end
 
@@ -209,6 +213,7 @@ class TopicsControllerTest < ActionDispatch::IntegrationTest
     assert_response :no_content
     preference.reload
     assert_nil preference.last_topic_id
+    assert_not preference.last_topic_all_messages?
     assert_equal 5, preference.last_topic_revision
   end
 

--- a/engines/collavre/test/controllers/user_creative_preferences_controller_test.rb
+++ b/engines/collavre/test/controllers/user_creative_preferences_controller_test.rb
@@ -142,21 +142,36 @@ class UserCreativePreferencesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     record = Collavre::UserCreativePreference.find_by(creative_id: @creative.id, user_id: @user.id)
     assert_equal topic.id, record.last_topic_id
+    assert_not record.last_topic_all_messages?
     assert_equal [ record.id, 1 ], response.parsed_body["last_topic_revision"]
+    assert_equal false, response.parsed_body["last_topic_all_messages"]
   end
 
   test "update_last_topic clears topic selection" do
     topic = Collavre::Topic.create!(creative: @creative, user: @user, name: "Test Topic")
-    Collavre::UserCreativePreference.create!(
+    preference = Collavre::UserCreativePreference.create!(
       creative_id: @creative.id, user_id: @user.id,
       expanded_status: { "1" => true }, last_topic_id: topic.id
     )
-    patch "/creatives/#{@creative.id}/user_creative_preferences/update_last_topic",
-          params: { last_topic_id: nil },
-          as: :json
+    stream = Collavre::TopicsChannel.broadcasting_for("user_#{@user.id}_creative_#{@creative.id}")
+
+    assert_broadcast_on(
+      stream,
+      {
+        action: "last_topic_changed", last_topic_id: nil, last_topic_all_messages: true,
+        last_topic_revision: [ preference.id, 1 ], client_id: nil
+      }
+    ) do
+      patch "/creatives/#{@creative.id}/user_creative_preferences/update_last_topic",
+            params: { last_topic_id: nil },
+            as: :json
+    end
+
     assert_response :success
-    record = Collavre::UserCreativePreference.find_by(creative_id: @creative.id, user_id: @user.id)
+    record = preference.reload
     assert_nil record.last_topic_id
+    assert record.last_topic_all_messages?
+    assert_equal true, response.parsed_body["last_topic_all_messages"]
   end
 
   test "clearing a last topic preserves its ordering tombstone" do
@@ -173,6 +188,7 @@ class UserCreativePreferencesControllerTest < ActionDispatch::IntegrationTest
 
     preference.reload
     assert_nil preference.last_topic_id
+    assert preference.last_topic_all_messages?
     assert_equal 2, preference.last_topic_revision
 
     post "/creative_expanded_states/toggle", params: { creative_id: @creative.id, node_id: @creative.id, expanded: false }
@@ -193,7 +209,10 @@ class UserCreativePreferencesControllerTest < ActionDispatch::IntegrationTest
 
     assert_broadcast_on(
       stream,
-      { action: "last_topic_changed", last_topic_id: topic.id, last_topic_revision: [ preference.id, 1 ], client_id: "save-abc" }
+      {
+        action: "last_topic_changed", last_topic_id: topic.id, last_topic_all_messages: false,
+        last_topic_revision: [ preference.id, 1 ], client_id: "save-abc"
+      }
     ) do
       patch "/creatives/#{@creative.id}/user_creative_preferences/update_last_topic",
             params: { last_topic_id: topic.id, client_id: "save-abc" },
@@ -210,7 +229,10 @@ class UserCreativePreferencesControllerTest < ActionDispatch::IntegrationTest
 
     assert_broadcast_on(
       stream,
-      { action: "last_topic_changed", last_topic_id: topic.id, last_topic_revision: [ preference.id, 1 ], client_id: nil }
+      {
+        action: "last_topic_changed", last_topic_id: topic.id, last_topic_all_messages: false,
+        last_topic_revision: [ preference.id, 1 ], client_id: nil
+      }
     ) do
       patch "/creatives/#{@creative.id}/user_creative_preferences/update_last_topic",
             params: { last_topic_id: topic.id },

--- a/engines/collavre/test/services/collavre/topics/topic_move_test.rb
+++ b/engines/collavre/test/services/collavre/topics/topic_move_test.rb
@@ -202,6 +202,7 @@ module Collavre
 
         preference.reload
         assert_nil preference.last_topic_id
+        assert_not preference.last_topic_all_messages?
         assert_equal 5, preference.last_topic_revision
       end
 


### PR DESCRIPTION
## Summary
- preserve an explicit All Messages selection across topic-list re-renders
- store explicit All Messages intent separately from deletion and move tombstones
- keep deletion and move fallbacks local until Main is restored, without persisting a blank selection
- invalidate pre-removal topic-list responses before and during response decoding
- reload after deletion invalidates an in-flight topic request so the strip is repopulated without stale chips
- defer selection restoration until that replacement list arrives, preserving distinct preferences behind removed deep links
- retain distinct saved preferences behind removed deep links while clearing preferences that name the removed topic itself
- keep deep links isolated from the saved preference, including empty overrides
- avoid persisting an unresolved Main placeholder as an explicit All Messages choice
- prevent legacy localStorage migration from overriding the persisted selection

## Tests
- `npm test -- --runInBand` (127 suites, 1,737 tests)
- `npm test -- --runInBand engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_selection_race.test.js engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_archived.test.js engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_scroll.test.js engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_delete.test.js` (142 tests)
- `npm run test:coverage -- --runInBand`
- `mise x -- bin/rails test engines/collavre/test/controllers/user_creative_preferences_controller_test.rb engines/collavre/test/controllers/topics_controller_test.rb engines/collavre/test/services/collavre/topics/topic_move_test.rb` (109 tests, 512 assertions)
- `mise x -- ./bin/rubocop -a` (1,336 files, no offenses)
- `mise x -- bin/complexity_check`
- `mise x -- bin/rails test` (existing unrelated Active Record encryption configuration errors in 11 GitHub tests; 160 passed, 11 errors)
- `mise x -- bin/rails test:system` (existing host runner issue: missing `test/system`; the engine system suite result from the first revision remains 109 passed, 1 unrelated failure, 1 skipped)
