### PR TITLE
fix: unify chat context add button styling

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -1149,7 +1149,9 @@ body.chat-fullscreen {
     justify-content: center;
 }
 
-.add-participant-btn {
+.add-participant-btn,
+.add-context-btn,
+.add-topic-btn {
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -1166,7 +1168,9 @@ body.chat-fullscreen {
     flex-shrink: 0;
 }
 
-.add-participant-btn:hover {
+.add-participant-btn:hover,
+.add-context-btn:hover,
+.add-topic-btn:hover {
     background: var(--color-section-bg);
     color: var(--color-text);
 }
@@ -1481,27 +1485,6 @@ body.chat-fullscreen {
 
 .delete-context-btn:hover {
     color: var(--color-danger);
-}
-
-.add-context-btn {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    flex-shrink: 0;
-    width: 22px;
-    height: 22px;
-    border-radius: 50%;
-    background: var(--color-secondary-background);
-    border: 1px dashed var(--color-border);
-    color: var(--color-text-muted);
-    font-size: 0.85em;
-    cursor: pointer;
-    transition: all 0.2s;
-}
-
-.add-context-btn:hover {
-    background: var(--color-border);
-    color: var(--color-text);
 }
 
 /* Context toggle button in header */
@@ -1861,28 +1844,6 @@ body.chat-fullscreen {
 .topic-creation-container[hidden] {
     display: none;
 }
-
-.add-topic-btn {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 20px;
-    height: 20px;
-    border-radius: 50%;
-    border: 1px solid var(--color-border);
-    background: transparent;
-    cursor: pointer;
-    color: var(--color-muted);
-    font-size: 1.2em;
-    line-height: 1;
-    padding: 0;
-}
-
-.add-topic-btn:hover {
-    background: var(--color-section-bg);
-    color: var(--color-text);
-}
-
 
 .topic-input {
     display: inline-block;

--- a/engines/collavre/test/system/chat_bar_list_popup_test.rb
+++ b/engines/collavre/test/system/chat_bar_list_popup_test.rb
@@ -75,12 +75,24 @@ class ChatBarListPopupTest < ApplicationSystemTestCase
     assert_selector "#comment-contexts .context-chip.context-disabled", text: "Context One", wait: 5
   end
 
-  test "the context add button sits outside the scrolling chip strip" do
+  test "the context add button sits outside the scrolling chip strip and matches the other add buttons" do
     open_comments_popup
     assert_selector "#comment-contexts .context-chip", text: "Context One", wait: 10
 
     assert_selector "#comments-popup .comment-contexts-bar > .add-context-btn"
     assert_no_selector "#comment-contexts .add-context-btn"
+
+    properties = %w[
+      width height border-radius border-style border-width
+      background-color color font-size line-height padding
+    ]
+    style_value_script = "getComputedStyle(document.querySelector(arguments[0])).getPropertyValue(arguments[1])"
+    styles = %w[.add-context-btn .add-participant-btn].to_h do |selector|
+      values = properties.to_h { |property| [ property, evaluate_script(style_value_script, selector, property) ] }
+      [ selector, values ]
+    end
+
+    assert_equal styles.fetch(".add-participant-btn"), styles.fetch(".add-context-btn")
   end
 
   test "user list button opens a searchable popup and the picked user's profile menu" do


### PR DESCRIPTION
## Summary
- share one visual style across the context, participant, and topic add buttons
- remove the context-only dashed/background treatment
- verify computed context button styles match the participant add button

## Tests
- mise exec -- ./bin/rubocop -a
- mise exec -- bin/complexity_check
- mise exec -- bin/rails test engines/collavre/test/system/chat_bar_list_popup_test.rb
- mise exec -- npm run build

## Known baseline issue
- The full host test suite reports 11 Active Record encryption configuration errors in existing GitHub webhook tests; those files pass when run in isolation.