### PR TITLE
fix(topics): drop DISTINCT over users rows so agent lookup runs on PostgreSQL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,17 @@ jobs:
           DATABASE_URL: postgresql://collavre:collavre@localhost:5432/collavre_test
         run: bin/rails db:schema:load
 
+      # Loading the schema only proves the DDL is portable. Query text diverges
+      # too: SQLite compares `json` columns, Postgres has no equality operator
+      # for `json`, so `SELECT DISTINCT users.*` passes the whole SQLite suite
+      # and raises PG::UndefinedFunction in the deployed environment. This runs
+      # the request-path queries that hit those tables for real.
+      - name: Smoke request-path queries on PostgreSQL
+        env:
+          RAILS_ENV: test
+          DATABASE_URL: postgresql://collavre:collavre@localhost:5432/collavre_test
+        run: bin/rails runner script/postgres_query_smoke.rb
+
   test:
     runs-on: ubuntu-latest
 

--- a/engines/collavre/app/models/collavre/user.rb
+++ b/engines/collavre/app/models/collavre/user.rb
@@ -224,10 +224,17 @@ module Collavre
 
     scope :ai_agents, -> { where.not(llm_vendor: [ nil, "" ]) }
 
+    # No DISTINCT here on purpose. `or` merges two predicates over the same
+    # single table, so a row can match both branches but is still returned once.
+    # DISTINCT would only add a Postgres-only failure: `users` carries `json`
+    # columns (`tools`, `dismissed_notices`) and Postgres has no equality
+    # operator for `json`, so `SELECT DISTINCT users.*` raises
+    # PG::UndefinedFunction. Dev and test run SQLite, which accepts it, so the
+    # crash surfaces only in the deployed environment.
     def self.accessible_ai_agents_for(user)
       owned = ai_agents.where(created_by_id: user.id)
       searchable = ai_agents.where(searchable: true)
-      owned.or(searchable).distinct.order(:name)
+      owned.or(searchable).order(:name)
     end
 
     def self.mentionable_for(creative)

--- a/engines/collavre/app/services/collavre/topics/agent_resolver.rb
+++ b/engines/collavre/app/services/collavre/topics/agent_resolver.rb
@@ -42,6 +42,12 @@ module Collavre
           raise(UnknownAgentError, unknown_message(token))
       end
 
+      # Both branches are `id IN (...)` over the same table, so an agent that is
+      # both accessible and shared still comes back once and DISTINCT buys
+      # nothing. It does cost something: `users` has `json` columns and Postgres
+      # cannot compare `json`, so `SELECT DISTINCT users.*` raises
+      # PG::UndefinedFunction. SQLite (dev/test) accepts it, so a DISTINCT here
+      # only ever breaks the deployed environment.
       def candidates_for(actor, creative)
         accessible = User.accessible_ai_agents_for(actor)
         return accessible unless creative
@@ -50,7 +56,7 @@ module Collavre
         base = User.ai_agents
         base.where(id: accessible.reorder(nil).select(:id))
             .or(base.where(id: shared.reorder(nil).select(:id)))
-            .distinct.order(:name)
+            .order(:name)
       end
 
       def find_by_id(candidates, token)

--- a/engines/collavre/test/services/collavre/topics/agent_resolver_test.rb
+++ b/engines/collavre/test/services/collavre/topics/agent_resolver_test.rb
@@ -71,6 +71,21 @@ module Collavre
         assert_raises(AgentResolver::UnknownAgentError) { AgentResolver.call(users(:two).email, actor: @user) }
       end
 
+      # The candidate scope unions "accessible to the actor" with "shared on the
+      # creative" and no longer applies DISTINCT — DISTINCT over whole `users`
+      # rows raises PG::UndefinedFunction on PostgreSQL, because the table has
+      # `json` columns. An agent in both branches must still come back once;
+      # a duplicated row would surface as a bogus AmbiguousAgentError.
+      test "an agent that is both accessible and shared on the creative resolves once" do
+        both = create_agent(name: "Both Ways", searchable: true, created_by: @user)
+        Collavre::CreativeShare.create!(
+          creative: @creative, user: both, shared_by: @user, permission: :feedback
+        )
+
+        assert_equal [ both ], AgentResolver.candidates_for(@user, @creative).where(id: both.id).to_a
+        assert_equal both, AgentResolver.call("Both Ways", actor: @user, creative: @creative)
+      end
+
       test "an unmatched token explains what is accepted" do
         error = assert_raises(AgentResolver::UnknownAgentError) { AgentResolver.call("nobody", actor: @user) }
 

--- a/script/postgres_query_smoke.rb
+++ b/script/postgres_query_smoke.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+# Executes request-path queries against a real PostgreSQL, from CI's
+# `postgres_schema_load` job.
+#
+# Dev and test run SQLite, production runs PostgreSQL, and the two disagree
+# about more than schema DDL. `SELECT DISTINCT users.*` is the standing example:
+# SQLite compares the table's `json` columns happily, PostgreSQL has no equality
+# operator for `json` and raises
+# `PG::UndefinedFunction: could not identify an equality operator for type json`.
+# A fully green SQLite suite says nothing about that, so the queries that MCP
+# callers reach are run here for real.
+#
+# Usage: RAILS_ENV=test DATABASE_URL=postgresql://... bin/rails runner script/postgres_query_smoke.rb
+
+abort "postgres_query_smoke expects a PostgreSQL connection" unless
+  ActiveRecord::Base.connection.adapter_name.match?(/postg/i)
+
+failures = []
+
+def check(failures, label)
+  yield
+  puts "ok   #{label}"
+rescue StandardError => e
+  failures << "#{label}: #{e.class}: #{e.message.lines.first.to_s.strip}"
+  puts "FAIL #{label}"
+end
+
+suffix = SecureRandom.hex(4)
+actor = Collavre::User.create!(
+  name: "Smoke Owner", email: "smoke-owner-#{suffix}@example.test", password: "password123"
+)
+Collavre::Current.user = actor
+creative = Collavre::Creative.create!(description: "Smoke Host", user: actor)
+Collavre::User.create!(
+  name: "Smoke Reviewer", email: "smoke-agent-#{suffix}@example.test", password: "password123",
+  llm_vendor: "google", llm_model: "gemini-1.5-flash", searchable: true
+)
+
+# Reached by the completion API's model list.
+check(failures, "User.accessible_ai_agents_for") do
+  Collavre::User.accessible_ai_agents_for(actor).to_a
+end
+
+# Reached by topic_create / topic_update with primary_agent, both with and
+# without a creative to scope the candidates.
+check(failures, "AgentResolver.candidates_for(no creative)") do
+  Collavre::Topics::AgentResolver.candidates_for(actor, nil).to_a
+end
+
+check(failures, "AgentResolver.candidates_for(creative)") do
+  Collavre::Topics::AgentResolver.candidates_for(actor, creative).to_a
+end
+
+check(failures, "AgentResolver.call(name, creative:)") do
+  Collavre::Topics::AgentResolver.call("Smoke Reviewer", actor: actor, creative: creative) ||
+    raise("expected the searchable agent to resolve")
+end
+
+abort "\n#{failures.size} PostgreSQL-incompatible query/queries:\n- #{failures.join("\n- ")}" if failures.any?
+puts "\nAll guarded queries execute on PostgreSQL."

--- a/test/db/postgres_query_compatibility_test.rb
+++ b/test/db/postgres_query_compatibility_test.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Dev and test run SQLite; the deployed environment runs PostgreSQL. SQLite will
+# compare `json` values, PostgreSQL has no equality operator for the `json` type
+# at all, so `SELECT DISTINCT users.*` is accepted here and raises
+# `PG::UndefinedFunction: could not identify an equality operator for type json`
+# there. The CI `postgres_schema_load` job covers SQLite-only *schema*
+# constructs; this covers SQLite-only *queries*, which no amount of green local
+# test runs would surface.
+#
+# Guarded relations are the ones that load whole AI-agent rows on request paths
+# an MCP caller reaches (`topic_create` / `topic_update` with `primary_agent`,
+# and the completion API's model list).
+class PostgresQueryCompatibilityTest < ActiveSupport::TestCase
+  DISTINCT = /SELECT\s+DISTINCT/i
+
+  setup do
+    @user = users(:one)
+    @creative = Collavre::Creative.create!(description: "Agent Host", user: @user)
+  end
+
+  # Pins the premise. If `users` ever loses its `json` columns the assertions
+  # below stop meaning anything, and this test says so out loud instead.
+  test "the users table carries json columns" do
+    json_columns = Collavre::User.columns.select { |c| c.sql_type.to_s.downcase == "json" }.map(&:name)
+
+    assert_includes json_columns, "tools"
+    assert_includes json_columns, "dismissed_notices"
+  end
+
+  test "accessible_ai_agents_for selects whole rows without DISTINCT" do
+    sql = Collavre::User.accessible_ai_agents_for(@user).to_sql
+
+    refute_match DISTINCT, sql,
+      "DISTINCT over users.* raises PG::UndefinedFunction on PostgreSQL because users has json columns"
+  end
+
+  test "the agent resolver candidate scope selects whole rows without DISTINCT" do
+    [ nil, @creative ].each do |creative|
+      sql = Collavre::Topics::AgentResolver.candidates_for(@user, creative).to_sql
+
+      refute_match DISTINCT, sql,
+        "DISTINCT over users.* raises PG::UndefinedFunction on PostgreSQL (creative: #{creative.inspect})"
+    end
+  end
+end


### PR DESCRIPTION
## Problem

`topic_create` / `topic_update` with a `primary_agent` argument fails in the deployed environment:

```
PG::UndefinedFunction: ERROR:  could not identify an equality operator for type json
```

`users` carries two `json` columns (`tools`, `dismissed_notices`). PostgreSQL defines no equality operator for the `json` type, so `SELECT DISTINCT users.*` cannot be planned at all. Dev and test run SQLite, which compares `json` values without complaint — the full suite stays green while the query is unrunnable in production.

Two call sites produced that SQL:

- `Collavre::User.accessible_ai_agents_for` — `owned.or(searchable).distinct.order(:name)`
- `Collavre::Topics::AgentResolver.candidates_for` — the union of accessible and creative-shared agents, `.distinct.order(:name)`

The second is the reported blocker (pinning an agent on `topic_create`). The first also breaks the completion API's `GET /v1/models`, which loads whole rows from the same scope — same root cause, independent symptom.

## Fix

Both `DISTINCT`s were already redundant. `or` merges two predicates over a single table with no join, so a row matching both branches is returned once regardless. Removing them is a no-op on SQLite and the fix on PostgreSQL.

## Verification

Reproduced and fixed against a real PostgreSQL 16, schema loaded from `db/schema.rb`:

| | before | after |
|---|---|---|
| `User.accessible_ai_agents_for` | `PG::UndefinedFunction` | ok |
| `AgentResolver.candidates_for(actor, nil)` | `PG::UndefinedFunction` | ok |
| `AgentResolver.candidates_for(actor, creative)` | `PG::UndefinedFunction` | ok |
| `AgentResolver.call(name, creative:)` | `PG::UndefinedFunction` | resolves the agent |

Test runs (SQLite, as CI does):

- `agent_resolver_test.rb` + `postgres_query_compatibility_test.rb` — 12 runs, 37 assertions, 0 failures
- `topic_create_service_test.rb`, `topic_update_service_test.rb`, `models_controller_test.rb` — 46 runs, 111 assertions, 0 failures
- `bin/rubocop` — 5 files, no offenses

## Guards

A green SQLite suite says nothing about this class of bug, so the fix ships with two:

1. **`test/db/postgres_query_compatibility_test.rb`** — asserts the guarded relations emit no `SELECT DISTINCT`, and pins the premise (that `users` still has `json` columns) so the assertions cannot quietly become vacuous. Runs in the ordinary suite on every PR.
2. **`script/postgres_query_smoke.rb`** — executes those queries against a real PostgreSQL, wired into the existing `postgres_schema_load` CI job. That job only ran `db:schema:load`; portable DDL does not imply portable query text. Confirmed to exit 1 on the unpatched code and 0 on this branch.

## Line count

+92 / −4 across 6 files (2 source lines changed; the rest is guards, tests, and comments).