### PR TITLE
feat(dnd): add DOM-independent creative move command

### DIFF
--- a/engines/collavre/app/javascript/creatives/drag_drop/__tests__/move_command.test.js
+++ b/engines/collavre/app/javascript/creatives/drag_drop/__tests__/move_command.test.js
@@ -1,0 +1,466 @@
+/**
+ * @jest-environment jsdom
+ */
+import { jest } from '@jest/globals'
+import {
+  MOVE_MODES,
+  MOVE_DIRECTIONS,
+  MOVE_FAILURE_REASONS,
+  InvalidMoveCommandError,
+  createMoveCommand,
+  executeMoveCommand,
+} from '../move_command'
+
+function okResponse() {
+  return { ok: true, status: 200 }
+}
+
+function failedResponse(status = 422) {
+  return { ok: false, status }
+}
+
+// Stands in for the ApiError thrown by sendLinkedCreative on a non-ok response.
+function httpError(status, message = `HTTP ${status}`) {
+  const error = new Error(message)
+  error.status = status
+  return error
+}
+
+describe('createMoveCommand', () => {
+  test('normalises a single numeric id into a string array', () => {
+    const command = createMoveCommand({ ids: 7, targetId: 9, direction: 'child' })
+
+    expect(command.ids).toEqual(['7'])
+    expect(command.targetId).toBe('9')
+  })
+
+  test('drops blank and duplicate ids while preserving first-seen order', () => {
+    const command = createMoveCommand({
+      ids: ['3', '', '5', ' ', '3', null, 4],
+      targetId: '9',
+      direction: 'up',
+    })
+
+    expect(command.ids).toEqual(['3', '5', '4'])
+  })
+
+  test('defaults the mode to a plain move', () => {
+    const command = createMoveCommand({ ids: ['3'], targetId: '9', direction: 'up' })
+
+    expect(command.mode).toBe(MOVE_MODES.MOVE)
+  })
+
+  test('returns a frozen command so adapters cannot mutate it mid-flight', () => {
+    const command = createMoveCommand({ ids: ['3'], targetId: '9', direction: 'up' })
+
+    expect(Object.isFrozen(command)).toBe(true)
+    expect(Object.isFrozen(command.ids)).toBe(true)
+  })
+
+  test('rejects an empty selection', () => {
+    expect(() => createMoveCommand({ ids: ['', null], targetId: '9', direction: 'up' }))
+      .toThrow(expect.objectContaining({ reason: 'empty_ids' }))
+  })
+
+  test('rejects a missing target', () => {
+    expect(() => createMoveCommand({ ids: ['3'], targetId: '  ', direction: 'up' }))
+      .toThrow(expect.objectContaining({ reason: 'missing_target' }))
+  })
+
+  test('rejects an unknown direction', () => {
+    expect(() => createMoveCommand({ ids: ['3'], targetId: '9', direction: 'sideways' }))
+      .toThrow(expect.objectContaining({ reason: 'invalid_direction' }))
+  })
+
+  test('rejects an unknown mode', () => {
+    expect(() => createMoveCommand({ ids: ['3'], targetId: '9', direction: 'up', mode: 'copy' }))
+      .toThrow(expect.objectContaining({ reason: 'invalid_mode' }))
+  })
+
+  test('rejects a selection that contains its own drop target', () => {
+    expect(() => createMoveCommand({ ids: ['3', '9'], targetId: '9', direction: 'child' }))
+      .toThrow(expect.objectContaining({ reason: 'target_in_selection' }))
+  })
+
+  test('throws InvalidMoveCommandError, not a bare Error', () => {
+    expect(() => createMoveCommand({ ids: [], targetId: '9', direction: 'up' }))
+      .toThrow(InvalidMoveCommandError)
+  })
+
+  test('accepts every supported direction', () => {
+    MOVE_DIRECTIONS.forEach((direction) => {
+      expect(createMoveCommand({ ids: ['3'], targetId: '9', direction }).direction).toBe(direction)
+    })
+  })
+})
+
+describe('executeMoveCommand — move mode', () => {
+  test('sends a single-id selection as dragged_id, not dragged_ids', async () => {
+    const sendNewOrder = jest.fn().mockResolvedValue(okResponse())
+
+    await executeMoveCommand(
+      createMoveCommand({ ids: ['3'], targetId: '9', direction: 'child' }),
+      { api: { sendNewOrder } }
+    )
+
+    expect(sendNewOrder).toHaveBeenCalledWith({ draggedId: '3', targetId: '9', direction: 'child' })
+  })
+
+  test('sends a multi-id selection as dragged_ids', async () => {
+    const sendNewOrder = jest.fn().mockResolvedValue(okResponse())
+
+    await executeMoveCommand(
+      createMoveCommand({ ids: ['3', '4'], targetId: '9', direction: 'down' }),
+      { api: { sendNewOrder } }
+    )
+
+    expect(sendNewOrder).toHaveBeenCalledWith({
+      draggedIds: ['3', '4'],
+      targetId: '9',
+      direction: 'down',
+    })
+  })
+
+  test('reports every id as succeeded when the reorder is accepted', async () => {
+    const sendNewOrder = jest.fn().mockResolvedValue(okResponse())
+
+    const result = await executeMoveCommand(
+      createMoveCommand({ ids: ['3', '4'], targetId: '9', direction: 'down' }),
+      { api: { sendNewOrder } }
+    )
+
+    expect(result.status).toBe('success')
+    expect(result.ok).toBe(true)
+    expect(result.succeededIds).toEqual(['3', '4'])
+    expect(result.failedIds).toEqual([])
+    expect(result.failures).toEqual([])
+  })
+
+  test('a rejected reorder fails the whole selection — the server batch is atomic', async () => {
+    const sendNewOrder = jest.fn().mockResolvedValue(failedResponse(422))
+
+    const result = await executeMoveCommand(
+      createMoveCommand({ ids: ['3', '4'], targetId: '9', direction: 'down' }),
+      { api: { sendNewOrder } }
+    )
+
+    expect(result.status).toBe('failure')
+    expect(result.ok).toBe(false)
+    expect(result.succeededIds).toEqual([])
+    expect(result.failedIds).toEqual(['3', '4'])
+    expect(result.failures.map((failure) => failure.reason))
+      .toEqual([MOVE_FAILURE_REASONS.REJECTED, MOVE_FAILURE_REASONS.REJECTED])
+  })
+
+  test('a 403 is reported as a permission failure, not a generic rejection', async () => {
+    const sendNewOrder = jest.fn().mockResolvedValue(failedResponse(403))
+
+    const result = await executeMoveCommand(
+      createMoveCommand({ ids: ['3'], targetId: '9', direction: 'up' }),
+      { api: { sendNewOrder } }
+    )
+
+    expect(result.failures[0]).toMatchObject({
+      id: '3',
+      status: 403,
+      reason: MOVE_FAILURE_REASONS.PERMISSION_DENIED,
+    })
+  })
+
+  test('a 500 is reported as a server failure', async () => {
+    const sendNewOrder = jest.fn().mockResolvedValue(failedResponse(500))
+
+    const result = await executeMoveCommand(
+      createMoveCommand({ ids: ['3'], targetId: '9', direction: 'up' }),
+      { api: { sendNewOrder } }
+    )
+
+    expect(result.failures[0].reason).toBe(MOVE_FAILURE_REASONS.SERVER_ERROR)
+  })
+
+  test('a transport error resolves to a failure result instead of rejecting', async () => {
+    const sendNewOrder = jest.fn().mockRejectedValue(new Error('offline'))
+
+    const result = await executeMoveCommand(
+      createMoveCommand({ ids: ['3'], targetId: '9', direction: 'up' }),
+      { api: { sendNewOrder } }
+    )
+
+    expect(result.status).toBe('failure')
+    expect(result.failures[0]).toMatchObject({
+      id: '3',
+      reason: MOVE_FAILURE_REASONS.NETWORK_ERROR,
+      message: 'offline',
+    })
+  })
+})
+
+describe('executeMoveCommand — link mode', () => {
+  test('issues one link_drop per selected id', async () => {
+    const sendLinkedCreative = jest.fn().mockResolvedValue({ creative_id: 1 })
+
+    await executeMoveCommand(
+      createMoveCommand({ ids: ['3', '4'], targetId: '9', direction: 'child', mode: MOVE_MODES.LINK }),
+      { api: { sendLinkedCreative } }
+    )
+
+    expect(sendLinkedCreative).toHaveBeenCalledTimes(2)
+    expect(sendLinkedCreative).toHaveBeenNthCalledWith(1, { draggedId: '3', targetId: '9', direction: 'child' })
+    expect(sendLinkedCreative).toHaveBeenNthCalledWith(2, { draggedId: '4', targetId: '9', direction: 'child' })
+  })
+
+  test('returns the server payloads in selection order', async () => {
+    const sendLinkedCreative = jest.fn(({ draggedId }) =>
+      Promise.resolve({ creative_id: Number(draggedId) * 10 }))
+
+    const result = await executeMoveCommand(
+      createMoveCommand({ ids: ['3', '4'], targetId: '9', direction: 'child', mode: 'link' }),
+      { api: { sendLinkedCreative } }
+    )
+
+    expect(result.status).toBe('success')
+    expect(result.payloads).toEqual([
+      { id: '3', data: { creative_id: 30 } },
+      { id: '4', data: { creative_id: 40 } },
+    ])
+  })
+
+  test('one failing link still attempts the rest and reports a partial success', async () => {
+    const sendLinkedCreative = jest.fn(({ draggedId }) =>
+      draggedId === '4' ? Promise.reject(httpError(422)) : Promise.resolve({ creative_id: 1 }))
+
+    const result = await executeMoveCommand(
+      createMoveCommand({ ids: ['3', '4', '5'], targetId: '9', direction: 'child', mode: 'link' }),
+      { api: { sendLinkedCreative } }
+    )
+
+    expect(sendLinkedCreative).toHaveBeenCalledTimes(3)
+    expect(result.status).toBe('partial')
+    expect(result.ok).toBe(false)
+    expect(result.succeededIds).toEqual(['3', '5'])
+    expect(result.failedIds).toEqual(['4'])
+  })
+
+  test('a partial link result keeps the shells that were already created', async () => {
+    const sendLinkedCreative = jest.fn(({ draggedId }) =>
+      draggedId === '4' ? Promise.reject(httpError(422)) : Promise.resolve({ creative_id: 1 }))
+
+    const result = await executeMoveCommand(
+      createMoveCommand({ ids: ['3', '4'], targetId: '9', direction: 'child', mode: 'link' }),
+      { api: { sendLinkedCreative } }
+    )
+
+    expect(result.payloads).toEqual([{ id: '3', data: { creative_id: 1 } }])
+    expect(result.rolledBack).toBe(false)
+  })
+
+  test('every link failing reports a plain failure, not a partial success', async () => {
+    const sendLinkedCreative = jest.fn().mockRejectedValue(httpError(422))
+
+    const result = await executeMoveCommand(
+      createMoveCommand({ ids: ['3', '4'], targetId: '9', direction: 'child', mode: 'link' }),
+      { api: { sendLinkedCreative } }
+    )
+
+    expect(result.status).toBe('failure')
+    expect(result.succeededIds).toEqual([])
+  })
+
+  test('classifies a 403 link failure as a permission failure', async () => {
+    const sendLinkedCreative = jest.fn().mockRejectedValue(httpError(403))
+
+    const result = await executeMoveCommand(
+      createMoveCommand({ ids: ['3'], targetId: '9', direction: 'child', mode: 'link' }),
+      { api: { sendLinkedCreative } }
+    )
+
+    expect(result.failures[0].reason).toBe(MOVE_FAILURE_REASONS.PERMISSION_DENIED)
+  })
+
+  test('classifies a status-less link failure as a transport failure', async () => {
+    const sendLinkedCreative = jest.fn().mockRejectedValue(new Error('offline'))
+
+    const result = await executeMoveCommand(
+      createMoveCommand({ ids: ['3'], targetId: '9', direction: 'child', mode: 'link' }),
+      { api: { sendLinkedCreative } }
+    )
+
+    expect(result.failures[0].reason).toBe(MOVE_FAILURE_REASONS.NETWORK_ERROR)
+  })
+
+  test('runs the link requests one at a time so the server resequence cannot race', async () => {
+    let inFlight = 0
+    let maxInFlight = 0
+    const sendLinkedCreative = jest.fn(() => {
+      inFlight += 1
+      maxInFlight = Math.max(maxInFlight, inFlight)
+      return new Promise((resolve) => {
+        setTimeout(() => {
+          inFlight -= 1
+          resolve({ creative_id: 1 })
+        }, 0)
+      })
+    })
+
+    await executeMoveCommand(
+      createMoveCommand({ ids: ['3', '4', '5'], targetId: '9', direction: 'child', mode: 'link' }),
+      { api: { sendLinkedCreative } }
+    )
+
+    expect(maxInFlight).toBe(1)
+  })
+
+  test('links downwards in reverse so the shells land in selection order', async () => {
+    const seen = []
+    const sendLinkedCreative = jest.fn(({ draggedId }) => {
+      seen.push(draggedId)
+      return Promise.resolve({ creative_id: 1 })
+    })
+
+    const result = await executeMoveCommand(
+      createMoveCommand({ ids: ['3', '4', '5'], targetId: '9', direction: 'down', mode: 'link' }),
+      { api: { sendLinkedCreative } }
+    )
+
+    // Each "down" link inserts directly after the target, so the last request
+    // ends up closest to it. Sending the selection backwards is what makes the
+    // final sibling order read 3, 4, 5.
+    expect(seen).toEqual(['5', '4', '3'])
+    expect(result.succeededIds).toEqual(['3', '4', '5'])
+  })
+
+  test('links upwards in selection order', async () => {
+    const seen = []
+    const sendLinkedCreative = jest.fn(({ draggedId }) => {
+      seen.push(draggedId)
+      return Promise.resolve({ creative_id: 1 })
+    })
+
+    await executeMoveCommand(
+      createMoveCommand({ ids: ['3', '4'], targetId: '9', direction: 'up', mode: 'link' }),
+      { api: { sendLinkedCreative } }
+    )
+
+    expect(seen).toEqual(['3', '4'])
+  })
+})
+
+describe('executeMoveCommand — contract', () => {
+  test('normalises a plain object command', async () => {
+    const sendNewOrder = jest.fn().mockResolvedValue(okResponse())
+
+    const result = await executeMoveCommand(
+      { ids: [3], targetId: 9, direction: 'up' },
+      { api: { sendNewOrder } }
+    )
+
+    expect(result.command.ids).toEqual(['3'])
+    expect(result.succeededIds).toEqual(['3'])
+  })
+
+  test('an invalid command is the only rejection path', async () => {
+    await expect(executeMoveCommand({ ids: [], targetId: '9', direction: 'up' }, { api: {} }))
+      .rejects.toThrow(InvalidMoveCommandError)
+  })
+})
+
+describe('executeMoveCommand — defensive paths', () => {
+  test('createMoveCommand called with no intent at all rejects as an empty selection', () => {
+    expect(() => createMoveCommand()).toThrow(expect.objectContaining({ reason: 'empty_ids' }))
+  })
+
+  test('a reorder that resolves nothing at all is a transport failure, not a success', async () => {
+    const sendNewOrder = jest.fn().mockResolvedValue(undefined)
+
+    const result = await executeMoveCommand(
+      createMoveCommand({ ids: ['3'], targetId: '9', direction: 'up' }),
+      { api: { sendNewOrder } }
+    )
+
+    expect(result.status).toBe('failure')
+    expect(result.failures[0].reason).toBe(MOVE_FAILURE_REASONS.NETWORK_ERROR)
+  })
+
+  test('a rejection carrying no error object is still reported per id', async () => {
+    const sendLinkedCreative = jest.fn().mockRejectedValue(undefined)
+
+    const result = await executeMoveCommand(
+      createMoveCommand({ ids: ['3'], targetId: '9', direction: 'child', mode: 'link' }),
+      { api: { sendLinkedCreative } }
+    )
+
+    expect(result.failures[0]).toMatchObject({
+      id: '3',
+      status: null,
+      reason: MOVE_FAILURE_REASONS.NETWORK_ERROR,
+      message: '',
+    })
+  })
+
+  test('falls back to the real reorder endpoint when no api override is given', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers(),
+    })
+    global.fetch = fetchMock
+
+    const result = await executeMoveCommand(
+      createMoveCommand({ ids: ['3'], targetId: '9', direction: 'up' })
+    )
+
+    expect(fetchMock.mock.calls[0][0]).toBe('/creatives/reorder')
+    expect(result.status).toBe('success')
+    delete global.fetch
+  })
+})
+
+// An expired session sends *any* request to the login page
+// (Authentication#request_authentication redirects unconditionally), and fetch
+// follows that redirect and hands back a perfectly ok HTML response. Trusting
+// `response.ok` alone would report a move that never reached the endpoint as
+// applied, and the adapter would keep an optimistic DOM the database disagrees
+// with until the next reload.
+describe('executeMoveCommand — expired session', () => {
+  test('a reorder answered by the login redirect is not a success', async () => {
+    const sendNewOrder = jest.fn().mockResolvedValue({ ok: true, status: 200, redirected: true })
+
+    const result = await executeMoveCommand(
+      createMoveCommand({ ids: ['3', '4'], targetId: '9', direction: 'child' }),
+      { api: { sendNewOrder } }
+    )
+
+    expect(result.status).toBe('failure')
+    expect(result.succeededIds).toEqual([])
+    expect(result.failures.map((failure) => failure.reason))
+      .toEqual([
+        MOVE_FAILURE_REASONS.AUTHENTICATION_REQUIRED,
+        MOVE_FAILURE_REASONS.AUTHENTICATION_REQUIRED,
+      ])
+  })
+
+  test('a 401 asks for a new session rather than blaming permissions', async () => {
+    const sendNewOrder = jest.fn().mockResolvedValue(failedResponse(401))
+
+    const result = await executeMoveCommand(
+      createMoveCommand({ ids: ['3'], targetId: '9', direction: 'up' }),
+      { api: { sendNewOrder } }
+    )
+
+    expect(result.failures[0].reason).toBe(MOVE_FAILURE_REASONS.AUTHENTICATION_REQUIRED)
+  })
+
+  test('a link rejected as unauthenticated is reported as such', async () => {
+    const error = new Error('Authentication required')
+    error.status = 200
+    error.authenticationRequired = true
+    const sendLinkedCreative = jest.fn().mockRejectedValue(error)
+
+    const result = await executeMoveCommand(
+      createMoveCommand({ ids: ['3'], targetId: '9', direction: 'child', mode: 'link' }),
+      { api: { sendLinkedCreative } }
+    )
+
+    expect(result.failures[0].reason).toBe(MOVE_FAILURE_REASONS.AUTHENTICATION_REQUIRED)
+  })
+})

--- a/engines/collavre/app/javascript/creatives/drag_drop/__tests__/move_command_dom_recovery.test.js
+++ b/engines/collavre/app/javascript/creatives/drag_drop/__tests__/move_command_dom_recovery.test.js
@@ -1,0 +1,233 @@
+/**
+ * @jest-environment jsdom
+ */
+
+// The right-hand creative tree moves the row before the server has agreed to
+// anything, so every non-success outcome has to put the DOM back. That recovery
+// is adapter work — `move_command.js` stays DOM-free — and this file pins the
+// seam between the two.
+import { jest } from '@jest/globals'
+import {
+  createMoveContext,
+  applyMove,
+  runMoveWithDomRecovery,
+} from '../operations'
+import { createMoveCommand, InvalidMoveCommandError } from '../move_command'
+
+function mountTree() {
+  document.body.innerHTML = `
+    <div id="creatives">
+      <creative-tree-row creative-id="3" parent-id="1" level="2">
+        <div class="creative-tree" id="creative-3" data-id="3" data-level="2"></div>
+      </creative-tree-row>
+      <creative-tree-row creative-id="9" parent-id="1" level="2">
+        <div class="creative-tree" id="creative-9" data-id="9" data-level="2"></div>
+      </creative-tree-row>
+    </div>
+  `
+
+  return {
+    draggedRow: document.querySelector('creative-tree-row[creative-id="3"]'),
+    targetRow: document.querySelector('creative-tree-row[creative-id="9"]'),
+  }
+}
+
+// Drops row 3 onto row 9 as a child, exactly as the drop handler does, and
+// hands back what the adapter needs to undo it.
+function optimisticallyDropAsChild() {
+  const { draggedRow, targetRow } = mountTree()
+  const draggedState = { row: draggedRow, parentId: '1', level: 2, isRoot: false }
+  const moveContext = createMoveContext(draggedState, targetRow, null)
+  const { newParentId } = applyMove({
+    direction: 'child',
+    targetRow,
+    draggedState,
+    draggedChildren: null,
+    moveContext,
+  })
+
+  return { draggedRow, targetRow, moveContext, newParentId }
+}
+
+function childrenContainer() {
+  return document.getElementById('creative-children-9')
+}
+
+function topLevelRowIds() {
+  return Array.from(document.querySelectorAll('#creatives > creative-tree-row'))
+    .map((row) => row.getAttribute('creative-id'))
+}
+
+const COMMAND = () => createMoveCommand({ ids: ['3'], targetId: '9', direction: 'child' })
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+test('an accepted move leaves the optimistic DOM exactly where the drop put it', async () => {
+  const { draggedRow, moveContext, newParentId } = optimisticallyDropAsChild()
+  const execute = jest.fn().mockResolvedValue({ status: 'success', ok: true })
+
+  const result = await runMoveWithDomRecovery({
+    command: COMMAND(),
+    moveContext,
+    attemptedParentId: newParentId,
+    execute,
+  })
+
+  expect(result.status).toBe('success')
+  expect(childrenContainer().contains(draggedRow)).toBe(true)
+  expect(draggedRow.getAttribute('parent-id')).toBe('9')
+})
+
+test('a rejected move puts the row back under its original parent', async () => {
+  const { draggedRow, moveContext, newParentId } = optimisticallyDropAsChild()
+  const execute = jest.fn().mockResolvedValue({ status: 'failure', ok: false })
+
+  await runMoveWithDomRecovery({
+    command: COMMAND(),
+    moveContext,
+    attemptedParentId: newParentId,
+    execute,
+  })
+
+  expect(topLevelRowIds()).toEqual(['3', '9'])
+  expect(draggedRow.getAttribute('parent-id')).toBe('1')
+  expect(draggedRow.getAttribute('level')).toBe('2')
+  // ensureChildrenContainer created it for the optimistic drop; the undo takes
+  // it away again so row 9 does not keep a phantom expand arrow.
+  expect(childrenContainer()).toBeNull()
+  expect(document.querySelector('creative-tree-row[creative-id="9"]').hasAttribute('has-children'))
+    .toBe(false)
+})
+
+test('a transport failure recovers the DOM just like a rejection', async () => {
+  const { draggedRow, moveContext, newParentId } = optimisticallyDropAsChild()
+  const execute = jest.fn().mockResolvedValue({
+    status: 'failure',
+    ok: false,
+    failures: [{ id: '3', reason: 'network_error' }],
+  })
+
+  await runMoveWithDomRecovery({
+    command: COMMAND(),
+    moveContext,
+    attemptedParentId: newParentId,
+    execute,
+  })
+
+  expect(topLevelRowIds()).toEqual(['3', '9'])
+  expect(draggedRow.getAttribute('parent-id')).toBe('1')
+})
+
+test('a partial result recovers the DOM — half a move is not a move', async () => {
+  const { draggedRow, moveContext, newParentId } = optimisticallyDropAsChild()
+  const execute = jest.fn().mockResolvedValue({ status: 'partial', ok: false })
+
+  await runMoveWithDomRecovery({
+    command: COMMAND(),
+    moveContext,
+    attemptedParentId: newParentId,
+    execute,
+  })
+
+  expect(topLevelRowIds()).toEqual(['3', '9'])
+  expect(draggedRow.getAttribute('parent-id')).toBe('1')
+})
+
+test('a failure without an optimistic context is reported without touching the DOM', async () => {
+  mountTree()
+  const execute = jest.fn().mockResolvedValue({ status: 'partial', ok: false })
+
+  const result = await runMoveWithDomRecovery({
+    command: createMoveCommand({ ids: ['3'], targetId: '9', direction: 'child', mode: 'link' }),
+    execute,
+  })
+
+  expect(result.status).toBe('partial')
+  expect(topLevelRowIds()).toEqual(['3', '9'])
+})
+
+test('an invalid command recovers the DOM and surfaces the error', async () => {
+  const { draggedRow, moveContext, newParentId } = optimisticallyDropAsChild()
+
+  await expect(runMoveWithDomRecovery({
+    command: { ids: [], targetId: '9', direction: 'child' },
+    moveContext,
+    attemptedParentId: newParentId,
+  })).rejects.toThrow(InvalidMoveCommandError)
+
+  expect(topLevelRowIds()).toEqual(['3', '9'])
+  expect(draggedRow.getAttribute('parent-id')).toBe('1')
+})
+
+test('the command reaches the server through the injected api', async () => {
+  const { moveContext, newParentId } = optimisticallyDropAsChild()
+  const sendNewOrder = jest.fn().mockResolvedValue({ ok: true, status: 200 })
+
+  const result = await runMoveWithDomRecovery({
+    command: COMMAND(),
+    moveContext,
+    attemptedParentId: newParentId,
+    api: { sendNewOrder },
+  })
+
+  expect(sendNewOrder).toHaveBeenCalledWith({ draggedId: '3', targetId: '9', direction: 'child' })
+  expect(result.status).toBe('success')
+})
+
+test('the real reorder path reverts the DOM on a 403', async () => {
+  const { draggedRow, moveContext, newParentId } = optimisticallyDropAsChild()
+  const sendNewOrder = jest.fn().mockResolvedValue({ ok: false, status: 403 })
+
+  const result = await runMoveWithDomRecovery({
+    command: COMMAND(),
+    moveContext,
+    attemptedParentId: newParentId,
+    api: { sendNewOrder },
+  })
+
+  expect(result.failures[0].reason).toBe('permission_denied')
+  expect(topLevelRowIds()).toEqual(['3', '9'])
+  expect(draggedRow.getAttribute('parent-id')).toBe('1')
+})
+
+test('a command runner that throws synchronously still triggers recovery', async () => {
+  const { draggedRow, moveContext, newParentId } = optimisticallyDropAsChild()
+  const execute = jest.fn(() => { throw new Error('boom') })
+
+  await expect(runMoveWithDomRecovery({
+    command: COMMAND(),
+    moveContext,
+    attemptedParentId: newParentId,
+    execute,
+  })).rejects.toThrow('boom')
+
+  expect(topLevelRowIds()).toEqual(['3', '9'])
+  expect(draggedRow.getAttribute('parent-id')).toBe('1')
+})
+
+test('a move swallowed by the login redirect reverts the optimistic DOM', async () => {
+  const { draggedRow, moveContext, newParentId } = optimisticallyDropAsChild()
+  const sendNewOrder = jest.fn().mockResolvedValue({ ok: true, status: 200, redirected: true })
+
+  const result = await runMoveWithDomRecovery({
+    command: COMMAND(),
+    moveContext,
+    attemptedParentId: newParentId,
+    api: { sendNewOrder },
+  })
+
+  expect(result.failures[0].reason).toBe('authentication_required')
+  expect(topLevelRowIds()).toEqual(['3', '9'])
+  expect(draggedRow.getAttribute('parent-id')).toBe('1')
+})
+
+test('an omitted move intent rejects without changing the existing tree', async () => {
+  mountTree()
+  const before = document.getElementById('creatives').innerHTML
+
+  await expect(runMoveWithDomRecovery()).rejects.toThrow(InvalidMoveCommandError)
+
+  expect(document.getElementById('creatives').innerHTML).toBe(before)
+})

--- a/engines/collavre/app/javascript/creatives/drag_drop/move_command.js
+++ b/engines/collavre/app/javascript/creatives/drag_drop/move_command.js
@@ -1,0 +1,276 @@
+/**
+ * DOM-independent creative move command.
+ *
+ * A move is described by `{ ids, targetId, direction, mode }` and nothing else:
+ * no rows, no containers, no drag session. That is the whole point — the right
+ * creative tree, the left workspace tree, and the keyboard/menu move path all
+ * express the same intent, and only the *adapter* that issued it knows how to
+ * repaint anything. Adapters own the optimistic DOM; this module owns the
+ * server call and the outcome vocabulary.
+ *
+ * Two server endpoints sit behind one command:
+ *
+ *   mode 'move' -> POST /creatives/reorder    (Reorderer#reorder / #reorder_multiple)
+ *   mode 'link' -> POST /creatives/link_drop  (Reorderer#link_drop)
+ *
+ * ## Partial success policy
+ *
+ * `move` is atomic. `reorder_multiple` authorises and validates every id before
+ * it mutates a row, so the batch either lands whole or not at all — the result
+ * is `success` or `failure`, never `partial`.
+ *
+ * `link` is not atomic and cannot be made atomic from the client: there is no
+ * batch link endpoint, so N selected creatives mean N independent inserts. The
+ * policy this module implements, deliberately:
+ *
+ *   1. Every id is attempted. One failure does not cancel the ids behind it —
+ *      a link shell is an additive, non-destructive insert, so a permission
+ *      failure on one creative says nothing about the next.
+ *   2. Shells that were already created are NOT rolled back. Undoing them would
+ *      need destroy calls that can fail in turn, leaving a worse mess than the
+ *      partial state. `rolledBack` is therefore always false, and is reported
+ *      explicitly so callers do not have to assume.
+ *   3. `partial` is a distinct status. Callers must not treat it as success
+ *      (some links are missing) nor as failure (some links exist, and a blanket
+ *      "failed" message would send the user to create duplicates).
+ *   4. Requests run one at a time. Each link_drop resequences the destination's
+ *      sibling list, so concurrent inserts race and produce a scrambled order.
+ *   5. For direction 'down' the requests are issued in reverse selection order,
+ *      because every insert lands directly after the target — sending 3,4,5
+ *      forwards would leave them ordered 5,4,3. `succeededIds` and `payloads`
+ *      are still reported in selection order. A DOM adapter must insert these
+ *      payloads as a contiguous run in that order, rather than repeatedly
+ *      inserting each payload immediately after the original target.
+ *
+ * ## Expired sessions
+ *
+ * `Authentication#request_authentication` redirects *any* request without a
+ * live session to the login page, POSTs included, and fetch follows that
+ * redirect and returns an `ok` HTML response. A redirected response is
+ * therefore reported as `authentication_required`, never as a move that
+ * landed — otherwise the adapter would keep an optimistic DOM the database
+ * disagrees with until the next reload.
+ *
+ * `executeMoveCommand` resolves for every transport and server outcome. The
+ * only rejection path is an invalid command, which is a programming error.
+ */
+
+import { sendNewOrder, sendLinkedCreative, isAuthenticationRedirect } from '../../lib/api/drag_drop';
+
+export const MOVE_MODES = Object.freeze({
+  MOVE: 'move',
+  LINK: 'link',
+});
+
+export const MOVE_DIRECTIONS = Object.freeze(['up', 'down', 'child']);
+
+export const MOVE_STATUSES = Object.freeze({
+  SUCCESS: 'success',
+  PARTIAL: 'partial',
+  FAILURE: 'failure',
+});
+
+export const MOVE_FAILURE_REASONS = Object.freeze({
+  AUTHENTICATION_REQUIRED: 'authentication_required',
+  PERMISSION_DENIED: 'permission_denied',
+  REJECTED: 'rejected',
+  SERVER_ERROR: 'server_error',
+  NETWORK_ERROR: 'network_error',
+});
+
+/** Thrown by {@link createMoveCommand} when the command cannot describe a move. */
+export class InvalidMoveCommandError extends Error {
+  constructor(reason) {
+    super(`Invalid move command: ${reason}`);
+    this.name = 'InvalidMoveCommandError';
+    this.reason = reason;
+  }
+}
+
+function normalizeId(value) {
+  if (value === null || value === undefined) return '';
+  return String(value).trim();
+}
+
+function normalizeIds(value) {
+  const list = Array.isArray(value) ? value : [value];
+  const seen = new Set();
+  const ids = [];
+
+  list.forEach((entry) => {
+    const id = normalizeId(entry);
+    if (!id || seen.has(id)) return;
+    seen.add(id);
+    ids.push(id);
+  });
+
+  return ids;
+}
+
+/**
+ * Validate and normalise a move intent.
+ *
+ * @param {{ids: (string|number|Array), targetId: string|number, direction: string, mode?: string}} intent
+ * @returns {Readonly<{ids: string[], targetId: string, direction: string, mode: string}>}
+ * @throws {InvalidMoveCommandError}
+ */
+export function createMoveCommand({ ids, targetId, direction, mode = MOVE_MODES.MOVE } = {}) {
+  const normalizedIds = normalizeIds(ids);
+  if (normalizedIds.length === 0) throw new InvalidMoveCommandError('empty_ids');
+
+  const normalizedTargetId = normalizeId(targetId);
+  if (!normalizedTargetId) throw new InvalidMoveCommandError('missing_target');
+
+  if (!MOVE_DIRECTIONS.includes(direction)) throw new InvalidMoveCommandError('invalid_direction');
+  if (!Object.values(MOVE_MODES).includes(mode)) throw new InvalidMoveCommandError('invalid_mode');
+
+  // The server rejects this too, but catching it here keeps an adapter from
+  // optimistically moving a row onto itself and then having to undo it.
+  if (normalizedIds.includes(normalizedTargetId)) {
+    throw new InvalidMoveCommandError('target_in_selection');
+  }
+
+  return Object.freeze({
+    ids: Object.freeze(normalizedIds),
+    targetId: normalizedTargetId,
+    direction,
+    mode,
+  });
+}
+
+function classifyStatus(status) {
+  // 401 is "sign in again", 403 is "you may not do that" — different messages,
+  // so they get different reasons.
+  if (status === 401) return MOVE_FAILURE_REASONS.AUTHENTICATION_REQUIRED;
+  if (status === 403) return MOVE_FAILURE_REASONS.PERMISSION_DENIED;
+  if (typeof status !== 'number') return MOVE_FAILURE_REASONS.NETWORK_ERROR;
+  if (status >= 500) return MOVE_FAILURE_REASONS.SERVER_ERROR;
+  return MOVE_FAILURE_REASONS.REJECTED;
+}
+
+function failureFromError(id, error) {
+  const status = typeof error?.status === 'number' ? error.status : null;
+  return {
+    id,
+    status,
+    reason: error?.authenticationRequired
+      ? MOVE_FAILURE_REASONS.AUTHENTICATION_REQUIRED
+      : classifyStatus(status),
+    message: error?.message || '',
+  };
+}
+
+function buildResult(command, { succeeded, failures, payloads = [] }) {
+  const failedIds = new Set(failures.map((failure) => failure.id));
+  const succeededIds = command.ids.filter((id) => succeeded.has(id));
+  let status = MOVE_STATUSES.FAILURE;
+  if (failedIds.size === 0) {
+    status = MOVE_STATUSES.SUCCESS;
+  } else if (succeededIds.length > 0) {
+    status = MOVE_STATUSES.PARTIAL;
+  }
+
+  return {
+    command,
+    status,
+    ok: status === MOVE_STATUSES.SUCCESS,
+    succeededIds,
+    failedIds: command.ids.filter((id) => failedIds.has(id)),
+    failures,
+    payloads,
+    // Always false: see the partial success policy at the top of this file.
+    rolledBack: false,
+  };
+}
+
+async function executeReorder(command, api) {
+  const { ids, targetId, direction } = command;
+  const payload = ids.length > 1
+    ? { draggedIds: [...ids], targetId, direction }
+    : { draggedId: ids[0], targetId, direction };
+
+  let response;
+  try {
+    response = await api.sendNewOrder(payload);
+  } catch (error) {
+    return buildResult(command, {
+      succeeded: new Set(),
+      failures: ids.map((id) => failureFromError(id, error)),
+    });
+  }
+
+  // An expired session redirects the POST to the login page and fetch follows
+  // it, so a redirected response is `ok` without the reorder ever running.
+  const unauthenticated = isAuthenticationRedirect(response);
+
+  if (response && response.ok && !unauthenticated) {
+    return buildResult(command, { succeeded: new Set(ids), failures: [] });
+  }
+
+  const status = typeof response?.status === 'number' ? response.status : null;
+  return buildResult(command, {
+    succeeded: new Set(),
+    failures: ids.map((id) => ({
+      id,
+      status,
+      reason: unauthenticated
+        ? MOVE_FAILURE_REASONS.AUTHENTICATION_REQUIRED
+        : classifyStatus(status),
+      message: '',
+    })),
+  });
+}
+
+async function executeLinkDrop(command, api) {
+  const { ids, targetId, direction } = command;
+  // See policy note 5: "down" inserts each shell immediately after the target.
+  const requestOrder = direction === 'down' ? [...ids].reverse() : [...ids];
+
+  const succeeded = new Set();
+  const failures = [];
+  const dataById = new Map();
+
+  // Sequential on purpose (policy note 4) — link_drop resequences siblings.
+  for (const id of requestOrder) {
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      const data = await api.sendLinkedCreative({ draggedId: id, targetId, direction });
+      succeeded.add(id);
+      dataById.set(id, data);
+    } catch (error) {
+      failures.push(failureFromError(id, error));
+    }
+  }
+
+  return buildResult(command, {
+    succeeded,
+    // Report in selection order regardless of the order the requests went out.
+    failures: ids.map((id) => failures.find((failure) => failure.id === id)).filter(Boolean),
+    payloads: ids
+      .filter((id) => succeeded.has(id))
+      .map((id) => ({ id, data: dataById.get(id) })),
+  });
+}
+
+/**
+ * Run a move command against the server.
+ *
+ * Never rejects for a transport or server failure — inspect `result.status`.
+ *
+ * @param {object} command a command from {@link createMoveCommand}, or a plain
+ *   intent object which is normalised the same way.
+ * @param {{api?: {sendNewOrder?: Function, sendLinkedCreative?: Function}}} [options]
+ * @returns {Promise<object>} move result
+ * @throws {InvalidMoveCommandError} when the command cannot describe a move
+ */
+export async function executeMoveCommand(command, { api = {} } = {}) {
+  const normalized = createMoveCommand(command);
+  const resolvedApi = {
+    sendNewOrder: api.sendNewOrder || sendNewOrder,
+    sendLinkedCreative: api.sendLinkedCreative || sendLinkedCreative,
+  };
+
+  return normalized.mode === MOVE_MODES.LINK
+    ? executeLinkDrop(normalized, resolvedApi)
+    : executeReorder(normalized, resolvedApi);
+}

--- a/engines/collavre/app/javascript/creatives/drag_drop/operations.js
+++ b/engines/collavre/app/javascript/creatives/drag_drop/operations.js
@@ -11,6 +11,7 @@ import {
   setExpanded,
   syncParentHasChildren,
 } from './dom';
+import { MOVE_STATUSES, executeMoveCommand } from './move_command';
 
 export function createMoveContext(draggedState, targetRow, draggedChildren) {
   return {
@@ -113,4 +114,58 @@ export function revertMove(context, attemptedParentId) {
 
   syncParentHasChildren(originalParentId);
   syncParentHasChildren(attemptedParentId);
+}
+
+/**
+ * Right-hand tree adapter: run a move command with optimistic-DOM recovery.
+ *
+ * The creative tree moves the row the instant the pointer is released, so the
+ * DOM is ahead of the server for the length of one request. Anything short of
+ * an outright success has to be undone — a `partial` link result included,
+ * since a half-applied move on screen is a lie either way.
+ *
+ * Recovery lives here, not in `move_command.js`: the command is DOM-free by
+ * contract so the left workspace tree and the keyboard move menu can reuse it
+ * with their own (or no) repaint strategy. Pass `moveContext: null` when there
+ * was no optimistic move to undo and this becomes a plain command runner.
+ *
+ * @param {object} options
+ * @param {object} options.command move command (or plain intent) to execute
+ * @param {object|null} [options.moveContext] context from {@link createMoveContext}
+ * @param {string|null} [options.attemptedParentId] parent the row was moved into
+ * @param {Function} [options.execute] command runner, injectable for tests
+ * @param {object} [options.api] API overrides forwarded to the command runner
+ * @returns {Promise<object>} the move result; rejects only for an invalid command
+ */
+export function runMoveWithDomRecovery({
+  command,
+  moveContext = null,
+  attemptedParentId = null,
+  execute = executeMoveCommand,
+  api,
+} = {}) {
+  const recoverDom = () => {
+    if (moveContext) revertMove(moveContext, attemptedParentId);
+  };
+
+  let running;
+  try {
+    running = Promise.resolve(execute(command, { api }));
+  } catch (error) {
+    // A synchronous throw from a non-async `execute` still leaves the row in
+    // the wrong place.
+    recoverDom();
+    return Promise.reject(error);
+  }
+
+  return running.then(
+    (result) => {
+      if (!result || result.status !== MOVE_STATUSES.SUCCESS) recoverDom();
+      return result;
+    },
+    (error) => {
+      recoverDom();
+      throw error;
+    }
+  );
 }

--- a/engines/collavre/app/javascript/lib/api/__tests__/drag_drop.test.js
+++ b/engines/collavre/app/javascript/lib/api/__tests__/drag_drop.test.js
@@ -1,0 +1,136 @@
+/**
+ * @jest-environment jsdom
+ */
+import { jest } from '@jest/globals'
+import { sendNewOrder, sendLinkedCreative, isAuthenticationRedirect } from '../drag_drop'
+import { ApiError } from '../api_error'
+
+function stubFetch({ status = 200, statusText = 'OK', body = '' } = {}) {
+  const response = {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText,
+    headers: new Headers(),
+    json: async () => JSON.parse(body || '{}'),
+    text: async () => body,
+  }
+  const fetchMock = jest.fn().mockResolvedValue(response)
+  global.fetch = fetchMock
+  return fetchMock
+}
+
+function bodyOf(fetchMock) {
+  return JSON.parse(fetchMock.mock.calls[0][1].body)
+}
+
+afterEach(() => {
+  delete global.fetch
+})
+
+describe('sendNewOrder', () => {
+  test('sends a single drag as dragged_id', async () => {
+    const fetchMock = stubFetch()
+
+    await sendNewOrder({ draggedId: '3', targetId: '9', direction: 'child' })
+
+    expect(fetchMock.mock.calls[0][0]).toBe('/creatives/reorder')
+    expect(bodyOf(fetchMock)).toEqual({ dragged_id: '3', target_id: '9', direction: 'child' })
+  })
+
+  test('sends a multi-drag as dragged_ids', async () => {
+    const fetchMock = stubFetch()
+
+    await sendNewOrder({ draggedIds: ['3', '4'], targetId: '9', direction: 'down' })
+
+    expect(bodyOf(fetchMock)).toEqual({ dragged_ids: ['3', '4'], target_id: '9', direction: 'down' })
+  })
+
+  test('resolves the raw response so the caller can branch on ok', async () => {
+    stubFetch({ status: 422, statusText: 'Unprocessable Entity' })
+
+    const response = await sendNewOrder({ draggedId: '3', targetId: '9', direction: 'up' })
+
+    expect(response.ok).toBe(false)
+    expect(response.status).toBe(422)
+  })
+})
+
+describe('sendLinkedCreative', () => {
+  test('resolves the created node payload', async () => {
+    stubFetch({ body: JSON.stringify({ creative_id: 31, parent_id: 9 }) })
+
+    await expect(sendLinkedCreative({ draggedId: '3', targetId: '9', direction: 'child' }))
+      .resolves.toEqual({ creative_id: 31, parent_id: 9 })
+  })
+
+  // Without the status a caller cannot tell "you may not do that" from "the
+  // server is down", and the multi-link partial-success report collapses into
+  // one undifferentiated failure.
+  test('carries the HTTP status on failure', async () => {
+    stubFetch({ status: 403, statusText: 'Forbidden' })
+
+    const error = await sendLinkedCreative({ draggedId: '3', targetId: '9', direction: 'child' })
+      .catch((caught) => caught)
+
+    expect(error).toBeInstanceOf(ApiError)
+    expect(error.status).toBe(403)
+  })
+
+  test('surfaces the server error message when the body carries one', async () => {
+    stubFetch({
+      status: 422,
+      statusText: 'Unprocessable Entity',
+      body: JSON.stringify({ error: 'Invalid creatives' }),
+    })
+
+    const error = await sendLinkedCreative({ draggedId: '3', targetId: '9', direction: 'child' })
+      .catch((caught) => caught)
+
+    expect(error.message).toBe('Invalid creatives')
+  })
+
+  test('falls back to the status line when the failure body is empty', async () => {
+    stubFetch({ status: 500, statusText: 'Internal Server Error' })
+
+    const error = await sendLinkedCreative({ draggedId: '3', targetId: '9', direction: 'child' })
+      .catch((caught) => caught)
+
+    expect(error.message).toBe('HTTP 500: Internal Server Error')
+  })
+})
+
+describe('expired session', () => {
+  test('a link_drop followed to the login page is rejected, not parsed as a node', async () => {
+    const response = {
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      redirected: true,
+      headers: new Headers(),
+      json: async () => { throw new SyntaxError('Unexpected token <') },
+      text: async () => '<!DOCTYPE html>',
+    }
+    global.fetch = jest.fn().mockResolvedValue(response)
+
+    const error = await sendLinkedCreative({ draggedId: '3', targetId: '9', direction: 'child' })
+      .catch((caught) => caught)
+
+    expect(error).toBeInstanceOf(ApiError)
+    expect(error.authenticationRequired).toBe(true)
+  })
+
+  test('a reorder followed to the login page is flagged on the response', async () => {
+    const fetchMock = stubFetch()
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      redirected: true,
+      headers: new Headers(),
+    })
+
+    const response = await sendNewOrder({ draggedId: '3', targetId: '9', direction: 'up' })
+
+    expect(isAuthenticationRedirect(response)).toBe(true)
+  })
+})

--- a/engines/collavre/app/javascript/lib/api/drag_drop.js
+++ b/engines/collavre/app/javascript/lib/api/drag_drop.js
@@ -1,4 +1,20 @@
 import csrfFetch from './csrf_fetch';
+import { ApiError, apiErrorFromResponse } from './api_error';
+
+/**
+ * True when the response is the login page rather than the endpoint's answer.
+ *
+ * `Authentication#request_authentication` redirects *every* request without a
+ * live session to `new_session_path` — POSTs included — and fetch follows that
+ * redirect and returns a perfectly `ok` HTML page. Trusting `response.ok`
+ * alone would read an expired session as a successful move.
+ *
+ * @param {Response} response
+ * @returns {boolean}
+ */
+export function isAuthenticationRedirect(response) {
+  return response?.redirected === true;
+}
 
 export function sendNewOrder({ draggedId, draggedIds, targetId, direction }) {
   const payload = { target_id: targetId, direction };
@@ -42,7 +58,15 @@ export function sendLinkedCreative({ draggedId, targetId, direction }) {
     },
     body: JSON.stringify({ dragged_id: draggedId, target_id: targetId, direction }),
   }).then((response) => {
-    if (!response.ok) throw new Error('Failed to create linked creative');
+    if (isAuthenticationRedirect(response)) {
+      const error = new ApiError('Authentication required', { status: response.status });
+      error.authenticationRequired = true;
+      throw error;
+    }
+    // An ApiError keeps the HTTP status attached: link_drop answers 403 for a
+    // permission failure and 422 for a domain rejection, and a multi-link drop
+    // has to report which of the two happened per creative.
+    if (!response.ok) return apiErrorFromResponse(response).then((error) => { throw error; });
     return response.json();
   });
 }


### PR DESCRIPTION
Creative moves now use a DOM-independent `{ ids, targetId, direction, mode }` command with explicit success, partial success, and failure results. Reorders use the existing atomic API; links run in order and preserve successful IDs when another link fails. Authentication redirects are rejected, and `runMoveWithDomRecovery` restores the right-tree adapter on unsuccessful moves.

This T2 foundation is rebased onto the merged T1 foundation `faf124a4`. T3 owns production call-site adoption and deletion of the old per-handler API paths; that adoption is already exercised in the separate integration branch. Existing MIME and T1 canonical IDs/DropIntent remain unchanged.

Vrex follow-ups are included: child links assert request order, the payload documentation specifies contiguous DOM insertion order, and missing-command input has explicit boundary coverage.

Validation: full Jest 136 suites / 1,840 tests and build passed; after the final test-only addition, all 57 focused tests passed. Changed executable statements, branch paths, and functions are 100% covered. Ruby is unavailable in the local integration environment, so Rails/Rubocop verification remains with the refreshed PR CI and Mac validation. Do not merge until every required CI check is green.

Partial link policy: successful shells remain, failed IDs are explicit, and callers must retry only failures. Only `down` reverses request order. DOM recovery stays in the adapter.