### PR TITLE
Refactor shared drag-and-drop data foundation

### DIFF
--- a/engines/collavre/app/javascript/creatives/drag_drop/__tests__/event_handlers_data.test.js
+++ b/engines/collavre/app/javascript/creatives/drag_drop/__tests__/event_handlers_data.test.js
@@ -1,0 +1,74 @@
+/**
+ * @jest-environment jsdom
+ */
+import { jest } from '@jest/globals';
+import { handleDragOver } from '../event_handlers';
+import { resetDraggedState } from '../state';
+
+function mountTarget() {
+  document.body.innerHTML = `
+    <creative-tree-row creative-id="7">
+      <div class="creative-tree" id="creative-7" draggable="true">
+        <span id="target"></span>
+      </div>
+    </creative-tree-row>
+  `;
+  const tree = document.getElementById('creative-7');
+  tree.getBoundingClientRect = () => ({ top: 100, height: 100 });
+  return { tree, target: document.getElementById('target') };
+}
+
+function dragEvent(target, types, clientY = 150) {
+  return {
+    target,
+    clientY,
+    clientX: 0,
+    shiftKey: false,
+    preventDefault: jest.fn(),
+    dataTransfer: { types, dropEffect: 'none' },
+  };
+}
+
+afterEach(() => {
+  resetDraggedState();
+  document.body.innerHTML = '';
+  jest.restoreAllMocks();
+});
+
+test('uses MIME types to ignore unsupported drags during dragover', () => {
+  const { tree, target } = mountTarget();
+  const event = dragEvent(target, ['Files']);
+
+  handleDragOver(event);
+
+  expect(event.preventDefault).not.toHaveBeenCalled();
+  expect(tree.classList.contains('drag-over')).toBe(false);
+});
+
+test('uses the shared boundary and hysteresis result for creative drags', () => {
+  const { tree, target } = mountTarget();
+  const boundary = dragEvent(target, ['application/x-collavre-creative'], 130);
+
+  handleDragOver(boundary);
+  expect(boundary.preventDefault).toHaveBeenCalled();
+  expect(boundary.dataTransfer.dropEffect).toBe('move');
+  expect(tree.classList.contains('drag-over-child')).toBe(true);
+
+  const outsideChildHysteresis = dragEvent(
+    target,
+    ['application/x-collavre-creative'],
+    117.9
+  );
+  handleDragOver(outsideChildHysteresis);
+  expect(tree.classList.contains('drag-over-top')).toBe(true);
+});
+
+test('keeps topic moves as child drops', () => {
+  const { tree, target } = mountTarget();
+  const event = dragEvent(target, ['application/x-topic-move'], 101);
+
+  handleDragOver(event);
+
+  expect(event.preventDefault).toHaveBeenCalled();
+  expect(tree.classList.contains('drag-over-child')).toBe(true);
+});

--- a/engines/collavre/app/javascript/creatives/drag_drop/__tests__/event_handlers_data.test.js
+++ b/engines/collavre/app/javascript/creatives/drag_drop/__tests__/event_handlers_data.test.js
@@ -76,6 +76,17 @@ test('uses MIME types to ignore unsupported drags during dragover', () => {
   expect(tree.classList.contains('drag-over')).toBe(false);
 });
 
+test('allows same-window dragover when storage prevented MIME writes', () => {
+  const { tree, target } = mountTarget();
+  setDraggedState({ creativeId: '1' });
+  const event = dragEvent(target, []);
+
+  handleDragOver(event);
+
+  expect(event.preventDefault).toHaveBeenCalled();
+  expect(tree.classList.contains('drag-over-child')).toBe(true);
+});
+
 test('clears the previous target and intent when dragover changes rows', () => {
   const { target } = mountTarget();
   const previous = document.createElement('div');

--- a/engines/collavre/app/javascript/creatives/drag_drop/__tests__/event_handlers_data.test.js
+++ b/engines/collavre/app/javascript/creatives/drag_drop/__tests__/event_handlers_data.test.js
@@ -2,14 +2,37 @@
  * @jest-environment jsdom
  */
 import { jest } from '@jest/globals';
-import { handleDragOver, handleDrop } from '../event_handlers';
 import {
+  addGlobalListeners,
+  handleDragLeave,
+  handleDragOver,
+  handleDragStart,
+  handleDrop,
+  removeGlobalListeners,
+} from '../event_handlers';
+import {
+  getDraggedState,
   getLastDragOverPosition,
   resetDraggedState,
   setDraggedState,
   setLastDragOverRow,
 } from '../state';
-import { writeDragData } from '../../../lib/dnd/envelope';
+import { LEGACY_MIME_TYPES, writeDragData } from '../../../lib/dnd/envelope';
+
+function dataTransfer() {
+  const transfer = new Map();
+  return {
+    types: [],
+    effectAllowed: 'none',
+    dropEffect: 'none',
+    setDragImage: jest.fn(),
+    setData(type, value) {
+      transfer.set(type, value);
+      this.types = [...transfer.keys()];
+    },
+    getData: (type) => transfer.get(type) || '',
+  };
+}
 
 function mountTarget() {
   document.body.innerHTML = `
@@ -36,8 +59,10 @@ function dragEvent(target, types, clientY = 150) {
 }
 
 afterEach(() => {
+  removeGlobalListeners();
   resetDraggedState();
   document.body.innerHTML = '';
+  delete globalThis.fetch;
   jest.restoreAllMocks();
 });
 
@@ -49,6 +74,18 @@ test('uses MIME types to ignore unsupported drags during dragover', () => {
 
   expect(event.preventDefault).not.toHaveBeenCalled();
   expect(tree.classList.contains('drag-over')).toBe(false);
+});
+
+test('clears the previous target and intent when dragover changes rows', () => {
+  const { target } = mountTarget();
+  const previous = document.createElement('div');
+  previous.className = 'drag-over drag-over-top';
+  setLastDragOverRow(previous, 'up');
+
+  handleDragOver(dragEvent(target, ['Files']));
+
+  expect(previous.classList.contains('drag-over')).toBe(false);
+  expect(getLastDragOverPosition()).toBeNull();
 });
 
 test('uses the shared boundary and hysteresis result for creative drags', () => {
@@ -81,32 +118,51 @@ test('keeps topic moves as child drops', () => {
   expect(tree.classList.contains('drag-over-child')).toBe(true);
 });
 
-test('drops with the stored intent without reading preview CSS classes', async () => {
+test('starts a selected creative bundle through the shared writer', () => {
   document.body.innerHTML = `
-    <div id="creatives">
-      <creative-tree-row creative-id="1" level="1" is-root>
-        <div class="creative-tree" id="creative-1" draggable="true"></div>
-      </creative-tree-row>
-      <creative-tree-row creative-id="2" level="1" is-root>
-        <div class="creative-tree" id="creative-2" draggable="true">
-          <span id="drop-target"></span>
-        </div>
-      </creative-tree-row>
-    </div>
+    <input class="select-creative-checkbox" type="checkbox" value="2" checked>
+    <creative-tree-row creative-id="1" level="1" is-root>
+      <div class="creative-tree" id="creative-1" draggable="true">
+      <span class="creative-content">First</span>
+      <span id="drag-target"></span>
+      </div>
+    </creative-tree-row>
   `;
+  const transfer = dataTransfer();
+
+  handleDragStart({
+    target: document.getElementById('drag-target'),
+    dataTransfer: transfer,
+  });
+
+  expect(transfer.effectAllowed).toBe('move');
+  expect(transfer.types).toContain(LEGACY_MIME_TYPES.creative);
+  expect(JSON.parse(transfer.getData(LEGACY_MIME_TYPES.creative))).toMatchObject({
+    creativeId: '1',
+    selectedCreativeIds: ['2', '1'],
+  });
+  expect(getDraggedState()).toMatchObject({
+    creativeId: '1',
+    selectedCreativeIds: ['2', '1'],
+  });
+});
+
+test('drops with the stored intent without reading preview CSS classes', async () => {
+  document.body.innerHTML = `<div id="creatives">
+    <creative-tree-row creative-id="1" level="1" is-root>
+      <div class="creative-tree" id="creative-1" draggable="true"></div>
+    </creative-tree-row>
+    <creative-tree-row creative-id="2" level="1" is-root>
+      <div class="creative-tree" id="creative-2" draggable="true">
+      <span id="drop-target"></span>
+      </div>
+    </creative-tree-row>
+  </div>`;
   const sourceTree = document.getElementById('creative-1');
   const sourceRow = sourceTree.closest('creative-tree-row');
   const targetTree = document.getElementById('creative-2');
-  const transfer = new Map();
-  const dataTransfer = {
-    types: [],
-    setData(type, value) {
-      transfer.set(type, value);
-      this.types = [...transfer.keys()];
-    },
-    getData: (type) => transfer.get(type) || '',
-  };
-  writeDragData(dataTransfer, {
+  const transfer = dataTransfer();
+  writeDragData(transfer, {
     kind: 'creative',
     ids: ['1'],
     payload: {
@@ -139,7 +195,7 @@ test('drops with the stored intent without reading preview CSS classes', async (
     clientY: 150,
     shiftKey: false,
     preventDefault: jest.fn(),
-    dataTransfer,
+    dataTransfer: transfer,
   });
   await new Promise((resolve) => setTimeout(resolve, 0));
 
@@ -149,5 +205,110 @@ test('drops with the stored intent without reading preview CSS classes', async (
     target_id: '2',
     direction: 'up',
   });
-  delete globalThis.fetch;
+});
+
+test('preserves canonical ids for an external creative bundle', () => {
+  document.body.innerHTML = `<creative-tree-row creative-id="9" level="1" is-root>
+    <div class="creative-tree" id="creative-9" draggable="true">
+      <span id="external-drop-target"></span>
+    </div>
+  </creative-tree-row>`;
+  const targetTree = document.getElementById('creative-9');
+  const transfer = dataTransfer();
+  writeDragData(transfer, {
+    kind: 'creative',
+    ids: ['1', '2'],
+    payload: {
+      creativeId: '1',
+      treeId: 'creative-1',
+      level: 1,
+      isRoot: true,
+    },
+  });
+  setLastDragOverRow(targetTree, 'child');
+
+  const fetchMock = jest.fn(() => new Promise(() => {}));
+  globalThis.fetch = fetchMock;
+  handleDrop({
+    target: document.getElementById('external-drop-target'),
+    clientY: 150,
+    shiftKey: false,
+    preventDefault: jest.fn(),
+    dataTransfer: transfer,
+  });
+
+  const options = fetchMock.mock.calls[0][1];
+  expect(JSON.parse(options.body)).toMatchObject({
+    dragged_ids: ['1', '2'],
+    target_id: '9',
+    direction: 'child',
+  });
+});
+
+test('falls back to hit testing when no preview intent is stored', () => {
+  const { tree, target } = mountTarget();
+  const transfer = dataTransfer();
+  writeDragData(transfer, {
+    kind: 'creative',
+    ids: ['1'],
+    payload: { creativeId: '1', treeId: 'creative-1' },
+  });
+  const fetchMock = jest.fn(() => new Promise(() => {}));
+  globalThis.fetch = fetchMock;
+
+  handleDrop({
+    target,
+    clientY: 101,
+    shiftKey: false,
+    preventDefault: jest.fn(),
+    dataTransfer: transfer,
+  });
+
+  expect(JSON.parse(fetchMock.mock.calls[0][1].body).direction).toBe('up');
+  expect(tree.classList.contains('drag-over')).toBe(false);
+});
+
+test('rejects a drop when fallback hit-test geometry is invalid', () => {
+  const { tree, target } = mountTarget();
+  tree.getBoundingClientRect = () => ({ top: 0, height: 0 });
+  const transfer = dataTransfer();
+  writeDragData(transfer, {
+    kind: 'creative',
+    ids: ['1'],
+    payload: { creativeId: '1', treeId: 'creative-1' },
+  });
+  const fetchMock = jest.fn();
+  globalThis.fetch = fetchMock;
+
+  handleDrop({
+    target,
+    clientY: 0,
+    shiftKey: false,
+    preventDefault: jest.fn(),
+    dataTransfer: transfer,
+  });
+
+  expect(fetchMock).not.toHaveBeenCalled();
+});
+
+test('clears stored intent when the active target is left', () => {
+  const { tree, target } = mountTarget();
+  setLastDragOverRow(tree, 'child');
+  tree.classList.add('drag-over', 'drag-over-child');
+
+  handleDragLeave({ target });
+
+  expect(tree.classList.contains('drag-over')).toBe(false);
+  expect(getLastDragOverPosition()).toBeNull();
+});
+
+test('ignores unrelated storage events through the shared signal reader', () => {
+  addGlobalListeners();
+
+  window.dispatchEvent(new StorageEvent('storage', {
+    key: 'unrelated',
+    newValue: '{}',
+  }));
+
+  removeGlobalListeners();
 });

--- a/engines/collavre/app/javascript/creatives/drag_drop/__tests__/event_handlers_data.test.js
+++ b/engines/collavre/app/javascript/creatives/drag_drop/__tests__/event_handlers_data.test.js
@@ -2,8 +2,14 @@
  * @jest-environment jsdom
  */
 import { jest } from '@jest/globals';
-import { handleDragOver } from '../event_handlers';
-import { resetDraggedState } from '../state';
+import { handleDragOver, handleDrop } from '../event_handlers';
+import {
+  getLastDragOverPosition,
+  resetDraggedState,
+  setDraggedState,
+  setLastDragOverRow,
+} from '../state';
+import { writeDragData } from '../../../lib/dnd/envelope';
 
 function mountTarget() {
   document.body.innerHTML = `
@@ -53,6 +59,7 @@ test('uses the shared boundary and hysteresis result for creative drags', () => 
   expect(boundary.preventDefault).toHaveBeenCalled();
   expect(boundary.dataTransfer.dropEffect).toBe('move');
   expect(tree.classList.contains('drag-over-child')).toBe(true);
+  expect(getLastDragOverPosition()).toBe('child');
 
   const outsideChildHysteresis = dragEvent(
     target,
@@ -61,6 +68,7 @@ test('uses the shared boundary and hysteresis result for creative drags', () => 
   );
   handleDragOver(outsideChildHysteresis);
   expect(tree.classList.contains('drag-over-top')).toBe(true);
+  expect(getLastDragOverPosition()).toBe('up');
 });
 
 test('keeps topic moves as child drops', () => {
@@ -71,4 +79,75 @@ test('keeps topic moves as child drops', () => {
 
   expect(event.preventDefault).toHaveBeenCalled();
   expect(tree.classList.contains('drag-over-child')).toBe(true);
+});
+
+test('drops with the stored intent without reading preview CSS classes', async () => {
+  document.body.innerHTML = `
+    <div id="creatives">
+      <creative-tree-row creative-id="1" level="1" is-root>
+        <div class="creative-tree" id="creative-1" draggable="true"></div>
+      </creative-tree-row>
+      <creative-tree-row creative-id="2" level="1" is-root>
+        <div class="creative-tree" id="creative-2" draggable="true">
+          <span id="drop-target"></span>
+        </div>
+      </creative-tree-row>
+    </div>
+  `;
+  const sourceTree = document.getElementById('creative-1');
+  const sourceRow = sourceTree.closest('creative-tree-row');
+  const targetTree = document.getElementById('creative-2');
+  const transfer = new Map();
+  const dataTransfer = {
+    types: [],
+    setData(type, value) {
+      transfer.set(type, value);
+      this.types = [...transfer.keys()];
+    },
+    getData: (type) => transfer.get(type) || '',
+  };
+  writeDragData(dataTransfer, {
+    kind: 'creative',
+    ids: ['1'],
+    payload: {
+      creativeId: '1',
+      treeId: 'creative-1',
+      level: 1,
+      isRoot: true,
+    },
+  });
+  setDraggedState({
+    tree: sourceTree,
+    row: sourceRow,
+    treeId: 'creative-1',
+    creativeId: '1',
+    parentId: null,
+    level: 1,
+    isRoot: true,
+    selectedCreativeIds: ['1'],
+  });
+  setLastDragOverRow(targetTree, 'up');
+  expect(targetTree.className).toBe('creative-tree');
+
+  const fetchMock = jest.fn().mockResolvedValue({
+    ok: true,
+    headers: { get: () => null },
+  });
+  globalThis.fetch = fetchMock;
+  handleDrop({
+    target: document.getElementById('drop-target'),
+    clientY: 150,
+    shiftKey: false,
+    preventDefault: jest.fn(),
+    dataTransfer,
+  });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  const options = fetchMock.mock.calls[0][1];
+  expect(JSON.parse(options.body)).toMatchObject({
+    dragged_id: '1',
+    target_id: '2',
+    direction: 'up',
+  });
+  delete globalThis.fetch;
 });

--- a/engines/collavre/app/javascript/creatives/drag_drop/__tests__/state.test.js
+++ b/engines/collavre/app/javascript/creatives/drag_drop/__tests__/state.test.js
@@ -1,0 +1,36 @@
+import {
+  getDraggedState,
+  getLastDragOverPosition,
+  getLastDragOverRow,
+  hasDraggedState,
+  resetDraggedState,
+  setDraggedState,
+  setLastDragOverRow,
+} from '../state';
+
+afterEach(() => resetDraggedState());
+
+test('stores drag payload and drop intent independently', () => {
+  const dragged = { creativeId: '7' };
+  const row = {};
+
+  setDraggedState(dragged);
+  setLastDragOverRow(row, 'child');
+
+  expect(getDraggedState()).toBe(dragged);
+  expect(hasDraggedState()).toBe(true);
+  expect(getLastDragOverRow()).toBe(row);
+  expect(getLastDragOverPosition()).toBe('child');
+});
+
+test('clears the row position by default and resets all drag state', () => {
+  setDraggedState({ creativeId: '7' });
+  setLastDragOverRow({}, 'up');
+  setLastDragOverRow(null);
+
+  expect(getLastDragOverPosition()).toBeNull();
+  resetDraggedState();
+  expect(getDraggedState()).toBeNull();
+  expect(getLastDragOverRow()).toBeNull();
+  expect(hasDraggedState()).toBe(false);
+});

--- a/engines/collavre/app/javascript/creatives/drag_drop/event_handlers.js
+++ b/engines/collavre/app/javascript/creatives/drag_drop/event_handlers.js
@@ -248,7 +248,9 @@ function getDraggedContext(event) {
   const transfer = event.dataTransfer;
   const hasTrustedPayload = getDragKind(transfer) === 'creative';
   const data = readDragData(transfer);
-  const parsed = data?.kind === 'creative' ? data.payload : null;
+  const parsed = data?.kind === 'creative'
+    ? { ...data.payload, selectedCreativeIds: data.ids }
+    : null;
   const wasRejectedPayload = hasTrustedPayload && !parsed;
 
   if (existing) {

--- a/engines/collavre/app/javascript/creatives/drag_drop/event_handlers.js
+++ b/engines/collavre/app/javascript/creatives/drag_drop/event_handlers.js
@@ -23,6 +23,7 @@ import {
   getLastDragOverRow,
   hasDraggedState,
 } from './state';
+import * as dragState from './state';
 import { createMoveContext, applyMove, revertMove } from './operations';
 import { sendNewOrder, sendLinkedCreative, sendTopicMove } from '../../lib/api/drag_drop';
 import { initIndicator, showLinkHover, hideLinkHover } from './indicator';
@@ -335,6 +336,7 @@ export function handleDragOver(event) {
   const lastRow = getLastDragOverRow();
   if (lastRow && lastRow !== tree) {
     clearDragHighlight(lastRow);
+    setLastDragOverRow(null);
   }
   if (!tree || tree.draggable === false) return;
 
@@ -346,7 +348,7 @@ export function handleDragOver(event) {
     event.dataTransfer.dropEffect = 'move';
     tree.classList.add('drag-over', 'drag-over-child', 'child-drop-indicator-active');
     tree.classList.remove('drag-over-top', 'drag-over-bottom');
-    setLastDragOverRow(tree);
+    setLastDragOverRow(tree, 'child');
     return;
   }
 
@@ -355,10 +357,9 @@ export function handleDragOver(event) {
   event.preventDefault();
   event.dataTransfer.dropEffect = 'move';
 
-  let previousPosition = null;
-  if (tree.classList.contains('drag-over-top')) previousPosition = 'up';
-  else if (tree.classList.contains('drag-over-child')) previousPosition = 'child';
-  else if (tree.classList.contains('drag-over-bottom')) previousPosition = 'down';
+  const previousPosition = getLastDragOverRow() === tree
+    ? dragState.getLastDragOverPosition?.() || null
+    : null;
 
   const position = getVerticalDropPosition({
     clientY: event.clientY,
@@ -383,7 +384,7 @@ export function handleDragOver(event) {
     hideLinkHover();
   }
 
-  setLastDragOverRow(tree);
+  setLastDragOverRow(tree, position);
 }
 
 function resetDrag() {
@@ -401,6 +402,7 @@ export function handleDrop(event) {
     event.preventDefault();
     clearDragHighlight(targetTree);
     clearDragHighlight(getLastDragOverRow());
+    setLastDragOverRow(null);
 
     try {
       const topicId = dragData.ids[0];
@@ -443,10 +445,9 @@ export function handleDrop(event) {
     return;
   }
 
-  // Capture visual state before clearing highlights to ensure WYSIWYG
-  const isVisualTop = targetTree && targetTree.classList.contains('drag-over-top');
-  const isVisualBottom = targetTree && targetTree.classList.contains('drag-over-bottom');
-  const isVisualChild = targetTree && targetTree.classList.contains('drag-over-child');
+  const previewedDirection = targetTree && getLastDragOverRow() === targetTree
+    ? dragState.getLastDragOverPosition?.() || null
+    : null;
 
   clearDragHighlight(targetTree);
   clearDragHighlight(getLastDragOverRow());
@@ -521,14 +522,8 @@ export function handleDrop(event) {
     }
   }
 
-  let direction;
-  if (isVisualTop) {
-    direction = 'up';
-  } else if (isVisualBottom) {
-    direction = 'down';
-  } else if (isVisualChild) {
-    direction = 'child';
-  } else {
+  let direction = previewedDirection;
+  if (!direction) {
     // Fallback calculation
     direction = getVerticalDropPosition({
       clientY: event.clientY,
@@ -655,6 +650,7 @@ export function handleDragLeave(event) {
   const tree = event.target.closest(DRAGGABLE_SELECTOR);
   if (!tree || tree.draggable === false) return;
   clearDragHighlight(tree);
+  if (getLastDragOverRow() === tree) setLastDragOverRow(null);
   hideLinkHover();
 }
 

--- a/engines/collavre/app/javascript/creatives/drag_drop/event_handlers.js
+++ b/engines/collavre/app/javascript/creatives/drag_drop/event_handlers.js
@@ -29,52 +29,25 @@ import { initIndicator, showLinkHover, hideLinkHover } from './indicator';
 import { showMissingMembersPopup } from '../topic_move_members_popup';
 import { alertDialog } from '../../lib/utils/dialog';
 import { restoreTreeEmptyState } from '../../modules/creative_tree_empty_state';
+import { getDragKind, readDragData, writeDragData } from '../../lib/dnd/envelope';
+import { getVerticalDropPosition } from '../../lib/dnd/hit_test';
+import {
+  DROP_COMPLETED_EVENT,
+  dispatchDropCompletion,
+  emitDropSignal,
+  ensureDragWindowId,
+  readDragWindowId,
+  readDropSignal,
+} from '../../lib/dnd/session';
 
-const childZoneRatio = 0.3;
 const coordPrecision = 5;
 
-const TRANSFER_MIME_TYPE = 'application/x-collavre-creative';
-const DRAG_TOKEN_STORAGE_KEY = 'collavre.dragToken';
-const DROP_SIGNAL_STORAGE_KEY = 'collavre.dragDropSignal';
-const WINDOW_ID_SESSION_KEY = 'collavre.dragWindowId';
 const INVALID_DROP_MESSAGE =
   'We could not verify that drop. Please refresh the page and try again.';
-const DROP_COMPLETED_EVENT = 'collavre:creative-drop-complete';
-
-let cachedDragToken;
-let cachedWindowId;
 
 function getRowByCreativeId(creativeId) {
   if (typeof document === 'undefined' || !creativeId) return null;
   return document.querySelector(`creative-tree-row[creative-id="${creativeId}"]`);
-}
-
-function generateRandomIdentifier(context) {
-  const fallback = () =>
-    `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
-
-  if (typeof window === 'undefined') return fallback();
-
-  try {
-    const { crypto } = window;
-    if (crypto && typeof crypto.randomUUID === 'function') {
-      return crypto.randomUUID();
-    }
-  } catch (error) {
-    if (context) {
-      console.error(`Failed to access crypto API for ${context}`, error);
-    } else {
-      console.error('Failed to access crypto API for identifier generation', error);
-    }
-  }
-
-  return fallback();
-}
-
-function generateDragToken() {
-  if (typeof window === 'undefined') return null;
-
-  return generateRandomIdentifier('drag token generation');
 }
 
 function collectSelectedCreativeIds(activeCreativeId) {
@@ -125,88 +98,6 @@ function resolveDraggedIds(state) {
   return result;
 }
 
-function readStoredDragToken() {
-  if (cachedDragToken) return cachedDragToken;
-  if (typeof window === 'undefined') return null;
-
-  try {
-    const storage = window.localStorage;
-    if (!storage) return null;
-
-    const storedToken = storage.getItem(DRAG_TOKEN_STORAGE_KEY);
-    if (storedToken) {
-      cachedDragToken = storedToken;
-    }
-
-    return cachedDragToken || null;
-  } catch (error) {
-    console.error('Failed to read drag session token from storage', error);
-    return null;
-  }
-}
-
-function ensureDragSessionToken() {
-  if (typeof window === 'undefined') return null;
-
-  const existing = readStoredDragToken();
-  if (existing) return existing;
-
-  try {
-    const storage = window.localStorage;
-    if (!storage) return null;
-
-    const freshToken = generateDragToken();
-    if (!freshToken) return null;
-
-    storage.setItem(DRAG_TOKEN_STORAGE_KEY, freshToken);
-    cachedDragToken = freshToken;
-    return freshToken;
-  } catch (error) {
-    console.error('Failed to persist drag session token', error);
-    return null;
-  }
-}
-
-function readWindowId() {
-  if (cachedWindowId) return cachedWindowId;
-  if (typeof window === 'undefined') return null;
-
-  try {
-    const storage = window.sessionStorage;
-    if (!storage) return null;
-
-    const stored = storage.getItem(WINDOW_ID_SESSION_KEY);
-    if (stored) {
-      cachedWindowId = stored;
-    }
-    return cachedWindowId || null;
-  } catch (error) {
-    console.error('Failed to read drag window id from session storage', error);
-    return cachedWindowId || null;
-  }
-}
-
-function ensureWindowId() {
-  if (typeof window === 'undefined') return null;
-
-  const existing = readWindowId();
-  if (existing) return existing;
-
-  const freshId = generateRandomIdentifier('drag window id generation');
-  if (!freshId) return null;
-
-  try {
-    const storage = window.sessionStorage;
-    storage?.setItem(WINDOW_ID_SESSION_KEY, freshId);
-    cachedWindowId = freshId;
-    return freshId;
-  } catch (error) {
-    console.error('Failed to persist drag window id', error);
-    cachedWindowId = freshId;
-    return freshId;
-  }
-}
-
 function resolveDraggedStateFromDom(state) {
   if (!state) return null;
   if (typeof document === 'undefined') return null;
@@ -250,105 +141,6 @@ function resolveTargetTree(targetTreeId) {
 
 function relaxedCoord(value) {
   return Math.round(value / coordPrecision) * coordPrecision;
-}
-
-function serializeDragState(state, sessionToken) {
-  if (!sessionToken) return null;
-
-  try {
-    return JSON.stringify({
-      creativeId: state.creativeId,
-      treeId: state.treeId,
-      parentId: state.parentId,
-      level: state.level,
-      isRoot: state.isRoot,
-      token: sessionToken,
-      sourceWindowId: state.sourceWindowId,
-      selectedCreativeIds: Array.isArray(state.selectedCreativeIds)
-        ? state.selectedCreativeIds
-        : [],
-    });
-  } catch (error) {
-    console.error('Failed to serialize drag state', error);
-    return null;
-  }
-}
-
-function parseDragState(data) {
-  if (!data) return null;
-
-  try {
-    const parsed = JSON.parse(data);
-    if (parsed && parsed.creativeId && parsed.treeId) {
-      const expectedToken = readStoredDragToken();
-      if (!expectedToken || parsed.token !== expectedToken) {
-        return null;
-      }
-
-      const {
-        creativeId,
-        treeId,
-        parentId = null,
-        level,
-        isRoot,
-        sourceWindowId = null,
-        selectedCreativeIds = [],
-      } = parsed;
-      const normalizedSelected = Array.isArray(selectedCreativeIds)
-        ? selectedCreativeIds.map((id) => String(id)).filter((value, index, array) => array.indexOf(value) === index)
-        : [];
-      return {
-        creativeId,
-        treeId,
-        parentId,
-        level,
-        isRoot,
-        sourceWindowId,
-        selectedCreativeIds: normalizedSelected,
-      };
-    }
-  } catch (error) {
-    console.error('Failed to parse drag data', error);
-  }
-
-  return null;
-}
-
-function emitDropSignal(detail) {
-  if (typeof window === 'undefined') return;
-
-  const sessionToken = readStoredDragToken();
-  if (!sessionToken) return;
-
-  try {
-    const storage = window.localStorage;
-    if (!storage) return;
-
-    const payload = JSON.stringify({
-      ...detail,
-      sessionToken,
-      nonce: generateRandomIdentifier('drag drop signal'),
-    });
-
-    storage.setItem(DROP_SIGNAL_STORAGE_KEY, payload);
-    storage.removeItem(DROP_SIGNAL_STORAGE_KEY);
-  } catch (error) {
-    console.error('Failed to broadcast drop completion signal', error);
-  }
-}
-
-function dispatchDropCompletion(detail) {
-  if (typeof window === 'undefined') return;
-
-  try {
-    window.dispatchEvent(
-      new CustomEvent(DROP_COMPLETED_EVENT, {
-        detail,
-      })
-    );
-  } catch (error) {
-    console.error('Failed to dispatch creative drop completion event', error);
-  }
 }
 
 function removeDroppedCreative({ creativeId, treeId }) {
@@ -421,27 +213,8 @@ function syncSourceWindowDrop(detail) {
 }
 
 function handleStorageChange(event) {
-  if (!event || event.key !== DROP_SIGNAL_STORAGE_KEY || !event.newValue) {
-    return;
-  }
-
-  let payload;
-  try {
-    payload = JSON.parse(event.newValue);
-  } catch (error) {
-    console.error('Failed to parse drop completion payload', error);
-    return;
-  }
-
-  const expectedToken = readStoredDragToken();
-  if (!expectedToken || payload.sessionToken !== expectedToken) {
-    return;
-  }
-
-  const windowId = readWindowId();
-  if (!windowId || payload.sourceWindowId !== windowId) {
-    return;
-  }
+  const payload = readDropSignal(event);
+  if (!payload) return;
 
   const { creativeId } = payload;
   if (!creativeId) return;
@@ -459,7 +232,7 @@ function handleDropCompletionEvent(event) {
   const { creativeId, treeId = null, sourceWindowId = null, context } = detail;
   if (!creativeId || !context) return;
 
-  const windowId = readWindowId();
+  const windowId = readDragWindowId();
   if (!windowId || sourceWindowId !== windowId) {
     return;
   }
@@ -472,13 +245,9 @@ function handleDropCompletionEvent(event) {
 function getDraggedContext(event) {
   const existing = getDraggedState();
   const transfer = event.dataTransfer;
-  const transferTypes = transfer?.types
-    ? new Set(Array.from(transfer.types))
-    : new Set();
-  const hasTrustedPayload = transferTypes.has(TRANSFER_MIME_TYPE);
-
-  const rawData = hasTrustedPayload ? transfer.getData(TRANSFER_MIME_TYPE) : null;
-  const parsed = parseDragState(rawData);
+  const hasTrustedPayload = getDragKind(transfer) === 'creative';
+  const data = readDragData(transfer);
+  const parsed = data?.kind === 'creative' ? data.payload : null;
   const wasRejectedPayload = hasTrustedPayload && !parsed;
 
   if (existing) {
@@ -524,7 +293,7 @@ export function handleDragStart(event) {
   if (!tree || tree.draggable === false) return;
   const row = asTreeRow(tree);
   if (!row) return;
-  const windowId = ensureWindowId();
+  const windowId = ensureDragWindowId();
   const creativeId = row.getAttribute('creative-id');
   const selectedCreativeIds = collectSelectedCreativeIds(creativeId);
   setDraggedState({
@@ -545,12 +314,20 @@ export function handleDragStart(event) {
     attachBundleDragImage(event, selectedCreativeIds.length, getCreativeText(creativeId));
   }
 
-  const sessionToken = ensureDragSessionToken();
-  const serialized = serializeDragState(getDraggedState(), sessionToken);
-  if (serialized) {
-    event.dataTransfer.setData(TRANSFER_MIME_TYPE, serialized);
-    event.dataTransfer.setData('text/plain', serialized);
-  }
+  const state = getDraggedState();
+  writeDragData(event.dataTransfer, {
+    kind: 'creative',
+    ids: selectedCreativeIds,
+    payload: {
+      creativeId: state.creativeId,
+      treeId: state.treeId,
+      parentId: state.parentId,
+      level: state.level,
+      isRoot: state.isRoot,
+      sourceWindowId: state.sourceWindowId,
+      selectedCreativeIds: state.selectedCreativeIds,
+    },
+  });
 }
 
 export function handleDragOver(event) {
@@ -561,8 +338,10 @@ export function handleDragOver(event) {
   }
   if (!tree || tree.draggable === false) return;
 
+  const dragKind = getDragKind(event.dataTransfer);
+
   // Topic move drag: always show as child drop target
-  if (event.dataTransfer.types.includes('application/x-topic-move')) {
+  if (dragKind === 'topic') {
     event.preventDefault();
     event.dataTransfer.dropEffect = 'move';
     tree.classList.add('drag-over', 'drag-over-child', 'child-drop-indicator-active');
@@ -571,40 +350,26 @@ export function handleDragOver(event) {
     return;
   }
 
+  if (dragKind !== 'creative') return;
+
   event.preventDefault();
   event.dataTransfer.dropEffect = 'move';
 
-  const rect = tree.getBoundingClientRect();
-  const height = rect.height;
-  const relY = event.clientY - rect.top;
+  let previousPosition = null;
+  if (tree.classList.contains('drag-over-top')) previousPosition = 'up';
+  else if (tree.classList.contains('drag-over-child')) previousPosition = 'child';
+  else if (tree.classList.contains('drag-over-bottom')) previousPosition = 'down';
 
-  // Hysteresis buffer (12% of height or at least 12px to handle small items)
-  // Increased from 5% to provide more stability against tremors
-  const hysteresis = Math.max(12, height * 0.12);
-  const topLimit = height * childZoneRatio;
-  const bottomLimit = height * (1 - childZoneRatio);
+  const position = getVerticalDropPosition({
+    clientY: event.clientY,
+    rect: tree.getBoundingClientRect(),
+    previousPosition,
+  });
 
-  const isTop = tree.classList.contains('drag-over-top');
-  const isBottom = tree.classList.contains('drag-over-bottom');
-  const isChild = tree.classList.contains('drag-over-child');
-
-  let effectiveTop = topLimit;
-  let effectiveBottom = bottomLimit;
-
-  // Apply hysteresis based on current state to create "stickiness"
-  if (isTop) {
-    effectiveTop += hysteresis;
-  } else if (isChild) {
-    effectiveTop -= hysteresis;
-    effectiveBottom += hysteresis;
-  } else if (isBottom) {
-    effectiveBottom -= hysteresis;
-  }
-
-  if (relY < effectiveTop) {
+  if (position === 'up') {
     tree.classList.add('drag-over', 'drag-over-top');
     tree.classList.remove('drag-over-bottom', 'drag-over-child', 'child-drop-indicator-active');
-  } else if (relY > effectiveBottom) {
+  } else if (position === 'down') {
     tree.classList.add('drag-over', 'drag-over-bottom');
     tree.classList.remove('drag-over-top', 'drag-over-child', 'child-drop-indicator-active');
   } else {
@@ -631,14 +396,15 @@ export function handleDrop(event) {
   const targetId = targetTree ? targetTree.id : '';
 
   // Handle topic move drop
-  const topicMoveData = event.dataTransfer.getData('application/x-topic-move');
-  if (topicMoveData && targetTree) {
+  const dragData = readDragData(event.dataTransfer);
+  if (dragData?.kind === 'topic' && targetTree) {
     event.preventDefault();
     clearDragHighlight(targetTree);
     clearDragHighlight(getLastDragOverRow());
 
     try {
-      const { topicId, sourceCreativeId } = JSON.parse(topicMoveData);
+      const topicId = dragData.ids[0];
+      const { sourceCreativeId } = dragData.payload;
       const targetCreativeId = targetId.replace('creative-', '');
 
       if (sourceCreativeId === targetCreativeId) return;
@@ -764,18 +530,13 @@ export function handleDrop(event) {
     direction = 'child';
   } else {
     // Fallback calculation
-    const rect = targetTree.getBoundingClientRect();
-    const height = rect.height;
-    const relY = event.clientY - rect.top;
-    const topLimit = height * childZoneRatio;
-    const bottomLimit = height * (1 - childZoneRatio);
-
-    if (relY < topLimit) {
-      direction = 'up';
-    } else if (relY > bottomLimit) {
-      direction = 'down';
-    } else {
-      direction = 'child';
+    direction = getVerticalDropPosition({
+      clientY: event.clientY,
+      rect: targetTree.getBoundingClientRect(),
+    });
+    if (!direction) {
+      resetDrag();
+      return;
     }
   }
 

--- a/engines/collavre/app/javascript/creatives/drag_drop/event_handlers.js
+++ b/engines/collavre/app/javascript/creatives/drag_drop/event_handlers.js
@@ -243,11 +243,10 @@ function handleDropCompletionEvent(event) {
   }
 }
 
-function getDraggedContext(event) {
+function getDraggedContext(event, data) {
   const existing = getDraggedState();
   const transfer = event.dataTransfer;
   const hasTrustedPayload = getDragKind(transfer) === 'creative';
-  const data = readDragData(transfer);
   const parsed = data?.kind === 'creative'
     ? { ...data.payload, selectedCreativeIds: data.ids }
     : null;
@@ -354,7 +353,7 @@ export function handleDragOver(event) {
     return;
   }
 
-  if (dragKind !== 'creative') return;
+  if (dragKind !== 'creative' && !hasDraggedState()) return;
 
   event.preventDefault();
   event.dataTransfer.dropEffect = 'move';
@@ -454,7 +453,10 @@ export function handleDrop(event) {
   clearDragHighlight(targetTree);
   clearDragHighlight(getLastDragOverRow());
 
-  const { draggedState, isExternal, wasRejectedPayload } = getDraggedContext(event);
+  const { draggedState, isExternal, wasRejectedPayload } = getDraggedContext(
+    event,
+    dragData
+  );
 
   if (!targetTree || targetTree.draggable === false) {
     resetDrag();

--- a/engines/collavre/app/javascript/creatives/drag_drop/state.js
+++ b/engines/collavre/app/javascript/creatives/drag_drop/state.js
@@ -1,6 +1,7 @@
 const state = {
   dragged: null,
   lastOverRow: null,
+  lastOverPosition: null,
 };
 
 export function setDraggedState(payload) {
@@ -14,14 +15,20 @@ export function getDraggedState() {
 export function resetDraggedState() {
   state.dragged = null;
   state.lastOverRow = null;
+  state.lastOverPosition = null;
 }
 
-export function setLastDragOverRow(row) {
+export function setLastDragOverRow(row, position = null) {
   state.lastOverRow = row;
+  state.lastOverPosition = position;
 }
 
 export function getLastDragOverRow() {
   return state.lastOverRow;
+}
+
+export function getLastDragOverPosition() {
+  return state.lastOverPosition;
 }
 
 export function hasDraggedState() {

--- a/engines/collavre/app/javascript/lib/dnd/__tests__/envelope.test.js
+++ b/engines/collavre/app/javascript/lib/dnd/__tests__/envelope.test.js
@@ -1,6 +1,5 @@
 import { jest } from '@jest/globals';
 import {
-  DND_MIME_TYPE,
   LEGACY_MIME_TYPES,
   getDragKind,
   readDragData,
@@ -36,7 +35,7 @@ beforeEach(() => {
   resetDragSessionCache();
 });
 
-test('writes the v1 creative envelope and legacy MIME data together', () => {
+test('writes creative data using the existing MIME boundary', () => {
   const transfer = new FakeDataTransfer();
 
   expect(writeDragData(transfer, {
@@ -51,22 +50,18 @@ test('writes the v1 creative envelope and legacy MIME data together', () => {
     },
   })).toBe(true);
 
-  const envelope = JSON.parse(transfer.getData(DND_MIME_TYPE));
   const legacy = JSON.parse(transfer.getData(LEGACY_MIME_TYPES.creative));
 
-  expect(envelope).toMatchObject({
-    v: 1,
-    kind: 'creative',
-    ids: ['7', '8'],
-    token: window.localStorage.getItem(DRAG_TOKEN_STORAGE_KEY),
-    sourceWindowId: window.sessionStorage.getItem(WINDOW_ID_SESSION_KEY),
-  });
+  expect(transfer.types).toEqual([
+    LEGACY_MIME_TYPES.creative,
+    'text/plain',
+  ]);
   expect(legacy).toMatchObject({
     creativeId: '7',
     treeId: 'creative-7',
     selectedCreativeIds: ['7', '8'],
-    token: envelope.token,
-    sourceWindowId: envelope.sourceWindowId,
+    token: window.localStorage.getItem(DRAG_TOKEN_STORAGE_KEY),
+    sourceWindowId: window.sessionStorage.getItem(WINDOW_ID_SESSION_KEY),
   });
   expect(transfer.getData('text/plain')).toBe(transfer.getData(LEGACY_MIME_TYPES.creative));
   expect(getDragKind(transfer)).toBe('creative');
@@ -76,7 +71,7 @@ test('writes the v1 creative envelope and legacy MIME data together', () => {
     payload: expect.objectContaining({
       creativeId: '7',
       treeId: 'creative-7',
-      sourceWindowId: envelope.sourceWindowId,
+      sourceWindowId: legacy.sourceWindowId,
     }),
   });
 });
@@ -98,7 +93,7 @@ test.each([
   });
 });
 
-test('normalizes each legacy MIME without requiring the common envelope', () => {
+test('normalizes each existing MIME into the shared data shape', () => {
   window.localStorage.setItem(DRAG_TOKEN_STORAGE_KEY, 'token');
   resetDragSessionCache();
 
@@ -161,51 +156,13 @@ test('detects topic-id legacy data and never reads payload during kind detection
   expect(getDragKind(null)).toBeNull();
 });
 
-test('prefers a valid common envelope and falls back from an invalid one', () => {
-  window.localStorage.setItem(DRAG_TOKEN_STORAGE_KEY, 'token');
-  resetDragSessionCache();
-
-  const common = new FakeDataTransfer({
-    [DND_MIME_TYPE]: JSON.stringify({
-      v: 1,
-      kind: 'agent',
-      ids: [9],
-      payload: { name: 'Common' },
-      token: 'token',
-      sourceWindowId: 'window',
-    }),
-    [LEGACY_MIME_TYPES.context]: '10',
-  });
-  expect(readDragData(common)).toEqual({
-    kind: 'agent',
-    ids: ['9'],
-    payload: { name: 'Common', sourceWindowId: 'window' },
-  });
-
-  common.setData(DND_MIME_TYPE, '{bad json');
-  expect(readDragData(common)).toEqual({ kind: 'context', ids: ['10'], payload: {} });
-});
-
 test('rejects malformed, empty, and untrusted data', () => {
   const error = jest.spyOn(console, 'error').mockImplementation(() => {});
   window.localStorage.setItem(DRAG_TOKEN_STORAGE_KEY, 'expected');
   resetDragSessionCache();
 
-  const invalidCommonValues = [
-    null,
-    { v: 2, kind: 'creative', ids: ['1'], payload: {}, token: 'expected' },
-    { v: 1, kind: 'unknown', ids: ['1'], payload: {}, token: 'expected' },
-    { v: 1, kind: 'creative', ids: '1', payload: {}, token: 'expected' },
-    { v: 1, kind: 'creative', ids: [], payload: {}, token: 'expected' },
-    { v: 1, kind: 'creative', ids: ['1'], payload: [], token: 'expected' },
-    { v: 1, kind: 'creative', ids: ['1'], payload: {}, token: 'wrong' },
-  ];
-  invalidCommonValues.forEach((value) => {
-    const transfer = new FakeDataTransfer({ [DND_MIME_TYPE]: JSON.stringify(value) });
-    expect(readDragData(transfer)).toBeNull();
-  });
-
   const invalidLegacyValues = [
+    new FakeDataTransfer({ [LEGACY_MIME_TYPES.creative]: '{bad json' }),
     new FakeDataTransfer({
       [LEGACY_MIME_TYPES.creative]: JSON.stringify({
         creativeId: 1,

--- a/engines/collavre/app/javascript/lib/dnd/__tests__/envelope.test.js
+++ b/engines/collavre/app/javascript/lib/dnd/__tests__/envelope.test.js
@@ -1,0 +1,262 @@
+import { jest } from '@jest/globals';
+import {
+  DND_MIME_TYPE,
+  LEGACY_MIME_TYPES,
+  getDragKind,
+  readDragData,
+  writeDragData,
+} from '../envelope';
+import {
+  DRAG_TOKEN_STORAGE_KEY,
+  WINDOW_ID_SESSION_KEY,
+  resetDragSessionCache,
+} from '../session';
+
+class FakeDataTransfer {
+  constructor(initial = {}) {
+    this.data = new Map(Object.entries(initial));
+  }
+
+  get types() {
+    return [...this.data.keys()];
+  }
+
+  getData(type) {
+    return this.data.get(type) || '';
+  }
+
+  setData(type, value) {
+    this.data.set(type, String(value));
+  }
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+  window.sessionStorage.clear();
+  resetDragSessionCache();
+});
+
+test('writes the v1 creative envelope and legacy MIME data together', () => {
+  const transfer = new FakeDataTransfer();
+
+  expect(writeDragData(transfer, {
+    kind: 'creative',
+    ids: [7, '7', 8],
+    payload: {
+      creativeId: '7',
+      treeId: 'creative-7',
+      parentId: null,
+      level: 1,
+      isRoot: true,
+    },
+  })).toBe(true);
+
+  const envelope = JSON.parse(transfer.getData(DND_MIME_TYPE));
+  const legacy = JSON.parse(transfer.getData(LEGACY_MIME_TYPES.creative));
+
+  expect(envelope).toMatchObject({
+    v: 1,
+    kind: 'creative',
+    ids: ['7', '8'],
+    token: window.localStorage.getItem(DRAG_TOKEN_STORAGE_KEY),
+    sourceWindowId: window.sessionStorage.getItem(WINDOW_ID_SESSION_KEY),
+  });
+  expect(legacy).toMatchObject({
+    creativeId: '7',
+    treeId: 'creative-7',
+    selectedCreativeIds: ['7', '8'],
+    token: envelope.token,
+    sourceWindowId: envelope.sourceWindowId,
+  });
+  expect(transfer.getData('text/plain')).toBe(transfer.getData(LEGACY_MIME_TYPES.creative));
+  expect(getDragKind(transfer)).toBe('creative');
+  expect(readDragData(transfer)).toEqual({
+    kind: 'creative',
+    ids: ['7', '8'],
+    payload: expect.objectContaining({
+      creativeId: '7',
+      treeId: 'creative-7',
+      sourceWindowId: envelope.sourceWindowId,
+    }),
+  });
+});
+
+test.each([
+  ['topic', ['5'], { sourceCreativeId: '3' }, LEGACY_MIME_TYPES.topic],
+  ['context', ['6'], {}, LEGACY_MIME_TYPES.context],
+  ['comments', ['7', '8'], {}, LEGACY_MIME_TYPES.comments],
+  ['agent', ['9'], { name: 'Agent' }, LEGACY_MIME_TYPES.agent],
+])('round-trips %s data while preserving its legacy MIME', (kind, ids, payload, mime) => {
+  const transfer = new FakeDataTransfer();
+  expect(writeDragData(transfer, { kind, ids, payload })).toBe(true);
+  expect(transfer.types).toContain(mime);
+  expect(getDragKind(transfer)).toBe(kind);
+  expect(readDragData(transfer)).toEqual({
+    kind,
+    ids,
+    payload: expect.objectContaining(payload),
+  });
+});
+
+test('normalizes each legacy MIME without requiring the common envelope', () => {
+  window.localStorage.setItem(DRAG_TOKEN_STORAGE_KEY, 'token');
+  resetDragSessionCache();
+
+  const cases = [
+    [
+      new FakeDataTransfer({
+        [LEGACY_MIME_TYPES.creative]: JSON.stringify({
+          creativeId: 1,
+          treeId: 'creative-1',
+          selectedCreativeIds: [2, 1, 2],
+          token: 'token',
+          sourceWindowId: 'source',
+        }),
+      }),
+      { kind: 'creative', ids: ['2', '1'] },
+    ],
+    [
+      new FakeDataTransfer({
+        [LEGACY_MIME_TYPES.topic]: JSON.stringify({ topicId: 3, sourceCreativeId: 4 }),
+      }),
+      { kind: 'topic', ids: ['3'], payload: { sourceCreativeId: 4 } },
+    ],
+    [
+      new FakeDataTransfer({ [LEGACY_MIME_TYPES.context]: '5' }),
+      { kind: 'context', ids: ['5'], payload: {} },
+    ],
+    [
+      new FakeDataTransfer({
+        [LEGACY_MIME_TYPES.comments]: JSON.stringify([6, '6', 7]),
+      }),
+      { kind: 'comments', ids: ['6', '7'], payload: {} },
+    ],
+    [
+      new FakeDataTransfer({
+        [LEGACY_MIME_TYPES.agent]: JSON.stringify({ id: 8, name: 'Agent' }),
+      }),
+      { kind: 'agent', ids: ['8'], payload: { name: 'Agent' } },
+    ],
+  ];
+
+  cases.forEach(([transfer, expected]) => {
+    expect(readDragData(transfer)).toMatchObject(expected);
+  });
+});
+
+test('detects topic-id legacy data and never reads payload during kind detection', () => {
+  const topicTransfer = new FakeDataTransfer({ 'application/x-topic-id': '12' });
+  expect(getDragKind(topicTransfer)).toBe('topic');
+  expect(readDragData(topicTransfer)).toEqual({
+    kind: 'topic',
+    ids: ['12'],
+    payload: {},
+  });
+
+  const typesOnly = {
+    types: [LEGACY_MIME_TYPES.context],
+    getData: () => { throw new Error('getData must not run'); },
+  };
+  expect(getDragKind(typesOnly)).toBe('context');
+  expect(getDragKind(null)).toBeNull();
+});
+
+test('prefers a valid common envelope and falls back from an invalid one', () => {
+  window.localStorage.setItem(DRAG_TOKEN_STORAGE_KEY, 'token');
+  resetDragSessionCache();
+
+  const common = new FakeDataTransfer({
+    [DND_MIME_TYPE]: JSON.stringify({
+      v: 1,
+      kind: 'agent',
+      ids: [9],
+      payload: { name: 'Common' },
+      token: 'token',
+      sourceWindowId: 'window',
+    }),
+    [LEGACY_MIME_TYPES.context]: '10',
+  });
+  expect(readDragData(common)).toEqual({
+    kind: 'agent',
+    ids: ['9'],
+    payload: { name: 'Common', sourceWindowId: 'window' },
+  });
+
+  common.setData(DND_MIME_TYPE, '{bad json');
+  expect(readDragData(common)).toEqual({ kind: 'context', ids: ['10'], payload: {} });
+});
+
+test('rejects malformed, empty, and untrusted data', () => {
+  const error = jest.spyOn(console, 'error').mockImplementation(() => {});
+  window.localStorage.setItem(DRAG_TOKEN_STORAGE_KEY, 'expected');
+  resetDragSessionCache();
+
+  const invalidCommonValues = [
+    null,
+    { v: 2, kind: 'creative', ids: ['1'], payload: {}, token: 'expected' },
+    { v: 1, kind: 'unknown', ids: ['1'], payload: {}, token: 'expected' },
+    { v: 1, kind: 'creative', ids: '1', payload: {}, token: 'expected' },
+    { v: 1, kind: 'creative', ids: [], payload: {}, token: 'expected' },
+    { v: 1, kind: 'creative', ids: ['1'], payload: [], token: 'expected' },
+    { v: 1, kind: 'creative', ids: ['1'], payload: {}, token: 'wrong' },
+  ];
+  invalidCommonValues.forEach((value) => {
+    const transfer = new FakeDataTransfer({ [DND_MIME_TYPE]: JSON.stringify(value) });
+    expect(readDragData(transfer)).toBeNull();
+  });
+
+  const invalidLegacyValues = [
+    new FakeDataTransfer({
+      [LEGACY_MIME_TYPES.creative]: JSON.stringify({
+        creativeId: 1,
+        treeId: 'creative-1',
+        token: 'wrong',
+      }),
+    }),
+    new FakeDataTransfer({ [LEGACY_MIME_TYPES.topic]: '{}' }),
+    new FakeDataTransfer({ [LEGACY_MIME_TYPES.context]: '' }),
+    new FakeDataTransfer({ [LEGACY_MIME_TYPES.comments]: '{}' }),
+    new FakeDataTransfer({ [LEGACY_MIME_TYPES.agent]: '{}' }),
+  ];
+  invalidLegacyValues.forEach((transfer) => expect(readDragData(transfer)).toBeNull());
+
+  expect(readDragData({
+    types: [LEGACY_MIME_TYPES.context],
+    getData: () => { throw new Error('blocked'); },
+  })).toBeNull();
+  expect(error).toHaveBeenCalled();
+  error.mockRestore();
+});
+
+test('rejects invalid writes', () => {
+  expect(writeDragData(null, { kind: 'creative', ids: ['1'], payload: {} })).toBe(false);
+  expect(writeDragData({}, { kind: 'creative', ids: ['1'], payload: {} })).toBe(false);
+  expect(writeDragData(new FakeDataTransfer(), null)).toBe(false);
+  expect(writeDragData(new FakeDataTransfer(), { kind: 'unknown', ids: ['1'] }))
+    .toBe(false);
+  expect(writeDragData(new FakeDataTransfer(), { kind: 'creative', ids: ['1'] }))
+    .toBe(false);
+  expect(writeDragData(new FakeDataTransfer(), {
+    kind: 'creative', ids: ['1'], payload: [],
+  })).toBe(false);
+  expect(writeDragData(new FakeDataTransfer(), { kind: 'creative', ids: [] }))
+    .toBe(false);
+});
+
+test('does not expose an unverifiable creative legacy payload', () => {
+  const error = jest.spyOn(console, 'error').mockImplementation(() => {});
+  jest.spyOn(window.Storage.prototype, 'setItem').mockImplementation(() => {
+    throw new Error('blocked');
+  });
+  const transfer = new FakeDataTransfer();
+
+  expect(writeDragData(transfer, {
+    kind: 'creative',
+    ids: ['1'],
+    payload: { creativeId: '1', treeId: 'creative-1' },
+  })).toBe(false);
+  expect(transfer.types).toEqual([]);
+  expect(error).toHaveBeenCalled();
+  error.mockRestore();
+  jest.restoreAllMocks();
+});

--- a/engines/collavre/app/javascript/lib/dnd/__tests__/hit_test.test.js
+++ b/engines/collavre/app/javascript/lib/dnd/__tests__/hit_test.test.js
@@ -1,0 +1,58 @@
+import {
+  DEFAULT_CHILD_ZONE_RATIO,
+  DEFAULT_HYSTERESIS_RATIO,
+  DEFAULT_MIN_HYSTERESIS,
+  getVerticalDropPosition,
+} from '../hit_test';
+
+const rect = { top: 100, height: 100 };
+
+test('uses strict 0.3 child-zone boundaries', () => {
+  expect(DEFAULT_CHILD_ZONE_RATIO).toBe(0.3);
+  expect(getVerticalDropPosition({ clientY: 129.9, rect })).toBe('up');
+  expect(getVerticalDropPosition({ clientY: 130, rect })).toBe('child');
+  expect(getVerticalDropPosition({ clientY: 170, rect })).toBe('child');
+  expect(getVerticalDropPosition({ clientY: 170.1, rect })).toBe('down');
+});
+
+test('keeps the previous position inside the hysteresis buffer', () => {
+  expect(DEFAULT_HYSTERESIS_RATIO).toBe(0.12);
+  expect(DEFAULT_MIN_HYSTERESIS).toBe(12);
+
+  expect(getVerticalDropPosition({ clientY: 141.9, rect, previousPosition: 'up' }))
+    .toBe('up');
+  expect(getVerticalDropPosition({ clientY: 142, rect, previousPosition: 'up' }))
+    .toBe('child');
+
+  expect(getVerticalDropPosition({ clientY: 117.9, rect, previousPosition: 'child' }))
+    .toBe('up');
+  expect(getVerticalDropPosition({ clientY: 118, rect, previousPosition: 'child' }))
+    .toBe('child');
+  expect(getVerticalDropPosition({ clientY: 182, rect, previousPosition: 'child' }))
+    .toBe('child');
+  expect(getVerticalDropPosition({ clientY: 182.1, rect, previousPosition: 'child' }))
+    .toBe('down');
+
+  expect(getVerticalDropPosition({ clientY: 158, rect, previousPosition: 'down' }))
+    .toBe('child');
+  expect(getVerticalDropPosition({ clientY: 158.1, rect, previousPosition: 'down' }))
+    .toBe('down');
+});
+
+test('supports explicit ratios and validates geometry', () => {
+  expect(getVerticalDropPosition({
+    clientY: 40,
+    rect: { top: 0, height: 200 },
+    childZoneRatio: 0.25,
+    hysteresisRatio: 0.2,
+    minHysteresis: 0,
+    previousPosition: 'up',
+  })).toBe('up');
+
+  expect(getVerticalDropPosition({ clientY: Number.NaN, rect })).toBeNull();
+  expect(getVerticalDropPosition({ clientY: 1, rect: null })).toBeNull();
+  expect(getVerticalDropPosition({ clientY: 1, rect: { top: 0, height: 0 } }))
+    .toBeNull();
+  expect(getVerticalDropPosition({ clientY: 1, rect: { top: 'bad', height: 10 } }))
+    .toBeNull();
+});

--- a/engines/collavre/app/javascript/lib/dnd/__tests__/session.test.js
+++ b/engines/collavre/app/javascript/lib/dnd/__tests__/session.test.js
@@ -1,0 +1,194 @@
+import { jest } from '@jest/globals';
+import {
+  DRAG_TOKEN_STORAGE_KEY,
+  DROP_COMPLETED_EVENT,
+  DROP_SIGNAL_STORAGE_KEY,
+  WINDOW_ID_SESSION_KEY,
+  dispatchDropCompletion,
+  emitDropSignal,
+  ensureDragSessionToken,
+  ensureDragWindowId,
+  readDragSessionToken,
+  readDragWindowId,
+  readDropSignal,
+  resetDragSessionCache,
+} from '../session';
+
+beforeEach(() => {
+  window.localStorage.clear();
+  window.sessionStorage.clear();
+  resetDragSessionCache();
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+test('creates and reuses one shared token and one id per window', () => {
+  const token = ensureDragSessionToken();
+  const windowId = ensureDragWindowId();
+
+  expect(token).toBeTruthy();
+  expect(windowId).toBeTruthy();
+  expect(window.localStorage.getItem(DRAG_TOKEN_STORAGE_KEY)).toBe(token);
+  expect(window.sessionStorage.getItem(WINDOW_ID_SESSION_KEY)).toBe(windowId);
+  expect(ensureDragSessionToken()).toBe(token);
+  expect(ensureDragWindowId()).toBe(windowId);
+
+  resetDragSessionCache();
+  expect(readDragSessionToken()).toBe(token);
+  expect(readDragWindowId()).toBe(windowId);
+});
+
+test('emits a nonce-bearing signal and validates its session and source window', () => {
+  window.localStorage.setItem(DRAG_TOKEN_STORAGE_KEY, 'token');
+  window.sessionStorage.setItem(WINDOW_ID_SESSION_KEY, 'source-window');
+  resetDragSessionCache();
+
+  let written;
+  const originalSetItem = window.Storage.prototype.setItem;
+  jest.spyOn(window.Storage.prototype, 'setItem').mockImplementation(function (key, value) {
+    if (key === DROP_SIGNAL_STORAGE_KEY) written = value;
+    return originalSetItem.call(this, key, value);
+  });
+
+  expect(emitDropSignal({ creativeId: '7', sourceWindowId: 'source-window' }))
+    .toBe(true);
+  const payload = JSON.parse(written);
+  expect(payload).toMatchObject({
+    creativeId: '7',
+    sourceWindowId: 'source-window',
+    sessionToken: 'token',
+  });
+  expect(payload.nonce).toBeTruthy();
+  expect(window.localStorage.getItem(DROP_SIGNAL_STORAGE_KEY)).toBeNull();
+
+  expect(readDropSignal({ key: DROP_SIGNAL_STORAGE_KEY, newValue: written }))
+    .toEqual(payload);
+  expect(readDropSignal({ key: 'other', newValue: written })).toBeNull();
+  expect(readDropSignal({ key: DROP_SIGNAL_STORAGE_KEY, newValue: '' })).toBeNull();
+  expect(readDropSignal({
+    key: DROP_SIGNAL_STORAGE_KEY,
+    newValue: JSON.stringify({ ...payload, sessionToken: 'wrong' }),
+  })).toBeNull();
+  expect(readDropSignal({
+    key: DROP_SIGNAL_STORAGE_KEY,
+    newValue: JSON.stringify({ ...payload, sourceWindowId: 'other-window' }),
+  })).toBeNull();
+});
+
+test('rejects malformed signals and reports storage failures', () => {
+  const error = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+  expect(readDropSignal({ key: DROP_SIGNAL_STORAGE_KEY, newValue: '{bad' })).toBeNull();
+  expect(readDropSignal({ key: DROP_SIGNAL_STORAGE_KEY, newValue: 'null' })).toBeNull();
+  expect(error).toHaveBeenCalledWith(
+    'Failed to parse drop completion payload',
+    expect.any(SyntaxError)
+  );
+
+  jest.spyOn(window.Storage.prototype, 'getItem').mockImplementation(() => {
+    throw new Error('blocked');
+  });
+  resetDragSessionCache();
+  expect(readDragSessionToken()).toBeNull();
+  expect(readDragWindowId()).toBeNull();
+  expect(emitDropSignal({ sourceWindowId: 'x' })).toBe(false);
+  error.mockRestore();
+});
+
+test('keeps a generated window id when session storage cannot persist it', () => {
+  const error = jest.spyOn(console, 'error').mockImplementation(() => {});
+  jest.spyOn(window.Storage.prototype, 'setItem').mockImplementation(() => {
+    throw new Error('blocked');
+  });
+
+  const windowId = ensureDragWindowId();
+  expect(windowId).toBeTruthy();
+  expect(readDragWindowId()).toBe(windowId);
+  expect(error).toHaveBeenCalledWith(
+    'Failed to persist drag window id',
+    expect.any(Error)
+  );
+  error.mockRestore();
+});
+
+test('reports token persistence and signal broadcast failures', () => {
+  const error = jest.spyOn(console, 'error').mockImplementation(() => {});
+  const setItem = jest.spyOn(window.Storage.prototype, 'setItem');
+  setItem.mockImplementation(() => { throw new Error('blocked'); });
+
+  expect(ensureDragSessionToken()).toBeNull();
+  expect(error).toHaveBeenCalledWith(
+    'Failed to persist drag session token',
+    expect.any(Error)
+  );
+
+  setItem.mockRestore();
+  window.localStorage.setItem(DRAG_TOKEN_STORAGE_KEY, 'token');
+  resetDragSessionCache();
+  jest.spyOn(window.Storage.prototype, 'setItem').mockImplementation(() => {
+    throw new Error('blocked');
+  });
+  expect(emitDropSignal({ sourceWindowId: 'x' })).toBe(false);
+  expect(error).toHaveBeenCalledWith(
+    'Failed to broadcast drop completion signal',
+    expect.any(Error)
+  );
+  error.mockRestore();
+});
+
+test('dispatches the shared completion event', () => {
+  const listener = jest.fn();
+  window.addEventListener(DROP_COMPLETED_EVENT, listener);
+
+  expect(dispatchDropCompletion({ creativeId: '7' })).toBe(true);
+  expect(listener).toHaveBeenCalledTimes(1);
+  expect(listener.mock.calls[0][0].detail).toEqual({ creativeId: '7' });
+
+  window.removeEventListener(DROP_COMPLETED_EVENT, listener);
+});
+
+test('falls back when crypto identifiers are unavailable', () => {
+  const descriptor = Object.getOwnPropertyDescriptor(window, 'crypto');
+  Object.defineProperty(window, 'crypto', {
+    configurable: true,
+    value: {},
+  });
+
+  const token = ensureDragSessionToken();
+  expect(token).toMatch(/^[a-z0-9]+-[a-z0-9]+$/);
+
+  Object.defineProperty(window, 'crypto', descriptor);
+});
+
+test('falls back and reports errors when crypto access or event dispatch fails', () => {
+  const descriptor = Object.getOwnPropertyDescriptor(window, 'crypto');
+  const error = jest.spyOn(console, 'error').mockImplementation(() => {});
+  Object.defineProperty(window, 'crypto', {
+    configurable: true,
+    value: {
+      get randomUUID() {
+        throw new Error('blocked');
+      },
+    },
+  });
+
+  expect(ensureDragWindowId()).toBeTruthy();
+  expect(error).toHaveBeenCalledWith(
+    'Failed to access crypto API for drag window id generation',
+    expect.any(Error)
+  );
+
+  jest.spyOn(window, 'dispatchEvent').mockImplementation(() => {
+    throw new Error('blocked');
+  });
+  expect(dispatchDropCompletion({ creativeId: '7' })).toBe(false);
+  expect(error).toHaveBeenCalledWith(
+    'Failed to dispatch creative drop completion event',
+    expect.any(Error)
+  );
+
+  Object.defineProperty(window, 'crypto', descriptor);
+  error.mockRestore();
+});

--- a/engines/collavre/app/javascript/lib/dnd/envelope.js
+++ b/engines/collavre/app/javascript/lib/dnd/envelope.js
@@ -1,0 +1,224 @@
+import {
+  ensureDragSessionToken,
+  ensureDragWindowId,
+  readDragSessionToken,
+} from './session';
+
+export const DND_MIME_TYPE = 'application/x-collavre-dnd';
+export const LEGACY_MIME_TYPES = Object.freeze({
+  creative: 'application/x-collavre-creative',
+  topic: 'application/x-topic-move',
+  context: 'application/x-context-id',
+  comments: 'application/x-comment-ids',
+  agent: 'application/x-agent-drop',
+});
+
+const TOPIC_ID_MIME_TYPE = 'application/x-topic-id';
+const SUPPORTED_KINDS = Object.keys(LEGACY_MIME_TYPES);
+
+function transferTypes(dataTransfer) {
+  if (!dataTransfer?.types) return new Set();
+  return new Set(Array.from(dataTransfer.types));
+}
+
+export function getDragKind(dataTransfer) {
+  const types = transferTypes(dataTransfer);
+  return SUPPORTED_KINDS.find((kind) => {
+    if (types.has(LEGACY_MIME_TYPES[kind])) return true;
+    return kind === 'topic' && types.has(TOPIC_ID_MIME_TYPE);
+  }) || null;
+}
+
+function normalizedIds(ids) {
+  if (!Array.isArray(ids)) return null;
+
+  const values = ids
+    .filter((id) => id !== null && id !== undefined && String(id) !== '')
+    .map(String);
+  const unique = [...new Set(values)];
+  return unique.length > 0 ? unique : null;
+}
+
+function isPayload(value) {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function normalizeCommonEnvelope(envelope) {
+  if (!isPayload(envelope) || envelope.v !== 1) return null;
+  if (!SUPPORTED_KINDS.includes(envelope.kind)) return null;
+
+  const ids = normalizedIds(envelope.ids);
+  if (!ids || !isPayload(envelope.payload)) return null;
+
+  const expectedToken = readDragSessionToken();
+  if (!expectedToken || envelope.token !== expectedToken) return null;
+
+  return {
+    kind: envelope.kind,
+    ids,
+    payload: {
+      ...envelope.payload,
+      sourceWindowId: envelope.sourceWindowId || envelope.payload.sourceWindowId || null,
+    },
+  };
+}
+
+function safeParse(data) {
+  if (!data) return null;
+  try {
+    return JSON.parse(data);
+  } catch (error) {
+    console.error('Failed to parse drag data', error);
+    return null;
+  }
+}
+
+function readTransferData(dataTransfer, type) {
+  if (!dataTransfer || typeof dataTransfer.getData !== 'function') return '';
+  try {
+    return dataTransfer.getData(type) || '';
+  } catch (error) {
+    console.error(`Failed to read drag data for ${type}`, error);
+    return '';
+  }
+}
+
+function probeLegacyKind(dataTransfer) {
+  const declaredKind = getDragKind(dataTransfer);
+  if (declaredKind) return declaredKind;
+
+  return SUPPORTED_KINDS.find((kind) =>
+    !!readTransferData(dataTransfer, LEGACY_MIME_TYPES[kind])) ||
+    (readTransferData(dataTransfer, TOPIC_ID_MIME_TYPE) ? 'topic' : null);
+}
+
+function readCreative(dataTransfer) {
+  const parsed = safeParse(readTransferData(dataTransfer, LEGACY_MIME_TYPES.creative));
+  if (!isPayload(parsed) || !parsed.creativeId || !parsed.treeId) return null;
+
+  const expectedToken = readDragSessionToken();
+  if (!expectedToken || parsed.token !== expectedToken) return null;
+
+  const ids = normalizedIds([
+    ...(Array.isArray(parsed.selectedCreativeIds) ? parsed.selectedCreativeIds : []),
+    parsed.creativeId,
+  ]);
+  if (!ids) return null;
+
+  const { token: _token, ...payload } = parsed;
+  return { kind: 'creative', ids, payload };
+}
+
+function readTopic(dataTransfer) {
+  const moveData = readTransferData(dataTransfer, LEGACY_MIME_TYPES.topic);
+  if (moveData) {
+    const parsed = safeParse(moveData);
+    if (!isPayload(parsed) || !parsed.topicId) return null;
+    const ids = normalizedIds([parsed.topicId]);
+    const { topicId: _topicId, ...payload } = parsed;
+    return ids ? { kind: 'topic', ids, payload } : null;
+  }
+
+  const ids = normalizedIds([readTransferData(dataTransfer, TOPIC_ID_MIME_TYPE)]);
+  return ids ? { kind: 'topic', ids, payload: {} } : null;
+}
+
+function readContext(dataTransfer) {
+  const ids = normalizedIds([
+    readTransferData(dataTransfer, LEGACY_MIME_TYPES.context),
+  ]);
+  return ids ? { kind: 'context', ids, payload: {} } : null;
+}
+
+function readComments(dataTransfer) {
+  const ids = normalizedIds(
+    safeParse(readTransferData(dataTransfer, LEGACY_MIME_TYPES.comments))
+  );
+  return ids ? { kind: 'comments', ids, payload: {} } : null;
+}
+
+function readAgent(dataTransfer) {
+  const parsed = safeParse(readTransferData(dataTransfer, LEGACY_MIME_TYPES.agent));
+  if (!isPayload(parsed) || !parsed.id) return null;
+  const ids = normalizedIds([parsed.id]);
+  const { id: _id, ...payload } = parsed;
+  return ids ? { kind: 'agent', ids, payload } : null;
+}
+
+const LEGACY_READERS = {
+  creative: readCreative,
+  topic: readTopic,
+  context: readContext,
+  comments: readComments,
+  agent: readAgent,
+};
+
+export function readDragData(dataTransfer) {
+  const commonData = readTransferData(dataTransfer, DND_MIME_TYPE);
+  if (commonData) {
+    const normalized = normalizeCommonEnvelope(safeParse(commonData));
+    if (normalized) return normalized;
+  }
+
+  const legacyKind = probeLegacyKind(dataTransfer);
+  return legacyKind ? LEGACY_READERS[legacyKind](dataTransfer) : null;
+}
+
+function writeLegacyData(dataTransfer, data, token, sourceWindowId) {
+  const { kind, ids, payload } = data;
+
+  if (kind === 'creative') {
+    const creativeId = payload.creativeId || ids[0];
+    const legacyPayload = JSON.stringify({
+      ...payload,
+      creativeId,
+      selectedCreativeIds: ids,
+      token,
+      sourceWindowId,
+    });
+    dataTransfer.setData(LEGACY_MIME_TYPES.creative, legacyPayload);
+    dataTransfer.setData('text/plain', legacyPayload);
+  } else if (kind === 'topic') {
+    dataTransfer.setData(TOPIC_ID_MIME_TYPE, ids[0]);
+    dataTransfer.setData(LEGACY_MIME_TYPES.topic, JSON.stringify({
+      ...payload,
+      topicId: ids[0],
+    }));
+  } else if (kind === 'context') {
+    dataTransfer.setData(LEGACY_MIME_TYPES.context, ids[0]);
+  } else if (kind === 'comments') {
+    dataTransfer.setData(LEGACY_MIME_TYPES.comments, JSON.stringify(ids));
+  } else if (kind === 'agent') {
+    dataTransfer.setData(LEGACY_MIME_TYPES.agent, JSON.stringify({
+      ...payload,
+      id: ids[0],
+    }));
+  }
+}
+
+export function writeDragData(dataTransfer, data) {
+  if (!dataTransfer || typeof dataTransfer.setData !== 'function') return false;
+  if (!isPayload(data) || !SUPPORTED_KINDS.includes(data.kind)) return false;
+  if (!isPayload(data.payload)) return false;
+
+  const ids = normalizedIds(data.ids);
+  if (!ids) return false;
+
+  const token = ensureDragSessionToken();
+  if (data.kind === 'creative' && !token) return false;
+
+  const payload = data.payload;
+  const sourceWindowId = payload.sourceWindowId || ensureDragWindowId();
+  const normalized = { kind: data.kind, ids, payload };
+
+  if (token) {
+    dataTransfer.setData(DND_MIME_TYPE, JSON.stringify({
+      v: 1,
+      ...normalized,
+      token,
+      sourceWindowId,
+    }));
+  }
+  writeLegacyData(dataTransfer, normalized, token, sourceWindowId);
+  return true;
+}

--- a/engines/collavre/app/javascript/lib/dnd/envelope.js
+++ b/engines/collavre/app/javascript/lib/dnd/envelope.js
@@ -4,7 +4,6 @@ import {
   readDragSessionToken,
 } from './session';
 
-export const DND_MIME_TYPE = 'application/x-collavre-dnd';
 export const LEGACY_MIME_TYPES = Object.freeze({
   creative: 'application/x-collavre-creative',
   topic: 'application/x-topic-move',
@@ -41,26 +40,6 @@ function normalizedIds(ids) {
 
 function isPayload(value) {
   return !!value && typeof value === 'object' && !Array.isArray(value);
-}
-
-function normalizeCommonEnvelope(envelope) {
-  if (!isPayload(envelope) || envelope.v !== 1) return null;
-  if (!SUPPORTED_KINDS.includes(envelope.kind)) return null;
-
-  const ids = normalizedIds(envelope.ids);
-  if (!ids || !isPayload(envelope.payload)) return null;
-
-  const expectedToken = readDragSessionToken();
-  if (!expectedToken || envelope.token !== expectedToken) return null;
-
-  return {
-    kind: envelope.kind,
-    ids,
-    payload: {
-      ...envelope.payload,
-      sourceWindowId: envelope.sourceWindowId || envelope.payload.sourceWindowId || null,
-    },
-  };
 }
 
 function safeParse(data) {
@@ -154,12 +133,6 @@ const LEGACY_READERS = {
 };
 
 export function readDragData(dataTransfer) {
-  const commonData = readTransferData(dataTransfer, DND_MIME_TYPE);
-  if (commonData) {
-    const normalized = normalizeCommonEnvelope(safeParse(commonData));
-    if (normalized) return normalized;
-  }
-
   const legacyKind = probeLegacyKind(dataTransfer);
   return legacyKind ? LEGACY_READERS[legacyKind](dataTransfer) : null;
 }
@@ -204,21 +177,15 @@ export function writeDragData(dataTransfer, data) {
   const ids = normalizedIds(data.ids);
   if (!ids) return false;
 
-  const token = ensureDragSessionToken();
+  const token = data.kind === 'creative' ? ensureDragSessionToken() : null;
   if (data.kind === 'creative' && !token) return false;
 
   const payload = data.payload;
-  const sourceWindowId = payload.sourceWindowId || ensureDragWindowId();
+  const sourceWindowId = data.kind === 'creative'
+    ? payload.sourceWindowId || ensureDragWindowId()
+    : payload.sourceWindowId || null;
   const normalized = { kind: data.kind, ids, payload };
 
-  if (token) {
-    dataTransfer.setData(DND_MIME_TYPE, JSON.stringify({
-      v: 1,
-      ...normalized,
-      token,
-      sourceWindowId,
-    }));
-  }
   writeLegacyData(dataTransfer, normalized, token, sourceWindowId);
   return true;
 }

--- a/engines/collavre/app/javascript/lib/dnd/envelope.js
+++ b/engines/collavre/app/javascript/lib/dnd/envelope.js
@@ -24,6 +24,7 @@ export function getDragKind(dataTransfer) {
   const types = transferTypes(dataTransfer);
   return SUPPORTED_KINDS.find((kind) => {
     if (types.has(LEGACY_MIME_TYPES[kind])) return true;
+    // Topic list reordering historically declares only this topic-specific type.
     return kind === 'topic' && types.has(TOPIC_ID_MIME_TYPE);
   }) || null;
 }

--- a/engines/collavre/app/javascript/lib/dnd/hit_test.js
+++ b/engines/collavre/app/javascript/lib/dnd/hit_test.js
@@ -1,0 +1,36 @@
+export const DEFAULT_CHILD_ZONE_RATIO = 0.3;
+export const DEFAULT_HYSTERESIS_RATIO = 0.12;
+export const DEFAULT_MIN_HYSTERESIS = 12;
+
+export function getVerticalDropPosition({
+  clientY,
+  rect,
+  previousPosition = null,
+  childZoneRatio = DEFAULT_CHILD_ZONE_RATIO,
+  hysteresisRatio = DEFAULT_HYSTERESIS_RATIO,
+  minHysteresis = DEFAULT_MIN_HYSTERESIS,
+}) {
+  if (!rect || !Number.isFinite(clientY)) return null;
+
+  const height = Number(rect.height);
+  const top = Number(rect.top);
+  if (!Number.isFinite(height) || height <= 0 || !Number.isFinite(top)) return null;
+
+  const relativeY = clientY - top;
+  const hysteresis = Math.max(minHysteresis, height * hysteresisRatio);
+  let topLimit = height * childZoneRatio;
+  let bottomLimit = height * (1 - childZoneRatio);
+
+  if (previousPosition === 'up') {
+    topLimit += hysteresis;
+  } else if (previousPosition === 'child') {
+    topLimit -= hysteresis;
+    bottomLimit += hysteresis;
+  } else if (previousPosition === 'down') {
+    bottomLimit -= hysteresis;
+  }
+
+  if (relativeY < topLimit) return 'up';
+  if (relativeY > bottomLimit) return 'down';
+  return 'child';
+}

--- a/engines/collavre/app/javascript/lib/dnd/session.js
+++ b/engines/collavre/app/javascript/lib/dnd/session.js
@@ -1,0 +1,154 @@
+export const DRAG_TOKEN_STORAGE_KEY = 'collavre.dragToken';
+export const DROP_SIGNAL_STORAGE_KEY = 'collavre.dragDropSignal';
+export const WINDOW_ID_SESSION_KEY = 'collavre.dragWindowId';
+export const DROP_COMPLETED_EVENT = 'collavre:creative-drop-complete';
+
+let cachedDragToken;
+let cachedWindowId;
+
+function generateRandomIdentifier(context) {
+  const fallback = () =>
+    `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+
+  if (typeof window === 'undefined') return fallback();
+
+  try {
+    const { crypto } = window;
+    if (crypto && typeof crypto.randomUUID === 'function') {
+      return crypto.randomUUID();
+    }
+  } catch (error) {
+    console.error(`Failed to access crypto API for ${context}`, error);
+  }
+
+  return fallback();
+}
+
+export function readDragSessionToken() {
+  if (cachedDragToken) return cachedDragToken;
+  if (typeof window === 'undefined') return null;
+
+  try {
+    const storedToken = window.localStorage?.getItem(DRAG_TOKEN_STORAGE_KEY);
+    if (storedToken) cachedDragToken = storedToken;
+    return cachedDragToken || null;
+  } catch (error) {
+    console.error('Failed to read drag session token from storage', error);
+    return null;
+  }
+}
+
+export function ensureDragSessionToken() {
+  if (typeof window === 'undefined') return null;
+
+  const existing = readDragSessionToken();
+  if (existing) return existing;
+
+  try {
+    const storage = window.localStorage;
+    if (!storage) return null;
+
+    const token = generateRandomIdentifier('drag token generation');
+    storage.setItem(DRAG_TOKEN_STORAGE_KEY, token);
+    cachedDragToken = token;
+    return token;
+  } catch (error) {
+    console.error('Failed to persist drag session token', error);
+    return null;
+  }
+}
+
+export function readDragWindowId() {
+  if (cachedWindowId) return cachedWindowId;
+  if (typeof window === 'undefined') return null;
+
+  try {
+    const storedId = window.sessionStorage?.getItem(WINDOW_ID_SESSION_KEY);
+    if (storedId) cachedWindowId = storedId;
+    return cachedWindowId || null;
+  } catch (error) {
+    console.error('Failed to read drag window id from session storage', error);
+    return cachedWindowId || null;
+  }
+}
+
+export function ensureDragWindowId() {
+  if (typeof window === 'undefined') return null;
+
+  const existing = readDragWindowId();
+  if (existing) return existing;
+
+  const id = generateRandomIdentifier('drag window id generation');
+  try {
+    window.sessionStorage?.setItem(WINDOW_ID_SESSION_KEY, id);
+  } catch (error) {
+    console.error('Failed to persist drag window id', error);
+  }
+  cachedWindowId = id;
+  return id;
+}
+
+export function emitDropSignal(detail) {
+  if (typeof window === 'undefined') return false;
+
+  const sessionToken = readDragSessionToken();
+  if (!sessionToken) return false;
+
+  try {
+    const storage = window.localStorage;
+    if (!storage) return false;
+
+    const payload = JSON.stringify({
+      ...detail,
+      sessionToken,
+      nonce: generateRandomIdentifier('drag drop signal'),
+    });
+    storage.setItem(DROP_SIGNAL_STORAGE_KEY, payload);
+    storage.removeItem(DROP_SIGNAL_STORAGE_KEY);
+    return true;
+  } catch (error) {
+    console.error('Failed to broadcast drop completion signal', error);
+    return false;
+  }
+}
+
+export function readDropSignal(event) {
+  if (!event || event.key !== DROP_SIGNAL_STORAGE_KEY || !event.newValue) {
+    return null;
+  }
+
+  let payload;
+  try {
+    payload = JSON.parse(event.newValue);
+  } catch (error) {
+    console.error('Failed to parse drop completion payload', error);
+    return null;
+  }
+
+  if (!payload || typeof payload !== 'object') return null;
+
+  const sessionToken = readDragSessionToken();
+  if (!sessionToken || payload.sessionToken !== sessionToken) return null;
+
+  const windowId = readDragWindowId();
+  if (!windowId || payload.sourceWindowId !== windowId) return null;
+
+  return payload;
+}
+
+export function dispatchDropCompletion(detail) {
+  if (typeof window === 'undefined') return false;
+
+  try {
+    window.dispatchEvent(new window.CustomEvent(DROP_COMPLETED_EVENT, { detail }));
+    return true;
+  } catch (error) {
+    console.error('Failed to dispatch creative drop completion event', error);
+    return false;
+  }
+}
+
+export function resetDragSessionCache() {
+  cachedDragToken = undefined;
+  cachedWindowId = undefined;
+}


### PR DESCRIPTION
## Summary

- normalize all five existing MIME formats into the internal `{ kind, ids, payload }` contract
- preserve the existing MIME boundaries and creative `text/plain` fallback without introducing a new wire format
- extract shared drag session, cross-window signaling, and vertical hit testing
- store the current drop intent separately from preview CSS classes
- preserve canonical IDs when adapting external creative bundles
- keep business operations and DOM rollback behavior in the existing creative adapter

## Tests

- `npm run build`
- `npm run test:coverage -- --runInBand` (133 suites, 1,784 tests; 100% patch coverage)
- focused DnD data/session/hit-test/adapter tests (5 suites, 35 tests)
- `PARALLEL_WORKERS=1 mise exec -- bin/rails test engines/collavre/test/system/drag_drop_system_test.rb engines/collavre/test/system/context_drop_system_test.rb` (2 runs, 14 assertions)
- isolated GitHub tests (11 runs, 74 assertions)
- `mise exec -- ./bin/rubocop -a` (1,344 files, no offenses)
- `mise exec -- bin/complexity_check`

## Environment note

The full host `bin/rails test` reaches 171 runs and 402 assertions with no failures, but 11 unrelated GitHub tests error when run in the full suite because the Active Record encryption config is cleared by suite ordering. Those same 11 tests pass in isolation with one worker. The host has no `test/system` directory, so the two relevant engine system tests were run directly and pass.

