### PR TITLE
fix(creatives): reject a single cyclic drag in Reorderer instead of raising

### DIFF
--- a/engines/collavre/app/services/collavre/creatives/reorderer.rb
+++ b/engines/collavre/app/services/collavre/creatives/reorderer.rb
@@ -19,6 +19,13 @@ module Creatives
       raise Error, "Invalid creatives" unless dragged && target
 
       authorize_move!([ dragged ], target, direction)
+      # Same cycle guard the multi-drag path already runs. Without it the drop
+      # reaches closure_tree's own validation, which raises RecordInvalid - not
+      # a Reorderer::Error - so it misses the controller's rescue and leaves as
+      # an unhandled exception. rescue_responses still maps that to 422, but the
+      # request is logged as an error and a JSON client is answered with the
+      # exception page instead of an empty body.
+      validate_not_target_ancestors!([ dragged ], target)
 
       if direction == "child"
         reorder_as_child(dragged, target)
@@ -27,6 +34,8 @@ module Creatives
       end
 
       true
+    rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotSaved => e
+      raise Error, e.message
     end
 
     def reorder_multiple(dragged_ids:, target_id:, direction:)

--- a/engines/collavre/test/integration/creatives_reorder_authorization_test.rb
+++ b/engines/collavre/test/integration/creatives_reorder_authorization_test.rb
@@ -276,6 +276,30 @@ class CreativesReorderAuthorizationTest < ActionDispatch::IntegrationTest
     assert_response :unprocessable_entity
   end
 
+  # Nothing in the drag layer stops a single drag onto a row's own descendant -
+  # expanding a row puts its children on screen as drop targets - so the cyclic
+  # case is an ordinary rejection the endpoint has to answer itself.
+  #
+  # The status alone does not prove that: an unhandled RecordInvalid is mapped
+  # to 422 by rescue_responses too. The empty body is what distinguishes a
+  # `head :unprocessable_entity` from an escaped exception rendered as the
+  # exception page - which a JSON client would receive as HTML, and which is
+  # logged as an application error on every such drop.
+  test "single reorder onto its own descendant is rejected without raising" do
+    sign_in_as(@owner)
+
+    %w[child up down].each do |direction|
+      post reorder_creatives_path, params: {
+        dragged_id: @owner_root.id, target_id: @owner_a.id, direction: direction
+      }, as: :json
+
+      assert_response :unprocessable_entity, "direction #{direction}"
+      assert_predicate response.body, :blank?, "direction #{direction} answered with an exception page"
+      assert_nil @owner_root.reload.parent_id, "direction #{direction} moved the root"
+      assert_equal @owner_root.id, @owner_a.reload.parent_id, "direction #{direction} reparented the target"
+    end
+  end
+
   private
 
   def create_user(handle)

--- a/engines/collavre/test/services/creatives/reorderer_test.rb
+++ b/engines/collavre/test/services/creatives/reorderer_test.rb
@@ -116,5 +116,44 @@ module Creatives
         )
       end
     end
+
+    # A single drag has to reject a cycle the same way a multi drag does. It
+    # used to reach closure_tree's validation instead, and RecordInvalid is not
+    # a Reorderer::Error, so the controller answered 500 where it promises 422.
+    test "reorder raises Reorderer::Error when target is a descendant of the dragged creative" do
+      descendant = Creative.create!(description: "Grandchild", user: @user, parent: @child_a)
+
+      %w[child up down].each do |direction|
+        assert_raises(Reorderer::Error, "direction #{direction}") do
+          @reorderer.reorder(
+            dragged_id: @child_a.id,
+            target_id: descendant.id,
+            direction: direction
+          )
+        end
+
+        assert_equal @root.id, @child_a.reload.parent_id, "direction #{direction} moved the dragged creative"
+      end
+    end
+
+    # Guards the rescue rather than the pre-check: a validation failure raised
+    # while the rows are being written still has to surface as Reorderer::Error.
+    test "reorder converts a record validation failure into Reorderer::Error" do
+      @child_a.define_singleton_method(:update!) do |*|
+        errors.add(:base, "boom")
+        raise ActiveRecord::RecordInvalid, self
+      end
+
+      lookup = lambda do |*args, **kwargs|
+        id = kwargs[:id] || args.first&.fetch(:id, nil)
+        id.to_s == @child_a.id.to_s ? @child_a : Creative.where(id: id).first
+      end
+
+      Creative.stub(:find_by, lookup) do
+        assert_raises(Reorderer::Error) do
+          @reorderer.reorder(dragged_id: @child_a.id, target_id: @child_b.id, direction: "child")
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## What

`Creatives::Reorderer#reorder` (the single-drag path) had no cycle guard. Dragging a row onto one of its own descendants reached closure_tree's validation instead, which raises `ActiveRecord::RecordInvalid` — not a `Reorderer::Error` — so it missed the controller's rescue and left the action as an unhandled exception.

This runs the same guard the batch path already runs, and rescues `RecordInvalid` the same way `reorder_multiple` and `link_drop` do.

## Why it is reachable

There is no descendant filter anywhere in `engines/collavre/app/javascript/creatives/drag_drop/`. Expanding a row puts its own children on screen as drop targets, so "drag a parent onto its child" is one ordinary gesture.

`reorder_multiple` rejects the same input twice — `validate_not_target_ancestors!` up front and a `RecordInvalid` rescue behind it. The single-id path had neither, so one drag and a multi-drag of the same rows behaved differently.

## What actually broke — and what did not

The HTTP status was **never** wrong. Rails' `rescue_responses` maps `ActiveRecord::RecordInvalid` to `:unprocessable_entity`, so the client saw 422 either way. What changes:

| | before | after |
| --- | --- | --- |
| status | 422 (via `rescue_responses`) | 422 (via `head`) |
| body for `as: :json` | Action Controller exception page | empty |
| logs | unhandled exception per cyclic drop | nothing |
| `Reorderer#reorder` raises | `ActiveRecord::RecordInvalid` | `Reorderer::Error` |

The last row is the one that matters beyond noise: `reorder_multiple` and `link_drop` both promise `Reorderer::Error`, and the header of `creatives_reorder_authorization_test.rb` already documents "422 reserved for malformed or cyclic input" as the contract. The single path was the only one not keeping it.

## Tests

Three cases, all verified to fail on `main` and pass here:

- `reorderer_test.rb` — single `reorder` onto a descendant raises `Reorderer::Error` for `child`, `up` and `down`, and leaves the tree untouched.
- `reorderer_test.rb` — a `RecordInvalid` raised during the write still surfaces as `Reorderer::Error`, covering the rescue rather than only the pre-check.
- `creatives_reorder_authorization_test.rb` — the endpoint answers 422 **with an empty body**. Asserting the status alone would have passed against the unfixed code; the empty body is what separates `head :unprocessable_entity` from an escaped exception.

Without the fix: 3 failures. With it: 26 runs, 117 assertions, 0 failures.

Rubocop clean. Complexity ratchet: none grew.

## Provenance

Found while reviewing #1629 (T2, DOM-independent move command) — `classifyStatus` there maps this response to a failure and reverts the optimistic DOM, which would have quietly made an unhandled server exception look like a handled rejection. Unrelated to the D&D expansion itself, so this targets `main` rather than `feature/dnd-expansion`.
