### PR TITLE
feat(dnd): connect workspace and creative trees through shared input

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/workspace.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/workspace.css
@@ -103,8 +103,26 @@ body.creative-workspace .indent3 {
 
 .creative-workspace-tree-row {
     display: flex;
+    position: relative;
     align-items: center;
     min-width: 0;
+}
+
+.creative-workspace-tree-row.is-dragging {
+    opacity: 0.55;
+}
+
+.creative-workspace-tree-row.drag-over-top {
+    box-shadow: inset 0 2px 0 var(--color-active);
+}
+
+.creative-workspace-tree-row.drag-over-bottom {
+    box-shadow: inset 0 -2px 0 var(--color-active);
+}
+
+.creative-workspace-tree-row.drag-over-child {
+    background: color-mix(in srgb, var(--color-active) 12%, transparent);
+    border-radius: var(--radius-2);
 }
 
 .creative-workspace-tree-branch-toggle,

--- a/engines/collavre/app/javascript/components/creative_tree_row.js
+++ b/engines/collavre/app/javascript/components/creative_tree_row.js
@@ -238,9 +238,6 @@ class CreativeTreeRow extends LitElement {
 
     const dragEnabled = !this.selectMode || this.canWrite;
     const draggableAttr = dragEnabled ? "true" : nothing;
-    const dragActions = dragEnabled
-      ? "dragstart->creatives--drag-drop#start dragover->creatives--drag-drop#over drop->creatives--drag-drop#drop dragleave->creatives--drag-drop#leave"
-      : nothing;
 
     return html`
       <div
@@ -250,7 +247,6 @@ class CreativeTreeRow extends LitElement {
         data-parent-id=${this.parentId ?? ""}
         data-level=${this.level ?? nothing}
         draggable=${draggableAttr}
-        data-action=${dragActions}
       >
         <div class="creative-row level-${this.level}" data-creatives--select-mode-target="row">
           <div class="creative-row-start">

--- a/engines/collavre/app/javascript/controllers/__tests__/workspace_tree_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/workspace_tree_controller.test.js
@@ -12,6 +12,8 @@ describe('WorkspaceTreeController', () => {
   let fetchMock
   let preventNavigation
 
+
+
   beforeEach(async () => {
     window.localStorage.clear()
     fetchMock = jest.fn().mockImplementation((url) => Promise.resolve(
@@ -100,6 +102,331 @@ describe('WorkspaceTreeController', () => {
     expect(document.querySelector('[data-creative-id="2"] a').dataset.turboPrefetch).toBe('false')
     expect(document.querySelector('.creative-workspace-tree-branch-toggle').getAttribute('aria-label')).toBe('Root')
     expect(document.querySelector('.creative-workspace-tree-branch-toggle svg path').getAttribute('d')).toBe('M6 9L12 15L18 9')
+  })
+
+  test('retains the actual parent of a branch displayed at the top level', () => {
+    const element = document.querySelector('[data-controller="workspace-tree"]')
+    const controller = application.getControllerForElementAndIdentifier(element, 'workspace-tree')
+    controller.render([{ id: 50, parent_id: 49, label: 'Shared branch', url: '/creatives?id=50', children: [] }])
+    const item = document.querySelector('.creative-workspace-tree-item[data-creative-id="50"]')
+    expect(item.dataset.parentId).toBe('49')
+    expect(item.querySelector('.creative-workspace-tree-row').dataset.parentId).toBe('49')
+    expect(item.dataset.level).toBe('1')
+  })
+
+  test('renders rows as creative drag handles without native link dragging', () => {
+    const rootItem = document.querySelector('.creative-workspace-tree-item[data-creative-id="1"]')
+    const childItem = document.querySelector('.creative-workspace-tree-item[data-creative-id="2"]')
+    const childRow = childItem.querySelector(':scope > .creative-workspace-tree-row')
+    const childLink = childRow.querySelector('.creative-workspace-tree-link')
+
+    expect(rootItem.dataset.level).toBe('1')
+    expect(childItem.dataset.parentId).toBe('1')
+    expect(childItem.dataset.level).toBe('2')
+    expect(childRow.draggable).toBe(true)
+    expect(childRow.dataset.parentId).toBe('1')
+    expect(childLink.draggable).toBe(false)
+  })
+
+  test('expands a drag target without replacing the hovered row', async () => {
+    const item = document.querySelector('.creative-workspace-tree-item[data-creative-id="1"]')
+    const hoveredRow = item.querySelector(':scope > .creative-workspace-tree-row')
+    item.querySelector(':scope > .creative-workspace-tree-list').remove()
+    item.dataset.expanded = 'false'
+    controller.expandedCreativeIds.delete('1')
+    controller.committedExpandedCreativeIds.delete('1')
+
+    await controller.expandBranchForDrag('1')
+
+    expect(document.getElementById('workspace-creative-1')).toBe(hoveredRow)
+    expect(item.dataset.expanded).toBe('true')
+    expect(item.querySelector(':scope > .creative-workspace-tree-list')).not.toBeNull()
+  })
+
+  // Nesting a row under a collapsed branch would drop it out of this partial
+  // view entirely, leaving the user with no sign the move landed.
+  test('opens the destination branch before refreshing after a nesting drop', () => {
+    controller.expandedCreativeIds.delete('1')
+
+    window.dispatchEvent(new CustomEvent('collavre:creative-drop-complete', {
+      detail: { creativeIds: ['9'], targetCreativeId: '1', direction: 'child' },
+    }))
+
+    expect(controller.expandedCreativeIds.has('1')).toBe(true)
+  })
+
+  // The centre pane reloads its own tree on a drop, so a request that started
+  // before the drop can answer after it — and it must not close the branch the
+  // drop just revealed.
+  test('keeps the destination open when an older tree response lands after the drop', async () => {
+    let answerInFlight
+    fetchMock.mockImplementationOnce(() => new Promise((resolve) => {
+      answerInFlight = () => resolve({ ok: true, headers: new Headers(), json: async () => ({ creatives: [] }) })
+    }))
+    const inFlight = controller.load({ showLoading: false })
+
+    window.dispatchEvent(new CustomEvent('collavre:creative-drop-complete', {
+      detail: { creativeIds: ['9'], targetCreativeId: '7', direction: 'child' },
+    }))
+    answerInFlight()
+    await inFlight
+
+    expect(controller.expandedCreativeIds.has('7')).toBe(true)
+
+    fetchMock.mockClear()
+    await new Promise((resolve) => setTimeout(resolve, 150))
+    const [requestedUrl] = fetchMock.mock.calls.find(([url]) => url.includes('workspace_tree=1'))
+    expect(requestedUrl).toContain('expand%5B%5D=7')
+  })
+
+  test('leaves the expansion set alone for a sibling drop', () => {
+    controller.expandedCreativeIds.delete('1')
+
+    window.dispatchEvent(new CustomEvent('collavre:creative-drop-complete', {
+      detail: { creativeIds: ['9'], targetCreativeId: '1', direction: 'down' },
+    }))
+    window.dispatchEvent(new CustomEvent('collavre:creative-drop-complete', { detail: {} }))
+    document.dispatchEvent(new CustomEvent('workspace-tree:invalidate'))
+
+    expect(controller.expandedCreativeIds.has('1')).toBe(false)
+  })
+
+  test('collapses a stale drag target when its refreshed branch is empty', async () => {
+    const item = document.querySelector('.creative-workspace-tree-item[data-creative-id="1"]')
+    item.querySelector(':scope > .creative-workspace-tree-list').remove()
+    item.dataset.expanded = 'false'
+    controller.expandedCreativeIds.delete('1')
+    controller.committedExpandedCreativeIds.delete('1')
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      headers: new Headers(),
+      json: async () => ({ creatives: [{ id: 1, label: 'Root', url: '/creatives?id=1', has_children: false, children: [] }] }),
+    })
+
+    await controller.expandBranchForDrag('1')
+
+    expect(item.dataset.hasChildren).toBe('false')
+    expect(item.dataset.expanded).toBe('false')
+    expect(item.querySelector(':scope > .creative-workspace-tree-list')).toBeNull()
+    expect(item.querySelector(':scope > .creative-workspace-tree-row > .creative-workspace-tree-branch-toggle')).toBeNull()
+    expect(item.querySelector(':scope > .creative-workspace-tree-row > .creative-workspace-tree-branch-spacer')).not.toBeNull()
+    expect(controller.expandedCreativeIds.has('1')).toBe(false)
+    expect(controller.committedExpandedCreativeIds.has('1')).toBe(false)
+  })
+
+  test('skips a branch request for a target that is already open', async () => {
+    fetchMock.mockClear()
+
+    await controller.expandBranchForDrag('1')
+
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  test('collapses an empty nested drag target found deeper in the payload', async () => {
+    const childItem = document.querySelector('.creative-workspace-tree-item[data-creative-id="2"]')
+    childItem.dataset.expanded = 'false'
+    controller.expandedCreativeIds.delete('2')
+
+    await controller.expandBranchForDrag('2')
+
+    expect(childItem.dataset.expanded).toBe('false')
+    expect(controller.expandedCreativeIds.has('2')).toBe(false)
+  })
+
+  test('leaves the hovered row untouched when the payload omits its branch', async () => {
+    const item = document.querySelector('.creative-workspace-tree-item[data-creative-id="1"]')
+    item.dataset.expanded = 'false'
+    controller.expandedCreativeIds.delete('1')
+    fetchMock.mockResolvedValueOnce({ ok: true, headers: new Headers(), json: async () => ({}) })
+
+    await controller.expandBranchForDrag('1')
+
+    expect(item.dataset.expanded).toBe('false')
+  })
+
+  // A hover expansion that fails must not leave the pointer over a row the
+  // controller believes is open — the next re-render would drop the children.
+  test('ignores a hover expansion for a row that is not rendered', async () => {
+    fetchMock.mockClear()
+
+    await controller.expandBranchForDrag('999')
+
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  test('rolls the expansion back when the branch request fails', async () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
+    const item = document.querySelector('.creative-workspace-tree-item[data-creative-id="1"]')
+    item.dataset.expanded = 'false'
+    controller.expandedCreativeIds.delete('1')
+    controller.committedExpandedCreativeIds = new Set(controller.expandedCreativeIds)
+    fetchMock.mockResolvedValueOnce({ ok: false, status: 500 })
+
+    await controller.expandBranchForDrag('1')
+
+    expect(controller.expandedCreativeIds.has('1')).toBe(false)
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'Failed to expand workspace tree branch: 500' })
+    )
+    consoleError.mockRestore()
+  })
+
+  test('stays quiet when a newer hover supersedes an in-flight branch request', async () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
+    const item = document.querySelector('.creative-workspace-tree-item[data-creative-id="1"]')
+    item.dataset.expanded = 'false'
+    controller.expandedCreativeIds.delete('1')
+    controller.committedExpandedCreativeIds = new Set(controller.expandedCreativeIds)
+    fetchMock.mockRejectedValueOnce(
+      Object.assign(new Error('The user aborted a request.'), { name: 'AbortError' })
+    )
+
+    await controller.expandBranchForDrag('1')
+
+    expect(consoleError).not.toHaveBeenCalled()
+    // The branch never rendered, so it must not linger as expanded state that a
+    // later load would replay onto a row the user only passed over.
+    expect(controller.expandedCreativeIds.has('1')).toBe(false)
+    consoleError.mockRestore()
+  })
+
+  // Hovering a second branch aborts the first request. The abandoned id used to
+  // stay in `expandedCreativeIds`, so coming back to the still-collapsed branch
+  // short-circuited and it could never be expanded again.
+  test('retries a hover expansion whose earlier request was aborted', async () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
+    const item = document.querySelector('.creative-workspace-tree-item[data-creative-id="1"]')
+    item.querySelector(':scope > .creative-workspace-tree-list').remove()
+    item.dataset.expanded = 'false'
+    controller.expandedCreativeIds.delete('1')
+    controller.committedExpandedCreativeIds = new Set(controller.expandedCreativeIds)
+    fetchMock.mockRejectedValueOnce(
+      Object.assign(new Error('The user aborted a request.'), { name: 'AbortError' })
+    )
+
+    await controller.expandBranchForDrag('1')
+    expect(item.dataset.expanded).toBe('false')
+
+    fetchMock.mockClear()
+    await controller.expandBranchForDrag('1')
+
+    expect(fetchMock).toHaveBeenCalled()
+    expect(item.dataset.expanded).toBe('true')
+    consoleError.mockRestore()
+  })
+
+  // A hover response that outlives the reload triggered by a completed drop
+  // would splice the pre-move children back in and overwrite `nodesData`.
+  test('discards a hover expansion answered after a full reload started', async () => {
+    const item = document.querySelector('.creative-workspace-tree-item[data-creative-id="1"]')
+    item.querySelector(':scope > .creative-workspace-tree-list').remove()
+    item.dataset.expanded = 'false'
+    controller.expandedCreativeIds.delete('1')
+    controller.committedExpandedCreativeIds = new Set(controller.expandedCreativeIds)
+
+    let releaseHover
+    fetchMock.mockImplementationOnce(() => new Promise((resolve) => {
+      releaseHover = () => resolve({
+        ok: true,
+        headers: new Headers(),
+        json: async () => ({ creatives: [{ id: 1, label: 'Stale', url: '/creatives?id=1', children: [] }] }),
+      })
+    }))
+
+    const hover = controller.expandBranchForDrag('1')
+    await controller.load({ showLoading: false, syncChat: false })
+    const reloadedNodes = controller.nodesData
+    releaseHover()
+    await hover
+
+    expect(controller.nodesData).toBe(reloadedNodes)
+  })
+
+  test.each(['AbortError', 'TypeError'])('a stale %s cannot remove the latest hover expansion', async name => {
+    const item = document.querySelector('.creative-workspace-tree-item[data-creative-id="1"]')
+    item.dataset.expanded = 'false'
+    controller.expandedCreativeIds.delete('1')
+    controller.committedExpandedCreativeIds.delete('1')
+    let rejectOld
+    fetchMock.mockImplementationOnce(() => new Promise((_, reject) => { rejectOld = reject }))
+    const oldHover = controller.expandBranchForDrag('1')
+    fetchMock.mockImplementationOnce(() => new Promise(() => {}))
+    controller.expandBranchForDrag('1')
+    rejectOld(Object.assign(new Error('stale request'), { name }))
+    await oldHover
+    expect(controller.expandedCreativeIds.has('1')).toBe(true)
+  })
+
+  test('aborts an in-flight hover expansion when a full load starts', async () => {
+    const item = document.querySelector('.creative-workspace-tree-item[data-creative-id="1"]')
+    item.dataset.expanded = 'false'
+    controller.expandedCreativeIds.delete('1')
+    let signal
+    fetchMock.mockImplementationOnce((_url, options) => {
+      signal = options.signal
+      return new Promise(() => {})
+    })
+
+    controller.expandBranchForDrag('1')
+    expect(signal.aborted).toBe(false)
+
+    await controller.load({ showLoading: false, syncChat: false })
+
+    expect(signal.aborted).toBe(true)
+  })
+
+  test('discards a hover response after the drag preview is cleared', async () => {
+    const item = document.querySelector('.creative-workspace-tree-item[data-creative-id="1"]')
+    item.querySelector(':scope > .creative-workspace-tree-list').remove()
+    item.dataset.expanded = 'false'
+    controller.expandedCreativeIds.delete('1')
+    controller.committedExpandedCreativeIds.delete('1')
+    const renderedNodes = controller.nodesData
+    let releaseResponse
+    let signal
+    fetchMock.mockImplementationOnce((_url, options) => {
+      signal = options.signal
+      return new Promise((resolve) => {
+        releaseResponse = () => resolve({
+          ok: true,
+          headers: new Headers(),
+          json: async () => ({
+            creatives: [{ id: 1, label: 'Stale', url: '/creatives?id=1', children: [{ id: 9 }] }],
+          }),
+        })
+      })
+    })
+
+    const hover = controller.expandBranchForDrag('1')
+    controller.cancelDragExpansion()
+    releaseResponse()
+    await hover
+
+    expect(signal.aborted).toBe(true)
+    expect(item.dataset.expanded).toBe('false')
+    expect(item.querySelector(':scope > .creative-workspace-tree-list')).toBeNull()
+    expect(controller.expandedCreativeIds.has('1')).toBe(false)
+    expect(controller.nodesData).toBe(renderedNodes)
+  })
+
+  test('keeps a successful child drop target expanded for the authoritative reload', () => {
+    controller.expandedCreativeIds.delete('2')
+
+    controller.revealDropDestination({ detail: { targetCreativeId: '2', direction: 'child' } })
+
+    expect(controller.expandedCreativeIds.has('2')).toBe(true)
+  })
+
+  test('nests a branch under a row that never declared its depth', async () => {
+    const item = document.querySelector('.creative-workspace-tree-item[data-creative-id="1"]')
+    item.querySelector(':scope > .creative-workspace-tree-list').remove()
+    item.dataset.expanded = 'false'
+    delete item.dataset.level
+    controller.expandedCreativeIds.delete('1')
+
+    await controller.expandBranchForDrag('1')
+
+    expect(item.querySelector(':scope > .creative-workspace-tree-list [data-creative-id="2"]').dataset.level).toBe('2')
   })
 
   test('records the visible creative after a cached Turbo history restore', async () => {
@@ -414,6 +741,18 @@ describe('WorkspaceTreeController', () => {
     expect(controller.committedExpandedCreativeIds.has('1')).toBe(true)
     expect(document.querySelector('[data-creative-id="1"] > ul')).not.toBeNull()
     console.error.mockRestore()
+  })
+
+  test('does not replay a pending drop destination evicted by the expansion bound', async () => {
+    controller.currentPathValue = []
+    controller.expandedCreativeIds.clear()
+    controller.revealDropDestination({ detail: { targetCreativeId: '9000', direction: 'child' } })
+    const path = Array.from({ length: 100 }, (_, index) => index + 1000)
+    controller.addExpandedPath(path)
+    expect(controller.pendingDropDestinationIds.has('9000')).toBe(false)
+    await controller.load({ showLoading: false, syncChat: false })
+    expect(controller.expandedCreativeIds.has('9000')).toBe(false)
+    expect(controller.expandedCreativeIds.size).toBe(100)
   })
 
   test('bounds the expanded branch request state', () => {

--- a/engines/collavre/app/javascript/controllers/creatives/__tests__/drag_drop_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/creatives/__tests__/drag_drop_controller.test.js
@@ -1,0 +1,63 @@
+/**
+ * @jest-environment jsdom
+ */
+import { jest } from '@jest/globals'
+import { Application } from '@hotwired/stimulus'
+
+const initIndicator = jest.fn()
+const addGlobalListeners = jest.fn()
+const removeGlobalListeners = jest.fn()
+const registries = []
+const createCreativeTreeDragDrop = jest.fn(() => {
+  const registry = { destroy: jest.fn() }
+  registries.push(registry)
+  return registry
+})
+jest.unstable_mockModule('../../../creatives/drag_drop/indicator', () => ({ initIndicator }))
+jest.unstable_mockModule('../../../creatives/drag_drop/event_handlers', () => ({
+  addGlobalListeners, removeGlobalListeners, createCreativeTreeDragDrop,
+}))
+const DragDropController = (await import('../drag_drop_controller')).default
+const flush = () => new Promise(resolve => setTimeout(resolve, 0))
+
+test('shares one gesture registry across tree mounts and releases it after the last Turbo disconnect', async () => {
+  const application = Application.start()
+  application.register('creatives--drag-drop', DragDropController)
+  const mount = () => {
+    const element = document.createElement('div')
+    element.dataset.controller = 'creatives--drag-drop'
+    element.setAttribute('data-creatives--drag-drop-partial-failure-text-value', '일부 항목을 이동하지 못했습니다.')
+    document.body.appendChild(element)
+    return element
+  }
+  try {
+    const first = mount()
+    const second = mount()
+    await flush()
+    expect(createCreativeTreeDragDrop).toHaveBeenCalledTimes(1)
+    expect(createCreativeTreeDragDrop).toHaveBeenCalledWith({ partialFailureMessage: '일부 항목을 이동하지 못했습니다.' })
+    expect(addGlobalListeners).toHaveBeenCalledTimes(1)
+
+    first.remove()
+    await flush()
+    expect(registries[0].destroy).not.toHaveBeenCalled()
+    expect(removeGlobalListeners).not.toHaveBeenCalled()
+
+    second.remove()
+    await flush()
+    expect(registries[0].destroy).toHaveBeenCalledTimes(1)
+    expect(removeGlobalListeners).toHaveBeenCalledTimes(1)
+
+    document.body.appendChild(first)
+    await flush()
+    expect(createCreativeTreeDragDrop).toHaveBeenCalledTimes(2)
+    expect(initIndicator).toHaveBeenCalledTimes(2)
+    first.remove()
+    await flush()
+    expect(registries[1].destroy).toHaveBeenCalledTimes(1)
+  } finally {
+    document.body.innerHTML = ''
+    await flush()
+    application.stop()
+  }
+})

--- a/engines/collavre/app/javascript/controllers/creatives/__tests__/tree_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/creatives/__tests__/tree_controller.test.js
@@ -17,7 +17,7 @@ jest.unstable_mockModule('../../../utils/emoji_parser', () => ({
 
 const { Application } = await import('@hotwired/stimulus')
 const TreeController = (await import('../tree_controller')).default
-const { appendCreativeNodes } = await import('../../../creatives/tree_renderer')
+const { appendCreativeNodes, renderCreativeTree } = await import('../../../creatives/tree_renderer')
 const { restoreTreeEmptyState } = await import('../../../modules/creative_tree_empty_state')
 
 const TRANSIENT_RETRY_DELAYS = [200, 600]
@@ -730,6 +730,45 @@ describe('CreativesTreeController requestReload', () => {
     jest.advanceTimersByTime(300)
 
     expect(load).toHaveBeenCalledTimes(1)
+    expect(load).toHaveBeenCalledWith({ preserveView: true })
+
+    application.stop()
+  })
+
+  test('reloads with view preservation after a creative drop completes', async () => {
+    const { application, controller, load } = await installConnected()
+
+    controller._handleCreativeDrop()
+    jest.advanceTimersByTime(300)
+
+    expect(load).toHaveBeenCalledWith({ preserveView: true })
+
+    application.stop()
+  })
+
+  // The listener has to be removed by the same reference connect() registered,
+  // or every reconnect leaves another tree reloading off a window-wide event.
+  test('stops listening for drop completions once disconnected', async () => {
+    const { application, controller } = await installConnected()
+    const removeEventListener = jest.spyOn(window, 'removeEventListener')
+
+    controller.disconnect()
+
+    expect(removeEventListener).toHaveBeenCalledWith(
+      'collavre:creative-drop-complete',
+      controller._handleCreativeDrop
+    )
+
+    application.stop()
+  })
+
+  test('replaces the view outright when the caller does not ask to preserve it', async () => {
+    const { application, controller, load } = await installConnected()
+
+    controller.debouncedLoad()
+    jest.advanceTimersByTime(300)
+
+    expect(load).toHaveBeenCalledWith({ preserveView: false })
 
     application.stop()
   })
@@ -870,6 +909,92 @@ describe('CreativesTreeController requestReload', () => {
     jest.advanceTimersByTime(300)
     expect(load).toHaveBeenCalledTimes(1)
 
+    application.stop()
+  })
+
+  test('keeps captured view state when a preserved load supersedes an in-flight load', async () => {
+    jest.useRealTimers()
+    global.fetch = jest.fn(() => new Promise(() => {}))
+    const container = document.createElement('div')
+    container.setAttribute('data-controller', 'creatives--tree')
+    container.setAttribute('data-creatives--tree-url-value', '/creatives?format=json&id=991')
+    container.setAttribute('data-creatives--tree-loading-text-value', 'Loading creatives')
+    container.dataset.loaded = 'true'
+    container.innerHTML = `
+<creative-tree-row creative-id="1" expanded>
+<button id="focused-control">Creative 1</button>
+</creative-tree-row>
+`
+    document.body.appendChild(container)
+    document.getElementById('focused-control').focus()
+    const application = Application.start()
+    application.register('creatives--tree', TreeController)
+    await flush()
+    const controller = application.getControllerForElementAndIdentifier(container, 'creatives--tree')
+
+    controller.load({ preserveView: true })
+    const capturedState = controller._pendingViewState
+    controller.load({ preserveView: true })
+
+    expect(controller._pendingViewState).toBe(capturedState)
+    expect(capturedState.expansion).toEqual([{ creativeId: '1', expanded: true }])
+    expect(capturedState.focus).toEqual(expect.objectContaining({ creativeId: '1' }))
+
+    controller.stopAnimation()
+    application.stop()
+  })
+
+  test('keeps pending view state when a reload supersedes asynchronous restoration', async () => {
+    jest.useRealTimers()
+    let releaseChildren
+    global.fetch = jest.fn((url) => {
+      if (url === '/children/1') {
+        return new Promise((resolve) => {
+          releaseChildren = () => resolve({
+            ok: true,
+            json: async () => ({ creatives: [{ id: 2 }] }),
+          })
+        })
+      }
+      return new Promise(() => {})
+    })
+    const container = document.createElement('div')
+    container.setAttribute('data-controller', 'creatives--tree')
+    container.setAttribute('data-creatives--tree-url-value', '/creatives?format=json&id=991')
+    container.setAttribute('data-creatives--tree-loading-text-value', 'Loading creatives')
+    container.dataset.loaded = 'true'
+    document.body.appendChild(container)
+    const application = Application.start()
+    application.register('creatives--tree', TreeController)
+    await flush()
+    const controller = application.getControllerForElementAndIdentifier(container, 'creatives--tree')
+    const viewState = {
+      scrolling: document.documentElement,
+      scrollTop: 120,
+      focus: { creativeId: '1', controlId: 'focused-control', controlIndex: 0 },
+      expansion: [{ creativeId: '1', expanded: true }],
+    }
+    controller._pendingViewState = viewState
+    renderCreativeTree.mockImplementationOnce((element) => {
+      element.innerHTML = `
+        <creative-tree-row creative-id="1" has-children>
+          <button id="focused-control">Creative 1</button>
+        </creative-tree-row>
+        <div id="creative-children-1" data-loaded="false" data-load-url="/children/1"></div>
+      `
+    })
+
+    const restoration = controller.renderData({ creatives: [{ id: 1 }] })
+    expect(controller._pendingViewState).toBe(viewState)
+
+    controller.load({ preserveView: true })
+    expect(controller._pendingViewState).toBe(viewState)
+    releaseChildren()
+    await restoration
+
+    expect(controller._pendingViewState).toBe(viewState)
+
+    controller.stopAnimation()
     application.stop()
   })
 })

--- a/engines/collavre/app/javascript/controllers/creatives/drag_drop_controller.js
+++ b/engines/collavre/app/javascript/controllers/creatives/drag_drop_controller.js
@@ -3,19 +3,20 @@ import { initIndicator } from '../../creatives/drag_drop/indicator'
 import {
   addGlobalListeners,
   removeGlobalListeners,
-  handleDragStart,
-  handleDragOver,
-  handleDrop,
-  handleDragLeave,
+  createCreativeTreeDragDrop,
 } from '../../creatives/drag_drop/event_handlers'
 
 let connectionCount = 0
+let registry = null
 
 export default class extends Controller {
+  static values = { partialFailureText: String }
+
   connect() {
     if (connectionCount === 0) {
       initIndicator()
       addGlobalListeners()
+      registry = createCreativeTreeDragDrop({ partialFailureMessage: this.partialFailureTextValue })
     }
     connectionCount += 1
   }
@@ -23,23 +24,10 @@ export default class extends Controller {
   disconnect() {
     connectionCount = Math.max(0, connectionCount - 1)
     if (connectionCount === 0) {
+      registry?.destroy()
+      registry = null
       removeGlobalListeners()
     }
   }
 
-  start(event) {
-    handleDragStart(event)
-  }
-
-  over(event) {
-    handleDragOver(event)
-  }
-
-  drop(event) {
-    handleDrop(event)
-  }
-
-  leave(event) {
-    handleDragLeave(event)
-  }
 }

--- a/engines/collavre/app/javascript/controllers/creatives/tree_controller.js
+++ b/engines/collavre/app/javascript/controllers/creatives/tree_controller.js
@@ -6,6 +6,10 @@ import {
   restoreTreeEmptyState,
   PAGINATION_PENDING_ATTRIBUTE,
 } from '../../modules/creative_tree_empty_state'
+import {
+  captureCreativeTreeViewState,
+  restoreCreativeTreeViewState,
+} from '../../creatives/tree_view_state'
 
 const TREE_RETRY_DELAYS_MS = [200, 600]
 
@@ -35,6 +39,8 @@ export default class extends Controller {
     this._loadingMore = false
     this._loadMoreAbort = null
     this._loadMoreIndicator = null
+    this._pendingViewState = null
+    this._viewRestoreGeneration = 0
     this.handleResize = this.updateAlignmentOffset.bind(this)
     this.handleTreeUpdated = () => this.queueAlignmentUpdate()
     this._handleEditStart = () => { this._editing = true }
@@ -55,10 +61,13 @@ export default class extends Controller {
     document.addEventListener('creative-editing:stop', this._handleEditStop)
     this._handleSyncRefetch = () => this.requestReload()
     document.addEventListener('creative-sync:refetch', this._handleSyncRefetch)
+    this._handleCreativeDrop = () => this.requestReload()
+    window.addEventListener('collavre:creative-drop-complete', this._handleCreativeDrop)
     this._setupArchiveToggle()
   }
 
   disconnect() {
+    this._viewRestoreGeneration += 1
     if (this.abortController) {
       this.abortController.abort()
       this.abortController = null
@@ -72,6 +81,7 @@ export default class extends Controller {
     document.removeEventListener('creative-editing:start', this._handleEditStart)
     document.removeEventListener('creative-editing:stop', this._handleEditStop)
     document.removeEventListener('creative-sync:refetch', this._handleSyncRefetch)
+    window.removeEventListener('collavre:creative-drop-complete', this._handleCreativeDrop)
     this._teardownPagination()
     if (this._debouncedLoadTimer) clearTimeout(this._debouncedLoadTimer)
     if (this._archiveToggleHandler) {
@@ -145,8 +155,9 @@ export default class extends Controller {
     })
   }
 
-  debouncedLoad() {
+  debouncedLoad({ preserveView = false } = {}) {
     if (this._debouncedLoadTimer) clearTimeout(this._debouncedLoadTimer)
+    this._debouncedPreserveView = this._debouncedPreserveView || preserveView
     this._debouncedLoadTimer = setTimeout(() => {
       // Re-check rather than trusting the check requestReload() already made.
       // Switching rows is a `creative-editing:stop` immediately followed by a
@@ -159,7 +170,9 @@ export default class extends Controller {
         this._pendingRefetch = true
         return
       }
-      this.load()
+      const shouldPreserveView = this._debouncedPreserveView
+      this._debouncedPreserveView = false
+      this.load({ preserveView: shouldPreserveView })
     }, 300)
   }
 
@@ -179,7 +192,7 @@ export default class extends Controller {
       this._pendingRefetch = true
       return
     }
-    this.debouncedLoad()
+    this.debouncedLoad({ preserveView: true })
   }
 
   // Keep editing-aware reloads pending while an operation is between its local
@@ -197,11 +210,21 @@ export default class extends Controller {
   _drainPendingReload() {
     if (!this._pendingRefetch || this._editing || this._reloadHoldCount > 0) return
     this._pendingRefetch = false
-    this.debouncedLoad()
+    this.debouncedLoad({ preserveView: true })
   }
 
-  load() {
+  load({ preserveView = false } = {}) {
     if (!this.hasUrlValue) return
+
+    const viewRestoreGeneration = this._viewRestoreGeneration + 1
+    this._viewRestoreGeneration = viewRestoreGeneration
+
+    // A superseding preserved load starts after the first load replaced the tree
+    // with its loading placeholder. Keep the state captured from the real rows;
+    // capturing the placeholder would overwrite it with empty expansion/focus.
+    this._pendingViewState = preserveView
+      ? (this._pendingViewState || captureCreativeTreeViewState(this.element))
+      : null
 
     // A fresh load replaces the whole list (filter change, archive toggle, sync
     // refetch), so any active load-more session is stale — tear it down before
@@ -214,10 +237,12 @@ export default class extends Controller {
     this.abortController = new AbortController()
     this._retryCount = 0
     this.showLoadingIndicator()
-    this._fetchTree()
+    this._fetchTree(viewRestoreGeneration)
   }
 
-  _fetchTree() {
+  _fetchTree(viewRestoreGeneration = this._viewRestoreGeneration) {
+    if (viewRestoreGeneration !== this._viewRestoreGeneration) return
+
     fetch(this.urlValue, {
       headers: { Accept: 'application/json' },
       signal: this.abortController.signal,
@@ -227,18 +252,19 @@ export default class extends Controller {
         return response.json()
       })
       .then((data) => {
+        if (viewRestoreGeneration !== this._viewRestoreGeneration) return
         this.hideLoadingIndicator()
-        this.renderData(data)
+        return this.renderData(data, viewRestoreGeneration)
       })
       .catch((error) => {
-        if (error.name === 'AbortError') return
+        if (error.name === 'AbortError' || viewRestoreGeneration !== this._viewRestoreGeneration) return
         // Transient network failures (ERR_NETWORK_CHANGED, offline blips, VPN
         // toggles) surface as TypeError "Failed to fetch". Retry briefly so a
         // momentary network event doesn't leave the user with an empty tree.
         if (this._isTransientNetworkError(error) && this._retryCount < TREE_RETRY_DELAYS_MS.length) {
           const delay = TREE_RETRY_DELAYS_MS[this._retryCount]
           this._retryCount += 1
-          this._retryTimer = setTimeout(() => this._fetchTree(), delay)
+          this._retryTimer = setTimeout(() => this._fetchTree(viewRestoreGeneration), delay)
           return
         }
         console.error(error)
@@ -251,12 +277,16 @@ export default class extends Controller {
     return error instanceof TypeError && /fetch|network/i.test(error.message || '')
   }
 
-  renderData(data) {
+  async renderData(data, viewRestoreGeneration = this._viewRestoreGeneration) {
     const nodes = Array.isArray(data?.creatives) ? data.creatives : []
+    const viewState = this._pendingViewState
+    const isCurrent = () => viewRestoreGeneration === this._viewRestoreGeneration
 
     if (nodes.length === 0) {
       this.showEmptyState()
       dispatchCreativeTreeUpdated(this.element)
+      await restoreCreativeTreeViewState(this.element, viewState, { isCurrent })
+      if (isCurrent() && this._pendingViewState === viewState) this._pendingViewState = null
       return
     }
 
@@ -265,6 +295,8 @@ export default class extends Controller {
     dispatchCreativeTreeUpdated(this.element)
     this.queueAlignmentUpdate()
     this._setupPagination(data?.pagination)
+    await restoreCreativeTreeViewState(this.element, viewState, { isCurrent })
+    if (isCurrent() && this._pendingViewState === viewState) this._pendingViewState = null
   }
 
   // --- Load-more (paginated "Chats" feed) -------------------------------------

--- a/engines/collavre/app/javascript/controllers/workspace_tree_controller.js
+++ b/engines/collavre/app/javascript/controllers/workspace_tree_controller.js
@@ -7,6 +7,7 @@ import {
 // Keep the workspace tree's branch affordance visually aligned with the
 // central creative tree (components/creative_tree_row.js#_toggleIcon).
 import { CHEVRON_COLLAPSED, CHEVRON_EXPANDED } from '../utils/chevron_icons'
+import { createWorkspaceTreeDragDrop } from '../creatives/drag_drop/workspace_tree_adapter'
 
 // Module-scoped: a history restore replaces the whole body, swapping this
 // controller's instance mid-visit. The instance that observes turbo:visit is
@@ -28,15 +29,18 @@ export default class extends Controller {
     loadingText: String,
     emptyText: String,
     errorText: String,
+    partialFailureText: String,
   }
 
   connect() {
     this.expandedCreativeIds = new Set()
+    this.pendingDropDestinationIds = new Set()
     this.addExpandedPath(this.currentPathValue)
     this.committedExpandedCreativeIds = new Set(this.expandedCreativeIds)
     this.invalidatedCreativeIds = new Set()
     this.destroyedCreativeIds = new Set()
     this.invalidationGeneration = 0
+    this.dragExpandGeneration = 0
     this.handleFrameLoad = this.handleFrameLoad.bind(this)
     this.handleFrameRequest = this.handleFrameRequest.bind(this)
     this.handleFetchRequest = this.handleFetchRequest.bind(this)
@@ -60,6 +64,11 @@ export default class extends Controller {
     document.addEventListener('workspace-tree:invalidate', this.queueRefresh)
     document.addEventListener('creative-destroyed', this.queueRefresh)
     window.addEventListener('collavre:creative-drop-complete', this.queueRefresh)
+    this.dragDropRegistry = createWorkspaceTreeDragDrop({
+      root: this.treeTarget,
+      controller: this,
+      partialFailureMessage: this.partialFailureTextValue,
+    })
     this.observeWorkspaceFrame()
     // A restore render may reconnect this controller after turbo:render has
     // already fired on the previous, now-disconnected instance's listeners.
@@ -79,6 +88,7 @@ export default class extends Controller {
 
   disconnect() {
     this.loadAbortController?.abort()
+    this.cancelDragExpansion()
     this.frameObserver?.disconnect()
     if (this.refreshTimeout) window.clearTimeout(this.refreshTimeout)
     if (this.popStateSyncTimer) window.clearTimeout(this.popStateSyncTimer)
@@ -95,11 +105,16 @@ export default class extends Controller {
     document.removeEventListener('workspace-tree:invalidate', this.queueRefresh)
     document.removeEventListener('creative-destroyed', this.queueRefresh)
     window.removeEventListener('collavre:creative-drop-complete', this.queueRefresh)
+    this.dragDropRegistry?.destroy()
+    this.dragDropRegistry = null
   }
 
   async load({ showLoading = true, syncChat = true, preserveView = false, focusCreativeId } = {}) {
     this.loadAbortController?.abort()
     this.loadAbortController = new AbortController()
+    // A full load re-renders the whole tree from an authoritative payload, so
+    // any hover expansion still in flight is stale the moment it starts.
+    this.cancelDragExpansion()
     if (this.pendingRevealPath) this.addExpandedPath(this.pendingRevealPath)
     const requestId = (this.loadRequestId || 0) + 1
     this.loadRequestId = requestId
@@ -122,8 +137,13 @@ export default class extends Controller {
 
       const nodes = Array.isArray(data.creatives) ? data.creatives : []
       if (invalidationGeneration === this.invalidationGeneration) this.restoreReadableCreativeIds(nodes)
-      this.expandedCreativeIds = new Set(requestedExpandedIds)
-      this.committedExpandedCreativeIds = new Set(requestedExpandedIds)
+      // A drop can reveal a branch while this response is still in flight, and
+      // that reveal has not been rendered yet — carry it into the next request
+      // instead of letting an older answer erase it.
+      this.expandedCreativeIds = new Set([...requestedExpandedIds, ...this.pendingDropDestinationIds])
+      this.trimExpandedCreativeIds()
+      this.committedExpandedCreativeIds = new Set(this.expandedCreativeIds)
+      requestedExpandedIds.forEach((id) => this.pendingDropDestinationIds.delete(id))
       if (requestedRevealPath && this.samePath(requestedRevealPath, this.pendingRevealPath || [])) {
         this.pendingRevealPath = null
       }
@@ -156,24 +176,34 @@ export default class extends Controller {
     this.syncFromWorkspaceFrame(undefined, { syncChat })
   }
 
-  buildList(nodes) {
+  buildList(nodes, parentId = null, level = 1) {
     const list = document.createElement('ul')
     list.className = 'creative-workspace-tree-list'
 
-    nodes.forEach((node) => list.appendChild(this.buildNode(node)))
+    nodes.forEach((node) => list.appendChild(this.buildNode(node, parentId, level)))
     return list
   }
 
-  buildNode(node) {
+  buildNode(node, parentId = null, level = 1) {
     const item = document.createElement('li')
     item.className = 'creative-workspace-tree-item'
     item.dataset.creativeId = String(node.id)
+    parentId = node.parent_id === undefined ? parentId : node.parent_id
+    item.dataset.level = String(level)
+    if (parentId) item.dataset.parentId = String(parentId)
 
     const row = document.createElement('div')
     row.className = 'creative-workspace-tree-row'
+    row.id = `workspace-creative-${node.id}`
+    row.draggable = true
+    row.dataset.creativeId = String(node.id)
+    row.dataset.level = String(level)
+    if (parentId) row.dataset.parentId = String(parentId)
     const children = Array.isArray(node.children) ? node.children : []
     const hasChildren = node.has_children === true || children.length > 0
     const expanded = hasChildren && this.expandedCreativeIds.has(String(node.id))
+    item.dataset.hasChildren = String(hasChildren)
+    item.dataset.expanded = String(expanded)
 
     if (hasChildren) {
       const toggle = document.createElement('button')
@@ -193,6 +223,7 @@ export default class extends Controller {
 
     const link = document.createElement('a')
     link.href = node.url
+    link.draggable = false
     link.textContent = node.label
     link.className = 'creative-workspace-tree-link'
     link.dataset.turboFrame = 'creative-workspace-content'
@@ -210,7 +241,7 @@ export default class extends Controller {
     item.appendChild(row)
 
     if (hasChildren && expanded) {
-      const childList = this.buildList(children)
+      const childList = this.buildList(children, node.id, level + 1)
       item.appendChild(childList)
     }
 
@@ -223,6 +254,7 @@ export default class extends Controller {
 
     if (this.expandedCreativeIds.has(creativeId)) {
       this.expandedCreativeIds.delete(creativeId)
+      this.pendingDropDestinationIds.delete(creativeId)
     } else {
       this.expandedCreativeIds.delete(creativeId)
       this.expandedCreativeIds.add(creativeId)
@@ -235,6 +267,118 @@ export default class extends Controller {
       preserveView: true,
       focusCreativeId: creativeId,
     })
+  }
+
+  async expandBranchForDrag(creativeId) {
+    const id = String(creativeId)
+    // Hovering a second branch aborts the first request but leaves its id in
+    // `expandedCreativeIds`, so only the rendered row can say whether a branch
+    // is actually open — otherwise the aborted one can never be retried.
+    const hoveredItem = this.findWorkspaceItem(id)
+    if (!hoveredItem || hoveredItem.dataset.expanded === 'true') return
+
+    this.cancelDragExpansion()
+    this.expandedCreativeIds.add(id)
+    this.trimExpandedCreativeIds()
+    const requestedExpandedIds = new Set(this.expandedCreativeIds)
+    const abortController = new AbortController()
+    this.dragExpandAbortController = abortController
+    this.dragExpandCreativeId = id
+    const expandGeneration = this.dragExpandGeneration
+    const loadGeneration = this.loadRequestId
+
+    try {
+      const requestOptions = { headers: { Accept: 'application/json' } }
+      requestOptions.signal = abortController.signal
+      const response = await fetch(this.workspaceTreeUrl(requestedExpandedIds), requestOptions)
+      if (!response.ok) throw new Error(`Failed to expand workspace tree branch: ${response.status}`)
+      const data = await response.json()
+      // A load that started after this request owns the tree. Splicing these
+      // children in would overwrite `nodesData` with the pre-move placement.
+      if (this.loadRequestId !== loadGeneration || this.dragExpandGeneration !== expandGeneration) return
+
+      const nodes = Array.isArray(data.creatives) ? data.creatives : []
+      const expanded = this.renderExpandedBranch(id, nodes)
+      if (expanded === false) requestedExpandedIds.delete(id)
+      this.nodesData = nodes
+      this.committedExpandedCreativeIds = new Set(requestedExpandedIds)
+    } catch (error) {
+      if (this.loadRequestId !== loadGeneration || this.dragExpandGeneration !== expandGeneration) return
+      if (error.name === 'AbortError') {
+        // The branch was never rendered, so it must not survive as expanded
+        // state that a later load would replay.
+        if (!this.committedExpandedCreativeIds.has(id)) this.expandedCreativeIds.delete(id)
+        return
+      }
+      this.expandedCreativeIds = new Set(this.committedExpandedCreativeIds)
+      console.error(error)
+    } finally {
+      if (this.dragExpandAbortController === abortController) {
+        this.dragExpandAbortController = null
+        this.dragExpandCreativeId = null
+      }
+    }
+  }
+
+  cancelDragExpansion() {
+    this.dragExpandGeneration += 1
+    this.dragExpandAbortController?.abort()
+    const creativeId = this.dragExpandCreativeId
+    this.dragExpandAbortController = null
+    this.dragExpandCreativeId = null
+    if (creativeId && !this.committedExpandedCreativeIds.has(creativeId)) {
+      this.expandedCreativeIds.delete(creativeId)
+    }
+  }
+
+  findWorkspaceItem(creativeId) {
+    return [...this.treeTarget.querySelectorAll('.creative-workspace-tree-item[data-creative-id]')]
+      .find((candidate) => candidate.dataset.creativeId === String(creativeId)) || null
+  }
+
+  renderExpandedBranch(creativeId, nodes) {
+    const node = this.findNode(nodes, creativeId)
+    const item = this.findWorkspaceItem(creativeId)
+    if (!node || !item) return
+
+    const existingList = [...item.children]
+      .find((child) => child.matches?.('.creative-workspace-tree-list'))
+    existingList?.remove()
+    const children = Array.isArray(node.children) ? node.children : []
+    if (children.length === 0) return this.collapseEmptyBranch(item, creativeId)
+
+    item.appendChild(this.buildList(children, node.id, Number(item.dataset.level || 1) + 1))
+    item.dataset.hasChildren = 'true'
+    item.dataset.expanded = 'true'
+    const toggle = item.querySelector(':scope > .creative-workspace-tree-row > .creative-workspace-tree-branch-toggle')
+    if (toggle) {
+      toggle.setAttribute('aria-expanded', 'true')
+      toggle.innerHTML = CHEVRON_EXPANDED
+    }
+    return true
+  }
+
+  collapseEmptyBranch(item, creativeId) {
+    this.expandedCreativeIds.delete(String(creativeId))
+    item.dataset.hasChildren = 'false'
+    item.dataset.expanded = 'false'
+    const toggle = item.querySelector(':scope > .creative-workspace-tree-row > .creative-workspace-tree-branch-toggle')
+    if (toggle) {
+      const spacer = document.createElement('span')
+      spacer.className = 'creative-workspace-tree-branch-spacer'
+      spacer.setAttribute('aria-hidden', 'true')
+      toggle.replaceWith(spacer)
+    }
+    return false
+  }
+
+  findNode(nodes, creativeId) {
+    for (const node of nodes) {
+      if (String(node.id) === String(creativeId)) return node
+      const found = this.findNode(Array.isArray(node.children) ? node.children : [], creativeId)
+      if (found) return found
+    }
+    return null
   }
 
   togglePanel() {
@@ -377,11 +521,23 @@ export default class extends Controller {
 
   queueRefresh(event) {
     this.rememberInvalidatedCreativeIds(event)
+    this.revealDropDestination(event)
     if (this.refreshTimeout) window.clearTimeout(this.refreshTimeout)
     this.refreshTimeout = window.setTimeout(() => {
       this.refreshTimeout = null
       this.load({ showLoading: false, syncChat: false, preserveView: true })
     }, 100)
+  }
+
+  // A row dropped into a collapsed branch would simply disappear from this
+  // partial view, so the destination is opened before the tree is fetched again.
+  revealDropDestination(event) {
+    const { direction, targetCreativeId } = event?.detail || {}
+    if (direction !== 'child' || !targetCreativeId) return
+
+    this.pendingDropDestinationIds.add(String(targetCreativeId))
+    this.expandedCreativeIds.add(String(targetCreativeId))
+    this.trimExpandedCreativeIds()
   }
 
   syncFromWorkspaceFrame(
@@ -518,6 +674,7 @@ export default class extends Controller {
       if (!evictedId) return
 
       this.expandedCreativeIds.delete(evictedId)
+      this.pendingDropDestinationIds.delete(evictedId)
     }
   }
 

--- a/engines/collavre/app/javascript/creatives/__tests__/tree_view_state.test.js
+++ b/engines/collavre/app/javascript/creatives/__tests__/tree_view_state.test.js
@@ -1,0 +1,261 @@
+/**
+ * @jest-environment jsdom
+ */
+import { jest } from '@jest/globals'
+
+jest.unstable_mockModule('../../lib/api/creatives', () => ({ loadChildren: jest.fn() }))
+jest.unstable_mockModule('../tree_renderer', () => ({
+  renderCreativeTree: jest.fn(),
+  dispatchCreativeTreeUpdated: jest.fn(),
+}))
+
+const { loadChildren } = await import('../../lib/api/creatives')
+const { renderCreativeTree } = await import('../tree_renderer')
+const { expandBranchWithChildren } = await import('../branch_expansion')
+const { captureCreativeTreeViewState, restoreCreativeTreeViewState } = await import('../tree_view_state')
+
+function row(id, expanded = false) {
+  return `
+    <creative-tree-row creative-id="${id}" ${expanded ? 'expanded' : ''}>
+      <div class="creative-tree"><button id="toggle-${id}">Toggle</button></div>
+    </creative-tree-row>
+    <div id="creative-children-${id}" style="display: ${expanded ? '' : 'none'}"></div>
+  `
+}
+
+describe('creative tree view state', () => {
+  beforeEach(() => {
+    loadChildren.mockReset()
+    renderCreativeTree.mockReset()
+    renderCreativeTree.mockImplementation((container, nodes) => {
+      container.innerHTML = nodes.map((node) => row(String(node.id))).join('')
+    })
+  })
+
+  test('restores expansion, focus, and the workspace main scroll position', async () => {
+    document.body.innerHTML = `<main><div id="creatives">${row('1', true)}${row('2')}</div></main>`
+    const main = document.querySelector('main')
+    const tree = document.getElementById('creatives')
+    main.scrollTop = 180
+    document.getElementById('toggle-2').focus()
+    const state = captureCreativeTreeViewState(tree)
+
+    tree.innerHTML = `${row('1')}${row('2', true)}`
+    main.scrollTop = 0
+    await restoreCreativeTreeViewState(tree, state)
+
+    expect(tree.querySelector('creative-tree-row[creative-id="1"]').hasAttribute('expanded')).toBe(true)
+    expect(tree.querySelector('creative-tree-row[creative-id="2"]').hasAttribute('expanded')).toBe(false)
+    expect(document.getElementById('creative-children-1').style.display).toBe('')
+    expect(document.getElementById('creative-children-2').style.display).toBe('none')
+    expect(main.scrollTop).toBe(180)
+    expect(document.activeElement.id).toBe('toggle-2')
+  })
+
+  // A hover expansion is never persisted, so the reloaded payload renders that
+  // branch unloaded. Revealing the empty container would leave it looking open
+  // but blank until the user collapsed and reopened it.
+  test('reloads the children of a branch the refreshed payload left unloaded', async () => {
+    document.body.innerHTML = `<main><div id="creatives">${row('1', true)}</div></main>`
+    const tree = document.getElementById('creatives')
+    const state = captureCreativeTreeViewState(tree)
+
+    tree.innerHTML = `
+      <creative-tree-row creative-id="1"></creative-tree-row>
+      <div id="creative-children-1" class="creative-children" style="display:none"
+           data-loaded="false" data-load-url="/creatives/1/children.json"></div>
+    `
+    const container = document.getElementById('creative-children-1')
+    loadChildren.mockResolvedValue({ creatives: [{ id: 2 }] })
+
+    await restoreCreativeTreeViewState(tree, state)
+
+    expect(loadChildren).toHaveBeenCalledWith('/creatives/1/children.json')
+    expect(renderCreativeTree).toHaveBeenCalledWith(container, [{ id: 2 }])
+    expect(container.dataset.loaded).toBe('true')
+    expect(container.style.display).toBe('')
+    expect(tree.querySelector('creative-tree-row[creative-id="1"]').hasAttribute('expanded')).toBe(true)
+  })
+
+  test('restores nested expansion and focus after loading each ancestor', async () => {
+    document.body.innerHTML = `
+      <main><div id="creatives">
+        <creative-tree-row creative-id="1" expanded>
+          <div><button id="toggle-1">Toggle</button></div>
+        </creative-tree-row>
+        <div id="creative-children-1" data-loaded="true">
+          <creative-tree-row creative-id="2" expanded>
+            <div><button id="toggle-2">Toggle</button></div>
+          </creative-tree-row>
+          <div id="creative-children-2" data-loaded="true"></div>
+        </div>
+      </div></main>
+    `
+    const tree = document.getElementById('creatives')
+    document.getElementById('toggle-2').focus()
+    const state = captureCreativeTreeViewState(tree)
+
+    tree.innerHTML = `
+      <creative-tree-row creative-id="1" has-children>
+        <div><button id="toggle-1">Toggle</button></div>
+      </creative-tree-row>
+      <div id="creative-children-1" data-loaded="false" data-load-url="/children/1"></div>
+    `
+    loadChildren
+      .mockResolvedValueOnce({ creatives: [{ id: 2 }] })
+      .mockResolvedValueOnce({ creatives: [{ id: 3 }] })
+    renderCreativeTree
+      .mockImplementationOnce((container) => {
+        container.innerHTML = `
+          <creative-tree-row creative-id="2" has-children>
+            <div><button id="toggle-2">Toggle</button></div>
+          </creative-tree-row>
+          <div id="creative-children-2" data-loaded="false" data-load-url="/children/2"></div>
+        `
+      })
+      .mockImplementationOnce((container) => {
+        container.innerHTML = row('3')
+      })
+
+    await restoreCreativeTreeViewState(tree, state)
+
+    expect(loadChildren.mock.calls.map(([url]) => url)).toEqual(['/children/1', '/children/2'])
+    expect(tree.querySelector('[creative-id="1"]').hasAttribute('expanded')).toBe(true)
+    expect(tree.querySelector('[creative-id="2"]').hasAttribute('expanded')).toBe(true)
+    expect(document.activeElement.id).toBe('toggle-2')
+  })
+
+  test('collapses a stale branch when lazy loading finds no children', async () => {
+    document.body.innerHTML = `<main><div id="creatives">${row('1', true)}</div></main>`
+    const tree = document.getElementById('creatives')
+    const state = captureCreativeTreeViewState(tree)
+
+    tree.innerHTML = `
+      <creative-tree-row creative-id="1" has-children expanded></creative-tree-row>
+      <div id="creative-children-1" data-loaded="false" data-load-url="/children/1"></div>
+    `
+    loadChildren.mockResolvedValue({ creatives: [] })
+
+    await restoreCreativeTreeViewState(tree, state)
+
+    const restoredRow = tree.querySelector('[creative-id="1"]')
+    const container = document.getElementById('creative-children-1')
+    expect(restoredRow.hasAttribute('has-children')).toBe(false)
+    expect(restoredRow.hasAttribute('expanded')).toBe(false)
+    expect(container.dataset.loaded).toBe('true')
+    expect(container.style.display).toBe('none')
+  })
+
+  test('leaves an expanded row alone when its children container is gone', async () => {
+    document.body.innerHTML = `<main><div id="creatives">${row('1', true)}</div></main>`
+    const tree = document.getElementById('creatives')
+    const state = captureCreativeTreeViewState(tree)
+
+    tree.innerHTML = '<creative-tree-row creative-id="1"></creative-tree-row>'
+    loadChildren.mockClear()
+
+    await restoreCreativeTreeViewState(tree, state)
+
+    expect(loadChildren).not.toHaveBeenCalled()
+  })
+
+  test('ignores rows and controls that disappear during reload', async () => {
+    document.body.innerHTML = `<main><div id="creatives">${row('1', true)}</div></main>`
+    const tree = document.getElementById('creatives')
+    document.getElementById('toggle-1').focus()
+    const state = captureCreativeTreeViewState(tree)
+
+    tree.replaceChildren()
+
+    await expect(restoreCreativeTreeViewState(tree, state)).resolves.toBeUndefined()
+  })
+
+  test('stops an obsolete restoration before applying lazy children, scroll, or focus', async () => {
+    document.body.innerHTML = `<main><div id="creatives">${row('1', true)}</div></main>`
+    const main = document.querySelector('main')
+    const tree = document.getElementById('creatives')
+    main.scrollTop = 140
+    document.getElementById('toggle-1').focus()
+    const state = captureCreativeTreeViewState(tree)
+    tree.innerHTML = `
+      <creative-tree-row creative-id="1" has-children>
+        <div><button id="replacement-toggle">Toggle</button></div>
+      </creative-tree-row>
+      <div id="creative-children-1" data-loaded="false" data-load-url="/children/1"></div>
+    `
+    main.scrollTop = 0
+    let releaseChildren
+    loadChildren.mockReturnValue(new Promise((resolve) => {
+      releaseChildren = () => resolve({ creatives: [{ id: 2 }] })
+    }))
+    let current = true
+
+    const restoration = restoreCreativeTreeViewState(tree, state, { isCurrent: () => current })
+    current = false
+    releaseChildren()
+    await restoration
+
+    expect(renderCreativeTree).not.toHaveBeenCalled()
+    expect(tree.querySelector('[creative-id="1"]').hasAttribute('expanded')).toBe(false)
+    expect(main.scrollTop).toBe(0)
+    expect(document.activeElement.id).not.toBe('replacement-toggle')
+  })
+
+  // A row's controls are rebuilt without their ids on some renders, so the
+  // captured position is the only way back to the same control.
+  test('restores an anonymous control by its position in the row', async () => {
+    document.body.innerHTML = `
+      <main><div id="creatives">
+        <creative-tree-row creative-id="1">
+          <button>First</button><button>Second</button>
+        </creative-tree-row>
+      </div></main>
+    `
+    const tree = document.getElementById('creatives')
+    tree.querySelectorAll('button')[1].focus()
+
+    const state = captureCreativeTreeViewState(tree)
+    expect(state.focus).toMatchObject({ creativeId: '1', controlId: null, controlIndex: 1 })
+
+    tree.innerHTML = `
+      <creative-tree-row creative-id="1">
+        <button>First</button><button>Second</button>
+      </creative-tree-row>
+    `
+    await restoreCreativeTreeViewState(tree, state)
+
+    expect(document.activeElement.textContent).toBe('Second')
+  })
+
+  test('restores a scroll position captured without any expansion record', async () => {
+    document.body.innerHTML = `<main><div id="creatives">${row('1')}</div></main>`
+    const main = document.querySelector('main')
+    const tree = document.getElementById('creatives')
+
+    await restoreCreativeTreeViewState(tree, { scrolling: main, scrollTop: 42, focus: null })
+
+    expect(main.scrollTop).toBe(42)
+  })
+  test('an already superseded restore does not load or change any row', async () => {
+    document.body.innerHTML = `<main><div id="creatives">${row('1')}</div></main>`
+    const tree = document.getElementById('creatives')
+    const state = captureCreativeTreeViewState(tree)
+    state.expansion[0].expanded = true
+    await restoreCreativeTreeViewState(tree, state, { isCurrent: () => false })
+    expect(loadChildren).not.toHaveBeenCalled()
+    expect(tree.querySelector('creative-tree-row').hasAttribute('expanded')).toBe(false)
+  })
+
+  test('branch expansion tolerates a missing container and a missing child payload', async () => {
+    document.body.innerHTML = `<div id="creatives">${row('1')}</div>`
+    const creative = document.querySelector('creative-tree-row')
+    expect(await expandBranchWithChildren(creative, null)).toBe(false)
+    const container = document.getElementById('creative-children-1')
+    container.dataset.loadUrl = '/creatives/1/children.json'
+    loadChildren.mockResolvedValue(undefined)
+    expect(await expandBranchWithChildren(creative, container)).toBe(false)
+    expect(container.dataset.loaded).toBe('true')
+    expect(creative.hasAttribute('expanded')).toBe(false)
+  })
+
+})

--- a/engines/collavre/app/javascript/creatives/branch_expansion.js
+++ b/engines/collavre/app/javascript/creatives/branch_expansion.js
@@ -1,0 +1,39 @@
+import { setExpanded, setHasChildren } from './drag_drop/dom'
+import { loadChildren } from '../lib/api/creatives'
+import { renderCreativeTree, dispatchCreativeTreeUpdated } from './tree_renderer'
+
+// A collapsed branch is rendered empty with `data-loaded="false"`, so revealing
+// its container on its own shows nothing. Fill it the way a click-driven
+// expansion does (expansion_controller#ensureLoaded) before expanding, or the
+// branch looks open but blank — and, mid-drag, offers no rows to drop onto.
+export function expandBranchWithChildren(row, container, { isCurrent = () => true } = {}) {
+  if (!container) return Promise.resolve(false)
+
+  const loadUrl = container.dataset.loadUrl
+  if (container.dataset.loaded === 'true' || !loadUrl) {
+    setExpanded(row, true, container)
+    return Promise.resolve(true)
+  }
+
+  return loadChildren(loadUrl)
+    .then((data) => {
+      if (!isCurrent()) return false
+      const nodes = Array.isArray(data?.creatives) ? data.creatives : []
+      renderCreativeTree(container, nodes)
+      container.dataset.loaded = 'true'
+      const hasChildren = !!container.querySelector('creative-tree-row')
+      setHasChildren(row, hasChildren)
+      if (!hasChildren) {
+        setExpanded(row, false, container)
+        dispatchCreativeTreeUpdated(container)
+        return false
+      }
+      dispatchCreativeTreeUpdated(container)
+      setExpanded(row, true, container)
+      return true
+    })
+    .catch((error) => {
+      console.error('Failed to load children for branch expansion', error)
+      return false
+    })
+}

--- a/engines/collavre/app/javascript/creatives/drag_drop/__tests__/command_integration.test.js
+++ b/engines/collavre/app/javascript/creatives/drag_drop/__tests__/command_integration.test.js
@@ -1,0 +1,194 @@
+/**
+ * @jest-environment jsdom
+ */
+import { jest } from '@jest/globals';
+
+const sendNewOrder = jest.fn();
+const sendLinkedCreative = jest.fn();
+const alertDialog = jest.fn();
+jest.unstable_mockModule('../../../lib/api/drag_drop', () => ({
+  sendNewOrder,
+  sendLinkedCreative,
+  sendTopicMove: jest.fn(),
+  isAuthenticationRedirect: response => response?.redirected === true,
+}));
+jest.unstable_mockModule('../../../lib/utils/dialog', () => ({ alertDialog }));
+const { handleDragOver, handleDragLeave, handleDragStart, handleDrop } = await import('../event_handlers');
+const { resetDraggedState, getLastDragOverPosition } = await import('../state');
+const { writeDragData } = await import('../../../lib/dnd/envelope');
+const { resetDragSessionCache } = await import('../../../lib/dnd/session');
+
+function transfer() {
+  const values = new Map();
+  return {
+    get types() { return [...values.keys()]; },
+    setData: (key, value) => values.set(key, value),
+    getData: key => values.get(key) || '',
+  };
+}
+
+function event(target, dataTransfer, clientY = 150) {
+  return { target, dataTransfer, clientY, clientX: 0, shiftKey: false, preventDefault: jest.fn() };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+  resetDraggedState();
+  resetDragSessionCache();
+  localStorage.clear();
+  sessionStorage.clear();
+  document.body.innerHTML = '<div id="creatives">' + ['1', '9'].map(id => `
+    <creative-tree-row creative-id="${id}" level="1">
+      <div class="creative-tree" id="creative-${id}" draggable="true"></div>
+    </creative-tree-row>`).join('') + '</div>';
+  document.querySelectorAll('.creative-tree').forEach(tree => {
+    tree.getBoundingClientRect = () => ({ top: 100, height: 100 });
+  });
+  sendNewOrder.mockResolvedValue({ ok: false, status: 403 });
+});
+
+afterEach(() => {
+  resetDraggedState();
+  resetDragSessionCache();
+  document.body.innerHTML = '';
+  jest.restoreAllMocks();
+});
+
+test('cross-window canonical IDs reach the batch command without duplicate payload IDs', async () => {
+  const dataTransfer = transfer();
+  writeDragData(dataTransfer, { kind: 'creative', ids: ['2', '3'], payload: { creativeId: '2', treeId: 'creative-2' } });
+  const result = await handleDrop(event(document.getElementById('creative-9'), dataTransfer));
+  expect(sendNewOrder).toHaveBeenCalledWith({ draggedIds: ['2', '3'], targetId: '9', direction: 'child' });
+  expect(result.status).toBe('failure');
+  expect(result.failedIds).toEqual(['2', '3']);
+});
+
+test('canonical IDs override stale payload selection and supply the active ID', async () => {
+  const dataTransfer = transfer();
+  writeDragData(dataTransfer, { kind: 'creative', ids: ['2', '3'], payload: { treeId: 'creative-2', selectedCreativeIds: ['7'] } });
+  await handleDrop(event(document.getElementById('creative-9'), dataTransfer));
+  expect(sendNewOrder).toHaveBeenCalledWith({ draggedIds: ['2', '3'], targetId: '9', direction: 'child' });
+});
+
+test('drop direction follows intent even if presentation classes are replaced', async () => {
+  const dataTransfer = transfer();
+  writeDragData(dataTransfer, { kind: 'creative', ids: ['2'], payload: { treeId: 'creative-2' } });
+  const target = document.getElementById('creative-9');
+  handleDragOver(event(target, dataTransfer, 101));
+  target.classList.remove('drag-over-top');
+  target.classList.add('drag-over-bottom');
+  await handleDrop(event(target, dataTransfer, 199));
+  expect(sendNewOrder).toHaveBeenCalledWith({ draggedId: '2', targetId: '9', direction: 'up' });
+  expect(getLastDragOverPosition()).toBeNull();
+});
+
+test('hysteresis follows state and leave discards the previous intent', () => {
+  const dataTransfer = transfer();
+  writeDragData(dataTransfer, { kind: 'creative', ids: ['2'], payload: { treeId: 'creative-2' } });
+  const target = document.getElementById('creative-9');
+  handleDragOver(event(target, dataTransfer, 101));
+  target.classList.remove('drag-over-top');
+  handleDragOver(event(target, dataTransfer, 140));
+  expect(getLastDragOverPosition()).toBe('up');
+  handleDragLeave(event(target, dataTransfer));
+  expect(getLastDragOverPosition()).toBeNull();
+  handleDragOver(event(target, dataTransfer, 140));
+  expect(getLastDragOverPosition()).toBe('child');
+});
+
+test.each([
+  ['permission failure', { ok: false, status: 403 }],
+  ['authentication redirect', { ok: true, redirected: true, status: 200 }],
+])('local optimistic move is restored after %s', async (_label, response) => {
+  const dataTransfer = transfer();
+  const source = document.getElementById('creative-1');
+  const target = document.getElementById('creative-9');
+  sendNewOrder.mockResolvedValue(response);
+  handleDragStart(event(source, dataTransfer));
+  const running = handleDrop(event(target, dataTransfer));
+  expect(source.closest('creative-tree-row').getAttribute('parent-id')).toBe('9');
+  const result = await running;
+  expect(result.status).toBe('failure');
+  expect(source.closest('creative-tree-row').parentElement.id).toBe('creatives');
+  expect(source.closest('creative-tree-row').getAttribute('parent-id')).toBeFalsy();
+});
+
+test('Shift bundle uses the ordered link command and reports all failures', async () => {
+  const dataTransfer = transfer();
+  writeDragData(dataTransfer, { kind: 'creative', ids: ['2', '3'], payload: { treeId: 'creative-2' } });
+  sendLinkedCreative.mockRejectedValue(new Error('offline'));
+  const drop = event(document.getElementById('creative-9'), dataTransfer, 199);
+  drop.shiftKey = true;
+  const result = await handleDrop(drop);
+  expect(sendLinkedCreative.mock.calls.map(([call]) => call.draggedId)).toEqual(['3', '2']);
+  expect(sendNewOrder).not.toHaveBeenCalled();
+  expect(result.failedIds).toEqual(['2', '3']);
+});
+
+test('tampered session data never reaches the move command', async () => {
+  const dataTransfer = transfer();
+  writeDragData(dataTransfer, { kind: 'creative', ids: ['2'], payload: { treeId: 'creative-2' } });
+  for (const type of dataTransfer.types) {
+    const data = JSON.parse(dataTransfer.getData(type));
+    data.token = 'untrusted';
+    dataTransfer.setData(type, JSON.stringify(data));
+  }
+  await handleDrop(event(document.getElementById('creative-9'), dataTransfer));
+  expect(sendNewOrder).not.toHaveBeenCalled();
+  expect(alertDialog).toHaveBeenCalled();
+});
+
+test('a successful local move keeps the optimistic row and emits completion', async () => {
+  const dataTransfer = transfer();
+  const source = document.getElementById('creative-1');
+  const completed = jest.fn();
+  window.addEventListener('collavre:creative-drop-complete', completed);
+  try {
+    sendNewOrder.mockResolvedValue({ ok: true, status: 200 });
+    handleDragStart(event(source, dataTransfer));
+    const result = await handleDrop(event(document.getElementById('creative-9'), dataTransfer));
+    expect(result.status).toBe('success');
+    expect(source.closest('creative-tree-row').getAttribute('parent-id')).toBe('9');
+    expect(completed).toHaveBeenCalledTimes(1);
+    expect(completed.mock.calls[0][0].detail).toMatchObject({ creativeId: '1', context: 'target' });
+  } finally {
+    window.removeEventListener('collavre:creative-drop-complete', completed);
+  }
+});
+
+test('a single canonical ID cannot drop onto itself with a different tree ID', async () => {
+  const dataTransfer = transfer();
+  writeDragData(dataTransfer, { kind: 'creative', ids: ['9'], payload: { treeId: 'workspace-9' } });
+  await handleDrop(event(document.getElementById('creative-9'), dataTransfer));
+  expect(sendNewOrder).not.toHaveBeenCalled();
+  expect(sendLinkedCreative).not.toHaveBeenCalled();
+});
+
+test('invalid target geometry does not retain an actionable preview', () => {
+  const dataTransfer = transfer();
+  writeDragData(dataTransfer, { kind: 'creative', ids: ['2'], payload: { treeId: 'creative-2' } });
+  const target = document.getElementById('creative-9');
+  handleDragOver(event(target, dataTransfer, 101));
+  target.getBoundingClientRect = () => ({ top: 100, height: 0 });
+  handleDragOver(event(target, dataTransfer));
+  expect(getLastDragOverPosition()).toBeNull();
+  expect(target.classList.contains('drag-over')).toBe(false);
+});
+
+test('a partially successful link bundle preserves the command outcome', async () => {
+  const dataTransfer = transfer();
+  writeDragData(dataTransfer, { kind: 'creative', ids: ['2', '3'], payload: { treeId: 'creative-2' } });
+  sendLinkedCreative.mockImplementation(async ({ draggedId }) => {
+    if (draggedId === '3') throw new Error('offline');
+    return { id: 'shell-2' };
+  });
+  const drop = event(document.getElementById('creative-9'), dataTransfer, 199);
+  drop.shiftKey = true;
+  const result = await handleDrop(drop);
+  expect(result.status).toBe('partial');
+  expect(result.succeededIds).toEqual(['2']);
+  expect(result.failedIds).toEqual(['3']);
+  expect(result.rolledBack).toBe(false);
+  expect(sendLinkedCreative).toHaveBeenCalledTimes(2);
+});

--- a/engines/collavre/app/javascript/creatives/drag_drop/__tests__/creative_tree_drop.test.js
+++ b/engines/collavre/app/javascript/creatives/drag_drop/__tests__/creative_tree_drop.test.js
@@ -1,0 +1,768 @@
+/**
+ * @jest-environment jsdom
+ */
+import { jest } from '@jest/globals'
+
+// The move itself belongs to T2's command layer, which has its own suite. Here
+// only the wiring matters: which command handleDrop builds, when it declines to
+// build one at all, and what it broadcasts once the command settles.
+const createMoveContext = jest.fn(() => ({ context: true }))
+const applyMove = jest.fn(() => ({ newParentId: '2' }))
+const revertMove = jest.fn()
+const runMoveWithDomRecovery = jest.fn()
+
+jest.unstable_mockModule('../operations', () => ({
+  createMoveContext,
+  applyMove,
+  revertMove,
+  runMoveWithDomRecovery,
+}))
+jest.unstable_mockModule('../../../lib/api/drag_drop', () => ({
+  sendNewOrder: jest.fn(),
+  sendLinkedCreative: jest.fn(),
+  sendTopicMove: jest.fn(),
+}))
+jest.unstable_mockModule('../indicator', () => ({
+  initIndicator: jest.fn(),
+  showLinkHover: jest.fn(),
+  hideLinkHover: jest.fn(),
+}))
+jest.unstable_mockModule('../../topic_move_members_popup', () => ({
+  showMissingMembersPopup: jest.fn(),
+}))
+const alertDialog = jest.fn()
+jest.unstable_mockModule('../../../lib/utils/dialog', () => ({ alertDialog }))
+
+const loadChildren = jest.fn()
+jest.unstable_mockModule('../../../lib/api/creatives', () => ({
+  loadChildren,
+  default: { loadChildren },
+}))
+
+const renderCreativeTree = jest.fn()
+jest.unstable_mockModule('../../tree_renderer', () => ({
+  renderCreativeTree,
+  appendCreativeNodes: jest.fn(),
+  dispatchCreativeTreeUpdated: jest.fn(),
+  applyRowProperties: jest.fn(),
+}))
+
+const {
+  addGlobalListeners,
+  createCreativeTreeDragDrop,
+  handleDragLeave,
+  handleDragOver,
+  handleDragStart,
+  handleDrop,
+  removeGlobalListeners,
+} = await import('../event_handlers')
+const { readDragData } = await import('../../../lib/dnd/envelope')
+const { resetDragSessionCache } = await import('../../../lib/dnd/session')
+const { resetDraggedState } = await import('../state')
+
+const DROP_SIGNAL_STORAGE_KEY = 'collavre.dragDropSignal'
+const DRAG_TOKEN_STORAGE_KEY = 'collavre.dragToken'
+
+function row(id, { parentId = null, isRoot = false, level = 1 } = {}) {
+  const parent = parentId ? ` parent-id="${parentId}"` : ''
+  return `
+    <creative-tree-row creative-id="${id}" level="${level}"${parent}${isRoot ? ' is-root' : ''}>
+      <div class="creative-tree" id="creative-${id}" draggable="true">
+        <span class="creative-content">Creative ${id}</span>
+      </div>
+    </creative-tree-row>
+  `
+}
+
+function transfer() {
+  const values = new Map()
+  return {
+    dropEffect: 'none',
+    effectAllowed: 'none',
+    setDragImage: jest.fn(),
+    get types() { return [...values.keys()] },
+    getData(type) { return values.get(type) || '' },
+    setData(type, value) { values.set(type, String(value)) },
+  }
+}
+
+function dragEvent(target, dataTransfer, { clientY = 50, shiftKey = false } = {}) {
+  return { target, dataTransfer, clientX: 10, clientY, shiftKey, preventDefault: jest.fn() }
+}
+
+function tree(id) {
+  return document.getElementById(`creative-${id}`)
+}
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0))
+
+function nativeDrag(type, target, dataTransfer) {
+  const event = new Event(type, { bubbles: true, cancelable: true })
+  Object.assign(event, { dataTransfer, clientX: 0, clientY: 10, shiftKey: false })
+  target.dispatchEvent(event)
+  return event
+}
+
+describe('right creative tree drop wiring', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    window.sessionStorage.clear()
+    resetDragSessionCache()
+    resetDraggedState()
+    // T2 always answers with a full result; a mock that omits `succeededIds`
+    // would let a real crash pass unnoticed here.
+    runMoveWithDomRecovery.mockImplementation(({ command }) => Promise.resolve({
+      command, status: 'success', ok: true, succeededIds: [...command.ids], failedIds: [], failures: [],
+    }))
+    document.body.innerHTML = `
+      <div id="creatives">
+        ${row('1', { isRoot: true })}
+        <div class="creative-children" id="creative-children-1"></div>
+        ${row('2', { isRoot: true })}
+        ${row('3', { isRoot: true })}
+        ${row('4', { isRoot: true })}
+      </div>
+    `
+    document.getElementById('creative-children-1').appendChild(
+      document.getElementById('creative-3').closest('creative-tree-row')
+    )
+    document.getElementById('creative-3').closest('creative-tree-row')
+      .setAttribute('parent-id', '1')
+    document.querySelectorAll('.creative-tree').forEach((element) => {
+      element.getBoundingClientRect = () => ({ top: 0, height: 100 })
+    })
+  })
+
+  afterEach(() => {
+    resetDraggedState()
+    jest.clearAllMocks()
+    document.body.innerHTML = ''
+  })
+
+  test('publishes an envelope the shared reader accepts', () => {
+    const dataTransfer = transfer()
+
+    handleDragStart(dragEvent(tree('1'), dataTransfer))
+
+    // A shift-drag links, and a link target answers 'copy'. Advertising 'move'
+    // alone makes the browser negotiate that pair down to no drag operation.
+    expect(dataTransfer.effectAllowed).toBe('copyMove')
+    expect(readDragData(dataTransfer)).toEqual({
+      kind: 'creative',
+      ids: ['1'],
+      payload: expect.objectContaining({
+        creativeId: '1',
+        treeId: 'creative-1',
+        parentId: null,
+        isRoot: true,
+        sourceWindowId: expect.any(String),
+      }),
+    })
+  })
+
+  // The workspace tree answers a shift-drag with dropEffect 'copy'. Reporting
+  // 'move' here would leave the two trees advertising incompatible effects.
+  test('answers a shift-drag with the copy effect', () => {
+    const dataTransfer = transfer()
+    handleDragStart(dragEvent(tree('1'), dataTransfer))
+
+    handleDragOver(dragEvent(tree('2'), dataTransfer, { shiftKey: true }))
+    expect(dataTransfer.dropEffect).toBe('copy')
+
+    handleDragOver(dragEvent(tree('2'), dataTransfer))
+    expect(dataTransfer.dropEffect).toBe('move')
+  })
+
+  test('carries a multi-selection into the envelope and the command', async () => {
+    document.body.insertAdjacentHTML('beforeend', `
+      <input class="select-creative-checkbox" type="checkbox" value="1" checked>
+      <input class="select-creative-checkbox" type="checkbox" value="2" checked>
+    `)
+    const dataTransfer = transfer()
+
+    handleDragStart(dragEvent(tree('1'), dataTransfer))
+    expect(readDragData(dataTransfer).ids).toEqual(['1', '2'])
+
+    handleDragOver(dragEvent(tree('4'), dataTransfer, { clientY: 50 }))
+    handleDrop(dragEvent(tree('4'), dataTransfer, { clientY: 50 }))
+    await flush()
+
+    // A bundle keeps its own subtree intact, so no optimistic DOM move is staged.
+    expect(applyMove).not.toHaveBeenCalled()
+    expect(runMoveWithDomRecovery).toHaveBeenCalledWith(expect.objectContaining({
+      command: { ids: ['1', '2'], targetId: '4', direction: 'child', mode: 'move' },
+      moveContext: null,
+    }))
+  })
+
+  test('the registry preserves same-window dragging when storage blocks MIME writes', async () => {
+    const getItem = jest.spyOn(Storage.prototype, 'getItem').mockImplementation(() => { throw new Error('blocked') })
+    const setItem = jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => { throw new Error('blocked') })
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
+    const registry = createCreativeTreeDragDrop()
+    try {
+      const dataTransfer = transfer()
+      nativeDrag('dragstart', tree('2'), dataTransfer)
+      expect(dataTransfer.types).toEqual([])
+      expect(nativeDrag('dragover', tree('1'), dataTransfer).defaultPrevented).toBe(true)
+      nativeDrag('drop', tree('1'), dataTransfer)
+      await flush()
+      expect(runMoveWithDomRecovery).toHaveBeenCalledWith(expect.objectContaining({
+        command: { ids: ['2'], targetId: '1', direction: 'up', mode: 'move' },
+        moveContext: { context: true },
+      }))
+    } finally {
+      registry.destroy()
+      getItem.mockRestore()
+      setItem.mockRestore()
+      consoleError.mockRestore()
+    }
+  })
+
+  test.each(['invalid token', 'malformed JSON', 'unrelated MIME'])(
+    'the registry never replaces %s with local drag state', async kind => {
+      const registry = createCreativeTreeDragDrop()
+      const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
+      try {
+        let dataTransfer = transfer()
+        nativeDrag('dragstart', tree('2'), dataTransfer)
+        if (kind === 'unrelated MIME') {
+          dataTransfer = transfer()
+          dataTransfer.setData('text/plain', 'untrusted')
+        } else {
+          const payload = JSON.parse(dataTransfer.getData('application/x-collavre-creative'))
+          dataTransfer.setData('application/x-collavre-creative', kind === 'malformed JSON'
+            ? 'not JSON' : JSON.stringify({ ...payload, token: 'invalid' }))
+        }
+        nativeDrag('dragover', tree('1'), dataTransfer)
+        nativeDrag('drop', tree('1'), dataTransfer)
+        await flush()
+        expect(runMoveWithDomRecovery).not.toHaveBeenCalled()
+      } finally {
+        registry.destroy()
+        consoleError.mockRestore()
+      }
+    }
+  )
+
+  test('a numeric legacy creative id keeps same-window DOM recovery', async () => {
+    const dataTransfer = transfer()
+    handleDragStart(dragEvent(tree('2'), dataTransfer))
+    const payload = JSON.parse(dataTransfer.getData('application/x-collavre-creative'))
+    dataTransfer.setData('application/x-collavre-creative', JSON.stringify({ ...payload, creativeId: 2 }))
+    await handleDrop(dragEvent(tree('1'), dataTransfer, { clientY: 10 }))
+    expect(createMoveContext).toHaveBeenCalled()
+    expect(runMoveWithDomRecovery).toHaveBeenCalledWith(expect.objectContaining({
+      command: { ids: ['2'], targetId: '1', direction: 'up', mode: 'move' },
+      moveContext: { context: true },
+    }))
+  })
+
+  test('stages an optimistic move and broadcasts once the command succeeds', async () => {
+    const completion = jest.fn()
+    window.addEventListener('collavre:creative-drop-complete', completion, { once: true })
+    const dataTransfer = transfer()
+
+    handleDragStart(dragEvent(tree('2'), dataTransfer))
+    handleDragOver(dragEvent(tree('1'), dataTransfer, { clientY: 10 }))
+    handleDrop(dragEvent(tree('1'), dataTransfer, { clientY: 10 }))
+    await flush()
+
+    expect(createMoveContext).toHaveBeenCalled()
+    expect(applyMove).toHaveBeenCalledWith(expect.objectContaining({ direction: 'up' }))
+    expect(runMoveWithDomRecovery).toHaveBeenCalledWith({
+      command: { ids: ['2'], targetId: '1', direction: 'up', mode: 'move' },
+      moveContext: { context: true },
+      attemptedParentId: '2',
+    })
+    expect(completion).toHaveBeenCalledWith(expect.objectContaining({
+      detail: expect.objectContaining({
+        creativeIds: ['2'], targetCreativeId: '1', direction: 'up', context: 'target',
+      }),
+    }))
+    expect(window.localStorage.getItem(DROP_SIGNAL_STORAGE_KEY)).toBeNull()
+  })
+
+  test('links with shift without staging an optimistic move', async () => {
+    const dataTransfer = transfer()
+
+    handleDragStart(dragEvent(tree('2'), dataTransfer, { shiftKey: true }))
+    handleDragOver(dragEvent(tree('1'), dataTransfer, { clientY: 50, shiftKey: true }))
+    handleDrop(dragEvent(tree('1'), dataTransfer, { clientY: 50, shiftKey: true }))
+    await flush()
+
+    expect(applyMove).not.toHaveBeenCalled()
+    expect(runMoveWithDomRecovery).toHaveBeenCalledWith(expect.objectContaining({
+      command: { ids: ['2'], targetId: '1', direction: 'child', mode: 'link' },
+    }))
+  })
+
+  test('stays silent when the command reports it did not move anything', async () => {
+    runMoveWithDomRecovery.mockResolvedValue({
+      status: 'failure', ok: false, succeededIds: [], failedIds: ['2'], failures: [],
+    })
+    const completion = jest.fn()
+    window.addEventListener('collavre:creative-drop-complete', completion, { once: true })
+    const dataTransfer = transfer()
+
+    handleDragStart(dragEvent(tree('2'), dataTransfer))
+    handleDrop(dragEvent(tree('1'), dataTransfer, { clientY: 50 }))
+    await flush()
+
+    expect(completion).not.toHaveBeenCalled()
+  })
+
+  test('surfaces a partial move instead of reporting a clean success', async () => {
+    runMoveWithDomRecovery.mockResolvedValue({
+      status: 'partial',
+      succeededIds: ['1'],
+      failedIds: ['2'],
+      failures: [{
+        id: '2',
+        reason: 'permission_denied',
+        message: 'HTTP 403: Forbidden',
+        serverMessage: 'Not allowed',
+      }],
+    })
+    const completion = jest.fn()
+    window.addEventListener('collavre:creative-drop-complete', completion, { once: true })
+    const dataTransfer = transfer()
+
+    handleDragStart(dragEvent(tree('2'), dataTransfer))
+    handleDrop(dragEvent(tree('1'), dataTransfer, { clientY: 50 }))
+    await flush()
+
+    expect(alertDialog).toHaveBeenCalledWith('Not allowed')
+    // The rows that did move still need both trees to refresh.
+    expect(completion).toHaveBeenCalled()
+  })
+
+  test('the registered drop path uses the translated partial failure message', async () => {
+    runMoveWithDomRecovery.mockResolvedValue({
+      status: 'partial', succeededIds: ['2'], failedIds: ['9'], failures: [],
+    })
+    const registry = createCreativeTreeDragDrop({ partialFailureMessage: 'Retry missing links only' })
+    const dataTransfer = transfer()
+    handleDragStart(dragEvent(tree('2'), dataTransfer))
+    const drop = new Event('drop', { bubbles: true, cancelable: true })
+    Object.assign(drop, { dataTransfer, clientX: 0, clientY: 50, shiftKey: true })
+    tree('1').dispatchEvent(drop)
+    await flush()
+    expect(alertDialog).toHaveBeenCalledWith('Retry missing links only')
+    registry.destroy()
+  })
+
+  test('reports a command that rejects outright', async () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
+    runMoveWithDomRecovery.mockRejectedValue(new Error('network down'))
+    const dataTransfer = transfer()
+
+    handleDragStart(dragEvent(tree('2'), dataTransfer))
+    handleDrop(dragEvent(tree('1'), dataTransfer, { clientY: 50 }))
+    await flush()
+
+    expect(consoleError).toHaveBeenCalledWith(
+      'Failed to update order',
+      expect.objectContaining({ message: 'network down' })
+    )
+    consoleError.mockRestore()
+  })
+
+  test('broadcasts to the originating window when the drag came from elsewhere', async () => {
+    window.localStorage.setItem(DRAG_TOKEN_STORAGE_KEY, 'token-under-test')
+    resetDragSessionCache()
+    const dataTransfer = transfer()
+    dataTransfer.setData('application/x-collavre-creative', JSON.stringify({
+      creativeId: '9',
+      treeId: 'creative-9',
+      token: 'token-under-test',
+      sourceWindowId: 'other-window',
+      selectedCreativeIds: [],
+    }))
+
+    handleDrop(dragEvent(tree('1'), dataTransfer, { clientY: 50 }))
+    await flush()
+
+    expect(runMoveWithDomRecovery).toHaveBeenCalledWith(expect.objectContaining({
+      command: { ids: ['9'], targetId: '1', direction: 'child', mode: 'move' },
+      moveContext: null,
+    }))
+  })
+
+  // A partial view can hand back an envelope whose tree id no longer resolves,
+  // so the row identity — not the tree id — has to catch the self drop.
+  test('declines an envelope that resolves back onto its own row', async () => {
+    window.localStorage.setItem(DRAG_TOKEN_STORAGE_KEY, 'token-under-test')
+    resetDragSessionCache()
+    const dataTransfer = transfer()
+    dataTransfer.setData('application/x-collavre-creative', JSON.stringify({
+      creativeId: '1',
+      treeId: 'creative-detached',
+      token: 'token-under-test',
+      sourceWindowId: 'other-window',
+      selectedCreativeIds: [],
+    }))
+
+    handleDrop(dragEvent(tree('1'), dataTransfer, { clientY: 50 }))
+    await flush()
+
+    expect(runMoveWithDomRecovery).not.toHaveBeenCalled()
+  })
+
+  test('ignores a drop carrying a kind the creative tree does not handle', async () => {
+    const dataTransfer = transfer()
+    dataTransfer.setData('application/x-context-id', '5')
+
+    handleDrop(dragEvent(tree('1'), dataTransfer, { clientY: 50 }))
+    await flush()
+
+    expect(runMoveWithDomRecovery).not.toHaveBeenCalled()
+  })
+
+  test('declines a drop whose target row cannot report a drop position', () => {
+    const dataTransfer = transfer()
+    tree('1').getBoundingClientRect = () => ({ top: 0, height: 0 })
+
+    handleDragStart(dragEvent(tree('2'), dataTransfer))
+    handleDrop(dragEvent(tree('1'), dataTransfer, { clientY: 50 }))
+
+    expect(runMoveWithDomRecovery).not.toHaveBeenCalled()
+  })
+
+  test('declines a drop onto the dragged row itself', () => {
+    const dataTransfer = transfer()
+    document.body.insertAdjacentHTML('beforeend', `
+      <input class="select-creative-checkbox" type="checkbox" value="1" checked>
+      <input class="select-creative-checkbox" type="checkbox" value="2" checked>
+    `)
+
+    handleDragStart(dragEvent(tree('1'), dataTransfer))
+    // #creative-2 is inside the bundle, so it cannot also be the destination.
+    handleDrop(dragEvent(tree('2'), dataTransfer, { clientY: 50 }))
+
+    expect(runMoveWithDomRecovery).not.toHaveBeenCalled()
+  })
+
+  test('declines a drop into a descendant the DOM can prove', () => {
+    const dataTransfer = transfer()
+
+    handleDragStart(dragEvent(tree('1'), dataTransfer))
+    handleDrop(dragEvent(tree('3'), dataTransfer, { clientY: 50 }))
+
+    expect(runMoveWithDomRecovery).not.toHaveBeenCalled()
+  })
+
+  // Only the parent chain can prove a cycle once a partial view hides the
+  // subtree, so a row still in the DOM has to be walked upward.
+  test('declines a drop under a descendant that is no longer nested in the DOM', () => {
+    const detached = document.getElementById('creative-3').closest('creative-tree-row')
+    document.getElementById('creatives').appendChild(detached)
+    const dataTransfer = transfer()
+
+    handleDragStart(dragEvent(tree('1'), dataTransfer))
+    handleDrop(dragEvent(tree('3'), dataTransfer, { clientY: 50 }))
+
+    expect(runMoveWithDomRecovery).not.toHaveBeenCalled()
+  })
+
+  // A row rendered without its id gives the cycle check nothing to compare, so
+  // the drop is refused rather than sent to the server on a guess.
+  test('declines a drop onto a row that names no creative', () => {
+    const anonymous = document.getElementById('creative-4').closest('creative-tree-row')
+    anonymous.removeAttribute('creative-id')
+    const dataTransfer = transfer()
+
+    handleDragStart(dragEvent(tree('2'), dataTransfer))
+    handleDrop(dragEvent(tree('4'), dataTransfer, { clientY: 50 }))
+
+    expect(runMoveWithDomRecovery).not.toHaveBeenCalled()
+  })
+
+  test('allows a sibling drop next to a row whose parent chain is unknown', async () => {
+    const detached = document.getElementById('creative-3').closest('creative-tree-row')
+    document.getElementById('creatives').appendChild(detached)
+    detached.setAttribute('parent-id', '404')
+    const dataTransfer = transfer()
+
+    handleDragStart(dragEvent(tree('2'), dataTransfer))
+    handleDrop(dragEvent(tree('3'), dataTransfer, { clientY: 10 }))
+    await flush()
+
+    expect(runMoveWithDomRecovery).toHaveBeenCalledWith(expect.objectContaining({
+      command: { ids: ['2'], targetId: '3', direction: 'up', mode: 'move' },
+    }))
+  })
+})
+
+describe('right creative tree drag feedback', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    window.sessionStorage.clear()
+    resetDragSessionCache()
+    resetDraggedState()
+    jest.useFakeTimers()
+    document.body.innerHTML = `<div id="creatives">${row('1', { isRoot: true })}</div>`
+    tree('1').getBoundingClientRect = () => ({ top: 0, height: 100 })
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+    resetDraggedState()
+    jest.clearAllMocks()
+    document.body.innerHTML = ''
+  })
+
+  test('sticks to the previous edge decision across repeated dragover events', () => {
+    const dataTransfer = transfer()
+    handleDragStart(dragEvent(tree('1'), dataTransfer))
+
+    handleDragOver(dragEvent(tree('1'), dataTransfer, { clientY: 10 }))
+    expect(tree('1').classList.contains('drag-over-top')).toBe(true)
+
+    // 32 sits past the 30% boundary but inside the 12% hysteresis band, so the
+    // row must stay on the top edge instead of flipping to a child drop.
+    handleDragOver(dragEvent(tree('1'), dataTransfer, { clientY: 32 }))
+    expect(tree('1').classList.contains('drag-over-top')).toBe(true)
+
+    handleDragOver(dragEvent(tree('1'), dataTransfer, { clientY: 90 }))
+    expect(tree('1').classList.contains('drag-over-bottom')).toBe(true)
+    handleDragOver(dragEvent(tree('1'), dataTransfer, { clientY: 68 }))
+    expect(tree('1').classList.contains('drag-over-bottom')).toBe(true)
+  })
+
+  test('schedules the hover expansion once while the pointer stays on the row', () => {
+    document.body.innerHTML = `
+      <div id="creatives">
+        <creative-tree-row creative-id="1" level="1" has-children>
+          <div class="creative-tree" id="creative-1" draggable="true"></div>
+        </creative-tree-row>
+        <div class="creative-children" id="creative-children-1" style="display:none"></div>
+      </div>
+    `
+    tree('1').getBoundingClientRect = () => ({ top: 0, height: 100 })
+    const dataTransfer = transfer()
+    handleDragStart(dragEvent(tree('1'), dataTransfer))
+
+    handleDragOver(dragEvent(tree('1'), dataTransfer, { clientY: 50 }))
+    jest.advanceTimersByTime(300)
+    handleDragOver(dragEvent(tree('1'), dataTransfer, { clientY: 51 }))
+    jest.advanceTimersByTime(300)
+
+    // The second dragover must not restart the timer, or a hovering pointer
+    // would never reach the 600ms threshold.
+    expect(tree('1').closest('creative-tree-row').hasAttribute('expanded')).toBe(true)
+  })
+
+  // A collapsed branch renders empty with data-loaded="false", so revealing the
+  // container alone would advertise an expansion with nothing to drop onto.
+  test('fills a lazily loaded branch before revealing it', async () => {
+    document.body.innerHTML = `
+      <div id="creatives">
+        <creative-tree-row creative-id="1" level="1" has-children>
+          <div class="creative-tree" id="creative-1" draggable="true"></div>
+        </creative-tree-row>
+        <div class="creative-children" id="creative-children-1" style="display:none"
+             data-loaded="false" data-load-url="/creatives/1/children.json"></div>
+      </div>
+    `
+    tree('1').getBoundingClientRect = () => ({ top: 0, height: 100 })
+    loadChildren.mockResolvedValue({ creatives: [{ id: 2 }] })
+    const container = document.getElementById('creative-children-1')
+    renderCreativeTree.mockImplementationOnce((target) => {
+      target.innerHTML = row('2', { parentId: '1', level: 2 })
+    })
+    const dataTransfer = transfer()
+    handleDragStart(dragEvent(tree('1'), dataTransfer))
+
+    handleDragOver(dragEvent(tree('1'), dataTransfer, { clientY: 50 }))
+    await jest.advanceTimersByTimeAsync(600)
+
+    expect(loadChildren).toHaveBeenCalledWith('/creatives/1/children.json')
+    expect(renderCreativeTree).toHaveBeenCalledWith(container, [{ id: 2 }])
+    expect(container.dataset.loaded).toBe('true')
+    expect(tree('1').closest('creative-tree-row').hasAttribute('has-children')).toBe(true)
+    expect(tree('1').closest('creative-tree-row').hasAttribute('expanded')).toBe(true)
+  })
+
+  test('does not apply an in-flight hover response after the drop starts', async () => {
+    let resolveChildren
+    document.body.innerHTML = `
+<div id="creatives">
+${row('1', { isRoot: true })}
+<creative-tree-row creative-id="2" level="1" has-children>
+<div class="creative-tree" id="creative-2" draggable="true"></div>
+</creative-tree-row>
+<div class="creative-children" id="creative-children-2" style="display:none"
+data-loaded="false" data-load-url="/creatives/2/children.json"></div>
+</div>
+`
+    tree('1').getBoundingClientRect = () => ({ top: 0, height: 100 })
+    tree('2').getBoundingClientRect = () => ({ top: 0, height: 100 })
+    loadChildren.mockImplementation(() => new Promise((resolve) => { resolveChildren = resolve }))
+    runMoveWithDomRecovery.mockResolvedValue({ status: 'success' })
+    const dataTransfer = transfer()
+    handleDragStart(dragEvent(tree('1'), dataTransfer))
+    handleDragOver(dragEvent(tree('2'), dataTransfer, { clientY: 50 }))
+    await jest.advanceTimersByTimeAsync(600)
+
+    handleDrop(dragEvent(tree('2'), dataTransfer, { clientY: 50 }))
+    resolveChildren({ creatives: [{ id: 3 }] })
+    await Promise.resolve()
+
+    expect(runMoveWithDomRecovery).toHaveBeenCalled()
+    expect(renderCreativeTree).not.toHaveBeenCalled()
+    expect(document.getElementById('creative-children-2').dataset.loaded).toBe('false')
+  })
+
+  test('does not apply an in-flight hover response after leaving the target', async () => {
+    let resolveChildren
+    document.body.innerHTML = `
+<creative-tree-row creative-id="1" level="1" has-children>
+<div class="creative-tree" id="creative-1" draggable="true"></div>
+</creative-tree-row>
+<div class="creative-children" id="creative-children-1" style="display:none"
+data-loaded="false" data-load-url="/creatives/1/children.json"></div>
+`
+    tree('1').getBoundingClientRect = () => ({ top: 0, height: 100 })
+    loadChildren.mockImplementation(() => new Promise((resolve) => { resolveChildren = resolve }))
+    const dataTransfer = transfer()
+    handleDragStart(dragEvent(tree('1'), dataTransfer))
+    handleDragOver(dragEvent(tree('1'), dataTransfer, { clientY: 50 }))
+    await jest.advanceTimersByTimeAsync(600)
+
+    handleDragLeave(dragEvent(tree('1'), dataTransfer))
+    resolveChildren({ creatives: [{ id: 2 }] })
+    await Promise.resolve()
+
+    expect(renderCreativeTree).not.toHaveBeenCalled()
+    expect(document.getElementById('creative-children-1').dataset.loaded).toBe('false')
+  })
+
+  test('allows dragleave cleanup when no hover expansion is pending', () => {
+    const dataTransfer = transfer()
+
+    expect(() => handleDragLeave(dragEvent(tree('1'), dataTransfer))).not.toThrow()
+  })
+
+  test('settles a branch the server reports as empty', async () => {
+    document.body.innerHTML = `
+      <div id="creatives">
+        <creative-tree-row creative-id="1" level="1" has-children>
+          <div class="creative-tree" id="creative-1" draggable="true"></div>
+        </creative-tree-row>
+        <div class="creative-children" id="creative-children-1" style="display:none"
+             data-loaded="false" data-load-url="/creatives/1/children.json"></div>
+      </div>
+    `
+    tree('1').getBoundingClientRect = () => ({ top: 0, height: 100 })
+    loadChildren.mockResolvedValue({})
+    const container = document.getElementById('creative-children-1')
+    const dataTransfer = transfer()
+    handleDragStart(dragEvent(tree('1'), dataTransfer))
+
+    handleDragOver(dragEvent(tree('1'), dataTransfer, { clientY: 50 }))
+    await jest.advanceTimersByTimeAsync(600)
+
+    expect(renderCreativeTree).toHaveBeenCalledWith(container, [])
+    expect(container.dataset.loaded).toBe('true')
+    expect(tree('1').closest('creative-tree-row').hasAttribute('has-children')).toBe(false)
+    expect(tree('1').closest('creative-tree-row').hasAttribute('expanded')).toBe(false)
+    expect(container.style.display).toBe('none')
+  })
+
+  test('leaves the branch collapsed when its children cannot be loaded', async () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
+    document.body.innerHTML = `
+      <div id="creatives">
+        <creative-tree-row creative-id="1" level="1" has-children>
+          <div class="creative-tree" id="creative-1" draggable="true"></div>
+        </creative-tree-row>
+        <div class="creative-children" id="creative-children-1" style="display:none"
+             data-loaded="false" data-load-url="/creatives/1/children.json"></div>
+      </div>
+    `
+    tree('1').getBoundingClientRect = () => ({ top: 0, height: 100 })
+    loadChildren.mockRejectedValue(new Error('offline'))
+    const dataTransfer = transfer()
+    handleDragStart(dragEvent(tree('1'), dataTransfer))
+
+    handleDragOver(dragEvent(tree('1'), dataTransfer, { clientY: 50 }))
+    await jest.advanceTimersByTimeAsync(600)
+
+    expect(tree('1').closest('creative-tree-row').hasAttribute('expanded')).toBe(false)
+    expect(consoleError).toHaveBeenCalledWith(
+      'Failed to load children for branch expansion',
+      expect.objectContaining({ message: 'offline' })
+    )
+    consoleError.mockRestore()
+  })
+
+  test('cancels a pending expansion when the drag ends', () => {
+    document.body.innerHTML = `
+      <div id="creatives">
+        <creative-tree-row creative-id="1" level="1" has-children>
+          <div class="creative-tree" id="creative-1" draggable="true"></div>
+        </creative-tree-row>
+        <div class="creative-children" id="creative-children-1" style="display:none"></div>
+      </div>
+    `
+    tree('1').getBoundingClientRect = () => ({ top: 0, height: 100 })
+    const dataTransfer = transfer()
+    addGlobalListeners()
+    handleDragStart(dragEvent(tree('1'), dataTransfer))
+    handleDragOver(dragEvent(tree('1'), dataTransfer, { clientY: 50 }))
+
+    document.dispatchEvent(new Event('dragend', { bubbles: true }))
+    jest.advanceTimersByTime(600)
+    removeGlobalListeners()
+
+    expect(tree('1').closest('creative-tree-row').hasAttribute('expanded')).toBe(false)
+  })
+})
+
+describe('source window synchronization', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    window.sessionStorage.clear()
+    resetDragSessionCache()
+    document.body.innerHTML = `<div id="creatives">${row('7', { isRoot: true })}</div>`
+    addGlobalListeners()
+  })
+
+  afterEach(() => {
+    removeGlobalListeners()
+    jest.clearAllMocks()
+    document.body.innerHTML = ''
+  })
+
+  // The originating window learns about the move through localStorage, so a
+  // signal it can verify has to reach the tree and take the row away.
+  test('removes the moved row when the originating window verifies the signal', () => {
+    window.localStorage.setItem(DRAG_TOKEN_STORAGE_KEY, 'token-under-test')
+    window.sessionStorage.setItem('collavre.dragWindowId', 'this-window')
+    resetDragSessionCache()
+
+    window.dispatchEvent(Object.assign(new Event('storage'), {
+      key: DROP_SIGNAL_STORAGE_KEY,
+      newValue: JSON.stringify({
+        creativeId: '7', sessionToken: 'token-under-test', sourceWindowId: 'this-window',
+      }),
+    }))
+
+    expect(document.querySelector('creative-tree-row[creative-id="7"]')).toBeNull()
+  })
+
+  test('ignores a storage event that carries no verifiable drop signal', () => {
+    const completion = jest.fn()
+    window.addEventListener('collavre:creative-drop-complete', completion)
+
+    window.dispatchEvent(Object.assign(new Event('storage'), {
+      key: DROP_SIGNAL_STORAGE_KEY,
+      newValue: JSON.stringify({ creativeId: '7', sessionToken: 'not-our-token' }),
+    }))
+
+    window.removeEventListener('collavre:creative-drop-complete', completion)
+    expect(completion).not.toHaveBeenCalled()
+    expect(document.querySelector('creative-tree-row')).not.toBeNull()
+  })
+})

--- a/engines/collavre/app/javascript/creatives/drag_drop/__tests__/creative_tree_drop.test.js
+++ b/engines/collavre/app/javascript/creatives/drag_drop/__tests__/creative_tree_drop.test.js
@@ -96,9 +96,9 @@ function tree(id) {
 
 const flush = () => new Promise((resolve) => setTimeout(resolve, 0))
 
-function nativeDrag(type, target, dataTransfer) {
+function nativeDrag(type, target, dataTransfer, { clientY = 10 } = {}) {
   const event = new Event(type, { bubbles: true, cancelable: true })
-  Object.assign(event, { dataTransfer, clientX: 0, clientY: 10, shiftKey: false })
+  Object.assign(event, { dataTransfer, clientX: 0, clientY, shiftKey: false })
   target.dispatchEvent(event)
   return event
 }
@@ -695,6 +695,84 @@ data-loaded="false" data-load-url="/creatives/1/children.json"></div>
       expect.objectContaining({ message: 'offline' })
     )
     consoleError.mockRestore()
+  })
+
+  test('retries a failed hover load while the registry preview stays active', async () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
+    document.body.innerHTML = `
+      <div id="creatives">
+        <creative-tree-row creative-id="1" level="1" has-children>
+          <div class="creative-tree" id="creative-1" draggable="true"></div>
+        </creative-tree-row>
+        <div class="creative-children" id="creative-children-1" style="display:none"
+             data-loaded="false" data-load-url="/creatives/1/children.json"></div>
+      </div>
+    `
+    tree('1').getBoundingClientRect = () => ({ top: 0, height: 100 })
+    loadChildren
+      .mockRejectedValueOnce(new Error('offline'))
+      .mockResolvedValueOnce({ creatives: [{ id: 2 }] })
+    renderCreativeTree.mockImplementationOnce((target) => {
+      target.innerHTML = row('2', { parentId: '1', level: 2 })
+    })
+    const dataTransfer = transfer()
+    const registry = createCreativeTreeDragDrop()
+
+    try {
+      nativeDrag('dragstart', tree('1'), dataTransfer)
+      nativeDrag('dragover', tree('1'), dataTransfer, { clientY: 50 })
+      await jest.advanceTimersByTimeAsync(600)
+
+      nativeDrag('dragover', tree('1'), dataTransfer, { clientY: 50 })
+      await jest.advanceTimersByTimeAsync(600)
+
+      expect(loadChildren).toHaveBeenCalledTimes(2)
+      expect(tree('1').closest('creative-tree-row').hasAttribute('expanded')).toBe(true)
+    } finally {
+      registry.destroy()
+      consoleError.mockRestore()
+    }
+  })
+
+  test('retries when the pointer re-enters during an obsolete hover load', async () => {
+    let resolveFirstLoad
+    document.body.innerHTML = `
+      <div id="creatives">
+        <creative-tree-row creative-id="1" level="1" has-children>
+          <div class="creative-tree" id="creative-1" draggable="true"></div>
+        </creative-tree-row>
+        <div class="creative-children" id="creative-children-1" style="display:none"
+             data-loaded="false" data-load-url="/creatives/1/children.json"></div>
+      </div>
+    `
+    tree('1').getBoundingClientRect = () => ({ top: 0, height: 100 })
+    loadChildren
+      .mockImplementationOnce(() => new Promise((resolve) => { resolveFirstLoad = resolve }))
+      .mockResolvedValueOnce({ creatives: [{ id: 2 }] })
+    renderCreativeTree.mockImplementationOnce((target) => {
+      target.innerHTML = row('2', { parentId: '1', level: 2 })
+    })
+    const dataTransfer = transfer()
+    const registry = createCreativeTreeDragDrop()
+
+    try {
+      nativeDrag('dragstart', tree('1'), dataTransfer)
+      nativeDrag('dragover', tree('1'), dataTransfer, { clientY: 50 })
+      await jest.advanceTimersByTimeAsync(600)
+
+      nativeDrag('dragleave', tree('1'), dataTransfer)
+      nativeDrag('dragover', tree('1'), dataTransfer, { clientY: 50 })
+      resolveFirstLoad({ creatives: [{ id: 2 }] })
+      await jest.advanceTimersByTimeAsync(0)
+      expect(renderCreativeTree).not.toHaveBeenCalled()
+
+      await jest.advanceTimersByTimeAsync(600)
+
+      expect(loadChildren).toHaveBeenCalledTimes(2)
+      expect(tree('1').closest('creative-tree-row').hasAttribute('expanded')).toBe(true)
+    } finally {
+      registry.destroy()
+    }
   })
 
   test('cancels a pending expansion when the drag ends', () => {

--- a/engines/collavre/app/javascript/creatives/drag_drop/__tests__/event_handlers_data.test.js
+++ b/engines/collavre/app/javascript/creatives/drag_drop/__tests__/event_handlers_data.test.js
@@ -146,7 +146,7 @@ test('starts a selected creative bundle through the shared writer', () => {
     dataTransfer: transfer,
   });
 
-  expect(transfer.effectAllowed).toBe('move');
+  expect(transfer.effectAllowed).toBe('copyMove');
   expect(transfer.types).toContain(LEGACY_MIME_TYPES.creative);
   expect(JSON.parse(transfer.getData(LEGACY_MIME_TYPES.creative))).toMatchObject({
     creativeId: '1',

--- a/engines/collavre/app/javascript/creatives/drag_drop/__tests__/hover_expand.test.js
+++ b/engines/collavre/app/javascript/creatives/drag_drop/__tests__/hover_expand.test.js
@@ -1,0 +1,134 @@
+/**
+ * @jest-environment jsdom
+ */
+import { jest } from '@jest/globals'
+import { writeDragData } from '../../../lib/dnd/envelope'
+import { resetDragSessionCache } from '../../../lib/dnd/session'
+import { handleDragLeave, handleDragOver } from '../event_handlers'
+
+function transfer() {
+  const values = new Map()
+  return {
+    dropEffect: 'none',
+    get types() { return [...values.keys()] },
+    getData(type) { return values.get(type) || '' },
+    setData(type, value) { values.set(type, String(value)) },
+  }
+}
+
+function event(tree, dataTransfer) {
+  return {
+    target: tree,
+    dataTransfer,
+    clientX: 10,
+    clientY: 50,
+    shiftKey: false,
+    preventDefault: jest.fn(),
+  }
+}
+
+describe('right creative tree hover expansion', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+    window.localStorage.clear()
+    window.sessionStorage.clear()
+    resetDragSessionCache()
+    document.body.innerHTML = `
+      <creative-tree-row creative-id="2" has-children>
+        <div id="creative-2" class="creative-tree" draggable="true"></div>
+      </creative-tree-row>
+      <div id="creative-children-2" style="display:none"></div>
+    `
+    document.getElementById('creative-2').getBoundingClientRect = () => ({ top: 0, height: 100 })
+  })
+
+  afterEach(() => jest.useRealTimers())
+
+  test('expands a collapsed child target after 600ms', () => {
+    const dataTransfer = transfer()
+    writeDragData(dataTransfer, {
+      kind: 'creative', ids: ['1'], payload: { creativeId: '1', treeId: 'creative-1' },
+    })
+    const tree = document.getElementById('creative-2')
+
+    handleDragOver(event(tree, dataTransfer))
+    jest.advanceTimersByTime(599)
+    expect(tree.closest('creative-tree-row').hasAttribute('expanded')).toBe(false)
+    jest.advanceTimersByTime(1)
+
+    expect(tree.closest('creative-tree-row').hasAttribute('expanded')).toBe(true)
+    expect(document.getElementById('creative-children-2').style.display).toBe('')
+  })
+
+  test('cancels expansion after leaving the target', () => {
+    const dataTransfer = transfer()
+    writeDragData(dataTransfer, {
+      kind: 'creative', ids: ['1'], payload: { creativeId: '1', treeId: 'creative-1' },
+    })
+    const tree = document.getElementById('creative-2')
+
+    handleDragOver(event(tree, dataTransfer))
+    handleDragLeave(event(tree, dataTransfer))
+    jest.advanceTimersByTime(600)
+
+    expect(tree.closest('creative-tree-row').hasAttribute('expanded')).toBe(false)
+  })
+
+  // `has-children` is rendered from the server's count, so the container can
+  // still be missing on a row whose children have not been fetched yet.
+  test('leaves a branch alone when its children container is absent', () => {
+    document.getElementById('creative-children-2').remove()
+    const dataTransfer = transfer()
+    writeDragData(dataTransfer, {
+      kind: 'creative', ids: ['1'], payload: { creativeId: '1', treeId: 'creative-1' },
+    })
+    const tree = document.getElementById('creative-2')
+
+    handleDragOver(event(tree, dataTransfer))
+    jest.advanceTimersByTime(600)
+
+    expect(tree.closest('creative-tree-row').hasAttribute('expanded')).toBe(false)
+  })
+
+  test('leaving a row the pointer never entered keeps the pending expansion', () => {
+    document.body.insertAdjacentHTML('beforeend', `
+      <creative-tree-row creative-id="3">
+        <div id="creative-3" class="creative-tree" draggable="true"></div>
+      </creative-tree-row>
+    `)
+    const dataTransfer = transfer()
+    writeDragData(dataTransfer, {
+      kind: 'creative', ids: ['1'], payload: { creativeId: '1', treeId: 'creative-1' },
+    })
+    const tree = document.getElementById('creative-2')
+
+    handleDragOver(event(tree, dataTransfer))
+    handleDragLeave(event(document.getElementById('creative-3'), dataTransfer))
+    jest.advanceTimersByTime(600)
+
+    expect(tree.closest('creative-tree-row').hasAttribute('expanded')).toBe(true)
+  })
+  test('does not schedule another load while hover expansion is in flight', () => {
+    document.body.innerHTML = `
+      <creative-tree-row creative-id="2" has-children>
+        <div id="creative-2" class="creative-tree" draggable="true"></div>
+      </creative-tree-row>
+      <div id="creative-children-2" style="display:none" data-loaded="false"
+           data-load-url="/creatives/2/children.json"></div>
+    `
+    const tree = document.getElementById('creative-2')
+    tree.getBoundingClientRect = () => ({ top: 0, height: 100 })
+    global.fetch = jest.fn(() => new Promise(() => {}))
+    const dataTransfer = transfer()
+    writeDragData(dataTransfer, {
+      kind: 'creative', ids: ['1'], payload: { creativeId: '1', treeId: 'creative-1' },
+    })
+
+    handleDragOver(event(tree, dataTransfer))
+    jest.advanceTimersByTime(600)
+    handleDragOver(event(tree, dataTransfer))
+    jest.advanceTimersByTime(600)
+
+    expect(global.fetch).toHaveBeenCalledTimes(1)
+  })
+})

--- a/engines/collavre/app/javascript/creatives/drag_drop/__tests__/move_feedback.test.js
+++ b/engines/collavre/app/javascript/creatives/drag_drop/__tests__/move_feedback.test.js
@@ -1,0 +1,79 @@
+/**
+ * @jest-environment jsdom
+ */
+import { jest } from '@jest/globals'
+
+const alertDialog = jest.fn()
+jest.unstable_mockModule('../../../lib/utils/dialog', () => ({ alertDialog }))
+
+const { reportPartialMove } = await import('../move_feedback')
+
+let consoleError
+
+beforeEach(() => {
+  consoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  consoleError.mockRestore()
+  jest.clearAllMocks()
+})
+
+test('relays the rejection the server phrased for the rows that failed', () => {
+  const reported = reportPartialMove({
+    status: 'partial',
+    failedIds: ['3'],
+    failures: [{
+      id: '3',
+      reason: 'permission_denied',
+      message: 'HTTP 403: Forbidden',
+      serverMessage: '이동 권한이 없습니다.',
+    }],
+  })
+
+  expect(reported).toBe(true)
+  expect(alertDialog).toHaveBeenCalledWith('이동 권한이 없습니다.')
+  expect(consoleError).toHaveBeenCalledWith(
+    'Creative move partially failed',
+    expect.objectContaining({ failedIds: ['3'] })
+  )
+})
+
+// There is no client-side copy for a move rejection, so a silent server leaves
+// the log as the only record rather than an untranslated placeholder dialog.
+test('logs without a dialog when the server explained nothing', () => {
+  const reported = reportPartialMove({
+    status: 'partial',
+    failedIds: ['3'],
+    failures: [{ id: '3', reason: 'network_error', message: '' }],
+  })
+
+  expect(reported).toBe(true)
+  expect(alertDialog).not.toHaveBeenCalled()
+  expect(consoleError).toHaveBeenCalled()
+})
+
+test('uses translated page copy instead of an HTTP status fallback', () => {
+  reportPartialMove({
+    status: 'partial',
+    failedIds: ['3'],
+    failures: [{
+      id: '3',
+      reason: 'permission_denied',
+      message: 'HTTP 403: Forbidden',
+      serverMessage: '',
+    }],
+  }, '일부 크리에이티브를 링크하지 못했습니다. 다시 시도해 주세요.')
+
+  expect(alertDialog).toHaveBeenCalledWith(
+    '일부 크리에이티브를 링크하지 못했습니다. 다시 시도해 주세요.'
+  )
+})
+
+test('stays out of the way for any other outcome', () => {
+  expect(reportPartialMove({ status: 'success', failures: [] })).toBe(false)
+  expect(reportPartialMove(null)).toBe(false)
+  expect(reportPartialMove({ status: 'partial' })).toBe(true)
+
+  expect(alertDialog).not.toHaveBeenCalled()
+})

--- a/engines/collavre/app/javascript/creatives/drag_drop/__tests__/source_window_bundle.test.js
+++ b/engines/collavre/app/javascript/creatives/drag_drop/__tests__/source_window_bundle.test.js
@@ -81,7 +81,7 @@ test('bundle children retain their order and parent metadata', () => {
   expect(children.map(row => row.getAttribute('level'))).toEqual(['2', '2'])
 })
 
-test.each([undefined, [], [null, '']])('legacy scalar completion remains valid with creativeIds=%s', creativeIds => {
+test.each([undefined, [], [null, ''], 'malformed', { id: 8 }])('legacy scalar completion remains valid with creativeIds=%s', creativeIds => {
   controller.beginReloadHold()
   signal({ creativeId: 7, creativeIds, treeId: 'creative-7' })
   expect(ids()).toEqual(['8', '9'])
@@ -104,6 +104,19 @@ test('link completion never removes or reparents source rows', () => {
 test('a completion with no usable identifiers leaves the source untouched', () => {
   signal({ creativeIds: [null, ''] })
   jest.advanceTimersByTime(400)
+  expect(ids()).toEqual(['7', '8', '9'])
+  expect(load).not.toHaveBeenCalled()
+})
+
+
+test.each([
+  { creativeId: '7', sourceWindowId: 'source-window' },
+  { creativeId: '', context: 'source', sourceWindowId: 'source-window' },
+  { creativeIds: [null, undefined, ''], context: 'source', sourceWindowId: 'source-window' },
+  { creativeIds: [7, 8], context: 'source' },
+])('an incomplete direct completion never mutates the source: %j', detail => {
+  controller.beginReloadHold()
+  window.dispatchEvent(new CustomEvent('collavre:creative-drop-complete', { detail }))
   expect(ids()).toEqual(['7', '8', '9'])
   expect(load).not.toHaveBeenCalled()
 })

--- a/engines/collavre/app/javascript/creatives/drag_drop/__tests__/source_window_bundle.test.js
+++ b/engines/collavre/app/javascript/creatives/drag_drop/__tests__/source_window_bundle.test.js
@@ -1,0 +1,109 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals'
+import { Application } from '@hotwired/stimulus'
+import TreeController from '../../../controllers/creatives/tree_controller'
+import { addGlobalListeners, removeGlobalListeners } from '../event_handlers'
+import { resetDragSessionCache } from '../../../lib/dnd/session'
+
+let application, controller, load, container
+const ids = () => [...container.querySelectorAll(':scope > creative-tree-row')].map(row => row.getAttribute('creative-id'))
+const row = id => `<creative-tree-row creative-id="${id}" level="1"><div class="creative-tree" id="creative-${id}"></div></creative-tree-row>`
+function signal(detail) {
+  window.dispatchEvent(new StorageEvent('storage', {
+    key: 'collavre.dragDropSignal',
+    newValue: JSON.stringify({ sessionToken: 'verified-token', sourceWindowId: 'source-window', ...detail }),
+  }))
+}
+
+beforeEach(async () => {
+  document.body.innerHTML = `<div id="creatives" data-controller="creatives--tree" data-loaded="true">${[7, 8, 9].map(row).join('')}</div>`
+  container = document.getElementById('creatives')
+  localStorage.setItem('collavre.dragToken', 'verified-token')
+  sessionStorage.setItem('collavre.dragWindowId', 'source-window')
+  resetDragSessionCache()
+  application = Application.start()
+  application.register('creatives--tree', TreeController)
+  await new Promise(resolve => setTimeout(resolve, 0))
+  controller = application.getControllerForElementAndIdentifier(container, 'creatives--tree')
+  load = jest.spyOn(controller, 'load').mockImplementation(() => {})
+  addGlobalListeners()
+  jest.useFakeTimers()
+})
+
+afterEach(() => {
+  removeGlobalListeners()
+  controller.disconnect()
+  application.stop()
+  document.body.innerHTML = ''
+  localStorage.clear()
+  sessionStorage.clear()
+  resetDragSessionCache()
+  jest.useRealTimers()
+  jest.restoreAllMocks()
+})
+
+test.each(['editing', 'operation hold'])('a verified bundle removes every moved row while reload waits for %s', reason => {
+  const draft = document.createElement('textarea')
+  draft.value = 'Unsaved draft'
+  container.lastElementChild.appendChild(draft)
+  if (reason === 'editing') document.dispatchEvent(new Event('creative-editing:start'))
+  else controller.beginReloadHold()
+
+  signal({ creativeId: '7', creativeIds: [7, '7', null, '', 8, '8'], treeId: 'creative-7', mode: 'move' })
+  jest.advanceTimersByTime(400)
+  expect(ids()).toEqual(['9'])
+  expect(draft.isConnected).toBe(true)
+  expect(draft.value).toBe('Unsaved draft')
+  expect(load).not.toHaveBeenCalled()
+
+  if (reason === 'editing') document.dispatchEvent(new Event('creative-editing:stop'))
+  else controller.endReloadHold()
+  jest.advanceTimersByTime(400)
+  expect(load).toHaveBeenCalledTimes(1)
+})
+
+test.each([
+  ['up', ['7', '8', '9']],
+  ['down', ['9', '7', '8']],
+])('array-only completion preserves bundle order for a local %s target', (direction, expected) => {
+  controller.beginReloadHold()
+  signal({ creativeIds: [7, 8, 7], direction, targetTreeId: 'creative-9', mode: 'move' })
+  expect(ids()).toEqual(expected)
+  expect(load).not.toHaveBeenCalled()
+})
+
+test('bundle children retain their order and parent metadata', () => {
+  controller.beginReloadHold()
+  signal({ creativeId: '7', creativeIds: [7, 8], treeId: 'creative-7', direction: 'child', targetTreeId: 'creative-9' })
+  expect(ids()).toEqual(['9'])
+  const children = [...container.querySelectorAll('creative-tree-row[parent-id="9"]')]
+  expect(children.map(row => row.getAttribute('creative-id'))).toEqual(['7', '8'])
+  expect(children.map(row => row.getAttribute('level'))).toEqual(['2', '2'])
+})
+
+test.each([undefined, [], [null, '']])('legacy scalar completion remains valid with creativeIds=%s', creativeIds => {
+  controller.beginReloadHold()
+  signal({ creativeId: 7, creativeIds, treeId: 'creative-7' })
+  expect(ids()).toEqual(['8', '9'])
+})
+
+test('a partial-success array is authoritative over the legacy dragged row', () => {
+  controller.beginReloadHold()
+  signal({ creativeId: '7', creativeIds: [8], treeId: 'creative-7' })
+  expect(ids()).toEqual(['7', '9'])
+})
+
+test('link completion never removes or reparents source rows', () => {
+  controller.beginReloadHold()
+  signal({ creativeId: '7', creativeIds: [7, 8], treeId: 'creative-7', mode: 'link',
+    direction: 'child', targetTreeId: 'creative-9' })
+  expect(ids()).toEqual(['7', '8', '9'])
+  expect(container.querySelector('[parent-id]')).toBeNull()
+})
+
+test('a completion with no usable identifiers leaves the source untouched', () => {
+  signal({ creativeIds: [null, ''] })
+  jest.advanceTimersByTime(400)
+  expect(ids()).toEqual(['7', '8', '9'])
+  expect(load).not.toHaveBeenCalled()
+})

--- a/engines/collavre/app/javascript/creatives/drag_drop/__tests__/workspace_tree_adapter.test.js
+++ b/engines/collavre/app/javascript/creatives/drag_drop/__tests__/workspace_tree_adapter.test.js
@@ -1,0 +1,448 @@
+/**
+ * @jest-environment jsdom
+ */
+import { jest } from '@jest/globals'
+import { writeDragData } from '../../../lib/dnd/envelope'
+import { resetDragSessionCache } from '../../../lib/dnd/session'
+import { createWorkspaceTreeDragDrop } from '../workspace_tree_adapter'
+
+function item(id, { parentId = null, level = 1, hasChildren = false, expanded = false } = {}) {
+  const parent = parentId ? ` data-parent-id="${parentId}"` : ''
+  return `
+    <li class="creative-workspace-tree-item" data-creative-id="${id}" data-level="${level}"
+        data-has-children="${hasChildren}" data-expanded="${expanded}"${parent}>
+      <div id="workspace-creative-${id}" class="creative-workspace-tree-row"
+           data-creative-id="${id}" data-level="${level}"${parent} draggable="true"></div>
+    </li>
+  `
+}
+
+function dataTransfer() {
+  const values = new Map()
+  return {
+    dropEffect: 'none',
+    effectAllowed: 'none',
+    get types() { return [...values.keys()] },
+    getData(type) { return values.get(type) || '' },
+    setData(type, value) { values.set(type, String(value)) },
+  }
+}
+
+function event(type, element, transfer, { clientY = 50, shiftKey = false } = {}) {
+  const dragEvent = new Event(type, { bubbles: true, cancelable: true })
+  Object.defineProperties(dragEvent, {
+    dataTransfer: { value: transfer },
+    clientY: { value: clientY },
+    shiftKey: { value: shiftKey },
+  })
+  element.dispatchEvent(dragEvent)
+  return dragEvent
+}
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0))
+
+describe('workspace tree drag and drop adapter', () => {
+  let root
+  let controller
+  let execute
+  let registry
+
+  beforeEach(() => {
+    window.localStorage.clear()
+    window.sessionStorage.clear()
+    resetDragSessionCache()
+    document.body.innerHTML = `
+      <nav id="workspace-tree"><ul class="creative-workspace-tree-list">
+        ${item('1')}${item('2', { hasChildren: true })}${item('3')}
+      </ul></nav>
+    `
+    root = document.getElementById('workspace-tree')
+    root.querySelectorAll('.creative-workspace-tree-row').forEach((row) => {
+      row.getBoundingClientRect = () => ({ top: 0, height: 100 })
+    })
+    controller = { expandBranchForDrag: jest.fn(), cancelDragExpansion: jest.fn() }
+    execute = jest.fn(async command => ({ status: 'success', succeededIds: command.ids }))
+    registry = createWorkspaceTreeDragDrop({ root, controller, execute })
+  })
+
+  afterEach(() => {
+    registry.destroy()
+    jest.useRealTimers()
+  })
+
+  test('moves from the left tree to the left tree and emits synchronization', async () => {
+    const completion = jest.fn()
+    window.addEventListener('collavre:creative-drop-complete', completion, { once: true })
+    const transfer = dataTransfer()
+    event('dragstart', document.getElementById('workspace-creative-1'), transfer)
+    event('dragover', document.getElementById('workspace-creative-2'), transfer)
+    event('drop', document.getElementById('workspace-creative-2'), transfer)
+    await flush()
+
+    expect(execute).toHaveBeenCalledWith({ ids: ['1'], targetId: '2', direction: 'child', mode: 'move' })
+    expect([...root.querySelector('ul').children].map(entry => entry.dataset.creativeId)).toEqual(['1', '2', '3'])
+    expect(completion).toHaveBeenCalledWith(expect.objectContaining({
+      detail: expect.objectContaining({ creativeIds: ['1'], targetCreativeId: '2' }),
+    }))
+  })
+
+  test('accepts a right-tree envelope and reloads through the completion event', async () => {
+    const transfer = dataTransfer()
+    writeDragData(transfer, {
+      kind: 'creative',
+      ids: ['9'],
+      payload: { creativeId: '9', treeId: 'creative-9', sourceWindowId: 'right-window' },
+    })
+
+    event('dragover', document.getElementById('workspace-creative-3'), transfer, { clientY: 10 })
+    event('drop', document.getElementById('workspace-creative-3'), transfer, { clientY: 10 })
+    await flush()
+
+    expect(execute).toHaveBeenCalledWith({ ids: ['9'], targetId: '3', direction: 'up', mode: 'move' })
+  })
+
+  test('keeps the left-tree placement when the server rejects the move', async () => {
+    execute.mockResolvedValue({ status: 'failure' })
+    const transfer = dataTransfer()
+    event('dragstart', document.getElementById('workspace-creative-1'), transfer)
+    event('dragover', document.getElementById('workspace-creative-3'), transfer)
+    event('drop', document.getElementById('workspace-creative-3'), transfer)
+    await flush()
+
+    expect([...root.querySelector('ul').children].map((entry) => entry.dataset.creativeId)).toEqual(['1', '2', '3'])
+  })
+
+  test('does not send a move into a visibly known descendant', async () => {
+    const rootItem = root.querySelector('[data-creative-id="1"]')
+    const descendants = document.createElement('ul')
+    descendants.className = 'creative-workspace-tree-list'
+    descendants.innerHTML = item('4', { parentId: '1', level: 2 })
+    rootItem.appendChild(descendants)
+    const target = document.getElementById('workspace-creative-4')
+    target.getBoundingClientRect = () => ({ top: 0, height: 100 })
+
+    const transfer = dataTransfer()
+    event('dragstart', document.getElementById('workspace-creative-1'), transfer)
+    event('dragover', target, transfer)
+    event('drop', target, transfer)
+    await flush()
+
+    expect(execute).not.toHaveBeenCalled()
+  })
+
+  test('ignores a drag that starts on a row outside the tree structure', () => {
+    const orphan = document.createElement('div')
+    orphan.className = 'creative-workspace-tree-row'
+    orphan.dataset.creativeId = '99'
+    orphan.draggable = true
+    root.appendChild(orphan)
+    const transfer = dataTransfer()
+
+    event('dragstart', orphan, transfer)
+
+    expect(transfer.types).toEqual([])
+    expect(orphan.classList.contains('is-dragging')).toBe(false)
+  })
+
+  test('clears the dragging marker when the drag ends', () => {
+    const source = document.getElementById('workspace-creative-1')
+    const transfer = dataTransfer()
+
+    event('dragstart', source, transfer)
+    expect(source.classList.contains('is-dragging')).toBe(true)
+
+    event('dragend', source, transfer)
+    expect(source.classList.contains('is-dragging')).toBe(false)
+  })
+
+  test('links a multi-selection with shift instead of moving it optimistically', async () => {
+    const transfer = dataTransfer()
+    writeDragData(transfer, {
+      kind: 'creative', ids: ['8', '9'], payload: { creativeId: '8', treeId: 'creative-8' },
+    })
+    const target = document.getElementById('workspace-creative-2')
+
+    const over = event('dragover', target, transfer, { shiftKey: true })
+    event('drop', target, transfer, { shiftKey: true })
+    await flush()
+
+    expect(over.dataTransfer.dropEffect).toBe('copy')
+    expect(execute).toHaveBeenCalledWith({ ids: ['8', '9'], targetId: '2', direction: 'child', mode: 'link' })
+    expect(document.querySelector('[data-creative-id="2"] > ul')).toBeNull()
+  })
+
+  test('restores an optimistic move and reports when the request itself fails', async () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
+    execute.mockRejectedValue(new Error('network down'))
+    const transfer = dataTransfer()
+
+    event('dragstart', document.getElementById('workspace-creative-1'), transfer)
+    event('dragover', document.getElementById('workspace-creative-3'), transfer)
+    event('drop', document.getElementById('workspace-creative-3'), transfer)
+    await flush()
+
+    expect([...root.querySelector('ul').children].map((entry) => entry.dataset.creativeId)).toEqual(['1', '2', '3'])
+    expect(consoleError).toHaveBeenCalledWith(
+      'Failed to execute workspace tree drop',
+      expect.objectContaining({ message: 'network down' })
+    )
+    consoleError.mockRestore()
+  })
+
+  test('reports a registry failure without leaving a stale preview', () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
+    const target = document.getElementById('workspace-creative-3')
+    target.getBoundingClientRect = () => { throw new Error('layout unavailable') }
+    const transfer = dataTransfer()
+    writeDragData(transfer, {
+      kind: 'creative', ids: ['9'], payload: { creativeId: '9', treeId: 'creative-9' },
+    })
+
+    const over = event('dragover', target, transfer)
+
+    expect(over.defaultPrevented).toBe(false)
+    expect(consoleError).toHaveBeenCalledWith(
+      'Workspace tree drag and drop failed',
+      expect.objectContaining({ message: 'layout unavailable' })
+    )
+    consoleError.mockRestore()
+  })
+
+  test('carries a defaulted level and a payload-less envelope through a drop', async () => {
+    const bare = document.createElement('li')
+    bare.className = 'creative-workspace-tree-item'
+    bare.dataset.creativeId = '5'
+    bare.innerHTML = `
+      <div id="workspace-creative-5" class="creative-workspace-tree-row"
+           data-creative-id="5" draggable="true"></div>
+    `
+    root.querySelector('ul').appendChild(bare)
+    const source = document.getElementById('workspace-creative-5')
+    source.getBoundingClientRect = () => ({ top: 0, height: 100 })
+
+    const completion = jest.fn()
+    window.addEventListener('collavre:creative-drop-complete', completion, { once: true })
+    const transfer = dataTransfer()
+    event('dragstart', source, transfer)
+    const target = document.getElementById('workspace-creative-1')
+    event('dragover', target, transfer, { clientY: 90 })
+    event('drop', target, transfer, { clientY: 90 })
+    await flush()
+
+    expect(execute).toHaveBeenCalledWith({ ids: ['5'], targetId: '1', direction: 'down', mode: 'move' })
+    expect(completion).toHaveBeenCalledWith(expect.objectContaining({
+      detail: expect.objectContaining({ treeId: 'workspace-creative-5', sourceWindowId: expect.any(String) }),
+    }))
+  })
+
+  test('falls back to the document root and the shared defaults', () => {
+    const defaulted = createWorkspaceTreeDragDrop()
+    try {
+      expect(typeof defaulted.destroy).toBe('function')
+    } finally {
+      defaulted.destroy()
+    }
+  })
+
+  test('reports a failed cross-tree drop that had nothing to roll back', async () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
+    execute.mockRejectedValue(new Error('server down'))
+    const transfer = dataTransfer()
+    writeDragData(transfer, {
+      kind: 'creative', ids: ['8', '9'], payload: { creativeId: '8', treeId: 'creative-8' },
+    })
+    const target = document.getElementById('workspace-creative-2')
+
+    event('dragover', target, transfer)
+    event('drop', target, transfer)
+    await flush()
+
+    expect([...root.querySelector('ul').children].map((entry) => entry.dataset.creativeId)).toEqual(['1', '2', '3'])
+    expect(consoleError).toHaveBeenCalledWith(
+      'Failed to execute workspace tree drop',
+      expect.objectContaining({ message: 'server down' })
+    )
+    consoleError.mockRestore()
+  })
+
+  test('leaves the tree untouched when a cross-tree move is rejected', async () => {
+    execute.mockResolvedValue({ status: 'failure' })
+    const transfer = dataTransfer()
+    writeDragData(transfer, {
+      kind: 'creative', ids: ['8', '9'], payload: { creativeId: '8', treeId: 'creative-8' },
+    })
+    const target = document.getElementById('workspace-creative-2')
+
+    event('dragover', target, transfer)
+    event('drop', target, transfer)
+    await flush()
+
+    expect([...root.querySelector('ul').children].map((entry) => entry.dataset.creativeId)).toEqual(['1', '2', '3'])
+  })
+
+  // A creative envelope has to name the tree it came from: the completion event
+  // is how the originating view learns to re-render, and an unnamed source
+  // leaves nobody to tell. The shared reader declines it before the zone runs.
+  test('declines an envelope that never names its originating tree', async () => {
+    const completion = jest.fn()
+    window.addEventListener('collavre:creative-drop-complete', completion, { once: true })
+    const transfer = dataTransfer()
+    writeDragData(transfer, { kind: 'creative', ids: ['9'], payload: { creativeId: '9' } })
+    const target = document.getElementById('workspace-creative-2')
+
+    event('dragover', target, transfer)
+    event('drop', target, transfer)
+    await flush()
+
+    expect(execute).not.toHaveBeenCalled()
+    expect(completion).not.toHaveBeenCalled()
+  })
+
+  // A tab still running the pre-envelope build writes only the legacy payload and
+  // never names its window, so there is nobody to signal back to.
+  test('completes a legacy drop that names no originating window', async () => {
+    window.localStorage.setItem('collavre.dragToken', 'token-under-test')
+    resetDragSessionCache()
+    const completion = jest.fn()
+    window.addEventListener('collavre:creative-drop-complete', completion, { once: true })
+    const transfer = dataTransfer()
+    transfer.setData('application/x-collavre-creative', JSON.stringify({
+      creativeId: '9',
+      treeId: 'creative-9',
+      token: 'token-under-test',
+      selectedCreativeIds: [],
+    }))
+    const target = document.getElementById('workspace-creative-2')
+
+    event('dragover', target, transfer)
+    event('drop', target, transfer)
+    await flush()
+
+    expect(completion).toHaveBeenCalledWith(expect.objectContaining({
+      detail: expect.objectContaining({ sourceWindowId: null }),
+    }))
+    expect(window.localStorage.getItem('collavre.dragDropSignal')).toBeNull()
+  })
+
+  // The source window reacts to this signal by deleting the row it dragged, so
+  // broadcasting a link would destroy the original the link was made from.
+  test('signals the source window for a cross-window move but never for a link', async () => {
+    const setItem = jest.spyOn(Storage.prototype, 'setItem')
+    const target = document.getElementById('workspace-creative-2')
+    const envelope = () => {
+      const transfer = dataTransfer()
+      writeDragData(transfer, {
+        kind: 'creative',
+        ids: ['9'],
+        payload: { creativeId: '9', treeId: 'creative-9', sourceWindowId: 'right-window' },
+      })
+      return transfer
+    }
+
+    const linked = envelope()
+    event('dragover', target, linked, { shiftKey: true })
+    event('drop', target, linked, { shiftKey: true })
+    await flush()
+    expect(setItem).not.toHaveBeenCalledWith('collavre.dragDropSignal', expect.any(String))
+
+    const moved = envelope()
+    event('dragover', target, moved)
+    event('drop', target, moved)
+    await flush()
+    expect(setItem).toHaveBeenCalledWith('collavre.dragDropSignal', expect.any(String))
+
+    setItem.mockRestore()
+  })
+
+  // The dialog copy comes from the server and is covered by move_feedback's own
+  // suite; here only the hand-off from the adapter matters.
+  test('surfaces the rows a partial move left behind', async () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
+    execute.mockResolvedValue({
+      status: 'partial',
+      succeededIds: ['8'],
+      failedIds: ['9'],
+      failures: [{ id: '9', reason: 'network_error', message: '' }],
+    })
+    const transfer = dataTransfer()
+    writeDragData(transfer, {
+      kind: 'creative', ids: ['8', '9'], payload: { creativeId: '8', treeId: 'creative-8' },
+    })
+    const target = document.getElementById('workspace-creative-2')
+
+    event('dragover', target, transfer)
+    event('drop', target, transfer)
+    await flush()
+
+    expect(consoleError).toHaveBeenCalledWith(
+      'Creative move partially failed',
+      expect.objectContaining({ failedIds: ['9'] })
+    )
+    consoleError.mockRestore()
+  })
+
+  test('expands after 600ms and invalidates the request on leave, drop, and dragend', () => {
+    jest.useFakeTimers()
+    const target = document.getElementById('workspace-creative-2')
+    const transfer = dataTransfer()
+    writeDragData(transfer, {
+      kind: 'creative', ids: ['9'], payload: { creativeId: '9', treeId: 'creative-9' },
+    })
+
+    event('dragover', target, transfer)
+    jest.advanceTimersByTime(599)
+    expect(controller.expandBranchForDrag).not.toHaveBeenCalled()
+    jest.advanceTimersByTime(1)
+    expect(controller.expandBranchForDrag).toHaveBeenCalledWith('2')
+
+    controller.expandBranchForDrag.mockClear()
+    event('dragover', target, transfer)
+    event('dragleave', target, transfer)
+    jest.advanceTimersByTime(600)
+    expect(controller.expandBranchForDrag).not.toHaveBeenCalled()
+    expect(controller.cancelDragExpansion).toHaveBeenCalledTimes(1)
+
+    event('dragover', target, transfer)
+    event('drop', target, transfer)
+    expect(controller.cancelDragExpansion).toHaveBeenCalledTimes(2)
+
+    event('dragover', target, transfer)
+    event('dragend', target, transfer)
+    expect(controller.cancelDragExpansion).toHaveBeenCalledTimes(3)
+  })
+  test('keeps placements unchanged while the server request is pending', async () => {
+    let finish
+    execute.mockImplementation(() => new Promise(resolve => { finish = resolve }))
+    const transfer = dataTransfer()
+    event('dragstart', document.getElementById('workspace-creative-1'), transfer)
+    event('drop', document.getElementById('workspace-creative-3'), transfer)
+    expect([...root.querySelector('ul').children].map(entry => entry.dataset.creativeId)).toEqual(['1', '2', '3'])
+    finish({ status: 'failure', succeededIds: [] })
+    await flush()
+    expect([...root.querySelector('ul').children].map(entry => entry.dataset.creativeId)).toEqual(['1', '2', '3'])
+  })
+
+  test('link completion never broadcasts a source move', async () => {
+    const transfer = dataTransfer()
+    event('dragstart', document.getElementById('workspace-creative-1'), transfer)
+    const setItem = jest.spyOn(Storage.prototype, 'setItem')
+    event('drop', document.getElementById('workspace-creative-3'), transfer, { shiftKey: true })
+    await flush()
+    expect(execute).toHaveBeenCalledWith(expect.objectContaining({ mode: 'link' }))
+    expect(setItem.mock.calls.some(([key]) => key === 'collavre.dragDropSignal')).toBe(false)
+    setItem.mockRestore()
+  })
+
+  test('uses stored hysteresis rather than reading workspace CSS', async () => {
+    const transfer = dataTransfer()
+    event('dragstart', document.getElementById('workspace-creative-1'), transfer)
+    const target = document.getElementById('workspace-creative-3')
+    event('dragover', target, transfer, { clientY: 1 })
+    target.className = 'creative-workspace-tree-row'
+    event('dragover', target, transfer, { clientY: 40 })
+    event('drop', target, transfer, { clientY: 99 })
+    await flush()
+    expect(execute).toHaveBeenCalledWith(expect.objectContaining({ direction: 'up' }))
+  })
+
+})

--- a/engines/collavre/app/javascript/creatives/drag_drop/__tests__/workspace_tree_dom.test.js
+++ b/engines/collavre/app/javascript/creatives/drag_drop/__tests__/workspace_tree_dom.test.js
@@ -1,0 +1,105 @@
+/**
+ * @jest-environment jsdom
+ */
+import {
+  findWorkspaceItem,
+  hasKnownWorkspaceCycle,
+  showWorkspaceDropPreview,
+} from '../workspace_tree_dom'
+
+function item(id, parentId = null, level = 1, children = '') {
+  const parent = parentId ? ` data-parent-id="${parentId}"` : ''
+  return `
+    <li class="creative-workspace-tree-item" data-creative-id="${id}" data-level="${level}"${parent}>
+      <div class="creative-workspace-tree-row" data-creative-id="${id}" data-level="${level}"${parent}></div>
+      ${children}
+    </li>
+  `
+}
+
+function list(children) {
+  return `<ul class="creative-workspace-tree-list">${children}</ul>`
+}
+
+describe('workspace tree move DOM', () => {
+  let root
+
+  beforeEach(() => {
+    document.body.innerHTML = `<nav id="tree">${list([
+      item('1', null, 1, list(item('2', '1', 2))),
+      item('3'),
+      item('4'),
+    ].join(''))}</nav>`
+    root = document.getElementById('tree')
+  })
+
+  test('blocks cycles whose ancestor chain is visible', () => {
+    expect(hasKnownWorkspaceCycle({
+      root,
+      ids: ['1'],
+      targetItem: findWorkspaceItem(root, '2'),
+      direction: 'child',
+    })).toBe(true)
+    expect(hasKnownWorkspaceCycle({
+      root,
+      ids: ['1'],
+      targetItem: findWorkspaceItem(root, '2'),
+      direction: 'down',
+    })).toBe(true)
+  })
+
+  test('allows an incomplete parent chain for server-side validation', () => {
+    const target = findWorkspaceItem(root, '3')
+    target.dataset.parentId = '999'
+
+    expect(hasKnownWorkspaceCycle({ root, ids: ['1'], targetItem: target, direction: 'down' })).toBe(false)
+  })
+
+  test('blocks a selected target for single and bundled moves', () => {
+    expect(hasKnownWorkspaceCycle({
+      root,
+      ids: ['3', '4'],
+      targetItem: findWorkspaceItem(root, '4'),
+      direction: 'up',
+    })).toBe(true)
+  })
+
+  describe('showWorkspaceDropPreview', () => {
+    let row
+
+    beforeEach(() => {
+      row = document.createElement('div')
+    })
+
+    // The stylesheet only knows top/bottom/child, so a preview named after the
+    // move direction would draw nothing at all for up and down.
+    test.each([
+      ['up', 'drag-over-top'],
+      ['down', 'drag-over-bottom'],
+      ['child', 'drag-over-child'],
+    ])('marks a %s drop with the styled class', (direction, className) => {
+      showWorkspaceDropPreview(row, direction)
+
+      expect([...row.classList]).toEqual([className])
+    })
+
+    test('leaves no class behind when the preview is cleared', () => {
+      showWorkspaceDropPreview(row, 'up')()
+
+      expect([...row.classList]).toEqual([])
+    })
+
+    test('replaces the previous class when the direction changes', () => {
+      showWorkspaceDropPreview(row, 'up')
+      showWorkspaceDropPreview(row, 'down')
+
+      expect([...row.classList]).toEqual(['drag-over-bottom'])
+    })
+
+    test('marks nothing for a direction the stylesheet cannot draw', () => {
+      showWorkspaceDropPreview(row, 'sideways')
+
+      expect([...row.classList]).toEqual([])
+    })
+  })
+})

--- a/engines/collavre/app/javascript/creatives/drag_drop/event_handlers.js
+++ b/engines/collavre/app/javascript/creatives/drag_drop/event_handlers.js
@@ -12,7 +12,6 @@ import {
   setRowParent,
   setRowRootState,
   setHasChildren,
-  setExpanded,
   syncParentHasChildren,
 } from './dom';
 import {
@@ -25,12 +24,16 @@ import {
 } from './state';
 import * as dragState from './state';
 import { createMoveContext, applyMove, revertMove } from './operations';
-import { sendNewOrder, sendLinkedCreative, sendTopicMove } from '../../lib/api/drag_drop';
+import * as moveOperations from './operations';
+import { reportPartialMove } from './move_feedback';
+import { expandBranchWithChildren } from '../branch_expansion';
+import { sendTopicMove } from '../../lib/api/drag_drop';
 import { initIndicator, showLinkHover, hideLinkHover } from './indicator';
 import { showMissingMembersPopup } from '../topic_move_members_popup';
 import { alertDialog } from '../../lib/utils/dialog';
 import { restoreTreeEmptyState } from '../../modules/creative_tree_empty_state';
 import { getDragKind, readDragData, writeDragData } from '../../lib/dnd/envelope';
+import { createDragDropRegistry } from '../../lib/dnd/registry';
 import { getVerticalDropPosition } from '../../lib/dnd/hit_test';
 import {
   DROP_COMPLETED_EVENT,
@@ -42,6 +45,46 @@ import {
 } from '../../lib/dnd/session';
 
 const coordPrecision = 5;
+export const CREATIVE_TREE_EXPAND_DELAY_MS = 600;
+
+let hoverExpandTimer = null;
+let hoverExpandTree = null;
+let hoverExpansionVersion = 0;
+const hoverExpandingTrees = new WeakSet();
+
+function clearHoverExpand() {
+  if (hoverExpandTimer) clearTimeout(hoverExpandTimer);
+  hoverExpandTimer = null;
+  hoverExpandTree = null;
+  hoverExpansionVersion += 1;
+}
+
+function scheduleHoverExpand(tree, position) {
+  if (position !== 'child') {
+    clearHoverExpand();
+    return;
+  }
+
+  const row = asTreeRow(tree);
+  if (!row?.hasAttribute('has-children') || row.hasAttribute('expanded')) {
+    clearHoverExpand();
+    return;
+  }
+  if (hoverExpandTree === tree || hoverExpandingTrees.has(tree)) return;
+
+  clearHoverExpand();
+  const expansionVersion = hoverExpansionVersion;
+  hoverExpandTree = tree;
+  hoverExpandTimer = setTimeout(() => {
+    hoverExpandTimer = null;
+    hoverExpandTree = null;
+    hoverExpandingTrees.add(tree);
+    expandBranchWithChildren(row, getChildrenContainer(row), {
+      isCurrent: () => expansionVersion === hoverExpansionVersion,
+    })
+      .finally(() => hoverExpandingTrees.delete(tree));
+  }, CREATIVE_TREE_EXPAND_DELAY_MS);
+}
 
 const INVALID_DROP_MESSAGE =
   'We could not verify that drop. Please refresh the page and try again.';
@@ -248,13 +291,13 @@ function getDraggedContext(event, data) {
   const transfer = event.dataTransfer;
   const hasTrustedPayload = getDragKind(transfer) === 'creative';
   const parsed = data?.kind === 'creative'
-    ? { ...data.payload, selectedCreativeIds: data.ids }
+    ? { ...data.payload, creativeId: String(data.payload.creativeId), selectedCreativeIds: data.ids }
     : null;
   const wasRejectedPayload = hasTrustedPayload && !parsed;
 
   if (existing) {
-    if (parsed && parsed.creativeId === existing.creativeId && parsed.treeId === existing.treeId) {
-      return { draggedState: existing, isExternal: false, wasRejectedPayload };
+    if (parsed && parsed.creativeId === String(existing.creativeId) && parsed.treeId === existing.treeId) {
+      return { draggedState: { ...existing, ...parsed }, isExternal: false, wasRejectedPayload };
     }
 
     if (parsed) {
@@ -309,7 +352,7 @@ export function handleDragStart(event) {
     sourceWindowId: windowId,
     selectedCreativeIds,
   });
-  event.dataTransfer.effectAllowed = 'move';
+  event.dataTransfer.effectAllowed = 'copyMove';
 
   // Custom bundle drag image for multi-select
   if (selectedCreativeIds.length > 1) {
@@ -332,12 +375,13 @@ export function handleDragStart(event) {
   });
 }
 
-export function handleDragOver(event) {
+export function handleDragOver(event, intent = null) {
   const tree = event.target.closest(DRAGGABLE_SELECTOR);
   const lastRow = getLastDragOverRow();
   if (lastRow && lastRow !== tree) {
     clearDragHighlight(lastRow);
     setLastDragOverRow(null);
+    clearHoverExpand();
   }
   if (!tree || tree.draggable === false) return;
 
@@ -356,17 +400,21 @@ export function handleDragOver(event) {
   if (dragKind !== 'creative' && !hasDraggedState()) return;
 
   event.preventDefault();
-  event.dataTransfer.dropEffect = 'move';
+  event.dataTransfer.dropEffect = event.shiftKey ? 'copy' : 'move';
 
-  const previousPosition = getLastDragOverRow() === tree
-    ? dragState.getLastDragOverPosition?.() || null
-    : null;
+  const previousPosition = getLastDragOverRow() === tree ? dragState.getLastDragOverPosition() : null;
 
-  const position = getVerticalDropPosition({
+  const position = intent || getVerticalDropPosition({
     clientY: event.clientY,
     rect: tree.getBoundingClientRect(),
     previousPosition,
   });
+
+  setLastDragOverRow(tree, position);
+  if (!position) {
+    clearDragHighlight(tree);
+    return;
+  }
 
   if (position === 'up') {
     tree.classList.add('drag-over', 'drag-over-top');
@@ -379,6 +427,8 @@ export function handleDragOver(event) {
     tree.classList.remove('drag-over-top', 'drag-over-bottom');
   }
 
+  scheduleHoverExpand(tree, position);
+
   if (event.shiftKey) {
     showLinkHover(event.clientX, event.clientY);
   } else {
@@ -389,11 +439,13 @@ export function handleDragOver(event) {
 }
 
 function resetDrag() {
+  clearHoverExpand();
   resetDraggedState();
   hideLinkHover();
 }
 
-export function handleDrop(event) {
+export function handleDrop(event, intent = null, { partialFailureMessage = '' } = {}) {
+  clearHoverExpand();
   const targetTree = event.target.closest(DRAGGABLE_SELECTOR);
   const targetId = targetTree ? targetTree.id : '';
 
@@ -446,17 +498,13 @@ export function handleDrop(event) {
     return;
   }
 
-  const previewedDirection = targetTree && getLastDragOverRow() === targetTree
-    ? dragState.getLastDragOverPosition?.() || null
-    : null;
+  const previewedDirection = intent || (getLastDragOverRow() === targetTree
+    ? dragState.getLastDragOverPosition() : null);
 
   clearDragHighlight(targetTree);
   clearDragHighlight(getLastDragOverRow());
 
-  const { draggedState, isExternal, wasRejectedPayload } = getDraggedContext(
-    event,
-    dragData
-  );
+  const { draggedState, isExternal, wasRejectedPayload } = getDraggedContext(event, dragData);
 
   if (!targetTree || targetTree.draggable === false) {
     resetDrag();
@@ -497,13 +545,12 @@ export function handleDrop(event) {
     return;
   }
 
-  if (isMultiDrag) {
-    const targetCreativeId = targetRow.getAttribute('creative-id');
-    if (draggedIds.includes(String(targetCreativeId))) {
-      resetDrag();
-      return;
-    }
+  if (draggedIds.includes(String(targetRow.getAttribute('creative-id')))) {
+    resetDrag();
+    return;
+  }
 
+  if (isMultiDrag) {
     if (typeof document !== 'undefined') {
       const selectedRows = draggedIds
         .map((id) => {
@@ -526,54 +573,25 @@ export function handleDrop(event) {
     }
   }
 
-  let direction = previewedDirection;
+  const direction = previewedDirection || getVerticalDropPosition({
+    clientY: event.clientY,
+    rect: targetTree.getBoundingClientRect(),
+  });
   if (!direction) {
-    // Fallback calculation
-    direction = getVerticalDropPosition({
-      clientY: event.clientY,
-      rect: targetTree.getBoundingClientRect(),
-    });
-    if (!direction) {
-      resetDrag();
-      return;
-    }
-  }
-
-  if (event.shiftKey) {
-    const snapshot = { ...draggedState };
     resetDrag();
-
-    if (isMultiDrag) {
-      // Handle multiple linked creatives
-      const promises = draggedIds.map(draggedId =>
-        sendLinkedCreative({
-          draggedId,
-          targetId: targetId.replace('creative-', ''),
-          direction,
-        })
-      );
-
-      Promise.all(promises)
-        .then(() => window.location.reload())
-        .catch((error) => console.error('Failed to create linked creatives', error));
-    } else {
-      // Handle single linked creative
-      sendLinkedCreative({
-        draggedId: snapshot.creativeId,
-        targetId: targetId.replace('creative-', ''),
-        direction,
-      })
-        .then(() => window.location.reload())
-        .catch((error) => console.error('Failed to create linked creative', error));
-    }
     return;
   }
+  if (hasKnownCreativeTreeCycle(draggedIds, targetRow, direction)) {
+    resetDrag();
+    return;
+  }
+  const mode = event.shiftKey ? 'link' : 'move';
 
   let moveContext = null;
   let newParentId = null;
   let draggedChildren = null;
 
-  if (draggedRow && !isMultiDrag) {
+  if (draggedRow && !isMultiDrag && !isExternal && mode === 'move') {
     draggedChildren = getChildrenContainer(draggedRow);
     moveContext = createMoveContext(
       resolvedDraggedState,
@@ -590,64 +608,55 @@ export function handleDrop(event) {
     }));
   }
 
-  const draggedNumericId = draggedState.creativeId;
-  const dropSignalDetails = isMultiDrag
-    ? null
-    : {
-      creativeId: draggedNumericId,
-      treeId: draggedState.treeId,
-      sourceWindowId: draggedState.sourceWindowId,
-      targetTreeId: targetId,
-      direction,
-    };
-
+  const dropSignalDetails = {
+    treeId: draggedState.treeId,
+    sourceWindowId: draggedState.sourceWindowId,
+    targetTreeId: targetId,
+    targetCreativeId: targetId.replace('creative-', ''),
+    direction,
+    mode,
+  };
   resetDrag();
 
-  const shouldReloadOnFinalize = isExternal && !moveContext;
-
-  const finalizeDrop = () => {
-    if (shouldReloadOnFinalize) {
-      window.location.reload();
+  return moveOperations.runMoveWithDomRecovery({
+    command: { ids: draggedIds, targetId: targetId.replace('creative-', ''), direction, mode },
+    moveContext,
+    attemptedParentId: newParentId,
+  }).then((result) => {
+    reportPartialMove(result, partialFailureMessage);
+    if (!result.ok) {
+      console.error('Creative move did not fully complete', result);
     }
-  };
+    if (result.succeededIds.length === 0) return result;
+    const detail = {
+      ...dropSignalDetails,
+      creativeId: result.succeededIds[0],
+      creativeIds: result.succeededIds,
+    };
+    if (mode === 'move' && detail.sourceWindowId) emitDropSignal(detail);
+    dispatchDropCompletion({ ...detail, context: 'target' });
+    return result;
+  }).catch((error) => {
+    // Only an unusable command or a synchronous transport failure lands here;
+    // the DOM is already restored, so all that is left is to say why.
+    console.error('Failed to update order', error);
+  });
+}
 
-  const reorderPayload = {
-    targetId: targetId.replace('creative-', ''),
-    direction,
-  };
+function hasKnownCreativeTreeCycle(ids, targetRow, direction) {
+  const movingIds = new Set(ids.map(String));
+  const targetId = targetRow.getAttribute('creative-id');
+  if (!targetId || movingIds.has(String(targetId))) return true;
 
-  if (isMultiDrag) {
-    reorderPayload.draggedIds = draggedIds;
-  } else {
-    reorderPayload.draggedId = draggedNumericId;
+  let parentId = direction === 'child' ? targetId : targetRow.getAttribute('parent-id');
+  const visited = new Set();
+  while (parentId && !visited.has(String(parentId))) {
+    const normalizedId = String(parentId);
+    if (movingIds.has(normalizedId)) return true;
+    visited.add(normalizedId);
+    parentId = getRowByCreativeId(normalizedId)?.getAttribute('parent-id') || null;
   }
-
-  sendNewOrder(reorderPayload)
-    .then((response) => {
-      if (!response.ok) {
-        if (moveContext) {
-          revertMove(moveContext, newParentId);
-        }
-        return;
-      }
-
-      if (isMultiDrag) {
-        window.location.reload();
-        return;
-      }
-
-      if (dropSignalDetails?.sourceWindowId) {
-        emitDropSignal(dropSignalDetails);
-        dispatchDropCompletion({ ...dropSignalDetails, context: 'target' });
-      }
-    })
-    .catch((error) => {
-      console.error('Failed to update order', error);
-      if (moveContext) {
-        revertMove(moveContext, newParentId);
-      }
-    })
-    .finally(finalizeDrop);
+  return false;
 }
 
 export function handleDragLeave(event) {
@@ -655,6 +664,7 @@ export function handleDragLeave(event) {
   if (!tree || tree.draggable === false) return;
   clearDragHighlight(tree);
   if (getLastDragOverRow() === tree) setLastDragOverRow(null);
+  if (hoverExpandTree === tree || hoverExpandingTrees.has(tree)) clearHoverExpand();
   hideLinkHover();
 }
 
@@ -681,4 +691,51 @@ export function registerGlobalHandlers() {
 
 export function hasActiveDrag() {
   return hasDraggedState();
+}
+
+// Keep domain commands and DOM recovery in this adapter; the registry owns
+// native event routing, hit intent and cleanup.
+export function createCreativeTreeDragDrop({ partialFailureMessage = '' } = {}) {
+  const localData = (transfer) => {
+    if (Array.from(transfer?.types || []).length || !hasDraggedState()) return null;
+    const { tree: _tree, row: _row, ...payload } = getDraggedState();
+    return { kind: 'creative', ids: resolveDraggedIds(payload), payload };
+  };
+  const registry = createDragDropRegistry({
+    getKind: (transfer) => getDragKind(transfer) || localData(transfer)?.kind || null,
+    readData: (transfer) => readDragData(transfer) || localData(transfer),
+  });
+  registry.registerDragSource({
+    selector: DRAGGABLE_SELECTOR,
+    onDragStart: ({ event }) => handleDragStart(event),
+    onDragEnd: () => {
+      clearDragHighlight(getLastDragOverRow());
+      resetDrag();
+    },
+  });
+  registry.registerDropZone({
+    selector: DRAGGABLE_SELECTOR,
+    accepts: ['creative', 'topic'],
+    hitTest: ({ el, event, kind, previousHit }) => {
+      if (el.draggable === false) return null;
+      if (kind === 'topic') return 'child';
+      return getVerticalDropPosition({
+        clientY: event.clientY,
+        rect: el.getBoundingClientRect(),
+        previousPosition: previousHit,
+      });
+    },
+    preview: ({ event, hit }) => {
+      handleDragOver(event, hit);
+      return () => handleDragLeave(event);
+    },
+    dropEffect: ({ event, kind }) => {
+      if (kind === 'topic') { hideLinkHover(); return 'move'; }
+      if (event.shiftKey) showLinkHover(event.clientX, event.clientY);
+      else hideLinkHover();
+      return event.shiftKey ? 'copy' : 'move';
+    },
+    onDrop: ({ event, hit }) => handleDrop(event, hit, { partialFailureMessage }),
+  });
+  return registry;
 }

--- a/engines/collavre/app/javascript/creatives/drag_drop/event_handlers.js
+++ b/engines/collavre/app/javascript/creatives/drag_drop/event_handlers.js
@@ -52,6 +52,13 @@ let hoverExpandTree = null;
 let hoverExpansionVersion = 0;
 const hoverExpandingTrees = new WeakSet();
 
+function retryHoverExpand(tree) {
+  const row = asTreeRow(tree);
+  if (!tree.isConnected || !getChildrenContainer(row)) return;
+  if (getLastDragOverRow() !== tree || dragState.getLastDragOverPosition() !== 'child') return;
+  scheduleHoverExpand(tree, 'child');
+}
+
 function clearHoverExpand() {
   if (hoverExpandTimer) clearTimeout(hoverExpandTimer);
   hoverExpandTimer = null;
@@ -79,10 +86,15 @@ function scheduleHoverExpand(tree, position) {
     hoverExpandTimer = null;
     hoverExpandTree = null;
     hoverExpandingTrees.add(tree);
+    let expanded = false;
     expandBranchWithChildren(row, getChildrenContainer(row), {
       isCurrent: () => expansionVersion === hoverExpansionVersion,
     })
-      .finally(() => hoverExpandingTrees.delete(tree));
+      .then((result) => { expanded = result; })
+      .finally(() => {
+        hoverExpandingTrees.delete(tree);
+        if (!expanded) retryHoverExpand(tree);
+      });
   }, CREATIVE_TREE_EXPAND_DELAY_MS);
 }
 

--- a/engines/collavre/app/javascript/creatives/drag_drop/event_handlers.js
+++ b/engines/collavre/app/javascript/creatives/drag_drop/event_handlers.js
@@ -209,7 +209,7 @@ function removeDroppedCreative({ creativeId, treeId }) {
   restoreTreeEmptyState();
 }
 
-function syncSourceWindowDrop(detail) {
+function syncSourceWindowCreative(detail) {
   const { creativeId, treeId = null, direction, targetTreeId = null } = detail;
   if (!creativeId || !direction || !targetTreeId) {
     removeDroppedCreative({ creativeId, treeId });
@@ -256,12 +256,35 @@ function syncSourceWindowDrop(detail) {
   }
 }
 
+function completedCreativeIds(detail) {
+  const ids = Array.isArray(detail.creativeIds) ? detail.creativeIds : [];
+  const normalized = [...new Set(ids
+    .filter(id => id !== null && id !== undefined && String(id) !== '')
+    .map(String))];
+  if (normalized.length) return normalized;
+  return detail.creativeId == null || String(detail.creativeId) === '' ? [] : [String(detail.creativeId)];
+}
+
+function syncSourceWindowDrop(detail) {
+  if (detail.mode === 'link') return;
+  const ids = completedCreativeIds(detail);
+  // Each 'down' insertion is immediately after the target, so replay backwards
+  // to retain the server's selection order. Child inserts append in forward order.
+  if (detail.direction === 'down') ids.reverse();
+  for (const creativeId of ids) {
+    syncSourceWindowCreative({
+      ...detail,
+      creativeId,
+      treeId: creativeId === String(detail.creativeId) ? detail.treeId : null,
+    });
+  }
+}
+
 function handleStorageChange(event) {
   const payload = readDropSignal(event);
   if (!payload) return;
 
-  const { creativeId } = payload;
-  if (!creativeId) return;
+  if (!completedCreativeIds(payload).length) return;
 
   dispatchDropCompletion({
     ...payload,
@@ -273,8 +296,8 @@ function handleDropCompletionEvent(event) {
   if (!event || !event.detail) return;
 
   const detail = event.detail;
-  const { creativeId, treeId = null, sourceWindowId = null, context } = detail;
-  if (!creativeId || !context) return;
+  const { sourceWindowId = null, context } = detail;
+  if (!completedCreativeIds(detail).length || !context) return;
 
   const windowId = readDragWindowId();
   if (!windowId || sourceWindowId !== windowId) {

--- a/engines/collavre/app/javascript/creatives/drag_drop/move_feedback.js
+++ b/engines/collavre/app/javascript/creatives/drag_drop/move_feedback.js
@@ -1,0 +1,22 @@
+import { alertDialog } from '../../lib/utils/dialog';
+
+// A partial move leaves some rows where the user dropped them and some where
+// they were. The trees still refresh, so without a notice the missing rows read
+// as a rendering glitch rather than a rejected request.
+export function reportPartialMove(result, fallbackMessage = '') {
+  if (result?.status !== 'partial') return false;
+
+  const failures = Array.isArray(result.failures) ? result.failures : [];
+  console.error('Creative move partially failed', {
+    failedIds: result.failedIds,
+    failures,
+  });
+
+  // Only errors parsed from a server payload are safe to present verbatim.
+  // Transport/status messages such as "HTTP 403: Forbidden" are diagnostic
+  // English and must not bypass the page's translated fallback.
+  const message = failures.map((failure) => failure?.serverMessage).find(Boolean)
+    || fallbackMessage;
+  if (message) alertDialog(message);
+  return true;
+}

--- a/engines/collavre/app/javascript/creatives/drag_drop/workspace_tree_adapter.js
+++ b/engines/collavre/app/javascript/creatives/drag_drop/workspace_tree_adapter.js
@@ -1,0 +1,149 @@
+import { createDragDropRegistry } from '../../lib/dnd/registry'
+import { getDragKind, readDragData, writeDragData } from '../../lib/dnd/envelope'
+import {
+  dispatchDropCompletion,
+  emitDropSignal,
+  ensureDragWindowId,
+} from '../../lib/dnd/session'
+import { getVerticalDropPosition } from '../../lib/dnd/hit_test'
+import { reportPartialMove } from './move_feedback'
+import { executeMoveCommand } from './move_command'
+import {
+  hasKnownWorkspaceCycle,
+  showWorkspaceDropPreview,
+  workspaceItemFromRow,
+} from './workspace_tree_dom'
+
+export const WORKSPACE_TREE_EXPAND_DELAY_MS = 600
+const ROW_SELECTOR = '.creative-workspace-tree-row[data-creative-id]'
+
+function creativePayload(item, row) {
+  const creativeId = item.dataset.creativeId
+  const parentId = item.dataset.parentId || null
+  return {
+    creativeId,
+    treeId: row.id,
+    parentId,
+    level: Number(item.dataset.level || 1),
+    isRoot: !parentId,
+    source: 'workspace-tree',
+    sourceWindowId: ensureDragWindowId(),
+  }
+}
+
+function startWorkspaceDrag({ el: row, event }) {
+  const item = workspaceItemFromRow(row)
+  if (!item || !event.dataTransfer) return
+
+  const payload = creativePayload(item, row)
+  writeDragData(event.dataTransfer, {
+    kind: 'creative',
+    ids: [payload.creativeId],
+    payload,
+  })
+  event.dataTransfer.effectAllowed = 'copyMove'
+  row.classList.add('is-dragging')
+}
+
+function endWorkspaceDrag({ el: row }) {
+  row.classList.remove('is-dragging')
+}
+
+function hitWorkspaceRow({ el: row, event, previousHit }) {
+  return getVerticalDropPosition({
+    clientY: event.clientY,
+    rect: row.getBoundingClientRect(),
+    previousPosition: previousHit,
+  })
+}
+
+function previewWorkspaceRow(controller, expandDelay, { el: row, hit }) {
+  const item = workspaceItemFromRow(row)
+  const clearHighlight = showWorkspaceDropPreview(row, hit)
+  let expandTimer = null
+  if (hit === 'child' && item?.dataset.hasChildren === 'true' && item.dataset.expanded !== 'true') {
+    expandTimer = window.setTimeout(() => {
+      expandTimer = null
+      controller.expandBranchForDrag(item.dataset.creativeId)
+    }, expandDelay)
+  }
+
+  return () => {
+    if (expandTimer) window.clearTimeout(expandTimer)
+    controller.cancelDragExpansion?.()
+    clearHighlight()
+  }
+}
+
+function completionDetail(ids, payload, targetId, direction) {
+  return {
+    creativeId: ids[0],
+    creativeIds: ids,
+    // The shared reader rejects a creative envelope with no originating tree.
+    treeId: payload.treeId,
+    sourceWindowId: payload.sourceWindowId || null,
+    targetCreativeId: targetId,
+    direction,
+    context: 'target',
+  }
+}
+
+function notifyMoveCompletion(ids, payload, targetId, direction, mode) {
+  const detail = completionDetail(ids, payload, targetId, direction)
+  dispatchDropCompletion(detail)
+  if (mode === 'move' && detail.sourceWindowId) emitDropSignal(detail)
+}
+
+async function performWorkspaceDrop({ root, execute, partialFailureMessage, el: row, event, hit, ids, payload }) {
+  const targetItem = workspaceItemFromRow(row)
+  if (!targetItem || hasKnownWorkspaceCycle({ root, ids, targetItem, direction: hit })) return
+
+  const mode = event.shiftKey ? 'link' : 'move'
+
+  let result
+  try {
+    result = await execute({ ids, targetId: targetItem.dataset.creativeId, direction: hit, mode })
+  } catch (error) {
+    console.error('Failed to execute workspace tree drop', error)
+    return
+  }
+
+  reportPartialMove(result, partialFailureMessage)
+
+  // A failure and a partial success differ only in how many ids landed, and
+  // nothing landing is the one case with nobody to notify.
+  if (result.succeededIds.length === 0) return
+
+  notifyMoveCompletion(result.succeededIds, payload, targetItem.dataset.creativeId, hit, mode)
+}
+
+export function createWorkspaceTreeDragDrop({
+  root = document,
+  controller,
+  execute = executeMoveCommand,
+  expandDelay = WORKSPACE_TREE_EXPAND_DELAY_MS,
+  partialFailureMessage = '',
+} = {}) {
+  const registry = createDragDropRegistry({
+    root,
+    getKind: getDragKind,
+    readData: readDragData,
+    onError: (error) => console.error('Workspace tree drag and drop failed', error),
+  })
+
+  registry.registerDragSource({
+    selector: ROW_SELECTOR,
+    onDragStart: startWorkspaceDrag,
+    onDragEnd: endWorkspaceDrag,
+  })
+  registry.registerDropZone({
+    selector: ROW_SELECTOR,
+    accepts: 'creative',
+    hitTest: hitWorkspaceRow,
+    preview: (details) => previewWorkspaceRow(controller, expandDelay, details),
+    onDrop: (details) => performWorkspaceDrop({ root, execute, partialFailureMessage, ...details }),
+    dropEffect: ({ event }) => event.shiftKey ? 'copy' : 'move',
+  })
+
+  return registry
+}

--- a/engines/collavre/app/javascript/creatives/drag_drop/workspace_tree_dom.js
+++ b/engines/collavre/app/javascript/creatives/drag_drop/workspace_tree_dom.js
@@ -1,0 +1,52 @@
+// The hit test speaks the move vocabulary the server accepts (up/down/child);
+// the stylesheet speaks the presentation vocabulary (top/bottom/child). Keeping
+// the translation here is what stops a preview from adding a class the cleanup
+// below has never heard of.
+const PREVIEW_CLASS_BY_DIRECTION = {
+  up: 'drag-over-top',
+  down: 'drag-over-bottom',
+  child: 'drag-over-child',
+}
+const PREVIEW_CLASSES = Object.values(PREVIEW_CLASS_BY_DIRECTION)
+
+export function workspaceItemFromRow(row) {
+  return row?.closest?.('.creative-workspace-tree-item') || null
+}
+
+export function findWorkspaceItem(root, creativeId) {
+  return [...root.querySelectorAll('.creative-workspace-tree-item[data-creative-id]')]
+    .find((item) => item.dataset.creativeId === String(creativeId)) || null
+}
+
+// Only reached once `hasKnownWorkspaceCycle` has proven the target names a
+// creative, so the item and its id are both there.
+function destinationParentId(targetItem, direction) {
+  if (direction === 'child') return targetItem.dataset.creativeId
+  return targetItem.dataset.parentId || null
+}
+
+export function hasKnownWorkspaceCycle({ root, ids, targetItem, direction }) {
+  const movingIds = new Set(ids.map(String))
+  const targetId = targetItem?.dataset.creativeId
+  if (!targetId || movingIds.has(String(targetId))) return true
+
+  let parentId = destinationParentId(targetItem, direction)
+  const visited = new Set()
+  while (parentId && !visited.has(String(parentId))) {
+    const normalizedId = String(parentId)
+    if (movingIds.has(normalizedId)) return true
+    visited.add(normalizedId)
+    const parentItem = findWorkspaceItem(root, normalizedId)
+    if (!parentItem) return false
+    parentId = parentItem.dataset.parentId || null
+  }
+  return false
+}
+
+export function showWorkspaceDropPreview(row, direction) {
+  const clearPreview = () => PREVIEW_CLASSES.forEach((className) => row.classList.remove(className))
+  clearPreview()
+  const className = PREVIEW_CLASS_BY_DIRECTION[direction]
+  if (className) row.classList.add(className)
+  return clearPreview
+}

--- a/engines/collavre/app/javascript/creatives/tree_view_state.js
+++ b/engines/collavre/app/javascript/creatives/tree_view_state.js
@@ -1,0 +1,85 @@
+import { getChildrenContainer, setExpanded } from './drag_drop/dom'
+import { expandBranchWithChildren } from './branch_expansion'
+
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'textarea:not([disabled])',
+  'select:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',')
+
+function scrollContainer(element) {
+  return element.closest('main') || document.scrollingElement || document.documentElement
+}
+
+function rowId(row) {
+  return row.getAttribute('creative-id')
+}
+
+function findRow(element, creativeId) {
+  return [...element.querySelectorAll('creative-tree-row[creative-id]')]
+    .find((row) => rowId(row) === String(creativeId)) || null
+}
+
+function focusState(element) {
+  const active = document.activeElement
+  const row = active?.closest?.('creative-tree-row')
+  if (!row || !element.contains(row)) return null
+
+  const controls = [...row.querySelectorAll(FOCUSABLE_SELECTOR)]
+  return {
+    creativeId: rowId(row),
+    controlId: active.id || null,
+    controlIndex: controls.indexOf(active),
+  }
+}
+
+export function captureCreativeTreeViewState(element) {
+  const scrolling = scrollContainer(element)
+  return {
+    scrolling,
+    scrollTop: scrolling.scrollTop,
+    focus: focusState(element),
+    expansion: [...element.querySelectorAll('creative-tree-row[creative-id]')].map((row) => ({
+      creativeId: rowId(row),
+      expanded: row.hasAttribute('expanded'),
+    })),
+  }
+}
+
+async function restoreExpansion(element, expansion, isCurrent) {
+  for (const { creativeId, expanded } of expansion) {
+    if (!isCurrent()) return false
+    const row = findRow(element, creativeId)
+    if (!row) continue
+
+    const container = getChildrenContainer(row)
+    // A hover expansion is never persisted, so the reloaded payload can render
+    // that branch collapsed and unloaded. Expanding the empty container alone
+    // would leave the row looking open but blank until the user re-toggles it.
+    if (expanded) await expandBranchWithChildren(row, container, { isCurrent })
+    else setExpanded(row, false, container)
+  }
+  return isCurrent()
+}
+
+function restoreFocus(element, focus) {
+  if (!focus?.creativeId) return
+  const row = findRow(element, focus.creativeId)
+  if (!row) return
+
+  const controls = [...row.querySelectorAll(FOCUSABLE_SELECTOR)]
+  const byId = focus.controlId ? controls.find((control) => control.id === focus.controlId) : null
+  const control = byId || controls[focus.controlIndex]
+  control?.focus({ preventScroll: true })
+}
+
+export async function restoreCreativeTreeViewState(element, state, { isCurrent = () => true } = {}) {
+  if (!state) return
+  const restored = await restoreExpansion(element, state.expansion || [], isCurrent)
+  if (!restored || !isCurrent()) return
+  state.scrolling.scrollTop = state.scrollTop
+  restoreFocus(element, state.focus)
+}

--- a/engines/collavre/app/javascript/lib/dnd/__tests__/hit_test.test.js
+++ b/engines/collavre/app/javascript/lib/dnd/__tests__/hit_test.test.js
@@ -56,3 +56,14 @@ test('supports explicit ratios and validates geometry', () => {
   expect(getVerticalDropPosition({ clientY: 1, rect: { top: 'bad', height: 10 } }))
     .toBeNull();
 });
+
+test('keeps the child band reachable on a row shorter than the hysteresis floor', () => {
+  const rect = { top: 0, height: 28 };
+
+  // Entering from above holds "up" through the top of the row...
+  expect(getVerticalDropPosition({ clientY: 13, rect, previousPosition: 'up' })).toBe('up');
+  // ...and hands over to "child" at the halfway line rather than skipping it.
+  expect(getVerticalDropPosition({ clientY: 14, rect, previousPosition: 'up' })).toBe('child');
+  expect(getVerticalDropPosition({ clientY: 14, rect, previousPosition: 'down' })).toBe('child');
+  expect(getVerticalDropPosition({ clientY: 15, rect, previousPosition: 'down' })).toBe('down');
+});

--- a/engines/collavre/app/javascript/lib/dnd/__tests__/registry.test.js
+++ b/engines/collavre/app/javascript/lib/dnd/__tests__/registry.test.js
@@ -1,0 +1,748 @@
+/**
+ * @jest-environment jsdom
+ */
+import { jest } from '@jest/globals'
+import { createDragDropRegistry } from '../registry'
+
+function transfer(kind = 'creative') {
+  return {
+    kind,
+    dropEffect: 'none',
+    types: [`application/x-${kind}`],
+  }
+}
+
+function dragEvent(type, target, dataTransfer, options = {}) {
+  const event = new Event(type, { bubbles: true, cancelable: true })
+  Object.defineProperties(event, {
+    target: { value: target },
+    dataTransfer: { value: dataTransfer },
+    relatedTarget: { value: options.relatedTarget || null },
+  })
+  return event
+}
+
+describe('createDragDropRegistry', () => {
+  let root
+  let registry
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <main id="root">
+        <div class="source"><span class="source-child"></span></div>
+        <div class="zone"><span class="zone-child"></span></div>
+      </main>
+    `
+    root = document.getElementById('root')
+  })
+
+  afterEach(() => registry?.destroy())
+
+  test('delegates source start and end for dynamically matched descendants', () => {
+    const onDragStart = jest.fn()
+    const onDragEnd = jest.fn()
+    registry = createDragDropRegistry({ root, getKind: () => null, readData: () => null })
+    registry.registerDragSource({ selector: '.source', onDragStart, onDragEnd })
+
+    const dataTransfer = transfer()
+    root.querySelector('.source-child').dispatchEvent(dragEvent('dragstart', root.querySelector('.source-child'), dataTransfer))
+    root.querySelector('.source-child').dispatchEvent(dragEvent('dragend', root.querySelector('.source-child'), dataTransfer))
+
+    expect(onDragStart).toHaveBeenCalledWith(expect.objectContaining({ el: root.querySelector('.source') }))
+    expect(onDragEnd).toHaveBeenCalledWith(expect.objectContaining({ el: root.querySelector('.source') }))
+  })
+
+  test('accepts a kind, previews one stable hit, and drops normalized data', () => {
+    const previewCleanup = jest.fn()
+    const preview = jest.fn(() => previewCleanup)
+    const onDrop = jest.fn()
+    registry = createDragDropRegistry({
+      root,
+      getKind: (dataTransfer) => dataTransfer.kind,
+      readData: () => ({ kind: 'creative', ids: ['7'], payload: { source: 'right' } }),
+    })
+    registry.registerDropZone({
+      selector: '.zone',
+      accepts: ['creative'],
+      hitTest: () => 'child',
+      preview,
+      onDrop,
+    })
+
+    const zoneChild = root.querySelector('.zone-child')
+    const dataTransfer = transfer()
+    const firstOver = dragEvent('dragover', zoneChild, dataTransfer)
+    zoneChild.dispatchEvent(firstOver)
+    zoneChild.dispatchEvent(dragEvent('dragover', zoneChild, dataTransfer))
+    zoneChild.dispatchEvent(dragEvent('drop', zoneChild, dataTransfer))
+
+    expect(firstOver.defaultPrevented).toBe(true)
+    expect(dataTransfer.dropEffect).toBe('move')
+    expect(preview).toHaveBeenCalledTimes(1)
+    expect(previewCleanup).toHaveBeenCalledTimes(1)
+    expect(onDrop).toHaveBeenCalledWith(expect.objectContaining({
+      el: root.querySelector('.zone'),
+      hit: 'child',
+      kind: 'creative',
+      ids: ['7'],
+      payload: { source: 'right' },
+    }))
+  })
+
+  test('cleans the previous preview when the hit changes', () => {
+    const cleanups = [jest.fn(), jest.fn()]
+    const preview = jest.fn(() => cleanups[preview.mock.calls.length - 1])
+    let hit = 'up'
+    registry = createDragDropRegistry({ root, getKind: () => 'creative', readData: () => null })
+    registry.registerDropZone({
+      selector: '.zone', accepts: 'creative', hitTest: () => hit, preview, onDrop: jest.fn(),
+    })
+
+    const zone = root.querySelector('.zone')
+    zone.dispatchEvent(dragEvent('dragover', zone, transfer()))
+    hit = 'down'
+    zone.dispatchEvent(dragEvent('dragover', zone, transfer()))
+
+    expect(cleanups[0]).toHaveBeenCalledTimes(1)
+    expect(preview).toHaveBeenCalledTimes(2)
+  })
+
+  test('ignores rejected kinds and malformed drop data', () => {
+    const onDrop = jest.fn()
+    registry = createDragDropRegistry({
+      root,
+      getKind: (dataTransfer) => dataTransfer.kind,
+      readData: () => null,
+    })
+    registry.registerDropZone({ selector: '.zone', accepts: 'creative', onDrop })
+    const zone = root.querySelector('.zone')
+
+    const topicOver = dragEvent('dragover', zone, transfer('topic'))
+    zone.dispatchEvent(topicOver)
+    zone.dispatchEvent(dragEvent('drop', zone, transfer()))
+
+    expect(topicOver.defaultPrevented).toBe(false)
+    expect(onDrop).not.toHaveBeenCalled()
+  })
+
+  // The readers default to T1's public envelope functions, so only a root that
+  // cannot deliver events or an explicitly broken reader is a construction error.
+  test('rejects a construction that cannot deliver events or read a payload', () => {
+    registry = null
+    expect(() => createDragDropRegistry({ root: {} })).toThrow(/event root/)
+    expect(() => createDragDropRegistry({ root, getKind: null })).toThrow(/getKind/)
+    expect(() => createDragDropRegistry({ root, readData: null })).toThrow(/readData/)
+  })
+
+  test('ignores elements matched outside the registry root', () => {
+    document.body.innerHTML = `
+      <div class="source"><main id="nested"><span class="inner"></span></main></div>
+    `
+    const nested = document.getElementById('nested')
+    const onDragStart = jest.fn()
+    registry = createDragDropRegistry({ root: nested, getKind: () => null, readData: () => null })
+    registry.registerDragSource({ selector: '.source', onDragStart })
+
+    const inner = nested.querySelector('.inner')
+    inner.dispatchEvent(dragEvent('dragstart', inner, transfer()))
+
+    expect(onDragStart).not.toHaveBeenCalled()
+  })
+
+  test('ignores a drag that starts outside every registered source', () => {
+    const onDragStart = jest.fn()
+    registry = createDragDropRegistry({ root, getKind: () => null, readData: () => null })
+    registry.registerDragSource({ selector: '.source', onDragStart })
+
+    const zone = root.querySelector('.zone')
+    zone.dispatchEvent(dragEvent('dragstart', zone, transfer()))
+
+    expect(onDragStart).not.toHaveBeenCalled()
+  })
+
+  test('ignores a drag end that never started and reports a failing end handler', () => {
+    const onError = jest.fn()
+    const onDragEnd = jest.fn(() => { throw new Error('broken end') })
+    registry = createDragDropRegistry({ root, getKind: () => null, readData: () => null, onError })
+    registry.registerDragSource({ selector: '.source', onDragStart: jest.fn(), onDragEnd })
+    const source = root.querySelector('.source')
+
+    source.dispatchEvent(dragEvent('dragend', source, transfer()))
+    expect(onDragEnd).not.toHaveBeenCalled()
+
+    source.dispatchEvent(dragEvent('dragstart', source, transfer()))
+    source.dispatchEvent(dragEvent('dragend', source, transfer()))
+    expect(onError).toHaveBeenCalledWith(expect.objectContaining({ message: 'broken end' }))
+  })
+
+  test('resolves acceptance through a predicate and skips a missing kind', () => {
+    const accepts = jest.fn((kind) => kind === 'creative')
+    const onDrop = jest.fn()
+    let kind = null
+    registry = createDragDropRegistry({
+      root,
+      getKind: () => kind,
+      readData: () => ({ kind: 'creative', ids: ['1'] }),
+    })
+    registry.registerDropZone({ selector: '.zone', accepts, onDrop })
+    const zone = root.querySelector('.zone')
+
+    const withoutKind = dragEvent('dragover', zone, transfer())
+    zone.dispatchEvent(withoutKind)
+    expect(withoutKind.defaultPrevented).toBe(false)
+    expect(accepts).not.toHaveBeenCalled()
+
+    kind = 'creative'
+    const withKind = dragEvent('dragover', zone, transfer())
+    zone.dispatchEvent(withKind)
+    expect(withKind.defaultPrevented).toBe(true)
+    expect(accepts).toHaveBeenCalledWith('creative', expect.anything())
+  })
+
+  test('declines a zone whose hit test rejects the pointer position', () => {
+    const onDrop = jest.fn()
+    registry = createDragDropRegistry({
+      root,
+      getKind: () => 'creative',
+      readData: () => ({ kind: 'creative', ids: ['1'] }),
+    })
+    registry.registerDropZone({ selector: '.zone', accepts: 'creative', hitTest: () => null, onDrop })
+    const zone = root.querySelector('.zone')
+
+    const over = dragEvent('dragover', zone, transfer())
+    zone.dispatchEvent(over)
+    zone.dispatchEvent(dragEvent('drop', zone, transfer()))
+
+    expect(over.defaultPrevented).toBe(false)
+    expect(onDrop).not.toHaveBeenCalled()
+  })
+
+  test('drops the preview when resolution itself fails', () => {
+    const onError = jest.fn()
+    const previewCleanup = jest.fn()
+    let failing = false
+    registry = createDragDropRegistry({
+      root,
+      getKind: () => {
+        if (failing) throw new Error('broken kind')
+        return 'creative'
+      },
+      readData: () => null,
+      onError,
+    })
+    registry.registerDropZone({
+      selector: '.zone', accepts: 'creative', preview: () => previewCleanup, onDrop: jest.fn(),
+    })
+    const zone = root.querySelector('.zone')
+
+    zone.dispatchEvent(dragEvent('dragover', zone, transfer()))
+    failing = true
+    const failed = dragEvent('dragover', zone, transfer())
+    zone.dispatchEvent(failed)
+
+    expect(failed.defaultPrevented).toBe(false)
+    expect(previewCleanup).toHaveBeenCalledTimes(1)
+    expect(onError).toHaveBeenCalledWith(expect.objectContaining({ message: 'broken kind' }))
+  })
+
+  test('reports a failing preview, a failing cleanup, and a failing drop handler', async () => {
+    const onError = jest.fn()
+    let previewMode = 'throw'
+    registry = createDragDropRegistry({
+      root,
+      getKind: () => 'creative',
+      readData: () => ({ kind: 'creative', ids: ['1'] }),
+      onError,
+    })
+    registry.registerDropZone({
+      selector: '.zone',
+      accepts: 'creative',
+      hitTest: () => previewMode,
+      preview: () => {
+        if (previewMode === 'throw') throw new Error('broken preview')
+        if (previewMode === 'cleanup') return () => { throw new Error('broken cleanup') }
+        return undefined
+      },
+      onDrop: () => { throw new Error('broken drop') },
+    })
+    const zone = root.querySelector('.zone')
+
+    zone.dispatchEvent(dragEvent('dragover', zone, transfer()))
+    expect(onError).toHaveBeenCalledWith(expect.objectContaining({ message: 'broken preview' }))
+
+    previewMode = 'cleanup'
+    zone.dispatchEvent(dragEvent('dragover', zone, transfer()))
+    previewMode = 'plain'
+    zone.dispatchEvent(dragEvent('dragover', zone, transfer()))
+    expect(onError).toHaveBeenCalledWith(expect.objectContaining({ message: 'broken cleanup' }))
+
+    zone.dispatchEvent(dragEvent('drop', zone, transfer()))
+    expect(onError).toHaveBeenCalledWith(expect.objectContaining({ message: 'broken drop' }))
+  })
+
+  test('falls back to the console when the error reporter itself fails', () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
+    const onError = jest.fn(() => { throw new Error('broken reporter') })
+    registry = createDragDropRegistry({ root, getKind: () => null, readData: () => null, onError })
+    registry.registerDragSource({
+      selector: '.source', onDragStart: () => { throw new Error('broken source') },
+    })
+    const source = root.querySelector('.source')
+
+    source.dispatchEvent(dragEvent('dragstart', source, transfer()))
+
+    expect(consoleError).toHaveBeenCalledWith(expect.objectContaining({ message: 'broken reporter' }))
+    consoleError.mockRestore()
+  })
+
+  test('reports to the console when no error reporter is supplied', () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
+    registry = createDragDropRegistry({ root, getKind: () => null, readData: () => null })
+    registry.registerDragSource({
+      selector: '.source', onDragStart: () => { throw new Error('unreported source') },
+    })
+    const source = root.querySelector('.source')
+
+    source.dispatchEvent(dragEvent('dragstart', source, transfer()))
+
+    expect(consoleError).toHaveBeenCalledWith(expect.objectContaining({ message: 'unreported source' }))
+    consoleError.mockRestore()
+  })
+
+  test('keeps the preview while the pointer stays inside the active zone', () => {
+    const previewCleanup = jest.fn()
+    registry = createDragDropRegistry({ root, getKind: () => 'creative', readData: () => null })
+    registry.registerDropZone({
+      selector: '.zone', accepts: 'creative', preview: () => previewCleanup, onDrop: jest.fn(),
+    })
+    const zone = root.querySelector('.zone')
+    const zoneChild = root.querySelector('.zone-child')
+
+    zone.dispatchEvent(dragEvent('dragleave', zone, transfer()))
+    expect(previewCleanup).not.toHaveBeenCalled()
+
+    zone.dispatchEvent(dragEvent('dragover', zone, transfer()))
+    zone.dispatchEvent(dragEvent('dragleave', zone, transfer(), { relatedTarget: zoneChild }))
+    expect(previewCleanup).not.toHaveBeenCalled()
+
+    zone.dispatchEvent(dragEvent('dragleave', zone, transfer(), { relatedTarget: root.querySelector('.source') }))
+    expect(previewCleanup).toHaveBeenCalledTimes(1)
+  })
+
+  test('ignores a drop that lands outside every registered zone', () => {
+    const readData = jest.fn(() => ({ kind: 'creative', ids: ['1'] }))
+    registry = createDragDropRegistry({ root, getKind: () => 'creative', readData })
+    const zone = root.querySelector('.zone')
+
+    const drop = dragEvent('drop', zone, transfer())
+    zone.dispatchEvent(drop)
+
+    expect(drop.defaultPrevented).toBe(false)
+    expect(readData).not.toHaveBeenCalled()
+  })
+
+  test('rejects registrations that cannot participate in a drag', () => {
+    registry = createDragDropRegistry({ root, getKind: () => null, readData: () => null })
+
+    expect(() => registry.registerDragSource()).toThrow(/selector and onDragStart/)
+    expect(() => registry.registerDragSource({ selector: '.source' })).toThrow(TypeError)
+    expect(() => registry.registerDropZone({ accepts: 'creative', onDrop: jest.fn() })).toThrow(TypeError)
+    expect(() => registry.registerDropZone({ selector: '.zone', onDrop: jest.fn() })).toThrow(TypeError)
+    expect(() => registry.registerDropZone({ selector: '.zone', accepts: 'creative' })).toThrow(/selector, accepts, and onDrop/)
+  })
+
+  test('unregisters a source and a zone exactly once', () => {
+    const onDragStart = jest.fn()
+    const onDrop = jest.fn()
+    registry = createDragDropRegistry({
+      root,
+      getKind: () => 'creative',
+      readData: () => ({ kind: 'creative', ids: ['1'] }),
+    })
+    const unregisterSource = registry.registerDragSource({ selector: '.source', onDragStart })
+    const unregisterZone = registry.registerDropZone({ selector: '.zone', accepts: 'creative', onDrop })
+
+    unregisterSource()
+    unregisterSource()
+    unregisterZone()
+    unregisterZone()
+
+    const source = root.querySelector('.source')
+    const zone = root.querySelector('.zone')
+    source.dispatchEvent(dragEvent('dragstart', source, transfer()))
+    zone.dispatchEvent(dragEvent('drop', zone, transfer()))
+
+    expect(onDragStart).not.toHaveBeenCalled()
+    expect(onDrop).not.toHaveBeenCalled()
+  })
+
+  test('reports handler errors without breaking later drags and destroy detaches listeners', () => {
+    const onError = jest.fn()
+    const onDragStart = jest.fn(() => { throw new Error('broken source') })
+    registry = createDragDropRegistry({ root, getKind: () => null, readData: () => null, onError })
+    registry.registerDragSource({ selector: '.source', onDragStart })
+    const source = root.querySelector('.source')
+
+    source.dispatchEvent(dragEvent('dragstart', source, transfer()))
+    expect(onError).toHaveBeenCalledWith(expect.objectContaining({ message: 'broken source' }))
+
+    registry.destroy()
+    source.dispatchEvent(dragEvent('dragstart', source, transfer()))
+    expect(onDragStart).toHaveBeenCalledTimes(1)
+    registry = null
+  })
+  test('defaults to the T1 public readers and does not read payload during dragover', () => {
+    const getData = jest.fn(() => '7')
+    registry = createDragDropRegistry({ root })
+    const onDrop = jest.fn()
+    registry.registerDropZone({ selector: '.zone', accepts: 'context', onDrop })
+    const zone = root.querySelector('.zone')
+    const data = { types: ['application/x-context-id'], getData }
+    zone.dispatchEvent(dragEvent('dragover', zone, data))
+    expect(getData).not.toHaveBeenCalled()
+    zone.dispatchEvent(dragEvent('drop', zone, data))
+    expect(onDrop).toHaveBeenCalledWith(expect.objectContaining({ kind: 'context', ids: ['7'], payload: {} }))
+  })
+
+  test('nested zones choose the closest match regardless of registration order', () => {
+    registry = createDragDropRegistry({ root, getKind: () => 'creative', readData: () => ({ kind: 'creative', ids: ['1'], payload: {} }) })
+    const outerDrop = jest.fn()
+    const innerDrop = jest.fn()
+    registry.registerDropZone({ selector: '.zone', accepts: 'creative', onDrop: outerDrop })
+    registry.registerDropZone({ selector: '.zone-child', accepts: 'creative', onDrop: innerDrop })
+    const child = root.querySelector('.zone-child')
+    child.dispatchEvent(dragEvent('drop', child, transfer()))
+    expect(innerDrop).toHaveBeenCalledTimes(1)
+    expect(outerDrop).not.toHaveBeenCalled()
+  })
+
+  test('drop consumes the displayed intent and preserves prior hit for hysteresis', () => {
+    registry = createDragDropRegistry({ root, getKind: () => 'creative', readData: () => ({ kind: 'creative', ids: ['1'], payload: {} }) })
+    const hitTest = jest.fn().mockReturnValueOnce('up').mockReturnValueOnce('child')
+    const onDrop = jest.fn()
+    registry.registerDropZone({ selector: '.zone', accepts: 'creative', hitTest, onDrop })
+    const zone = root.querySelector('.zone')
+    zone.dispatchEvent(dragEvent('dragover', zone, transfer()))
+    zone.dispatchEvent(dragEvent('dragover', zone, transfer()))
+    expect(hitTest.mock.calls[1][0].previousHit).toBe('up')
+    zone.dispatchEvent(dragEvent('drop', zone, transfer()))
+    expect(hitTest).toHaveBeenCalledTimes(2)
+    expect(onDrop.mock.calls[0][0].hit).toBe('child')
+  })
+
+  test('async drop rejection reports the error and clears preview', async () => {
+    const onError = jest.fn()
+    const cleanup = jest.fn()
+    registry = createDragDropRegistry({ root, getKind: () => 'creative', readData: () => ({ kind: 'creative', ids: ['1'], payload: {} }), onError })
+    registry.registerDropZone({ selector: '.zone', accepts: 'creative', preview: () => cleanup, onDrop: async () => { throw new Error('offline') } })
+    const zone = root.querySelector('.zone')
+    zone.dispatchEvent(dragEvent('dragover', zone, transfer()))
+    zone.dispatchEvent(dragEvent('drop', zone, transfer()))
+    await Promise.resolve()
+    expect(cleanup).toHaveBeenCalledTimes(1)
+    expect(onError).toHaveBeenCalledWith(expect.objectContaining({ message: 'offline' }))
+  })
+
+  test('unregistering the active zone clears its preview immediately', () => {
+    const cleanup = jest.fn()
+    registry = createDragDropRegistry({ root, getKind: () => 'creative', readData: () => null })
+    const unregister = registry.registerDropZone({ selector: '.zone', accepts: 'creative', preview: () => cleanup, onDrop: jest.fn() })
+    const zone = root.querySelector('.zone')
+    zone.dispatchEvent(dragEvent('dragover', zone, transfer()))
+    unregister()
+    expect(cleanup).toHaveBeenCalledTimes(1)
+    expect(dragEvent('drop', zone, transfer()).defaultPrevented).toBe(false)
+  })
+
+  test('rejects incomplete source and zone registrations', () => {
+    registry = createDragDropRegistry({ root, getKind: () => null, readData: () => null })
+
+    expect(() => registry.registerDragSource({ selector: '.source' })).toThrow(TypeError)
+    expect(() => registry.registerDropZone({ selector: '.zone', accepts: 'creative' })).toThrow(TypeError)
+    expect(() => createDragDropRegistry({ root: null })).toThrow(TypeError)
+    expect(() => createDragDropRegistry({ root, getKind: 'nope' })).toThrow(TypeError)
+    expect(() => createDragDropRegistry({ root, readData: 'nope' })).toThrow(TypeError)
+  })
+
+  test('unregistering a source stops it from claiming later drags', () => {
+    const onDragStart = jest.fn()
+    registry = createDragDropRegistry({ root, getKind: () => null, readData: () => null })
+    const unregister = registry.registerDragSource({ selector: '.source', onDragStart })
+    const source = root.querySelector('.source')
+
+    source.dispatchEvent(dragEvent('dragstart', source, transfer()))
+    unregister()
+    unregister()
+    source.dispatchEvent(dragEvent('dragstart', source, transfer()))
+
+    expect(onDragStart).toHaveBeenCalledTimes(1)
+  })
+
+  // A zone that cannot measure itself must not swallow the drag: the kernel
+  // reports and steps aside so nothing is left highlighted.
+  test('a throwing hitTest clears the preview and reports once', () => {
+    const onError = jest.fn()
+    const cleanup = jest.fn()
+    let hitTest = () => 'child'
+    registry = createDragDropRegistry({ root, getKind: () => 'creative', readData: () => null, onError })
+    registry.registerDropZone({
+      selector: '.zone', accepts: 'creative', hitTest: (...args) => hitTest(...args), preview: () => cleanup, onDrop: jest.fn(),
+    })
+    const zone = root.querySelector('.zone')
+
+    zone.dispatchEvent(dragEvent('dragover', zone, transfer()))
+    hitTest = () => { throw new Error('layout unavailable') }
+    const second = dragEvent('dragover', zone, transfer())
+    zone.dispatchEvent(second)
+
+    expect(second.defaultPrevented).toBe(false)
+    expect(cleanup).toHaveBeenCalledTimes(1)
+    expect(onError).toHaveBeenCalledWith(expect.objectContaining({ message: 'layout unavailable' }))
+  })
+
+  test('reports failures raised by preview, its cleanup, dragend, and drop reads', () => {
+    const onError = jest.fn()
+    registry = createDragDropRegistry({
+      root,
+      getKind: () => 'creative',
+      readData: () => { throw new Error('unreadable transfer') },
+      onError,
+    })
+    registry.registerDragSource({
+      selector: '.source', onDragStart: jest.fn(), onDragEnd: () => { throw new Error('broken end') },
+    })
+    let hit = 'up'
+    registry.registerDropZone({
+      selector: '.zone',
+      accepts: (kind) => kind === 'creative',
+      hitTest: () => hit,
+      preview: () => { throw new Error('broken preview') },
+      onDrop: jest.fn(),
+    })
+    const zone = root.querySelector('.zone')
+    const source = root.querySelector('.source')
+
+    zone.dispatchEvent(dragEvent('dragover', zone, transfer()))
+    zone.dispatchEvent(dragEvent('drop', zone, transfer()))
+    source.dispatchEvent(dragEvent('dragstart', source, transfer()))
+    source.dispatchEvent(dragEvent('dragend', source, transfer()))
+
+    expect(onError.mock.calls.map(([error]) => error.message)).toEqual([
+      'broken preview', 'unreadable transfer', 'broken end',
+    ])
+  })
+
+  test('a cleanup failure is reported and never escapes the kernel', () => {
+    const onError = jest.fn()
+    registry = createDragDropRegistry({ root, getKind: () => 'creative', readData: () => null, onError })
+    let hit = 'up'
+    registry.registerDropZone({
+      selector: '.zone',
+      accepts: 'creative',
+      hitTest: () => hit,
+      preview: () => () => { throw new Error('broken cleanup') },
+      onDrop: jest.fn(),
+    })
+    const zone = root.querySelector('.zone')
+
+    zone.dispatchEvent(dragEvent('dragover', zone, transfer()))
+    hit = 'down'
+    zone.dispatchEvent(dragEvent('dragover', zone, transfer()))
+
+    expect(onError).toHaveBeenCalledWith(expect.objectContaining({ message: 'broken cleanup' }))
+  })
+
+  test('falls back to console when no reporter is supplied and the reporter itself fails', () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
+    registry = createDragDropRegistry({ root, getKind: () => null, readData: () => null })
+    registry.registerDragSource({ selector: '.source', onDragStart: () => { throw new Error('default reporter') } })
+    const source = root.querySelector('.source')
+    source.dispatchEvent(dragEvent('dragstart', source, transfer()))
+    registry.destroy()
+
+    registry = createDragDropRegistry({
+      root, getKind: () => null, readData: () => null, onError: () => { throw new Error('reporter down') },
+    })
+    registry.registerDragSource({ selector: '.source', onDragStart: () => { throw new Error('source down') } })
+    source.dispatchEvent(dragEvent('dragstart', source, transfer()))
+
+    expect(consoleError.mock.calls.map(([error]) => error.message)).toEqual(['default reporter', 'reporter down'])
+    consoleError.mockRestore()
+  })
+
+  test('keeps the preview while the pointer moves inside the active zone', () => {
+    const cleanup = jest.fn()
+    registry = createDragDropRegistry({ root, getKind: () => 'creative', readData: () => null })
+    registry.registerDropZone({
+      selector: '.zone', accepts: 'creative', preview: () => cleanup, onDrop: jest.fn(), dropEffect: 'copy',
+    })
+    const zone = root.querySelector('.zone')
+    const zoneChild = root.querySelector('.zone-child')
+    const dataTransfer = transfer()
+
+    zone.dispatchEvent(dragEvent('dragover', zone, dataTransfer))
+    expect(dataTransfer.dropEffect).toBe('copy')
+    zone.dispatchEvent(dragEvent('dragleave', zone, dataTransfer, { relatedTarget: zoneChild }))
+    expect(cleanup).not.toHaveBeenCalled()
+
+    zone.dispatchEvent(dragEvent('dragleave', zone, dataTransfer, { relatedTarget: root }))
+    expect(cleanup).toHaveBeenCalledTimes(1)
+    zone.dispatchEvent(dragEvent('dragleave', zone, dataTransfer))
+    expect(cleanup).toHaveBeenCalledTimes(1)
+  })
+
+  test('ignores events outside the registry root and unmatched selectors', () => {
+    const outside = document.createElement('div')
+    outside.className = 'zone'
+    document.body.appendChild(outside)
+    const onDrop = jest.fn()
+    registry = createDragDropRegistry({ root, getKind: () => 'creative', readData: () => ({ kind: 'creative', ids: ['1'], payload: {} }) })
+    registry.registerDropZone({ selector: '.zone', accepts: 'creative', onDrop })
+
+    root.dispatchEvent(dragEvent('drop', outside, transfer()))
+    root.dispatchEvent(dragEvent('drop', root, transfer()))
+    root.dispatchEvent(dragEvent('dragstart', root, transfer()))
+    root.dispatchEvent(dragEvent('dragend', root, transfer()))
+
+    expect(onDrop).not.toHaveBeenCalled()
+  })
+
+  test('a document-rooted registry serves zones anywhere in the page', () => {
+    const onDrop = jest.fn()
+    registry = createDragDropRegistry({ getKind: () => 'creative', readData: () => ({ kind: 'creative', ids: ['1'], payload: {} }) })
+    registry.registerDropZone({ selector: '.zone', accepts: 'creative', onDrop })
+    const zone = root.querySelector('.zone')
+
+    zone.dispatchEvent(dragEvent('drop', zone, transfer()))
+
+    expect(onDrop).toHaveBeenCalledTimes(1)
+  })
+
+  test('declines drags with no readable kind', () => {
+    const onDrop = jest.fn()
+    registry = createDragDropRegistry({ root, getKind: () => null, readData: () => null })
+    registry.registerDropZone({ selector: '.zone', accepts: 'creative', onDrop })
+    const zone = root.querySelector('.zone')
+
+    const over = dragEvent('dragover', zone, transfer())
+    zone.dispatchEvent(over)
+
+    expect(over.defaultPrevented).toBe(false)
+    expect(onDrop).not.toHaveBeenCalled()
+  })
+
+  test('an outer zone registered last never steals an inner match', () => {
+    registry = createDragDropRegistry({ root, getKind: () => 'creative', readData: () => ({ kind: 'creative', ids: ['1'], payload: {} }) })
+    const innerDrop = jest.fn()
+    const outerDrop = jest.fn()
+    registry.registerDropZone({ selector: '.zone-child', accepts: 'creative', onDrop: innerDrop })
+    registry.registerDropZone({ selector: '.zone', accepts: 'creative', onDrop: outerDrop })
+    const child = root.querySelector('.zone-child')
+
+    child.dispatchEvent(dragEvent('drop', child, transfer()))
+
+    expect(innerDrop).toHaveBeenCalledTimes(1)
+    expect(outerDrop).not.toHaveBeenCalled()
+  })
+
+  test('a hitTest that finds no position leaves the drag unhandled', () => {
+    const onDrop = jest.fn()
+    registry = createDragDropRegistry({ root, getKind: () => 'creative', readData: () => ({ kind: 'creative', ids: ['1'], payload: {} }) })
+    registry.registerDropZone({ selector: '.zone', accepts: 'creative', hitTest: () => null, onDrop })
+    const zone = root.querySelector('.zone')
+
+    const over = dragEvent('dragover', zone, transfer())
+    zone.dispatchEvent(over)
+    zone.dispatchEvent(dragEvent('drop', zone, transfer()))
+
+    expect(over.defaultPrevented).toBe(false)
+    expect(onDrop).not.toHaveBeenCalled()
+  })
+
+  test('a computed drop effect sees the resolved hit', () => {
+    const dropEffect = jest.fn(() => 'link')
+    registry = createDragDropRegistry({ root, getKind: () => 'creative', readData: () => null })
+    registry.registerDropZone({ selector: '.zone', accepts: 'creative', hitTest: () => 'child', dropEffect, onDrop: jest.fn() })
+    const zone = root.querySelector('.zone')
+    const dataTransfer = transfer()
+
+    zone.dispatchEvent(dragEvent('dragover', zone, dataTransfer))
+
+    expect(dataTransfer.dropEffect).toBe('link')
+    expect(dropEffect).toHaveBeenCalledWith(expect.objectContaining({ hit: 'child', kind: 'creative' }))
+  })
+
+  test('unregistering an idle zone leaves an unrelated active preview alone', () => {
+    const cleanup = jest.fn()
+    registry = createDragDropRegistry({ root, getKind: () => 'creative', readData: () => null })
+    registry.registerDropZone({ selector: '.zone', accepts: 'creative', preview: () => cleanup, onDrop: jest.fn() })
+    const unregisterIdle = registry.registerDropZone({ selector: '.source', accepts: 'creative', onDrop: jest.fn() })
+    const zone = root.querySelector('.zone')
+
+    zone.dispatchEvent(dragEvent('dragover', zone, transfer()))
+    unregisterIdle()
+    unregisterIdle()
+
+    expect(cleanup).not.toHaveBeenCalled()
+  })
+
+  test('defaults every option when constructed bare', () => {
+    registry = createDragDropRegistry()
+    const onDrop = jest.fn()
+    registry.registerDropZone({ selector: '.zone', accepts: 'context', onDrop })
+    const zone = root.querySelector('.zone')
+
+    zone.dispatchEvent(dragEvent('drop', zone, { types: ['application/x-context-id'], getData: () => '7' }))
+
+    expect(onDrop).toHaveBeenCalledWith(expect.objectContaining({ kind: 'context', ids: ['7'] }))
+  })
+  test('Escape cleans a native drag while other keys keep the preview', () => {
+    const cleanup = jest.fn()
+    const end = jest.fn()
+    registry = createDragDropRegistry({ root, getKind: () => 'creative' })
+    registry.registerDragSource({ selector: '.source', onDragStart: jest.fn(), onDragEnd: end })
+    registry.registerDropZone({ selector: '.zone', accepts: 'creative', onDrop: jest.fn(), preview: () => cleanup })
+    root.dispatchEvent(dragEvent('dragstart', root.querySelector('.source'), transfer()))
+    root.dispatchEvent(dragEvent('dragover', root.querySelector('.zone'), transfer()))
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }))
+    expect(cleanup).not.toHaveBeenCalled()
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    expect(cleanup).toHaveBeenCalledTimes(1)
+    expect(end).toHaveBeenCalledTimes(1)
+  })
+
+  test.each([true, false])('the nearest source and drop zone own overlapping registries (outer first: %s)', (outerFirst) => {
+    const options = { getKind: () => 'creative', readData: () => ({ kind: 'creative', ids: ['1'], payload: {} }) }
+    let outer
+    let inner
+    const makeOuter = () => { outer = createDragDropRegistry({ root: document, ...options }) }
+    const makeInner = () => { inner = createDragDropRegistry({ root, ...options }) }
+    if (outerFirst) { makeOuter(); makeInner() } else { makeInner(); makeOuter() }
+    const outerStart = jest.fn()
+    const innerStart = jest.fn()
+    const outerDrop = jest.fn()
+    const innerDrop = jest.fn()
+    outer.registerDragSource({ selector: '#root', onDragStart: outerStart })
+    outer.registerDropZone({ selector: '#root', accepts: 'creative', onDrop: outerDrop })
+    inner.registerDragSource({ selector: '.source', onDragStart: innerStart })
+    inner.registerDropZone({ selector: '.zone', accepts: 'creative', onDrop: innerDrop })
+    try {
+      root.querySelector('.source').dispatchEvent(dragEvent('dragstart', root.querySelector('.source'), transfer()))
+      root.querySelector('.zone').dispatchEvent(dragEvent('dragover', root.querySelector('.zone'), transfer()))
+      root.querySelector('.zone').dispatchEvent(dragEvent('drop', root.querySelector('.zone'), transfer()))
+      expect(innerStart).toHaveBeenCalledTimes(1)
+      expect(outerStart).not.toHaveBeenCalled()
+      expect(innerDrop).toHaveBeenCalledTimes(1)
+      expect(outerDrop).not.toHaveBeenCalled()
+    } finally { outer.destroy(); inner.destroy() }
+  })
+
+  test('a source can decline a native drag before it starts', () => {
+    registry = createDragDropRegistry({ root })
+    registry.registerDragSource({ selector: '.source', onDragStart: () => false })
+    const event = dragEvent('dragstart', root.querySelector('.source'), transfer())
+    root.dispatchEvent(event)
+    expect(event.defaultPrevented).toBe(true)
+  })
+
+})

--- a/engines/collavre/app/javascript/lib/dnd/hit_test.js
+++ b/engines/collavre/app/javascript/lib/dnd/hit_test.js
@@ -17,9 +17,15 @@ export function getVerticalDropPosition({
   if (!Number.isFinite(height) || height <= 0 || !Number.isFinite(top)) return null;
 
   const relativeY = clientY - top;
-  const hysteresis = Math.max(minHysteresis, height * hysteresisRatio);
   let topLimit = height * childZoneRatio;
   let bottomLimit = height * (1 - childZoneRatio);
+  // A fixed 12px floor is wider than the whole child band on a compact row —
+  // left unclamped it closes the band, and dragging down the row would jump
+  // from "before" straight to "after" with no way to nest.
+  const hysteresis = Math.min(
+    Math.max(minHysteresis, height * hysteresisRatio),
+    (bottomLimit - topLimit) / 2
+  );
 
   if (previousPosition === 'up') {
     topLimit += hysteresis;

--- a/engines/collavre/app/javascript/lib/dnd/registry.js
+++ b/engines/collavre/app/javascript/lib/dnd/registry.js
@@ -1,0 +1,265 @@
+import { getDragKind, readDragData } from './envelope'
+
+const liveRegistries = new Set()
+
+function matchingElement(root, event, selector) {
+  const element = event.target?.closest?.(selector)
+  if (!element) return null
+  return root === document || root === element || root.contains(element) ? element : null
+}
+
+function acceptsKind(accepts, kind, event) {
+  if (!kind) return false
+  if (typeof accepts === 'function') return accepts(kind, event)
+  if (Array.isArray(accepts)) return accepts.includes(kind)
+  return accepts === kind
+}
+
+function reportError(onError, error) {
+  try {
+    onError(error)
+  } catch (reportingError) {
+    console.error(reportingError)
+  }
+}
+
+function previewKey(zone, element, hit) {
+  return { zone, element, hit: JSON.stringify(hit) }
+}
+
+function samePreview(left, right) {
+  return left?.zone === right?.zone && left?.element === right?.element && left?.hit === right?.hit
+}
+
+export function createDragDropRegistry({
+  root = document,
+  getKind = getDragKind,
+  readData = readDragData,
+  onError = (error) => console.error(error),
+} = {}) {
+  if (!root?.addEventListener) throw new TypeError('A drag and drop registry requires an event root')
+  if (typeof getKind !== 'function') throw new TypeError('A drag and drop registry requires getKind')
+  if (typeof readData !== 'function') throw new TypeError('A drag and drop registry requires readData')
+
+  const sources = []
+  const zones = []
+  let activeSource = null
+  let activeDrop = null
+  let activePreview = null
+  let previewCleanup = null
+
+  const clearPreview = () => {
+    try {
+      previewCleanup?.()
+    } catch (error) {
+      reportError(onError, error)
+    }
+    previewCleanup = null
+    activePreview = null
+  }
+
+  const matchZone = (event) => {
+    const kind = getKind(event.dataTransfer)
+    let match = null
+    for (const zone of zones) {
+      const element = matchingElement(root, event, zone.selector)
+      if (!element || !acceptsKind(zone.accepts, kind, event)) continue
+      if (!match || match.element.contains(element)) match = { zone, element }
+    }
+    return match ? { ...match, kind } : null
+  }
+
+  const resolveZone = (event, usePreview = false) => {
+    let owner = null
+    for (const candidate of liveRegistries) {
+      const match = candidate.matchDrop(event)
+      if (match && (!owner || (owner.match.element !== match.element && owner.match.element.contains(match.element)))) {
+        owner = { registry: candidate, match }
+      }
+    }
+    if (owner?.registry !== registry) return null
+    const { zone, element, kind } = owner.match
+    const previousHit = activeDrop?.zone === zone && activeDrop.element === element
+      ? activeDrop.hit : null
+    const hit = usePreview && previousHit
+      ? previousHit : (zone.hitTest ? zone.hitTest({ el: element, event, kind, previousHit }) : true)
+    return hit ? { zone, element, hit, kind } : null
+  }
+
+  const handleDragStart = (event) => {
+    let owner = null
+    for (const candidate of liveRegistries) {
+      const element = candidate.getDragSource(event.target)
+      if (element && (!owner || (owner.element !== element && owner.element.contains(element)))) {
+        owner = { registry: candidate, element }
+      }
+    }
+    if (owner?.registry !== registry) return
+    const source = sources.find((candidate) => matchingElement(root, event, candidate.selector))
+    const element = matchingElement(root, event, source.selector)
+    activeSource = { source, element }
+    try {
+      if (source.onDragStart({ el: element, event }) === false) event.preventDefault()
+      event.stopPropagation()
+    } catch (error) {
+      event.preventDefault()
+      activeSource = null
+      reportError(onError, error)
+    }
+  }
+
+  const handleDragEnd = (event) => {
+    clearPreview()
+    activeDrop = null
+    if (!activeSource) return
+
+    const { source, element } = activeSource
+    activeSource = null
+    try {
+      source.onDragEnd?.({ el: element, event })
+    } catch (error) {
+      reportError(onError, error)
+    }
+  }
+
+  const handleDragOver = (event) => {
+    let resolved
+    try {
+      resolved = resolveZone(event)
+    } catch (error) {
+      clearPreview()
+      activeDrop = null
+      reportError(onError, error)
+      return
+    }
+
+    if (!resolved) {
+      clearPreview()
+      activeDrop = null
+      return
+    }
+
+    event.preventDefault()
+    event.stopPropagation()
+    const { zone, element, hit, kind } = resolved
+    event.dataTransfer.dropEffect = typeof zone.dropEffect === 'function'
+      ? zone.dropEffect({ el: element, event, hit, kind })
+      : (zone.dropEffect || 'move')
+    activeDrop = resolved
+
+    const nextPreview = previewKey(zone, element, hit)
+    if (samePreview(activePreview, nextPreview)) return
+    clearPreview()
+    activePreview = nextPreview
+    try {
+      previewCleanup = zone.preview?.({ el: element, event, hit, kind }) || null
+    } catch (error) {
+      reportError(onError, error)
+    }
+  }
+
+  const handleDragLeave = (event) => {
+    if (!activeDrop?.element) return
+    if (event.relatedTarget && activeDrop.element.contains(event.relatedTarget)) return
+    clearPreview()
+    activeDrop = null
+  }
+
+  const handleDrop = (event) => {
+    let resolved
+    try {
+      resolved = resolveZone(event, true)
+      if (!resolved) return
+
+      const data = readData(event.dataTransfer)
+      if (!data || data.kind !== resolved.kind) return
+
+      event.preventDefault()
+      event.stopPropagation()
+      Promise.resolve(resolved.zone.onDrop({
+        el: resolved.element,
+        event,
+        hit: resolved.hit,
+        ...data,
+      })).catch(error => reportError(onError, error))
+    } catch (error) {
+      reportError(onError, error)
+    } finally {
+      if (resolved) {
+        for (const candidate of liveRegistries) candidate.finishDrag(event)
+      } else {
+        clearPreview()
+        activeDrop = null
+      }
+    }
+  }
+
+  const ownerDocument = root.ownerDocument || root
+  const handleKeyDown = (event) => {
+    if (event.key !== 'Escape') return
+    handleDragEnd(event)
+  }
+  ownerDocument.addEventListener('keydown', handleKeyDown)
+  if (root !== ownerDocument) ownerDocument.addEventListener('dragend', handleDragEnd)
+  root.addEventListener('dragstart', handleDragStart)
+  root.addEventListener('dragend', handleDragEnd)
+  root.addEventListener('dragover', handleDragOver)
+  root.addEventListener('dragleave', handleDragLeave)
+  root.addEventListener('drop', handleDrop)
+
+  const registry = {
+    finishDrag: handleDragEnd,
+    matchDrop: matchZone,
+    getDragSource(target) {
+      for (const source of sources) {
+        const element = matchingElement(root, { target }, source.selector)
+        if (element) return element
+      }
+      return null
+    },
+
+    registerDragSource(source) {
+      if (!source?.selector || typeof source.onDragStart !== 'function') {
+        throw new TypeError('A drag source requires selector and onDragStart')
+      }
+      sources.push(source)
+      return () => {
+        const index = sources.indexOf(source)
+        if (index >= 0) sources.splice(index, 1)
+      }
+    },
+
+    registerDropZone(zone) {
+      if (!zone?.selector || !zone.accepts || typeof zone.onDrop !== 'function') {
+        throw new TypeError('A drop zone requires selector, accepts, and onDrop')
+      }
+      zones.push(zone)
+      return () => {
+        if (activeDrop?.zone === zone) {
+          clearPreview()
+          activeDrop = null
+        }
+        const index = zones.indexOf(zone)
+        if (index >= 0) zones.splice(index, 1)
+      }
+    },
+
+    destroy() {
+      liveRegistries.delete(registry)
+      handleDragEnd({ type: 'destroy' })
+      ownerDocument.removeEventListener('keydown', handleKeyDown)
+      if (root !== ownerDocument) ownerDocument.removeEventListener('dragend', handleDragEnd)
+      root.removeEventListener('dragstart', handleDragStart)
+      root.removeEventListener('dragend', handleDragEnd)
+      root.removeEventListener('dragover', handleDragOver)
+      root.removeEventListener('dragleave', handleDragLeave)
+      root.removeEventListener('drop', handleDrop)
+      sources.length = 0
+      zones.length = 0
+      activeSource = null
+      activeDrop = null
+    },
+  }
+  liveRegistries.add(registry)
+  return registry
+}

--- a/engines/collavre/app/services/collavre/creatives/workspace_tree_builder.rb
+++ b/engines/collavre/app/services/collavre/creatives/workspace_tree_builder.rb
@@ -39,18 +39,25 @@ module Collavre
 
         entries.map do |entry|
           creative = entry.fetch(:creative)
-          visible_children = acyclic_children(entry, children_by_parent.fetch(creative.id))
-          children = child_entries_by_parent.fetch(entry.object_id).map { next_child_node.next }
-          {
-            id: creative.id,
-            label: Collavre::HtmlText.label(creative.effective_description),
-            snippet: creative.creative_snippet,
-            can_comment: allowed?(creative, :feedback),
-            url: view_context.collavre.creatives_path(id: creative.id),
-            has_children: visible_children.any?,
-            children: children
-          }
+          node(
+            creative,
+            visible_children: acyclic_children(entry, children_by_parent.fetch(creative.id)),
+            children: child_entries_by_parent.fetch(entry.object_id).map { next_child_node.next }
+          )
         end
+      end
+
+      def node(creative, visible_children:, children:)
+        {
+          id: creative.id,
+          parent_id: creative.parent_id,
+          label: Collavre::HtmlText.label(creative.effective_description),
+          snippet: creative.creative_snippet,
+          can_comment: allowed?(creative, :feedback),
+          url: view_context.collavre.creatives_path(id: creative.id),
+          has_children: visible_children.any?,
+          children: children
+        }
       end
 
       def acyclic_children(entry, children)

--- a/engines/collavre/app/views/collavre/creatives/_workspace_tree.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/_workspace_tree.html.erb
@@ -7,7 +7,8 @@
          data-workspace-tree-current-path-value="<%= @workspace_path_ids.to_json %>"
          data-workspace-tree-loading-text-value="<%= t('app.loading') %>"
          data-workspace-tree-empty-text-value="<%= t('collavre.creatives.workspace.empty') %>"
-         data-workspace-tree-error-text-value="<%= t('collavre.creatives.workspace.load_error') %>">
+         data-workspace-tree-error-text-value="<%= t('collavre.creatives.workspace.load_error') %>"
+         data-workspace-tree-partial-failure-text-value="<%= t('collavre.creatives.drag_drop.partial_failure') %>">
   <%# Keep the stream source inside the tree region: as a direct child of the
       grid shell it would become a grid item with its own implicit row and
       push all three columns down. %>

--- a/engines/collavre/app/views/collavre/creatives/index.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/index.html.erb
@@ -42,6 +42,7 @@
      data-creatives--import-success-value="<%= t('collavre.creatives.index.import_success') %>"
      data-creatives--import-failed-value="<%= t('collavre.creatives.index.import_failed') %>"
      data-creatives--import-only-markdown-value="<%= t('collavre.creatives.index.only_markdown') %>"
+     data-creatives--drag-drop-partial-failure-text-value="<%= t('collavre.creatives.drag_drop.partial_failure') %>"
      data-creatives--import-dragover-class="dragover">
   <% current_creative = @parent_creative || @creative %>
   <% can_manage_integrations = current_creative&.has_permission?(Current.user, :admin) %>

--- a/engines/collavre/config/locales/creatives.en.yml
+++ b/engines/collavre/config/locales/creatives.en.yml
@@ -2,6 +2,8 @@
 en:
   collavre:
     creatives:
+      drag_drop:
+        partial_failure: Some links were created. Retry only the missing links.
       workspace:
         tree_title: Creative tree
         tree_label: Creative navigation tree

--- a/engines/collavre/config/locales/creatives.ko.yml
+++ b/engines/collavre/config/locales/creatives.ko.yml
@@ -2,6 +2,8 @@
 ko:
   collavre:
     creatives:
+      drag_drop:
+        partial_failure: 일부 링크만 생성되었습니다. 누락된 링크만 다시 시도해 주세요.
       workspace:
         tree_title: 크리에이티브 트리
         tree_label: 크리에이티브 탐색 트리

--- a/engines/collavre/test/controllers/creatives_controller_test.rb
+++ b/engines/collavre/test/controllers/creatives_controller_test.rb
@@ -302,6 +302,8 @@ class CreativesControllerTest < ActionDispatch::IntegrationTest
     assert_select "#creative-workspace-tree"
     assert_select "[data-controller='workspace-tree'][data-workspace-tree-last-visited-creative-visit-token-value]"
     assert_select "[data-controller='workspace-tree'][data-workspace-tree-last-visited-creative-visit-sequence-value]"
+    assert_select "[data-controller='workspace-tree'][data-workspace-tree-partial-failure-text-value=?]",
+      I18n.t("collavre.creatives.drag_drop.partial_failure")
     assert_select "[data-controller='last-visited-creative']", count: 0
     assert_select "turbo-frame#creative-workspace-content:not([target]) [data-workspace-navigation-state][data-creative-id='#{creative.id}']"
     assert_select "turbo-frame#creative-workspace-content [data-workspace-navigation-state][data-last-visited-creative-visit-token][data-last-visited-creative-visit-sequence]"
@@ -730,6 +732,14 @@ class CreativesControllerTest < ActionDispatch::IntegrationTest
     # later reloads, so the accessible name does not switch languages mid-session.
     assert_equal I18n.t("collavre.creatives.index.loading_creatives"),
       css_select("#creatives").first["data-creatives--tree-loading-text-value"]
+  end
+
+  test "index supplies localized drag and drop failure copy" do
+    get creatives_path(id: creatives(:childless_creative).id)
+
+    assert_response :success
+    assert_select "[data-creatives--drag-drop-partial-failure-text-value=?]",
+      I18n.t("collavre.creatives.drag_drop.partial_failure")
   end
 
   test "index renders an empty-state template outside the client-rendered tree" do

--- a/engines/collavre/test/services/creatives/workspace_tree_builder_test.rb
+++ b/engines/collavre/test/services/creatives/workspace_tree_builder_test.rb
@@ -38,6 +38,16 @@ module Creatives
       assert_empty nodes.first[:children]
     end
 
+    test "reports the real parent of a displayed top-level branch" do
+      parent = Creative.create!(user: @user, description: "Parent")
+      branch = Creative.create!(user: @user, parent: parent, description: "Displayed branch")
+
+      node = build_tree([ branch ]).first
+
+      assert_equal branch.id, node[:id]
+      assert_equal parent.id, node[:parent_id]
+    end
+
     test "keeps a childless root visible with its own metadata" do
       root_leaf = Creative.create!(user: @user, description: "<em>Root leaf</em>")
 

--- a/engines/collavre/test/support/html5_dnd_helpers.rb
+++ b/engines/collavre/test/support/html5_dnd_helpers.rb
@@ -120,14 +120,21 @@ module Html5DndHelpers
   # with the synchronous `execute_script` instead left `arguments[6]` undefined, so
   # every drag closed with an uncaught `reading 'call'` TypeError in the browser
   # console and Ruby resumed before the drop had even been dispatched.
-  def html5_drag_by_offset(source, target, x_offset, y_offset, step_delay: 500)
+  #
+  # `Capybara::Session` forwards `execute_script` and `evaluate_script` but has no
+  # `execute_async_script`, so the async form has to go through the driver's
+  # browser directly. Callers that need a variant of the script (a different entry
+  # point, say) must come through here rather than reaching for `page`.
+  def html5_drag_async(source, target, x_offset, y_offset, step_delay:, script: HTML5_DRAG_DROP_SCRIPT)
     browser = page.driver.browser
     # dragenter, dragover and dragleave are each a `setTimeout` apart, so the
     # callback cannot fire until three delays have elapsed.
     browser.manage.timeouts.script_timeout =
       (step_delay * 3 / 1000.0) + Capybara.default_max_wait_time
-    browser.execute_async_script(
-      HTML5_DRAG_DROP_SCRIPT, source.native, target.native, step_delay, [], x_offset, y_offset
-    )
+    browser.execute_async_script(script, source.native, target.native, step_delay, [], x_offset, y_offset)
+  end
+
+  def html5_drag_by_offset(source, target, x_offset, y_offset, step_delay: 500)
+    html5_drag_async(source, target, x_offset, y_offset, step_delay: step_delay)
   end
 end

--- a/engines/collavre/test/support/html5_dnd_helpers.rb
+++ b/engines/collavre/test/support/html5_dnd_helpers.rb
@@ -115,7 +115,19 @@ module Html5DndHelpers
       window.setTimeout(dragEnterTarget, step_delay);
     JS
 
-  def html5_drag_by_offset(source, target, x_offset, y_offset)
-    page.execute_script(HTML5_DRAG_DROP_SCRIPT, source.native, target.native, 500, [], x_offset, y_offset)
+  # Capybara runs its own copy of this script through `execute_async_script`, where
+  # Selenium appends the completion callback as the trailing argument. Driving it
+  # with the synchronous `execute_script` instead left `arguments[6]` undefined, so
+  # every drag closed with an uncaught `reading 'call'` TypeError in the browser
+  # console and Ruby resumed before the drop had even been dispatched.
+  def html5_drag_by_offset(source, target, x_offset, y_offset, step_delay: 500)
+    browser = page.driver.browser
+    # dragenter, dragover and dragleave are each a `setTimeout` apart, so the
+    # callback cannot fire until three delays have elapsed.
+    browser.manage.timeouts.script_timeout =
+      (step_delay * 3 / 1000.0) + Capybara.default_max_wait_time
+    browser.execute_async_script(
+      HTML5_DRAG_DROP_SCRIPT, source.native, target.native, step_delay, [], x_offset, y_offset
+    )
   end
 end

--- a/engines/collavre/test/system/workspace_tree_drag_drop_system_test.rb
+++ b/engines/collavre/test/system/workspace_tree_drag_drop_system_test.rb
@@ -1,0 +1,155 @@
+require_relative "../application_system_test_case"
+
+class WorkspaceTreeDragDropSystemTest < ApplicationSystemTestCase
+  setup do
+    @user = User.create!(
+      email: "workspace-drag-user@example.com",
+      password: SystemHelpers::PASSWORD,
+      name: "Workspace Drag User",
+      email_verified_at: Time.current,
+      notifications_enabled: false,
+      creative_workspace_enabled: true,
+    )
+    @left_root = Creative.create!(description: "Left root", user: @user, sequence: 0)
+    @left_child = Creative.create!(description: "Left child", user: @user, parent: @left_root)
+    @right_root = Creative.create!(description: "Right root", user: @user, sequence: 1)
+    @right_child = Creative.create!(description: "Right child", user: @user, parent: @right_root)
+
+    resize_window_to(1440, 900)
+    sign_in_via_ui(@user)
+  end
+
+  test "user can drag from the workspace tree into the creative tree" do
+    visit collavre.creatives_path(id: @right_root.id)
+    assert_workspace_and_center_rows(@left_root, @right_child)
+
+    html5_drag_by_offset(
+      find("#workspace-creative-#{@left_root.id}"),
+      find("#creative-#{@right_child.id}"),
+      0,
+      60,
+    )
+
+    assert_selector "#workspace-creative-#{@left_root.id}[data-parent-id='#{@right_root.id}']", wait: 10
+    assert_equal @right_root, @left_root.reload.parent
+  end
+
+  test "user can drag from the creative tree into the workspace tree" do
+    visit collavre.creatives_path(id: @left_root.id)
+    assert_workspace_and_center_rows(@right_root, @left_child)
+
+    # The workspace rows are compact, so the child band is only a few pixels
+    # tall — aim at the exact centre rather than an offset from it.
+    html5_drag_by_offset(
+      find("#creative-#{@left_child.id}"),
+      find("#workspace-creative-#{@right_root.id}"),
+      0,
+      0,
+    )
+
+    assert_selector "#workspace-creative-#{@left_child.id}[data-parent-id='#{@right_root.id}']", wait: 10
+    assert_equal @right_root, @left_child.reload.parent
+  end
+
+  test "user can drag between workspace tree rows" do
+    visit collavre.creatives_path(id: @left_root.id)
+    assert_workspace_and_center_rows(@right_root, @left_child)
+
+    html5_drag_by_offset(
+      find("#workspace-creative-#{@left_root.id}"),
+      find("#workspace-creative-#{@right_root.id}"),
+      0,
+      0,
+    )
+
+    assert_selector "#workspace-creative-#{@left_root.id}[data-parent-id='#{@right_root.id}']", wait: 10
+    assert_equal @right_root, @left_root.reload.parent
+  end
+
+  test "visible descendant drops are rejected before any network write" do
+    descendant = Creative.create!(description: "Visible descendant", user: @user, parent: @left_child)
+    Creative.create!(description: "Descendant leaf", user: @user, parent: descendant)
+    visit collavre.creatives_path(id: @left_root.id)
+    expand_workspace_branch(@left_root)
+    expand_workspace_branch(@left_child)
+    assert_workspace_and_center_rows(descendant, @left_child)
+    track_workspace_writes
+
+    drag_between_workspace_rows(@left_child, descendant)
+
+    assert_equal 0, page.evaluate_script("window.workspaceDndWriteRequests")
+    assert_workspace_placement(@left_child, @left_root)
+    assert_workspace_placement(descendant, @left_child)
+    assert_selector "creative-tree-row[creative-id='#{@left_child.id}'][parent-id='#{@left_root.id}']"
+    assert_equal @left_root.id, @left_child.reload.parent_id
+    assert_equal @left_child.id, descendant.reload.parent_id
+  end
+
+  test "a forbidden workspace drop preserves placement in both trees and the database" do
+    Creative.create!(description: "Source leaf", user: @user, parent: @left_child)
+    visit collavre.creatives_path(id: @left_root.id)
+    expand_workspace_branch(@left_root)
+    assert_workspace_and_center_rows(@right_root, @left_child)
+    before = Creative.where(user: @user).order(:id).pluck(:id, :parent_id, :sequence)
+    track_workspace_writes(reject: true)
+
+    drag_between_workspace_rows(@left_child, @right_root)
+
+    assert_selector "body[data-workspace-dnd-rejected='true']"
+    assert_equal 1, page.evaluate_script("window.workspaceDndWriteRequests")
+    assert_workspace_placement(@left_child, @left_root)
+    assert_selector "creative-tree-row[creative-id='#{@left_child.id}'][parent-id='#{@left_root.id}']"
+    assert_equal before, Creative.where(user: @user).order(:id).pluck(:id, :parent_id, :sequence)
+  end
+
+  private
+
+  def assert_workspace_and_center_rows(workspace_creative, center_creative)
+    assert_selector "#workspace-creative-#{workspace_creative.id}", wait: 10
+    assert_selector "#creative-#{center_creative.id}", wait: 10
+  end
+  def assert_workspace_placement(creative, parent)
+    assert_selector ".creative-workspace-tree-item[data-creative-id='#{creative.id}'][data-parent-id='#{parent.id}']"
+  end
+
+  def expand_workspace_branch(creative)
+    selector = "#workspace-creative-#{creative.id} > .creative-workspace-tree-branch-toggle"
+    assert_selector selector
+    toggle = find(selector)
+    toggle.click if toggle["aria-expanded"] == "false"
+  end
+
+  # Await the delayed events, and enter at the same center point as the drop so
+  # hysteresis cannot change a requested child drop into a sibling drop.
+  def drag_between_workspace_rows(source, target)
+    script = Html5DndHelpers::HTML5_DRAG_DROP_SCRIPT.sub(
+      "var entryPoint = pointOnRect(sourceCenter, targetRect)",
+      "var entryPoint = rectCenter(targetRect); entryPoint.x += x_offset; entryPoint.y += y_offset;"
+    )
+    page.execute_async_script(
+      script, find("#workspace-creative-#{source.id}").native,
+      find("#workspace-creative-#{target.id}").native, 150, [], 0, 0
+    )
+  end
+
+  def track_workspace_writes(reject: false)
+    page.execute_script(<<~JS, reject)
+      const reject = arguments[0];
+      const originalFetch = window.fetch.bind(window);
+      window.workspaceDndWriteRequests = 0;
+      window.fetch = function(input, options = {}) {
+        const url = new URL(typeof input === 'string' ? input : input.url, location.href);
+        if (!['/creatives/reorder', '/creatives/link_drop'].includes(url.pathname)) return originalFetch(input, options);
+        const method = (options.method || input.method || 'GET').toUpperCase();
+        if (['GET', 'HEAD', 'OPTIONS'].includes(method)) return originalFetch(input, options);
+        window.workspaceDndWriteRequests += 1;
+        if (!reject || url.pathname !== '/creatives/reorder') return originalFetch(input, options);
+        const response = new Response(JSON.stringify({ error: 'Forbidden' }), {
+          status: 403, headers: { 'Content-Type': 'application/json' }
+        });
+        setTimeout(() => { document.body.dataset.workspaceDndRejected = 'true'; }, 0);
+        return Promise.resolve(response);
+      };
+    JS
+  end
+end

--- a/engines/collavre/test/system/workspace_tree_drag_drop_system_test.rb
+++ b/engines/collavre/test/system/workspace_tree_drag_drop_system_test.rb
@@ -126,9 +126,13 @@ class WorkspaceTreeDragDropSystemTest < ApplicationSystemTestCase
       "var entryPoint = pointOnRect(sourceCenter, targetRect)",
       "var entryPoint = rectCenter(targetRect); entryPoint.x += x_offset; entryPoint.y += y_offset;"
     )
-    page.execute_async_script(
-      script, find("#workspace-creative-#{source.id}").native,
-      find("#workspace-creative-#{target.id}").native, 150, [], 0, 0
+    html5_drag_async(
+      find("#workspace-creative-#{source.id}"),
+      find("#workspace-creative-#{target.id}"),
+      0,
+      0,
+      step_delay: 150,
+      script: script,
     )
   end
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2198,9 +2198,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.15.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
-      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+      "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7606,9 +7606,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Dragging between the workspace and creative trees uses the T1 public data/session/hit-test contract and the T2 movement command. The workspace adapter refreshes server-confirmed placement while preserving expansion, focus and scroll; the creative adapter retains DOM recovery.

Includes delegated native inputs, stored drop intent, narrow-row hysteresis, 600ms lazy branch expansion with retry after failed loads, stale-response protection, known descendant rejection, complete cross-window bundle synchronization, and translated partial-link feedback. Touch, comment-source migration, bundles and movement menus are separate follow-up PRs.

Validation: the latest T3 hover fix passed 2,027 Jest tests, 15 related system tests / 106 assertions, build, RuboCop and complexity. The integrated candidate abccc65a passed 154 Jest suites / 2,172 tests and build. Its prior tree dd6d6d57 passed all 4,832 Rails tests / 16,867 assertions, 13 focused UI/helper regressions, RuboCop and complexity on Mac. Independent review checked all 18 prior review findings and passed 205 focused tests; all findings are addressed. Latest CI must pass before merge.

Targets feature/dnd-expansion after T1 and T2. Only a local single right-tree move is optimistic; workspace and bundle placements refresh after server success.