### PR TITLE
feat(dnd): bridge touch gestures to registered drop zones

### DIFF
--- a/engines/collavre/app/javascript/creatives/drag_drop/__tests__/creative_tree_drop.test.js
+++ b/engines/collavre/app/javascript/creatives/drag_drop/__tests__/creative_tree_drop.test.js
@@ -389,6 +389,38 @@ describe('right creative tree drop wiring', () => {
     }))
   })
 
+  test.each([
+    [['8', '9'], '9', 'creative-9'],
+    [['8'], '8', null],
+    [['9'], '9', 'creative-9'],
+  ])('pairs the source tree with its successful dragged row for %j', async (succeededIds, creativeId, treeId) => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
+    window.localStorage.setItem(DRAG_TOKEN_STORAGE_KEY, 'token-under-test')
+    resetDragSessionCache()
+    const setItem = jest.spyOn(Storage.prototype, 'setItem')
+    const completion = jest.fn()
+    window.addEventListener('collavre:creative-drop-complete', completion, { once: true })
+    runMoveWithDomRecovery.mockResolvedValue({
+      status: succeededIds.length === 2 ? 'success' : 'partial', ok: succeededIds.length === 2,
+      succeededIds, failedIds: ['8', '9'].filter(id => !succeededIds.includes(id)), failures: [],
+    })
+    const dataTransfer = transfer()
+    dataTransfer.setData('application/x-collavre-creative', JSON.stringify({
+      creativeId: '9', treeId: 'creative-9', selectedCreativeIds: ['8', '9'],
+      token: 'token-under-test', sourceWindowId: 'other-window',
+    }))
+
+    await handleDrop(dragEvent(tree('1'), dataTransfer))
+
+    expect(completion).toHaveBeenCalledWith(expect.objectContaining({
+      detail: expect.objectContaining({ creativeId, treeId, creativeIds: succeededIds }),
+    }))
+    const signal = setItem.mock.calls.find(([key]) => key === DROP_SIGNAL_STORAGE_KEY)
+    expect(JSON.parse(signal[1])).toEqual(expect.objectContaining({ creativeId, treeId, creativeIds: succeededIds }))
+    setItem.mockRestore()
+    consoleError.mockRestore()
+  })
+
   // A partial view can hand back an envelope whose tree id no longer resolves,
   // so the row identity — not the tree id — has to catch the self drop.
   test('declines an envelope that resolves back onto its own row', async () => {

--- a/engines/collavre/app/javascript/creatives/drag_drop/__tests__/source_window_bundle.test.js
+++ b/engines/collavre/app/javascript/creatives/drag_drop/__tests__/source_window_bundle.test.js
@@ -72,6 +72,25 @@ test.each([
   expect(load).not.toHaveBeenCalled()
 })
 
+test.each([
+  { creativeId: '8', creativeIds: ['7', '8'], treeId: 'creative-8', expected: ['9', '7', '8'] },
+  { creativeId: '7', creativeIds: ['7'], treeId: null, expected: ['8', '9', '7'] },
+])('completion preserves bundle rows while editing defers refresh: %j', detail => {
+  const draft = document.createElement('textarea')
+  draft.value = 'Unsaved target draft'
+  container.lastElementChild.appendChild(draft)
+  document.dispatchEvent(new Event('creative-editing:start'))
+  signal({ ...detail, direction: 'down', targetTreeId: 'creative-9', mode: 'move' })
+  jest.advanceTimersByTime(400)
+  expect(ids()).toEqual(detail.expected)
+  expect(draft.isConnected).toBe(true)
+  expect(draft.value).toBe('Unsaved target draft')
+  expect(load).not.toHaveBeenCalled()
+  document.dispatchEvent(new Event('creative-editing:stop'))
+  jest.advanceTimersByTime(400)
+  expect(load).toHaveBeenCalledTimes(1)
+})
+
 test('bundle children retain their order and parent metadata', () => {
   controller.beginReloadHold()
   signal({ creativeId: '7', creativeIds: [7, 8], treeId: 'creative-7', direction: 'child', targetTreeId: 'creative-9' })

--- a/engines/collavre/app/javascript/creatives/drag_drop/__tests__/touch_tree_integration.test.js
+++ b/engines/collavre/app/javascript/creatives/drag_drop/__tests__/touch_tree_integration.test.js
@@ -1,0 +1,189 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals'
+
+const sendNewOrder = jest.fn()
+jest.unstable_mockModule('../../../lib/api/drag_drop', () => ({
+  sendNewOrder,
+  sendLinkedCreative: jest.fn(),
+  sendTopicMove: jest.fn(),
+  isAuthenticationRedirect: () => false,
+}))
+jest.unstable_mockModule('../../../lib/utils/dialog', () => ({ alertDialog: jest.fn() }))
+const { createCreativeTreeDragDrop } = await import('../event_handlers')
+const { createWorkspaceTreeDragDrop } = await import('../workspace_tree_adapter')
+const { resetDragSessionCache } = await import('../../../lib/dnd/session')
+const { getDraggedState, resetDraggedState } = await import('../state')
+
+let right, left, execute, pointTarget
+const row = id => document.getElementById(id)
+const point = el => ({ clientX: 50, clientY: el.getBoundingClientRect().top + 50, target: el })
+function touch(type, source, target = source) {
+  pointTarget = target
+  source.dispatchEvent(new TouchEvent(type, { bubbles: true, cancelable: true,
+    touches: type === 'touchend' ? [] : [point(target)],
+    changedTouches: [point(target)],
+  }))
+}
+
+beforeEach(() => {
+  jest.useFakeTimers()
+  jest.spyOn(console, 'error').mockImplementation(() => {})
+  sendNewOrder.mockReset().mockResolvedValue({ ok: false, status: 403 })
+  localStorage.clear()
+  sessionStorage.clear()
+  resetDragSessionCache()
+  document.body.innerHTML = '<div id="creatives">' + ['1', '9'].map(id => `
+    <creative-tree-row creative-id="${id}" level="1">
+      <div class="creative-tree" id="creative-${id}" draggable="true"></div>
+    </creative-tree-row>`).join('') + '</div><nav><ul>' + ['2', '3'].map(id => `
+    <li class="creative-workspace-tree-item" data-creative-id="${id}" data-level="1">
+      <div id="workspace-${id}" class="creative-workspace-tree-row" data-creative-id="${id}" draggable="true"></div>
+    </li>`).join('') + '</ul></nav>'
+  document.querySelectorAll('[draggable]').forEach((el, index) => {
+    el.getBoundingClientRect = () => ({ left: 0, right: 100, top: index * 100,
+      bottom: index * 100 + 100, width: 100, height: 100 })
+  })
+  document.elementFromPoint = () => pointTarget
+  execute = jest.fn(async command => ({ status: 'success', succeededIds: command.ids }))
+  right = createCreativeTreeDragDrop()
+  left = createWorkspaceTreeDragDrop({ root: document.querySelector('nav'),
+    controller: { expandBranchForDrag: jest.fn() }, execute })
+})
+
+afterEach(() => {
+  right.destroy()
+  left.destroy()
+  resetDraggedState()
+  resetDragSessionCache()
+  document.body.innerHTML = ''
+  delete document.elementFromPoint
+  jest.restoreAllMocks()
+  jest.useRealTimers()
+})
+
+test.each([
+  ['creative-1', 'workspace-2', '1', '2'],
+  ['workspace-2', 'workspace-3', '2', '3'],
+])('touch %s → %s invokes the shared move exactly once', async (sourceId, targetId, id, target) => {
+  const source = row(sourceId)
+  touch('touchstart', source)
+  jest.advanceTimersByTime(400)
+  touch('touchmove', source, row(targetId))
+  touch('touchend', source, row(targetId))
+  await Promise.resolve()
+  expect(execute).toHaveBeenCalledTimes(1)
+  expect(execute).toHaveBeenCalledWith({ ids: [id], targetId: target, direction: 'child', mode: 'move' })
+  expect(getDraggedState()).toBeNull()
+  expect(document.querySelector('.touch-drag-proxy')).toBeNull()
+})
+
+test.each(['workspace-2', 'creative-1'])('touch %s → right tree keeps command and failure recovery', async sourceId => {
+  const source = row(sourceId)
+  touch('touchstart', source)
+  jest.advanceTimersByTime(400)
+  touch('touchmove', source, row('creative-9'))
+  touch('touchend', source, row('creative-9'))
+  for (let i = 0; i < 10; i += 1) await Promise.resolve()
+  expect(sendNewOrder).toHaveBeenCalledTimes(1)
+  expect(sendNewOrder).toHaveBeenCalledWith({ draggedId: sourceId === 'workspace-2' ? '2' : '1',
+    targetId: '9', direction: 'child' })
+  expect(row('creative-1').closest('creative-tree-row').parentElement.id).toBe('creatives')
+  expect(getDraggedState()).toBeNull()
+  expect(document.querySelector('.drag-over')).toBeNull()
+})
+
+function native(type, source, transfer, target = source) {
+  const event = new Event(type, { bubbles: true, cancelable: true })
+  Object.defineProperties(event, {
+    dataTransfer: { value: transfer },
+    clientX: { value: point(target).clientX },
+    clientY: { value: point(target).clientY },
+  })
+  target.dispatchEvent(event)
+  return event
+}
+
+function emptyTransfer() {
+  return { types: [], getData: () => '', setData: jest.fn(), effectAllowed: 'none' }
+}
+
+function blockStorage() {
+  jest.spyOn(Storage.prototype, 'getItem').mockImplementation(() => { throw new Error('Storage blocked') })
+  jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => { throw new Error('Storage blocked') })
+}
+
+test.each(['native', 'touch'])('%s preserves all local tree routes when storage is blocked', async mode => {
+  blockStorage()
+  for (const [sourceId, targetId, id] of [
+    ['workspace-2', 'workspace-3', '2'],
+    ['workspace-2', 'creative-9', '2'],
+    ['creative-1', 'workspace-3', '1'],
+  ]) {
+    const source = row(sourceId)
+    const target = row(targetId)
+    const transfer = emptyTransfer()
+    execute.mockClear()
+    sendNewOrder.mockClear()
+    if (mode === 'native') {
+      native('dragstart', source, transfer)
+      expect(native('dragover', source, transfer, target).defaultPrevented).toBe(true)
+      native('drop', source, transfer, target)
+    } else {
+      touch('touchstart', source)
+      jest.advanceTimersByTime(400)
+      touch('touchmove', source, target)
+      touch('touchend', source, target)
+    }
+    for (let i = 0; i < 10; i += 1) await Promise.resolve()
+    if (targetId === 'creative-9') {
+      expect(sendNewOrder).toHaveBeenCalledWith({ draggedId: id, targetId: '9', direction: 'child' })
+    } else {
+      expect(execute).toHaveBeenCalledWith({ ids: [id], targetId: '3', direction: 'child', mode: 'move' })
+    }
+    execute.mockClear()
+    sendNewOrder.mockClear()
+    native('drop', source, emptyTransfer(), target)
+    expect(execute).not.toHaveBeenCalled()
+    expect(sendNewOrder).not.toHaveBeenCalled()
+    expect(document.querySelector('.is-dragging')).toBeNull()
+  }
+})
+
+test.each(['dragend', 'escape', 'destroy'])('%s clears the workspace gesture fallback', action => {
+  blockStorage()
+  const source = row('workspace-2')
+  const transfer = emptyTransfer()
+  native('dragstart', source, transfer)
+  if (action === 'dragend') native('dragend', source, transfer)
+  if (action === 'escape') document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+  if (action === 'destroy') left.destroy()
+  native('drop', source, transfer, row('creative-9'))
+  expect(sendNewOrder).not.toHaveBeenCalled()
+  expect(document.querySelector('.is-dragging')).toBeNull()
+})
+
+test('local fallback cannot authorize a rejected foreign transfer', () => {
+  blockStorage()
+  const source = row('workspace-2')
+  native('dragstart', source, emptyTransfer())
+  const foreign = { types: ['application/x-collavre-creative'], getData: () => JSON.stringify({
+    creativeId: '99', treeId: 'foreign-99', token: 'foreign', sourceWindowId: 'foreign',
+  }) }
+  native('drop', source, foreign, row('creative-9'))
+  expect(sendNewOrder).not.toHaveBeenCalled()
+  expect(execute).not.toHaveBeenCalled()
+})
+
+test('touch cancellation clears the workspace fallback before another drop', () => {
+  blockStorage()
+  const source = row('workspace-2')
+  touch('touchstart', source)
+  jest.advanceTimersByTime(400)
+  touch('touchmove', source, row('workspace-3'))
+  touch('touchcancel', source)
+  native('drop', source, emptyTransfer(), row('creative-9'))
+  expect(sendNewOrder).not.toHaveBeenCalled()
+  expect(execute).not.toHaveBeenCalled()
+  expect(document.querySelector('.touch-drag-proxy')).toBeNull()
+  expect(document.querySelector('.is-dragging')).toBeNull()
+})

--- a/engines/collavre/app/javascript/creatives/drag_drop/__tests__/workspace_tree_adapter.test.js
+++ b/engines/collavre/app/javascript/creatives/drag_drop/__tests__/workspace_tree_adapter.test.js
@@ -354,6 +354,37 @@ describe('workspace tree drag and drop adapter', () => {
     setItem.mockRestore()
   })
 
+  test.each([
+    [['8', '9'], '9', 'creative-9'],
+    [['8'], '8', null],
+    [['9'], '9', 'creative-9'],
+  ])('preserves the originating row/tree pair for successful IDs %j', async (succeededIds, creativeId, treeId) => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
+    const completion = jest.fn()
+    window.addEventListener('collavre:creative-drop-complete', completion, { once: true })
+    const setItem = jest.spyOn(Storage.prototype, 'setItem')
+    execute.mockResolvedValue({
+      status: succeededIds.length === 2 ? 'success' : 'partial', succeededIds,
+      failedIds: ['8', '9'].filter(id => !succeededIds.includes(id)), failures: [],
+    })
+    const transfer = dataTransfer()
+    writeDragData(transfer, {
+      kind: 'creative', ids: ['8', '9'],
+      payload: { creativeId: '9', treeId: 'creative-9', sourceWindowId: 'right-window' },
+    })
+    const target = document.getElementById('workspace-creative-2')
+    event('dragover', target, transfer)
+    event('drop', target, transfer)
+    await flush()
+    expect(completion).toHaveBeenCalledWith(expect.objectContaining({
+      detail: expect.objectContaining({ creativeId, treeId, creativeIds: succeededIds }),
+    }))
+    const signal = setItem.mock.calls.find(([key]) => key === 'collavre.dragDropSignal')
+    expect(JSON.parse(signal[1])).toEqual(expect.objectContaining({ creativeId, treeId, creativeIds: succeededIds }))
+    setItem.mockRestore()
+    consoleError.mockRestore()
+  })
+
   // The dialog copy comes from the server and is covered by move_feedback's own
   // suite; here only the hand-off from the adapter matters.
   test('surfaces the rows a partial move left behind', async () => {

--- a/engines/collavre/app/javascript/creatives/drag_drop/event_handlers.js
+++ b/engines/collavre/app/javascript/creatives/drag_drop/event_handlers.js
@@ -643,6 +643,7 @@ export function handleDrop(event, intent = null, { partialFailureMessage = '', d
   }
 
   const dropSignalDetails = {
+    creativeId: String(draggedState.creativeId),
     treeId: draggedState.treeId,
     sourceWindowId: draggedState.sourceWindowId,
     targetTreeId: targetId,
@@ -662,9 +663,13 @@ export function handleDrop(event, intent = null, { partialFailureMessage = '', d
       console.error('Creative move did not fully complete', result);
     }
     if (result.succeededIds.length === 0) return result;
+    // The source tree identifies the dragged row even when the bundle starts
+    // with another ID. Never attach it to a different successful row.
+    const sourceSucceeded = result.succeededIds.includes(dropSignalDetails.creativeId);
     const detail = {
       ...dropSignalDetails,
-      creativeId: result.succeededIds[0],
+      creativeId: sourceSucceeded ? dropSignalDetails.creativeId : result.succeededIds[0],
+      treeId: sourceSucceeded ? dropSignalDetails.treeId : null,
       creativeIds: result.succeededIds,
     };
     if (mode === 'move' && detail.sourceWindowId) emitDropSignal(detail);

--- a/engines/collavre/app/javascript/creatives/drag_drop/event_handlers.js
+++ b/engines/collavre/app/javascript/creatives/drag_drop/event_handlers.js
@@ -410,7 +410,7 @@ export function handleDragStart(event) {
   });
 }
 
-export function handleDragOver(event, intent = null) {
+export function handleDragOver(event, intent = null, kind = null) {
   const tree = event.target.closest(DRAGGABLE_SELECTOR);
   const lastRow = getLastDragOverRow();
   if (lastRow && lastRow !== tree) {
@@ -420,7 +420,7 @@ export function handleDragOver(event, intent = null) {
   }
   if (!tree || tree.draggable === false) return;
 
-  const dragKind = getDragKind(event.dataTransfer);
+  const dragKind = kind || getDragKind(event.dataTransfer);
 
   // Topic move drag: always show as child drop target
   if (dragKind === 'topic') {
@@ -479,13 +479,12 @@ function resetDrag() {
   hideLinkHover();
 }
 
-export function handleDrop(event, intent = null, { partialFailureMessage = '' } = {}) {
+export function handleDrop(event, intent = null, { partialFailureMessage = '', dragData = readDragData(event.dataTransfer) } = {}) {
   clearHoverExpand();
   const targetTree = event.target.closest(DRAGGABLE_SELECTOR);
   const targetId = targetTree ? targetTree.id : '';
 
   // Handle topic move drop
-  const dragData = readDragData(event.dataTransfer);
   if (dragData?.kind === 'topic' && targetTree) {
     event.preventDefault();
     clearDragHighlight(targetTree);
@@ -742,7 +741,11 @@ export function createCreativeTreeDragDrop({ partialFailureMessage = '' } = {}) 
   });
   registry.registerDragSource({
     selector: DRAGGABLE_SELECTOR,
-    onDragStart: ({ event }) => handleDragStart(event),
+    onDragStart: ({ event, setLocalData }) => {
+      handleDragStart(event);
+      const data = localData(event.dataTransfer);
+      if (data) setLocalData(data);
+    },
     onDragEnd: () => {
       clearDragHighlight(getLastDragOverRow());
       resetDrag();
@@ -760,8 +763,8 @@ export function createCreativeTreeDragDrop({ partialFailureMessage = '' } = {}) 
         previousPosition: previousHit,
       });
     },
-    preview: ({ event, hit }) => {
-      handleDragOver(event, hit);
+    preview: ({ event, hit, kind }) => {
+      handleDragOver(event, hit, kind);
       return () => handleDragLeave(event);
     },
     dropEffect: ({ event, kind }) => {
@@ -770,7 +773,9 @@ export function createCreativeTreeDragDrop({ partialFailureMessage = '' } = {}) 
       else hideLinkHover();
       return event.shiftKey ? 'copy' : 'move';
     },
-    onDrop: ({ event, hit }) => handleDrop(event, hit, { partialFailureMessage }),
+    onDrop: ({ event, hit, kind, ids, payload }) => handleDrop(event, hit, {
+      partialFailureMessage, dragData: { kind, ids, payload },
+    }),
   });
   return registry;
 }

--- a/engines/collavre/app/javascript/creatives/drag_drop/workspace_tree_adapter.js
+++ b/engines/collavre/app/javascript/creatives/drag_drop/workspace_tree_adapter.js
@@ -31,16 +31,17 @@ function creativePayload(item, row) {
   }
 }
 
-function startWorkspaceDrag({ el: row, event }) {
+function startWorkspaceDrag({ el: row, event, setLocalData }) {
   const item = workspaceItemFromRow(row)
-  if (!item || !event.dataTransfer) return
+  if (!item || !event.dataTransfer) return false
 
   const payload = creativePayload(item, row)
-  writeDragData(event.dataTransfer, {
+  const data = {
     kind: 'creative',
     ids: [payload.creativeId],
     payload,
-  })
+  }
+  if (!writeDragData(event.dataTransfer, data)) setLocalData(data)
   event.dataTransfer.effectAllowed = 'copyMove'
   row.classList.add('is-dragging')
 }

--- a/engines/collavre/app/javascript/creatives/drag_drop/workspace_tree_adapter.js
+++ b/engines/collavre/app/javascript/creatives/drag_drop/workspace_tree_adapter.js
@@ -77,11 +77,12 @@ function previewWorkspaceRow(controller, expandDelay, { el: row, hit }) {
 }
 
 function completionDetail(ids, payload, targetId, direction) {
+  const sourceSucceeded = ids.includes(String(payload.creativeId))
   return {
-    creativeId: ids[0],
+    creativeId: sourceSucceeded ? String(payload.creativeId) : ids[0],
     creativeIds: ids,
-    // The shared reader rejects a creative envelope with no originating tree.
-    treeId: payload.treeId,
+    // The originating tree belongs to the dragged row, not the first bundle ID.
+    treeId: sourceSucceeded ? payload.treeId : null,
     sourceWindowId: payload.sourceWindowId || null,
     targetCreativeId: targetId,
     direction,

--- a/engines/collavre/app/javascript/lib/__tests__/touch_drag_targets.test.js
+++ b/engines/collavre/app/javascript/lib/__tests__/touch_drag_targets.test.js
@@ -1,0 +1,247 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals'
+import TouchDragHandler from '../touch_drag'
+
+let handler, container, onDrop, onCancel, onTargetChange
+const rect = (top = 0) => ({ left: 0, right: 200, top, bottom: top + 100, width: 200, height: 100 })
+function target(top = 0) {
+  const el = document.createElement('div')
+  el.className = 'drop-target'
+  el.getBoundingClientRect = () => rect(top)
+  document.body.appendChild(el)
+  return el
+}
+function touch(type, x = 50, y = 50) {
+  const event = new TouchEvent(type, { bubbles: true, cancelable: true })
+  Object.defineProperty(event, 'touches', { value: type === 'touchend' || type === 'touchcancel'
+    ? [] : [{ clientX: x, clientY: y, target: container }] })
+  container.dispatchEvent(event)
+  return event
+}
+function start(x = 50, y = 50) {
+  touch('touchstart', x, y)
+  jest.advanceTimersByTime(400)
+}
+function setup(options = {}) {
+  handler = new TouchDragHandler({ container, singleElement: true, dropTargetSelector: '.drop-target',
+    onDrop, onCancel, onTargetChange, ...options })
+}
+beforeEach(() => {
+  jest.useFakeTimers()
+  container = document.createElement('div')
+  container.getBoundingClientRect = () => rect()
+  document.body.appendChild(container)
+  onDrop = jest.fn()
+  onCancel = jest.fn()
+  onTargetChange = jest.fn()
+})
+afterEach(() => {
+  handler?.destroy()
+  document.body.innerHTML = ''
+  jest.useRealTimers()
+})
+
+test('reports hit changes inside one target and delivers position at drop', () => {
+  const el = target()
+  const hitTest = jest.fn((target, point) => point.clientY < 30 ? 'up' : 'child')
+  setup({ hitTest })
+  start(50, 20)
+  touch('touchmove', 50, 60)
+  expect(hitTest).toHaveBeenLastCalledWith(el, { clientX: 50, clientY: 60 }, 'up')
+  expect(onTargetChange).toHaveBeenLastCalledWith(el, { clientX: 50, clientY: 60, hit: 'child' })
+  touch('touchend')
+  expect(onDrop).toHaveBeenCalledWith(el, { clientX: 50, clientY: 60, hit: 'child' })
+  expect(el.classList.contains('drag-over')).toBe(false)
+})
+
+test('refresh discovers expanded targets and forgets removed targets without finger movement', () => {
+  setup()
+  start()
+  const added = target()
+  handler.refreshDropTargets()
+  expect(added.classList.contains('drag-over')).toBe(true)
+  added.remove()
+  handler.refreshDropTargets()
+  touch('touchend')
+  expect(onDrop).not.toHaveBeenCalled()
+  expect(onCancel).toHaveBeenCalledTimes(1)
+})
+
+test('rejects hidden and disallowed targets, resolving fresh candidate lists', () => {
+  const hidden = target()
+  hidden.getBoundingClientRect = () => ({ ...rect(), width: 0 })
+  const rejected = target()
+  const accepted = target()
+  const getDropTargets = jest.fn(() => [hidden, rejected, accepted])
+  setup({ getDropTargets, hitTest: el => el === rejected ? null : 'down' })
+  start()
+  touch('touchend')
+  expect(onDrop).toHaveBeenCalledWith(accepted, expect.objectContaining({ hit: 'down' }))
+})
+
+test('touchcancel never commits a drop or triggers a pending tap', () => {
+  target()
+  const onTap = jest.fn()
+  setup({ onTap })
+  touch('touchstart')
+  touch('touchcancel')
+  expect(onTap).not.toHaveBeenCalled()
+  start()
+  touch('touchcancel')
+  expect(onDrop).not.toHaveBeenCalled()
+  expect(onCancel).toHaveBeenCalledTimes(1)
+  expect(document.querySelector('.touch-drag-proxy')).toBeNull()
+})
+
+test('autoscroll continues while stationary and stops on cancellation', () => {
+  const el = target()
+  const scrollContainer = jest.fn(() => container)
+  setup({ autoScroll: true, scrollContainer })
+  start(50, 95)
+  jest.advanceTimersByTime(48)
+  expect(container.scrollTop).toBeGreaterThan(0)
+  expect(scrollContainer).toHaveBeenCalledWith({ clientX: 50, clientY: 95 }, el)
+  touch('touchcancel')
+  const stopped = container.scrollTop
+  jest.advanceTimersByTime(100)
+  expect(container.scrollTop).toBe(stopped)
+  expect(jest.getTimerCount()).toBe(0)
+})
+
+test('autoscroll moves up near the top, stays still at the center and outside the pane', () => {
+  setup({ autoScroll: true })
+  container.scrollTop = 200
+  start(50, 5)
+  jest.advanceTimersByTime(32)
+  expect(container.scrollTop).toBeLessThan(200)
+  touch('touchmove', 50, 50)
+  const centered = container.scrollTop
+  jest.advanceTimersByTime(32)
+  expect(container.scrollTop).toBe(centered)
+  touch('touchmove', 250, 95)
+  jest.advanceTimersByTime(32)
+  expect(container.scrollTop).toBe(centered)
+})
+
+test('destroy clears active highlights, proxy and animation frames', () => {
+  const el = target()
+  setup({ autoScroll: true })
+  start()
+  handler.destroy()
+  expect(el.classList.contains('drag-over')).toBe(false)
+  expect(document.querySelector('.touch-drag-proxy')).toBeNull()
+  expect(jest.getTimerCount()).toBe(0)
+})
+
+test('legacy selected-item sources still reject controls and collect selected items', () => {
+  container.innerHTML = '<div class="selected"><button>Action</button><span>Item</span></div><div class="unselected"></div>'
+  const onDragStart = jest.fn()
+  setup({ singleElement: false, itemSelector: '.selected', onDragStart })
+  const startAt = element => {
+    const event = new TouchEvent('touchstart', { bubbles: true, cancelable: true,
+      touches: [{ target: element, clientX: 50, clientY: 50 }] })
+    element.dispatchEvent(event)
+    return event
+  }
+  expect(startAt(container.querySelector('button')).defaultPrevented).toBe(false)
+  expect(startAt(container.querySelector('.unselected')).defaultPrevented).toBe(false)
+  const span = container.querySelector('span')
+  expect(startAt(span).defaultPrevented).toBe(true)
+  jest.advanceTimersByTime(400)
+  expect(onDragStart.mock.calls[0][0]).toHaveLength(1)
+  const context = new Event('contextmenu', { cancelable: true })
+  document.dispatchEvent(context)
+  expect(context.defaultPrevented).toBe(true)
+  touch('touchcancel')
+})
+
+test.each([[75, 50], [50, 75]])('movement beyond tolerance cancels long press at %s/%s without a tap', (x, y) => {
+  const onTap = jest.fn()
+  setup({ onTap })
+  touch('touchstart')
+  expect(touch('touchmove', 52, 52).defaultPrevented).toBe(true)
+  expect(touch('touchmove', x, y).defaultPrevented).toBe(false)
+  jest.advanceTimersByTime(400)
+  touch('touchmove', x + 10, y + 10)
+  touch('touchend')
+  expect(onTap).not.toHaveBeenCalled()
+  expect(document.querySelector('.touch-drag-proxy')).toBeNull()
+})
+
+test('a selected item disappearing during the delay does not begin a drag', () => {
+  container.innerHTML = '<span class="selected"></span>'
+  setup({ singleElement: false, itemSelector: '.selected' })
+  const item = container.firstElementChild
+  item.dispatchEvent(new TouchEvent('touchstart', { bubbles: true, cancelable: true,
+    touches: [{ target: item, clientX: 50, clientY: 50 }] }))
+  item.className = ''
+  jest.advanceTimersByTime(400)
+  expect(document.querySelector('.touch-drag-proxy')).toBeNull()
+})
+
+test('empty touch notifications and repeated starts do not create another gesture', () => {
+  const onDragStart = jest.fn()
+  setup({ onDragStart })
+  container.dispatchEvent(new TouchEvent('touchstart', { bubbles: true }))
+  container.dispatchEvent(new TouchEvent('touchmove', { bubbles: true }))
+  expect(jest.getTimerCount()).toBe(0)
+  start()
+  touch('touchstart')
+  expect(onDragStart).toHaveBeenCalledTimes(1)
+})
+
+test('viewport autoscroll uses the window edges and provides optional haptic feedback', () => {
+  Object.defineProperty(document, 'scrollingElement', { configurable: true, value: document.documentElement })
+  navigator.vibrate = jest.fn()
+  try {
+    setup({ autoScroll: true, scrollContainer: document.documentElement })
+    start(50, window.innerHeight - 5)
+    jest.advanceTimersByTime(32)
+    expect(document.documentElement.scrollTop).toBeGreaterThan(0)
+    expect(navigator.vibrate).toHaveBeenCalledWith(30)
+    touch('touchcancel')
+    handler.refreshDropTargets()
+  } finally {
+    delete document.scrollingElement
+    delete navigator.vibrate
+  }
+})
+
+test('a queued animation callback cannot restart scrolling after cancellation', () => {
+  let callback
+  const schedule = jest.spyOn(window, 'requestAnimationFrame').mockImplementation(fn => { callback = fn; return 7 })
+  setup({ autoScroll: true })
+  start()
+  handler.cancel()
+  callback()
+  expect(schedule).toHaveBeenCalledTimes(1)
+  expect(document.querySelector('.touch-drag-proxy')).toBeNull()
+  schedule.mockRestore()
+})
+
+test('default selected-item mode keeps native menus after cancellation and can start again', () => {
+  container.innerHTML = '<span class="selected">One</span><span class="selected">Two</span>'
+  const item = container.firstElementChild
+  const onDragStart = jest.fn()
+  setup({ singleElement: undefined, itemSelector: '.selected', onDragStart })
+  const begin = () => {
+    item.dispatchEvent(new TouchEvent('touchstart', { bubbles: true, cancelable: true,
+      touches: [{ target: item, clientX: 50, clientY: 50 }] }))
+    jest.advanceTimersByTime(400)
+  }
+  begin()
+  expect(Array.from(onDragStart.mock.calls[0][0])).toEqual(Array.from(container.children))
+  expect(document.querySelector('.touch-drag-proxy').textContent).toBe('2')
+  const activeMenu = new Event('contextmenu', { cancelable: true })
+  document.dispatchEvent(activeMenu)
+  expect(activeMenu.defaultPrevented).toBe(true)
+
+  handler.cancel()
+  const nativeMenu = new Event('contextmenu', { cancelable: true })
+  document.dispatchEvent(nativeMenu)
+  expect(nativeMenu.defaultPrevented).toBe(false)
+  expect(document.querySelector('.touch-drag-proxy')).toBeNull()
+  begin()
+  expect(onDragStart).toHaveBeenCalledTimes(2)
+  expect(document.querySelectorAll('.touch-drag-proxy')).toHaveLength(1)
+})

--- a/engines/collavre/app/javascript/lib/dnd/__tests__/registry.test.js
+++ b/engines/collavre/app/javascript/lib/dnd/__tests__/registry.test.js
@@ -746,3 +746,52 @@ describe('createDragDropRegistry', () => {
   })
 
 })
+
+test('gesture fallback remains document-local and is cleared by source removal', () => {
+  document.body.innerHTML = '<div class="source"></div><div class="zone"></div>'
+  const foreignDocument = document.implementation.createHTMLDocument('foreign')
+  foreignDocument.body.innerHTML = '<div class="zone"></div>'
+  const sourceRegistry = createDragDropRegistry({ root: document, touch: false })
+  const foreignRegistry = createDragDropRegistry({ root: foreignDocument, touch: false })
+  const onDrop = jest.fn()
+  const data = { kind: 'creative', ids: ['1'], payload: { creativeId: '1', treeId: 'tree-1' } }
+  const unregister = sourceRegistry.registerDragSource({ selector: '.source',
+    onDragStart: ({ setLocalData }) => setLocalData(data) })
+  foreignRegistry.registerDropZone({ selector: '.zone', accepts: 'creative', onDrop })
+  try {
+    const transfer = { types: [], getData: () => '' }
+    const source = document.querySelector('.source')
+    source.dispatchEvent(dragEvent('dragstart', source, transfer))
+    expect(sourceRegistry.gestureData(document)).toEqual(data)
+    expect(sourceRegistry.gestureData(foreignDocument)).toBeNull()
+    const target = foreignDocument.querySelector('.zone')
+    target.dispatchEvent(dragEvent('drop', target, transfer))
+    expect(onDrop).not.toHaveBeenCalled()
+    unregister()
+    expect(sourceRegistry.gestureData(document)).toBeUndefined()
+  } finally {
+    foreignRegistry.destroy()
+    sourceRegistry.destroy()
+  }
+})
+
+test('touch cancels a source that provides neither serialized nor local data', () => {
+  jest.useFakeTimers()
+  document.body.innerHTML = '<div class="source"></div>'
+  const registry = createDragDropRegistry()
+  registry.registerDragSource({ selector: '.source', onDragStart: () => {} })
+  try {
+    const source = document.querySelector('.source')
+    const point = { target: source, clientX: 10, clientY: 10 }
+    source.dispatchEvent(new TouchEvent('touchstart', { bubbles: true, cancelable: true,
+      touches: [point], changedTouches: [point] }))
+    jest.advanceTimersByTime(400)
+    expect(registry.gestureData(document)).toBeUndefined()
+    expect(document.querySelector('.touch-drag-proxy')).toBeNull()
+    source.dispatchEvent(dragEvent('dragover', source, null))
+    source.dispatchEvent(dragEvent('dragover', source, {}))
+  } finally {
+    registry.destroy()
+    jest.useRealTimers()
+  }
+})

--- a/engines/collavre/app/javascript/lib/dnd/__tests__/touch_bridge.test.js
+++ b/engines/collavre/app/javascript/lib/dnd/__tests__/touch_bridge.test.js
@@ -1,0 +1,508 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals'
+import { createDragDropRegistry } from '../registry'
+import { createTouchBridge } from '../touch_bridge'
+
+let registry, bridge, source, zone, drops, previews
+function touch(type, y = 50, target = source) {
+  const event = new TouchEvent(type, { bubbles: true, cancelable: true })
+  Object.defineProperty(event, 'touches', { value: type === 'touchend' || type === 'touchcancel' ? []
+    : [{ clientX: 50, clientY: y, target }] })
+  target.dispatchEvent(event)
+  return event
+}
+function makeZone() {
+  const el = document.createElement('div')
+  el.className = 'zone'
+  el.getBoundingClientRect = () => ({ top: 0, left: 0, right: 100, bottom: 100, width: 100, height: 100 })
+  document.body.appendChild(el)
+  return el
+}
+beforeEach(() => {
+  jest.useFakeTimers()
+  source = document.createElement('div')
+  source.className = 'source'
+  document.body.appendChild(source)
+  zone = makeZone()
+  drops = jest.fn()
+  previews = jest.fn(() => jest.fn())
+  registry = createDragDropRegistry({ root: document, touch: false, getKind: dt => dt.types.includes('test') ? 'creative' : null,
+    readData: dt => JSON.parse(dt.getData('test')) })
+  registry.registerDragSource({ selector: '.source', onDragStart: ({ event }) => {
+    event.dataTransfer.setData('test', JSON.stringify({ kind: 'creative', ids: ['1'] }))
+  } })
+  registry.registerDropZone({ selector: '.zone', accepts: ['creative'],
+    hitTest: ({ event }) => event.clientY < 30 ? 'up' : event.clientY > 70 ? 'down' : 'child',
+    preview: previews, onDrop: drops })
+  bridge = createTouchBridge({ root: document, registry })
+})
+afterEach(() => {
+  bridge.destroy()
+  registry.destroy()
+  document.body.innerHTML = ''
+  jest.useRealTimers()
+  delete document.elementFromPoint
+})
+
+test.each([[10, 'up'], [50, 'child'], [90, 'down']])('touch uses shared directional hit at %s', async (y, hit) => {
+  touch('touchstart', y)
+  jest.advanceTimersByTime(400)
+  touch('touchend')
+  await Promise.resolve()
+  expect(drops).toHaveBeenCalledWith(expect.objectContaining({ kind: 'creative', ids: ['1'], hit, el: zone }))
+  expect(previews).toHaveBeenCalledWith(expect.objectContaining({ hit }))
+})
+
+test('ordinary touches are untouched and can scroll', () => {
+  const event = touch('touchstart', 50, zone)
+  expect(event.defaultPrevented).toBe(false)
+  jest.advanceTimersByTime(500)
+  expect(document.querySelector('.touch-drag-proxy')).toBeNull()
+})
+
+test('expansion replaces targets while the finger is stationary', () => {
+  touch('touchstart')
+  jest.advanceTimersByTime(400)
+  zone.remove()
+  const expanded = makeZone()
+  bridge.refreshDropTargets()
+  touch('touchend')
+  expect(drops).toHaveBeenCalledWith(expect.objectContaining({ el: expanded }))
+})
+
+test('cancellation and destruction clear preview, proxy and timers without drop', () => {
+  touch('touchstart')
+  jest.advanceTimersByTime(400)
+  touch('touchcancel')
+  expect(drops).not.toHaveBeenCalled()
+  expect(previews.mock.results[0].value).toHaveBeenCalled()
+  touch('touchstart')
+  jest.advanceTimersByTime(400)
+  bridge.destroy()
+  expect(document.querySelector('.touch-drag-proxy')).toBeNull()
+  expect(jest.getTimerCount()).toBe(0)
+})
+
+test('a target registered in another controller receives the same drop', () => {
+  zone.remove()
+  const pane = document.createElement('section')
+  document.body.appendChild(pane)
+  const external = makeZone()
+  external.className = 'external'
+  pane.appendChild(external)
+  const onDrop = jest.fn()
+  const otherRegistry = createDragDropRegistry({ root: pane, touch: false,
+    getKind: dt => dt.types.includes('test') ? 'creative' : null,
+    readData: dt => JSON.parse(dt.getData('test')) })
+  otherRegistry.registerDropZone({ selector: '.external', accepts: ['creative'], onDrop })
+  try {
+    touch('touchstart')
+    jest.advanceTimersByTime(400)
+    touch('touchend')
+    expect(onDrop).toHaveBeenCalledWith(expect.objectContaining({ ids: ['1'], el: external }))
+  } finally {
+    otherRegistry.destroy()
+  }
+})
+
+test('a source rejecting dragstart does not leave a proxy or timer', () => {
+  source.className = 'rejected'
+  registry.registerDragSource({ selector: '.rejected', onDragStart: ({ event }) => {
+    event.preventDefault()
+    return false
+  } })
+  touch('touchstart')
+  jest.advanceTimersByTime(400)
+  expect(document.querySelector('.touch-drag-proxy')).toBeNull()
+  expect(jest.getTimerCount()).toBe(0)
+  expect(drops).not.toHaveBeenCalled()
+})
+
+test('edge scrolling resolves the destination pane while the finger stays still', () => {
+  const pane = document.createElement('section')
+  pane.style.overflowY = 'auto'
+  pane.getBoundingClientRect = zone.getBoundingClientRect
+  Object.defineProperties(pane, { scrollHeight: { value: 500 }, clientHeight: { value: 100 } })
+  document.body.appendChild(pane)
+  pane.appendChild(zone)
+  touch('touchstart', 95)
+  jest.advanceTimersByTime(450)
+  expect(pane.scrollTop).toBeGreaterThan(0)
+  touch('touchmove', 250)
+  jest.advanceTimersByTime(32)
+  touch('touchend')
+  expect(drops).not.toHaveBeenCalled()
+})
+
+test('moving between targets clears the former registry preview', () => {
+  touch('touchstart')
+  jest.advanceTimersByTime(450)
+  const firstCleanup = previews.mock.results[0].value
+  zone.remove()
+  makeZone()
+  touch('touchmove')
+  expect(firstCleanup).toHaveBeenCalled()
+})
+
+test('drifting between descendants of one zone keeps its preview and hover timer', () => {
+  const label = document.createElement('span')
+  const badge = document.createElement('span')
+  zone.append(label, badge)
+  document.elementFromPoint = () => label
+  touch('touchstart')
+  jest.advanceTimersByTime(450)
+  expect(previews).toHaveBeenCalledTimes(1)
+  const cleanup = previews.mock.results[0].value
+
+  document.elementFromPoint = () => badge
+  touch('touchmove')
+  expect(cleanup).not.toHaveBeenCalled()
+  expect(previews).toHaveBeenCalledTimes(1)
+})
+
+test('native source adapters can replace transfer data and set a drag image', () => {
+  source.className = 'replacement'
+  registry.registerDragSource({ selector: '.replacement', onDragStart: ({ event }) => {
+    const dt = event.dataTransfer
+    dt.setData('old', 'discard')
+    dt.clearData('old')
+    expect(dt.getData('old')).toBe('')
+    dt.setData('another', 'discard')
+    dt.clearData()
+    expect(dt.types).toEqual([])
+    dt.setDragImage(source, 0, 0)
+    dt.setData('test', JSON.stringify({ kind: 'creative', ids: ['2'] }))
+  } })
+  touch('touchstart')
+  jest.advanceTimersByTime(400)
+  touch('touchend')
+  expect(drops).toHaveBeenCalledWith(expect.objectContaining({ ids: ['2'] }))
+})
+
+test('an element-scoped bridge handles dynamically added sources', () => {
+  bridge.destroy()
+  bridge = createTouchBridge({ root: document.body, registry })
+  touch('touchstart')
+  jest.advanceTimersByTime(400)
+  touch('touchend')
+  expect(drops).toHaveBeenCalledTimes(1)
+})
+
+test('a source removed during long press cannot begin dragging', () => {
+  touch('touchstart')
+  source.className = ''
+  jest.advanceTimersByTime(400)
+  expect(document.querySelector('.touch-drag-proxy')).toBeNull()
+})
+
+test('registry acceptance rules also reject touch targets', () => {
+  zone.className = 'blocked'
+  registry.registerDropZone({ selector: '.blocked', accepts: ['topic'], onDrop: drops })
+  touch('touchstart')
+  jest.advanceTimersByTime(400)
+  touch('touchend')
+  expect(drops).not.toHaveBeenCalled()
+})
+
+test('a quick tap retains the native nested button action without a duplicate click', () => {
+  const button = document.createElement('button')
+  source.appendChild(button)
+  const click = jest.fn()
+  button.addEventListener('click', click)
+  expect(touch('touchstart', 50, button).defaultPrevented).toBe(false)
+  expect(touch('touchend', 50, button).defaultPrevented).toBe(false)
+  expect(click).not.toHaveBeenCalled()
+  button.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+  expect(click).toHaveBeenCalledTimes(1)
+  expect(drops).not.toHaveBeenCalled()
+})
+
+test('editable controls retain native touch behavior', () => {
+  const input = document.createElement('input')
+  source.appendChild(input)
+  expect(touch('touchstart', 50, input).defaultPrevented).toBe(false)
+  expect(jest.getTimerCount()).toBe(0)
+})
+
+test('hit tests receive the actual nested pointer target instead of its zone ancestor', () => {
+  const form = document.createElement('form')
+  zone.appendChild(form)
+  document.elementFromPoint = () => form
+  touch('touchstart')
+  jest.advanceTimersByTime(400)
+  touch('touchend')
+  expect(drops.mock.calls[0][0].event.target).toBe(form)
+})
+
+test('an overlay outside the candidate blocks an otherwise matching rectangle', () => {
+  document.elementFromPoint = () => source
+  touch('touchstart')
+  jest.advanceTimersByTime(400)
+  touch('touchend')
+  expect(drops).not.toHaveBeenCalled()
+})
+
+test('source adapters can reject long presses on nested action buttons', () => {
+  source.className = 'actions'
+  const button = document.createElement('button')
+  source.appendChild(button)
+  registry.registerDragSource({ selector: '.actions', onDragStart: ({ event }) => {
+    expect(event.target).toBe(button)
+    if (event.target.closest('button')) { event.preventDefault(); return false }
+    event.dataTransfer.setData('test', JSON.stringify({ kind: 'creative', ids: ['1'] }))
+  } })
+  touch('touchstart', 50, button)
+  jest.advanceTimersByTime(400)
+  expect(document.querySelector('.touch-drag-proxy')).toBeNull()
+  expect(drops).not.toHaveBeenCalled()
+})
+
+test('overlapping registry roots share a single touch gesture and cancellation', () => {
+  const onEnd = jest.fn()
+  registry.registerDragSource({ selector: '.other', onDragStart: jest.fn(), onDragEnd: onEnd })
+  const nested = createDragDropRegistry({ root: document.body })
+  const starts = jest.fn()
+  source.addEventListener('dragstart', starts)
+  try {
+    touch('touchstart')
+    jest.advanceTimersByTime(400)
+    expect(starts).toHaveBeenCalledTimes(1)
+    expect(document.querySelectorAll('.touch-drag-proxy')).toHaveLength(1)
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    expect(document.querySelector('.touch-drag-proxy')).toBeNull()
+    touch('touchend')
+    expect(drops).not.toHaveBeenCalled()
+  } finally { nested.destroy() }
+})
+
+test('a scoped source can drag into another scoped registry and finish after DOM removal', () => {
+  bridge.destroy()
+  registry.destroy()
+  const sourcePane = document.createElement('section')
+  document.body.appendChild(sourcePane)
+  sourcePane.appendChild(source)
+  const targetPane = document.createElement('section')
+  document.body.appendChild(targetPane)
+  targetPane.appendChild(zone)
+  const getKind = dt => dt.types.includes('test') ? 'creative' : null
+  const readData = dt => JSON.parse(dt.getData('test'))
+  registry = createDragDropRegistry({ root: sourcePane, getKind, readData })
+  const ended = jest.fn()
+  registry.registerDragSource({ selector: '.source', onDragEnd: ended, onDragStart: ({ event }) => {
+    event.dataTransfer.setData('test', JSON.stringify({ kind: 'creative', ids: ['1'] }))
+  } })
+  const targetRegistry = createDragDropRegistry({ root: targetPane, getKind, readData })
+  const onDrop = jest.fn(() => source.remove())
+  targetRegistry.registerDropZone({ selector: '.zone', accepts: ['creative'], onDrop })
+  try {
+    touch('touchstart')
+    jest.advanceTimersByTime(400)
+    touch('touchend')
+    expect(onDrop).toHaveBeenCalledTimes(1)
+    expect(ended).toHaveBeenCalledTimes(1)
+  } finally { targetRegistry.destroy() }
+})
+
+test('a second finger cancels the drag instead of committing a pinch as a move', () => {
+  touch('touchstart')
+  jest.advanceTimersByTime(400)
+  source.dispatchEvent(new TouchEvent('touchstart', {
+    bubbles: true, cancelable: true,
+    touches: [{ target: source, clientX: 50, clientY: 50 }, { target: source, clientX: 60, clientY: 60 }],
+  }))
+  touch('touchend')
+  expect(drops).not.toHaveBeenCalled()
+  expect(document.querySelector('.touch-drag-proxy')).toBeNull()
+})
+
+test('the final touch coordinate is revalidated when no touchmove was delivered', () => {
+  touch('touchstart')
+  jest.advanceTimersByTime(400)
+  source.dispatchEvent(new TouchEvent('touchend', { bubbles: true, cancelable: true,
+    changedTouches: [{ target: source, clientX: 500, clientY: 500 }],
+  }))
+  expect(drops).not.toHaveBeenCalled()
+})
+
+test('touch preserves shared bundle artwork after the native drag image is removed', () => {
+  source.className = 'bundle-source'
+  source.setAttribute('aria-label', 'Single source label must not replace bundle artwork')
+  const image = document.createElement('div')
+  image.className = 'drag-bundle-image'
+  image.textContent = '3 selected'
+  registry.registerDragSource({ selector: '.bundle-source', onDragStart: ({ event }) => {
+    event.dataTransfer.setData('test', JSON.stringify({ kind: 'creative', ids: ['1', '2', '3'] }))
+    event.dataTransfer.setDragImage(image, 24, 24)
+  } })
+  touch('touchstart')
+  jest.advanceTimersByTime(400)
+  image.remove()
+  const proxy = document.querySelector('.touch-drag-proxy')
+  expect(proxy.style.position).toBe('fixed')
+  expect(proxy.querySelector('.drag-bundle-image').textContent).toBe('3 selected')
+  expect(proxy.querySelector('.drag-bundle-image').style.top).toBe('0px')
+  touch('touchend')
+  expect(drops).toHaveBeenCalledWith(expect.objectContaining({ ids: ['1', '2', '3'] }))
+})
+
+test('nested sources serialize only the closest owner when registries share a root', () => {
+  const ancestor = document.createElement('div')
+  ancestor.className = 'ancestor'
+  document.body.appendChild(ancestor)
+  ancestor.appendChild(source)
+  const onDragStart = jest.fn()
+  const parentRegistry = createDragDropRegistry({ root: document })
+  parentRegistry.registerDragSource({ selector: '.ancestor', onDragStart })
+  try {
+    touch('touchstart')
+    jest.advanceTimersByTime(400)
+    touch('touchend')
+    expect(onDragStart).not.toHaveBeenCalled()
+    expect(drops).toHaveBeenCalledTimes(1)
+  } finally { parentRegistry.destroy() }
+})
+
+test('a null browser hit cannot drop on an offscreen padded rectangle', () => {
+  document.elementFromPoint = () => null
+  touch('touchstart')
+  jest.advanceTimersByTime(400)
+  touch('touchend')
+  expect(drops).not.toHaveBeenCalled()
+})
+
+test('the closest drop zone wins across registries with the same root', () => {
+  const nested = document.createElement('div')
+  nested.className = 'inner-zone'
+  nested.getBoundingClientRect = zone.getBoundingClientRect
+  zone.appendChild(nested)
+  document.elementFromPoint = () => nested
+  const onDrop = jest.fn()
+  const nestedRegistry = createDragDropRegistry({ root: document,
+    getKind: dt => dt.types.includes('test') ? 'creative' : null,
+    readData: dt => JSON.parse(dt.getData('test')) })
+  nestedRegistry.registerDropZone({ selector: '.inner-zone', accepts: ['creative'], onDrop })
+  try {
+    touch('touchstart')
+    jest.advanceTimersByTime(400)
+    touch('touchend')
+    expect(onDrop).toHaveBeenCalledTimes(1)
+    expect(drops).not.toHaveBeenCalled()
+  } finally { nestedRegistry.destroy() }
+})
+
+test('a removed tap target cannot receive a stale click', () => {
+  const click = jest.fn()
+  source.addEventListener('click', click)
+  touch('touchstart')
+  source.remove()
+  document.documentElement.dispatchEvent(new TouchEvent('touchend', { bubbles: true, cancelable: true }))
+  expect(click).not.toHaveBeenCalled()
+})
+
+test('an overlay appearing during drop revalidation cancels the commit', () => {
+  touch('touchstart')
+  jest.advanceTimersByTime(400)
+  document.elementFromPoint = jest.fn().mockReturnValueOnce(zone).mockReturnValue(source)
+  touch('touchend')
+  expect(drops).not.toHaveBeenCalled()
+  expect(document.querySelector('.touch-drag-proxy')).toBeNull()
+})
+
+test('non-cancel keys do not interrupt a touch drag', () => {
+  touch('touchstart')
+  jest.advanceTimersByTime(400)
+  document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' }))
+  touch('touchend')
+  expect(drops).toHaveBeenCalledTimes(1)
+})
+
+test('live targets include a registered root and exclude another document', () => {
+  const foreignDocument = document.implementation.createHTMLDocument('Other pane')
+  foreignDocument.body.innerHTML = '<div class="foreign"></div>'
+  const foreign = createDragDropRegistry({ root: foreignDocument, touch: false })
+  foreign.registerDropZone({ selector: '.foreign', accepts: ['creative'], onDrop: jest.fn() })
+  const local = createDragDropRegistry({ root: zone, touch: false })
+  local.registerDropZone({ selector: '.zone', accepts: ['creative'], onDrop: jest.fn() })
+  try {
+    expect(local.localDropTargets()).toEqual([zone])
+    expect(registry.getDropTargets()).toEqual([zone])
+  } finally { local.destroy(); foreign.destroy() }
+})
+
+test('normal swipes retain native scrolling and never start a delayed drag', () => {
+  expect(touch('touchstart', 50).defaultPrevented).toBe(false)
+  expect(touch('touchmove', 55).defaultPrevented).toBe(false)
+  expect(touch('touchmove', 80).defaultPrevented).toBe(false)
+  jest.advanceTimersByTime(500)
+  expect(document.querySelector('.touch-drag-proxy')).toBeNull()
+  expect(touch('touchend').defaultPrevented).toBe(false)
+  expect(drops).not.toHaveBeenCalled()
+})
+
+test('committed long presses suppress native movement and the compatibility click', () => {
+  const click = jest.fn()
+  source.addEventListener('click', click)
+  expect(touch('touchstart').defaultPrevented).toBe(false)
+  jest.advanceTimersByTime(400)
+  expect(touch('touchmove', 55).defaultPrevented).toBe(true)
+  expect(touch('touchend').defaultPrevented).toBe(true)
+  expect(click).not.toHaveBeenCalled()
+  expect(drops).toHaveBeenCalledTimes(1)
+})
+
+test.each([
+  ['workspace row', '<a id="workspace-link" data-controller="row">  Workspace  one </a>', {}, 'Workspace one'],
+  ['topic chip', '<span>Visible topic</span>', { title: '  Planning topic  ' }, 'Planning topic'],
+  ['avatar', '<img id="agent-image" alt="Review agent">', {}, 'Review agent'],
+  ['accessible name', '<span>Visible label</span>', { 'aria-label': '  Accessible name  ', title: 'Title' }, 'Accessible name'],
+  ['blank name', '<span>Visible label</span>', { 'aria-label': ' ', title: 'Title fallback' }, 'Title fallback'],
+])('single %s touch proxies show a safe source label', (_kind, markup, attributes, expected) => {
+  source.innerHTML = markup
+  Object.entries(attributes).forEach(([name, value]) => source.setAttribute(name, value))
+  touch('touchstart')
+  jest.advanceTimersByTime(400)
+  const proxy = document.querySelector('.touch-drag-proxy')
+  expect(proxy.textContent).toBe(expected)
+  expect(proxy.children).toHaveLength(0)
+  expect(proxy.querySelector('[id], [data-controller]')).toBeNull()
+  touch('touchend')
+  expect(drops).toHaveBeenCalledTimes(1)
+})
+
+test('referenced accessible labels take precedence and never become HTML', () => {
+  const label = document.createElement('span')
+  label.id = 'drag-label'
+  label.textContent = '<img src=x onerror=alert(1)> & planning'
+  document.body.appendChild(label)
+  source.setAttribute('aria-labelledby', 'missing-label drag-label')
+  source.setAttribute('aria-label', 'Alternative label')
+  touch('touchstart')
+  jest.advanceTimersByTime(400)
+  const proxy = document.querySelector('.touch-drag-proxy')
+  expect(proxy.textContent).toBe(label.textContent)
+  expect(proxy.querySelector('img')).toBeNull()
+})
+
+test('an image source uses its own alt text', () => {
+  const avatar = document.createElement('img')
+  avatar.className = 'source'
+  avatar.alt = 'Agent avatar'
+  source.replaceWith(avatar)
+  source = avatar
+  touch('touchstart')
+  jest.advanceTimersByTime(400)
+  expect(document.querySelector('.touch-drag-proxy').textContent).toBe('Agent avatar')
+})
+
+test('visible text is used when available and empty labels keep the default count', () => {
+  source.textContent = 'Hidden source text'
+  Object.defineProperty(source, 'innerText', { configurable: true, value: '  Visible\n source ' })
+  touch('touchstart')
+  jest.advanceTimersByTime(400)
+  expect(document.querySelector('.touch-drag-proxy').textContent).toBe('Visible source')
+  touch('touchcancel')
+  Object.defineProperty(source, 'innerText', { value: '' })
+  touch('touchstart')
+  jest.advanceTimersByTime(400)
+  expect(document.querySelector('.touch-drag-proxy').textContent).toBe('1')
+})

--- a/engines/collavre/app/javascript/lib/dnd/registry.js
+++ b/engines/collavre/app/javascript/lib/dnd/registry.js
@@ -1,4 +1,5 @@
 import { getDragKind, readDragData } from './envelope'
+import { createTouchBridge } from './touch_bridge'
 
 const liveRegistries = new Set()
 
@@ -33,6 +34,7 @@ function samePreview(left, right) {
 
 export function createDragDropRegistry({
   root = document,
+  touch = true,
   getKind = getDragKind,
   readData = readDragData,
   onError = (error) => console.error(error),
@@ -58,8 +60,18 @@ export function createDragDropRegistry({
     activePreview = null
   }
 
+  const localData = (transfer) => {
+    // Never substitute memory for a rejected or cross-window transfer payload.
+    if (Array.from(transfer?.types || []).length) return null
+    for (const candidate of liveRegistries) {
+      const data = candidate.gestureData(root.ownerDocument || root)
+      if (data) return data
+    }
+    return null
+  }
+
   const matchZone = (event) => {
-    const kind = getKind(event.dataTransfer)
+    const kind = getKind(event.dataTransfer) || localData(event.dataTransfer)?.kind
     let match = null
     for (const zone of zones) {
       const element = matchingElement(root, event, zone.selector)
@@ -97,9 +109,15 @@ export function createDragDropRegistry({
     if (owner?.registry !== registry) return
     const source = sources.find((candidate) => matchingElement(root, event, candidate.selector))
     const element = matchingElement(root, event, source.selector)
-    activeSource = { source, element }
+    for (const candidate of liveRegistries) candidate.finishDrag(event)
+    activeSource = { source, element, data: null }
     try {
-      if (source.onDragStart({ el: element, event }) === false) event.preventDefault()
+      if (source.onDragStart({ el: element, event,
+        setLocalData: data => { activeSource.data = data },
+      }) === false) {
+        event.preventDefault()
+        handleDragEnd(event)
+      }
       event.stopPropagation()
     } catch (error) {
       event.preventDefault()
@@ -171,7 +189,7 @@ export function createDragDropRegistry({
       resolved = resolveZone(event, true)
       if (!resolved) return
 
-      const data = readData(event.dataTransfer)
+      const data = readData(event.dataTransfer) || localData(event.dataTransfer)
       if (!data || data.kind !== resolved.kind) return
 
       event.preventDefault()
@@ -197,6 +215,7 @@ export function createDragDropRegistry({
   const ownerDocument = root.ownerDocument || root
   const handleKeyDown = (event) => {
     if (event.key !== 'Escape') return
+    bridge?.cancel()
     handleDragEnd(event)
   }
   ownerDocument.addEventListener('keydown', handleKeyDown)
@@ -209,6 +228,9 @@ export function createDragDropRegistry({
 
   const registry = {
     finishDrag: handleDragEnd,
+    gestureData(document) {
+      return document === ownerDocument ? activeSource?.data : null
+    },
     matchDrop: matchZone,
     getDragSource(target) {
       for (const source of sources) {
@@ -218,6 +240,31 @@ export function createDragDropRegistry({
       return null
     },
 
+    localDropTargets() {
+      const selector = zones.map(zone => zone.selector).join(',')
+      return selector ? [...(root.matches?.(selector) ? [root] : []), ...root.querySelectorAll(selector)] : []
+    },
+
+    getDropTargets() {
+      const targets = new Set()
+      for (const candidate of liveRegistries) {
+        for (const target of candidate.localDropTargets()) {
+          if (target.ownerDocument === (root.ownerDocument || root)) targets.add(target)
+        }
+      }
+      // Edge scrolling resolves targets every animation frame, so measure each
+      // ancestor chain once instead of on every comparison.
+      const depth = element => {
+        let count = 0
+        for (let parent = element.parentElement; parent; parent = parent.parentElement) count += 1
+        return count
+      }
+      return [...targets]
+        .map(element => ({ element, depth: depth(element) }))
+        .sort((left, right) => right.depth - left.depth)
+        .map(({ element }) => element)
+    },
+
     registerDragSource(source) {
       if (!source?.selector || typeof source.onDragStart !== 'function') {
         throw new TypeError('A drag source requires selector and onDragStart')
@@ -225,6 +272,7 @@ export function createDragDropRegistry({
       sources.push(source)
       return () => {
         const index = sources.indexOf(source)
+        if (activeSource?.source === source) handleDragEnd({ type: 'unregister' })
         if (index >= 0) sources.splice(index, 1)
       }
     },
@@ -245,6 +293,7 @@ export function createDragDropRegistry({
     },
 
     destroy() {
+      bridge?.destroy()
       liveRegistries.delete(registry)
       handleDragEnd({ type: 'destroy' })
       ownerDocument.removeEventListener('keydown', handleKeyDown)
@@ -261,5 +310,6 @@ export function createDragDropRegistry({
     },
   }
   liveRegistries.add(registry)
+  const bridge = touch ? createTouchBridge({ root, registry }) : null
   return registry
 }

--- a/engines/collavre/app/javascript/lib/dnd/touch_bridge.js
+++ b/engines/collavre/app/javascript/lib/dnd/touch_bridge.js
@@ -1,0 +1,184 @@
+import TouchDragHandler from '../touch_drag'
+
+function sourceLabel(source) {
+  const document = source.ownerDocument
+  const labelledBy = (source.getAttribute('aria-labelledby') || '').split(/\s+/)
+    .map(id => document.getElementById(id)?.textContent || '').join(' ')
+  const image = source.matches('img') ? source : source.querySelector('img[alt]')
+  return [labelledBy, source.getAttribute('aria-label'), source.getAttribute('title'),
+    image?.getAttribute('alt'), source.innerText ?? source.textContent]
+    .map(value => (value || '').replace(/\s+/g, ' ').trim()).find(Boolean)
+}
+
+// Feed touch input through the same DOM events as native dragging so source
+// serialization, target policy, previews and business commands have one owner.
+function attachTouchBridge({ root, registry }) {
+  const document = root.ownerDocument || root
+  const container = document.documentElement
+  let source = null
+  let dataTransfer = null
+  let lastTarget = null
+  let dragImage = null
+
+  function dispatch(type, target, point = {}, relatedTarget = null) {
+    const event = new Event(type, { bubbles: true, cancelable: true })
+    Object.assign(event, { dataTransfer, relatedTarget, clientX: point.clientX ?? 0,
+      clientY: point.clientY ?? 0, shiftKey: false })
+    target.dispatchEvent(event)
+    return event
+  }
+
+  function finish() {
+    const endingSource = source
+    source = null
+    if (lastTarget) dispatch('dragleave', lastTarget)
+    if (endingSource) dispatch('dragend', endingSource)
+    dataTransfer = null
+    lastTarget = null
+    dragImage = null
+  }
+
+  function targetAtPoint(el, point) {
+    if (!document.elementFromPoint) return el
+    const actual = document.elementFromPoint(point.clientX, point.clientY)
+    return actual && el.contains(actual) ? actual : null
+  }
+
+  const handler = new TouchDragHandler({
+    container,
+    singleElement: true,
+    preserveNativeGestures: true,
+    canStart(touch) {
+      if (!registry.getDragSource(touch.target)) return false
+      // Editing keeps native focus and selection. Other sources retain native
+      // taps and swipes until the long press commits; no synthetic click replay.
+      if (touch.target.closest('input, textarea, select, [contenteditable]:not([contenteditable="false"])')) return false
+      return true
+    },
+    getDropTargets: () => registry.getDropTargets(),
+    proxyContent() {
+      if (dragImage) return dragImage
+      const label = sourceLabel(source)
+      // A text node preserves literal labels without cloning controllers or IDs.
+      return label ? document.createTextNode(label) : null
+    },
+    autoScroll: true,
+    scrollContainer(point, target) {
+      let el = target || document.elementFromPoint?.(point.clientX, point.clientY)
+      while (el) {
+        const overflow = document.defaultView.getComputedStyle(el).overflowY
+        if (/(auto|scroll)/.test(overflow) && el.scrollHeight > el.clientHeight) return el
+        el = el.parentElement
+      }
+      return document.scrollingElement
+    },
+    onDragStart(_items, touch) {
+      source = registry.getDragSource(touch.target)
+      if (!source) return false
+      const values = new Map()
+      dataTransfer = {
+        effectAllowed: 'all', dropEffect: 'none',
+        get types() { return [...values.keys()] },
+        setData(type, value) { values.set(type, String(value)) },
+        getData(type) { return values.get(type) || '' },
+        clearData(type) { type ? values.delete(type) : values.clear() },
+        setDragImage(image) {
+          // Reuse the shared bundle artwork without mounting a cloned source
+          // component (which could register controllers and duplicate IDs).
+          if (!image?.classList.contains('drag-bundle-image')) return
+          dragImage = image.cloneNode(true)
+          Object.assign(dragImage.style, { position: 'relative', top: '0', left: '0', height: '42px' })
+        },
+      }
+      const event = dispatch('dragstart', touch.target, touch)
+      if (event.defaultPrevented || (!dataTransfer.types.length && !registry.gestureData?.(document))) {
+        finish()
+        return false
+      }
+    },
+    hitTest(el, point) {
+      const target = targetAtPoint(el, point)
+      if (!target) return null
+      // Carry relatedTarget like a native dragleave so a zone can tell a move
+      // between its own descendants from a real departure and keep its preview.
+      if (lastTarget && lastTarget !== target) dispatch('dragleave', lastTarget, point, target)
+      lastTarget = target
+      return dispatch('dragover', target, point).defaultPrevented ? 'into' : null
+    },
+    onTargetChange(el, point) {
+      if (!el && lastTarget) {
+        dispatch('dragleave', lastTarget, point)
+        lastTarget = null
+      }
+    },
+    onDrop(el, point) {
+      try {
+        const target = targetAtPoint(el, point)
+        if (target) dispatch('drop', target, point)
+      } finally { finish() }
+    },
+    onCancel: finish,
+  })
+
+  return {
+    cancel() {
+      finish()
+      handler.cancel()
+    },
+    refreshDropTargets: () => handler.refreshDropTargets(),
+    destroy() {
+      finish()
+      handler.destroy()
+    },
+  }
+}
+
+// Controllers can register overlapping roots. One gesture must serialize and
+// finish only once, including when it crosses into another controller's pane.
+const bridges = new WeakMap()
+
+export function createTouchBridge({ root, registry }) {
+  const document = root.ownerDocument || root
+  let shared = bridges.get(document)
+  if (!shared) {
+    const registries = new Set()
+    const bridge = attachTouchBridge({ root: document, registry: {
+      getDragSource(target) {
+        let source = null
+        for (const candidate of registries) {
+          const match = candidate.getDragSource(target)
+          if (match && (!source || source.contains(match))) source = match
+        }
+        return source
+      },
+      gestureData(document) {
+        for (const candidate of registries) {
+          const data = candidate.gestureData(document)
+          if (data) return data
+        }
+        return null
+      },
+      getDropTargets() {
+        return registries.values().next().value.getDropTargets()
+      },
+    } })
+    shared = { registries, bridge }
+    bridges.set(document, shared)
+  }
+  shared.registries.add(registry)
+  let destroyed = false
+  return {
+    refreshDropTargets: () => shared.bridge.refreshDropTargets(),
+    cancel: () => shared.bridge.cancel(),
+    destroy() {
+      if (destroyed) return
+      destroyed = true
+      shared.bridge.cancel()
+      shared.registries.delete(registry)
+      if (shared.registries.size === 0) {
+        shared.bridge.destroy()
+        bridges.delete(document)
+      }
+    },
+  }
+}

--- a/engines/collavre/app/javascript/lib/touch_drag.js
+++ b/engines/collavre/app/javascript/lib/touch_drag.js
@@ -15,8 +15,16 @@
  *     onDrop(targetEl) {},              // called when dropped on a valid target
  *     onCancel() {},
  *     proxyContent(items) { return '...' }  // HTML for the drag proxy badge
+ *     getDropTargets() {},              // optional live target resolver
+ *     hitTest(el, point, previousHit) {}, // null rejects; otherwise domain hit
+ *     onTargetChange(el, { hit, clientX, clientY }) {},
+ *     preserveNativeGestures: true,     // native taps/scroll until long press
+ *     autoScroll: true,                 // opt in to continuous edge scrolling
+ *     scrollContainer(point, target) {}, // element or resolver; defaults to container
  *   })
  *
+ *   // onDrop also receives { hit, clientX, clientY } as a second argument.
+ *   td.refreshDropTargets() // after asynchronous folder expansion
  *   td.destroy()  // cleanup
  */
 
@@ -38,7 +46,16 @@ export default class TouchDragHandler {
     this.onDrop = opts.onDrop
     this.onCancel = opts.onCancel
     this.onTap = opts.onTap
+    this.preserveNativeGestures = opts.preserveNativeGestures ?? false
+    this.canStart = opts.canStart
     this.proxyContent = opts.proxyContent
+    this.getDropTargets = opts.getDropTargets ?? (() => document.querySelectorAll(this.dropTargetSelector))
+    this.hitTest = opts.hitTest
+    this.onTargetChange = opts.onTargetChange
+    this.autoScroll = opts.autoScroll ?? false
+    this.scrollContainer = opts.scrollContainer ?? this.container
+    this.scrollEdge = opts.scrollEdge ?? 40
+    this.scrollSpeed = opts.scrollSpeed ?? 12
 
     // State
     this._timer = null
@@ -47,6 +64,9 @@ export default class TouchDragHandler {
     this._startX = 0
     this._startY = 0
     this._currentTarget = null
+    this._currentHit = null
+    this._point = null
+    this._frame = null
 
     // Bind handlers
     this._onTouchStart = this._handleTouchStart.bind(this)
@@ -58,6 +78,11 @@ export default class TouchDragHandler {
     this.container.addEventListener('touchmove', this._onTouchMove, { passive: false })
     this.container.addEventListener('touchend', this._onTouchEnd, { passive: false })
     this.container.addEventListener('touchcancel', this._onTouchEnd, { passive: false })
+  }
+
+  cancel() {
+    if (this._dragging) this.onCancel?.()
+    this._endDrag()
   }
 
   destroy() {
@@ -72,10 +97,12 @@ export default class TouchDragHandler {
   // ── Private ───────────────────────────────────────────────
 
   _handleTouchStart(e) {
+    if (e.touches?.length > 1) { this.cancel(); return }
     if (this._dragging) return
 
-    const touch = e.touches[0]
+    const touch = e.touches?.[0]
     if (!touch) return
+    if (this.canStart && !this.canStart(touch, e)) return
 
     if (this.singleElement) {
       // In single-element mode, the container itself is the draggable
@@ -91,12 +118,9 @@ export default class TouchDragHandler {
     this._startX = touch.clientX
     this._startY = touch.clientY
 
-    // Prevent native long-press behavior (text selection, context menu,
-    // native drag preview) from stealing touch events after ~500ms.
-    // Scrolling is handled via touchmove: within tolerance we preventDefault,
-    // beyond tolerance we cancel the timer and the user can scroll normally
-    // on the next touch.
-    e.preventDefault()
+    // Legacy avatar-only consumers replay taps themselves. Delegated tree
+    // sources retain native taps and scrolling until the long press commits.
+    if (!this.preserveNativeGestures) e.preventDefault()
 
     this._cancelLongPress()
     this._timer = setTimeout(() => {
@@ -105,7 +129,7 @@ export default class TouchDragHandler {
   }
 
   _handleTouchMove(e) {
-    const touch = e.touches[0]
+    const touch = e.touches?.[0]
     if (!touch) return
 
     if (this._dragging) {
@@ -123,8 +147,8 @@ export default class TouchDragHandler {
       if (dx > this.moveTolerance || dy > this.moveTolerance) {
         // User intentionally scrolling — cancel long-press, let scroll happen
         this._cancelLongPress()
-      } else {
-        // Within tolerance — prevent scroll to keep the long-press alive
+      } else if (!this.preserveNativeGestures) {
+        // Legacy consumers opt into suppressing native gestures while waiting.
         e.preventDefault()
       }
     }
@@ -133,7 +157,7 @@ export default class TouchDragHandler {
   _handleTouchEnd(e) {
     if (this._timer) {
       this._cancelLongPress()
-      this.onTap?.(e)
+      if (e.type !== 'touchcancel' && !this.preserveNativeGestures) this.onTap?.(e)
       return
     }
 
@@ -141,13 +165,20 @@ export default class TouchDragHandler {
 
     e.preventDefault()
 
-    if (this._currentTarget) {
-      this.onDrop?.(this._currentTarget)
-    } else {
-      this.onCancel?.()
+    try {
+      if (e.type !== 'touchcancel') {
+        const touch = e.changedTouches?.[0]
+        if (touch) this._moveDrag(touch)
+        else this.refreshDropTargets()
+      }
+      if (e.type !== 'touchcancel' && this._currentTarget) {
+        this.onDrop?.(this._currentTarget, { ...this._point, hit: this._currentHit })
+      } else {
+        this.onCancel?.()
+      }
+    } finally {
+      this._endDrag()
     }
-
-    this._endDrag()
   }
 
   _handleContextMenu(e) {
@@ -167,7 +198,7 @@ export default class TouchDragHandler {
     if (!items || items.length === 0) return
 
     // Let caller cancel
-    if (this.onDragStart && this.onDragStart(items) === false) return
+    if (this.onDragStart && this.onDragStart(items, touch) === false) return
 
     this._dragging = true
 
@@ -183,12 +214,20 @@ export default class TouchDragHandler {
     // Create floating proxy
     this._proxy = document.createElement('div')
     this._proxy.className = this.proxyClass
-    this._proxy.innerHTML = this.proxyContent?.(items) ?? `${items.length}`
+    this._proxy.style.pointerEvents = 'none'
+    this._proxy.style.position = 'fixed'
+    this._proxy.style.zIndex = '10000'
+    this._proxy.setAttribute('aria-hidden', 'true')
+    const content = this.proxyContent?.(items) ?? `${items.length}`
+    if (content instanceof Node) this._proxy.appendChild(content)
+    else this._proxy.innerHTML = content
     document.body.appendChild(this._proxy)
-    this._moveProxy(touch.clientX, touch.clientY)
+    this._moveDrag(touch)
+    if (this.autoScroll) this._scheduleScroll()
   }
 
   _moveDrag(touch) {
+    this._point = { clientX: touch.clientX, clientY: touch.clientY }
     this._moveProxy(touch.clientX, touch.clientY)
     this._updateDropTarget(touch.clientX, touch.clientY)
   }
@@ -210,31 +249,67 @@ export default class TouchDragHandler {
     // elementFromPoint is unreliable on mobile when z-index, overlays,
     // or reflow timing interfere with the result.
     const PAD = 12 // extra padding for finger imprecision
-    // Cache drop targets on first call (topic list doesn't change during drag)
-    if (!this._cachedDropTargets) {
-      this._cachedDropTargets = document.querySelectorAll(this.dropTargetSelector)
-    }
-    const targets = this._cachedDropTargets
+    // Resolve each time: expanding folders can add or remove targets mid-drag.
+    const targets = this.getDropTargets()
     let found = null
+    let hit = null
 
     for (const target of targets) {
       const rect = target.getBoundingClientRect()
+      if (!target.isConnected || rect.width <= 0 || rect.height <= 0) continue
       if (x >= rect.left - PAD && x <= rect.right + PAD &&
           y >= rect.top - PAD && y <= rect.bottom + PAD) {
+        hit = this.hitTest ? this.hitTest(target, { clientX: x, clientY: y },
+          target === this._currentTarget ? this._currentHit : null) : 'into'
+        if (hit == null || hit === false) continue
         found = target
         break
       }
     }
 
-    if (found !== this._currentTarget) {
+    if (found !== this._currentTarget || hit !== this._currentHit) {
       this._currentTarget?.classList.remove(this.dragOverClass)
       this._currentTarget = found
+      this._currentHit = found ? hit : null
       this._currentTarget?.classList.add(this.dragOverClass)
+      this.onTargetChange?.(found, { clientX: x, clientY: y, hit: this._currentHit })
     }
+  }
+
+  // Call after asynchronous folder expansion, even if the finger has not moved.
+  refreshDropTargets() {
+    if (this._dragging && this._point) {
+      this._updateDropTarget(this._point.clientX, this._point.clientY)
+    }
+  }
+
+  _scheduleScroll() {
+    this._frame = requestAnimationFrame(() => {
+      this._frame = null
+      if (!this._dragging) return
+      const container = typeof this.scrollContainer === 'function'
+        ? this.scrollContainer(this._point, this._currentTarget) : this.scrollContainer
+      if (container && this._point) {
+        const doc = container.ownerDocument
+        const rect = container === doc.scrollingElement
+          ? { top: 0, left: 0, right: doc.defaultView.innerWidth, bottom: doc.defaultView.innerHeight }
+          : container.getBoundingClientRect()
+        const { clientX: x, clientY: y } = this._point
+        if (x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom) {
+          const distance = y < rect.top + this.scrollEdge ? y - rect.top - this.scrollEdge
+            : y > rect.bottom - this.scrollEdge ? y - rect.bottom + this.scrollEdge : 0
+          container.scrollTop += Math.round(distance / this.scrollEdge * this.scrollSpeed)
+        }
+      }
+      this.refreshDropTargets()
+      this._scheduleScroll()
+    })
   }
 
   _endDrag() {
     this._dragging = false
+    if (this._frame !== null) cancelAnimationFrame(this._frame)
+    this._frame = null
     this._cancelLongPress()
 
     document.removeEventListener('contextmenu', this._onContextMenu, { capture: true })
@@ -244,7 +319,10 @@ export default class TouchDragHandler {
     if (this._currentTarget) {
       this._currentTarget.classList.remove(this.dragOverClass)
       this._currentTarget = null
+      this.onTargetChange?.(null, { ...this._point, hit: null })
     }
+    this._currentHit = null
+    this._point = null
 
     if (this._proxy) {
       this._proxy.remove()
@@ -252,7 +330,6 @@ export default class TouchDragHandler {
       this._proxyHW = undefined
       this._proxyHH = undefined
     }
-    this._cachedDropTargets = null
   }
 
   _cancelLongPress() {

--- a/engines/collavre/test/system/creative_inline_edit_test.rb
+++ b/engines/collavre/test/system/creative_inline_edit_test.rb
@@ -137,6 +137,7 @@ class CreativeInlineEditTest < ApplicationSystemTestCase
     find("#inline-add", wait: 5).click
     fill_inline_editor("C")
     find("#inline-add", wait: 5).click
+    assert_selector "#creatives > creative-tree-row:nth-of-type(4) #inline-edit-form-element", wait: 10
     fill_inline_editor("D")
     close_inline_editor
 


### PR DESCRIPTION
Long-press dragging reaches registered sources and drop zones through the same payload and stored hit intent. Taps and swipes remain native before activation; cancellation clears previews and proxies. Lazy expansion refreshes target discovery, edge scrolling follows the pointer, and blocked storage falls back only to the current document's active gesture.

Also preserves the original creative/tree pair in cross-window bundle completion, including non-first dragged rows and partial success. Adapters retain movement commands and DOM recovery.

Validation: 149 Jest suites / 2,106 tests and explicit build passed. Eight new identity regressions fail against the old implementation. Changed registry/touch branches are covered. Vrex accepted the structure; the latest identity delta and CI are under final verification. Rebased onto merged T3 36181e39.