### PR TITLE
refactor(dnd): migrate comment drag inputs to the shared registry

### DIFF
--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -50,6 +50,8 @@ module Authentication
     end
 
     def request_authentication
+      return head :unauthorized if request.xhr?
+
       if request.get? && !request.path.start_with?("/inbox") && request.format.html?
         session[:return_to_after_authenticating] = request.url
       end

--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -294,7 +294,7 @@ body.chat-fullscreen {
     /* Prevent iOS zoom on focus */
 }
 
-#new-comment-form.creative-drop-hover textarea {
+#new-comment-form.dnd-over-into textarea {
     border-color: var(--link);
     box-shadow: 0 0 0 2px color-mix(in srgb, var(--link) 25%, transparent);
 }
@@ -1433,17 +1433,19 @@ body.chat-fullscreen {
     opacity: 0.5;
 }
 
-.context-chip.context-drag-over-left {
+.context-chip.dnd-over-left,
+.topic-tag.dnd-over-left {
     border-left: 3px solid var(--color-active);
     margin-left: -1px;
 }
 
-.context-chip.context-drag-over-right {
+.context-chip.dnd-over-right,
+.topic-tag.dnd-over-right {
     border-right: 3px solid var(--color-active);
     margin-right: -1px;
 }
 
-.comment-contexts-list.context-drop-active {
+.comment-contexts-list.dnd-over-into {
     outline: 2px dashed var(--color-link);
     outline-offset: -2px;
     background-color: color-mix(in srgb, var(--color-link) 8%, transparent);
@@ -1593,7 +1595,7 @@ body.chat-fullscreen {
     opacity: 0.5;
 }
 
-.topic-creation-container.drag-over {
+.topic-creation-container.dnd-over-into {
     background: var(--color-active);
     border-radius: 12px;
     opacity: 0.8;
@@ -1643,7 +1645,7 @@ body.chat-fullscreen {
 }
 
 /* Drag and drop styles for moving comments to topics */
-.topic-tag.drag-over {
+.topic-tag.dnd-over-into {
     background-color: var(--color-active);
     color: var(--color-badge-text);
     border-color: var(--color-active);
@@ -1666,16 +1668,6 @@ body.chat-fullscreen {
 
 .topic-tag.topic-dragging {
     opacity: 0.5;
-}
-
-.topic-tag.topic-drag-over-left {
-    border-left: 3px solid var(--color-active);
-    margin-left: -1px;
-}
-
-.topic-tag.topic-drag-over-right {
-    border-right: 3px solid var(--color-active);
-    margin-right: -1px;
 }
 
 .creative-history-list {

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/contexts_controller_dnd.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/contexts_controller_dnd.test.js
@@ -1,0 +1,107 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals'
+import { Application } from '@hotwired/stimulus'
+import ContextsController from '../contexts_controller'
+import { writeDragData } from '../../../lib/dnd/envelope'
+
+let application, controller, popup
+function drag(type, target, values = {}, x = 0) {
+  const event = new Event(type, { bubbles: true, cancelable: true })
+  Object.assign(event, { clientX: x, dataTransfer: {
+    get types() { return Object.keys(values) },
+    getData: type => values[type] || '', setData: (type, value) => { values[type] = value }
+  } })
+  target.dispatchEvent(event)
+  return event
+}
+function creativeValues(ids, activeId = ids[0]) {
+  const values = {}
+  writeDragData({ setData: (type, value) => { values[type] = value } },
+    { kind: 'creative', ids, payload: { creativeId: activeId, treeId: 'tree' } })
+  return values
+}
+beforeEach(async () => {
+  global.requestAnimationFrame = fn => { fn(); return 0 }
+  document.body.innerHTML = `<div id="comments-popup" data-controller="comments--contexts" data-creative-id="42">
+    <button data-comments--contexts-target="toggleButton"></button>
+    <div data-comments--contexts-target="bar"><div data-comments--contexts-target="list"></div></div>
+    <form id="new-comment-form"></form></div>`
+  popup = document.getElementById('comments-popup')
+  application = Application.start()
+  application.register('comments--contexts', ContextsController)
+  await new Promise(resolve => setTimeout(resolve, 0))
+  controller = application.getControllerForElementAndIdentifier(popup, 'comments--contexts')
+  controller.canManage = true
+  controller.contexts = [{ id: 10 }, { id: 20 }, { id: 99, inherited: true }]
+  controller._updateContextIds = jest.fn().mockResolvedValue()
+  controller.loadContexts = jest.fn().mockResolvedValue()
+  controller.renderContexts()
+  controller._bindPopupDragDetection()
+})
+afterEach(() => {
+  controller.disconnect()
+  application.stop()
+  document.body.innerHTML = ''
+})
+
+test('creative drop delegates to the existing context command and clears preview', async () => {
+  const values = creativeValues(['30'])
+  const over = drag('dragover', controller.listTarget, values)
+  expect(over.defaultPrevented).toBe(true)
+  expect(controller.listTarget.classList.contains('dnd-over-into')).toBe(true)
+  drag('drop', controller.listTarget, values)
+  await Promise.resolve()
+  expect(controller._updateContextIds).toHaveBeenCalledTimes(1)
+  expect(controller._updateContextIds).toHaveBeenCalledWith([10, 20, 30])
+  expect(controller.listTarget.classList.contains('dnd-over-into')).toBe(false)
+})
+
+test('form and unauthorized drops never add contexts', () => {
+  const values = creativeValues(['30'])
+  drag('drop', document.querySelector('form'), values)
+  controller.canManage = false
+  drag('drop', controller.listTarget, values)
+  expect(controller._updateContextIds).not.toHaveBeenCalled()
+})
+
+test('the single-context adapter keeps the active source when selection order differs', async () => {
+  drag('drop', controller.listTarget, creativeValues(['31', '30'], '30'))
+  await Promise.resolve()
+  expect(controller._updateContextIds).toHaveBeenCalledWith([10, 20, 30])
+})
+
+test('context reorder uses delegated rows after rendering and rejects self and inherited destinations', async () => {
+  const values = {}
+  const source = popup.querySelector('[data-context-id="10"]')
+  const target = popup.querySelector('[data-context-id="20"]')
+  drag('dragstart', source, values)
+  expect(values['application/x-context-id']).toBe('10')
+  expect(drag('dragover', source, values).defaultPrevented).toBe(false)
+  expect(drag('dragover', popup.querySelector('[data-context-id="99"]'), values).defaultPrevented).toBe(false)
+  drag('drop', target, values, 10)
+  await Promise.resolve()
+  expect(controller._updateContextIds).toHaveBeenCalledWith([20, 10])
+  drag('dragend', source, values)
+  expect(source.classList.contains('context-dragging')).toBe(false)
+})
+
+test('leaving an empty popup restores hidden context list', () => {
+  controller.contexts = []
+  const values = creativeValues(['30'])
+  drag('dragover', popup, values)
+  expect(controller.listVisible).toBe(true)
+  drag('dragleave', popup, values)
+  expect(controller.listVisible).toBe(false)
+})
+
+
+test('disconnect clears popup preview and removes delegated drop listeners', () => {
+  const values = creativeValues(['30'])
+  drag('dragover', controller.listTarget, values)
+  expect(controller.listTarget.classList.contains('dnd-over-into')).toBe(true)
+  controller.disconnect()
+  expect(controller.listTarget.classList.contains('dnd-over-into')).toBe(false)
+  expect(drag('dragover', controller.listTarget, values).defaultPrevented).toBe(false)
+  drag('drop', controller.listTarget, values)
+  expect(controller._updateContextIds).not.toHaveBeenCalled()
+})

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_draft.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_draft.test.js
@@ -6,6 +6,7 @@ import { jest } from '@jest/globals'
 import { Application } from '@hotwired/stimulus'
 import FormController from '../form_controller'
 import chatDrafts from '../../../lib/chat_drafts'
+import { writeDragData } from '../../../lib/dnd/envelope'
 
 describe('FormController - draft persistence', () => {
   let application
@@ -2066,4 +2067,37 @@ describe('FormController - draft persistence', () => {
     await new Promise((resolve) => setTimeout(resolve, 600))
     expect(window.localStorage.getItem('collavre_chat_drafts_9')).toBeNull()
   })
+  test.each([
+    [['application/x-collavre-creative'], [], true],
+    [['Files'], [new File(['image'], 'image.png', { type: 'image/png' })], true],
+    [['text/plain'], [], false],
+  ])('dragover accepts creative or image transfers and ignores other data (%j)', (types, files, accepted) => {
+    const event = new Event('dragover', { bubbles: true, cancelable: true })
+    Object.assign(event, { dataTransfer: { types, files } })
+    const stop = jest.spyOn(event, 'stopPropagation')
+    controller.handleDragOver(event)
+    expect(event.defaultPrevented).toBe(accepted)
+    expect(stop).toHaveBeenCalledTimes(accepted ? 1 : 0)
+  })
+
+  test.each([
+    { ids: ['10'], payload: { treeId: 'tree' } },
+    { ids: ['11', '10'], payload: { creativeId: '10', treeId: 'tree' } },
+  ])('dropping a creative inserts the active source link and preserves text after the cursor: %j', (data) => {
+    controller.formTarget.id = 'new-comment-form'
+    const textarea = controller.textareaTarget
+    textarea.value = 'Before after'
+    textarea.setSelectionRange(7, 7)
+    const event = new Event('drop', { bubbles: true, cancelable: true })
+    const values = {}
+    const dataTransfer = { types: [], files: [], getData: type => values[type] || '',
+      setData: (type, value) => { values[type] = value; dataTransfer.types = Object.keys(values) } }
+    writeDragData(dataTransfer, { kind: 'creative', ...data })
+    Object.assign(event, { dataTransfer })
+    textarea.dispatchEvent(event)
+    expect(event.defaultPrevented).toBe(true)
+    expect(textarea.value).toBe('Before [Creative #10](/creatives/10)after')
+    expect(textarea.selectionStart).toBe(textarea.value.indexOf('after'))
+  })
+
 })

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/list_controller_dnd.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/list_controller_dnd.test.js
@@ -1,0 +1,26 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals'
+import ListController from '../list_controller'
+import { readDragData } from '../../../lib/dnd/envelope'
+
+test('delegated selected comments preserve bundle IDs and release feedback on cancellation', () => {
+  document.body.innerHTML = '<div id="popup"><div id="list"><div class="comment-item" draggable="true"><span class="comment-body">Message</span></div></div></div>'
+  const controller = Object.create(ListController.prototype)
+  Object.defineProperty(controller, 'element', { value: document.querySelector('#popup') })
+  Object.defineProperty(controller, 'listTarget', { value: document.querySelector('#list') })
+  controller.connect()
+  controller.selection = new Set(['7', '9'])
+  const values = {}
+  const dataTransfer = { get types() { return Object.keys(values) }, getData: type => values[type] || '',
+    setData: (type, value) => { values[type] = value }, setDragImage: jest.fn() }
+  const event = new Event('dragstart', { bubbles: true, cancelable: true })
+  Object.assign(event, { dataTransfer })
+  controller.listTarget.querySelector('.comment-body').dispatchEvent(event)
+  expect(readDragData(dataTransfer)).toEqual(expect.objectContaining({ kind: 'comments', ids: ['7', '9'] }))
+  expect(JSON.parse(values['application/x-comment-ids'])).toEqual(['7', '9'])
+  expect(controller.listTarget.classList.contains('dragging-comments')).toBe(true)
+  document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+  expect(controller.listTarget.classList.contains('dragging-comments')).toBe(false)
+  controller.disconnect()
+  document.body.innerHTML = ''
+})

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/presence_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/presence_controller.test.js
@@ -179,6 +179,24 @@ describe('CommentsPresenceController', () => {
     expect(refreshChannelChips).toHaveBeenCalledWith('45')
   })
 
+  test('marks channel chip refreshes as background requests', () => {
+    controller.element.insertAdjacentHTML(
+      'beforeend',
+      '<div data-comments--presence-target="channelChips"></div>',
+    )
+    jest.spyOn(application, 'getControllerForElementAndIdentifier').mockReturnValue({
+      currentTopicId: '45',
+    })
+    global.fetch.mockResolvedValueOnce({ ok: false })
+
+    controller.refreshChannelChips('45')
+
+    expect(global.fetch).toHaveBeenCalledWith('/creatives/123/topics/45/channel_chips', {
+      headers: { Accept: 'text/html', 'X-Requested-With': 'XMLHttpRequest' },
+      credentials: 'same-origin',
+    })
+  })
+
   test('clears topic timers when the popup closes', () => {
     const resetAgentActivity = jest.spyOn(controller, 'resetAgentActivity').mockImplementation(() => {})
 

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/presence_controller_participant_list.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/presence_controller_participant_list.test.js
@@ -112,23 +112,41 @@ describe('CommentsPresenceController — pinned add/list buttons', () => {
         expect(controller.participantsTarget.querySelectorAll('.comment-user-menu')).toHaveLength(2)
     })
 
+    test('delegated agent dragging retains avatar metadata and cleans feedback', () => {
+        controller.participantsData = [USERS[1]]
+        controller.renderParticipants([])
+        const wrapper = controller.participantsTarget.querySelector('.ai-agent-draggable')
+        const values = {}
+        const event = new Event('dragstart', { bubbles: true, cancelable: true })
+        Object.assign(event, { dataTransfer: { setData: (type, value) => { values[type] = value } } })
+        wrapper.dispatchEvent(event)
+        expect(JSON.parse(values['application/x-agent-drop'])).toEqual({
+            id: String(USERS[1].id), name: USERS[1].name, avatar_url: USERS[1].avatar_url
+        })
+        expect(wrapper.classList.contains('dragging')).toBe(true)
+        document.dispatchEvent(new Event('dragend'))
+        expect(wrapper.classList.contains('dragging')).toBe(false)
+    })
+
     test('tapping an AI participant avatar opens its menu without intercepting menu controls', () => {
         window.ontouchstart = null
         controller.participantsData = [USERS[1]]
         controller.renderParticipants([])
         const trigger = controller.participantsTarget.querySelector('.comment-user-menu-trigger')
-        const click = jest.spyOn(trigger, 'click')
-        const handler = controller._agentTouchDragHandlers.at(-1)
+        const click = jest.fn()
+        trigger.addEventListener('click', click)
+        const touchStart = new Event('touchstart', { bubbles: true, cancelable: true })
+        Object.defineProperty(touchStart, 'touches', { value: [{ clientX: 10, clientY: 10, target: trigger }] })
+        trigger.dispatchEvent(touchStart)
+        const touchEnd = new Event('touchend', { bubbles: true, cancelable: true })
+        Object.defineProperty(touchEnd, 'touches', { value: [] })
+        trigger.dispatchEvent(touchEnd)
 
-        handler._handleTouchStart({
-            touches: [{ clientX: 10, clientY: 10 }],
-            preventDefault: jest.fn()
-        })
-        handler._handleTouchEnd({})
-
-        expect(handler.container).toBe(trigger)
-        expect(click).toHaveBeenCalled()
-        handler.destroy()
+        expect(touchStart.defaultPrevented).toBe(false)
+        expect(touchEnd.defaultPrevented).toBe(false)
+        expect(click).not.toHaveBeenCalled()
+        trigger.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+        expect(click).toHaveBeenCalledTimes(1)
         delete window.ontouchstart
     })
 
@@ -475,4 +493,18 @@ describe('CommentsPresenceController — pinned add/list buttons', () => {
         expect(controller.addParticipantButtonTarget.style.display).toBe('none')
         expect(controller.participantListButtonTarget.style.display).toBe('none')
     })
+    test('a stale agent avatar cannot start a drag after its participant is removed', () => {
+        controller.participantsData = USERS
+        controller.renderParticipants([1])
+        const wrapper = controller.participantsTarget.querySelector('.ai-agent-draggable')
+        controller.participantsData = []
+        const setData = jest.fn()
+        const event = new Event('dragstart', { bubbles: true, cancelable: true })
+        Object.assign(event, { dataTransfer: { setData } })
+        wrapper.dispatchEvent(event)
+        expect(event.defaultPrevented).toBe(true)
+        expect(setData).not.toHaveBeenCalled()
+        expect(wrapper.classList.contains('dragging')).toBe(false)
+    })
+
 })

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_dnd.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_dnd.test.js
@@ -1,0 +1,120 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals'
+import { Application } from '@hotwired/stimulus'
+import TopicsController from '../topics_controller'
+
+let application, controller
+function drag(type, target, values) {
+  const event = new Event(type, { bubbles: true, cancelable: true })
+  Object.assign(event, { clientX: 10, dataTransfer: {
+    get types() { return Object.keys(values) }, getData: type => values[type] || '',
+    setData: (type, value) => { values[type] = value }
+  } })
+  target.dispatchEvent(event)
+  return event
+}
+beforeEach(async () => {
+  global.requestAnimationFrame = fn => { fn(); return 0 }
+  document.body.innerHTML = `<div id="comments-popup" data-controller="comments--topics">
+    <div data-comments--topics-target="list"></div>
+    <span data-comments--topics-target="creationContainer"></span></div>`
+  application = Application.start()
+  application.register('comments--topics', TopicsController)
+  await new Promise(resolve => setTimeout(resolve, 0))
+  controller = application.getControllerForElementAndIdentifier(document.querySelector('#comments-popup'), 'comments--topics')
+  controller.creativeIdValue = '42'
+  controller.canManageTopics = true
+  controller.topics = [{ id: 1, name: 'First' }, { id: 2, name: 'Second' }, { id: 3, name: 'Read only', read_only: true }]
+  controller.renderTopics(controller.topics, true)
+  controller.saveTopicOrder = jest.fn().mockResolvedValue()
+  controller.setTopicPrimaryAgent = jest.fn().mockResolvedValue()
+  controller.createTopicWithAgent = jest.fn().mockResolvedValue()
+  controller.createTopicAndMoveComments = jest.fn().mockResolvedValue()
+})
+afterEach(() => {
+  controller.disconnect()
+  application.stop()
+  document.body.innerHTML = ''
+})
+
+test('topic source preserves reorder and cross-creative move MIME and reorders from normalized data', async () => {
+  const values = {}
+  const source = controller.listTarget.querySelector('[data-id="1"]')
+  drag('dragstart', source, values)
+  expect(values['application/x-topic-id']).toBe('1')
+  expect(JSON.parse(values['application/x-topic-move'])).toEqual({ topicId: '1', sourceCreativeId: '42' })
+  drag('drop', controller.listTarget.querySelector('[data-id="2"]'), values)
+  await Promise.resolve()
+  expect(controller.saveTopicOrder).toHaveBeenCalledWith([2, 1, 3])
+  drag('dragend', source, values)
+  expect(source.classList.contains('topic-dragging')).toBe(false)
+})
+
+test('agent and comments drops retain their different commands and read-only policy', async () => {
+  const agent = { id: 8, name: 'Agent', avatar_url: '/agent.png' }
+  const agentValues = { 'application/x-agent-drop': JSON.stringify(agent) }
+  const commentValues = { 'application/x-comment-ids': JSON.stringify(['7', '9']) }
+  const target = controller.listTarget.querySelector('[data-id="2"]')
+  const moved = jest.fn()
+  controller.element.addEventListener('comments--topics:move-to-topic', moved)
+  expect(drag('dragover', target, agentValues).dataTransfer.dropEffect).toBe('copy')
+  drag('drop', target, agentValues)
+  drag('drop', target, commentValues)
+  drag('drop', controller.creationContainerTarget, agentValues)
+  drag('drop', controller.creationContainerTarget, commentValues)
+  expect(drag('dragover', controller.listTarget.querySelector('[data-id="3"]'), agentValues).defaultPrevented).toBe(false)
+  await Promise.resolve()
+  expect(controller.setTopicPrimaryAgent).toHaveBeenCalledWith('2', { ...agent, id: '8' })
+  expect(moved.mock.calls[0][0].detail).toEqual({ targetTopicId: '2', commentIds: ['7', '9'] })
+  expect(controller.createTopicWithAgent).toHaveBeenCalledWith({ ...agent, id: '8' })
+  expect(controller.createTopicAndMoveComments).toHaveBeenCalledWith(['7', '9'])
+})
+
+test('all-messages uses the main topic for agents and preserves the unassigned comments destination', async () => {
+  const target = controller.listTarget.querySelector('.topic-all-messages')
+  const agent = { 'application/x-agent-drop': JSON.stringify({ id: 8 }) }
+  drag('drop', target, agent)
+  await Promise.resolve()
+  expect(controller.setTopicPrimaryAgent).not.toHaveBeenCalled()
+  const moved = jest.fn()
+  controller.element.addEventListener('comments--topics:move-to-topic', moved)
+  drag('drop', target, { 'application/x-comment-ids': '[7,9]' })
+  expect(moved.mock.calls[0][0].detail.targetTopicId).toBe(controller.mainTopicId)
+  controller.mainTopicId = '1'
+  drag('drop', target, agent)
+  await Promise.resolve()
+  expect(controller.setTopicPrimaryAgent).toHaveBeenCalledWith('1', { id: '8' })
+})
+
+test('topic cancellation before the animation frame never restores feedback', () => {
+  let frame
+  global.requestAnimationFrame = fn => { frame = fn; return 0 }
+  const source = controller.listTarget.querySelector('[data-id="1"]')
+  const values = {}
+  drag('dragstart', source, values)
+  expect(drag('dragover', source, values).defaultPrevented).toBe(false)
+  drag('dragend', source, values)
+  frame()
+  expect(source.classList.contains('topic-dragging')).toBe(false)
+})
+
+test('malformed comment and agent data never trigger topic commands', () => {
+  const moved = jest.fn()
+  controller.element.addEventListener('comments--topics:move-to-topic', moved)
+  for (const mime of ['application/x-comment-ids', 'application/x-agent-drop']) {
+    drag('drop', controller.creationContainerTarget, { [mime]: '{broken' })
+  }
+  expect(controller.createTopicWithAgent).not.toHaveBeenCalled()
+  expect(controller.createTopicAndMoveComments).not.toHaveBeenCalled()
+  expect(moved).not.toHaveBeenCalled()
+})
+
+test('topic reorder ignores stale source IDs and accepts placement before a target', async () => {
+  const el = controller.listTarget.querySelector('[data-id="1"]')
+  for (const ids of [[], ['1'], ['999']]) {
+    await controller.handleTopicReorderDrop({ el, ids, hit: 'left' })
+  }
+  expect(controller.saveTopicOrder).not.toHaveBeenCalled()
+  await controller.handleTopicReorderDrop({ el, ids: ['2'], hit: 'left' })
+  expect(controller.saveTopicOrder).toHaveBeenCalledWith([2, 1, 3])
+})

--- a/engines/collavre/app/javascript/controllers/comments/contexts_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/contexts_controller.js
@@ -1,8 +1,10 @@
+import { createDragDropRegistry } from '../../lib/dnd/registry'
+import { getDragKind, readDragData, writeDragData } from '../../lib/dnd/envelope'
+import { previewDrop, horizontalHit } from '../../lib/dnd/preview'
 import { Controller } from "@hotwired/stimulus"
 import PopupToggleGuard from '../../lib/popup_toggle_guard'
 import { elementAnchor } from '../../lib/common_popup'
 
-const CREATIVE_MIME_TYPE = 'application/x-collavre-creative'
 const CONTEXT_LIST_MODAL_ID = 'context-list-modal'
 const SELF_CONTEXT_ID = 'self'
 
@@ -22,10 +24,12 @@ export default class extends Controller {
         this.listVisible = false
         this.handleContextListClose = this.handleContextListClose.bind(this)
         this.element.addEventListener('entity-list:close', this.handleContextListClose)
-        // External drop zone handlers are now Stimulus actions on the list target
+        this._registerDragDrop()
     }
 
     disconnect() {
+        this.dnd?.destroy()
+        this._unbindPopupDragDetection()
         this._contextLoadVersion += 1
         this._closeContextListPopup()
         this.element.removeEventListener('entity-list:close', this.handleContextListClose)
@@ -149,15 +153,6 @@ export default class extends Controller {
         if (!this.hasListTarget) return
 
         this._updateToggleButton()
-        // Drop zone is handled by Stimulus data-action on the list element
-
-        const dragActions = this.canManage
-            ? 'dragstart->comments--contexts#handleDragStart dragend->comments--contexts#handleDragEnd'
-            : ''
-        const reorderActions = this.canManage
-            ? 'dragover->comments--contexts#handleReorderDragOver dragleave->comments--contexts#handleReorderDragLeave drop->comments--contexts#handleReorderDrop'
-            : ''
-
         let html = ''
 
         // Current creative self-context toggle (always first)
@@ -176,7 +171,7 @@ export default class extends Controller {
             const draggable = this.canManage && !ctx.inherited ? 'draggable="true"' : ''
 
             html += `<span class="context-chip ${disabledClass} ${inheritedClass}" ${draggable}
-                          data-action="click->comments--contexts#toggleContext ${dragActions} ${reorderActions}"
+                          data-action="click->comments--contexts#toggleContext"
                           data-context-id="${ctx.id}"
                           title="${ctx.inherited ? this.inheritedLabel : ''}">
                         ${this.constructor.ICON_CONTEXT_LINK} ${this._escapeHtml(ctx.description)}`
@@ -449,68 +444,28 @@ export default class extends Controller {
         await this.loadContexts()
     }
 
-    // --- Drag & Drop for reordering ---
-    handleDragStart(event) {
-        const chipEl = event.currentTarget
-        const contextId = chipEl.dataset.contextId
-        if (!contextId) { event.preventDefault(); return }
-
-        this.draggingContextId = contextId
-        event.dataTransfer.setData('application/x-context-id', contextId)
-        event.dataTransfer.effectAllowed = 'move'
-
-        requestAnimationFrame(() => {
-            chipEl.classList.add('context-dragging')
-        })
+    _registerDragDrop() {
+        this.dnd = createDragDropRegistry({ root: this.element, getKind: getDragKind, readData: readDragData })
+        const selector = '.context-chip[draggable="true"]'
+        this.dnd.registerDragSource({ selector,
+            onDragStart: ({ el, event }) => {
+                this.draggingContextId = el.dataset.contextId
+                writeDragData(event.dataTransfer, { kind: 'context', ids: [this.draggingContextId], payload: {} })
+                event.dataTransfer.effectAllowed = 'move'
+                requestAnimationFrame(() => {
+                    if (this.draggingContextId === el.dataset.contextId) el.classList.add('context-dragging')
+                })
+            },
+            onDragEnd: ({ el }) => { this.draggingContextId = null; el.classList.remove('context-dragging') } })
+        this.dnd.registerDropZone({ selector, accepts: ['context'],
+            hitTest: ({ el, event }) => this.canManage && this.draggingContextId && el.dataset.contextId !== this.draggingContextId
+                ? horizontalHit({ el, event }) : null,
+            preview: previewDrop, onDrop: this.handleReorderDrop.bind(this) })
     }
 
-    handleDragEnd(event) {
-        this.draggingContextId = null
-        event.currentTarget.classList.remove('context-dragging')
-        this.listTarget.querySelectorAll('.context-chip').forEach(el => {
-            el.classList.remove('context-drag-over-left', 'context-drag-over-right')
-        })
-    }
-
-    handleReorderDragOver(event) {
-        if (!event.dataTransfer.types.includes('application/x-context-id')) return
-        if (!this.draggingContextId) return
-
-        const targetEl = event.currentTarget
-        const targetId = targetEl.dataset.contextId
-        if (!targetId || targetId === this.draggingContextId) return
-        // Don't allow reorder onto inherited chips
-        const ctx = this.contexts.find(c => String(c.id) === targetId)
-        if (ctx?.inherited) return
-
-        event.preventDefault()
-        event.dataTransfer.dropEffect = 'move'
-
-        const rect = targetEl.getBoundingClientRect()
-        const midpoint = rect.left + rect.width / 2
-        const isLeft = event.clientX < midpoint
-
-        targetEl.classList.toggle('context-drag-over-left', isLeft)
-        targetEl.classList.toggle('context-drag-over-right', !isLeft)
-    }
-
-    handleReorderDragLeave(event) {
-        event.currentTarget.classList.remove('context-drag-over-left', 'context-drag-over-right')
-    }
-
-    async handleReorderDrop(event) {
-        const targetEl = event.currentTarget
-        targetEl.classList.remove('context-drag-over-left', 'context-drag-over-right')
-
-        // If this is a creative drag (not a context reorder), let it bubble to the list handler
-        if (!event.dataTransfer.types.includes('application/x-context-id')) return
-
-        event.preventDefault()
-        event.stopPropagation()
-
-        const draggedId = parseInt(event.dataTransfer.getData('application/x-context-id'))
-        const targetId = parseInt(targetEl.dataset.contextId)
-
+    async handleReorderDrop({ el, ids: draggedIds, hit }) {
+        const draggedId = Number(draggedIds[0])
+        const targetId = Number(el.dataset.contextId)
         if (!draggedId || !targetId || draggedId === targetId) return
 
         const ownContexts = this.contexts.filter(c => !c.inherited)
@@ -520,10 +475,7 @@ export default class extends Controller {
         const targetIndex = ids.indexOf(targetId)
         if (draggedIndex === -1 || targetIndex === -1) return
 
-        // Determine drop position
-        const rect = targetEl.getBoundingClientRect()
-        const midpoint = rect.left + rect.width / 2
-        const insertBefore = event.clientX < midpoint
+        const insertBefore = hit === 'left'
 
         ids.splice(draggedIndex, 1)
         let newIndex = ids.indexOf(targetId)
@@ -572,115 +524,35 @@ export default class extends Controller {
         }
     }
 
-    // --- Auto-show context list when dragging creative over popup ---
+    // The popup is also a drop zone; the form owns creative-link insertion.
     _bindPopupDragDetection() {
         const popup = this.element.closest('#comments-popup')
         if (!popup) return
-        // Unbind any existing handlers first to prevent accumulation across opens
         this._unbindPopupDragDetection()
-        this._popupEl = popup
-        this._boundPopupDragOver = this._handlePopupDragOver.bind(this)
-        this._boundPopupDragLeave = this._handlePopupDragLeave.bind(this)
-        this._boundPopupDrop = (event) => {
-            // Skip if dropping on the comment form — let form_controller handle it
-            if (event.target.closest('#new-comment-form')) return
-            this.handleExternalDrop(event)
-        }
-        popup.addEventListener('dragover', this._boundPopupDragOver)
-        popup.addEventListener('dragleave', this._boundPopupDragLeave)
-        popup.addEventListener('drop', this._boundPopupDrop)
+        this.popupDnd = createDragDropRegistry({ root: popup, getKind: getDragKind, readData: readDragData })
+        this.popupDnd.registerDropZone({ selector: '#comments-popup', accepts: ['creative'],
+            hitTest: ({ event }) => this.canManage && !event.target.closest('#new-comment-form') ? 'into' : null,
+            preview: () => {
+                this.listVisible = true
+                this._updateListVisibility()
+                const clear = previewDrop({ el: this.listTarget, hit: 'into' })
+                return () => {
+                    clear()
+                    if (!this._hasBeenManuallyToggled && this.contexts.length === 0) {
+                        this.listVisible = false
+                        this._updateListVisibility()
+                    }
+                }
+            },
+            onDrop: async ({ ids, payload, event }) => {
+                event.stopPropagation()
+                await this._addContextId(Number(payload.creativeId || ids[0]))
+            } })
     }
 
     _unbindPopupDragDetection() {
-        if (!this._popupEl) return
-        this._popupEl.removeEventListener('dragover', this._boundPopupDragOver)
-        this._popupEl.removeEventListener('dragleave', this._boundPopupDragLeave)
-        this._popupEl.removeEventListener('drop', this._boundPopupDrop)
-        this._popupEl = null
-    }
-
-    _handlePopupDragOver(event) {
-        if (this._isInternalReorder(event)) return
-        if (!this._isCreativeDrag(event)) return
-        if (!this.canManage) return
-        // Skip if dragging over the comment form — let form_controller handle it
-        if (event.target.closest('#new-comment-form')) return
-
-        // Must preventDefault to allow drop on the popup
-        event.preventDefault()
-        event.dataTransfer.dropEffect = 'move'
-
-        if (!this.listVisible) {
-            // Auto-show context list when dragging a creative over the popup
-            this.listVisible = true
-            this._updateListVisibility()
-        }
-    }
-
-    _handlePopupDragLeave(event) {
-        if (!this._popupEl) return
-        // Only hide if leaving the popup entirely
-        if (this._popupEl.contains(event.relatedTarget)) return
-        if (this._hasBeenManuallyToggled) return
-
-        // Restore original state if no contexts
-        if (this.contexts.length === 0) {
-            this.listVisible = false
-            this._updateListVisibility()
-        }
-    }
-
-    // --- Drop zone for adding creatives from tree ---
-
-    _isCreativeDrag(event) {
-        return event.dataTransfer.types.includes(CREATIVE_MIME_TYPE)
-    }
-
-    _isInternalReorder(event) {
-        return event.dataTransfer.types.includes('application/x-context-id')
-    }
-
-    handleExternalDragOver(event) {
-        if (this._isInternalReorder(event)) return
-        if (!this._isCreativeDrag(event)) return
-        if (!this.canManage) return
-
-        event.preventDefault()
-        event.dataTransfer.dropEffect = 'move'
-        this.listTarget.classList.add('context-drop-active')
-    }
-
-    handleExternalDragLeave(event) {
-        // Only remove highlight if truly leaving the list area
-        if (!this.listTarget.contains(event.relatedTarget)) {
-            this.listTarget.classList.remove('context-drop-active')
-        }
-    }
-
-    async handleExternalDrop(event) {
-        if (this._isInternalReorder(event)) return
-        if (!this._isCreativeDrag(event)) return
-        if (!this.canManage) return
-
-        // Always prevent default for creative drags to avoid browser navigation
-        event.preventDefault()
-        event.stopPropagation()
-
-        this.listTarget.classList.remove('context-drop-active')
-
-        let creativeId = null
-
-        const rawData = event.dataTransfer.getData(CREATIVE_MIME_TYPE)
-        if (rawData) {
-            try {
-                const parsed = JSON.parse(rawData)
-                creativeId = parseInt(parsed.creativeId)
-            } catch (e) { /* ignore */ }
-        }
-
-        if (!creativeId) return
-
-        await this._addContextId(creativeId)
+        this.popupDnd?.destroy()
+        this.popupDnd = null
     }
 
     _escapeHtml(text) {

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -1,3 +1,6 @@
+import { createDragDropRegistry } from '../../lib/dnd/registry'
+import { getDragKind, readDragData } from '../../lib/dnd/envelope'
+import { previewDrop } from '../../lib/dnd/preview'
 import { Controller } from '@hotwired/stimulus'
 import { renderMarkdownInContainer } from '../../lib/utils/markdown'
 import { wrapHtmlInCodeBlocks } from '../../lib/html_code_block_wrapper'
@@ -36,6 +39,14 @@ export default class extends Controller {
   ]
 
   connect() {
+    this.dnd = createDragDropRegistry({ root: this.formTarget, getKind: getDragKind, readData: readDragData })
+    this.dnd.registerDropZone({ selector: '#new-comment-form', accepts: ['creative'],
+      preview: previewDrop, dropEffect: 'copy',
+      onDrop: ({ ids, payload, event }) => {
+        event.stopPropagation()
+        const id = payload.creativeId || ids[0]
+        this.insertCreativeLink({ id, label: this.getCreativeLabelFromDom(id) || `Creative #${id}` })
+      } })
     this.creativeId = null
     this.editingId ??= null
     this.sending = false
@@ -57,7 +68,6 @@ export default class extends Controller {
     this.handleImageButtonClick = this.handleImageButtonClick.bind(this)
     this.handleImageChange = this.handleImageChange.bind(this)
     this.handleDragOver = this.handleDragOver.bind(this)
-    this.handleDragLeave = this.handleDragLeave.bind(this)
     this.handleDrop = this.handleDrop.bind(this)
 
     this.formTarget.addEventListener('submit', this.handleSubmit)
@@ -71,7 +81,6 @@ export default class extends Controller {
     this.imageButtonTarget?.addEventListener('click', this.handleImageButtonClick)
     this.imageInputTarget?.addEventListener('change', this.handleImageChange)
     this.formTarget.addEventListener('dragover', this.handleDragOver)
-    this.formTarget.addEventListener('dragleave', this.handleDragLeave)
     this.formTarget.addEventListener('drop', this.handleDrop)
     this.handlePaste = this.handlePaste.bind(this)
     this.textareaTarget.addEventListener('paste', this.handlePaste)
@@ -309,6 +318,7 @@ export default class extends Controller {
   }
 
   disconnect() {
+    this.dnd?.destroy()
     this._flushDraftSave()
     this.textareaTarget.removeEventListener('compositionend', this._handleCompositionEnd)
     this.textareaTarget.removeEventListener('keydown', this._expireImeCommitLatch)
@@ -329,7 +339,6 @@ export default class extends Controller {
     this.imageInputTarget?.removeEventListener('change', this.handleImageChange)
     this.textareaTarget.removeEventListener('input', this._autoResize)
     this.formTarget.removeEventListener('dragover', this.handleDragOver)
-    this.formTarget.removeEventListener('dragleave', this.handleDragLeave)
     this.formTarget.removeEventListener('drop', this.handleDrop)
     this.textareaTarget.removeEventListener('paste', this.handlePaste)
     this.element.removeEventListener('comments--topics:change', this.handleTopicChange)
@@ -1317,63 +1326,19 @@ export default class extends Controller {
   }
 
   handleDragOver(event) {
-    const isCreative = this.hasCreativeFromDataTransfer(event.dataTransfer)
-    const isImage = this.hasImageFromDataTransfer(event.dataTransfer)
-    if (isImage || isCreative) {
+    if (getDragKind(event.dataTransfer) === 'creative' || this.hasImageFromDataTransfer(event.dataTransfer)) {
       event.preventDefault()
       event.stopPropagation()
-      if (isCreative) {
-        this.formTarget.classList.add('creative-drop-hover')
-      }
-    }
-  }
-
-  handleDragLeave(event) {
-    // Only remove highlight if truly leaving the form
-    if (!this.formTarget.contains(event.relatedTarget)) {
-      this.formTarget.classList.remove('creative-drop-hover')
     }
   }
 
   handleDrop(event) {
-    this.formTarget.classList.remove('creative-drop-hover')
-
-    // Handle creative drop — stop propagation so contexts_controller doesn't intercept
-    if (this.hasCreativeFromDataTransfer(event.dataTransfer)) {
-      event.preventDefault()
-      event.stopPropagation()
-      const creativeData = this.extractCreativeData(event.dataTransfer)
-      if (creativeData) {
-        this.insertCreativeLink(creativeData)
-      }
-      return
-    }
-
     // Handle image drop
     const imageFiles = this.extractImageFiles(event.dataTransfer)
     if (!imageFiles.length) return
     event.preventDefault()
     this.setImageFiles([...this.currentImageFiles(), ...imageFiles])
     this.updateAttachmentList()
-  }
-
-  hasCreativeFromDataTransfer(dataTransfer) {
-    if (!dataTransfer || !dataTransfer.types) return false
-    return Array.from(dataTransfer.types).includes('application/x-collavre-creative')
-  }
-
-  extractCreativeData(dataTransfer) {
-    if (!dataTransfer) return null
-    const raw = dataTransfer.getData('application/x-collavre-creative') || dataTransfer.getData('text/plain')
-    if (!raw) return null
-    try {
-      const parsed = JSON.parse(raw)
-      if (!parsed || !parsed.creativeId) return null
-      const label = this.getCreativeLabelFromDom(parsed.creativeId)
-      return { id: parsed.creativeId, label: label || `Creative #${parsed.creativeId}` }
-    } catch {
-      return null
-    }
   }
 
   getCreativeLabelFromDom(creativeId) {

--- a/engines/collavre/app/javascript/controllers/comments/list_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/list_controller.js
@@ -1,3 +1,5 @@
+import { createDragDropRegistry } from '../../lib/dnd/registry'
+import { getDragKind, readDragData, writeDragData } from '../../lib/dnd/envelope'
 import { Controller } from '@hotwired/stimulus'
 import { copyTextToClipboard } from '../../utils/clipboard'
 import { attachBundleDragImage } from '../../utils/drag_bundle_image'
@@ -66,11 +68,11 @@ export default class extends Controller {
     this.element.addEventListener('comments--topics:change', this.handleTopicChange)
 
     // Drag and drop handlers for moving comments to topics
-    this.handleDragStart = this.handleDragStart.bind(this)
-    this.handleDragEnd = this.handleDragEnd.bind(this)
     this.handleMoveToTopic = this.handleMoveToTopic.bind(this)
-    this.listTarget.addEventListener('dragstart', this.handleDragStart)
-    this.listTarget.addEventListener('dragend', this.handleDragEnd)
+    this.dnd = createDragDropRegistry({ root: this.listTarget, getKind: getDragKind, readData: readDragData })
+    this.dnd.registerDragSource({ selector: '.comment-item[draggable="true"]',
+      onDragStart: ({ event }) => this.handleDragStart(event),
+      onDragEnd: () => this.listTarget.classList.remove('dragging-comments') })
     this.element.addEventListener('comments--topics:move-to-topic', this.handleMoveToTopic)
 
   }
@@ -109,8 +111,7 @@ export default class extends Controller {
     this.listTarget.removeEventListener('change', this.handleChange)
     this.listTarget.removeEventListener('click', this.handleClick)
     this.listTarget.removeEventListener('submit', this.handleSubmit)
-    this.listTarget.removeEventListener('dragstart', this.handleDragStart)
-    this.listTarget.removeEventListener('dragend', this.handleDragEnd)
+    this.dnd?.destroy()
     document.removeEventListener('turbo:before-stream-render', this.handleStreamRender)
     if (this.listObserver) {
       this.listObserver.disconnect()
@@ -1067,7 +1068,7 @@ export default class extends Controller {
 
     // Include all selected comment IDs
     const commentIds = Array.from(this.selection)
-    event.dataTransfer.setData('application/x-comment-ids', JSON.stringify(commentIds))
+    writeDragData(event.dataTransfer, { kind: 'comments', ids: commentIds, payload: {} })
     event.dataTransfer.effectAllowed = 'move'
 
     // Add visual feedback
@@ -1079,10 +1080,6 @@ export default class extends Controller {
       const text = bodyEl ? bodyEl.textContent.trim() : ''
       attachBundleDragImage(event, commentIds.length, text)
     }
-  }
-
-  handleDragEnd(event) {
-    this.listTarget.classList.remove('dragging-comments')
   }
 
   async handleMoveToTopic(event) {

--- a/engines/collavre/app/javascript/controllers/comments/presence_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/presence_controller.js
@@ -1,6 +1,7 @@
+import { createDragDropRegistry } from '../../lib/dnd/registry'
+import { getDragKind, readDragData, writeDragData } from '../../lib/dnd/envelope'
 import { Controller } from '@hotwired/stimulus'
 import { createSubscription } from '../../services/cable'
-import TouchDragHandler from '../../lib/touch_drag'
 import csrfFetch from '../../lib/api/csrf_fetch'
 import { alertDialog } from '../../lib/utils/dialog'
 import PopupToggleGuard from '../../lib/popup_toggle_guard'
@@ -24,6 +25,17 @@ export default class extends Controller {
     'addParticipantButton', 'participantListButton']
 
   connect() {
+    this.dnd = createDragDropRegistry({ root: this.element, getKind: getDragKind, readData: readDragData })
+    this.dnd.registerDragSource({ selector: '.ai-agent-draggable',
+      onDragStart: ({ el, event }) => {
+        const user = this.participantsData.find(user => String(user.id) === el.dataset.agentId)
+        if (!user) return false
+        writeDragData(event.dataTransfer, { kind: 'agent', ids: [user.id],
+          payload: { name: user.name, avatar_url: user.avatar_url } })
+        event.dataTransfer.effectAllowed = 'copy'
+        el.classList.add('dragging')
+      },
+      onDragEnd: ({ el }) => el.classList.remove('dragging') })
     this.creativeId = null
     this.participantsData = null
     this.canShare = false
@@ -63,6 +75,7 @@ export default class extends Controller {
   }
 
   disconnect() {
+    this.dnd?.destroy()
     this._participantLoadVersion += 1
     this._closeParticipantListPopup()
     this.unsubscribe()
@@ -501,22 +514,6 @@ export default class extends Controller {
         wrapper.dataset.agentName = user.name
         wrapper.dataset.agentAvatarUrl = user.avatar_url
 
-        // HTML5 DnD (desktop)
-        wrapper.addEventListener('dragstart', (e) => {
-          e.dataTransfer.setData('application/x-agent-drop', JSON.stringify({
-            id: user.id,
-            name: user.name,
-            avatar_url: user.avatar_url
-          }))
-          e.dataTransfer.effectAllowed = 'copy'
-          wrapper.classList.add('dragging')
-        })
-        wrapper.addEventListener('dragend', () => {
-          wrapper.classList.remove('dragging')
-        })
-
-        // Touch drag (mobile)
-        this._addAgentTouchDrag(wrapper, user)
       }
 
       this.participantsTarget.appendChild(wrapper)
@@ -878,7 +875,7 @@ export default class extends Controller {
     if (String(activeTopicId) !== String(topicId)) return
 
     fetch(`/creatives/${this.creativeId}/topics/${topicId}/channel_chips`, {
-      headers: { Accept: 'text/html' },
+      headers: { Accept: 'text/html', 'X-Requested-With': 'XMLHttpRequest' },
       credentials: 'same-origin',
     })
       .then((r) => (r.ok ? r.text() : null))
@@ -1079,44 +1076,4 @@ export default class extends Controller {
     }))
   }
 
-  // ── Agent touch drag-and-drop (mobile) ─────────────────
-
-  _addAgentTouchDrag(wrapper, user) {
-    if (!('ontouchstart' in window)) return
-    const trigger = wrapper.querySelector('.comment-user-menu-trigger')
-    if (!trigger) return
-
-    const handler = new TouchDragHandler({
-      container: trigger,
-      singleElement: true,
-      dropTargetSelector: '.topic-tag.topic-drop-target, .topic-creation-container',
-      draggingClass: 'dragging',
-
-      proxyContent: () =>
-        `<span class="touch-drag-proxy-badge">${user.name}</span>`,
-
-      onTap: () => trigger.click(),
-
-      onDrop: (targetEl) => {
-        const agentData = { id: user.id, name: user.name, avatar_url: user.avatar_url }
-        const topicsCtrl = this.application.getControllerForElementAndIdentifier(
-          this.element, 'comments--topics'
-        )
-        if (!topicsCtrl) return
-
-        if (targetEl.closest('.topic-creation-container')) {
-          topicsCtrl.createTopicWithAgent(agentData)
-        } else {
-          const topicTag = targetEl.closest('.topic-tag.topic-drop-target')
-          if (topicTag?.dataset.id) {
-            topicsCtrl.setTopicPrimaryAgent(topicTag.dataset.id, agentData)
-          }
-        }
-      }
-    })
-
-    // Store for cleanup if needed
-    if (!this._agentTouchDragHandlers) this._agentTouchDragHandlers = []
-    this._agentTouchDragHandlers.push(handler)
-  }
 }

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -1,3 +1,6 @@
+import { createDragDropRegistry } from '../../lib/dnd/registry'
+import { getDragKind, readDragData, writeDragData } from '../../lib/dnd/envelope'
+import { previewDrop, horizontalHit } from '../../lib/dnd/preview'
 import { Controller } from "@hotwired/stimulus"
 import { createSubscription } from "../../services/cable"
 import { fetchNextTopicName, createTopicWithComments, saveLastTopic } from "../../lib/api/topics"
@@ -35,6 +38,7 @@ export default class extends Controller {
     static targets = ["list", "creationContainer", "topicListButton"]
 
     connect() {
+        this._registerDragDrop()
         this.topics = []
         this.canManageTopics = false
         this.canCreateTopic = false
@@ -64,6 +68,7 @@ export default class extends Controller {
     }
 
     disconnect() {
+        this.dnd?.destroy()
         this.cancelProgrammaticScroll()
         window.removeEventListener('comments--topics:new-message', this.handleNewMessage)
         window.removeEventListener('collavre:topic-moved', this.handleTopicMoved)
@@ -483,14 +488,6 @@ export default class extends Controller {
     }
 
     renderTopics(topics, canManage = false, canCreateTopic = canManage, canSetPrimaryAgent = canManage, sourceCreativeId = this._topicsCreativeId || this.creativeId) {
-        const dragActions = canManage
-            ? 'dragstart->comments--topics#handleTopicDragStart dragend->comments--topics#handleTopicDragEnd'
-            : ''
-        const dropActions = 'dragover->comments--topics#handleDragOver dragleave->comments--topics#handleDragLeave drop->comments--topics#handleDrop'
-        const topicDropActions = canManage
-            ? 'dragover->comments--topics#handleTopicReorderDragOver dragleave->comments--topics#handleTopicReorderDragLeave drop->comments--topics#handleTopicReorderDrop'
-            : ''
-
         const allMessagesLabel = this.element.dataset.topicMainText || 'All Messages'
 
         const mainTopic = this.mainTopicId ? topics.find(t => String(t.id) === String(this.mainTopicId)) : null
@@ -514,9 +511,8 @@ export default class extends Controller {
                 : ''
             const cronBadge = topic.cron_badge_html || ''
             const isMainTopic = this.mainTopicId && String(topic.id) === String(this.mainTopicId)
-            const interactionActions = topic.read_only ? '' : `${dropActions} ${dragActions} ${topicDropActions}`
             let s = `<span class="topic-tag topic-drop-target ${isActive}" ${draggable}
-                          data-action="click->comments--topics#select ${interactionActions}"
+                          data-action="click->comments--topics#select" data-dnd-read-only="${!!topic.read_only}"
                           data-id="${topic.id}"${topic.source_topic_id ? ` data-source-topic-id="${topic.source_topic_id}"` : ''}>
                         ${agentAvatar}${branchIcon}#${topic.display_name || topic.name}${cronBadge}${unreadBadge}`
             if (canManage && !isMainTopic && !topic.read_only) {
@@ -531,7 +527,7 @@ export default class extends Controller {
         otherTopics.forEach(topic => { html += renderTopic(topic) })
 
         html += `<span class="topic-tag topic-drop-target topic-all-messages ${this.currentTopicId ? '' : 'active'}"
-                      data-action="click->comments--topics#select ${dropActions}"
+                      data-action="click->comments--topics#select"
                       data-id="">📋 ${allMessagesLabel}</span>`
 
         // Archived topics section
@@ -597,57 +593,36 @@ export default class extends Controller {
             `<button class="add-topic-btn" data-action="click->comments--topics#showInput">+</button>`
     }
 
-    handleDragOver(event) {
-        // Accept comment drops or agent drops
-        const isComment = event.dataTransfer.types.includes('application/x-comment-ids')
-        const isAgent = event.dataTransfer.types.includes('application/x-agent-drop')
-        if (!isComment && !isAgent) return
-
-        event.preventDefault()
-        event.dataTransfer.dropEffect = isAgent ? 'copy' : 'move'
-        event.currentTarget.classList.add('drag-over')
-    }
-
-    handleDragLeave(event) {
-        event.currentTarget.classList.remove('drag-over')
-    }
-
-    async handleDrop(event) {
-        event.preventDefault()
-        event.currentTarget.classList.remove('drag-over')
-
-        // Handle agent drop
-        const agentJson = event.dataTransfer.getData('application/x-agent-drop')
-        if (agentJson) {
-            const agent = JSON.parse(agentJson)
-            const targetTopicId = event.currentTarget.dataset.id || this.mainTopicId
-            if (targetTopicId) {
-                await this.setTopicPrimaryAgent(targetTopicId, agent)
-            }
-            return
+    _registerDragDrop() {
+        this.dnd = createDragDropRegistry({ root: this.element, getKind: getDragKind, readData: readDragData })
+        this.dnd.registerDragSource({ selector: '.topic-tag[draggable="true"]',
+            onDragStart: this.handleTopicDragStart.bind(this),
+            onDragEnd: ({ el }) => { this.draggingTopicId = null; el.classList.remove('topic-dragging') } })
+        const selector = '.topic-drop-target:not([data-dnd-read-only="true"]), [data-comments--topics-target="creationContainer"]'
+        for (const kind of ['comments', 'agent']) {
+            this.dnd.registerDropZone({ selector, accepts: [kind], dropEffect: kind === 'agent' ? 'copy' : 'move',
+                preview: previewDrop,
+                onDrop: async ({ el, ids, payload }) => {
+                    const agent = { ...payload, id: ids[0] }
+                    if (el === this.creationContainerTarget) {
+                        if (kind === 'comments') await this.createTopicAndMoveComments(ids)
+                        else await this.createTopicWithAgent(agent)
+                    } else {
+                        const targetTopicId = el.dataset.id || this.mainTopicId
+                        if (kind === 'agent') {
+                            if (targetTopicId) await this.setTopicPrimaryAgent(targetTopicId, agent)
+                        } else this.dispatch('move-to-topic', { detail: { commentIds: ids, targetTopicId } })
+                    }
+                } })
         }
-
-        // Handle comment drop
-        const commentIdsJson = event.dataTransfer.getData('application/x-comment-ids')
-        if (!commentIdsJson) return
-
-        const commentIds = JSON.parse(commentIdsJson)
-        if (!commentIds || commentIds.length === 0) return
-
-        const targetTopicId = event.currentTarget.dataset.id || this.mainTopicId
-
-        // Dispatch event for list_controller to handle the move
-        this.dispatch('move-to-topic', {
-            detail: {
-                commentIds,
-                targetTopicId
-            }
-        })
+        this.dnd.registerDropZone({ selector: '.topic-tag[draggable="true"]', accepts: ['topic'],
+            hitTest: ({ el, event }) => this.draggingTopicId && el.dataset.id !== this.draggingTopicId
+                ? horizontalHit({ el, event }) : null,
+            preview: previewDrop, onDrop: this.handleTopicReorderDrop.bind(this) })
     }
 
     // Topic reorder drag & drop handlers
-    handleTopicDragStart(event) {
-        const topicEl = event.currentTarget
+    handleTopicDragStart({ event, el: topicEl }) {
         const topicId = topicEl.dataset.id
         if (!topicId) {
             event.preventDefault()
@@ -655,69 +630,19 @@ export default class extends Controller {
         }
 
         this.draggingTopicId = topicId
-        event.dataTransfer.setData('application/x-topic-id', topicId)
-        // Include topic move data so creative tree rows can accept this drop
-        event.dataTransfer.setData('application/x-topic-move', JSON.stringify({
-            topicId,
-            sourceCreativeId: this.creativeId
-        }))
+        writeDragData(event.dataTransfer, { kind: 'topic', ids: [topicId], payload: { sourceCreativeId: this.creativeId } })
         event.dataTransfer.effectAllowed = 'move'
 
         requestAnimationFrame(() => {
-            topicEl.classList.add('topic-dragging')
+            if (this.draggingTopicId === topicId) topicEl.classList.add('topic-dragging')
         })
     }
 
-    handleTopicDragEnd(event) {
-        this.draggingTopicId = null
-        event.currentTarget.classList.remove('topic-dragging')
-        this.listTarget.querySelectorAll('.topic-tag').forEach(el => {
-            el.classList.remove('topic-drag-over-left', 'topic-drag-over-right')
-        })
-    }
-
-    handleTopicReorderDragOver(event) {
-        // Only accept topic reorder drops
-        if (!event.dataTransfer.types.includes('application/x-topic-id')) return
-        if (!this.draggingTopicId) return
-
-        const targetEl = event.currentTarget
-        const targetId = targetEl.dataset.id
-
-        // Don't allow drop on self or Main
-        if (!targetId || targetId === this.draggingTopicId) return
-
-        event.preventDefault()
-        event.dataTransfer.dropEffect = 'move'
-
-        // Determine drop position (left or right) based on mouse position
-        const rect = targetEl.getBoundingClientRect()
-        const midpoint = rect.left + rect.width / 2
-        const isLeft = event.clientX < midpoint
-
-        targetEl.classList.toggle('topic-drag-over-left', isLeft)
-        targetEl.classList.toggle('topic-drag-over-right', !isLeft)
-    }
-
-    handleTopicReorderDragLeave(event) {
-        event.currentTarget.classList.remove('topic-drag-over-left', 'topic-drag-over-right')
-    }
-
-    async handleTopicReorderDrop(event) {
-        event.preventDefault()
-
-        const targetEl = event.currentTarget
-        targetEl.classList.remove('topic-drag-over-left', 'topic-drag-over-right')
-
-        const draggedTopicId = event.dataTransfer.getData('application/x-topic-id')
-        const targetTopicId = targetEl.dataset.id
-
-        if (!draggedTopicId || !targetTopicId || draggedTopicId === targetTopicId) return
-
-        // Determine drop position
-        const rect = targetEl.getBoundingClientRect()
-        const midpoint = rect.left + rect.width / 2
-        const insertBefore = event.clientX < midpoint
+    async handleTopicReorderDrop({ el, ids, hit }) {
+        const draggedTopicId = ids[0]
+        const targetTopicId = el.dataset.id
+        if (!draggedTopicId || !targetTopicId || String(draggedTopicId) === targetTopicId) return
+        const insertBefore = hit === 'left'
 
         // Reorder topics array
         const topics = [...this.topics]
@@ -2622,37 +2547,6 @@ export default class extends Controller {
 
         this.renderTopics(this.topics, this.canManageTopics, this.canCreateTopic, this.canSetPrimaryAgent)
         this.restoreSelection()
-    }
-
-    handleAddButtonDragOver(event) {
-        const isAgent = event.dataTransfer.types.includes('application/x-agent-drop')
-        const isComment = event.dataTransfer.types.includes('application/x-comment-ids')
-        if (!isAgent && !isComment) return
-        event.preventDefault()
-        event.dataTransfer.dropEffect = isAgent ? 'copy' : 'move'
-        event.currentTarget.classList.add('drag-over')
-    }
-
-    async handleAddButtonDrop(event) {
-        event.preventDefault()
-        event.currentTarget.classList.remove('drag-over')
-
-        // Handle comment drop → create new topic + move
-        const commentIdsJson = event.dataTransfer.getData('application/x-comment-ids')
-        if (commentIdsJson) {
-            const commentIds = JSON.parse(commentIdsJson)
-            if (commentIds && commentIds.length > 0) {
-                await this.createTopicAndMoveComments(commentIds)
-            }
-            return
-        }
-
-        // Handle agent drop (existing logic)
-        const agentJson = event.dataTransfer.getData('application/x-agent-drop')
-        if (!agentJson) return
-
-        const agent = JSON.parse(agentJson)
-        await this.createTopicWithAgent(agent)
     }
 
     async createTopicAndMoveComments(commentIds, topicName = null) {

--- a/engines/collavre/app/javascript/creatives/drag_drop/__tests__/creative_tree_drop.test.js
+++ b/engines/collavre/app/javascript/creatives/drag_drop/__tests__/creative_tree_drop.test.js
@@ -389,6 +389,38 @@ describe('right creative tree drop wiring', () => {
     }))
   })
 
+  test.each([
+    [['8', '9'], '9', 'creative-9'],
+    [['8'], '8', null],
+    [['9'], '9', 'creative-9'],
+  ])('pairs the source tree with its successful dragged row for %j', async (succeededIds, creativeId, treeId) => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
+    window.localStorage.setItem(DRAG_TOKEN_STORAGE_KEY, 'token-under-test')
+    resetDragSessionCache()
+    const setItem = jest.spyOn(Storage.prototype, 'setItem')
+    const completion = jest.fn()
+    window.addEventListener('collavre:creative-drop-complete', completion, { once: true })
+    runMoveWithDomRecovery.mockResolvedValue({
+      status: succeededIds.length === 2 ? 'success' : 'partial', ok: succeededIds.length === 2,
+      succeededIds, failedIds: ['8', '9'].filter(id => !succeededIds.includes(id)), failures: [],
+    })
+    const dataTransfer = transfer()
+    dataTransfer.setData('application/x-collavre-creative', JSON.stringify({
+      creativeId: '9', treeId: 'creative-9', selectedCreativeIds: ['8', '9'],
+      token: 'token-under-test', sourceWindowId: 'other-window',
+    }))
+
+    await handleDrop(dragEvent(tree('1'), dataTransfer))
+
+    expect(completion).toHaveBeenCalledWith(expect.objectContaining({
+      detail: expect.objectContaining({ creativeId, treeId, creativeIds: succeededIds }),
+    }))
+    const signal = setItem.mock.calls.find(([key]) => key === DROP_SIGNAL_STORAGE_KEY)
+    expect(JSON.parse(signal[1])).toEqual(expect.objectContaining({ creativeId, treeId, creativeIds: succeededIds }))
+    setItem.mockRestore()
+    consoleError.mockRestore()
+  })
+
   // A partial view can hand back an envelope whose tree id no longer resolves,
   // so the row identity — not the tree id — has to catch the self drop.
   test('declines an envelope that resolves back onto its own row', async () => {

--- a/engines/collavre/app/javascript/creatives/drag_drop/__tests__/source_window_bundle.test.js
+++ b/engines/collavre/app/javascript/creatives/drag_drop/__tests__/source_window_bundle.test.js
@@ -72,6 +72,25 @@ test.each([
   expect(load).not.toHaveBeenCalled()
 })
 
+test.each([
+  { creativeId: '8', creativeIds: ['7', '8'], treeId: 'creative-8', expected: ['9', '7', '8'] },
+  { creativeId: '7', creativeIds: ['7'], treeId: null, expected: ['8', '9', '7'] },
+])('completion preserves bundle rows while editing defers refresh: %j', detail => {
+  const draft = document.createElement('textarea')
+  draft.value = 'Unsaved target draft'
+  container.lastElementChild.appendChild(draft)
+  document.dispatchEvent(new Event('creative-editing:start'))
+  signal({ ...detail, direction: 'down', targetTreeId: 'creative-9', mode: 'move' })
+  jest.advanceTimersByTime(400)
+  expect(ids()).toEqual(detail.expected)
+  expect(draft.isConnected).toBe(true)
+  expect(draft.value).toBe('Unsaved target draft')
+  expect(load).not.toHaveBeenCalled()
+  document.dispatchEvent(new Event('creative-editing:stop'))
+  jest.advanceTimersByTime(400)
+  expect(load).toHaveBeenCalledTimes(1)
+})
+
 test('bundle children retain their order and parent metadata', () => {
   controller.beginReloadHold()
   signal({ creativeId: '7', creativeIds: [7, 8], treeId: 'creative-7', direction: 'child', targetTreeId: 'creative-9' })

--- a/engines/collavre/app/javascript/creatives/drag_drop/__tests__/touch_tree_integration.test.js
+++ b/engines/collavre/app/javascript/creatives/drag_drop/__tests__/touch_tree_integration.test.js
@@ -1,0 +1,189 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals'
+
+const sendNewOrder = jest.fn()
+jest.unstable_mockModule('../../../lib/api/drag_drop', () => ({
+  sendNewOrder,
+  sendLinkedCreative: jest.fn(),
+  sendTopicMove: jest.fn(),
+  isAuthenticationRedirect: () => false,
+}))
+jest.unstable_mockModule('../../../lib/utils/dialog', () => ({ alertDialog: jest.fn() }))
+const { createCreativeTreeDragDrop } = await import('../event_handlers')
+const { createWorkspaceTreeDragDrop } = await import('../workspace_tree_adapter')
+const { resetDragSessionCache } = await import('../../../lib/dnd/session')
+const { getDraggedState, resetDraggedState } = await import('../state')
+
+let right, left, execute, pointTarget
+const row = id => document.getElementById(id)
+const point = el => ({ clientX: 50, clientY: el.getBoundingClientRect().top + 50, target: el })
+function touch(type, source, target = source) {
+  pointTarget = target
+  source.dispatchEvent(new TouchEvent(type, { bubbles: true, cancelable: true,
+    touches: type === 'touchend' ? [] : [point(target)],
+    changedTouches: [point(target)],
+  }))
+}
+
+beforeEach(() => {
+  jest.useFakeTimers()
+  jest.spyOn(console, 'error').mockImplementation(() => {})
+  sendNewOrder.mockReset().mockResolvedValue({ ok: false, status: 403 })
+  localStorage.clear()
+  sessionStorage.clear()
+  resetDragSessionCache()
+  document.body.innerHTML = '<div id="creatives">' + ['1', '9'].map(id => `
+    <creative-tree-row creative-id="${id}" level="1">
+      <div class="creative-tree" id="creative-${id}" draggable="true"></div>
+    </creative-tree-row>`).join('') + '</div><nav><ul>' + ['2', '3'].map(id => `
+    <li class="creative-workspace-tree-item" data-creative-id="${id}" data-level="1">
+      <div id="workspace-${id}" class="creative-workspace-tree-row" data-creative-id="${id}" draggable="true"></div>
+    </li>`).join('') + '</ul></nav>'
+  document.querySelectorAll('[draggable]').forEach((el, index) => {
+    el.getBoundingClientRect = () => ({ left: 0, right: 100, top: index * 100,
+      bottom: index * 100 + 100, width: 100, height: 100 })
+  })
+  document.elementFromPoint = () => pointTarget
+  execute = jest.fn(async command => ({ status: 'success', succeededIds: command.ids }))
+  right = createCreativeTreeDragDrop()
+  left = createWorkspaceTreeDragDrop({ root: document.querySelector('nav'),
+    controller: { expandBranchForDrag: jest.fn() }, execute })
+})
+
+afterEach(() => {
+  right.destroy()
+  left.destroy()
+  resetDraggedState()
+  resetDragSessionCache()
+  document.body.innerHTML = ''
+  delete document.elementFromPoint
+  jest.restoreAllMocks()
+  jest.useRealTimers()
+})
+
+test.each([
+  ['creative-1', 'workspace-2', '1', '2'],
+  ['workspace-2', 'workspace-3', '2', '3'],
+])('touch %s → %s invokes the shared move exactly once', async (sourceId, targetId, id, target) => {
+  const source = row(sourceId)
+  touch('touchstart', source)
+  jest.advanceTimersByTime(400)
+  touch('touchmove', source, row(targetId))
+  touch('touchend', source, row(targetId))
+  await Promise.resolve()
+  expect(execute).toHaveBeenCalledTimes(1)
+  expect(execute).toHaveBeenCalledWith({ ids: [id], targetId: target, direction: 'child', mode: 'move' })
+  expect(getDraggedState()).toBeNull()
+  expect(document.querySelector('.touch-drag-proxy')).toBeNull()
+})
+
+test.each(['workspace-2', 'creative-1'])('touch %s → right tree keeps command and failure recovery', async sourceId => {
+  const source = row(sourceId)
+  touch('touchstart', source)
+  jest.advanceTimersByTime(400)
+  touch('touchmove', source, row('creative-9'))
+  touch('touchend', source, row('creative-9'))
+  for (let i = 0; i < 10; i += 1) await Promise.resolve()
+  expect(sendNewOrder).toHaveBeenCalledTimes(1)
+  expect(sendNewOrder).toHaveBeenCalledWith({ draggedId: sourceId === 'workspace-2' ? '2' : '1',
+    targetId: '9', direction: 'child' })
+  expect(row('creative-1').closest('creative-tree-row').parentElement.id).toBe('creatives')
+  expect(getDraggedState()).toBeNull()
+  expect(document.querySelector('.drag-over')).toBeNull()
+})
+
+function native(type, source, transfer, target = source) {
+  const event = new Event(type, { bubbles: true, cancelable: true })
+  Object.defineProperties(event, {
+    dataTransfer: { value: transfer },
+    clientX: { value: point(target).clientX },
+    clientY: { value: point(target).clientY },
+  })
+  target.dispatchEvent(event)
+  return event
+}
+
+function emptyTransfer() {
+  return { types: [], getData: () => '', setData: jest.fn(), effectAllowed: 'none' }
+}
+
+function blockStorage() {
+  jest.spyOn(Storage.prototype, 'getItem').mockImplementation(() => { throw new Error('Storage blocked') })
+  jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => { throw new Error('Storage blocked') })
+}
+
+test.each(['native', 'touch'])('%s preserves all local tree routes when storage is blocked', async mode => {
+  blockStorage()
+  for (const [sourceId, targetId, id] of [
+    ['workspace-2', 'workspace-3', '2'],
+    ['workspace-2', 'creative-9', '2'],
+    ['creative-1', 'workspace-3', '1'],
+  ]) {
+    const source = row(sourceId)
+    const target = row(targetId)
+    const transfer = emptyTransfer()
+    execute.mockClear()
+    sendNewOrder.mockClear()
+    if (mode === 'native') {
+      native('dragstart', source, transfer)
+      expect(native('dragover', source, transfer, target).defaultPrevented).toBe(true)
+      native('drop', source, transfer, target)
+    } else {
+      touch('touchstart', source)
+      jest.advanceTimersByTime(400)
+      touch('touchmove', source, target)
+      touch('touchend', source, target)
+    }
+    for (let i = 0; i < 10; i += 1) await Promise.resolve()
+    if (targetId === 'creative-9') {
+      expect(sendNewOrder).toHaveBeenCalledWith({ draggedId: id, targetId: '9', direction: 'child' })
+    } else {
+      expect(execute).toHaveBeenCalledWith({ ids: [id], targetId: '3', direction: 'child', mode: 'move' })
+    }
+    execute.mockClear()
+    sendNewOrder.mockClear()
+    native('drop', source, emptyTransfer(), target)
+    expect(execute).not.toHaveBeenCalled()
+    expect(sendNewOrder).not.toHaveBeenCalled()
+    expect(document.querySelector('.is-dragging')).toBeNull()
+  }
+})
+
+test.each(['dragend', 'escape', 'destroy'])('%s clears the workspace gesture fallback', action => {
+  blockStorage()
+  const source = row('workspace-2')
+  const transfer = emptyTransfer()
+  native('dragstart', source, transfer)
+  if (action === 'dragend') native('dragend', source, transfer)
+  if (action === 'escape') document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+  if (action === 'destroy') left.destroy()
+  native('drop', source, transfer, row('creative-9'))
+  expect(sendNewOrder).not.toHaveBeenCalled()
+  expect(document.querySelector('.is-dragging')).toBeNull()
+})
+
+test('local fallback cannot authorize a rejected foreign transfer', () => {
+  blockStorage()
+  const source = row('workspace-2')
+  native('dragstart', source, emptyTransfer())
+  const foreign = { types: ['application/x-collavre-creative'], getData: () => JSON.stringify({
+    creativeId: '99', treeId: 'foreign-99', token: 'foreign', sourceWindowId: 'foreign',
+  }) }
+  native('drop', source, foreign, row('creative-9'))
+  expect(sendNewOrder).not.toHaveBeenCalled()
+  expect(execute).not.toHaveBeenCalled()
+})
+
+test('touch cancellation clears the workspace fallback before another drop', () => {
+  blockStorage()
+  const source = row('workspace-2')
+  touch('touchstart', source)
+  jest.advanceTimersByTime(400)
+  touch('touchmove', source, row('workspace-3'))
+  touch('touchcancel', source)
+  native('drop', source, emptyTransfer(), row('creative-9'))
+  expect(sendNewOrder).not.toHaveBeenCalled()
+  expect(execute).not.toHaveBeenCalled()
+  expect(document.querySelector('.touch-drag-proxy')).toBeNull()
+  expect(document.querySelector('.is-dragging')).toBeNull()
+})

--- a/engines/collavre/app/javascript/creatives/drag_drop/__tests__/workspace_tree_adapter.test.js
+++ b/engines/collavre/app/javascript/creatives/drag_drop/__tests__/workspace_tree_adapter.test.js
@@ -354,6 +354,37 @@ describe('workspace tree drag and drop adapter', () => {
     setItem.mockRestore()
   })
 
+  test.each([
+    [['8', '9'], '9', 'creative-9'],
+    [['8'], '8', null],
+    [['9'], '9', 'creative-9'],
+  ])('preserves the originating row/tree pair for successful IDs %j', async (succeededIds, creativeId, treeId) => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
+    const completion = jest.fn()
+    window.addEventListener('collavre:creative-drop-complete', completion, { once: true })
+    const setItem = jest.spyOn(Storage.prototype, 'setItem')
+    execute.mockResolvedValue({
+      status: succeededIds.length === 2 ? 'success' : 'partial', succeededIds,
+      failedIds: ['8', '9'].filter(id => !succeededIds.includes(id)), failures: [],
+    })
+    const transfer = dataTransfer()
+    writeDragData(transfer, {
+      kind: 'creative', ids: ['8', '9'],
+      payload: { creativeId: '9', treeId: 'creative-9', sourceWindowId: 'right-window' },
+    })
+    const target = document.getElementById('workspace-creative-2')
+    event('dragover', target, transfer)
+    event('drop', target, transfer)
+    await flush()
+    expect(completion).toHaveBeenCalledWith(expect.objectContaining({
+      detail: expect.objectContaining({ creativeId, treeId, creativeIds: succeededIds }),
+    }))
+    const signal = setItem.mock.calls.find(([key]) => key === 'collavre.dragDropSignal')
+    expect(JSON.parse(signal[1])).toEqual(expect.objectContaining({ creativeId, treeId, creativeIds: succeededIds }))
+    setItem.mockRestore()
+    consoleError.mockRestore()
+  })
+
   // The dialog copy comes from the server and is covered by move_feedback's own
   // suite; here only the hand-off from the adapter matters.
   test('surfaces the rows a partial move left behind', async () => {

--- a/engines/collavre/app/javascript/creatives/drag_drop/event_handlers.js
+++ b/engines/collavre/app/javascript/creatives/drag_drop/event_handlers.js
@@ -410,7 +410,7 @@ export function handleDragStart(event) {
   });
 }
 
-export function handleDragOver(event, intent = null) {
+export function handleDragOver(event, intent = null, kind = null) {
   const tree = event.target.closest(DRAGGABLE_SELECTOR);
   const lastRow = getLastDragOverRow();
   if (lastRow && lastRow !== tree) {
@@ -420,7 +420,7 @@ export function handleDragOver(event, intent = null) {
   }
   if (!tree || tree.draggable === false) return;
 
-  const dragKind = getDragKind(event.dataTransfer);
+  const dragKind = kind || getDragKind(event.dataTransfer);
 
   // Topic move drag: always show as child drop target
   if (dragKind === 'topic') {
@@ -479,13 +479,12 @@ function resetDrag() {
   hideLinkHover();
 }
 
-export function handleDrop(event, intent = null, { partialFailureMessage = '' } = {}) {
+export function handleDrop(event, intent = null, { partialFailureMessage = '', dragData = readDragData(event.dataTransfer) } = {}) {
   clearHoverExpand();
   const targetTree = event.target.closest(DRAGGABLE_SELECTOR);
   const targetId = targetTree ? targetTree.id : '';
 
   // Handle topic move drop
-  const dragData = readDragData(event.dataTransfer);
   if (dragData?.kind === 'topic' && targetTree) {
     event.preventDefault();
     clearDragHighlight(targetTree);
@@ -644,6 +643,7 @@ export function handleDrop(event, intent = null, { partialFailureMessage = '' } 
   }
 
   const dropSignalDetails = {
+    creativeId: String(draggedState.creativeId),
     treeId: draggedState.treeId,
     sourceWindowId: draggedState.sourceWindowId,
     targetTreeId: targetId,
@@ -663,9 +663,13 @@ export function handleDrop(event, intent = null, { partialFailureMessage = '' } 
       console.error('Creative move did not fully complete', result);
     }
     if (result.succeededIds.length === 0) return result;
+    // The source tree identifies the dragged row even when the bundle starts
+    // with another ID. Never attach it to a different successful row.
+    const sourceSucceeded = result.succeededIds.includes(dropSignalDetails.creativeId);
     const detail = {
       ...dropSignalDetails,
-      creativeId: result.succeededIds[0],
+      creativeId: sourceSucceeded ? dropSignalDetails.creativeId : result.succeededIds[0],
+      treeId: sourceSucceeded ? dropSignalDetails.treeId : null,
       creativeIds: result.succeededIds,
     };
     if (mode === 'move' && detail.sourceWindowId) emitDropSignal(detail);
@@ -742,7 +746,11 @@ export function createCreativeTreeDragDrop({ partialFailureMessage = '' } = {}) 
   });
   registry.registerDragSource({
     selector: DRAGGABLE_SELECTOR,
-    onDragStart: ({ event }) => handleDragStart(event),
+    onDragStart: ({ event, setLocalData }) => {
+      handleDragStart(event);
+      const data = localData(event.dataTransfer);
+      if (data) setLocalData(data);
+    },
     onDragEnd: () => {
       clearDragHighlight(getLastDragOverRow());
       resetDrag();
@@ -760,8 +768,8 @@ export function createCreativeTreeDragDrop({ partialFailureMessage = '' } = {}) 
         previousPosition: previousHit,
       });
     },
-    preview: ({ event, hit }) => {
-      handleDragOver(event, hit);
+    preview: ({ event, hit, kind }) => {
+      handleDragOver(event, hit, kind);
       return () => handleDragLeave(event);
     },
     dropEffect: ({ event, kind }) => {
@@ -770,7 +778,9 @@ export function createCreativeTreeDragDrop({ partialFailureMessage = '' } = {}) 
       else hideLinkHover();
       return event.shiftKey ? 'copy' : 'move';
     },
-    onDrop: ({ event, hit }) => handleDrop(event, hit, { partialFailureMessage }),
+    onDrop: ({ event, hit, kind, ids, payload }) => handleDrop(event, hit, {
+      partialFailureMessage, dragData: { kind, ids, payload },
+    }),
   });
   return registry;
 }

--- a/engines/collavre/app/javascript/creatives/drag_drop/workspace_tree_adapter.js
+++ b/engines/collavre/app/javascript/creatives/drag_drop/workspace_tree_adapter.js
@@ -31,16 +31,17 @@ function creativePayload(item, row) {
   }
 }
 
-function startWorkspaceDrag({ el: row, event }) {
+function startWorkspaceDrag({ el: row, event, setLocalData }) {
   const item = workspaceItemFromRow(row)
-  if (!item || !event.dataTransfer) return
+  if (!item || !event.dataTransfer) return false
 
   const payload = creativePayload(item, row)
-  writeDragData(event.dataTransfer, {
+  const data = {
     kind: 'creative',
     ids: [payload.creativeId],
     payload,
-  })
+  }
+  if (!writeDragData(event.dataTransfer, data)) setLocalData(data)
   event.dataTransfer.effectAllowed = 'copyMove'
   row.classList.add('is-dragging')
 }
@@ -76,11 +77,12 @@ function previewWorkspaceRow(controller, expandDelay, { el: row, hit }) {
 }
 
 function completionDetail(ids, payload, targetId, direction) {
+  const sourceSucceeded = ids.includes(String(payload.creativeId))
   return {
-    creativeId: ids[0],
+    creativeId: sourceSucceeded ? String(payload.creativeId) : ids[0],
     creativeIds: ids,
-    // The shared reader rejects a creative envelope with no originating tree.
-    treeId: payload.treeId,
+    // The originating tree belongs to the dragged row, not the first bundle ID.
+    treeId: sourceSucceeded ? payload.treeId : null,
     sourceWindowId: payload.sourceWindowId || null,
     targetCreativeId: targetId,
     direction,

--- a/engines/collavre/app/javascript/lib/__tests__/touch_drag_targets.test.js
+++ b/engines/collavre/app/javascript/lib/__tests__/touch_drag_targets.test.js
@@ -1,0 +1,247 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals'
+import TouchDragHandler from '../touch_drag'
+
+let handler, container, onDrop, onCancel, onTargetChange
+const rect = (top = 0) => ({ left: 0, right: 200, top, bottom: top + 100, width: 200, height: 100 })
+function target(top = 0) {
+  const el = document.createElement('div')
+  el.className = 'drop-target'
+  el.getBoundingClientRect = () => rect(top)
+  document.body.appendChild(el)
+  return el
+}
+function touch(type, x = 50, y = 50) {
+  const event = new TouchEvent(type, { bubbles: true, cancelable: true })
+  Object.defineProperty(event, 'touches', { value: type === 'touchend' || type === 'touchcancel'
+    ? [] : [{ clientX: x, clientY: y, target: container }] })
+  container.dispatchEvent(event)
+  return event
+}
+function start(x = 50, y = 50) {
+  touch('touchstart', x, y)
+  jest.advanceTimersByTime(400)
+}
+function setup(options = {}) {
+  handler = new TouchDragHandler({ container, singleElement: true, dropTargetSelector: '.drop-target',
+    onDrop, onCancel, onTargetChange, ...options })
+}
+beforeEach(() => {
+  jest.useFakeTimers()
+  container = document.createElement('div')
+  container.getBoundingClientRect = () => rect()
+  document.body.appendChild(container)
+  onDrop = jest.fn()
+  onCancel = jest.fn()
+  onTargetChange = jest.fn()
+})
+afterEach(() => {
+  handler?.destroy()
+  document.body.innerHTML = ''
+  jest.useRealTimers()
+})
+
+test('reports hit changes inside one target and delivers position at drop', () => {
+  const el = target()
+  const hitTest = jest.fn((target, point) => point.clientY < 30 ? 'up' : 'child')
+  setup({ hitTest })
+  start(50, 20)
+  touch('touchmove', 50, 60)
+  expect(hitTest).toHaveBeenLastCalledWith(el, { clientX: 50, clientY: 60 }, 'up')
+  expect(onTargetChange).toHaveBeenLastCalledWith(el, { clientX: 50, clientY: 60, hit: 'child' })
+  touch('touchend')
+  expect(onDrop).toHaveBeenCalledWith(el, { clientX: 50, clientY: 60, hit: 'child' })
+  expect(el.classList.contains('drag-over')).toBe(false)
+})
+
+test('refresh discovers expanded targets and forgets removed targets without finger movement', () => {
+  setup()
+  start()
+  const added = target()
+  handler.refreshDropTargets()
+  expect(added.classList.contains('drag-over')).toBe(true)
+  added.remove()
+  handler.refreshDropTargets()
+  touch('touchend')
+  expect(onDrop).not.toHaveBeenCalled()
+  expect(onCancel).toHaveBeenCalledTimes(1)
+})
+
+test('rejects hidden and disallowed targets, resolving fresh candidate lists', () => {
+  const hidden = target()
+  hidden.getBoundingClientRect = () => ({ ...rect(), width: 0 })
+  const rejected = target()
+  const accepted = target()
+  const getDropTargets = jest.fn(() => [hidden, rejected, accepted])
+  setup({ getDropTargets, hitTest: el => el === rejected ? null : 'down' })
+  start()
+  touch('touchend')
+  expect(onDrop).toHaveBeenCalledWith(accepted, expect.objectContaining({ hit: 'down' }))
+})
+
+test('touchcancel never commits a drop or triggers a pending tap', () => {
+  target()
+  const onTap = jest.fn()
+  setup({ onTap })
+  touch('touchstart')
+  touch('touchcancel')
+  expect(onTap).not.toHaveBeenCalled()
+  start()
+  touch('touchcancel')
+  expect(onDrop).not.toHaveBeenCalled()
+  expect(onCancel).toHaveBeenCalledTimes(1)
+  expect(document.querySelector('.touch-drag-proxy')).toBeNull()
+})
+
+test('autoscroll continues while stationary and stops on cancellation', () => {
+  const el = target()
+  const scrollContainer = jest.fn(() => container)
+  setup({ autoScroll: true, scrollContainer })
+  start(50, 95)
+  jest.advanceTimersByTime(48)
+  expect(container.scrollTop).toBeGreaterThan(0)
+  expect(scrollContainer).toHaveBeenCalledWith({ clientX: 50, clientY: 95 }, el)
+  touch('touchcancel')
+  const stopped = container.scrollTop
+  jest.advanceTimersByTime(100)
+  expect(container.scrollTop).toBe(stopped)
+  expect(jest.getTimerCount()).toBe(0)
+})
+
+test('autoscroll moves up near the top, stays still at the center and outside the pane', () => {
+  setup({ autoScroll: true })
+  container.scrollTop = 200
+  start(50, 5)
+  jest.advanceTimersByTime(32)
+  expect(container.scrollTop).toBeLessThan(200)
+  touch('touchmove', 50, 50)
+  const centered = container.scrollTop
+  jest.advanceTimersByTime(32)
+  expect(container.scrollTop).toBe(centered)
+  touch('touchmove', 250, 95)
+  jest.advanceTimersByTime(32)
+  expect(container.scrollTop).toBe(centered)
+})
+
+test('destroy clears active highlights, proxy and animation frames', () => {
+  const el = target()
+  setup({ autoScroll: true })
+  start()
+  handler.destroy()
+  expect(el.classList.contains('drag-over')).toBe(false)
+  expect(document.querySelector('.touch-drag-proxy')).toBeNull()
+  expect(jest.getTimerCount()).toBe(0)
+})
+
+test('legacy selected-item sources still reject controls and collect selected items', () => {
+  container.innerHTML = '<div class="selected"><button>Action</button><span>Item</span></div><div class="unselected"></div>'
+  const onDragStart = jest.fn()
+  setup({ singleElement: false, itemSelector: '.selected', onDragStart })
+  const startAt = element => {
+    const event = new TouchEvent('touchstart', { bubbles: true, cancelable: true,
+      touches: [{ target: element, clientX: 50, clientY: 50 }] })
+    element.dispatchEvent(event)
+    return event
+  }
+  expect(startAt(container.querySelector('button')).defaultPrevented).toBe(false)
+  expect(startAt(container.querySelector('.unselected')).defaultPrevented).toBe(false)
+  const span = container.querySelector('span')
+  expect(startAt(span).defaultPrevented).toBe(true)
+  jest.advanceTimersByTime(400)
+  expect(onDragStart.mock.calls[0][0]).toHaveLength(1)
+  const context = new Event('contextmenu', { cancelable: true })
+  document.dispatchEvent(context)
+  expect(context.defaultPrevented).toBe(true)
+  touch('touchcancel')
+})
+
+test.each([[75, 50], [50, 75]])('movement beyond tolerance cancels long press at %s/%s without a tap', (x, y) => {
+  const onTap = jest.fn()
+  setup({ onTap })
+  touch('touchstart')
+  expect(touch('touchmove', 52, 52).defaultPrevented).toBe(true)
+  expect(touch('touchmove', x, y).defaultPrevented).toBe(false)
+  jest.advanceTimersByTime(400)
+  touch('touchmove', x + 10, y + 10)
+  touch('touchend')
+  expect(onTap).not.toHaveBeenCalled()
+  expect(document.querySelector('.touch-drag-proxy')).toBeNull()
+})
+
+test('a selected item disappearing during the delay does not begin a drag', () => {
+  container.innerHTML = '<span class="selected"></span>'
+  setup({ singleElement: false, itemSelector: '.selected' })
+  const item = container.firstElementChild
+  item.dispatchEvent(new TouchEvent('touchstart', { bubbles: true, cancelable: true,
+    touches: [{ target: item, clientX: 50, clientY: 50 }] }))
+  item.className = ''
+  jest.advanceTimersByTime(400)
+  expect(document.querySelector('.touch-drag-proxy')).toBeNull()
+})
+
+test('empty touch notifications and repeated starts do not create another gesture', () => {
+  const onDragStart = jest.fn()
+  setup({ onDragStart })
+  container.dispatchEvent(new TouchEvent('touchstart', { bubbles: true }))
+  container.dispatchEvent(new TouchEvent('touchmove', { bubbles: true }))
+  expect(jest.getTimerCount()).toBe(0)
+  start()
+  touch('touchstart')
+  expect(onDragStart).toHaveBeenCalledTimes(1)
+})
+
+test('viewport autoscroll uses the window edges and provides optional haptic feedback', () => {
+  Object.defineProperty(document, 'scrollingElement', { configurable: true, value: document.documentElement })
+  navigator.vibrate = jest.fn()
+  try {
+    setup({ autoScroll: true, scrollContainer: document.documentElement })
+    start(50, window.innerHeight - 5)
+    jest.advanceTimersByTime(32)
+    expect(document.documentElement.scrollTop).toBeGreaterThan(0)
+    expect(navigator.vibrate).toHaveBeenCalledWith(30)
+    touch('touchcancel')
+    handler.refreshDropTargets()
+  } finally {
+    delete document.scrollingElement
+    delete navigator.vibrate
+  }
+})
+
+test('a queued animation callback cannot restart scrolling after cancellation', () => {
+  let callback
+  const schedule = jest.spyOn(window, 'requestAnimationFrame').mockImplementation(fn => { callback = fn; return 7 })
+  setup({ autoScroll: true })
+  start()
+  handler.cancel()
+  callback()
+  expect(schedule).toHaveBeenCalledTimes(1)
+  expect(document.querySelector('.touch-drag-proxy')).toBeNull()
+  schedule.mockRestore()
+})
+
+test('default selected-item mode keeps native menus after cancellation and can start again', () => {
+  container.innerHTML = '<span class="selected">One</span><span class="selected">Two</span>'
+  const item = container.firstElementChild
+  const onDragStart = jest.fn()
+  setup({ singleElement: undefined, itemSelector: '.selected', onDragStart })
+  const begin = () => {
+    item.dispatchEvent(new TouchEvent('touchstart', { bubbles: true, cancelable: true,
+      touches: [{ target: item, clientX: 50, clientY: 50 }] }))
+    jest.advanceTimersByTime(400)
+  }
+  begin()
+  expect(Array.from(onDragStart.mock.calls[0][0])).toEqual(Array.from(container.children))
+  expect(document.querySelector('.touch-drag-proxy').textContent).toBe('2')
+  const activeMenu = new Event('contextmenu', { cancelable: true })
+  document.dispatchEvent(activeMenu)
+  expect(activeMenu.defaultPrevented).toBe(true)
+
+  handler.cancel()
+  const nativeMenu = new Event('contextmenu', { cancelable: true })
+  document.dispatchEvent(nativeMenu)
+  expect(nativeMenu.defaultPrevented).toBe(false)
+  expect(document.querySelector('.touch-drag-proxy')).toBeNull()
+  begin()
+  expect(onDragStart).toHaveBeenCalledTimes(2)
+  expect(document.querySelectorAll('.touch-drag-proxy')).toHaveLength(1)
+})

--- a/engines/collavre/app/javascript/lib/dnd/__tests__/preview.test.js
+++ b/engines/collavre/app/javascript/lib/dnd/__tests__/preview.test.js
@@ -1,0 +1,22 @@
+import { horizontalHit, previewDrop } from '../preview.js'
+
+test('horizontal hit uses the midpoint and preview cleanup removes only its class', () => {
+  const el = document.createElement('span')
+  el.getBoundingClientRect = () => ({ left: 10, width: 20 })
+  expect(horizontalHit({ el, event: { clientX: 19 } })).toBe('left')
+  expect(horizontalHit({ el, event: { clientX: 20 } })).toBe('right')
+  el.classList.add('topic-tag')
+  const cleanup = previewDrop({ el, hit: 'left' })
+  expect(el.classList.contains('dnd-over-left')).toBe(true)
+  cleanup()
+  expect(el.className).toBe('topic-tag')
+})
+
+
+test('default registry hit uses the shared into style', () => {
+  const el = document.createElement('div')
+  const cleanup = previewDrop({ el, hit: true })
+  expect(el.className).toBe('dnd-over-into')
+  cleanup()
+  expect(el.className).toBe('')
+})

--- a/engines/collavre/app/javascript/lib/dnd/__tests__/registry.test.js
+++ b/engines/collavre/app/javascript/lib/dnd/__tests__/registry.test.js
@@ -746,3 +746,52 @@ describe('createDragDropRegistry', () => {
   })
 
 })
+
+test('gesture fallback remains document-local and is cleared by source removal', () => {
+  document.body.innerHTML = '<div class="source"></div><div class="zone"></div>'
+  const foreignDocument = document.implementation.createHTMLDocument('foreign')
+  foreignDocument.body.innerHTML = '<div class="zone"></div>'
+  const sourceRegistry = createDragDropRegistry({ root: document, touch: false })
+  const foreignRegistry = createDragDropRegistry({ root: foreignDocument, touch: false })
+  const onDrop = jest.fn()
+  const data = { kind: 'creative', ids: ['1'], payload: { creativeId: '1', treeId: 'tree-1' } }
+  const unregister = sourceRegistry.registerDragSource({ selector: '.source',
+    onDragStart: ({ setLocalData }) => setLocalData(data) })
+  foreignRegistry.registerDropZone({ selector: '.zone', accepts: 'creative', onDrop })
+  try {
+    const transfer = { types: [], getData: () => '' }
+    const source = document.querySelector('.source')
+    source.dispatchEvent(dragEvent('dragstart', source, transfer))
+    expect(sourceRegistry.gestureData(document)).toEqual(data)
+    expect(sourceRegistry.gestureData(foreignDocument)).toBeNull()
+    const target = foreignDocument.querySelector('.zone')
+    target.dispatchEvent(dragEvent('drop', target, transfer))
+    expect(onDrop).not.toHaveBeenCalled()
+    unregister()
+    expect(sourceRegistry.gestureData(document)).toBeUndefined()
+  } finally {
+    foreignRegistry.destroy()
+    sourceRegistry.destroy()
+  }
+})
+
+test('touch cancels a source that provides neither serialized nor local data', () => {
+  jest.useFakeTimers()
+  document.body.innerHTML = '<div class="source"></div>'
+  const registry = createDragDropRegistry()
+  registry.registerDragSource({ selector: '.source', onDragStart: () => {} })
+  try {
+    const source = document.querySelector('.source')
+    const point = { target: source, clientX: 10, clientY: 10 }
+    source.dispatchEvent(new TouchEvent('touchstart', { bubbles: true, cancelable: true,
+      touches: [point], changedTouches: [point] }))
+    jest.advanceTimersByTime(400)
+    expect(registry.gestureData(document)).toBeUndefined()
+    expect(document.querySelector('.touch-drag-proxy')).toBeNull()
+    source.dispatchEvent(dragEvent('dragover', source, null))
+    source.dispatchEvent(dragEvent('dragover', source, {}))
+  } finally {
+    registry.destroy()
+    jest.useRealTimers()
+  }
+})

--- a/engines/collavre/app/javascript/lib/dnd/__tests__/touch_bridge.test.js
+++ b/engines/collavre/app/javascript/lib/dnd/__tests__/touch_bridge.test.js
@@ -1,0 +1,508 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals'
+import { createDragDropRegistry } from '../registry'
+import { createTouchBridge } from '../touch_bridge'
+
+let registry, bridge, source, zone, drops, previews
+function touch(type, y = 50, target = source) {
+  const event = new TouchEvent(type, { bubbles: true, cancelable: true })
+  Object.defineProperty(event, 'touches', { value: type === 'touchend' || type === 'touchcancel' ? []
+    : [{ clientX: 50, clientY: y, target }] })
+  target.dispatchEvent(event)
+  return event
+}
+function makeZone() {
+  const el = document.createElement('div')
+  el.className = 'zone'
+  el.getBoundingClientRect = () => ({ top: 0, left: 0, right: 100, bottom: 100, width: 100, height: 100 })
+  document.body.appendChild(el)
+  return el
+}
+beforeEach(() => {
+  jest.useFakeTimers()
+  source = document.createElement('div')
+  source.className = 'source'
+  document.body.appendChild(source)
+  zone = makeZone()
+  drops = jest.fn()
+  previews = jest.fn(() => jest.fn())
+  registry = createDragDropRegistry({ root: document, touch: false, getKind: dt => dt.types.includes('test') ? 'creative' : null,
+    readData: dt => JSON.parse(dt.getData('test')) })
+  registry.registerDragSource({ selector: '.source', onDragStart: ({ event }) => {
+    event.dataTransfer.setData('test', JSON.stringify({ kind: 'creative', ids: ['1'] }))
+  } })
+  registry.registerDropZone({ selector: '.zone', accepts: ['creative'],
+    hitTest: ({ event }) => event.clientY < 30 ? 'up' : event.clientY > 70 ? 'down' : 'child',
+    preview: previews, onDrop: drops })
+  bridge = createTouchBridge({ root: document, registry })
+})
+afterEach(() => {
+  bridge.destroy()
+  registry.destroy()
+  document.body.innerHTML = ''
+  jest.useRealTimers()
+  delete document.elementFromPoint
+})
+
+test.each([[10, 'up'], [50, 'child'], [90, 'down']])('touch uses shared directional hit at %s', async (y, hit) => {
+  touch('touchstart', y)
+  jest.advanceTimersByTime(400)
+  touch('touchend')
+  await Promise.resolve()
+  expect(drops).toHaveBeenCalledWith(expect.objectContaining({ kind: 'creative', ids: ['1'], hit, el: zone }))
+  expect(previews).toHaveBeenCalledWith(expect.objectContaining({ hit }))
+})
+
+test('ordinary touches are untouched and can scroll', () => {
+  const event = touch('touchstart', 50, zone)
+  expect(event.defaultPrevented).toBe(false)
+  jest.advanceTimersByTime(500)
+  expect(document.querySelector('.touch-drag-proxy')).toBeNull()
+})
+
+test('expansion replaces targets while the finger is stationary', () => {
+  touch('touchstart')
+  jest.advanceTimersByTime(400)
+  zone.remove()
+  const expanded = makeZone()
+  bridge.refreshDropTargets()
+  touch('touchend')
+  expect(drops).toHaveBeenCalledWith(expect.objectContaining({ el: expanded }))
+})
+
+test('cancellation and destruction clear preview, proxy and timers without drop', () => {
+  touch('touchstart')
+  jest.advanceTimersByTime(400)
+  touch('touchcancel')
+  expect(drops).not.toHaveBeenCalled()
+  expect(previews.mock.results[0].value).toHaveBeenCalled()
+  touch('touchstart')
+  jest.advanceTimersByTime(400)
+  bridge.destroy()
+  expect(document.querySelector('.touch-drag-proxy')).toBeNull()
+  expect(jest.getTimerCount()).toBe(0)
+})
+
+test('a target registered in another controller receives the same drop', () => {
+  zone.remove()
+  const pane = document.createElement('section')
+  document.body.appendChild(pane)
+  const external = makeZone()
+  external.className = 'external'
+  pane.appendChild(external)
+  const onDrop = jest.fn()
+  const otherRegistry = createDragDropRegistry({ root: pane, touch: false,
+    getKind: dt => dt.types.includes('test') ? 'creative' : null,
+    readData: dt => JSON.parse(dt.getData('test')) })
+  otherRegistry.registerDropZone({ selector: '.external', accepts: ['creative'], onDrop })
+  try {
+    touch('touchstart')
+    jest.advanceTimersByTime(400)
+    touch('touchend')
+    expect(onDrop).toHaveBeenCalledWith(expect.objectContaining({ ids: ['1'], el: external }))
+  } finally {
+    otherRegistry.destroy()
+  }
+})
+
+test('a source rejecting dragstart does not leave a proxy or timer', () => {
+  source.className = 'rejected'
+  registry.registerDragSource({ selector: '.rejected', onDragStart: ({ event }) => {
+    event.preventDefault()
+    return false
+  } })
+  touch('touchstart')
+  jest.advanceTimersByTime(400)
+  expect(document.querySelector('.touch-drag-proxy')).toBeNull()
+  expect(jest.getTimerCount()).toBe(0)
+  expect(drops).not.toHaveBeenCalled()
+})
+
+test('edge scrolling resolves the destination pane while the finger stays still', () => {
+  const pane = document.createElement('section')
+  pane.style.overflowY = 'auto'
+  pane.getBoundingClientRect = zone.getBoundingClientRect
+  Object.defineProperties(pane, { scrollHeight: { value: 500 }, clientHeight: { value: 100 } })
+  document.body.appendChild(pane)
+  pane.appendChild(zone)
+  touch('touchstart', 95)
+  jest.advanceTimersByTime(450)
+  expect(pane.scrollTop).toBeGreaterThan(0)
+  touch('touchmove', 250)
+  jest.advanceTimersByTime(32)
+  touch('touchend')
+  expect(drops).not.toHaveBeenCalled()
+})
+
+test('moving between targets clears the former registry preview', () => {
+  touch('touchstart')
+  jest.advanceTimersByTime(450)
+  const firstCleanup = previews.mock.results[0].value
+  zone.remove()
+  makeZone()
+  touch('touchmove')
+  expect(firstCleanup).toHaveBeenCalled()
+})
+
+test('drifting between descendants of one zone keeps its preview and hover timer', () => {
+  const label = document.createElement('span')
+  const badge = document.createElement('span')
+  zone.append(label, badge)
+  document.elementFromPoint = () => label
+  touch('touchstart')
+  jest.advanceTimersByTime(450)
+  expect(previews).toHaveBeenCalledTimes(1)
+  const cleanup = previews.mock.results[0].value
+
+  document.elementFromPoint = () => badge
+  touch('touchmove')
+  expect(cleanup).not.toHaveBeenCalled()
+  expect(previews).toHaveBeenCalledTimes(1)
+})
+
+test('native source adapters can replace transfer data and set a drag image', () => {
+  source.className = 'replacement'
+  registry.registerDragSource({ selector: '.replacement', onDragStart: ({ event }) => {
+    const dt = event.dataTransfer
+    dt.setData('old', 'discard')
+    dt.clearData('old')
+    expect(dt.getData('old')).toBe('')
+    dt.setData('another', 'discard')
+    dt.clearData()
+    expect(dt.types).toEqual([])
+    dt.setDragImage(source, 0, 0)
+    dt.setData('test', JSON.stringify({ kind: 'creative', ids: ['2'] }))
+  } })
+  touch('touchstart')
+  jest.advanceTimersByTime(400)
+  touch('touchend')
+  expect(drops).toHaveBeenCalledWith(expect.objectContaining({ ids: ['2'] }))
+})
+
+test('an element-scoped bridge handles dynamically added sources', () => {
+  bridge.destroy()
+  bridge = createTouchBridge({ root: document.body, registry })
+  touch('touchstart')
+  jest.advanceTimersByTime(400)
+  touch('touchend')
+  expect(drops).toHaveBeenCalledTimes(1)
+})
+
+test('a source removed during long press cannot begin dragging', () => {
+  touch('touchstart')
+  source.className = ''
+  jest.advanceTimersByTime(400)
+  expect(document.querySelector('.touch-drag-proxy')).toBeNull()
+})
+
+test('registry acceptance rules also reject touch targets', () => {
+  zone.className = 'blocked'
+  registry.registerDropZone({ selector: '.blocked', accepts: ['topic'], onDrop: drops })
+  touch('touchstart')
+  jest.advanceTimersByTime(400)
+  touch('touchend')
+  expect(drops).not.toHaveBeenCalled()
+})
+
+test('a quick tap retains the native nested button action without a duplicate click', () => {
+  const button = document.createElement('button')
+  source.appendChild(button)
+  const click = jest.fn()
+  button.addEventListener('click', click)
+  expect(touch('touchstart', 50, button).defaultPrevented).toBe(false)
+  expect(touch('touchend', 50, button).defaultPrevented).toBe(false)
+  expect(click).not.toHaveBeenCalled()
+  button.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+  expect(click).toHaveBeenCalledTimes(1)
+  expect(drops).not.toHaveBeenCalled()
+})
+
+test('editable controls retain native touch behavior', () => {
+  const input = document.createElement('input')
+  source.appendChild(input)
+  expect(touch('touchstart', 50, input).defaultPrevented).toBe(false)
+  expect(jest.getTimerCount()).toBe(0)
+})
+
+test('hit tests receive the actual nested pointer target instead of its zone ancestor', () => {
+  const form = document.createElement('form')
+  zone.appendChild(form)
+  document.elementFromPoint = () => form
+  touch('touchstart')
+  jest.advanceTimersByTime(400)
+  touch('touchend')
+  expect(drops.mock.calls[0][0].event.target).toBe(form)
+})
+
+test('an overlay outside the candidate blocks an otherwise matching rectangle', () => {
+  document.elementFromPoint = () => source
+  touch('touchstart')
+  jest.advanceTimersByTime(400)
+  touch('touchend')
+  expect(drops).not.toHaveBeenCalled()
+})
+
+test('source adapters can reject long presses on nested action buttons', () => {
+  source.className = 'actions'
+  const button = document.createElement('button')
+  source.appendChild(button)
+  registry.registerDragSource({ selector: '.actions', onDragStart: ({ event }) => {
+    expect(event.target).toBe(button)
+    if (event.target.closest('button')) { event.preventDefault(); return false }
+    event.dataTransfer.setData('test', JSON.stringify({ kind: 'creative', ids: ['1'] }))
+  } })
+  touch('touchstart', 50, button)
+  jest.advanceTimersByTime(400)
+  expect(document.querySelector('.touch-drag-proxy')).toBeNull()
+  expect(drops).not.toHaveBeenCalled()
+})
+
+test('overlapping registry roots share a single touch gesture and cancellation', () => {
+  const onEnd = jest.fn()
+  registry.registerDragSource({ selector: '.other', onDragStart: jest.fn(), onDragEnd: onEnd })
+  const nested = createDragDropRegistry({ root: document.body })
+  const starts = jest.fn()
+  source.addEventListener('dragstart', starts)
+  try {
+    touch('touchstart')
+    jest.advanceTimersByTime(400)
+    expect(starts).toHaveBeenCalledTimes(1)
+    expect(document.querySelectorAll('.touch-drag-proxy')).toHaveLength(1)
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    expect(document.querySelector('.touch-drag-proxy')).toBeNull()
+    touch('touchend')
+    expect(drops).not.toHaveBeenCalled()
+  } finally { nested.destroy() }
+})
+
+test('a scoped source can drag into another scoped registry and finish after DOM removal', () => {
+  bridge.destroy()
+  registry.destroy()
+  const sourcePane = document.createElement('section')
+  document.body.appendChild(sourcePane)
+  sourcePane.appendChild(source)
+  const targetPane = document.createElement('section')
+  document.body.appendChild(targetPane)
+  targetPane.appendChild(zone)
+  const getKind = dt => dt.types.includes('test') ? 'creative' : null
+  const readData = dt => JSON.parse(dt.getData('test'))
+  registry = createDragDropRegistry({ root: sourcePane, getKind, readData })
+  const ended = jest.fn()
+  registry.registerDragSource({ selector: '.source', onDragEnd: ended, onDragStart: ({ event }) => {
+    event.dataTransfer.setData('test', JSON.stringify({ kind: 'creative', ids: ['1'] }))
+  } })
+  const targetRegistry = createDragDropRegistry({ root: targetPane, getKind, readData })
+  const onDrop = jest.fn(() => source.remove())
+  targetRegistry.registerDropZone({ selector: '.zone', accepts: ['creative'], onDrop })
+  try {
+    touch('touchstart')
+    jest.advanceTimersByTime(400)
+    touch('touchend')
+    expect(onDrop).toHaveBeenCalledTimes(1)
+    expect(ended).toHaveBeenCalledTimes(1)
+  } finally { targetRegistry.destroy() }
+})
+
+test('a second finger cancels the drag instead of committing a pinch as a move', () => {
+  touch('touchstart')
+  jest.advanceTimersByTime(400)
+  source.dispatchEvent(new TouchEvent('touchstart', {
+    bubbles: true, cancelable: true,
+    touches: [{ target: source, clientX: 50, clientY: 50 }, { target: source, clientX: 60, clientY: 60 }],
+  }))
+  touch('touchend')
+  expect(drops).not.toHaveBeenCalled()
+  expect(document.querySelector('.touch-drag-proxy')).toBeNull()
+})
+
+test('the final touch coordinate is revalidated when no touchmove was delivered', () => {
+  touch('touchstart')
+  jest.advanceTimersByTime(400)
+  source.dispatchEvent(new TouchEvent('touchend', { bubbles: true, cancelable: true,
+    changedTouches: [{ target: source, clientX: 500, clientY: 500 }],
+  }))
+  expect(drops).not.toHaveBeenCalled()
+})
+
+test('touch preserves shared bundle artwork after the native drag image is removed', () => {
+  source.className = 'bundle-source'
+  source.setAttribute('aria-label', 'Single source label must not replace bundle artwork')
+  const image = document.createElement('div')
+  image.className = 'drag-bundle-image'
+  image.textContent = '3 selected'
+  registry.registerDragSource({ selector: '.bundle-source', onDragStart: ({ event }) => {
+    event.dataTransfer.setData('test', JSON.stringify({ kind: 'creative', ids: ['1', '2', '3'] }))
+    event.dataTransfer.setDragImage(image, 24, 24)
+  } })
+  touch('touchstart')
+  jest.advanceTimersByTime(400)
+  image.remove()
+  const proxy = document.querySelector('.touch-drag-proxy')
+  expect(proxy.style.position).toBe('fixed')
+  expect(proxy.querySelector('.drag-bundle-image').textContent).toBe('3 selected')
+  expect(proxy.querySelector('.drag-bundle-image').style.top).toBe('0px')
+  touch('touchend')
+  expect(drops).toHaveBeenCalledWith(expect.objectContaining({ ids: ['1', '2', '3'] }))
+})
+
+test('nested sources serialize only the closest owner when registries share a root', () => {
+  const ancestor = document.createElement('div')
+  ancestor.className = 'ancestor'
+  document.body.appendChild(ancestor)
+  ancestor.appendChild(source)
+  const onDragStart = jest.fn()
+  const parentRegistry = createDragDropRegistry({ root: document })
+  parentRegistry.registerDragSource({ selector: '.ancestor', onDragStart })
+  try {
+    touch('touchstart')
+    jest.advanceTimersByTime(400)
+    touch('touchend')
+    expect(onDragStart).not.toHaveBeenCalled()
+    expect(drops).toHaveBeenCalledTimes(1)
+  } finally { parentRegistry.destroy() }
+})
+
+test('a null browser hit cannot drop on an offscreen padded rectangle', () => {
+  document.elementFromPoint = () => null
+  touch('touchstart')
+  jest.advanceTimersByTime(400)
+  touch('touchend')
+  expect(drops).not.toHaveBeenCalled()
+})
+
+test('the closest drop zone wins across registries with the same root', () => {
+  const nested = document.createElement('div')
+  nested.className = 'inner-zone'
+  nested.getBoundingClientRect = zone.getBoundingClientRect
+  zone.appendChild(nested)
+  document.elementFromPoint = () => nested
+  const onDrop = jest.fn()
+  const nestedRegistry = createDragDropRegistry({ root: document,
+    getKind: dt => dt.types.includes('test') ? 'creative' : null,
+    readData: dt => JSON.parse(dt.getData('test')) })
+  nestedRegistry.registerDropZone({ selector: '.inner-zone', accepts: ['creative'], onDrop })
+  try {
+    touch('touchstart')
+    jest.advanceTimersByTime(400)
+    touch('touchend')
+    expect(onDrop).toHaveBeenCalledTimes(1)
+    expect(drops).not.toHaveBeenCalled()
+  } finally { nestedRegistry.destroy() }
+})
+
+test('a removed tap target cannot receive a stale click', () => {
+  const click = jest.fn()
+  source.addEventListener('click', click)
+  touch('touchstart')
+  source.remove()
+  document.documentElement.dispatchEvent(new TouchEvent('touchend', { bubbles: true, cancelable: true }))
+  expect(click).not.toHaveBeenCalled()
+})
+
+test('an overlay appearing during drop revalidation cancels the commit', () => {
+  touch('touchstart')
+  jest.advanceTimersByTime(400)
+  document.elementFromPoint = jest.fn().mockReturnValueOnce(zone).mockReturnValue(source)
+  touch('touchend')
+  expect(drops).not.toHaveBeenCalled()
+  expect(document.querySelector('.touch-drag-proxy')).toBeNull()
+})
+
+test('non-cancel keys do not interrupt a touch drag', () => {
+  touch('touchstart')
+  jest.advanceTimersByTime(400)
+  document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' }))
+  touch('touchend')
+  expect(drops).toHaveBeenCalledTimes(1)
+})
+
+test('live targets include a registered root and exclude another document', () => {
+  const foreignDocument = document.implementation.createHTMLDocument('Other pane')
+  foreignDocument.body.innerHTML = '<div class="foreign"></div>'
+  const foreign = createDragDropRegistry({ root: foreignDocument, touch: false })
+  foreign.registerDropZone({ selector: '.foreign', accepts: ['creative'], onDrop: jest.fn() })
+  const local = createDragDropRegistry({ root: zone, touch: false })
+  local.registerDropZone({ selector: '.zone', accepts: ['creative'], onDrop: jest.fn() })
+  try {
+    expect(local.localDropTargets()).toEqual([zone])
+    expect(registry.getDropTargets()).toEqual([zone])
+  } finally { local.destroy(); foreign.destroy() }
+})
+
+test('normal swipes retain native scrolling and never start a delayed drag', () => {
+  expect(touch('touchstart', 50).defaultPrevented).toBe(false)
+  expect(touch('touchmove', 55).defaultPrevented).toBe(false)
+  expect(touch('touchmove', 80).defaultPrevented).toBe(false)
+  jest.advanceTimersByTime(500)
+  expect(document.querySelector('.touch-drag-proxy')).toBeNull()
+  expect(touch('touchend').defaultPrevented).toBe(false)
+  expect(drops).not.toHaveBeenCalled()
+})
+
+test('committed long presses suppress native movement and the compatibility click', () => {
+  const click = jest.fn()
+  source.addEventListener('click', click)
+  expect(touch('touchstart').defaultPrevented).toBe(false)
+  jest.advanceTimersByTime(400)
+  expect(touch('touchmove', 55).defaultPrevented).toBe(true)
+  expect(touch('touchend').defaultPrevented).toBe(true)
+  expect(click).not.toHaveBeenCalled()
+  expect(drops).toHaveBeenCalledTimes(1)
+})
+
+test.each([
+  ['workspace row', '<a id="workspace-link" data-controller="row">  Workspace  one </a>', {}, 'Workspace one'],
+  ['topic chip', '<span>Visible topic</span>', { title: '  Planning topic  ' }, 'Planning topic'],
+  ['avatar', '<img id="agent-image" alt="Review agent">', {}, 'Review agent'],
+  ['accessible name', '<span>Visible label</span>', { 'aria-label': '  Accessible name  ', title: 'Title' }, 'Accessible name'],
+  ['blank name', '<span>Visible label</span>', { 'aria-label': ' ', title: 'Title fallback' }, 'Title fallback'],
+])('single %s touch proxies show a safe source label', (_kind, markup, attributes, expected) => {
+  source.innerHTML = markup
+  Object.entries(attributes).forEach(([name, value]) => source.setAttribute(name, value))
+  touch('touchstart')
+  jest.advanceTimersByTime(400)
+  const proxy = document.querySelector('.touch-drag-proxy')
+  expect(proxy.textContent).toBe(expected)
+  expect(proxy.children).toHaveLength(0)
+  expect(proxy.querySelector('[id], [data-controller]')).toBeNull()
+  touch('touchend')
+  expect(drops).toHaveBeenCalledTimes(1)
+})
+
+test('referenced accessible labels take precedence and never become HTML', () => {
+  const label = document.createElement('span')
+  label.id = 'drag-label'
+  label.textContent = '<img src=x onerror=alert(1)> & planning'
+  document.body.appendChild(label)
+  source.setAttribute('aria-labelledby', 'missing-label drag-label')
+  source.setAttribute('aria-label', 'Alternative label')
+  touch('touchstart')
+  jest.advanceTimersByTime(400)
+  const proxy = document.querySelector('.touch-drag-proxy')
+  expect(proxy.textContent).toBe(label.textContent)
+  expect(proxy.querySelector('img')).toBeNull()
+})
+
+test('an image source uses its own alt text', () => {
+  const avatar = document.createElement('img')
+  avatar.className = 'source'
+  avatar.alt = 'Agent avatar'
+  source.replaceWith(avatar)
+  source = avatar
+  touch('touchstart')
+  jest.advanceTimersByTime(400)
+  expect(document.querySelector('.touch-drag-proxy').textContent).toBe('Agent avatar')
+})
+
+test('visible text is used when available and empty labels keep the default count', () => {
+  source.textContent = 'Hidden source text'
+  Object.defineProperty(source, 'innerText', { configurable: true, value: '  Visible\n source ' })
+  touch('touchstart')
+  jest.advanceTimersByTime(400)
+  expect(document.querySelector('.touch-drag-proxy').textContent).toBe('Visible source')
+  touch('touchcancel')
+  Object.defineProperty(source, 'innerText', { value: '' })
+  touch('touchstart')
+  jest.advanceTimersByTime(400)
+  expect(document.querySelector('.touch-drag-proxy').textContent).toBe('1')
+})

--- a/engines/collavre/app/javascript/lib/dnd/preview.js
+++ b/engines/collavre/app/javascript/lib/dnd/preview.js
@@ -1,0 +1,10 @@
+export function horizontalHit({ el, event }) {
+  const rect = el.getBoundingClientRect()
+  return event.clientX < rect.left + rect.width / 2 ? 'left' : 'right'
+}
+
+export function previewDrop({ el, hit }) {
+  const className = `dnd-over-${hit === true ? 'into' : hit}`
+  el.classList.add(className)
+  return () => el.classList.remove(className)
+}

--- a/engines/collavre/app/javascript/lib/dnd/registry.js
+++ b/engines/collavre/app/javascript/lib/dnd/registry.js
@@ -1,4 +1,5 @@
 import { getDragKind, readDragData } from './envelope'
+import { createTouchBridge } from './touch_bridge'
 
 const liveRegistries = new Set()
 
@@ -33,6 +34,7 @@ function samePreview(left, right) {
 
 export function createDragDropRegistry({
   root = document,
+  touch = true,
   getKind = getDragKind,
   readData = readDragData,
   onError = (error) => console.error(error),
@@ -58,8 +60,18 @@ export function createDragDropRegistry({
     activePreview = null
   }
 
+  const localData = (transfer) => {
+    // Never substitute memory for a rejected or cross-window transfer payload.
+    if (Array.from(transfer?.types || []).length) return null
+    for (const candidate of liveRegistries) {
+      const data = candidate.gestureData(root.ownerDocument || root)
+      if (data) return data
+    }
+    return null
+  }
+
   const matchZone = (event) => {
-    const kind = getKind(event.dataTransfer)
+    const kind = getKind(event.dataTransfer) || localData(event.dataTransfer)?.kind
     let match = null
     for (const zone of zones) {
       const element = matchingElement(root, event, zone.selector)
@@ -97,9 +109,15 @@ export function createDragDropRegistry({
     if (owner?.registry !== registry) return
     const source = sources.find((candidate) => matchingElement(root, event, candidate.selector))
     const element = matchingElement(root, event, source.selector)
-    activeSource = { source, element }
+    for (const candidate of liveRegistries) candidate.finishDrag(event)
+    activeSource = { source, element, data: null }
     try {
-      if (source.onDragStart({ el: element, event }) === false) event.preventDefault()
+      if (source.onDragStart({ el: element, event,
+        setLocalData: data => { activeSource.data = data },
+      }) === false) {
+        event.preventDefault()
+        handleDragEnd(event)
+      }
       event.stopPropagation()
     } catch (error) {
       event.preventDefault()
@@ -171,7 +189,7 @@ export function createDragDropRegistry({
       resolved = resolveZone(event, true)
       if (!resolved) return
 
-      const data = readData(event.dataTransfer)
+      const data = readData(event.dataTransfer) || localData(event.dataTransfer)
       if (!data || data.kind !== resolved.kind) return
 
       event.preventDefault()
@@ -197,6 +215,7 @@ export function createDragDropRegistry({
   const ownerDocument = root.ownerDocument || root
   const handleKeyDown = (event) => {
     if (event.key !== 'Escape') return
+    bridge?.cancel()
     handleDragEnd(event)
   }
   ownerDocument.addEventListener('keydown', handleKeyDown)
@@ -209,6 +228,9 @@ export function createDragDropRegistry({
 
   const registry = {
     finishDrag: handleDragEnd,
+    gestureData(document) {
+      return document === ownerDocument ? activeSource?.data : null
+    },
     matchDrop: matchZone,
     getDragSource(target) {
       for (const source of sources) {
@@ -218,6 +240,31 @@ export function createDragDropRegistry({
       return null
     },
 
+    localDropTargets() {
+      const selector = zones.map(zone => zone.selector).join(',')
+      return selector ? [...(root.matches?.(selector) ? [root] : []), ...root.querySelectorAll(selector)] : []
+    },
+
+    getDropTargets() {
+      const targets = new Set()
+      for (const candidate of liveRegistries) {
+        for (const target of candidate.localDropTargets()) {
+          if (target.ownerDocument === (root.ownerDocument || root)) targets.add(target)
+        }
+      }
+      // Edge scrolling resolves targets every animation frame, so measure each
+      // ancestor chain once instead of on every comparison.
+      const depth = element => {
+        let count = 0
+        for (let parent = element.parentElement; parent; parent = parent.parentElement) count += 1
+        return count
+      }
+      return [...targets]
+        .map(element => ({ element, depth: depth(element) }))
+        .sort((left, right) => right.depth - left.depth)
+        .map(({ element }) => element)
+    },
+
     registerDragSource(source) {
       if (!source?.selector || typeof source.onDragStart !== 'function') {
         throw new TypeError('A drag source requires selector and onDragStart')
@@ -225,6 +272,7 @@ export function createDragDropRegistry({
       sources.push(source)
       return () => {
         const index = sources.indexOf(source)
+        if (activeSource?.source === source) handleDragEnd({ type: 'unregister' })
         if (index >= 0) sources.splice(index, 1)
       }
     },
@@ -245,6 +293,7 @@ export function createDragDropRegistry({
     },
 
     destroy() {
+      bridge?.destroy()
       liveRegistries.delete(registry)
       handleDragEnd({ type: 'destroy' })
       ownerDocument.removeEventListener('keydown', handleKeyDown)
@@ -261,5 +310,6 @@ export function createDragDropRegistry({
     },
   }
   liveRegistries.add(registry)
+  const bridge = touch ? createTouchBridge({ root, registry }) : null
   return registry
 }

--- a/engines/collavre/app/javascript/lib/dnd/touch_bridge.js
+++ b/engines/collavre/app/javascript/lib/dnd/touch_bridge.js
@@ -1,0 +1,184 @@
+import TouchDragHandler from '../touch_drag'
+
+function sourceLabel(source) {
+  const document = source.ownerDocument
+  const labelledBy = (source.getAttribute('aria-labelledby') || '').split(/\s+/)
+    .map(id => document.getElementById(id)?.textContent || '').join(' ')
+  const image = source.matches('img') ? source : source.querySelector('img[alt]')
+  return [labelledBy, source.getAttribute('aria-label'), source.getAttribute('title'),
+    image?.getAttribute('alt'), source.innerText ?? source.textContent]
+    .map(value => (value || '').replace(/\s+/g, ' ').trim()).find(Boolean)
+}
+
+// Feed touch input through the same DOM events as native dragging so source
+// serialization, target policy, previews and business commands have one owner.
+function attachTouchBridge({ root, registry }) {
+  const document = root.ownerDocument || root
+  const container = document.documentElement
+  let source = null
+  let dataTransfer = null
+  let lastTarget = null
+  let dragImage = null
+
+  function dispatch(type, target, point = {}, relatedTarget = null) {
+    const event = new Event(type, { bubbles: true, cancelable: true })
+    Object.assign(event, { dataTransfer, relatedTarget, clientX: point.clientX ?? 0,
+      clientY: point.clientY ?? 0, shiftKey: false })
+    target.dispatchEvent(event)
+    return event
+  }
+
+  function finish() {
+    const endingSource = source
+    source = null
+    if (lastTarget) dispatch('dragleave', lastTarget)
+    if (endingSource) dispatch('dragend', endingSource)
+    dataTransfer = null
+    lastTarget = null
+    dragImage = null
+  }
+
+  function targetAtPoint(el, point) {
+    if (!document.elementFromPoint) return el
+    const actual = document.elementFromPoint(point.clientX, point.clientY)
+    return actual && el.contains(actual) ? actual : null
+  }
+
+  const handler = new TouchDragHandler({
+    container,
+    singleElement: true,
+    preserveNativeGestures: true,
+    canStart(touch) {
+      if (!registry.getDragSource(touch.target)) return false
+      // Editing keeps native focus and selection. Other sources retain native
+      // taps and swipes until the long press commits; no synthetic click replay.
+      if (touch.target.closest('input, textarea, select, [contenteditable]:not([contenteditable="false"])')) return false
+      return true
+    },
+    getDropTargets: () => registry.getDropTargets(),
+    proxyContent() {
+      if (dragImage) return dragImage
+      const label = sourceLabel(source)
+      // A text node preserves literal labels without cloning controllers or IDs.
+      return label ? document.createTextNode(label) : null
+    },
+    autoScroll: true,
+    scrollContainer(point, target) {
+      let el = target || document.elementFromPoint?.(point.clientX, point.clientY)
+      while (el) {
+        const overflow = document.defaultView.getComputedStyle(el).overflowY
+        if (/(auto|scroll)/.test(overflow) && el.scrollHeight > el.clientHeight) return el
+        el = el.parentElement
+      }
+      return document.scrollingElement
+    },
+    onDragStart(_items, touch) {
+      source = registry.getDragSource(touch.target)
+      if (!source) return false
+      const values = new Map()
+      dataTransfer = {
+        effectAllowed: 'all', dropEffect: 'none',
+        get types() { return [...values.keys()] },
+        setData(type, value) { values.set(type, String(value)) },
+        getData(type) { return values.get(type) || '' },
+        clearData(type) { type ? values.delete(type) : values.clear() },
+        setDragImage(image) {
+          // Reuse the shared bundle artwork without mounting a cloned source
+          // component (which could register controllers and duplicate IDs).
+          if (!image?.classList.contains('drag-bundle-image')) return
+          dragImage = image.cloneNode(true)
+          Object.assign(dragImage.style, { position: 'relative', top: '0', left: '0', height: '42px' })
+        },
+      }
+      const event = dispatch('dragstart', touch.target, touch)
+      if (event.defaultPrevented || (!dataTransfer.types.length && !registry.gestureData?.(document))) {
+        finish()
+        return false
+      }
+    },
+    hitTest(el, point) {
+      const target = targetAtPoint(el, point)
+      if (!target) return null
+      // Carry relatedTarget like a native dragleave so a zone can tell a move
+      // between its own descendants from a real departure and keep its preview.
+      if (lastTarget && lastTarget !== target) dispatch('dragleave', lastTarget, point, target)
+      lastTarget = target
+      return dispatch('dragover', target, point).defaultPrevented ? 'into' : null
+    },
+    onTargetChange(el, point) {
+      if (!el && lastTarget) {
+        dispatch('dragleave', lastTarget, point)
+        lastTarget = null
+      }
+    },
+    onDrop(el, point) {
+      try {
+        const target = targetAtPoint(el, point)
+        if (target) dispatch('drop', target, point)
+      } finally { finish() }
+    },
+    onCancel: finish,
+  })
+
+  return {
+    cancel() {
+      finish()
+      handler.cancel()
+    },
+    refreshDropTargets: () => handler.refreshDropTargets(),
+    destroy() {
+      finish()
+      handler.destroy()
+    },
+  }
+}
+
+// Controllers can register overlapping roots. One gesture must serialize and
+// finish only once, including when it crosses into another controller's pane.
+const bridges = new WeakMap()
+
+export function createTouchBridge({ root, registry }) {
+  const document = root.ownerDocument || root
+  let shared = bridges.get(document)
+  if (!shared) {
+    const registries = new Set()
+    const bridge = attachTouchBridge({ root: document, registry: {
+      getDragSource(target) {
+        let source = null
+        for (const candidate of registries) {
+          const match = candidate.getDragSource(target)
+          if (match && (!source || source.contains(match))) source = match
+        }
+        return source
+      },
+      gestureData(document) {
+        for (const candidate of registries) {
+          const data = candidate.gestureData(document)
+          if (data) return data
+        }
+        return null
+      },
+      getDropTargets() {
+        return registries.values().next().value.getDropTargets()
+      },
+    } })
+    shared = { registries, bridge }
+    bridges.set(document, shared)
+  }
+  shared.registries.add(registry)
+  let destroyed = false
+  return {
+    refreshDropTargets: () => shared.bridge.refreshDropTargets(),
+    cancel: () => shared.bridge.cancel(),
+    destroy() {
+      if (destroyed) return
+      destroyed = true
+      shared.bridge.cancel()
+      shared.registries.delete(registry)
+      if (shared.registries.size === 0) {
+        shared.bridge.destroy()
+        bridges.delete(document)
+      }
+    },
+  }
+}

--- a/engines/collavre/app/javascript/lib/touch_drag.js
+++ b/engines/collavre/app/javascript/lib/touch_drag.js
@@ -15,8 +15,16 @@
  *     onDrop(targetEl) {},              // called when dropped on a valid target
  *     onCancel() {},
  *     proxyContent(items) { return '...' }  // HTML for the drag proxy badge
+ *     getDropTargets() {},              // optional live target resolver
+ *     hitTest(el, point, previousHit) {}, // null rejects; otherwise domain hit
+ *     onTargetChange(el, { hit, clientX, clientY }) {},
+ *     preserveNativeGestures: true,     // native taps/scroll until long press
+ *     autoScroll: true,                 // opt in to continuous edge scrolling
+ *     scrollContainer(point, target) {}, // element or resolver; defaults to container
  *   })
  *
+ *   // onDrop also receives { hit, clientX, clientY } as a second argument.
+ *   td.refreshDropTargets() // after asynchronous folder expansion
  *   td.destroy()  // cleanup
  */
 
@@ -38,7 +46,16 @@ export default class TouchDragHandler {
     this.onDrop = opts.onDrop
     this.onCancel = opts.onCancel
     this.onTap = opts.onTap
+    this.preserveNativeGestures = opts.preserveNativeGestures ?? false
+    this.canStart = opts.canStart
     this.proxyContent = opts.proxyContent
+    this.getDropTargets = opts.getDropTargets ?? (() => document.querySelectorAll(this.dropTargetSelector))
+    this.hitTest = opts.hitTest
+    this.onTargetChange = opts.onTargetChange
+    this.autoScroll = opts.autoScroll ?? false
+    this.scrollContainer = opts.scrollContainer ?? this.container
+    this.scrollEdge = opts.scrollEdge ?? 40
+    this.scrollSpeed = opts.scrollSpeed ?? 12
 
     // State
     this._timer = null
@@ -47,6 +64,9 @@ export default class TouchDragHandler {
     this._startX = 0
     this._startY = 0
     this._currentTarget = null
+    this._currentHit = null
+    this._point = null
+    this._frame = null
 
     // Bind handlers
     this._onTouchStart = this._handleTouchStart.bind(this)
@@ -58,6 +78,11 @@ export default class TouchDragHandler {
     this.container.addEventListener('touchmove', this._onTouchMove, { passive: false })
     this.container.addEventListener('touchend', this._onTouchEnd, { passive: false })
     this.container.addEventListener('touchcancel', this._onTouchEnd, { passive: false })
+  }
+
+  cancel() {
+    if (this._dragging) this.onCancel?.()
+    this._endDrag()
   }
 
   destroy() {
@@ -72,10 +97,12 @@ export default class TouchDragHandler {
   // ── Private ───────────────────────────────────────────────
 
   _handleTouchStart(e) {
+    if (e.touches?.length > 1) { this.cancel(); return }
     if (this._dragging) return
 
-    const touch = e.touches[0]
+    const touch = e.touches?.[0]
     if (!touch) return
+    if (this.canStart && !this.canStart(touch, e)) return
 
     if (this.singleElement) {
       // In single-element mode, the container itself is the draggable
@@ -91,12 +118,9 @@ export default class TouchDragHandler {
     this._startX = touch.clientX
     this._startY = touch.clientY
 
-    // Prevent native long-press behavior (text selection, context menu,
-    // native drag preview) from stealing touch events after ~500ms.
-    // Scrolling is handled via touchmove: within tolerance we preventDefault,
-    // beyond tolerance we cancel the timer and the user can scroll normally
-    // on the next touch.
-    e.preventDefault()
+    // Legacy avatar-only consumers replay taps themselves. Delegated tree
+    // sources retain native taps and scrolling until the long press commits.
+    if (!this.preserveNativeGestures) e.preventDefault()
 
     this._cancelLongPress()
     this._timer = setTimeout(() => {
@@ -105,7 +129,7 @@ export default class TouchDragHandler {
   }
 
   _handleTouchMove(e) {
-    const touch = e.touches[0]
+    const touch = e.touches?.[0]
     if (!touch) return
 
     if (this._dragging) {
@@ -123,8 +147,8 @@ export default class TouchDragHandler {
       if (dx > this.moveTolerance || dy > this.moveTolerance) {
         // User intentionally scrolling — cancel long-press, let scroll happen
         this._cancelLongPress()
-      } else {
-        // Within tolerance — prevent scroll to keep the long-press alive
+      } else if (!this.preserveNativeGestures) {
+        // Legacy consumers opt into suppressing native gestures while waiting.
         e.preventDefault()
       }
     }
@@ -133,7 +157,7 @@ export default class TouchDragHandler {
   _handleTouchEnd(e) {
     if (this._timer) {
       this._cancelLongPress()
-      this.onTap?.(e)
+      if (e.type !== 'touchcancel' && !this.preserveNativeGestures) this.onTap?.(e)
       return
     }
 
@@ -141,13 +165,20 @@ export default class TouchDragHandler {
 
     e.preventDefault()
 
-    if (this._currentTarget) {
-      this.onDrop?.(this._currentTarget)
-    } else {
-      this.onCancel?.()
+    try {
+      if (e.type !== 'touchcancel') {
+        const touch = e.changedTouches?.[0]
+        if (touch) this._moveDrag(touch)
+        else this.refreshDropTargets()
+      }
+      if (e.type !== 'touchcancel' && this._currentTarget) {
+        this.onDrop?.(this._currentTarget, { ...this._point, hit: this._currentHit })
+      } else {
+        this.onCancel?.()
+      }
+    } finally {
+      this._endDrag()
     }
-
-    this._endDrag()
   }
 
   _handleContextMenu(e) {
@@ -167,7 +198,7 @@ export default class TouchDragHandler {
     if (!items || items.length === 0) return
 
     // Let caller cancel
-    if (this.onDragStart && this.onDragStart(items) === false) return
+    if (this.onDragStart && this.onDragStart(items, touch) === false) return
 
     this._dragging = true
 
@@ -183,12 +214,20 @@ export default class TouchDragHandler {
     // Create floating proxy
     this._proxy = document.createElement('div')
     this._proxy.className = this.proxyClass
-    this._proxy.innerHTML = this.proxyContent?.(items) ?? `${items.length}`
+    this._proxy.style.pointerEvents = 'none'
+    this._proxy.style.position = 'fixed'
+    this._proxy.style.zIndex = '10000'
+    this._proxy.setAttribute('aria-hidden', 'true')
+    const content = this.proxyContent?.(items) ?? `${items.length}`
+    if (content instanceof Node) this._proxy.appendChild(content)
+    else this._proxy.innerHTML = content
     document.body.appendChild(this._proxy)
-    this._moveProxy(touch.clientX, touch.clientY)
+    this._moveDrag(touch)
+    if (this.autoScroll) this._scheduleScroll()
   }
 
   _moveDrag(touch) {
+    this._point = { clientX: touch.clientX, clientY: touch.clientY }
     this._moveProxy(touch.clientX, touch.clientY)
     this._updateDropTarget(touch.clientX, touch.clientY)
   }
@@ -210,31 +249,67 @@ export default class TouchDragHandler {
     // elementFromPoint is unreliable on mobile when z-index, overlays,
     // or reflow timing interfere with the result.
     const PAD = 12 // extra padding for finger imprecision
-    // Cache drop targets on first call (topic list doesn't change during drag)
-    if (!this._cachedDropTargets) {
-      this._cachedDropTargets = document.querySelectorAll(this.dropTargetSelector)
-    }
-    const targets = this._cachedDropTargets
+    // Resolve each time: expanding folders can add or remove targets mid-drag.
+    const targets = this.getDropTargets()
     let found = null
+    let hit = null
 
     for (const target of targets) {
       const rect = target.getBoundingClientRect()
+      if (!target.isConnected || rect.width <= 0 || rect.height <= 0) continue
       if (x >= rect.left - PAD && x <= rect.right + PAD &&
           y >= rect.top - PAD && y <= rect.bottom + PAD) {
+        hit = this.hitTest ? this.hitTest(target, { clientX: x, clientY: y },
+          target === this._currentTarget ? this._currentHit : null) : 'into'
+        if (hit == null || hit === false) continue
         found = target
         break
       }
     }
 
-    if (found !== this._currentTarget) {
+    if (found !== this._currentTarget || hit !== this._currentHit) {
       this._currentTarget?.classList.remove(this.dragOverClass)
       this._currentTarget = found
+      this._currentHit = found ? hit : null
       this._currentTarget?.classList.add(this.dragOverClass)
+      this.onTargetChange?.(found, { clientX: x, clientY: y, hit: this._currentHit })
     }
+  }
+
+  // Call after asynchronous folder expansion, even if the finger has not moved.
+  refreshDropTargets() {
+    if (this._dragging && this._point) {
+      this._updateDropTarget(this._point.clientX, this._point.clientY)
+    }
+  }
+
+  _scheduleScroll() {
+    this._frame = requestAnimationFrame(() => {
+      this._frame = null
+      if (!this._dragging) return
+      const container = typeof this.scrollContainer === 'function'
+        ? this.scrollContainer(this._point, this._currentTarget) : this.scrollContainer
+      if (container && this._point) {
+        const doc = container.ownerDocument
+        const rect = container === doc.scrollingElement
+          ? { top: 0, left: 0, right: doc.defaultView.innerWidth, bottom: doc.defaultView.innerHeight }
+          : container.getBoundingClientRect()
+        const { clientX: x, clientY: y } = this._point
+        if (x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom) {
+          const distance = y < rect.top + this.scrollEdge ? y - rect.top - this.scrollEdge
+            : y > rect.bottom - this.scrollEdge ? y - rect.bottom + this.scrollEdge : 0
+          container.scrollTop += Math.round(distance / this.scrollEdge * this.scrollSpeed)
+        }
+      }
+      this.refreshDropTargets()
+      this._scheduleScroll()
+    })
   }
 
   _endDrag() {
     this._dragging = false
+    if (this._frame !== null) cancelAnimationFrame(this._frame)
+    this._frame = null
     this._cancelLongPress()
 
     document.removeEventListener('contextmenu', this._onContextMenu, { capture: true })
@@ -244,7 +319,10 @@ export default class TouchDragHandler {
     if (this._currentTarget) {
       this._currentTarget.classList.remove(this.dragOverClass)
       this._currentTarget = null
+      this.onTargetChange?.(null, { ...this._point, hit: null })
     }
+    this._currentHit = null
+    this._point = null
 
     if (this._proxy) {
       this._proxy.remove()
@@ -252,7 +330,6 @@ export default class TouchDragHandler {
       this._proxyHW = undefined
       this._proxyHH = undefined
     }
-    this._cachedDropTargets = null
   }
 
   _cancelLongPress() {

--- a/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
@@ -143,8 +143,7 @@
     <div id="comment-contexts" data-comments--contexts-target="list" class="comment-contexts-list"
          data-inherited-label="<%= t('collavre.contexts.inherited_label', default: 'Inherited from parent') %>"
          data-self-context-label="<%= t('collavre.contexts.self_context_label', default: 'Current creative context') %>"
-         data-navigate-label="<%= t('collavre.contexts.navigate_label', default: 'Go to creative') %>"
-         data-action="dragover->comments--contexts#handleExternalDragOver drop->comments--contexts#handleExternalDrop dragleave->comments--contexts#handleExternalDragLeave"></div>
+         data-navigate-label="<%= t('collavre.contexts.navigate_label', default: 'Go to creative') %>"></div>
     <button type="button" class="add-context-btn"
             data-comments--contexts-target="addButton"
             data-action="click->comments--contexts#addContext"
@@ -179,8 +178,7 @@
     <div id="comment-topics" data-comments--topics-target="list" class="comment-topics-list"
          data-confirm-delete-text="<%= t('collavre.topics.delete_confirm') %>"
          data-new-topic-placeholder="<%= t('collavre.topics.new_placeholder') %>"></div>
-    <span class="topic-creation-container" data-comments--topics-target="creationContainer" hidden
-          data-action="dragover->comments--topics#handleAddButtonDragOver dragleave->comments--topics#handleDragLeave drop->comments--topics#handleAddButtonDrop"></span>
+    <span class="topic-creation-container" data-comments--topics-target="creationContainer" hidden></span>
     <button type="button" class="topic-list-btn"
 			data-comments--topics-target="topicListButton"
 			data-action="pointerdown->comments--topics#prepareTopicListToggle pointerup->comments--topics#finishTopicListToggle pointercancel->comments--topics#cancelTopicListToggle click->comments--topics#openTopicListPopup"

--- a/engines/collavre/test/integration/background_authentication_test.rb
+++ b/engines/collavre/test/integration/background_authentication_test.rb
@@ -1,0 +1,24 @@
+require "test_helper"
+
+class BackgroundAuthenticationTest < ActionDispatch::IntegrationTest
+  setup do
+    creative = creatives(:tshirt)
+    topic = creative.topics.create!(name: "Background request", user: users(:one))
+    @background_path = collavre.channel_chips_creative_topic_url(creative, topic)
+    @page_path = collavre.creative_topics_url(creative)
+  end
+
+  test "unauthenticated background request does not replace the post-login destination" do
+    get @background_path, headers: { "HTTP_X_REQUESTED_WITH" => "XMLHttpRequest" }
+
+    assert_response :unauthorized
+    assert_nil session[:return_to_after_authenticating]
+  end
+
+  test "unauthenticated page navigation still stores the post-login destination" do
+    get @page_path
+
+    assert_redirected_to collavre.new_session_path
+    assert_equal @page_path, session[:return_to_after_authenticating]
+  end
+end

--- a/engines/collavre/test/system/creative_inline_edit_test.rb
+++ b/engines/collavre/test/system/creative_inline_edit_test.rb
@@ -137,6 +137,7 @@ class CreativeInlineEditTest < ApplicationSystemTestCase
     find("#inline-add", wait: 5).click
     fill_inline_editor("C")
     find("#inline-add", wait: 5).click
+    assert_selector "#creatives > creative-tree-row:nth-of-type(4) #inline-edit-form-element", wait: 10
     fill_inline_editor("D")
     close_inline_editor
 


### PR DESCRIPTION
Topics, contexts, selected comments and avatars register drag sources/drop zones with the shared input layer. Domain commands stay in their controllers; shared previews replace duplicated event wiring and highlight classes. This task retains the existing single-creative context/chat command, with bundle behavior in the following T5 PR.

Depends on T3 #1632 and the T7 touch bridge. Each dependency remains separately reviewable; merge in that order.

Validation: 41 comment/preview suites / 738 tests passed, then eight preview/topic tests passed after the default preview fix. Build passed. Vrex review and final Rails regression are pending.