### PR TITLE
fix(deps): bump js-yaml to 4.3.2 for GHSA-2883-xcg3-v3hh

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "dompurify": "^3.4.13",
         "firebase": "^12.2.1",
         "highlight.js": "^11.11.1",
-        "js-yaml": "^4.1.0",
+        "js-yaml": "^4.3.2",
         "lexical": "^0.38.2",
         "lit": "^3.1.2",
         "marked": "^16.4.1",
@@ -2198,9 +2198,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.15.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
-      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+      "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7606,9 +7606,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "dompurify": "^3.4.13",
     "firebase": "^12.2.1",
     "highlight.js": "^11.11.1",
-    "js-yaml": "^4.1.0",
+    "js-yaml": "^4.3.2",
     "lexical": "^0.38.2",
     "lit": "^3.1.2",
     "marked": "^16.4.1",


### PR DESCRIPTION
## Why

`npm audit --production` — the last step of the required `test_js` job — now fails on **every** branch in this repository, including `main`:

```
js-yaml  4.0.0 - 4.3.1
Severity: high
js-yaml: maxTotalMergeKeys does not limit CPU use for empty merge sources
https://github.com/advisories/GHSA-2883-xcg3-v3hh
```

The advisory was published after `main` last ran green, so the failure is unrelated to whatever a given PR changes. It is currently the only reason PR #1632 sits at `UNSTABLE` — its Jest run on that same job is `145 suites / 2027 tests, 0 failures`.

## Is it real?

Yes, not just an audit-noise bump. `js-yaml` is a production dependency, and `engines/collavre/app/javascript/modules/creative_row_editor.js` parses user-authored YAML in the browser. Unbounded merge-key expansion is reachable from user input, so the DoS is live rather than build-time only.

## Fix

`4.3.2` is the patched `v4-legacy` release. The `^4` range is kept and only the floor moves, so this is a lockfile bump plus a matching floor in `package.json` — no API change and no other dependency moves.

```
-      "version": "4.3.1",
+      "version": "4.3.2",
```

## Verification

- `npm audit --production`: **found 0 vulnerabilities** (was 1 high)
- Jest on this branch: **128 suites, 1749 tests, 0 failures**
- Cherry-picked onto `feat/bidirectional-tree-dnd-t3` (`5f39f6691`): **145 suites, 2027 tests, 0 failures**, `npm audit --production` clean
- `npm run build` passes on both

## Landing

This should go into `main` first. Every open PR — #1632 and the T4–T7 integration work — inherits the red check until it does, and each of them rebasing the same lockfile edit independently would just create conflicts.