### PR TITLE
Allow external Slack bot messages while filtering Collavre echoes

### DIFF
--- a/engines/collavre_slack/app/services/collavre_slack/slack_bot_message.rb
+++ b/engines/collavre_slack/app/services/collavre_slack/slack_bot_message.rb
@@ -1,0 +1,42 @@
+require "digest"
+
+module CollavreSlack
+  class SlackBotMessage
+    def initialize(account:, message:)
+      @account = account
+      @message = message
+    end
+
+    def bot?
+      @message[:bot_id].present? || @message[:subtype] == "bot_message"
+    end
+
+    def own?
+      return false unless bot?
+
+      identity = bot_identity
+      @message[:bot_id] == identity[:bot_id] ||
+        (@message[:user].present? && @message[:user] == identity[:user_id])
+    end
+
+    def sender
+      # Bots must not be auto-mapped to a person by email or queried with a nil user ID.
+      name = @message[:username].presence || @message.dig(:bot_profile, :name).presence || @message[:bot_id]
+      { user: nil, slack_display_name: name, slack_email: nil, slack_user_id: @message[:user] }
+    end
+
+    private
+
+    def bot_identity
+      token_digest = Digest::SHA256.hexdigest(@account.access_token)
+      Rails.cache.fetch([ "slack_bot_identity", @account.id, token_digest ], expires_in: 1.hour) do
+        response = SlackClient.new(access_token: @account.access_token).auth_test
+        # Raise before the webhook is acknowledged so Slack can retry; never cache failures.
+        unless response[:ok] && response[:bot_id].present? && response[:user_id].present?
+          raise "Unable to resolve Slack bot identity"
+        end
+        response.slice(:bot_id, :user_id)
+      end
+    end
+  end
+end

--- a/engines/collavre_slack/app/services/collavre_slack/slack_client.rb
+++ b/engines/collavre_slack/app/services/collavre_slack/slack_client.rb
@@ -69,6 +69,10 @@ module CollavreSlack
       post("chat.delete", { channel: channel, ts: timestamp })
     end
 
+    def auth_test
+      post("auth.test", {})
+    end
+
     def get_user_info(user_id:)
       get("users.info", user: user_id)
     end

--- a/engines/collavre_slack/app/services/collavre_slack/slack_event_handler.rb
+++ b/engines/collavre_slack/app/services/collavre_slack/slack_event_handler.rb
@@ -23,13 +23,7 @@ module CollavreSlack
       slack_email = user_result[:slack_email]
       slack_user_id = user_result[:slack_user_id]
 
-      normalized_content = MentionMapping.from_slack(formatted_content, slack_account)
-
-      # Prepend Slack username if user is not mapped
-      if user_result[:user].nil? && slack_display_name.present?
-        prefix = I18n.t("collavre_slack.messages.slack_user_prefix", name: slack_display_name)
-        normalized_content = "#{prefix} #{normalized_content}"
-      end
+      normalized_content = normalize_content(formatted_content, slack_account, user_result)
 
       {
         type: :message,
@@ -54,7 +48,8 @@ module CollavreSlack
       return unless message_ts
 
       # Ignore our own edits to prevent synchronization loops.
-      return if SlackBotMessage.new(account: slack_account, message: message).own?
+      bot_message = SlackBotMessage.new(account: slack_account, message: message)
+      return if bot_message.own?
 
       # Find the comment link by Slack message
       comment_link = SlackCommentLink.find_by_slack_message(
@@ -65,7 +60,8 @@ module CollavreSlack
       return unless comment_link
 
       new_text = message[:text].to_s
-      normalized_content = MentionMapping.from_slack(new_text, slack_account)
+      sender = bot_message.sender if bot_message.bot?
+      normalized_content = normalize_content(new_text, slack_account, sender)
 
       {
         type: :message_updated,
@@ -135,6 +131,14 @@ module CollavreSlack
 
     def linked_channel(slack_account)
       SlackChannelLink.find_by(slack_account: slack_account, channel_id: channel_id)
+    end
+
+    def normalize_content(text, slack_account, sender)
+      content = MentionMapping.from_slack(text, slack_account)
+      return content unless sender && sender[:user].nil? && sender[:slack_display_name].present?
+
+      prefix = I18n.t("collavre_slack.messages.slack_user_prefix", name: sender[:slack_display_name])
+      "#{prefix} #{content}"
     end
 
     def message_sender(slack_account)

--- a/engines/collavre_slack/app/services/collavre_slack/slack_event_handler.rb
+++ b/engines/collavre_slack/app/services/collavre_slack/slack_event_handler.rb
@@ -13,13 +13,11 @@ module CollavreSlack
       slack_account = SlackAccount.find_by(team_id: team_id)
       return unless slack_account
 
-      channel_link = SlackChannelLink.find_by(
-        slack_account: slack_account,
-        channel_id: channel_id
-      )
+      channel_link = linked_channel(slack_account)
       return unless channel_link
 
-      user_result = find_or_map_user(slack_account, event_user_id)
+      user_result = message_sender(slack_account)
+      return unless user_result
       user = user_result[:user] || channel_link.created_by
       slack_display_name = user_result[:slack_display_name]
       slack_email = user_result[:slack_email]
@@ -55,8 +53,8 @@ module CollavreSlack
       message_ts = message[:ts]
       return unless message_ts
 
-      # Skip bot messages
-      return if message[:bot_id].present?
+      # Ignore our own edits to prevent synchronization loops.
+      return if SlackBotMessage.new(account: slack_account, message: message).own?
 
       # Find the comment link by Slack message
       comment_link = SlackCommentLink.find_by_slack_message(
@@ -135,12 +133,21 @@ module CollavreSlack
 
     attr_reader :payload
 
+    def linked_channel(slack_account)
+      SlackChannelLink.find_by(slack_account: slack_account, channel_id: channel_id)
+    end
+
+    def message_sender(slack_account)
+      bot_message = SlackBotMessage.new(account: slack_account, message: event_payload)
+      return if bot_message.own?
+
+      bot_message.bot? ? bot_message.sender : find_or_map_user(slack_account, event_user_id)
+    end
+
     def message_event?
       return false unless event_type == "event_callback"
       return false unless event_payload[:type] == "message"
-      return false if event_payload[:subtype].present?
-      # Skip bot messages to prevent loops
-      return false if event_payload[:bot_id].present?
+      return false if event_payload[:subtype].present? && event_payload[:subtype] != "bot_message"
       true
     end
 

--- a/engines/collavre_slack/test/services/slack_bot_message_test.rb
+++ b/engines/collavre_slack/test/services/slack_bot_message_test.rb
@@ -1,0 +1,84 @@
+require_relative "../test_helper"
+
+module CollavreSlack
+  class SlackBotMessageTest < ActiveSupport::TestCase
+    setup do
+      @account = SlackAccount.new(id: 42, access_token: "bot-test-token")
+      @cache = ActiveSupport::Cache::MemoryStore.new
+      @identity_request = stub_request(:post, "https://slack.com/api/auth.test")
+        .with(headers: { "Authorization" => "Bearer bot-test-token" })
+        .to_return(status: 200, body: { ok: true, bot_id: "BSELF", user_id: "USELF" }.to_json)
+    end
+
+    test "rejects our bot with and without bot_message subtype" do
+      [ nil, "bot_message" ].each do |subtype|
+        assert own?(bot_id: "BSELF", subtype: subtype)
+      end
+    end
+
+    test "rejects our bot by user ID when bot ID is absent" do
+      assert own?(subtype: "bot_message", user: "USELF")
+    end
+
+    test "accepts foreign bots and ordinary human messages" do
+      assert_not own?(bot_id: "BOTHER", subtype: "bot_message")
+      assert_not own?(bot_id: "BOTHER", user: "UOTHER")
+      assert_not own?(user: "UHUMAN")
+      assert_requested @identity_request, times: 1
+    end
+
+    test "does not query identity for human messages" do
+      assert_not own?(user: "UHUMAN")
+      assert_not_requested @identity_request
+    end
+
+    test "retries identity resolution after an API failure" do
+      stub_request(:post, "https://slack.com/api/auth.test").to_return(
+        { status: 200, body: { ok: false, error: "ratelimited" }.to_json },
+        { status: 200, body: { ok: true, bot_id: "BSELF", user_id: "USELF" }.to_json }
+      )
+      assert_raises(RuntimeError) { own?(bot_id: "BOTHER") }
+      assert_not own?(bot_id: "BOTHER")
+    end
+
+    test "does not accept an incomplete identity" do
+      stub_request(:post, "https://slack.com/api/auth.test")
+        .to_return(status: 200, body: { ok: true, user_id: "USELF" }.to_json)
+      assert_raises(RuntimeError) { own?(bot_id: "BOTHER") }
+    end
+
+    test "token rotation invalidates the identity cache" do
+      assert own?(bot_id: "BSELF")
+      @account.access_token = "rotated-token"
+      stub_request(:post, "https://slack.com/api/auth.test")
+        .with(headers: { "Authorization" => "Bearer rotated-token" })
+        .to_return(status: 200, body: { ok: true, bot_id: "BNEW", user_id: "UNEW" }.to_json)
+      assert own?(bot_id: "BNEW")
+      assert_not own?(bot_id: "BSELF")
+    end
+
+    test "uses bot attribution without mapping to a person" do
+      sender = SlackBotMessage.new(account: @account, message: {
+        bot_id: "BOTHER", username: "GeekNews"
+      }).sender
+      assert_equal "GeekNews", sender[:slack_display_name]
+      assert_nil sender[:user]
+      assert_nil sender[:slack_email]
+      assert_nil sender[:slack_user_id]
+      assert_equal "News", SlackBotMessage.new(account: @account, message: {
+        bot_id: "BOTHER", bot_profile: { name: "News" }
+      }).sender[:slack_display_name]
+      assert_equal "BOTHER", SlackBotMessage.new(account: @account, message: {
+        bot_id: "BOTHER"
+      }).sender[:slack_display_name]
+    end
+
+    private
+
+    def own?(message)
+      Rails.stub(:cache, @cache) do
+        SlackBotMessage.new(account: @account, message: message).own?
+      end
+    end
+  end
+end

--- a/engines/collavre_slack/test/services/slack_event_handler_test.rb
+++ b/engines/collavre_slack/test/services/slack_event_handler_test.rb
@@ -104,7 +104,25 @@ module CollavreSlack
       result = SlackEventHandler.new(payload: payload).call
       assert_equal :message_updated, result[:type]
       assert_equal comment.id, result[:comment_id]
+      prefix = I18n.t("collavre_slack.messages.slack_user_prefix", name: "BNEWS")
+      assert_equal "#{prefix} Updated article", result[:content]
+
+      message = payload[:event][:message]
+      [ { username: "GeekNews" }, { bot_profile: { name: "GeekNews" } } ].each do |identity|
+        payload[:event][:message] = message.merge(identity)
+        result = SlackEventHandler.new(payload: payload).call
+        prefix = I18n.t("collavre_slack.messages.slack_user_prefix", name: "GeekNews")
+        assert_equal "#{prefix} Updated article", result[:content]
+        SlackInboundMessageUpdateJob.perform_now(result)
+        assert_equal result[:content], comment.reload.content
+      end
+      assert_not_requested :get, "https://slack.com/api/users.info"
+
+      payload[:event][:message] = message.except(:bot_id).merge(user: "UHUMAN")
+      result = SlackEventHandler.new(payload: payload).call
       assert_equal "Updated article", result[:content]
+
+      payload[:event][:message] = message
 
       payload[:event][:message][:bot_id] = "BSELF"
       assert_nil SlackEventHandler.new(payload: payload).call

--- a/engines/collavre_slack/test/services/slack_event_handler_test.rb
+++ b/engines/collavre_slack/test/services/slack_event_handler_test.rb
@@ -52,5 +52,62 @@ module CollavreSlack
       assert_includes result[:content], I18n.t("collavre_slack.messages.attachments")
       assert_includes result[:content], "spec.pdf"
     end
+    test "imports foreign bot messages without a Slack user and ignores our bot" do
+      user = create_user(email: "bots@example.com")
+      creative = create_creative(user)
+      account = SlackAccount.create!(user: user, team_id: "TBOTS", team_name: "Bots", access_token: "token")
+      link = SlackChannelLink.create!(creative: creative, slack_account: account,
+        channel_id: "CBOTS", channel_name: "geeknews", created_by: user)
+      stub_request(:post, "https://slack.com/api/auth.test")
+        .to_return(status: 200, body: { ok: true, bot_id: "BSELF", user_id: "USELF" }.to_json)
+      payload = { type: "event_callback", team_id: "TBOTS", event: {
+        type: "message", subtype: "bot_message", channel: "CBOTS", bot_id: "BNEWS",
+        username: "GeekNews", text: "New article", ts: "123.456"
+      } }
+
+      [ "bot_message", nil ].each do |subtype|
+        payload[:event][:subtype] = subtype
+        result = SlackEventHandler.new(payload: payload).call
+        assert_equal creative.id, result[:creative_id]
+        assert_equal link.id, result[:slack_channel_link_id]
+        assert_equal user.id, result[:user_id]
+        assert_equal "GeekNews", result[:slack_display_name]
+        assert_includes result[:content], "New article"
+        assert_nil result[:slack_user_id]
+      end
+      assert_not_requested :get, "https://slack.com/api/users.info"
+
+      payload[:event][:bot_id] = "BSELF"
+      assert_nil SlackEventHandler.new(payload: payload).call
+      payload[:event][:subtype] = "bot_message"
+      assert_nil SlackEventHandler.new(payload: payload).call
+
+      payload[:event][:bot_id] = "BNEWS"
+      payload[:event][:subtype] = "channel_join"
+      assert_nil SlackEventHandler.new(payload: payload).call
+    end
+
+    test "syncs foreign bot edits but ignores our own edits" do
+      user = create_user(email: "bot-edits@example.com")
+      creative = create_creative(user)
+      account = SlackAccount.create!(user: user, team_id: "TEDITS", team_name: "Edits", access_token: "token")
+      link = SlackChannelLink.create!(creative: creative, slack_account: account,
+        channel_id: "CEDITS", channel_name: "geeknews", created_by: user)
+      comment = Collavre::Comment.create!(creative: creative, user: user, content: "Original")
+      SlackCommentLink.create!(comment: comment, slack_channel_link: link, message_ts: "123.456")
+      stub_request(:post, "https://slack.com/api/auth.test")
+        .to_return(status: 200, body: { ok: true, bot_id: "BSELF", user_id: "USELF" }.to_json)
+      payload = { type: "event_callback", team_id: "TEDITS", event: {
+        type: "message", subtype: "message_changed", channel: "CEDITS",
+        message: { bot_id: "BNEWS", text: "Updated article", ts: "123.456" }
+      } }
+      result = SlackEventHandler.new(payload: payload).call
+      assert_equal :message_updated, result[:type]
+      assert_equal comment.id, result[:comment_id]
+      assert_equal "Updated article", result[:content]
+
+      payload[:event][:message][:bot_id] = "BSELF"
+      assert_nil SlackEventHandler.new(payload: payload).call
+    end
   end
 end


### PR DESCRIPTION
Slack messages from external bots such as GeekNews were discarded whenever `bot_id` or any subtype was present. Accept `bot_message` and bot messages without a subtype, and filter Collavre's own bot by the connected account's authenticated bot/user IDs. Apply the same filter to message edits; other message subtypes retain their existing behavior.

Resolve identity through `auth.test`, cache successful results for one hour per account/token digest, and raise before acknowledging the webhook when identity cannot be verified so Slack can retry. Existing installations need no migration or OAuth reinstall. External bots retain their bot name and do not enter human email auto-mapping, including legacy messages with no `user`.

Validation: added regression tests for external bot delivery, self-message/edit suppression, user-less bot attribution, ordinary messages, subtype filtering, identity failures, cache reuse, and token rotation. `git diff --check` passed. Local `./bin/rubocop -a`, `bin/complexity_check`, `bin/rails test`, `bin/rails test:system`, and the Slack engine tests could not run: `/usr/bin/env: ‘ruby’: No such file or directory`. Draft pending CI and reviewer execution of required checks.

The production Request URL correction is separate from this change; no production data or route configuration was changed.

Slack references: [auth.test](https://docs.slack.dev/reference/methods/auth.test/) and [bot_message](https://docs.slack.dev/reference/events/message/bot_message/).