### PR TITLE
fix(comments): anchor mobile user menus

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -1092,7 +1092,7 @@ body.chat-fullscreen {
     }
 
     #comments-popup.open {
-        transform: translateY(0);
+        transform: none;
     }
 
     #comments-popup[data-fullscreen="true"] {

--- a/engines/collavre/test/system/chat_bar_list_popup_test.rb
+++ b/engines/collavre/test/system/chat_bar_list_popup_test.rb
@@ -125,4 +125,25 @@ class ChatBarListPopupTest < ApplicationSystemTestCase
     assert_selector "#comments-popup .comment-participants-bar > .add-participant-btn"
     assert_no_selector "#comment-participants .add-participant-btn"
   end
+
+  test "message author menu stays anchored below the avatar on mobile" do
+    comment = Comment.create!(creative: @creative, user: @user, content: "Mobile menu anchor")
+    resize_window_to(390, 844)
+    open_comments_popup
+
+    trigger_selector = "#comment_#{comment.id} .comment-user-menu-trigger"
+    menu_selector = "#user_menu_comment_#{comment.id}"
+    find(trigger_selector).click
+    assert_selector menu_selector, visible: :visible
+
+    gap = page.evaluate_script(<<~JS)
+      (() => {
+        const trigger = document.querySelector('#{trigger_selector}').getBoundingClientRect()
+        const menu = document.querySelector('#{menu_selector}').getBoundingClientRect()
+        return menu.top - trigger.bottom
+      })()
+    JS
+
+    assert_in_delta 4, gap, 0.5
+  end
 end


### PR DESCRIPTION
## Summary

- Remove the open-state transform from the mobile comments popup so fixed-position user menus remain anchored to viewport coordinates.
- Add a mobile system regression test that verifies the menu stays 4px below the message avatar.

## Testing

- `bin/rails test engines/collavre/test/system/chat_bar_list_popup_test.rb` — 7 runs, 60 assertions, 0 failures
- `./bin/rubocop -a` — 1,351 files, 0 offenses
- `bin/complexity_check` — passed
- `bundle exec rake test` — 4,851 runs, 16,979 assertions, 0 failures
- `PARALLEL_WORKERS=1 bundle exec rake test:system` — core Collavre: 131 runs, 875 assertions, 0 failures, 1 existing skip; the following `collavre_plan` suite had a cross-engine modal visibility failure
- `bin/rails test engines/collavre_plan/test/system/plans_system_test.rb` — 2 runs, 10 assertions, 0 failures when run independently