### PR TITLE
fix(dnd): guard touch drags against native gesture takeover

### DIFF
--- a/engines/collavre/app/javascript/lib/__tests__/touch_drag_targets.test.js
+++ b/engines/collavre/app/javascript/lib/__tests__/touch_drag_targets.test.js
@@ -245,3 +245,49 @@ test('default selected-item mode keeps native menus after cancellation and can s
   expect(onDragStart).toHaveBeenCalledTimes(2)
   expect(document.querySelectorAll('.touch-drag-proxy')).toHaveLength(1)
 })
+
+
+test.each(['contextmenu', 'selectstart'])('blocks native %s only while a long press is pending or active', type => {
+  setup({ preserveNativeGestures: true })
+  const dispatch = () => {
+    const event = new Event(type, { bubbles: true, cancelable: true })
+    container.dispatchEvent(event)
+    return event.defaultPrevented
+  }
+  expect(dispatch()).toBe(false)
+  expect(touch('touchstart').defaultPrevented).toBe(false)
+  expect(dispatch()).toBe(true)
+  jest.advanceTimersByTime(400)
+  expect(dispatch()).toBe(true)
+  touch('touchcancel')
+  expect(dispatch()).toBe(false)
+  touch('touchstart')
+  touch('touchmove', 50, 80)
+  expect(dispatch()).toBe(false)
+  touch('touchstart')
+  handler.destroy()
+  expect(dispatch()).toBe(false)
+})
+
+test.each([0, 400])('native dragstart cannot take over a touch gesture at %sms', elapsed => {
+  const addListener = jest.spyOn(document, 'addEventListener')
+  setup({ preserveNativeGestures: true })
+  const listener = addListener.mock.calls.find(([type]) => type === 'dragstart')?.[1]
+  addListener.mockRestore()
+  expect(listener).toEqual(expect.any(Function))
+  touch('touchstart')
+  jest.advanceTimersByTime(elapsed)
+  const native = { type: 'dragstart', isTrusted: true,
+    preventDefault: jest.fn(), stopImmediatePropagation: jest.fn() }
+  listener(native)
+  expect(native.preventDefault).toHaveBeenCalledTimes(1)
+  expect(native.stopImmediatePropagation).toHaveBeenCalledTimes(1)
+  const synthetic = { ...native, isTrusted: false, preventDefault: jest.fn(), stopImmediatePropagation: jest.fn() }
+  listener(synthetic)
+  expect(synthetic.preventDefault).not.toHaveBeenCalled()
+  expect(synthetic.stopImmediatePropagation).not.toHaveBeenCalled()
+  touch('touchcancel')
+  native.preventDefault.mockClear()
+  listener(native)
+  expect(native.preventDefault).not.toHaveBeenCalled()
+})

--- a/engines/collavre/app/javascript/lib/touch_drag.js
+++ b/engines/collavre/app/javascript/lib/touch_drag.js
@@ -72,7 +72,10 @@ export default class TouchDragHandler {
     this._onTouchStart = this._handleTouchStart.bind(this)
     this._onTouchMove = this._handleTouchMove.bind(this)
     this._onTouchEnd = this._handleTouchEnd.bind(this)
-    this._onContextMenu = this._handleContextMenu.bind(this)
+    this._onNativeGesture = this._handleNativeGesture.bind(this)
+    for (const type of ['contextmenu', 'selectstart', 'dragstart']) {
+      document.addEventListener(type, this._onNativeGesture, { capture: true })
+    }
 
     this.container.addEventListener('touchstart', this._onTouchStart, { passive: false })
     this.container.addEventListener('touchmove', this._onTouchMove, { passive: false })
@@ -92,6 +95,9 @@ export default class TouchDragHandler {
     this.container.removeEventListener('touchmove', this._onTouchMove)
     this.container.removeEventListener('touchend', this._onTouchEnd)
     this.container.removeEventListener('touchcancel', this._onTouchEnd)
+    for (const type of ['contextmenu', 'selectstart', 'dragstart']) {
+      document.removeEventListener(type, this._onNativeGesture, { capture: true })
+    }
   }
 
   // ── Private ───────────────────────────────────────────────
@@ -181,11 +187,13 @@ export default class TouchDragHandler {
     }
   }
 
-  _handleContextMenu(e) {
-    // Suppress native context menu during drag
-    if (this._dragging || this._timer) {
-      e.preventDefault()
-    }
+  _handleNativeGesture(e) {
+    if (!this._dragging && !this._timer) return
+    // The bridge dispatches an untrusted dragstart to serialize the gesture.
+    // A browser drag would serialize it again and can cancel the touch stream.
+    if (e.type === 'dragstart' && !e.isTrusted) return
+    e.preventDefault()
+    if (e.type === 'dragstart') e.stopImmediatePropagation()
   }
 
   _startDrag(touch) {
@@ -201,9 +209,6 @@ export default class TouchDragHandler {
     if (this.onDragStart && this.onDragStart(items, touch) === false) return
 
     this._dragging = true
-
-    // Suppress context menu while dragging
-    document.addEventListener('contextmenu', this._onContextMenu, { capture: true })
 
     // Vibrate for haptic feedback (if supported)
     if (navigator.vibrate) navigator.vibrate(30)
@@ -311,8 +316,6 @@ export default class TouchDragHandler {
     if (this._frame !== null) cancelAnimationFrame(this._frame)
     this._frame = null
     this._cancelLongPress()
-
-    document.removeEventListener('contextmenu', this._onContextMenu, { capture: true })
 
     this.container.classList.remove(this.draggingClass)
 


### PR DESCRIPTION
A pending or active long press currently allows a browser-generated dragstart to re-enter the DnD registry, serializing the source a second time. Native text selection and context menus are also allowed while the long-press timer is pending.

Capture native dragstart, selectstart and contextmenu while a touch gesture is pending or active. Only trusted dragstart is stopped; the bridge's synthetic dragstart continues normally. Native taps and swipes remain available, and cancellation or destruction restores native behavior.

Validation:
- Four new regression cases fail before the change and pass afterward.
- 155 related Jest tests pass, including registry, touch bridge and cross-tree integration.
- touch_drag.js line coverage: 100%; branch coverage: 98.78% (remaining branches are outside the change).
- npm run build and git diff --check pass.
- Chromium CDP touch input plus a concurrent native mouse drag confirms the extra trusted dragstart reaches the registry before this change and is intercepted afterward. The touch drop still completes once and cleans up.

This is a candidate fix for the reported Android Chrome long-press regression. A real Android device was unavailable; desktop Chromium mobile emulation does not prove that the reported device failure is resolved. Keep draft pending Vrex review and Android validation (creative rows/topics/messages, tap, scroll, cancellation, and successful drop). Review requested in Collavre topic 19080; original report: topic 19078.

Production code: +14/-11 lines (net +3). No backend or CSS changes.