### PR TITLE
fix(dnd): hide the header move action on the root route

### DIFF
--- a/engines/collavre/app/helpers/collavre/creative_move_helper.rb
+++ b/engines/collavre/app/helpers/collavre/creative_move_helper.rb
@@ -1,7 +1,8 @@
 module Collavre
   module CreativeMoveHelper
     def render_creative_move_action(creative, can_write)
-      return safe_join([]) if Current.user.nil?
+      # The root route has no current creative, so the header has nothing to move.
+      return safe_join([]) if Current.user.nil? || creative.nil?
 
       # Archived parents still expose selection for their active children.
       creative = nil if creative&.archived?

--- a/engines/collavre/app/views/collavre/creatives/index.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/index.html.erb
@@ -99,7 +99,7 @@
             <span aria-hidden="true"><%= svg_tag 'share.svg', width: 16, height: 16 %></span> <%= t('collavre.creatives.index.share') %>
           </button>
         <% end %>
-        <% if current_creative || params[:id].blank? %>
+        <% if current_creative %>
           <%= render_creative_move_action(current_creative, current_creative&.has_permission?(Current.user, :write) && !current_creative.effective_origin.read_only_source?) %>
         <% end %>
         <% if authenticated? %>

--- a/engines/collavre/test/controllers/creatives_controller_test.rb
+++ b/engines/collavre/test/controllers/creatives_controller_test.rb
@@ -773,12 +773,15 @@ class CreativesControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "header move action remains available on the actual root route" do
+  test "header move action is hidden on the actual root route" do
     [ {}, { id: "" } ].each do |params|
-      get creatives_path, params: params
+      [ {}, { "Turbo-Frame" => "creative-workspace-content" } ].each do |headers|
+        get creatives_path, params: params, headers: headers
 
-      assert_response :success
-      assert_select "#creative-overflow-menu [data-creative-move-id='']", count: 1
+        assert_response :success
+        assert_select "#creative-overflow-menu [data-creative-move-id]", count: 0
+        assert_select "#creative-overflow-menu #select-creative-btn", count: 1
+      end
     end
   end
 

--- a/engines/collavre/test/helpers/creative_move_helper_test.rb
+++ b/engines/collavre/test/helpers/creative_move_helper_test.rb
@@ -47,10 +47,10 @@ class CreativeMoveHelperTest < ActionView::TestCase
     assert_empty render_creative_move_action(creative, true)
   end
 
-  test "the root menu supports selection without a current creative" do
-    html = render_creative_move_action(nil, nil)
-    assert_includes html, 'class="popup-menu-item"'
-    assert_includes html, 'data-creative-move-id=""'
+  # The root route renders the header without a current creative. There is
+  # nothing for the action to move there, so it is not offered at all.
+  test "the root menu has no move action without a current creative" do
+    assert_empty render_creative_move_action(nil, nil)
   end
 
   # The action is named by its visible label alone now that a page renders one

--- a/engines/collavre/test/system/creative_move_menu_system_test.rb
+++ b/engines/collavre/test/system/creative_move_menu_system_test.rb
@@ -76,19 +76,15 @@ class CreativeMoveMenuSystemTest < ApplicationSystemTestCase
     assert_nil @source.reload.parent_id
   end
 
-  # The header action is the only move entry point now, so the root page -- which
-  # has no current creative to act on -- has to lead somewhere rather than open an
-  # empty dialog. It starts select mode and puts the caret on the first checkbox.
-  test "the root action starts selection when nothing is selected" do
+  # The root page has no current creative to act on, so the header offers no move
+  # action there at all -- the rest of the overflow menu is untouched.
+  test "the root header offers no move action" do
     visit collavre.creatives_path
-    open_move_menu
+    assert_selector "#creative-#{@source.id}"
+    find('[aria-controls="creative-overflow-menu"]').click
 
-    assert_no_selector "dialog[open][data-creative-move-target]"
-    # The toggle lives inside the menu the action just closed, so its state is
-    # only assertable with the visibility filter off.
-    assert_selector "#select-creative-btn[aria-pressed='true']", visible: :all
-    assert_equal "select-creative-checkbox",
-      page.evaluate_script("document.activeElement.className")
+    assert_no_selector "#creative-overflow-menu [data-creative-move-id]", visible: :all
+    assert_selector "#select-creative-btn", visible: :all
     assert_nil @source.reload.parent_id
   end
 
@@ -96,12 +92,11 @@ class CreativeMoveMenuSystemTest < ApplicationSystemTestCase
   # the writable check now reads `can-write` off each row rather than a per-row
   # button that no longer exists.
   test "a multi-row selection moves every selected creative" do
-    extra = Creative.create!(description: "Menu extra", user: @user)
-    visit collavre.creatives_path
-    find('[aria-controls="creative-overflow-menu"]').click
-    find("#select-creative-btn").click
-    find("#creative-#{@source.id} .select-creative-checkbox").click
-    find("#creative-#{extra.id} .select-creative-checkbox").click
+    holder = Creative.create!(description: "Menu holder", user: @user)
+    first = Creative.create!(description: "Menu first child", user: @user, parent: holder)
+    second = Creative.create!(description: "Menu second child", user: @user, parent: holder)
+    visit collavre.creatives_path(id: holder.id)
+    select_rows(first, second)
 
     open_move_menu
     assert_equal "move", find('[data-creative-move-target="mode"]').value
@@ -111,16 +106,17 @@ class CreativeMoveMenuSystemTest < ApplicationSystemTestCase
     find('[data-creative-move-target="confirm"]').click
 
     assert_no_selector "dialog[open][data-creative-move-target]"
-    assert_equal @destination, @source.reload.parent
-    assert_equal @destination, extra.reload.parent
+    assert_equal @destination, first.reload.parent
+    assert_equal @destination, second.reload.parent
+    assert_nil holder.reload.parent_id
   end
 
-  # A filtered-to-nothing view still marks the tree loaded, so the header action
-  # has a confirmed empty result to report. Without the in-app dialog the click
-  # would look like a no-op, which is what the native alert did inside the
-  # packaged desktop webview.
-  test "the root action explains a view with nothing to select" do
-    visit collavre.creatives_path(search: "no-such-creative-#{SecureRandom.hex(4)}")
+  # An archived parent keeps the selection-only launcher, and a view with no
+  # active child still marks the tree loaded -- a confirmed empty result the
+  # action has to report. Without the in-app dialog the click would look like a
+  # no-op, which is what the native alert did inside the packaged desktop webview.
+  test "the selection-only action explains a view with nothing to select" do
+    visit collavre.creatives_path(id: archived_parent.id, show_archived: "true")
     assert_selector "#creatives[data-loaded='true']", visible: :all
 
     open_move_menu
@@ -141,7 +137,8 @@ class CreativeMoveMenuSystemTest < ApplicationSystemTestCase
   # A failed tree fetch is not a confirmed empty result. The header action has to
   # repeat the loading error instead of inviting the user to create a creative
   # that may already exist behind the failure.
-  test "the root action reports a failed tree load" do
+  test "the selection-only action reports a failed tree load" do
+    visit collavre.creatives_path(id: archived_parent.id, show_archived: "true")
     assert_selector "#creatives[data-loaded='true']", visible: :all
     fail_tree_fetch
     reload_tree
@@ -165,7 +162,8 @@ class CreativeMoveMenuSystemTest < ApplicationSystemTestCase
   # The failure can also land *after* the action was taken. The observer has to
   # keep waiting on the still-loading tree, hold focus on the visible launcher,
   # and then report the error rather than the empty-view copy.
-  test "the root action waits for a late tree failure" do
+  test "the selection-only action waits for a late tree failure" do
+    visit collavre.creatives_path(id: archived_parent.id, show_archived: "true")
     # The row alignment pass only reveals the header once rendered rows give it a
     # measurement, and a pending reload has no rows to measure. Wait for the real
     # launcher before injecting the failure, otherwise the test would be asserting
@@ -189,8 +187,9 @@ class CreativeMoveMenuSystemTest < ApplicationSystemTestCase
   # alert() -- invisible inside the packaged desktop webview. It has to be the
   # shared dialog, and closing it has to hand focus back to the launcher.
   test "an archived selection is refused with guidance" do
-    archived = Creative.create!(description: "Menu archived", user: @user, archived_at: Time.current)
-    visit collavre.creatives_path(show_archived: "true")
+    holder = Creative.create!(description: "Menu holder", user: @user)
+    archived = Creative.create!(description: "Menu archived", user: @user, parent: holder, archived_at: Time.current)
+    visit collavre.creatives_path(id: holder.id, show_archived: "true")
     select_rows(archived)
 
     open_move_menu
@@ -204,23 +203,25 @@ class CreativeMoveMenuSystemTest < ApplicationSystemTestCase
     assert_no_selector "dialog[role='alertdialog']"
     assert_equal "creative-overflow-menu",
       page.evaluate_script("document.activeElement.getAttribute('aria-controls')")
-    assert_nil archived.reload.parent_id
+    assert_equal holder, archived.reload.parent
   end
 
   # One archived row poisons the whole batch: the move is refused outright rather
   # than silently dropping the archived member and moving the rest.
   test "a selection mixing archived rows is refused" do
-    archived = Creative.create!(description: "Menu archived", user: @user, archived_at: Time.current)
-    visit collavre.creatives_path(show_archived: "true")
-    select_rows(@source, archived)
+    holder = Creative.create!(description: "Menu holder", user: @user)
+    active = Creative.create!(description: "Menu active", user: @user, parent: holder)
+    archived = Creative.create!(description: "Menu archived", user: @user, parent: holder, archived_at: Time.current)
+    visit collavre.creatives_path(id: holder.id, show_archived: "true")
+    select_rows(active, archived)
 
     open_move_menu
 
     assert_no_selector "dialog[open][data-creative-move-target]"
     assert_selector "dialog[role='alertdialog'] .confirm-dialog-message",
       text: I18n.t("collavre.dnd.archived_selection")
-    assert_nil @source.reload.parent_id
-    assert_nil archived.reload.parent_id
+    assert_equal holder, active.reload.parent
+    assert_equal holder, archived.reload.parent
   end
 
   # An archived parent is not a movable source, but its active children still
@@ -312,6 +313,14 @@ class CreativeMoveMenuSystemTest < ApplicationSystemTestCase
   end
 
   private
+
+  # The selection-only launcher (an empty move id) now lives on archived parents
+  # alone, so the fallback paths are exercised from one.
+  def archived_parent
+    @archived_parent ||= Creative.create!(
+      description: "Menu archived parent", user: @user, archived_at: Time.current
+    )
+  end
 
   def open_move_menu(key = nil)
     toggle = find('[aria-controls="creative-overflow-menu"]')


### PR DESCRIPTION
## Why

The root route renders the creative header without a current creative, so the overflow menu showed a **Move** entry carrying an empty id. That entry could not move anything by itself -- clicking it only switched select mode on -- so on the top-level screen it read as a dead menu item.

## What changed

- `render_creative_move_action` returns nothing when there is no creative to act on, and `creatives/index` no longer renders it on the id-less route.
- Archived parents keep their selection-only launcher (empty move id), so their active children stay movable.
- Creatives with `parent_id: nil` are unchanged: each is still movable from its own page.

Production code: +2 / -2 lines.

## Behaviour note

Bulk move of *top-level* creatives from the root screen is gone with the launcher -- the header is the only move entry point, and the root header no longer has one. Selection-driven moves still work everywhere a creative is on screen, and single top-level creatives are still movable from their own page. Say the word if the root screen should instead keep a Move entry that appears only while rows are selected (the pattern `#delete-selection-btn` already uses).

## Tests

- `engines/collavre/test/helpers/creative_move_helper_test.rb` -- no launcher without a current creative.
- `engines/collavre/test/controllers/creatives_controller_test.rb` -- the root route (no id and `id=""`, plain and Turbo Frame requests) renders no move id while the select action stays.
- `engines/collavre/test/system/creative_move_menu_system_test.rb` -- the root header offers no move action; the selection fallbacks (empty view, failed tree load, late failure) and the multi-row selection coverage now run from an archived parent / a parent page, the places the launcher still renders.

Local run: helper + controller `58 runs, 352 assertions, 0 failures`. System file: `14 runs, 1 failure` -- `a restored history snapshot drops the hidden selection` fails identically on unmodified `main` at the same seed (`--seed 47523`), so it is a pre-existing order-dependent flake, not a regression from this change. Rubocop clean on the changed files.