### PR TITLE
fix(comments): place popup menus against the visual viewport

### DIFF
--- a/Procfile.preview
+++ b/Procfile.preview
@@ -1,0 +1,2 @@
+web: env RUBY_DEBUG_OPEN=true bin/rails server -p $PORT -b 0.0.0.0
+js: npm run build -- --watch

--- a/engines/collavre/app/javascript/controllers/__tests__/popup_menu_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/popup_menu_controller.test.js
@@ -299,6 +299,83 @@ describe('PopupMenuController', () => {
       expect(menu.style.top).toBe('76px')
     })
 
+    // Pinch zoom shrinks the visual viewport below the menu's stylesheet floor
+    // (220px, 240px for the comment user popup). CSS resolves min-width over
+    // max-width, so capping the width alone leaves the menu wider than the
+    // screen with its right edge off in the part you cannot scroll to.
+    const stubStylesheetMinWidth = (value) => {
+      const style = document.createElement('style')
+      style.textContent = `.popup-menu { min-width: ${value}; }`
+      document.head.appendChild(style)
+      menu.classList.add('popup-menu')
+      return style
+    }
+
+    test('drops the stylesheet minimum when the strip is narrower than it', async () => {
+      const style = stubStylesheetMinWidth('240px')
+      stubVisualViewport({ width: 195, height: 400, offsetLeft: 0, offsetTop: 0 })
+      jest.spyOn(button, 'getBoundingClientRect').mockReturnValue({
+        top: 40, bottom: 60, left: 9, right: 29, width: 20, height: 20
+      })
+      jest.spyOn(menu, 'getBoundingClientRect').mockReturnValue({
+        top: 0, bottom: 153, left: 0, right: 240, width: 240, height: 153
+      })
+
+      controller.show()
+      await new Promise(resolve => requestAnimationFrame(resolve))
+
+      // 195 - 4 * 2 of usable width: the floor has to come down with the cap,
+      // otherwise the menu stays 240px wide however narrow the screen gets.
+      expect(menu.style.maxWidth).toBe('187px')
+      expect(menu.style.minWidth).toBe('187px')
+
+      style.remove()
+    })
+
+    test('leaves the stylesheet minimum alone when there is room for it', async () => {
+      const style = stubStylesheetMinWidth('240px')
+      stubVisualViewport({ width: 390, height: 400, offsetLeft: 0, offsetTop: 0 })
+      jest.spyOn(button, 'getBoundingClientRect').mockReturnValue({
+        top: 40, bottom: 60, left: 9, right: 29, width: 20, height: 20
+      })
+      jest.spyOn(menu, 'getBoundingClientRect').mockReturnValue({
+        top: 0, bottom: 153, left: 0, right: 240, width: 240, height: 153
+      })
+
+      controller.show()
+      await new Promise(resolve => requestAnimationFrame(resolve))
+
+      expect(menu.style.minWidth).toBe('')
+
+      style.remove()
+    })
+
+    // Pinching back out has to give the menu its designed width again, and a
+    // menu left narrow after hide() would open wrong on the next click.
+    test('restores the minimum when the strip widens again', async () => {
+      const style = stubStylesheetMinWidth('240px')
+      const { listeners } = stubVisualViewport({ width: 195, height: 400, offsetLeft: 0, offsetTop: 0 })
+      jest.spyOn(button, 'getBoundingClientRect').mockReturnValue({
+        top: 40, bottom: 60, left: 9, right: 29, width: 20, height: 20
+      })
+      jest.spyOn(menu, 'getBoundingClientRect').mockReturnValue({
+        top: 0, bottom: 153, left: 0, right: 240, width: 240, height: 153
+      })
+
+      controller.show()
+      await new Promise(resolve => requestAnimationFrame(resolve))
+      expect(menu.style.minWidth).toBe('187px')
+
+      window.visualViewport.width = 390
+      listeners.resize()
+      expect(menu.style.minWidth).toBe('')
+
+      controller.hide()
+      expect(menu.style.minWidth).toBe('')
+
+      style.remove()
+    })
+
     // The button can sit above the strip entirely (page scrolled under a pinned
     // sheet). The cap must respect the whole strip, not just the room below.
     test('never grows past the strip when the button is above it', async () => {

--- a/engines/collavre/app/javascript/controllers/__tests__/popup_menu_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/popup_menu_controller.test.js
@@ -193,4 +193,104 @@ describe('PopupMenuController', () => {
 
     expect(menu.classList.contains('popup-menu-right')).toBe(true)
   })
+
+  // The mobile chat is a bottom sheet inside the *visual* viewport: the on-screen
+  // keyboard shrinks that viewport and comments--presence lifts the sheet clear
+  // of it, while window.innerHeight keeps reporting the full screen. Placing a
+  // menu against innerHeight therefore drops it behind the keyboard on a phone
+  // and nowhere near where the same menu lands on desktop.
+  describe('visual viewport', () => {
+    const stubVisualViewport = (rect) => {
+      const listeners = {}
+      const viewport = {
+        ...rect,
+        addEventListener: (type, handler) => { listeners[type] = handler },
+        removeEventListener: (type) => { delete listeners[type] }
+      }
+      Object.defineProperty(window, 'visualViewport', {
+        writable: true, configurable: true, value: viewport
+      })
+      return { viewport, listeners }
+    }
+
+    afterEach(() => {
+      delete window.visualViewport
+    })
+
+    test('flips above the button when the keyboard covers the space below', async () => {
+      stubVisualViewport({ width: 390, height: 344, offsetLeft: 0, offsetTop: 0 })
+      jest.spyOn(button, 'getBoundingClientRect').mockReturnValue({
+        top: 234, bottom: 254, left: 9, right: 29, width: 20, height: 20
+      })
+      jest.spyOn(menu, 'getBoundingClientRect').mockReturnValue({
+        top: 0, bottom: 153, left: 0, right: 240, width: 240, height: 153
+      })
+
+      controller.show()
+      await new Promise(resolve => requestAnimationFrame(resolve))
+
+      // innerHeight (640) would leave room below and hide the menu behind the
+      // keyboard; against the 344px visual viewport it must flip above:
+      // 234 - 4 - 153 = 77
+      expect(menu.style.top).toBe('77px')
+    })
+
+    test('clamps into the visible strip when the visual viewport is offset', async () => {
+      stubVisualViewport({ width: 390, height: 300, offsetLeft: 0, offsetTop: 200 })
+      jest.spyOn(button, 'getBoundingClientRect').mockReturnValue({
+        top: 210, bottom: 230, left: 9, right: 29, width: 20, height: 20
+      })
+      jest.spyOn(menu, 'getBoundingClientRect').mockReturnValue({
+        top: 0, bottom: 400, left: 0, right: 240, width: 240, height: 400
+      })
+
+      controller.show()
+      await new Promise(resolve => requestAnimationFrame(resolve))
+
+      // Taller than the strip either way, so it clamps to the strip's top edge
+      // (200 + 4) instead of the document's.
+      expect(menu.style.top).toBe('204px')
+    })
+
+    test('re-places the open menu when the keyboard resizes the viewport', async () => {
+      const { viewport, listeners } = stubVisualViewport({
+        width: 390, height: 844, offsetLeft: 0, offsetTop: 0
+      })
+      jest.spyOn(button, 'getBoundingClientRect').mockReturnValue({
+        top: 234, bottom: 254, left: 9, right: 29, width: 20, height: 20
+      })
+      jest.spyOn(menu, 'getBoundingClientRect').mockReturnValue({
+        top: 0, bottom: 153, left: 0, right: 240, width: 240, height: 153
+      })
+
+      controller.show()
+      await new Promise(resolve => requestAnimationFrame(resolve))
+      expect(menu.style.top).toBe('258px')
+
+      viewport.height = 344
+      listeners.resize?.()
+      await new Promise(resolve => requestAnimationFrame(resolve))
+
+      expect(menu.style.top).toBe('77px')
+    })
+
+    test('drops the viewport listeners on hide', async () => {
+      const { listeners } = stubVisualViewport({
+        width: 390, height: 844, offsetLeft: 0, offsetTop: 0
+      })
+      jest.spyOn(button, 'getBoundingClientRect').mockReturnValue({
+        top: 234, bottom: 254, left: 9, right: 29, width: 20, height: 20
+      })
+      jest.spyOn(menu, 'getBoundingClientRect').mockReturnValue({
+        top: 0, bottom: 153, left: 0, right: 240, width: 240, height: 153
+      })
+
+      controller.show()
+      await new Promise(resolve => requestAnimationFrame(resolve))
+      controller.hide()
+
+      expect(listeners.resize).toBeUndefined()
+      expect(listeners.scroll).toBeUndefined()
+    })
+  })
 })

--- a/engines/collavre/app/javascript/controllers/__tests__/popup_menu_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/popup_menu_controller.test.js
@@ -278,6 +278,30 @@ describe('PopupMenuController', () => {
       expect(124 + 216).toBe(344 - 4)
     })
 
+    test('preserves a smaller stylesheet height cap when there is more room', async () => {
+      const style = document.createElement('style')
+      style.textContent = '.cron-badge-popup { max-height: 480px; }'
+      document.head.appendChild(style)
+      menu.classList.add('cron-badge-popup')
+      stubVisualViewport({ width: 390, height: 1000, offsetLeft: 0, offsetTop: 0 })
+      jest.spyOn(button, 'getBoundingClientRect').mockReturnValue({
+        top: 900, bottom: 920, left: 9, right: 29, width: 20, height: 20
+      })
+      jest.spyOn(menu, 'getBoundingClientRect').mockReturnValue({
+        top: 0, bottom: 480, left: 0, right: 240, width: 240, height: 480
+      })
+
+      controller.show()
+      await new Promise(resolve => requestAnimationFrame(resolve))
+
+      // The 892px above the trigger must not replace the cron popup's 480px
+      // stylesheet cap after it was measured at that height.
+      expect(menu.style.maxHeight).toBe('480px')
+      expect(menu.style.top).toBe('416px')
+
+      style.remove()
+    })
+
     // Both sides are under the sliver floor on a short phone with the keyboard
     // up, so the floor wins and the menu overhangs the button — then the bottom
     // clamp slides it back up inside the strip rather than off the screen.

--- a/engines/collavre/app/javascript/controllers/__tests__/popup_menu_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/popup_menu_controller.test.js
@@ -167,6 +167,8 @@ describe('PopupMenuController', () => {
     expect(menu.style.left).toBe('')
     expect(menu.style.right).toBe('')
     expect(menu.style.maxWidth).toBe('')
+    expect(menu.style.maxHeight).toBe('')
+    expect(menu.style.overflowY).toBe('')
     expect(menu.style.transform).toBe('')
   })
 
@@ -235,7 +237,7 @@ describe('PopupMenuController', () => {
       expect(menu.style.top).toBe('77px')
     })
 
-    test('clamps into the visible strip when the visual viewport is offset', async () => {
+    test('caps a menu taller than the strip instead of overflowing it', async () => {
       stubVisualViewport({ width: 390, height: 300, offsetLeft: 0, offsetTop: 200 })
       jest.spyOn(button, 'getBoundingClientRect').mockReturnValue({
         top: 210, bottom: 230, left: 9, right: 29, width: 20, height: 20
@@ -247,8 +249,72 @@ describe('PopupMenuController', () => {
       controller.show()
       await new Promise(resolve => requestAnimationFrame(resolve))
 
-      // Taller than the strip either way, so it clamps to the strip's top edge
-      // (200 + 4) instead of the document's.
+      // 400px of items into a 300px strip: sit below the button (230 + 4) and
+      // cap to the space left under it (496 - 234), scrolling the rest.
+      expect(menu.style.top).toBe('234px')
+      expect(menu.style.maxHeight).toBe('262px')
+      expect(menu.style.overflowY).toBe('auto')
+    })
+
+    // A cron popup listing many tasks is taller than the visible viewport once
+    // the keyboard is up. Clamping only its top leaves the lower actions behind
+    // the keyboard with nothing to scroll, since .popup-menu is overflow:hidden.
+    test('caps the menu to the region so its lower actions stay reachable', async () => {
+      stubVisualViewport({ width: 390, height: 344, offsetLeft: 0, offsetTop: 0 })
+      jest.spyOn(button, 'getBoundingClientRect').mockReturnValue({
+        top: 100, bottom: 120, left: 9, right: 29, width: 20, height: 20
+      })
+      jest.spyOn(menu, 'getBoundingClientRect').mockReturnValue({
+        top: 0, bottom: 600, left: 0, right: 240, width: 240, height: 600
+      })
+
+      controller.show()
+      await new Promise(resolve => requestAnimationFrame(resolve))
+
+      expect(menu.style.top).toBe('124px')
+      expect(menu.style.maxHeight).toBe('216px')
+      expect(menu.style.overflowY).toBe('auto')
+      // Bottom edge lands on the region's padded edge, not past it.
+      expect(124 + 216).toBe(344 - 4)
+    })
+
+    // Both sides are under the sliver floor on a short phone with the keyboard
+    // up, so the floor wins and the menu overhangs the button — then the bottom
+    // clamp slides it back up inside the strip rather than off the screen.
+    test('pulls a floored menu back inside the strip', async () => {
+      stubVisualViewport({ width: 390, height: 200, offsetLeft: 0, offsetTop: 0 })
+      jest.spyOn(button, 'getBoundingClientRect').mockReturnValue({
+        top: 90, bottom: 110, left: 9, right: 29, width: 20, height: 20
+      })
+      jest.spyOn(menu, 'getBoundingClientRect').mockReturnValue({
+        top: 0, bottom: 300, left: 0, right: 240, width: 240, height: 300
+      })
+
+      controller.show()
+      await new Promise(resolve => requestAnimationFrame(resolve))
+
+      // Floor of 120 against 82px of room below: placed at 114, clamped so its
+      // bottom lands on 196 instead of 234.
+      expect(menu.style.maxHeight).toBe('120px')
+      expect(menu.style.top).toBe('76px')
+    })
+
+    // The button can sit above the strip entirely (page scrolled under a pinned
+    // sheet). The cap must respect the whole strip, not just the room below.
+    test('never grows past the strip when the button is above it', async () => {
+      stubVisualViewport({ width: 390, height: 300, offsetLeft: 0, offsetTop: 200 })
+      jest.spyOn(button, 'getBoundingClientRect').mockReturnValue({
+        top: 120, bottom: 140, left: 9, right: 29, width: 20, height: 20
+      })
+      jest.spyOn(menu, 'getBoundingClientRect').mockReturnValue({
+        top: 0, bottom: 400, left: 0, right: 240, width: 240, height: 400
+      })
+
+      controller.show()
+      await new Promise(resolve => requestAnimationFrame(resolve))
+
+      // Capped to the strip (300 - 4 * 2) and clamped down to its top edge.
+      expect(menu.style.maxHeight).toBe('292px')
       expect(menu.style.top).toBe('204px')
     })
 

--- a/engines/collavre/app/javascript/controllers/popup_menu_controller.js
+++ b/engines/collavre/app/javascript/controllers/popup_menu_controller.js
@@ -1,11 +1,18 @@
 import { Controller } from '@hotwired/stimulus'
 import { notifyPopupOpen, onOtherPopupOpen } from '../lib/gnb_popup_manager'
+import visualViewportRect from '../lib/viewport_region'
+
+// Gap between the button and the menu, and the breathing room kept between the
+// menu and the edge of the visible region.
+const GAP = 4
+const VIEWPORT_PADDING = 4
 
 export default class extends Controller {
   static targets = ['menu', 'button']
 
   connect() {
     this.handleOutsideClick = this.handleOutsideClick.bind(this)
+    this.handleViewportChange = this.handleViewportChange.bind(this)
     this._popupId = 'popup-menu-' + (this.menuTarget.id || this.element.id || this.element.dataset.popupId || Math.random().toString(36).slice(2))
     this._initialAlignRight = this.menuTarget.classList.contains('popup-menu-right')
     this._cleanupPopupListener = onOtherPopupOpen(this._popupId, () => {
@@ -15,6 +22,7 @@ export default class extends Controller {
 
   disconnect() {
     this.removeOutsideClickListener()
+    this.removeViewportListeners()
     if (this._cleanupPopupListener) {
       this._cleanupPopupListener()
       this._cleanupPopupListener = null
@@ -39,8 +47,6 @@ export default class extends Controller {
   show() {
     notifyPopupOpen(this._popupId)
     const menu = this.menuTarget
-    const viewportPadding = 4
-    const gap = 4
 
     // Use fixed positioning to avoid creating scrollbars on any parent
     menu.style.position = 'fixed'
@@ -49,7 +55,7 @@ export default class extends Controller {
     menu.style.top = '0'
     menu.style.bottom = 'auto'
     menu.style.transform = ''
-    menu.style.maxWidth = `calc(100vw - ${viewportPadding * 2}px)`
+    menu.style.maxWidth = `${visualViewportRect().width - VIEWPORT_PADDING * 2}px`
     menu.classList.remove('popup-menu-right')
     // Render invisible while we compute position
     menu.style.visibility = 'hidden'
@@ -58,52 +64,79 @@ export default class extends Controller {
     this.buttonTarget?.setAttribute('aria-expanded', 'true')
 
     requestAnimationFrame(() => {
-      const btnRect = this.buttonTarget.getBoundingClientRect()
-      const menuRect = menu.getBoundingClientRect()
-      const menuW = menuRect.width
-      const menuH = menuRect.height
-      const vw = window.innerWidth
-      const vh = window.innerHeight
-
-      // Vertical: prefer below the button, flip above if not enough space
-      const spaceBelow = vh - btnRect.bottom - gap
-      const spaceAbove = btnRect.top - gap
-      let top
-      if (menuH <= spaceBelow || spaceBelow >= spaceAbove) {
-        top = btnRect.bottom + gap
-      } else {
-        top = btnRect.top - gap - menuH
-      }
-
-      // Horizontal: align left edge to button, shift if overflowing
-      let left
-      if (this._initialAlignRight) {
-        // Right-align: menu right edge to button right edge
-        left = btnRect.right - menuW
-      } else {
-        left = btnRect.left
-      }
-
-      // Clamp within viewport
-      if (left + menuW > vw - viewportPadding) {
-        left = vw - viewportPadding - menuW
-      }
-      if (left < viewportPadding) {
-        left = viewportPadding
-      }
-      if (top + menuH > vh - viewportPadding) {
-        top = vh - viewportPadding - menuH
-      }
-      if (top < viewportPadding) {
-        top = viewportPadding
-      }
-
-      menu.style.left = `${left}px`
-      menu.style.top = `${top}px`
+      this.place()
       menu.style.visibility = ''
     })
 
     this.addOutsideClickListener()
+    this.addViewportListeners()
+  }
+
+  // Place the menu against the button, inside the region that is actually on
+  // screen. Called again while the menu is open (see handleViewportChange): on
+  // mobile the keyboard both shrinks that region and moves the chat sheet the
+  // button sits in, so a placement made when the menu opened goes stale.
+  place() {
+    const menu = this.menuTarget
+    const btnRect = this.buttonTarget.getBoundingClientRect()
+    const menuRect = menu.getBoundingClientRect()
+    const menuW = menuRect.width
+    const menuH = menuRect.height
+    const region = visualViewportRect()
+
+    // Vertical: prefer below the button, flip above if not enough space
+    const spaceBelow = region.bottom - btnRect.bottom - GAP
+    const spaceAbove = btnRect.top - GAP - region.top
+    let top
+    if (menuH <= spaceBelow || spaceBelow >= spaceAbove) {
+      top = btnRect.bottom + GAP
+    } else {
+      top = btnRect.top - GAP - menuH
+    }
+
+    // Horizontal: align left edge to button, shift if overflowing
+    let left
+    if (this._initialAlignRight) {
+      // Right-align: menu right edge to button right edge
+      left = btnRect.right - menuW
+    } else {
+      left = btnRect.left
+    }
+
+    // Clamp within the visible region
+    if (left + menuW > region.right - VIEWPORT_PADDING) {
+      left = region.right - VIEWPORT_PADDING - menuW
+    }
+    if (left < region.left + VIEWPORT_PADDING) {
+      left = region.left + VIEWPORT_PADDING
+    }
+    if (top + menuH > region.bottom - VIEWPORT_PADDING) {
+      top = region.bottom - VIEWPORT_PADDING - menuH
+    }
+    if (top < region.top + VIEWPORT_PADDING) {
+      top = region.top + VIEWPORT_PADDING
+    }
+
+    menu.style.left = `${left}px`
+    menu.style.top = `${top}px`
+  }
+
+  // The keyboard opening/closing resizes the visual viewport, and pinch-zoom
+  // scrolls it. Both move the button out from under an open menu.
+  handleViewportChange() {
+    if (!this.isOpen()) return
+    this.menuTarget.style.maxWidth = `${visualViewportRect().width - VIEWPORT_PADDING * 2}px`
+    this.place()
+  }
+
+  addViewportListeners() {
+    window.visualViewport?.addEventListener('resize', this.handleViewportChange)
+    window.visualViewport?.addEventListener('scroll', this.handleViewportChange)
+  }
+
+  removeViewportListeners() {
+    window.visualViewport?.removeEventListener('resize', this.handleViewportChange)
+    window.visualViewport?.removeEventListener('scroll', this.handleViewportChange)
   }
 
   hide() {
@@ -124,6 +157,7 @@ export default class extends Controller {
     }
     this.buttonTarget?.setAttribute('aria-expanded', 'false')
     this.removeOutsideClickListener()
+    this.removeViewportListeners()
   }
 
   handleOutsideClick(event) {

--- a/engines/collavre/app/javascript/controllers/popup_menu_controller.js
+++ b/engines/collavre/app/javascript/controllers/popup_menu_controller.js
@@ -6,6 +6,11 @@ import visualViewportRect from '../lib/viewport_region'
 // menu and the edge of the visible region.
 const GAP = 4
 const VIEWPORT_PADDING = 4
+// Floor for the space-derived max-height. A menu squeezed under this shows no
+// usable row at all; overhanging the anchor slightly beats rendering a sliver.
+// The region ceiling still applies on top of it, so the menu never leaves the
+// visible strip no matter how little room the button leaves.
+const MIN_MENU_HEIGHT = 120
 
 export default class extends Controller {
   static targets = ['menu', 'button']
@@ -79,20 +84,40 @@ export default class extends Controller {
   place() {
     const menu = this.menuTarget
     const btnRect = this.buttonTarget.getBoundingClientRect()
+    const region = visualViewportRect()
+
+    // Measure unconstrained. A max-height left behind by an earlier placement
+    // would make the menu report that cap as its height, so every later call
+    // would agree it "fits" wherever it was first put.
+    menu.style.maxHeight = ''
     const menuRect = menu.getBoundingClientRect()
     const menuW = menuRect.width
     const menuH = menuRect.height
-    const region = visualViewportRect()
+
+    const regionTop = region.top + VIEWPORT_PADDING
+    const regionBottom = region.bottom - VIEWPORT_PADDING
 
     // Vertical: prefer below the button, flip above if not enough space
-    const spaceBelow = region.bottom - btnRect.bottom - GAP
-    const spaceAbove = btnRect.top - GAP - region.top
-    let top
-    if (menuH <= spaceBelow || spaceBelow >= spaceAbove) {
-      top = btnRect.bottom + GAP
-    } else {
-      top = btnRect.top - GAP - menuH
-    }
+    const spaceBelow = regionBottom - (btnRect.bottom + GAP)
+    const spaceAbove = (btnRect.top - GAP) - regionTop
+    const placeBelow = menuH <= spaceBelow || spaceBelow >= spaceAbove
+
+    // Cap to the room actually available so a long menu scrolls inside itself
+    // rather than running off the bottom of the screen. Clamping the top alone
+    // is not enough: a cron popup listing many tasks is taller than the visual
+    // viewport once the keyboard is up, and .popup-menu is overflow:hidden, so
+    // everything past the fold would simply be unreachable. The region ceiling
+    // keeps the menu inside the visible strip even when the button sits outside
+    // it, which is what makes the two clamps below sufficient.
+    const available = Math.min(
+      Math.max(placeBelow ? spaceBelow : spaceAbove, MIN_MENU_HEIGHT),
+      regionBottom - regionTop
+    )
+    menu.style.maxHeight = `${available}px`
+    menu.style.overflowY = 'auto'
+    const menuHeight = Math.min(menuH, available)
+
+    let top = placeBelow ? btnRect.bottom + GAP : btnRect.top - GAP - menuHeight
 
     // Horizontal: align left edge to button, shift if overflowing
     let left
@@ -110,11 +135,11 @@ export default class extends Controller {
     if (left < region.left + VIEWPORT_PADDING) {
       left = region.left + VIEWPORT_PADDING
     }
-    if (top + menuH > region.bottom - VIEWPORT_PADDING) {
-      top = region.bottom - VIEWPORT_PADDING - menuH
+    if (top + menuHeight > regionBottom) {
+      top = regionBottom - menuHeight
     }
-    if (top < region.top + VIEWPORT_PADDING) {
-      top = region.top + VIEWPORT_PADDING
+    if (top < regionTop) {
+      top = regionTop
     }
 
     menu.style.left = `${left}px`
@@ -149,6 +174,8 @@ export default class extends Controller {
     menu.style.top = ''
     menu.style.bottom = ''
     menu.style.maxWidth = ''
+    menu.style.maxHeight = ''
+    menu.style.overflowY = ''
     menu.style.transform = ''
     if (this._initialAlignRight) {
       menu.classList.add('popup-menu-right')

--- a/engines/collavre/app/javascript/controllers/popup_menu_controller.js
+++ b/engines/collavre/app/javascript/controllers/popup_menu_controller.js
@@ -131,9 +131,12 @@ export default class extends Controller {
       Math.max(placeBelow ? spaceBelow : spaceAbove, MIN_MENU_HEIGHT),
       regionBottom - regionTop
     )
-    menu.style.maxHeight = `${available}px`
-    menu.style.overflowY = 'auto'
     const menuHeight = Math.min(menuH, available)
+    // menuH already reflects any smaller stylesheet cap (the cron popup uses
+    // 480px). Do not replace that cap with a larger amount of free space after
+    // measuring, or the menu can grow beyond the height used for positioning.
+    menu.style.maxHeight = `${menuHeight}px`
+    menu.style.overflowY = 'auto'
 
     let top = placeBelow ? btnRect.bottom + GAP : btnRect.top - GAP - menuHeight
 

--- a/engines/collavre/app/javascript/controllers/popup_menu_controller.js
+++ b/engines/collavre/app/javascript/controllers/popup_menu_controller.js
@@ -60,7 +60,7 @@ export default class extends Controller {
     menu.style.top = '0'
     menu.style.bottom = 'auto'
     menu.style.transform = ''
-    menu.style.maxWidth = `${visualViewportRect().width - VIEWPORT_PADDING * 2}px`
+    this.constrainWidth()
     menu.classList.remove('popup-menu-right')
     // Render invisible while we compute position
     menu.style.visibility = 'hidden'
@@ -75,6 +75,24 @@ export default class extends Controller {
 
     this.addOutsideClickListener()
     this.addViewportListeners()
+  }
+
+  // Fit the menu to the width that is actually on screen. CSS resolves
+  // min-width over max-width, so the cap alone cannot shrink a menu whose
+  // stylesheet floor is wider than the strip -- .popup-menu sets 220px and the
+  // comment user popup 240px, while a pinch-zoomed visual viewport is nearer
+  // 195px. Left as is, the menu keeps its designed width with the right edge
+  // parked outside the visible region, and the scroll listener re-pins it there
+  // every frame so that edge can never be reached. Clearing the inline minimum
+  // first is what lets the stylesheet value be read back, so pinching out
+  // restores the designed width instead of leaving the menu stuck narrow.
+  constrainWidth() {
+    const menu = this.menuTarget
+    const available = visualViewportRect().width - VIEWPORT_PADDING * 2
+    menu.style.minWidth = ''
+    const floor = parseFloat(getComputedStyle(menu).minWidth) || 0
+    if (floor > available) menu.style.minWidth = `${available}px`
+    menu.style.maxWidth = `${available}px`
   }
 
   // Place the menu against the button, inside the region that is actually on
@@ -150,7 +168,7 @@ export default class extends Controller {
   // scrolls it. Both move the button out from under an open menu.
   handleViewportChange() {
     if (!this.isOpen()) return
-    this.menuTarget.style.maxWidth = `${visualViewportRect().width - VIEWPORT_PADDING * 2}px`
+    this.constrainWidth()
     this.place()
   }
 
@@ -173,6 +191,7 @@ export default class extends Controller {
     menu.style.right = ''
     menu.style.top = ''
     menu.style.bottom = ''
+    menu.style.minWidth = ''
     menu.style.maxWidth = ''
     menu.style.maxHeight = ''
     menu.style.overflowY = ''

--- a/engines/collavre/app/javascript/lib/common_popup.js
+++ b/engines/collavre/app/javascript/lib/common_popup.js
@@ -1,3 +1,5 @@
+import visualViewportRect from './viewport_region'
+
 // Gap between the anchor (caret, button) and the popup edge.
 const ANCHOR_GAP = 4
 // Breathing room kept between the popup and the edge of its region.
@@ -150,17 +152,14 @@ export default class CommonPopup {
 
   // The region the popup must stay inside: an explicit bounds element (the chat
   // box) when caged, otherwise the visual viewport. window.innerHeight is the
-  // wrong number on mobile — it still counts the strip the keyboard covers.
+  // wrong number on mobile — it still counts the strip the keyboard covers, so
+  // the viewport case goes through the shared helper that popup_menu_controller
+  // also uses, keeping one definition of "the part of the screen you can see".
   regionRect() {
     const bounds = this._boundsElement?.getBoundingClientRect?.()
     if (bounds) return bounds
 
-    const viewport = window.visualViewport
-    const left = viewport?.offsetLeft || 0
-    const top = viewport?.offsetTop || 0
-    const width = viewport?.width || window.innerWidth
-    const height = viewport?.height || window.innerHeight
-    return { left, top, right: left + width, bottom: top + height, width, height }
+    return visualViewportRect()
   }
 
   updatePosition(anchorRect) {

--- a/engines/collavre/app/javascript/lib/viewport_region.js
+++ b/engines/collavre/app/javascript/lib/viewport_region.js
@@ -1,0 +1,20 @@
+// The region a fixed-position popup has to stay inside: the *visual* viewport,
+// not window.innerWidth/innerHeight.
+//
+// On a phone those two disagree exactly when it matters. The on-screen keyboard
+// shrinks the visual viewport while innerHeight keeps counting the strip the
+// keyboard covers, so a menu placed against innerHeight lands behind the
+// keyboard — and comments--presence lifts the chat sheet clear of the keyboard
+// on that same resize, moving the anchor out from under any menu already open.
+// Desktop has no such split, which is why the same menu looks right there.
+//
+// offsetLeft/offsetTop put the region back into client coordinates, the ones
+// getBoundingClientRect reports and position:fixed resolves against.
+export default function visualViewportRect() {
+  const viewport = window.visualViewport
+  const left = viewport?.offsetLeft || 0
+  const top = viewport?.offsetTop || 0
+  const width = viewport?.width || window.innerWidth
+  const height = viewport?.height || window.innerHeight
+  return { left, top, right: left + width, bottom: top + height, width, height }
+}

--- a/engines/collavre/test/system/chat_bar_list_popup_test.rb
+++ b/engines/collavre/test/system/chat_bar_list_popup_test.rb
@@ -146,4 +146,34 @@ class ChatBarListPopupTest < ApplicationSystemTestCase
 
     assert_in_delta 4, gap, 0.5
   end
+
+  # The on-screen keyboard shrinks the visual viewport without touching
+  # window.innerHeight, and comments--presence lifts the sheet clear of it. A
+  # menu placed against innerHeight lands behind the keyboard; Selenium cannot
+  # raise a keyboard, so stub the viewport the way the browser reports one.
+  test "message author menu stays clear of the on-screen keyboard on mobile" do
+    comment = Comment.create!(creative: @creative, user: @user, content: "Keyboard anchor")
+    resize_window_to(390, 844)
+    open_comments_popup
+
+    trigger_selector = "#comment_#{comment.id} .comment-user-menu-trigger"
+    menu_selector = "#user_menu_comment_#{comment.id}"
+    keyboard_top = 344
+    page.execute_script(<<~JS)
+      window.__fakeViewport = { width: 390, height: #{keyboard_top}, offsetLeft: 0, offsetTop: 0,
+                                addEventListener() {}, removeEventListener() {} }
+      Object.defineProperty(window, 'visualViewport', { value: window.__fakeViewport, configurable: true })
+    JS
+
+    # Capybara's click asks chromedriver for the element region, which reads the
+    # real window.visualViewport we just replaced. Dispatch the click ourselves.
+    page.execute_script("document.querySelector('#{trigger_selector}').click()")
+    assert_selector menu_selector, visible: :visible
+
+    bottom = page.evaluate_script(<<~JS)
+      document.querySelector('#{menu_selector}').getBoundingClientRect().bottom
+    JS
+
+    assert_operator bottom, :<=, keyboard_top
+  end
 end


### PR DESCRIPTION
## Problem

On mobile, the chat avatar menu and the cron badge popup land in a different place than the identical menus on desktop.

Both are rendered by `popup_menu_controller`, which positions them with `position: fixed` against `window.innerWidth` / `window.innerHeight`. On a phone those numbers keep counting the strip the on-screen keyboard covers, and `comments--presence` lifts the chat sheet clear of the keyboard on that same resize. So the menu is measured against a viewport the user cannot see, and it is placed behind the keyboard — or detaches from its trigger when the sheet moves. Desktop has no visual/layout viewport split, which is why only mobile looks wrong.

Measured on a 390x844 viewport with the visual viewport shrunk to 344px (keyboard up):

| | before | after |
|---|---|---|
| avatar menu | 258 → 412 (68px behind the keyboard) | 77 → 231, fully visible |
| cron badge popup | 295 → 568 (224px behind the keyboard) | 4 → 277, fully visible |

## Fix

- New `lib/viewport_region.js` returns the visible region from `window.visualViewport` (with `offsetLeft`/`offsetTop`, so it is in the same client coordinates `getBoundingClientRect` and `position: fixed` use), falling back to `window.innerWidth`/`innerHeight`. `common_popup.js` already had this logic inline; this is the same rule in one place.
- `popup_menu_controller` places against that region, and re-places an open menu on `visualViewport` `resize`/`scroll` — the keyboard opening or closing no longer leaves the menu stranded.
- Listeners are dropped on `hide()` and `disconnect()`.

Placement with no keyboard is unchanged: verified below-the-trigger with a 4px gap at both 390px and 1440px viewports, before and after.

## Tests

- `popup_menu_controller.test.js`: flips above the trigger when the keyboard covers the space below, clamps into an offset visual viewport strip, re-places on `resize`, and drops listeners on hide. All three placement tests fail on `main`.
- `chat_bar_list_popup_test.rb`: system test that stubs the shrunk visual viewport and asserts the author menu stays above the keyboard line. On `main` it reports `Expected 657.78 to be <= 344`.
- Full jest suite: 2251 passing. Affected system tests (chat bar list popup, cron badge alignment, creative share, topic list popup, comments popup action alignment): 18 runs, 0 failures.