### PR TITLE
Refactor comment list read tracking

### DIFF
--- a/engines/collavre/app/javascript/controllers/comments/__tests__/comment_read_tracker.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/comment_read_tracker.test.js
@@ -1,0 +1,71 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { jest } from '@jest/globals'
+import CommentReadTracker from '../comment_read_tracker'
+
+describe('CommentReadTracker', () => {
+  let controller
+  let request
+  let tracker
+
+  beforeEach(() => {
+    jest.useFakeTimers()
+    request = jest.fn().mockResolvedValue({ ok: true })
+    controller = {
+      creativeId: '42',
+      currentTopicId: null,
+      element: document.createElement('div'),
+      popupController: { topicsController: { loadTopics: jest.fn() } },
+    }
+    document.body.appendChild(controller.element)
+    tracker = new CommentReadTracker(controller, { request })
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+    jest.useRealTimers()
+  })
+
+  test('owns the rendered All Messages snapshot lifecycle', () => {
+    tracker.captureRenderedSnapshot('1,2', '{"1":20,"2":21,"_legacy":19}')
+
+    expect(controller.renderedAllTopicIds).toEqual(['1', '2'])
+    expect(controller.renderedAllTopicWatermarks).toEqual({ 1: 20, 2: 21, _legacy: 19 })
+    expect(controller.renderedAllIncludesLegacy).toBe(true)
+
+    tracker.resetRenderedSnapshot()
+
+    expect(controller.renderedAllTopicIds).toBeNull()
+    expect(controller.renderedAllTopicWatermarks).toBeNull()
+    expect(controller.renderedAllIncludesLegacy).toBe(false)
+  })
+
+  test('keeps topic IDs while discarding a malformed watermark header', () => {
+    tracker.captureRenderedSnapshot('1,2', '{malformed')
+
+    expect(controller.renderedAllTopicIds).toEqual(['1', '2'])
+    expect(controller.renderedAllTopicWatermarks).toBeNull()
+    expect(controller.renderedAllIncludesLegacy).toBe(false)
+  })
+
+  test('flushes the captured snapshot with unload-safe request options', () => {
+    controller.renderedAllTopicIds = ['1', '2']
+    controller.renderedAllTopicWatermarks = { 1: 20, 2: 21 }
+    tracker.markCommentsRead()
+
+    tracker.flushPendingRead({ keepalive: true })
+
+    expect(request).toHaveBeenCalledWith('/comment_read_pointers/update', expect.objectContaining({
+      method: 'POST',
+      keepalive: true,
+      body: JSON.stringify({
+        creative_id: '42',
+        topic_id: null,
+        topic_ids: ['1', '2'],
+        topic_watermarks: { 1: 20, 2: 21 },
+      }),
+    }))
+  })
+})

--- a/engines/collavre/app/javascript/controllers/comments/comment_read_tracker.js
+++ b/engines/collavre/app/javascript/controllers/comments/comment_read_tracker.js
@@ -1,0 +1,149 @@
+import csrfFetch from '../../lib/api/csrf_fetch'
+
+const READ_DEBOUNCE_MS = 2000
+
+export default class CommentReadTracker {
+  constructor(controller, { request = csrfFetch } = {}) {
+    this.controller = controller
+    this.request = request
+  }
+
+  resetRenderedSnapshot() {
+    this.controller.renderedAllTopicIds = null
+    this.controller.renderedAllTopicWatermarks = null
+    this.controller.renderedAllIncludesLegacy = false
+  }
+
+  captureRenderedSnapshot(topicIds, topicWatermarks) {
+    this.controller.renderedAllTopicIds = topicIds.split(',').filter(Boolean)
+    try {
+      this.controller.renderedAllTopicWatermarks = topicWatermarks ? JSON.parse(topicWatermarks) : null
+      this.controller.renderedAllIncludesLegacy = Boolean(
+        this.controller.renderedAllTopicWatermarks &&
+        Object.hasOwn(this.controller.renderedAllTopicWatermarks, '_legacy')
+      )
+    } catch (_error) {
+      this.controller.renderedAllTopicWatermarks = null
+      this.controller.renderedAllIncludesLegacy = false
+    }
+  }
+
+  markCommentsRead() {
+    const controller = this.controller
+    if (!controller.creativeId) return
+    if (controller.markReadTimeout) window.clearTimeout(controller.markReadTimeout)
+
+    const creativeId = controller.creativeId
+    const topicId = controller.currentTopicId || null
+    const topicIds = topicId ? null : controller.renderedAllTopicIds
+    const topicWatermarks = topicId ? null : controller.renderedAllTopicWatermarks
+    const pendingRead = { creativeId, topicId, topicIds, topicWatermarks }
+    controller.pendingRead = pendingRead
+    controller.markReadTimeout = window.setTimeout(() => {
+      controller.markReadTimeout = null
+      if (controller.pendingRead !== pendingRead) return
+      controller.pendingRead = null
+      if (!controller.element.isConnected || controller.creativeId !== creativeId ||
+          (controller.currentTopicId || null) !== topicId) return
+
+      this.updateReadPointer(creativeId, topicId, topicIds, topicWatermarks)
+    }, READ_DEBOUNCE_MS)
+  }
+
+  flushPendingRead({ keepalive = false } = {}) {
+    const controller = this.controller
+    const pendingRead = controller.pendingRead
+    if (!pendingRead) return
+
+    if (controller.markReadTimeout) window.clearTimeout(controller.markReadTimeout)
+    controller.markReadTimeout = null
+    controller.pendingRead = null
+    this.updateReadPointer(
+      pendingRead.creativeId,
+      pendingRead.topicId,
+      pendingRead.topicIds,
+      pendingRead.topicWatermarks,
+      { keepalive }
+    )
+  }
+
+  updateReadPointer(creativeId, topicId, topicIds = null, topicWatermarks = null, { keepalive = false } = {}) {
+    if (!creativeId) return
+
+    this.request('/comment_read_pointers/update', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      keepalive,
+      body: JSON.stringify({
+        creative_id: creativeId,
+        topic_id: topicId,
+        ...(topicIds ? { topic_ids: topicIds } : {}),
+        ...(topicWatermarks ? { topic_watermarks: topicWatermarks } : {}),
+      }),
+    }).then((response) => {
+      const controller = this.controller
+      if (!response.ok || !controller.element.isConnected || controller.creativeId !== creativeId ||
+          (controller.currentTopicId || null) !== topicId) return
+
+      controller.popupController?.topicsController?.loadTopics?.()
+    }).catch(() => { /* ignore — creative may have been deleted */ })
+  }
+
+  recordRenderedAllTopicWatermarks(comments, { includeNewTopics = false } = {}) {
+    const controller = this.controller
+    if (controller.currentTopicId || !Array.isArray(controller.renderedAllTopicIds)) return false
+
+    let addedTopic = false
+    const renderedComments = comments instanceof Element ? [comments] : Array.from(comments || [])
+    renderedComments.forEach((comment) => {
+      const topicId = comment.dataset.topicId
+      const commentId = Number.parseInt(comment.dataset.commentId, 10)
+      if (!Number.isSafeInteger(commentId) || commentId <= 0) return
+
+      const watermarkKey = topicId || '_legacy'
+      if (!topicId && !controller.renderedAllIncludesLegacy) {
+        if (!includeNewTopics) return
+
+        controller.renderedAllIncludesLegacy = true
+        addedTopic = true
+      }
+
+      if (topicId && !controller.renderedAllTopicIds.some((id) => String(id) === String(topicId))) {
+        if (!includeNewTopics) return
+
+        controller.renderedAllTopicIds.push(String(topicId))
+        addedTopic = true
+      }
+
+      controller.renderedAllTopicWatermarks ||= {}
+      const previousId = Number.parseInt(controller.renderedAllTopicWatermarks[watermarkKey], 10)
+      if (!Number.isSafeInteger(previousId) || commentId > previousId) {
+        controller.renderedAllTopicWatermarks[watermarkKey] = commentId
+      }
+    })
+
+    return addedTopic
+  }
+
+  reportRenderedAllTopics() {
+    const controller = this.controller
+    if (controller.currentTopicId || !Array.isArray(controller.renderedAllTopicIds)) return
+
+    controller.element.dispatchEvent(new CustomEvent('comments--list:rendered-all-topics', {
+      bubbles: true,
+      detail: {
+        creativeId: controller.creativeId,
+        topicIds: controller.renderedAllTopicIds,
+        includesLegacy: controller.renderedAllIncludesLegacy,
+      },
+    }))
+  }
+
+  isOutsideRenderedAllTopics(topicId) {
+    const topicIds = this.controller.renderedAllTopicIds
+    return Array.isArray(topicIds) &&
+      !topicIds.some((id) => String(id) === String(topicId))
+  }
+}

--- a/engines/collavre/app/javascript/controllers/comments/list_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/list_controller.js
@@ -6,8 +6,9 @@ import { attachBundleDragImage } from '../../lib/dnd/bundle_image'
 import { renderMarkdownInContainer } from '../../lib/utils/markdown'
 import creativesApi from '../../lib/api/creatives'
 import { renderCreativeTree, dispatchCreativeTreeUpdated } from '../../creatives/tree_renderer'
-import csrfFetch, { updateCsrfTokenFromResponse } from '../../lib/api/csrf_fetch'
+import { updateCsrfTokenFromResponse } from '../../lib/api/csrf_fetch'
 import { alertDialog, confirmDialog } from '../../lib/utils/dialog'
+import CommentReadTracker from './comment_read_tracker'
 import PrevMessageNavigator from './prev_message_navigator'
 // CommonPopup is now used via TopicSearchController (Stimulus)
 
@@ -31,6 +32,7 @@ export default class extends Controller {
     this.highlightCreativeId = null
     this._loadCommentsVersion = 0
     this.markReadTimeout = null
+    this.commentReadTracker = new CommentReadTracker(this)
     this.prevMsgNavigator = new PrevMessageNavigator()
 
     this.handleScroll = this.handleScroll.bind(this)
@@ -144,9 +146,7 @@ export default class extends Controller {
       ? this.highlightAfterLoad
       : null
     this.creativeId = creativeId
-    this.renderedAllTopicIds = null
-    this.renderedAllTopicWatermarks = null
-    this.renderedAllIncludesLegacy = false
+    this.getCommentReadTracker().resetRenderedSnapshot()
     this.initialLoadComplete = false
     // highlightId from popup args takes precedence, else fallback to URL param if first load
     this.highlightAfterLoad = highlightId || pendingHighlight || this.deepLinkCommentId
@@ -169,9 +169,7 @@ export default class extends Controller {
     this.flushPendingRead()
     this._loadCommentsVersion += 1
     this.creativeId = null
-    this.renderedAllTopicIds = null
-    this.renderedAllTopicWatermarks = null
-    this.renderedAllIncludesLegacy = false
+    this.getCommentReadTracker().resetRenderedSnapshot()
     this.highlightAfterLoad = null
     this.highlightCreativeId = null
     this.suppressTopicChangeLoad = false
@@ -391,14 +389,10 @@ export default class extends Controller {
       // happen later and may observe a topic-strip archive change without
       // rendering that topic's existing history.
       if (loadVersion !== undefined && !pagination && !superseded && !this.currentTopicId && renderedTopicIds !== null) {
-        this.renderedAllTopicIds = renderedTopicIds.split(',').filter(Boolean)
-        try {
-          this.renderedAllTopicWatermarks = renderedTopicWatermarks ? JSON.parse(renderedTopicWatermarks) : null
-          this.renderedAllIncludesLegacy = Boolean(this.renderedAllTopicWatermarks && Object.hasOwn(this.renderedAllTopicWatermarks, '_legacy'))
-        } catch (_error) {
-          this.renderedAllTopicWatermarks = null
-          this.renderedAllIncludesLegacy = false
-        }
+        this.getCommentReadTracker().captureRenderedSnapshot(
+          renderedTopicIds,
+          renderedTopicWatermarks
+        )
       }
       // A load superseded while in flight must not retopic anything: its own HTML
       // is dropped, so moving currentTopicId (and the strip, and the form) to its
@@ -498,62 +492,21 @@ export default class extends Controller {
   }
 
   markCommentsRead() {
-    if (!this.creativeId) return
-    if (this.markReadTimeout) window.clearTimeout(this.markReadTimeout)
-    const creativeId = this.creativeId
-    const topicId = this.currentTopicId || null
-    const topicIds = topicId ? null : this.renderedAllTopicIds
-    const topicWatermarks = topicId ? null : this.renderedAllTopicWatermarks
-    const pendingRead = { creativeId, topicId, topicIds, topicWatermarks }
-    this.pendingRead = pendingRead
-    this.markReadTimeout = window.setTimeout(() => {
-      this.markReadTimeout = null
-      if (this.pendingRead !== pendingRead) return
-      this.pendingRead = null
-      if (!this.element.isConnected || this.creativeId !== creativeId || (this.currentTopicId || null) !== topicId) return
-
-      this.updateReadPointer(creativeId, topicId, topicIds, topicWatermarks)
-    }, 2000);
+    this.getCommentReadTracker().markCommentsRead()
   }
 
   flushPendingRead({ keepalive = false } = {}) {
-    const pendingRead = this.pendingRead
-    if (!pendingRead) return
-
-    if (this.markReadTimeout) window.clearTimeout(this.markReadTimeout)
-    this.markReadTimeout = null
-    this.pendingRead = null
-    this.updateReadPointer(
-      pendingRead.creativeId,
-      pendingRead.topicId,
-      pendingRead.topicIds,
-      pendingRead.topicWatermarks,
-      { keepalive }
-    )
+    this.getCommentReadTracker().flushPendingRead({ keepalive })
   }
 
   updateReadPointer(creativeId, topicId, topicIds = null, topicWatermarks = null, { keepalive = false } = {}) {
-    if (!creativeId) return
-
-    csrfFetch('/comment_read_pointers/update', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      keepalive,
-      body: JSON.stringify({
-        creative_id: creativeId,
-        topic_id: topicId,
-        ...(topicIds ? { topic_ids: topicIds } : {}),
-        ...(topicWatermarks ? { topic_watermarks: topicWatermarks } : {}),
-      }),
-    }).then((response) => {
-      if (!response.ok || !this.element.isConnected || this.creativeId !== creativeId || (this.currentTopicId || null) !== topicId) return
-
-      // A successful topic read changes its chip and the aggregate creative
-      // badge. Reload immediately instead of leaving stale counts on screen.
-      this.popupController?.topicsController?.loadTopics?.()
-    }).catch(() => { /* ignore — creative may have been deleted */ })
+    this.getCommentReadTracker().updateReadPointer(
+      creativeId,
+      topicId,
+      topicIds,
+      topicWatermarks,
+      { keepalive }
+    )
   }
 
   handlePrevMsgUserInput() {
@@ -676,56 +629,20 @@ export default class extends Controller {
   // visible in the DOM. Live streams still fence topics outside the initial
   // snapshot because older history for those topics may be unseen.
   recordRenderedAllTopicWatermarks(comments, { includeNewTopics = false } = {}) {
-    if (this.currentTopicId || !Array.isArray(this.renderedAllTopicIds)) return false
-
-    let addedTopic = false
-    const renderedComments = comments instanceof Element ? [comments] : Array.from(comments || [])
-    renderedComments.forEach((comment) => {
-      const topicId = comment.dataset.topicId
-      const commentId = Number.parseInt(comment.dataset.commentId, 10)
-      if (!Number.isSafeInteger(commentId) || commentId <= 0) return
-
-      const watermarkKey = topicId || '_legacy'
-      if (!topicId && !this.renderedAllIncludesLegacy) {
-        if (!includeNewTopics) return
-
-        this.renderedAllIncludesLegacy = true
-        addedTopic = true
-      }
-
-      if (topicId && !this.renderedAllTopicIds.some((id) => String(id) === String(topicId))) {
-        if (!includeNewTopics) return
-
-        this.renderedAllTopicIds.push(String(topicId))
-        addedTopic = true
-      }
-
-      this.renderedAllTopicWatermarks ||= {}
-      const previousId = Number.parseInt(this.renderedAllTopicWatermarks[watermarkKey], 10)
-      if (!Number.isSafeInteger(previousId) || commentId > previousId) {
-        this.renderedAllTopicWatermarks[watermarkKey] = commentId
-      }
-    })
-
-    return addedTopic
+    return this.getCommentReadTracker().recordRenderedAllTopicWatermarks(comments, { includeNewTopics })
   }
 
   reportRenderedAllTopics() {
-    if (this.currentTopicId || !Array.isArray(this.renderedAllTopicIds)) return
-
-    this.element.dispatchEvent(new CustomEvent('comments--list:rendered-all-topics', {
-      bubbles: true,
-      detail: {
-        creativeId: this.creativeId,
-        topicIds: this.renderedAllTopicIds,
-        includesLegacy: this.renderedAllIncludesLegacy,
-      },
-    }))
+    this.getCommentReadTracker().reportRenderedAllTopics()
   }
 
   isOutsideRenderedAllTopics(topicId) {
-    return Array.isArray(this.renderedAllTopicIds) &&
-      !this.renderedAllTopicIds.some((id) => String(id) === String(topicId))
+    return this.getCommentReadTracker().isOutsideRenderedAllTopics(topicId)
+  }
+
+  getCommentReadTracker() {
+    this.commentReadTracker ||= new CommentReadTracker(this)
+    return this.commentReadTracker
   }
 
   handleStreamRender(event) {


### PR DESCRIPTION
## Summary
- extract read-pointer debounce, persistence, and rendered-topic watermark tracking from the 1,472-line comments list controller
- preserve the controller's public seams while delegating the cohesive responsibility to `CommentReadTracker`
- add focused regression coverage for snapshot parsing, reset, and unload-safe flushing

## Verification
- `npm test -- --runInBand` (157 suites, 2,250 tests)
- `npm run build`
- `mise exec -- ./bin/rubocop -a`
- `mise exec -- bin/complexity_check --base origin/feature/refactor-reduce-dupl`