### PR TITLE
Refactor comment form draft lifecycle

### DIFF
--- a/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_draft.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_draft.test.js
@@ -253,7 +253,7 @@ describe('FormController - draft persistence', () => {
     controller.textareaTarget.value = 'still composing'
     dispatchTopicChange('77', '10074')
     expect(chatDrafts.get('77')).toBeNull()
-    expect(controller._activeDraftKey).toBe('77')
+    expect(controller._drafts._activeDraftKey).toBe('77')
   })
 
   test('switching linked creatives flushes before resetting a shared effective draft', () => {
@@ -275,7 +275,7 @@ describe('FormController - draft persistence', () => {
     popupEl.dispatchEvent(
       new CustomEvent('comments--topics:change', { detail: { topicId: '10073' } }),
     )
-    expect(controller._activeDraftKey).toBe('66')
+    expect(controller._drafts._activeDraftKey).toBe('66')
   })
 
   test('keeps the draft key empty when no creative id is available', () => {
@@ -284,7 +284,7 @@ describe('FormController - draft persistence', () => {
     popupEl.dispatchEvent(
       new CustomEvent('comments--topics:change', { detail: { topicId: '10073' } }),
     )
-    expect(controller._activeDraftKey).toBeNull()
+    expect(controller._drafts._activeDraftKey).toBeNull()
   })
 
   test('closing the popup flush-saves the draft; blank input deletes it', () => {
@@ -387,7 +387,7 @@ describe('FormController - draft persistence', () => {
     popupEl.dataset.creativeId = '88'
     dispatchTopicChange('88')
     controller.onPopupOpened({ creativeId: '88', canComment: true })
-    expect(controller._activeDraftKey).toBeNull()
+    expect(controller._drafts._activeDraftKey).toBeNull()
     typeInto(controller.textareaTarget, 'must not persist for the old user')
     controller.onPopupClosed()
     await new Promise((resolve) => setTimeout(resolve, 600))
@@ -484,14 +484,14 @@ describe('FormController - draft persistence', () => {
 
     expect(submissionBackup('77')).toBeNull()
     expect(freshController._draftPersistenceDisabled()).toBe(true)
-    expect(freshController._observedDraftClearNonces.has(namespace)).toBe(false)
+    expect(freshController._drafts._observedDraftClearNonces.has(namespace)).toBe(false)
 
     setItem.mockRestore()
     freshController.disconnect()
     freshController.connect()
 
     expect(freshController._draftPersistenceDisabled()).toBe(false)
-    expect(freshController._observedDraftClearNonces.get(namespace)).toBe('logout-2')
+    expect(freshController._drafts._observedDraftClearNonces.get(namespace)).toBe('logout-2')
     controller = freshController
   })
 
@@ -502,7 +502,7 @@ describe('FormController - draft persistence', () => {
       nonce: 'missed-logout',
     }))
     controller.disconnect()
-    controller._observedDraftClearNonces.clear()
+    controller._drafts._observedDraftClearNonces.clear()
     const storageGetter = jest.spyOn(window, 'sessionStorage', 'get').mockImplementation(() => {
       throw new DOMException('denied', 'SecurityError')
     })
@@ -521,7 +521,7 @@ describe('FormController - draft persistence', () => {
   test('storage recovery does not treat an existing clear marker as a new logout', () => {
     controller.disconnect()
     chatDrafts.clearAll()
-    controller._observedDraftClearNonces.clear()
+    controller._drafts._observedDraftClearNonces.clear()
     const storageGetter = jest.spyOn(window, 'localStorage', 'get').mockImplementation(() => {
       throw new DOMException('denied', 'SecurityError')
     })
@@ -1491,7 +1491,7 @@ describe('FormController - draft persistence', () => {
     delete popupEl.dataset.effectiveCreativeId
     controller.onChatWillOpen({ creativeId: '78' })
     chatDrafts.saveSubmissionBackup('78', 'failed submission restored after reload')
-    controller._pendingDraftSubmissions.clear()
+    controller._drafts._pendingDraftSubmissions.clear()
     controller.resetForm()
     controller._restoreDraft()
 
@@ -1614,15 +1614,15 @@ describe('FormController - draft persistence', () => {
     dispatchTopicChange('70')
     controller.onPopupOpened({ creativeId: '78', canComment: true })
 
-    expect(controller._activeDraftKey).toBe('78')
-    expect(controller._awaitingEffectiveDraftKeyFor).toBe('78')
+    expect(controller._drafts._activeDraftKey).toBe('78')
+    expect(controller._drafts._awaitingEffectiveDraftKeyFor).toBe('78')
     expect(controller.textareaTarget.value).toBe('latest raw draft')
 
     dispatchTopicChange('70')
     controller.onPopupOpened({ creativeId: '78', canComment: true })
 
-    expect(controller._activeDraftKey).toBe('70')
-    expect(controller._awaitingEffectiveDraftKeyFor).toBeNull()
+    expect(controller._drafts._activeDraftKey).toBe('70')
+    expect(controller._drafts._awaitingEffectiveDraftKeyFor).toBeNull()
     expect(controller.textareaTarget.value).toBe('latest raw draft')
     expect(chatDrafts.get('78')).toBeNull()
     expect(chatDrafts.get('70')).toBe('latest raw draft')
@@ -1642,8 +1642,8 @@ describe('FormController - draft persistence', () => {
     dispatchTopicChange('70')
     controller.onPopupOpened({ creativeId: '78', canComment: true })
 
-    expect(controller._activeDraftKey).toBe('70')
-    expect(controller._awaitingEffectiveDraftKeyFor).toBeNull()
+    expect(controller._drafts._activeDraftKey).toBe('70')
+    expect(controller._drafts._awaitingEffectiveDraftKeyFor).toBeNull()
     expect(controller.textareaTarget.value).toBe('newer canonical draft')
   })
 
@@ -1847,8 +1847,8 @@ describe('FormController - draft persistence', () => {
 
     controller.disconnect()
     controller.connect()
-    expect(controller._activeDraftKey).toBe('78')
-    expect(controller._awaitingEffectiveDraftKeyFor).toBe('78')
+    expect(controller._drafts._activeDraftKey).toBe('78')
+    expect(controller._drafts._awaitingEffectiveDraftKeyFor).toBe('78')
     typeInto(controller.textareaTarget, 'next message after reconnect')
 
     popupEl.dataset.creativeId = '78'

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_stashed_draft.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_stashed_draft.test.js
@@ -26,7 +26,7 @@ const buildController = () => {
 // The stash is tagged with the creative it was typed in, so tests build it the
 // way handleStashDraft does rather than assigning a bare string.
 const stash = (controller, draft) => {
-  controller._stashedDraft = { draft, creativeId: controller.creativeId }
+  controller._drafts._stashedDraft = { draft, creativeId: controller.creativeId }
 }
 
 describe('CommentsFormController stashed draft', () => {
@@ -37,7 +37,7 @@ describe('CommentsFormController stashed draft', () => {
       new CustomEvent('comments--form:stash-draft', { detail: { draft: 'roadmap notes' } }),
     )
 
-    expect(controller._stashedDraft).toEqual({ draft: 'roadmap notes', creativeId: '7' })
+    expect(controller._drafts._stashedDraft).toEqual({ draft: 'roadmap notes', creativeId: '7' })
   })
 
   test('receives the event dispatched on the textarea, which bubbles to the popup', () => {
@@ -58,7 +58,7 @@ describe('CommentsFormController stashed draft', () => {
       }),
     )
 
-    expect(controller._stashedDraft).toEqual({ draft: 'roadmap notes', creativeId: '7' })
+    expect(controller._drafts._stashedDraft).toEqual({ draft: 'roadmap notes', creativeId: '7' })
   })
 
   test('restores the draft into the textarea the send cleared', () => {
@@ -116,7 +116,7 @@ describe('CommentsFormController stashed draft', () => {
     stash(controller, 'roadmap notes')
 
     controller._restoreStashedDraft()
-    expect(controller._stashedDraft).toBeNull()
+    expect(controller._drafts._stashedDraft).toBeNull()
 
     textarea.value = ''
     controller._restoreStashedDraft()

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_stashed_draft_creative_switch.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_stashed_draft_creative_switch.test.js
@@ -106,7 +106,7 @@ describe('CommentsFormController stashed draft across a creative switch', () => 
     await flush()
 
     expect(textarea.value).toBe('')
-    expect(controller._stashedDraft).toBeNull()
+    expect(controller._drafts._stashedDraft).toBeNull()
   })
 
   test('still restores the draft when the same creative is reopened mid-flight', async () => {
@@ -161,6 +161,6 @@ describe('CommentsFormController stashed draft across a creative switch', () => 
     controller._restoreStashedDraft('')
 
     expect(textarea.value).toBe('')
-    expect(controller._stashedDraft).toBeNull()
+    expect(controller._drafts._stashedDraft).toBeNull()
   })
 })

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/form_draft_manager.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/form_draft_manager.test.js
@@ -1,0 +1,154 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { jest } from '@jest/globals'
+import FormDraftManager from '../form_draft_manager'
+import chatDrafts from '../../../lib/chat_drafts'
+
+// The draft lifecycle was extracted out of comments--form so it can be
+// exercised without Stimulus. These tests drive it through a plain host object
+// that offers only the form surface the manager is allowed to touch, which is
+// what keeps the seam honest: anything the manager reaches for that is not
+// listed here shows up as a failure rather than as accidental coupling.
+const buildManager = () => {
+  document.body.innerHTML = '<div id="host"><textarea></textarea></div>'
+  const element = document.getElementById('host')
+  const textarea = element.querySelector('textarea')
+  const host = {
+    element,
+    textareaTarget: textarea,
+    editingId: null,
+    creativeId: null,
+    _reviewStore: { isEmpty: true },
+    _autoResize: jest.fn(),
+    _updateSubmitButton: jest.fn(),
+    resetForm: jest.fn(() => { textarea.value = '' }),
+  }
+
+  return { host, element, textarea, manager: new FormDraftManager(host) }
+}
+
+describe('FormDraftManager', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    window.sessionStorage.clear()
+    document.body.dataset.currentUserId = '9'
+    if (typeof global.requestAnimationFrame !== 'function') {
+      global.requestAnimationFrame = (cb) => setTimeout(cb, 0)
+    }
+  })
+
+  test('debounce-saves typed input under the active chat key', () => {
+    jest.useFakeTimers()
+    try {
+      const { manager, textarea } = buildManager()
+      manager.connect()
+      manager._activeDraftKey = '42'
+
+      textarea.value = 'roadmap notes'
+      textarea.dispatchEvent(new Event('input', { bubbles: true }))
+      expect(chatDrafts.get('42')).toBeNull()
+
+      jest.advanceTimersByTime(500)
+      expect(chatDrafts.get('42')).toBe('roadmap notes')
+    } finally {
+      jest.useRealTimers()
+    }
+  })
+
+  test('restores the stored draft when its chat opens', () => {
+    chatDrafts.set('42', 'roadmap notes')
+    const { manager, textarea, host } = buildManager()
+    manager.connect()
+
+    manager.onChatWillOpen({ creativeId: '42' })
+
+    expect(textarea.value).toBe('roadmap notes')
+    expect(host.creativeId).toBe('42')
+    expect(manager._activeDraftKey).toBe('42')
+    // The topics event has not landed yet, so the raw id is still provisional.
+    expect(manager._awaitingEffectiveDraftKeyFor).toBe('42')
+  })
+
+  test('re-opening the chat it already owns leaves the in-progress text alone', () => {
+    const { manager, textarea, host } = buildManager()
+    manager.connect()
+    manager.onChatWillOpen({ creativeId: '42' })
+    host.resetForm.mockClear()
+
+    textarea.value = 'half-typed reply'
+    manager.onChatWillOpen({ creativeId: 42 })
+
+    // resetForm would have wiped the textarea; the repeat open must be a no-op.
+    expect(host.resetForm).not.toHaveBeenCalled()
+    expect(textarea.value).toBe('half-typed reply')
+  })
+
+  test('discarding a draft cancels the pending save instead of writing it back', () => {
+    jest.useFakeTimers()
+    try {
+      const { manager, textarea } = buildManager()
+      manager.connect()
+      manager._activeDraftKey = '42'
+
+      textarea.value = 'roadmap notes'
+      textarea.dispatchEvent(new Event('input', { bubbles: true }))
+      manager.discardDraft()
+      jest.advanceTimersByTime(500)
+
+      expect(chatDrafts.get('42')).toBeNull()
+      expect(manager._activeDraftKey).toBeNull()
+    } finally {
+      jest.useRealTimers()
+    }
+  })
+
+  test('disconnecting stops the textarea from feeding further saves', () => {
+    jest.useFakeTimers()
+    try {
+      const { manager, textarea } = buildManager()
+      manager.connect()
+      manager._activeDraftKey = '42'
+      manager.disconnect()
+
+      textarea.value = 'typed after teardown'
+      textarea.dispatchEvent(new Event('input', { bubbles: true }))
+      jest.advanceTimersByTime(500)
+
+      expect(chatDrafts.get('42')).toBeNull()
+    } finally {
+      jest.useRealTimers()
+    }
+  })
+
+  test('a partial key migration only tracks the plain draft that was sent', () => {
+    const { manager } = buildManager()
+    manager.connect()
+    const namespace = chatDrafts.namespace()
+    const sourceDraft = { text: 'roadmap notes', revision: 3, updatedAt: 10 }
+    const targetDraft = { text: 'roadmap notes', revision: 3, updatedAt: 10 }
+    const plainSubmission = {
+      namespace,
+      key: '42',
+      storedRevision: 3,
+      migratedSources: [],
+    }
+    // A stashed command carries text the user never meant to keep as a draft,
+    // so the migration must not adopt the new key on its behalf.
+    const stashedSubmission = {
+      namespace,
+      key: '42',
+      storedRevision: 3,
+      hadStash: true,
+      migratedSources: [],
+    }
+    manager._pendingDraftSubmissions.add(plainSubmission)
+    manager._pendingDraftSubmissions.add(stashedSubmission)
+
+    manager._trackPartialDraftMigration('42', '77', sourceDraft, targetDraft)
+
+    expect(plainSubmission.migratedSources).toEqual([{ key: '77', revision: 3 }])
+    expect(stashedSubmission.migratedSources).toEqual([])
+  })
+})

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -188,7 +188,7 @@ export default class extends Controller {
   onPopupOpened({ creativeId, canComment }) {
     this.creativeId = creativeId
     this.element.dataset.creativeId = creativeId || ''
-    if (canComment) this._draftSaveSuspendedForPermission = false
+    if (canComment) this._drafts._draftSaveSuspendedForPermission = false
     // Stale topic ids from the previous creative are cleared by the popup
     // controller BEFORE topics loadTopics() dispatches comments--topics:change,
     // so by the time we get here, currentTopicId already reflects the new
@@ -198,9 +198,9 @@ export default class extends Controller {
     // Capture input entered while topics were loading before reset clears it.
     // Without a pending input timer, a blank textarea must not erase a draft
     // that is waiting in storage to be restored below.
-    if (this._draftSaveTimer) this._flushDraftSave()
+    if (this._drafts._draftSaveTimer) this._flushDraftSave()
     this.resetForm()
-    this._draftSaveSuspendedForPermission = !canComment
+    this._drafts._draftSaveSuspendedForPermission = !canComment
     if (canComment && this.shouldAutoFocusOnOpen()) {
       requestAnimationFrame(() => this.textareaTarget.focus())
     }
@@ -213,9 +213,9 @@ export default class extends Controller {
 
   onPopupClosed() {
     this._flushDraftSave()
-    this._activeDraftKey = null
-    this._activeDraftCreativeId = null
-    this._awaitingEffectiveDraftKeyFor = null
+    this._drafts._activeDraftKey = null
+    this._drafts._activeDraftCreativeId = null
+    this._drafts._awaitingEffectiveDraftKeyFor = null
     this.stopSpeechRecognition()
     this.resetForm()
   }
@@ -230,13 +230,13 @@ export default class extends Controller {
 
     if (!canComment) {
       this._flushDraftSave()
-      this._draftSaveSuspendedForPermission = true
+      this._drafts._draftSaveSuspendedForPermission = true
       this.stopSpeechRecognition()
       this.resetForm()
       return
     }
 
-    this._draftSaveSuspendedForPermission = false
+    this._drafts._draftSaveSuspendedForPermission = false
     this._restoreDraft()
     if (this.shouldAutoFocusOnOpen()) {
       requestAnimationFrame(() => this.textareaTarget.focus())
@@ -285,10 +285,6 @@ export default class extends Controller {
     return this._drafts._stashedDraftBelongsToCurrentCreative()
   }
 
-  _shouldSuppressDraftSaveForStash() {
-    return this._drafts._shouldSuppressDraftSaveForStash()
-  }
-
   _restoreStashedDraft(submittedText) {
     this._drafts._restoreStashedDraft(submittedText)
   }
@@ -309,79 +305,20 @@ export default class extends Controller {
     this.textareaTarget.style.height = 'auto'
   }
 
-  get _activeDraftKey() { return this._drafts._activeDraftKey }
-  set _activeDraftKey(value) { this._drafts._activeDraftKey = value }
-  get _activeDraftCreativeId() { return this._drafts._activeDraftCreativeId }
-  set _activeDraftCreativeId(value) { this._drafts._activeDraftCreativeId = value }
-  get _awaitingEffectiveDraftKeyFor() { return this._drafts._awaitingEffectiveDraftKeyFor }
-  set _awaitingEffectiveDraftKeyFor(value) { this._drafts._awaitingEffectiveDraftKeyFor = value }
-  get _draftSaveTimer() { return this._drafts._draftSaveTimer }
-  set _draftSaveTimer(value) { this._drafts._draftSaveTimer = value }
-  get _draftSaveSuspendedForPermission() { return this._drafts._draftSaveSuspendedForPermission }
-  set _draftSaveSuspendedForPermission(value) { this._drafts._draftSaveSuspendedForPermission = value }
-  get _disabledDraftNamespaces() { return this._drafts._disabledDraftNamespaces }
-  set _disabledDraftNamespaces(value) { this._drafts._disabledDraftNamespaces = value }
-  get _draftBackupCleanupPendingNamespaces() { return this._drafts._draftBackupCleanupPendingNamespaces }
-  set _draftBackupCleanupPendingNamespaces(value) { this._drafts._draftBackupCleanupPendingNamespaces = value }
-  get _observedDraftClearNonces() { return this._drafts._observedDraftClearNonces }
-  set _observedDraftClearNonces(value) { this._drafts._observedDraftClearNonces = value }
-  get _draftRevisions() { return this._drafts._draftRevisions }
-  set _draftRevisions(value) { this._drafts._draftRevisions = value }
-  get _observedDrafts() { return this._drafts._observedDrafts }
-  set _observedDrafts(value) { this._drafts._observedDrafts = value }
-  get _observedDisplayedDrafts() { return this._drafts._observedDisplayedDrafts }
-  set _observedDisplayedDrafts(value) { this._drafts._observedDisplayedDrafts = value }
-  get _observedDraftRevisions() { return this._drafts._observedDraftRevisions }
-  set _observedDraftRevisions(value) { this._drafts._observedDraftRevisions = value }
-  get _observedStoredDraftRevisions() { return this._drafts._observedStoredDraftRevisions }
-  set _observedStoredDraftRevisions(value) { this._drafts._observedStoredDraftRevisions = value }
-  get _pendingDraftSubmissions() { return this._drafts._pendingDraftSubmissions }
-  set _pendingDraftSubmissions(value) { this._drafts._pendingDraftSubmissions = value }
-  get _stashedDraft() { return this._drafts._stashedDraft }
-  set _stashedDraft(value) { this._drafts._stashedDraft = value }
-
-  _saveDraftNow() {
-    this._drafts._saveDraftNow()
-  }
-
   _flushDraftSave() {
     this._drafts._flushDraftSave()
-  }
-
-  _currentTextIsPendingSubmission() {
-    return this._drafts._currentTextIsPendingSubmission()
-  }
-
-  _currentPendingSubmission() {
-    return this._drafts._currentPendingSubmission()
   }
 
   _restoreDraft() {
     this._drafts._restoreDraft()
   }
 
-  _restorePendingSubmittedDraft() {
-    this._drafts._restorePendingSubmittedDraft()
-  }
-
   _draftPersistenceDisabled(namespace) {
     return this._drafts._draftPersistenceDisabled(namespace)
   }
 
-  _disableDraftNamespace(namespace) {
-    this._drafts._disableDraftNamespace(namespace)
-  }
-
   _observeDraft(...args) {
     this._drafts._observeDraft(...args)
-  }
-
-  _rebindPendingDraftSubmissions(...args) {
-    this._drafts._rebindPendingDraftSubmissions(...args)
-  }
-
-  _trackPartialDraftMigration(...args) {
-    this._drafts._trackPartialDraftMigration(...args)
   }
 
   _clearMigratedSubmittedSources(submission) {
@@ -444,9 +381,9 @@ export default class extends Controller {
     // Cancel any pending input debounce before capturing the submission. A
     // write while the request is in flight looks like a newer draft and can
     // restore the already-sent text on success. Failures persist below.
-    if (this._draftSaveTimer) {
-      clearTimeout(this._draftSaveTimer)
-      this._draftSaveTimer = null
+    if (this._drafts._draftSaveTimer) {
+      clearTimeout(this._drafts._draftSaveTimer)
+      this._drafts._draftSaveTimer = null
     }
 
     // Build final content from review quotes + user text
@@ -462,7 +399,7 @@ export default class extends Controller {
     // going to the server. _restoreStashedDraft compares against it to tell a
     // failure that left the command text behind from text typed mid-flight.
     const submittedText = this.textareaTarget.value
-    const initialSubmittedDraftKey = this._activeDraftKey
+    const initialSubmittedDraftKey = this._drafts._activeDraftKey
     const submittedDraftNamespace = chatDrafts.namespace()
     const initialSubmittedDraftRevisionKey =
       `${submittedDraftNamespace}:${initialSubmittedDraftKey}`
@@ -474,22 +411,22 @@ export default class extends Controller {
       (initialSubmittedDraft.updatedAt || 0) + 1,
     )
     const observedSubmittedText =
-      this._observedDrafts?.get(initialSubmittedDraftRevisionKey)
+      this._drafts._observedDrafts?.get(initialSubmittedDraftRevisionKey)
     const observedSubmittedStoredRevision =
-      this._observedStoredDraftRevisions?.get(initialSubmittedDraftRevisionKey) || null
+      this._drafts._observedStoredDraftRevisions?.get(initialSubmittedDraftRevisionKey) || null
     const submittedTextChangedOutsideController =
       observedSubmittedText !== initialSubmittedDraft.text
     const submittedRevisionChangedOutsideController =
       observedSubmittedStoredRevision !== initialSubmittedDraft.revision
     const submittedStoredDraftChangedOutsideController =
-      this._observedDrafts?.has(initialSubmittedDraftRevisionKey) &&
+      this._drafts._observedDrafts?.has(initialSubmittedDraftRevisionKey) &&
       (submittedTextChangedOutsideController || submittedRevisionChangedOutsideController)
     const submittedDraft = {
       key: initialSubmittedDraftKey,
       namespace: submittedDraftNamespace,
       revisionKey: initialSubmittedDraftRevisionKey,
       storedChangedOutsideController: submittedStoredDraftChangedOutsideController,
-      keyRevision: this._draftRevisions?.get(initialSubmittedDraftRevisionKey) || 0,
+      keyRevision: this._drafts._draftRevisions?.get(initialSubmittedDraftRevisionKey) || 0,
       storedRevision: initialSubmittedDraft.revision,
       storedUpdatedAt: initialSubmittedDraft.updatedAt,
       backupUpdatedAt: submittedBackupUpdatedAt,
@@ -498,14 +435,14 @@ export default class extends Controller {
       backupKey: submittedBackup?.text === submittedText ? submittedBackup.key : null,
       migratedSources: [],
     }
-    this._pendingDraftSubmissions ||= new Set()
-    this._pendingDraftSubmissions.add(submittedDraft)
+    this._drafts._pendingDraftSubmissions ||= new Set()
+    this._drafts._pendingDraftSubmissions.add(submittedDraft)
     const submittedEditingId = this.editingId
     const submittedHadReview = hasQuotes
     submittedDraft.editing = Boolean(submittedEditingId)
     submittedDraft.hadReview = submittedHadReview
     if (submittedHadStash) {
-      this._stashedDraft.submittedText = submittedText
+      this._drafts._stashedDraft.submittedText = submittedText
     }
 
     const formData = new FormData(this.formTarget)
@@ -578,18 +515,18 @@ export default class extends Controller {
         const switchedChats =
           ownsSubmittedDraftNamespace &&
           submittedDraftKey &&
-          this._activeDraftKey &&
-          String(submittedDraftKey) !== String(this._activeDraftKey)
+          this._drafts._activeDraftKey &&
+          String(submittedDraftKey) !== String(this._drafts._activeDraftKey)
         const submittedChatStillActive =
           submittedDraftKey &&
-          this._activeDraftKey &&
-          String(submittedDraftKey) === String(this._activeDraftKey)
+          this._drafts._activeDraftKey &&
+          String(submittedDraftKey) === String(this._drafts._activeDraftKey)
         const hasNewerActiveDraft =
           ownsSubmittedDraftNamespace &&
           !submittedEditingId &&
           !submittedHadReview &&
           submittedChatStillActive &&
-          (this._draftRevisions?.get(submittedDraftRevisionKey) || 0) !==
+          (this._drafts._draftRevisions?.get(submittedDraftRevisionKey) || 0) !==
             submittedDraftKeyRevision
         const hasNewerStoredDraft =
           ownsSubmittedDraftNamespace &&
@@ -597,7 +534,7 @@ export default class extends Controller {
           !submittedHadReview &&
           submittedDraftKey &&
           (
-            (this._draftRevisions?.get(submittedDraftRevisionKey) || 0) !==
+            (this._drafts._draftRevisions?.get(submittedDraftRevisionKey) || 0) !==
               submittedDraftKeyRevision ||
             submittedStoredDraftChangedOutsideController ||
             chatDrafts.revision(submittedDraftKey) !== submittedDraftStoredRevision
@@ -605,14 +542,14 @@ export default class extends Controller {
         const hasNewerDraft = hasNewerActiveDraft || hasNewerStoredDraft
         const newerDraft = hasNewerActiveDraft
           ? (
-            this._draftSaveSuspendedForPermission
+            this._drafts._draftSaveSuspendedForPermission
               ? chatDrafts.get(submittedDraftKey)
               : this.textareaTarget.value
           )
           : null
         if (switchedChats) this._flushDraftSave()
-        clearTimeout(this._draftSaveTimer)
-        this._draftSaveTimer = null
+        clearTimeout(this._drafts._draftSaveTimer)
+        this._drafts._draftSaveTimer = null
         this.resetForm()
         if (submittedEditingId) {
           if (ownsSubmittedDraftNamespace) this._restoreDraft()
@@ -689,7 +626,7 @@ export default class extends Controller {
         settlementUi = alertDialog(error?.message || 'Failed to submit comment')
       })
       .finally(() => {
-        this._pendingDraftSubmissions.delete(submittedDraft)
+        this._drafts._pendingDraftSubmissions.delete(submittedDraft)
         inFlightSends.delete(sendKey)
         this._hasRetried = false
         this.setSendingState(false)
@@ -699,7 +636,7 @@ export default class extends Controller {
         ) {
           this._restoreStashedDraft(submittedText)
         } else {
-          this._stashedDraft = null
+          this._drafts._stashedDraft = null
         }
         const announceSettlement = () => {
           this.element.dispatchEvent(new CustomEvent('comments--form:submit-settled', {

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -6,6 +6,7 @@ import { renderMarkdownInContainer } from '../../lib/utils/markdown'
 import { wrapHtmlInCodeBlocks } from '../../lib/html_code_block_wrapper'
 import { refreshCsrfToken } from '../../lib/api/csrf_fetch'
 import ReviewQuotesStore from './review_quotes_store'
+import FormDraftManager from './form_draft_manager'
 import { alertDialog } from '../../lib/utils/dialog'
 import chatDrafts from '../../lib/chat_drafts'
 
@@ -37,6 +38,11 @@ export default class extends Controller {
     'reviewQuotesContainer',
     'quoteCancelButton',
   ]
+
+  get _drafts() {
+    this.__drafts ||= new FormDraftManager(this)
+    return this.__drafts
+  }
 
   connect() {
     this.dnd = createDragDropRegistry({ root: this.formTarget, getKind: getDragKind, readData: readDragData })
@@ -98,115 +104,7 @@ export default class extends Controller {
     }
     this.textareaTarget.addEventListener('input', this._autoResize)
 
-    // Draft persistence: debounce-save unsent input per chat.
-    // _activeDraftKey always identifies the chat whose text is in the textarea.
-    this._activeDraftKey ??= null
-    this._activeDraftCreativeId ??= null
-    this._awaitingEffectiveDraftKeyFor ??= null
-    this._draftSaveTimer = null
-    this._draftSaveSuspendedForPermission ??= false
-    // A cross-tab logout permanently retires the old user's namespace for this
-    // controller lifetime, including Stimulus reconnects in the stale tab.
-    this._disabledDraftNamespaces ||= new Set()
-    this._draftBackupCleanupPendingNamespaces ||= new Set()
-    this._observedDraftClearNonces ||= new Map()
-    // A pending send survives a Stimulus reconnect on this controller instance,
-    // so its completion must keep comparing against the same draft history.
-    this._draftRevisions ||= new Map()
-    this._observedDrafts ||= new Map()
-    this._observedDisplayedDrafts ||= new Map()
-    this._observedDraftRevisions ||= new Map()
-    this._observedStoredDraftRevisions ||= new Map()
-    // A linked chat can replace its temporary raw key while its request is in
-    // flight. Keep mutable submission state across that migration/reconnect.
-    this._pendingDraftSubmissions ||= new Set()
-    const draftNamespace = chatDrafts.namespace()
-    const draftClearNonce = chatDrafts.clearNonce(draftNamespace)
-    const draftClearNoncePending = chatDrafts.clearNoncePending(draftNamespace)
-    const observedDraftClearNonce = this._observedDraftClearNonces.has(draftNamespace)
-    let canObserveDraftClearNonce = true
-    if (draftClearNonce && !observedDraftClearNonce) {
-      canObserveDraftClearNonce = chatDrafts.clearSubmissionBackupsForClear(
-	draftNamespace,
-	draftClearNonce,
-      )
-      if (canObserveDraftClearNonce && !draftClearNoncePending) {
-	this._draftBackupCleanupPendingNamespaces.delete(draftNamespace)
-      } else {
-	this._draftBackupCleanupPendingNamespaces.add(draftNamespace)
-      }
-    }
-    if (
-      draftClearNonce &&
-      observedDraftClearNonce &&
-      this._observedDraftClearNonces.get(draftNamespace) !== draftClearNonce
-    ) {
-      this._disableDraftNamespace(draftNamespace)
-    }
-    if (
-      draftClearNonce !== undefined &&
-      canObserveDraftClearNonce &&
-      !draftClearNoncePending
-    ) {
-      this._observedDraftClearNonces.set(draftNamespace, draftClearNonce)
-    }
-    this._handlePageHide = () => {
-      if (!this.element.isConnected) return
-
-      this._flushDraftSave()
-    }
-    this._handleDraftStorage = (event) => {
-      if (!this.element.isConnected || !chatDrafts.wasCleared(event)) return
-
-      const clearedNamespace = chatDrafts.namespace()
-      this._disableDraftNamespace(clearedNamespace)
-    }
-    this._handleCompositionEnd = () => {
-      this._imeCommitPending = true
-    }
-    // Chrome fires the commit `input` after `compositionend`, but Firefox has
-    // shipped the reverse order, where the commit input consumes the latch
-    // before it is even set. Nothing would clear the leftover latch, so the
-    // next ordinary edit would be misread as a commit. The commit input always
-    // arrives before the user can act again, so any fresh gesture expires it.
-    this._expireImeCommitLatch = (event) => {
-      if (event?.isComposing || event?.keyCode === 229) return
-
-      this._imeCommitPending = false
-    }
-    this._handleDraftInput = (event) => {
-      // Consume the composition flag before any early return, so it can never
-      // outlive the `input` event that the commit itself fired. Firefox has
-      // shipped both orderings, so accept isComposing on the input event too.
-      const isImeCommit = Boolean(event?.isComposing) || this._imeCommitPending === true
-      this._imeCommitPending = false
-      if (
-        this.editingId ||
-	this._draftPersistenceDisabled() ||
-        this._draftSaveSuspendedForPermission ||
-        this._shouldSuppressDraftSaveForStash() ||
-        !this._reviewStore.isEmpty ||
-        !this._activeDraftKey
-      ) return
-      // An IME commit fires `input` after the keydown that started a send, so
-      // the textarea still holds exactly what went to the server. Counting it
-      // as a revision would defeat _currentPendingSubmission and make the sent
-      // message look like a draft typed mid-flight, restoring it on success.
-      // Text equality alone is not enough to suppress: re-entering the same
-      // string mid-flight (select-all + paste to send it twice) is a real edit.
-      if (isImeCommit && this._currentTextIsPendingSubmission()) return
-      const revisionKey = `${chatDrafts.namespace()}:${this._activeDraftKey}`
-      this._draftRevisions.set(revisionKey, (this._draftRevisions.get(revisionKey) || 0) + 1)
-      clearTimeout(this._draftSaveTimer)
-      this._draftSaveTimer = setTimeout(() => this._saveDraftNow(), 500)
-    }
-    this.textareaTarget.addEventListener('compositionend', this._handleCompositionEnd)
-    this.textareaTarget.addEventListener('keydown', this._expireImeCommitLatch)
-    this.textareaTarget.addEventListener('paste', this._expireImeCommitLatch)
-    this.textareaTarget.addEventListener('drop', this._expireImeCommitLatch)
-    this.textareaTarget.addEventListener('input', this._handleDraftInput)
-    window.addEventListener('pagehide', this._handlePageHide)
-    window.addEventListener('storage', this._handleDraftStorage)
+    this._drafts.connect()
 
     this.textareaTarget.addEventListener('keydown', (event) => {
       if (event.key === 'Escape') {
@@ -240,66 +138,7 @@ export default class extends Controller {
   }
 
   handleTopicChange(event) {
-    // This event fires before onPopupOpened during a chat switch, while the
-    // textarea still contains the outgoing chat's text. Flush before re-keying.
-    const draftPersistenceDisabled = this._draftPersistenceDisabled()
-    const nextDraftKey = draftPersistenceDisabled
-      ? null
-      : this.element.dataset.effectiveCreativeId || this.element.dataset.creativeId || null
-    const nextCreativeId = draftPersistenceDisabled
-      ? null
-      : this.element.dataset.creativeId || null
-    const draftKeyChanged = String(this._activeDraftKey || '') !== String(nextDraftKey || '')
-    const creativeChanged =
-      String(this._activeDraftCreativeId || '') !== String(nextCreativeId || '')
-    const resolvingIncomingDraftKey =
-      this._awaitingEffectiveDraftKeyFor &&
-      String(this._awaitingEffectiveDraftKeyFor) === String(nextCreativeId || '')
-    let keepAwaitingEffectiveDraftKey = false
-    if (draftKeyChanged || creativeChanged) {
-      const previousDraftKey = this._activeDraftKey
-      // onChatWillOpen already flushed the outgoing chat. While the effective
-      // key is loading, save only actual new input; rewriting a restored raw
-      // draft here would make stale text appear newer than the canonical draft.
-      if (!resolvingIncomingDraftKey || this._draftSaveTimer) this._flushDraftSave()
-      this._activeDraftKey = nextDraftKey ? String(nextDraftKey) : null
-      this._activeDraftCreativeId = nextCreativeId ? String(nextCreativeId) : null
-      if (
-        resolvingIncomingDraftKey &&
-        previousDraftKey &&
-        this._activeDraftKey
-      ) {
-        const sourceDraft = chatDrafts.snapshot(previousDraftKey)
-	const moveCompleted = chatDrafts.move(previousDraftKey, this._activeDraftKey)
-        const targetDraft = chatDrafts.snapshot(this._activeDraftKey)
-	const movedBackups = moveCompleted
-	  ? chatDrafts.moveSubmissionBackups(previousDraftKey, this._activeDraftKey)
-	  : new Map()
-	if (moveCompleted && (targetDraft.revision || !sourceDraft.revision)) {
-          this._rebindPendingDraftSubmissions(
-            previousDraftKey,
-            this._activeDraftKey,
-            sourceDraft,
-            targetDraft,
-            movedBackups,
-          )
-	} else if (!moveCompleted) {
-	  this._trackPartialDraftMigration(
-	    previousDraftKey,
-	    this._activeDraftKey,
-	    sourceDraft,
-	    targetDraft,
-	  )
-	  if (chatDrafts.isNewer(previousDraftKey, this._activeDraftKey)) {
-	    this._activeDraftKey = String(previousDraftKey)
-	    keepAwaitingEffectiveDraftKey = true
-	  }
-        }
-      }
-    }
-    if (resolvingIncomingDraftKey && !keepAwaitingEffectiveDraftKey) {
-      this._awaitingEffectiveDraftKeyFor = null
-    }
+    this._drafts.handleTopicChange()
     this.currentTopicId = event.detail.topicId
     this.readOnlyTopic = event.detail.readOnly || false
     this._isInbox = event.detail.isInbox || false
@@ -318,14 +157,7 @@ export default class extends Controller {
 
   disconnect() {
     this.dnd?.destroy()
-    this._flushDraftSave()
-    this.textareaTarget.removeEventListener('compositionend', this._handleCompositionEnd)
-    this.textareaTarget.removeEventListener('keydown', this._expireImeCommitLatch)
-    this.textareaTarget.removeEventListener('paste', this._expireImeCommitLatch)
-    this.textareaTarget.removeEventListener('drop', this._expireImeCommitLatch)
-    this.textareaTarget.removeEventListener('input', this._handleDraftInput)
-    window.removeEventListener('pagehide', this._handlePageHide)
-    window.removeEventListener('storage', this._handleDraftStorage)
+    this._drafts.disconnect()
     this.formTarget.removeEventListener('submit', this.handleSubmit)
     this.submitTarget.removeEventListener('click', this.handleSend)
     this.submitTarget.removeEventListener('pointerup', this.handlePointerSend)
@@ -376,29 +208,7 @@ export default class extends Controller {
   }
 
   onChatWillOpen({ creativeId }) {
-    const nextCreativeId = creativeId ? String(creativeId) : null
-    if (
-      String(this._activeDraftCreativeId || '') === String(nextCreativeId || '')
-    ) return
-
-    // The popup publishes its raw creative id before awaiting topics. Flush the
-    // outgoing chat now, then give any input typed during that await a key owned
-    // by the incoming chat. The topics event replaces it with the effective id.
-    this._flushDraftSave()
-    if (this._draftPersistenceDisabled()) {
-      this._activeDraftKey = null
-      this._activeDraftCreativeId = null
-      this._awaitingEffectiveDraftKeyFor = null
-      this.creativeId = creativeId
-      this.resetForm()
-      return
-    }
-    this._activeDraftKey = nextCreativeId
-    this._activeDraftCreativeId = nextCreativeId
-    this._awaitingEffectiveDraftKeyFor = nextCreativeId
-    this.creativeId = creativeId
-    this.resetForm()
-    this._restoreDraft()
+    this._drafts.onChatWillOpen({ creativeId })
   }
 
   onPopupClosed() {
@@ -411,17 +221,7 @@ export default class extends Controller {
   }
 
   discardDraft() {
-    const namespace = chatDrafts.namespace()
-    this._pendingDraftSubmissions?.forEach((submission) => {
-      if (submission.namespace === namespace) submission.invalidated = true
-    })
-    clearTimeout(this._draftSaveTimer)
-    this._draftSaveTimer = null
-    this._activeDraftKey = null
-    this._activeDraftCreativeId = null
-    this._awaitingEffectiveDraftKeyFor = null
-    this._stashedDraft = null
-    this.resetForm()
+    this._drafts.discardDraft()
   }
 
   setCommentPermission(canComment) {
@@ -478,55 +278,19 @@ export default class extends Controller {
   }
 
   handleStashDraft(event) {
-    const draft = event.detail?.draft || null
-    if (draft) this._flushDraftSave()
-    // Tagged with the conversation it was typed in: the popup reuses this one
-    // controller for every creative, so a stash left over from another one must
-    // not be handed back here.
-    this._stashedDraft = draft ? { draft, creativeId: this.creativeId } : null
+    this._drafts.handleStashDraft(event)
   }
 
   _stashedDraftBelongsToCurrentCreative() {
-    return Boolean(
-      this._stashedDraft &&
-      String(this._stashedDraft.creativeId) === String(this.creativeId),
-    )
+    return this._drafts._stashedDraftBelongsToCurrentCreative()
   }
 
   _shouldSuppressDraftSaveForStash() {
-    if (!this._stashedDraftBelongsToCurrentCreative()) return false
-
-    // Before handleSend captures the command, the command-menu input event
-    // must not replace the stashed ordinary draft. Once the send starts, only
-    // the submitted command remains suppressed; later input is a new draft.
-    return !this._stashedDraft.submittedText ||
-      this.textareaTarget.value === this._stashedDraft.submittedText
+    return this._drafts._shouldSuppressDraftSaveForStash()
   }
 
   _restoreStashedDraft(submittedText) {
-    const stashed = this._stashedDraft
-    this._stashedDraft = null
-    if (!stashed) return
-    // Switching creatives calls onPopupOpened on this same instance (there is
-    // no disconnect between conversations), so a send that settles after the
-    // switch would drop the previous conversation's draft into the new one.
-    // The draft belongs to a conversation that is no longer on screen; discard
-    // it rather than misfile it.
-    if (String(stashed.creativeId ?? '') !== String(this.creativeId ?? '')) return
-    const draft = stashed.draft
-    // Two boxes are safe to overwrite: an empty one (the success path runs
-    // resetForm) and one still holding exactly what we submitted (the failure
-    // path never clears it, so the command text is left sitting there). Any
-    // other content is text the user typed while the request was in flight, or
-    // a review quote the failure path restored, and must not be clobbered.
-    const current = this.textareaTarget.value
-    if (current.trim().length > 0 && current !== submittedText) return
-    this.textareaTarget.value = draft
-    // Resize and re-enable send directly rather than dispatching `input`, which
-    // would re-open the command menu for a draft that starts with "/".
-    this._autoResize()
-    this._updateSubmitButton()
-    this._saveDraftNow()
+    this._drafts._restoreStashedDraft(submittedText)
   }
 
   resetForm() {
@@ -545,279 +309,87 @@ export default class extends Controller {
     this.textareaTarget.style.height = 'auto'
   }
 
+  get _activeDraftKey() { return this._drafts._activeDraftKey }
+  set _activeDraftKey(value) { this._drafts._activeDraftKey = value }
+  get _activeDraftCreativeId() { return this._drafts._activeDraftCreativeId }
+  set _activeDraftCreativeId(value) { this._drafts._activeDraftCreativeId = value }
+  get _awaitingEffectiveDraftKeyFor() { return this._drafts._awaitingEffectiveDraftKeyFor }
+  set _awaitingEffectiveDraftKeyFor(value) { this._drafts._awaitingEffectiveDraftKeyFor = value }
+  get _draftSaveTimer() { return this._drafts._draftSaveTimer }
+  set _draftSaveTimer(value) { this._drafts._draftSaveTimer = value }
+  get _draftSaveSuspendedForPermission() { return this._drafts._draftSaveSuspendedForPermission }
+  set _draftSaveSuspendedForPermission(value) { this._drafts._draftSaveSuspendedForPermission = value }
+  get _disabledDraftNamespaces() { return this._drafts._disabledDraftNamespaces }
+  set _disabledDraftNamespaces(value) { this._drafts._disabledDraftNamespaces = value }
+  get _draftBackupCleanupPendingNamespaces() { return this._drafts._draftBackupCleanupPendingNamespaces }
+  set _draftBackupCleanupPendingNamespaces(value) { this._drafts._draftBackupCleanupPendingNamespaces = value }
+  get _observedDraftClearNonces() { return this._drafts._observedDraftClearNonces }
+  set _observedDraftClearNonces(value) { this._drafts._observedDraftClearNonces = value }
+  get _draftRevisions() { return this._drafts._draftRevisions }
+  set _draftRevisions(value) { this._drafts._draftRevisions = value }
+  get _observedDrafts() { return this._drafts._observedDrafts }
+  set _observedDrafts(value) { this._drafts._observedDrafts = value }
+  get _observedDisplayedDrafts() { return this._drafts._observedDisplayedDrafts }
+  set _observedDisplayedDrafts(value) { this._drafts._observedDisplayedDrafts = value }
+  get _observedDraftRevisions() { return this._drafts._observedDraftRevisions }
+  set _observedDraftRevisions(value) { this._drafts._observedDraftRevisions = value }
+  get _observedStoredDraftRevisions() { return this._drafts._observedStoredDraftRevisions }
+  set _observedStoredDraftRevisions(value) { this._drafts._observedStoredDraftRevisions = value }
+  get _pendingDraftSubmissions() { return this._drafts._pendingDraftSubmissions }
+  set _pendingDraftSubmissions(value) { this._drafts._pendingDraftSubmissions = value }
+  get _stashedDraft() { return this._drafts._stashedDraft }
+  set _stashedDraft(value) { this._drafts._stashedDraft = value }
+
   _saveDraftNow() {
-    if (
-      !this._activeDraftKey ||
-      this._draftPersistenceDisabled() ||
-      this._draftSaveSuspendedForPermission ||
-      this.editingId ||
-      this._shouldSuppressDraftSaveForStash() ||
-      !this._reviewStore.isEmpty
-    ) return
-    if (this._currentTextIsPendingSubmission()) return
-    const draftKey = this._activeDraftKey
-    const text = this.textareaTarget.value
-    const blank = !text.trim()
-    const storedDraft = chatDrafts.snapshot(draftKey)
-    const storedText = storedDraft.text
-    const hasStoredEntry = chatDrafts.updatedAt(draftKey) !== null
-    const observationKey = `${chatDrafts.namespace()}:${draftKey}`
-    const hasObservedDraft = this._observedDrafts?.has(observationKey)
-    const observedText = this._observedDrafts?.get(observationKey)
-    const hasObservedDisplayedDraft =
-      this._observedDisplayedDrafts?.has(observationKey)
-    const observedDisplayedText = hasObservedDisplayedDraft
-      ? this._observedDisplayedDrafts.get(observationKey)
-      : observedText
-    const observedRevision = this._observedDraftRevisions?.get(observationKey) || 0
-    const observedStoredRevision =
-      this._observedStoredDraftRevisions?.get(observationKey) || null
-    const currentRevision = this._draftRevisions?.get(observationKey) || 0
-    const inputChangedLocally = currentRevision !== observedRevision
-    const preserveBlank =
-      blank && Boolean(this._awaitingEffectiveDraftKeyFor) && inputChangedLocally
-    const displayedDraftChanged =
-      (hasObservedDisplayedDraft || hasObservedDraft) &&
-      (observedDisplayedText || '') !== text
-    const draftChangedLocally =
-      inputChangedLocally || displayedDraftChanged
-    const storedDraftChangedOutsideController = hasObservedDraft && (
-      observedText !== storedText || observedStoredRevision !== storedDraft.revision
-    )
-    // An idle tab can retain stale restored text after another tab updates the
-    // same draft. Closing or switching that idle tab must not write it back.
-    if (!draftChangedLocally && storedDraftChangedOutsideController) return
-    if (preserveBlank) {
-      if (storedText !== null || !hasStoredEntry) {
-        chatDrafts.set(draftKey, '', { preserveBlank: true })
-      }
-    } else if (blank) {
-      if (hasStoredEntry) {
-        chatDrafts.clear(draftKey)
-      }
-    } else if (storedText !== text) {
-      chatDrafts.set(draftKey, text)
-    }
-    if (blank && draftChangedLocally) chatDrafts.clearSubmissionBackups(draftKey)
-    this._observeDraft(draftKey)
+    this._drafts._saveDraftNow()
   }
 
   _flushDraftSave() {
-    clearTimeout(this._draftSaveTimer)
-    this._draftSaveTimer = null
-    this._saveDraftNow()
+    this._drafts._flushDraftSave()
   }
 
   _currentTextIsPendingSubmission() {
-    return Boolean(this._currentPendingSubmission())
+    return this._drafts._currentTextIsPendingSubmission()
   }
 
   _currentPendingSubmission() {
-    const namespace = chatDrafts.namespace()
-    const key = String(this._activeDraftKey || '')
-
-    return [...(this._pendingDraftSubmissions || [])].find((submission) => (
-      !submission.invalidated &&
-      submission.namespace === namespace &&
-      String(submission.key || '') === key &&
-      !submission.hadStash &&
-      !submission.hadReview &&
-      !submission.editing &&
-      submission.text === this.textareaTarget.value &&
-      (this._draftRevisions?.get(submission.revisionKey) || 0) === submission.keyRevision
-    ))
+    return this._drafts._currentPendingSubmission()
   }
 
   _restoreDraft() {
-    if (
-      !this._activeDraftKey ||
-      this._draftPersistenceDisabled() ||
-      this.editingId
-    ) return
-    if (this.textareaTarget.value.trim()) return
-
-    const draft = chatDrafts.snapshot(this._activeDraftKey)
-    const backup = chatDrafts.latestSubmissionBackup(this._activeDraftKey)
-    const restoreBackup = Boolean(
-      backup?.text &&
-      (draft.updatedAt === null || backup.updatedAt > draft.updatedAt),
-    )
-    if (backup && !restoreBackup) chatDrafts.removeSubmissionBackup(backup.key)
-    const restoredText = restoreBackup ? backup.text : draft.text
-    this._observeDraft(
-      this._activeDraftKey,
-      draft.text,
-      chatDrafts.namespace(),
-      draft.revision,
-      restoredText,
-    )
-    if (restoredText) {
-      this.textareaTarget.value = restoredText
-      requestAnimationFrame(() => this._autoResize())
-    } else if (draft.updatedAt === null) {
-      this._restorePendingSubmittedDraft()
-    }
+    this._drafts._restoreDraft()
   }
 
   _restorePendingSubmittedDraft() {
-    const namespace = chatDrafts.namespace()
-    const pending = [...(this._pendingDraftSubmissions || [])].find((submission) => (
-      !submission.invalidated &&
-      submission.namespace === namespace &&
-      String(submission.key || '') === String(this._activeDraftKey || '') &&
-      !submission.hadStash &&
-      !submission.hadReview &&
-      !submission.editing
-    ))
-    if (!pending) return
-
-    this.textareaTarget.value = pending.text
-    requestAnimationFrame(() => this._autoResize())
-    this._updateSubmitButton()
+    this._drafts._restorePendingSubmittedDraft()
   }
 
-  _draftPersistenceDisabled(namespace = chatDrafts.namespace()) {
-    return this._disabledDraftNamespaces?.has(namespace) ||
-      this._draftBackupCleanupPendingNamespaces?.has(namespace) ||
-      false
+  _draftPersistenceDisabled(namespace) {
+    return this._drafts._draftPersistenceDisabled(namespace)
   }
 
   _disableDraftNamespace(namespace) {
-    this._disabledDraftNamespaces.add(namespace)
-    this.discardDraft()
-    // A timer in this tab may have raced with the logout tab's first clear.
-    chatDrafts.clearAll({ broadcast: false })
+    this._drafts._disableDraftNamespace(namespace)
   }
 
-  _observeDraft(
-    draftKey,
-    text,
-    namespace = chatDrafts.namespace(),
-    storedRevision,
-    displayedText,
-  ) {
-    if (!draftKey) return
-    const storedDraft = storedRevision === undefined
-      ? chatDrafts.snapshot(draftKey)
-      : { text, revision: storedRevision }
-    const observationKey = `${namespace}:${draftKey}`
-    this._observedDrafts?.set(observationKey, storedDraft.text)
-    this._observedDisplayedDrafts?.set(
-      observationKey,
-      displayedText === undefined ? storedDraft.text : displayedText,
-    )
-    this._observedDraftRevisions?.set(
-      observationKey,
-      this._draftRevisions?.get(observationKey) || 0,
-    )
-    this._observedStoredDraftRevisions?.set(observationKey, storedDraft.revision)
+  _observeDraft(...args) {
+    this._drafts._observeDraft(...args)
   }
 
-  _rebindPendingDraftSubmissions(
-    sourceKey,
-    targetKey,
-    sourceDraft,
-    targetDraft,
-    movedBackups = new Map(),
-  ) {
-    const namespace = chatDrafts.namespace()
-    const targetRevisionKey = `${namespace}:${targetKey}`
-
-    this._pendingDraftSubmissions?.forEach((submission) => {
-      if (
-        submission.namespace !== namespace ||
-        String(submission.key) !== String(sourceKey)
-      ) return
-
-      const targetMatchesStoredBaseline = submission.storedRevision && targetDraft.revision === submission.storedRevision
-      const sourceMatchesSubmission =
-        sourceDraft.revision &&
-        targetDraft.revision === sourceDraft.revision &&
-        targetDraft.text === submission.text
-      const submittedDraftWasUnstored =
-        !submission.storedRevision &&
-        !sourceDraft.revision &&
-        !targetDraft.revision
-      const submittedDraftWasMoved = targetMatchesStoredBaseline || sourceMatchesSubmission || submittedDraftWasUnstored
-      if (
-        sourceDraft.revision &&
-        sourceDraft.text === submission.text
-      ) {
-        submission.migratedSources.push({
-          key: String(sourceKey),
-          revision: sourceDraft.revision,
-        })
-      }
-      submission.key = String(targetKey)
-      submission.revisionKey = targetRevisionKey
-      submission.keyRevision = this._draftRevisions?.get(targetRevisionKey) || 0
-      submission.storedRevision = targetDraft.revision
-      submission.storedUpdatedAt = targetDraft.updatedAt
-      submission.storedChangedOutsideController ||=
-        !submittedDraftWasMoved
-      if (submission.backupKey && movedBackups.has(submission.backupKey)) {
-        submission.backupKey = movedBackups.get(submission.backupKey)
-      }
-    })
+  _rebindPendingDraftSubmissions(...args) {
+    this._drafts._rebindPendingDraftSubmissions(...args)
   }
 
-  _trackPartialDraftMigration(sourceKey, targetKey, sourceDraft, targetDraft) {
-    if (
-      !sourceDraft.revision ||
-      targetDraft.revision !== sourceDraft.revision
-    ) return
-
-    const namespace = chatDrafts.namespace()
-    this._pendingDraftSubmissions?.forEach((submission) => {
-      if (
-	submission.namespace !== namespace ||
-	String(submission.key) !== String(sourceKey) ||
-	submission.hadStash ||
-	submission.hadReview ||
-	submission.editing ||
-	submission.storedRevision !== sourceDraft.revision
-      ) return
-
-      submission.migratedSources.push({
-	key: String(targetKey),
-	revision: targetDraft.revision,
-      })
-    })
+  _trackPartialDraftMigration(...args) {
+    this._drafts._trackPartialDraftMigration(...args)
   }
 
   _clearMigratedSubmittedSources(submission) {
-    submission.migratedSources.forEach(({ key, revision }) => {
-      if (chatDrafts.revision(key) !== revision) return
-
-      chatDrafts.clear(key)
-      this._observeDraft(key, null, submission.namespace)
-    })
+    this._drafts._clearMigratedSubmittedSources(submission)
   }
 
   _persistFailedSubmissionDraft(submission) {
-    if (
-      submission.invalidated ||
-      submission.hadStash ||
-      submission.hadReview ||
-      submission.editing ||
-      submission.namespace !== chatDrafts.namespace()
-    ) return
-
-    const currentDraft = chatDrafts.snapshot(submission.key)
-    const currentKeyRevision =
-      this._draftRevisions?.get(submission.revisionKey) || 0
-    const submittedChatAdvanced =
-      submission.storedChangedOutsideController ||
-      currentKeyRevision !== submission.keyRevision ||
-      currentDraft.revision !== submission.storedRevision ||
-      currentDraft.updatedAt !== submission.storedUpdatedAt
-    if (submittedChatAdvanced) return
-
-    submission.backupKey ||= chatDrafts.saveSubmissionBackup(
-      submission.key,
-      submission.text,
-      { updatedAt: submission.backupUpdatedAt },
-    )
+    this._drafts._persistFailedSubmissionDraft(submission)
   }
 
   setSendingState(isSending) {

--- a/engines/collavre/app/javascript/controllers/comments/form_draft_manager.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_draft_manager.js
@@ -9,7 +9,6 @@ export default class FormDraftManager {
   get element() { return this.form.element }
   get textareaTarget() { return this.form.textareaTarget }
   get editingId() { return this.form.editingId }
-  set editingId(value) { this.form.editingId = value }
   get creativeId() { return this.form.creativeId }
   set creativeId(value) { this.form.creativeId = value }
   get _reviewStore() { return this.form._reviewStore }

--- a/engines/collavre/app/javascript/controllers/comments/form_draft_manager.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_draft_manager.js
@@ -1,0 +1,581 @@
+import chatDrafts from '../../lib/chat_drafts'
+
+// Owns the stateful draft lifecycle while the Stimulus controller coordinates UI concerns.
+export default class FormDraftManager {
+  constructor(form) {
+    this.form = form
+  }
+
+  get element() { return this.form.element }
+  get textareaTarget() { return this.form.textareaTarget }
+  get editingId() { return this.form.editingId }
+  set editingId(value) { this.form.editingId = value }
+  get creativeId() { return this.form.creativeId }
+  set creativeId(value) { this.form.creativeId = value }
+  get _reviewStore() { return this.form._reviewStore }
+
+  _autoResize() {
+    this.form._autoResize()
+  }
+
+  _updateSubmitButton() {
+    this.form._updateSubmitButton()
+  }
+
+  resetForm() {
+    this.form.resetForm()
+  }
+
+  connect() {
+    // Draft persistence: debounce-save unsent input per chat.
+    // _activeDraftKey always identifies the chat whose text is in the textarea.
+    this._activeDraftKey ??= null
+    this._activeDraftCreativeId ??= null
+    this._awaitingEffectiveDraftKeyFor ??= null
+    this._draftSaveTimer = null
+    this._draftSaveSuspendedForPermission ??= false
+    // A cross-tab logout permanently retires the old user's namespace for this
+    // controller lifetime, including Stimulus reconnects in the stale tab.
+    this._disabledDraftNamespaces ||= new Set()
+    this._draftBackupCleanupPendingNamespaces ||= new Set()
+    this._observedDraftClearNonces ||= new Map()
+    // A pending send survives a Stimulus reconnect on this controller instance,
+    // so its completion must keep comparing against the same draft history.
+    this._draftRevisions ||= new Map()
+    this._observedDrafts ||= new Map()
+    this._observedDisplayedDrafts ||= new Map()
+    this._observedDraftRevisions ||= new Map()
+    this._observedStoredDraftRevisions ||= new Map()
+    // A linked chat can replace its temporary raw key while its request is in
+    // flight. Keep mutable submission state across that migration/reconnect.
+    this._pendingDraftSubmissions ||= new Set()
+    const draftNamespace = chatDrafts.namespace()
+    const draftClearNonce = chatDrafts.clearNonce(draftNamespace)
+    const draftClearNoncePending = chatDrafts.clearNoncePending(draftNamespace)
+    const observedDraftClearNonce = this._observedDraftClearNonces.has(draftNamespace)
+    let canObserveDraftClearNonce = true
+    if (draftClearNonce && !observedDraftClearNonce) {
+      canObserveDraftClearNonce = chatDrafts.clearSubmissionBackupsForClear(
+	draftNamespace,
+	draftClearNonce,
+      )
+      if (canObserveDraftClearNonce && !draftClearNoncePending) {
+	this._draftBackupCleanupPendingNamespaces.delete(draftNamespace)
+      } else {
+	this._draftBackupCleanupPendingNamespaces.add(draftNamespace)
+      }
+    }
+    if (
+      draftClearNonce &&
+      observedDraftClearNonce &&
+      this._observedDraftClearNonces.get(draftNamespace) !== draftClearNonce
+    ) {
+      this._disableDraftNamespace(draftNamespace)
+    }
+    if (
+      draftClearNonce !== undefined &&
+      canObserveDraftClearNonce &&
+      !draftClearNoncePending
+    ) {
+      this._observedDraftClearNonces.set(draftNamespace, draftClearNonce)
+    }
+    this._handlePageHide = () => {
+      if (!this.element.isConnected) return
+
+      this._flushDraftSave()
+    }
+    this._handleDraftStorage = (event) => {
+      if (!this.element.isConnected || !chatDrafts.wasCleared(event)) return
+
+      const clearedNamespace = chatDrafts.namespace()
+      this._disableDraftNamespace(clearedNamespace)
+    }
+    this._handleCompositionEnd = () => {
+      this._imeCommitPending = true
+    }
+    // Chrome fires the commit `input` after `compositionend`, but Firefox has
+    // shipped the reverse order, where the commit input consumes the latch
+    // before it is even set. Nothing would clear the leftover latch, so the
+    // next ordinary edit would be misread as a commit. The commit input always
+    // arrives before the user can act again, so any fresh gesture expires it.
+    this._expireImeCommitLatch = (event) => {
+      if (event?.isComposing || event?.keyCode === 229) return
+
+      this._imeCommitPending = false
+    }
+    this._handleDraftInput = (event) => {
+      // Consume the composition flag before any early return, so it can never
+      // outlive the `input` event that the commit itself fired. Firefox has
+      // shipped both orderings, so accept isComposing on the input event too.
+      const isImeCommit = Boolean(event?.isComposing) || this._imeCommitPending === true
+      this._imeCommitPending = false
+      if (
+	this.editingId ||
+	this._draftPersistenceDisabled() ||
+	this._draftSaveSuspendedForPermission ||
+	this._shouldSuppressDraftSaveForStash() ||
+	!this._reviewStore.isEmpty ||
+	!this._activeDraftKey
+      ) return
+      // An IME commit fires `input` after the keydown that started a send, so
+      // the textarea still holds exactly what went to the server. Counting it
+      // as a revision would defeat _currentPendingSubmission and make the sent
+      // message look like a draft typed mid-flight, restoring it on success.
+      // Text equality alone is not enough to suppress: re-entering the same
+      // string mid-flight (select-all + paste to send it twice) is a real edit.
+      if (isImeCommit && this._currentTextIsPendingSubmission()) return
+      const revisionKey = `${chatDrafts.namespace()}:${this._activeDraftKey}`
+      this._draftRevisions.set(revisionKey, (this._draftRevisions.get(revisionKey) || 0) + 1)
+      clearTimeout(this._draftSaveTimer)
+      this._draftSaveTimer = setTimeout(() => this._saveDraftNow(), 500)
+    }
+    this.textareaTarget.addEventListener('compositionend', this._handleCompositionEnd)
+    this.textareaTarget.addEventListener('keydown', this._expireImeCommitLatch)
+    this.textareaTarget.addEventListener('paste', this._expireImeCommitLatch)
+    this.textareaTarget.addEventListener('drop', this._expireImeCommitLatch)
+    this.textareaTarget.addEventListener('input', this._handleDraftInput)
+    window.addEventListener('pagehide', this._handlePageHide)
+    window.addEventListener('storage', this._handleDraftStorage)
+  }
+
+  disconnect() {
+    this._flushDraftSave()
+    this.textareaTarget.removeEventListener('compositionend', this._handleCompositionEnd)
+    this.textareaTarget.removeEventListener('keydown', this._expireImeCommitLatch)
+    this.textareaTarget.removeEventListener('paste', this._expireImeCommitLatch)
+    this.textareaTarget.removeEventListener('drop', this._expireImeCommitLatch)
+    this.textareaTarget.removeEventListener('input', this._handleDraftInput)
+    window.removeEventListener('pagehide', this._handlePageHide)
+    window.removeEventListener('storage', this._handleDraftStorage)
+  }
+
+  handleTopicChange() {
+    // This event fires before onPopupOpened during a chat switch, while the
+    // textarea still contains the outgoing chat's text. Flush before re-keying.
+    const draftPersistenceDisabled = this._draftPersistenceDisabled()
+    const nextDraftKey = draftPersistenceDisabled
+      ? null
+      : this.element.dataset.effectiveCreativeId || this.element.dataset.creativeId || null
+    const nextCreativeId = draftPersistenceDisabled
+      ? null
+      : this.element.dataset.creativeId || null
+    const draftKeyChanged = String(this._activeDraftKey || '') !== String(nextDraftKey || '')
+    const creativeChanged =
+      String(this._activeDraftCreativeId || '') !== String(nextCreativeId || '')
+    const resolvingIncomingDraftKey =
+      this._awaitingEffectiveDraftKeyFor &&
+      String(this._awaitingEffectiveDraftKeyFor) === String(nextCreativeId || '')
+    let keepAwaitingEffectiveDraftKey = false
+    if (draftKeyChanged || creativeChanged) {
+      const previousDraftKey = this._activeDraftKey
+      // onChatWillOpen already flushed the outgoing chat. While the effective
+      // key is loading, save only actual new input; rewriting a restored raw
+      // draft here would make stale text appear newer than the canonical draft.
+      if (!resolvingIncomingDraftKey || this._draftSaveTimer) this._flushDraftSave()
+      this._activeDraftKey = nextDraftKey ? String(nextDraftKey) : null
+      this._activeDraftCreativeId = nextCreativeId ? String(nextCreativeId) : null
+      if (
+	resolvingIncomingDraftKey &&
+	previousDraftKey &&
+	this._activeDraftKey
+      ) {
+	const sourceDraft = chatDrafts.snapshot(previousDraftKey)
+	const moveCompleted = chatDrafts.move(previousDraftKey, this._activeDraftKey)
+	const targetDraft = chatDrafts.snapshot(this._activeDraftKey)
+	const movedBackups = moveCompleted
+	  ? chatDrafts.moveSubmissionBackups(previousDraftKey, this._activeDraftKey)
+	  : new Map()
+	if (moveCompleted && (targetDraft.revision || !sourceDraft.revision)) {
+	  this._rebindPendingDraftSubmissions(
+	    previousDraftKey,
+	    this._activeDraftKey,
+	    sourceDraft,
+	    targetDraft,
+	    movedBackups,
+	  )
+	} else if (!moveCompleted) {
+	  this._trackPartialDraftMigration(
+	    previousDraftKey,
+	    this._activeDraftKey,
+	    sourceDraft,
+	    targetDraft,
+	  )
+	  if (chatDrafts.isNewer(previousDraftKey, this._activeDraftKey)) {
+	    this._activeDraftKey = String(previousDraftKey)
+	    keepAwaitingEffectiveDraftKey = true
+	  }
+	}
+      }
+    }
+    if (resolvingIncomingDraftKey && !keepAwaitingEffectiveDraftKey) {
+      this._awaitingEffectiveDraftKeyFor = null
+    }
+  }
+
+  onChatWillOpen({ creativeId }) {
+    const nextCreativeId = creativeId ? String(creativeId) : null
+    if (
+      String(this._activeDraftCreativeId || '') === String(nextCreativeId || '')
+    ) return
+
+    // The popup publishes its raw creative id before awaiting topics. Flush the
+    // outgoing chat now, then give any input typed during that await a key owned
+    // by the incoming chat. The topics event replaces it with the effective id.
+    this._flushDraftSave()
+    if (this._draftPersistenceDisabled()) {
+      this._activeDraftKey = null
+      this._activeDraftCreativeId = null
+      this._awaitingEffectiveDraftKeyFor = null
+      this.creativeId = creativeId
+      this.resetForm()
+      return
+    }
+    this._activeDraftKey = nextCreativeId
+    this._activeDraftCreativeId = nextCreativeId
+    this._awaitingEffectiveDraftKeyFor = nextCreativeId
+    this.creativeId = creativeId
+    this.resetForm()
+    this._restoreDraft()
+  }
+
+  discardDraft() {
+    const namespace = chatDrafts.namespace()
+    this._pendingDraftSubmissions?.forEach((submission) => {
+      if (submission.namespace === namespace) submission.invalidated = true
+    })
+    clearTimeout(this._draftSaveTimer)
+    this._draftSaveTimer = null
+    this._activeDraftKey = null
+    this._activeDraftCreativeId = null
+    this._awaitingEffectiveDraftKeyFor = null
+    this._stashedDraft = null
+    this.resetForm()
+  }
+
+  handleStashDraft(event) {
+    const draft = event.detail?.draft || null
+    if (draft) this._flushDraftSave()
+    // Tagged with the conversation it was typed in: the popup reuses this one
+    // controller for every creative, so a stash left over from another one must
+    // not be handed back here.
+    this._stashedDraft = draft ? { draft, creativeId: this.creativeId } : null
+  }
+
+  _stashedDraftBelongsToCurrentCreative() {
+    return Boolean(
+      this._stashedDraft &&
+      String(this._stashedDraft.creativeId) === String(this.creativeId),
+    )
+  }
+
+  _shouldSuppressDraftSaveForStash() {
+    if (!this._stashedDraftBelongsToCurrentCreative()) return false
+
+    // Before handleSend captures the command, the command-menu input event
+    // must not replace the stashed ordinary draft. Once the send starts, only
+    // the submitted command remains suppressed; later input is a new draft.
+    return !this._stashedDraft.submittedText ||
+      this.textareaTarget.value === this._stashedDraft.submittedText
+  }
+
+  _restoreStashedDraft(submittedText) {
+    const stashed = this._stashedDraft
+    this._stashedDraft = null
+    if (!stashed) return
+    // Switching creatives calls onPopupOpened on this same instance (there is
+    // no disconnect between conversations), so a send that settles after the
+    // switch would drop the previous conversation's draft into the new one.
+    // The draft belongs to a conversation that is no longer on screen; discard
+    // it rather than misfile it.
+    if (String(stashed.creativeId ?? '') !== String(this.creativeId ?? '')) return
+    const draft = stashed.draft
+    // Two boxes are safe to overwrite: an empty one (the success path runs
+    // resetForm) and one still holding exactly what we submitted (the failure
+    // path never clears it, so the command text is left sitting there). Any
+    // other content is text the user typed while the request was in flight, or
+    // a review quote the failure path restored, and must not be clobbered.
+    const current = this.textareaTarget.value
+    if (current.trim().length > 0 && current !== submittedText) return
+    this.textareaTarget.value = draft
+    // Resize and re-enable send directly rather than dispatching `input`, which
+    // would re-open the command menu for a draft that starts with "/".
+    this._autoResize()
+    this._updateSubmitButton()
+    this._saveDraftNow()
+  }
+
+  _saveDraftNow() {
+    if (
+      !this._activeDraftKey ||
+      this._draftPersistenceDisabled() ||
+      this._draftSaveSuspendedForPermission ||
+      this.editingId ||
+      this._shouldSuppressDraftSaveForStash() ||
+      !this._reviewStore.isEmpty
+    ) return
+    if (this._currentTextIsPendingSubmission()) return
+    const draftKey = this._activeDraftKey
+    const text = this.textareaTarget.value
+    const blank = !text.trim()
+    const storedDraft = chatDrafts.snapshot(draftKey)
+    const storedText = storedDraft.text
+    const hasStoredEntry = chatDrafts.updatedAt(draftKey) !== null
+    const observationKey = `${chatDrafts.namespace()}:${draftKey}`
+    const hasObservedDraft = this._observedDrafts?.has(observationKey)
+    const observedText = this._observedDrafts?.get(observationKey)
+    const hasObservedDisplayedDraft =
+      this._observedDisplayedDrafts?.has(observationKey)
+    const observedDisplayedText = hasObservedDisplayedDraft
+      ? this._observedDisplayedDrafts.get(observationKey)
+      : observedText
+    const observedRevision = this._observedDraftRevisions?.get(observationKey) || 0
+    const observedStoredRevision =
+      this._observedStoredDraftRevisions?.get(observationKey) || null
+    const currentRevision = this._draftRevisions?.get(observationKey) || 0
+    const inputChangedLocally = currentRevision !== observedRevision
+    const preserveBlank =
+      blank && Boolean(this._awaitingEffectiveDraftKeyFor) && inputChangedLocally
+    const displayedDraftChanged =
+      (hasObservedDisplayedDraft || hasObservedDraft) &&
+      (observedDisplayedText || '') !== text
+    const draftChangedLocally =
+      inputChangedLocally || displayedDraftChanged
+    const storedDraftChangedOutsideController = hasObservedDraft && (
+      observedText !== storedText || observedStoredRevision !== storedDraft.revision
+    )
+    // An idle tab can retain stale restored text after another tab updates the
+    // same draft. Closing or switching that idle tab must not write it back.
+    if (!draftChangedLocally && storedDraftChangedOutsideController) return
+    if (preserveBlank) {
+      if (storedText !== null || !hasStoredEntry) {
+	chatDrafts.set(draftKey, '', { preserveBlank: true })
+      }
+    } else if (blank) {
+      if (hasStoredEntry) {
+	chatDrafts.clear(draftKey)
+      }
+    } else if (storedText !== text) {
+      chatDrafts.set(draftKey, text)
+    }
+    if (blank && draftChangedLocally) chatDrafts.clearSubmissionBackups(draftKey)
+    this._observeDraft(draftKey)
+  }
+
+  _flushDraftSave() {
+    clearTimeout(this._draftSaveTimer)
+    this._draftSaveTimer = null
+    this._saveDraftNow()
+  }
+
+  _currentTextIsPendingSubmission() {
+    return Boolean(this._currentPendingSubmission())
+  }
+
+  _currentPendingSubmission() {
+    const namespace = chatDrafts.namespace()
+    const key = String(this._activeDraftKey || '')
+
+    return [...(this._pendingDraftSubmissions || [])].find((submission) => (
+      !submission.invalidated &&
+      submission.namespace === namespace &&
+      String(submission.key || '') === key &&
+      !submission.hadStash &&
+      !submission.hadReview &&
+      !submission.editing &&
+      submission.text === this.textareaTarget.value &&
+      (this._draftRevisions?.get(submission.revisionKey) || 0) === submission.keyRevision
+    ))
+  }
+
+  _restoreDraft() {
+    if (
+      !this._activeDraftKey ||
+      this._draftPersistenceDisabled() ||
+      this.editingId
+    ) return
+    if (this.textareaTarget.value.trim()) return
+
+    const draft = chatDrafts.snapshot(this._activeDraftKey)
+    const backup = chatDrafts.latestSubmissionBackup(this._activeDraftKey)
+    const restoreBackup = Boolean(
+      backup?.text &&
+      (draft.updatedAt === null || backup.updatedAt > draft.updatedAt),
+    )
+    if (backup && !restoreBackup) chatDrafts.removeSubmissionBackup(backup.key)
+    const restoredText = restoreBackup ? backup.text : draft.text
+    this._observeDraft(
+      this._activeDraftKey,
+      draft.text,
+      chatDrafts.namespace(),
+      draft.revision,
+      restoredText,
+    )
+    if (restoredText) {
+      this.textareaTarget.value = restoredText
+      requestAnimationFrame(() => this._autoResize())
+    } else if (draft.updatedAt === null) {
+      this._restorePendingSubmittedDraft()
+    }
+  }
+
+  _restorePendingSubmittedDraft() {
+    const namespace = chatDrafts.namespace()
+    const pending = [...(this._pendingDraftSubmissions || [])].find((submission) => (
+      !submission.invalidated &&
+      submission.namespace === namespace &&
+      String(submission.key || '') === String(this._activeDraftKey || '') &&
+      !submission.hadStash &&
+      !submission.hadReview &&
+      !submission.editing
+    ))
+    if (!pending) return
+
+    this.textareaTarget.value = pending.text
+    requestAnimationFrame(() => this._autoResize())
+    this._updateSubmitButton()
+  }
+
+  _draftPersistenceDisabled(namespace = chatDrafts.namespace()) {
+    return this._disabledDraftNamespaces?.has(namespace) ||
+      this._draftBackupCleanupPendingNamespaces?.has(namespace) ||
+      false
+  }
+
+  _disableDraftNamespace(namespace) {
+    this._disabledDraftNamespaces.add(namespace)
+    this.discardDraft()
+    // A timer in this tab may have raced with the logout tab's first clear.
+    chatDrafts.clearAll({ broadcast: false })
+  }
+
+  _observeDraft(
+    draftKey,
+    text,
+    namespace = chatDrafts.namespace(),
+    storedRevision,
+    displayedText,
+  ) {
+    if (!draftKey) return
+    const storedDraft = storedRevision === undefined
+      ? chatDrafts.snapshot(draftKey)
+      : { text, revision: storedRevision }
+    const observationKey = `${namespace}:${draftKey}`
+    this._observedDrafts?.set(observationKey, storedDraft.text)
+    this._observedDisplayedDrafts?.set(
+      observationKey,
+      displayedText === undefined ? storedDraft.text : displayedText,
+    )
+    this._observedDraftRevisions?.set(
+      observationKey,
+      this._draftRevisions?.get(observationKey) || 0,
+    )
+    this._observedStoredDraftRevisions?.set(observationKey, storedDraft.revision)
+  }
+
+  _rebindPendingDraftSubmissions(
+    sourceKey,
+    targetKey,
+    sourceDraft,
+    targetDraft,
+    movedBackups = new Map(),
+  ) {
+    const namespace = chatDrafts.namespace()
+    const targetRevisionKey = `${namespace}:${targetKey}`
+
+    this._pendingDraftSubmissions?.forEach((submission) => {
+      if (
+	submission.namespace !== namespace ||
+	String(submission.key) !== String(sourceKey)
+      ) return
+
+      const targetMatchesStoredBaseline = submission.storedRevision && targetDraft.revision === submission.storedRevision
+      const sourceMatchesSubmission =
+	sourceDraft.revision &&
+	targetDraft.revision === sourceDraft.revision &&
+	targetDraft.text === submission.text
+      const submittedDraftWasUnstored =
+	!submission.storedRevision &&
+	!sourceDraft.revision &&
+	!targetDraft.revision
+      const submittedDraftWasMoved = targetMatchesStoredBaseline || sourceMatchesSubmission || submittedDraftWasUnstored
+      if (
+	sourceDraft.revision &&
+	sourceDraft.text === submission.text
+      ) {
+	submission.migratedSources.push({
+	  key: String(sourceKey),
+	  revision: sourceDraft.revision,
+	})
+      }
+      submission.key = String(targetKey)
+      submission.revisionKey = targetRevisionKey
+      submission.keyRevision = this._draftRevisions?.get(targetRevisionKey) || 0
+      submission.storedRevision = targetDraft.revision
+      submission.storedUpdatedAt = targetDraft.updatedAt
+      submission.storedChangedOutsideController ||=
+	!submittedDraftWasMoved
+      if (submission.backupKey && movedBackups.has(submission.backupKey)) {
+	submission.backupKey = movedBackups.get(submission.backupKey)
+      }
+    })
+  }
+
+  _trackPartialDraftMigration(sourceKey, targetKey, sourceDraft, targetDraft) {
+    if (
+      !sourceDraft.revision ||
+      targetDraft.revision !== sourceDraft.revision
+    ) return
+
+    const namespace = chatDrafts.namespace()
+    this._pendingDraftSubmissions?.forEach((submission) => {
+      if (
+	submission.namespace !== namespace ||
+	String(submission.key) !== String(sourceKey) ||
+	submission.hadStash ||
+	submission.hadReview ||
+	submission.editing ||
+	submission.storedRevision !== sourceDraft.revision
+      ) return
+
+      submission.migratedSources.push({
+	key: String(targetKey),
+	revision: targetDraft.revision,
+      })
+    })
+  }
+
+  _clearMigratedSubmittedSources(submission) {
+    submission.migratedSources.forEach(({ key, revision }) => {
+      if (chatDrafts.revision(key) !== revision) return
+
+      chatDrafts.clear(key)
+      this._observeDraft(key, null, submission.namespace)
+    })
+  }
+
+  _persistFailedSubmissionDraft(submission) {
+    if (
+      submission.invalidated ||
+      submission.hadStash ||
+      submission.hadReview ||
+      submission.editing ||
+      submission.namespace !== chatDrafts.namespace()
+    ) return
+
+    const currentDraft = chatDrafts.snapshot(submission.key)
+    const currentKeyRevision =
+      this._draftRevisions?.get(submission.revisionKey) || 0
+    const submittedChatAdvanced =
+      submission.storedChangedOutsideController ||
+      currentKeyRevision !== submission.keyRevision ||
+      currentDraft.revision !== submission.storedRevision ||
+      currentDraft.updatedAt !== submission.storedUpdatedAt
+    if (submittedChatAdvanced) return
+
+    submission.backupKey ||= chatDrafts.saveSubmissionBackup(
+      submission.key,
+      submission.text,
+      { updatedAt: submission.backupUpdatedAt },
+    )
+  }
+}


### PR DESCRIPTION
## Summary

- verify that draft persistence and send-settlement state account for the largest cohesive responsibility in the 1,833-line comment form controller
- extract that stateful lifecycle into FormDraftManager while keeping the Stimulus controller focused on UI coordination
- preserve the controller-facing compatibility surface used by comment submission and regression tests
- reduce form_controller.js from 1,833 to 1,405 lines

## Verification

- npm test -- --runInBand (156 suites, 2,247 tests)
- npm test -- --runInBand engines/collavre/app/javascript/controllers/comments/__tests__/form_controller (9 suites, 176 tests)
- targeted coverage: FormDraftManager 98.56% statements / 92.71% branches
- mise exec -- ./bin/rubocop -a
- mise exec -- bin/complexity_check --base origin/feature/refactor-reduce-dupl
- bin/rails test: 160/171 pass locally; 11 unrelated GitHub encryption tests require missing local Active Record encryption credentials and pass when run directly with a local test secret
- bin/rails test:system cannot run because this checkout has no test/system directory
