### PR TITLE
Extend the complexity ratchet to the core engine's JavaScript

### DIFF
--- a/.complexity_waivers.yml
+++ b/.complexity_waivers.yml
@@ -15,33 +15,4 @@
 #   reason: "Vendor protocol handshake is a single linear sequence; splitting it hides the order."
 #   expires: "2026-11-09"
 
-waivers:
-  # The three below are the JavaScript gate's own arrival cost, not new debt.
-  #
-  # This gate's baseline is merge-base(HEAD, main). The integration branch it
-  # lands on carries refactors (#1649, #1654) that MOVED three already-oversized
-  # entities rather than growing them, and a move changes the entity key — which
-  # the ratchet reads as new debt. It is the same property the Ruby half has and
-  # the reason waivers exist. Measured on both sides:
-  #
-  #   entity                                 merge base   integration branch
-  #   updateReadPointer (max-params)         5            5   (moved file)
-  #   flushSaveLastTopic callback            46 / 76      35 / 70
-  #     (complexity / max-lines-per-function)
-  #
-  # Nothing got worse and two got better. Short expiry on purpose: once the
-  # integration branch reaches main these entities are in the baseline, the
-  # waivers stop suppressing anything, and bin/complexity_check will say so
-  # ("waiver is no longer needed; delete it").
-  - key: "engines/collavre/app/javascript/controllers/comments/comment_read_tracker.js | max-params | CommentReadTracker#updateReadPointer"
-    owner: "@sh1nj1"
-    reason: "Unchanged 5-param signature moved out of list_controller.js by #1649; it is 5 params at the merge base too. Delete once the integration branch is on main."
-    expires: "2026-10-10"
-  - key: "engines/collavre/app/javascript/controllers/comments/topics_controller.js | complexity | default#flushSaveLastTopic>[this.saveOrderState.enqueue]"
-    owner: "@sh1nj1"
-    reason: "Same callback as the merge base's `>[then]`, rehomed onto SaveOrderState by #1654 and simplified from 46 to 35. The key moved, the code improved. Delete once the integration branch is on main."
-    expires: "2026-10-10"
-  - key: "engines/collavre/app/javascript/controllers/comments/topics_controller.js | max-lines-per-function | default#flushSaveLastTopic>[this.saveOrderState.enqueue]"
-    owner: "@sh1nj1"
-    reason: "Same callback as the merge base's `>[then]`, rehomed onto SaveOrderState by #1654 and shortened from 76 to 70 lines. Delete once the integration branch is on main."
-    expires: "2026-10-10"
+waivers: []

--- a/.complexity_waivers.yml
+++ b/.complexity_waivers.yml
@@ -15,4 +15,33 @@
 #   reason: "Vendor protocol handshake is a single linear sequence; splitting it hides the order."
 #   expires: "2026-11-09"
 
-waivers: []
+waivers:
+  # The three below are the JavaScript gate's own arrival cost, not new debt.
+  #
+  # This gate's baseline is merge-base(HEAD, main). The integration branch it
+  # lands on carries refactors (#1649, #1654) that MOVED three already-oversized
+  # entities rather than growing them, and a move changes the entity key — which
+  # the ratchet reads as new debt. It is the same property the Ruby half has and
+  # the reason waivers exist. Measured on both sides:
+  #
+  #   entity                                 merge base   integration branch
+  #   updateReadPointer (max-params)         5            5   (moved file)
+  #   flushSaveLastTopic callback            46 / 76      35 / 70
+  #     (complexity / max-lines-per-function)
+  #
+  # Nothing got worse and two got better. Short expiry on purpose: once the
+  # integration branch reaches main these entities are in the baseline, the
+  # waivers stop suppressing anything, and bin/complexity_check will say so
+  # ("waiver is no longer needed; delete it").
+  - key: "engines/collavre/app/javascript/controllers/comments/comment_read_tracker.js | max-params | CommentReadTracker#updateReadPointer"
+    owner: "@sh1nj1"
+    reason: "Unchanged 5-param signature moved out of list_controller.js by #1649; it is 5 params at the merge base too. Delete once the integration branch is on main."
+    expires: "2026-10-10"
+  - key: "engines/collavre/app/javascript/controllers/comments/topics_controller.js | complexity | default#flushSaveLastTopic>[this.saveOrderState.enqueue]"
+    owner: "@sh1nj1"
+    reason: "Same callback as the merge base's `>[then]`, rehomed onto SaveOrderState by #1654 and simplified from 46 to 35. The key moved, the code improved. Delete once the integration branch is on main."
+    expires: "2026-10-10"
+  - key: "engines/collavre/app/javascript/controllers/comments/topics_controller.js | max-lines-per-function | default#flushSaveLastTopic>[this.saveOrderState.enqueue]"
+    owner: "@sh1nj1"
+    reason: "Same callback as the merge base's `>[then]`, rehomed onto SaveOrderState by #1654 and shortened from 76 to 70 lines. Delete once the integration branch is on main."
+    expires: "2026-10-10"

--- a/.eslint_metrics.yml
+++ b/.eslint_metrics.yml
@@ -17,16 +17,16 @@
 # Why these numbers: unlike the Ruby side — where RuboCop's defaults put ~90% of
 # entities in violation and the budget had to be set at the 75th percentile of
 # the violators — ESLint's documented defaults are already within reach here.
-# Measured over the 163 files this file selects, on 2026-09-10, the budget
+# Measured over the 161 files this file selects, on 2026-09-10, the budget
 # below leaves 214 entities over it, and each rule catches only the tail:
 #
 #   rule                     budget   entities   over budget
-#   complexity               13       3,123      88   (2.8%)
-#   max-depth                3        3,448      19   (0.6%)
-#   max-lines                300      163        21   (12.9%)
-#   max-lines-per-function   50       3,076      78   (2.5%)
-#   max-nested-callbacks     10       1,006      0    (0.0%)
-#   max-params               4        1,920      8    (0.4%)
+#   complexity               13       3,083      88   (2.9%)
+#   max-depth                3        3,402      19   (0.6%)
+#   max-lines                300      161        21   (13.0%)
+#   max-lines-per-function   50       3,036      78   (2.6%)
+#   max-nested-callbacks     10       1,001      0    (0.0%)
+#   max-params               4        1,880      8    (0.4%)
 #
 # Those 214 are grandfathered by the ratchet — they may shrink but not grow.
 # The budget is what NEW code has to fit, and ordinary Stimulus controllers and
@@ -35,12 +35,15 @@
 # Everything the core engine ships, not a hand-written list of directories: a
 # glob and the real file set drift apart, and the half that drifts is always the
 # one nobody is looking at.
+#
+# The core engine and nothing else. lib/js_complexity — the measurement itself —
+# is deliberately NOT here: this gate is being introduced for engines/collavre,
+# and a tool that measures itself makes every change to the tool read as engine
+# debt. It is a two-line addition whenever someone wants it, and the tool's own
+# tests are in lib/js_complexity/__tests__ either way.
 include:
   - "engines/collavre/**/*.js"
   - "engines/collavre/**/*.jsx"
-  # The measurement holds itself to the budget it enforces, the way the Ruby
-  # half's own lib/complexity_ratchet is measured by RuboCop's Metrics cops.
-  - "lib/js_complexity/**/*.js"
 
 exclude:
   # Tests are excluded for the same reason as on the Ruby side: a 2,000-line

--- a/.eslint_metrics.yml
+++ b/.eslint_metrics.yml
@@ -1,0 +1,61 @@
+# Complexity budget for the JavaScript half of the ratchet
+# (bin/complexity_check, lib/js_complexity/). The Ruby half is
+# .rubocop_metrics.yml; the rules, the waivers and the merge-base comparison are
+# shared. See docs/complexity_budget.md.
+#
+# There is no ESLint in this repository — no config file, no lint job, no
+# devDependency — so until now none of the core engine's ~34,000 lines of
+# non-test JavaScript were measured by anything. That is more code than the
+# 40,000 lines of core Ruby the ratchet already covers, and it holds the two
+# largest source files in the engine.
+#
+# This file holds ONLY thresholds. Rule options that are not thresholds
+# (skipBlankLines, IIFEs) are fixed in lib/js_complexity/measure.js, and there
+# is no per-file override syntax at all, because every one of those is a way to
+# silence the gate while the number above it still reads like a budget.
+#
+# Why these numbers: unlike the Ruby side — where RuboCop's defaults put ~90% of
+# entities in violation and the budget had to be set at the 75th percentile of
+# the violators — ESLint's documented defaults are already within reach here.
+# Measured over the 162 non-test files on 2026-09-10, the budget below leaves
+# 214 entities over it, and each rule catches only the tail:
+#
+#   rule                     budget   entities   over budget
+#   complexity               13       3,108      88   (2.8%)
+#   max-depth                3        3,402      19   (0.6%)
+#   max-lines                300      162        21   (13.0%)
+#   max-lines-per-function   50       3,038      78   (2.6%)
+#   max-nested-callbacks     10       1,001      0    (0.0%)
+#   max-params               4        1,881      8    (0.4%)
+#
+# Those 214 are grandfathered by the ratchet — they may shrink but not grow.
+# The budget is what NEW code has to fit, and ordinary Stimulus controllers and
+# modules already fit it.
+
+# Everything the core engine ships, not a hand-written list of directories: a
+# glob and the real file set drift apart, and the half that drifts is always the
+# one nobody is looking at.
+include:
+  - "engines/collavre/**/*.js"
+  - "engines/collavre/**/*.jsx"
+
+exclude:
+  # Tests are excluded for the same reason as on the Ruby side: a 2,000-line
+  # test file is a list, not a god object. It has no callers and no shared
+  # mutable state, and splitting it buys nothing. Test bloat is real but it is a
+  # coverage-quality problem, and mixing it in here would bury the app-code
+  # signal under hundreds of function-length offenses.
+  - "**/__tests__/**"
+  - "engines/collavre/test/**"
+  - "**/node_modules/**"
+
+# Only satellite-free core JavaScript is measured. The satellites hold about
+# 3,200 lines between them against the core's 34,000, and adding them here is a
+# two-line change once someone wants it.
+rules:
+  complexity: 13
+  max-depth: 3
+  max-lines: 300
+  max-lines-per-function: 50
+  max-nested-callbacks: 10
+  max-params: 4

--- a/.eslint_metrics.yml
+++ b/.eslint_metrics.yml
@@ -4,8 +4,8 @@
 # shared. See docs/complexity_budget.md.
 #
 # There is no ESLint in this repository — no config file, no lint job, no
-# devDependency — so until now none of the core engine's 35,390 lines of
-# non-test JavaScript, across 161 files, were measured by anything. That sits
+# devDependency — so until now none of the core engine's 35,978 lines of
+# non-test JavaScript, across 168 files, were measured by anything. That sits
 # beside 40,153 lines of core Ruby the ratchet already covers, and it holds the
 # two largest source files in the engine.
 #
@@ -17,18 +17,18 @@
 # Why these numbers: unlike the Ruby side — where RuboCop's defaults put ~90% of
 # entities in violation and the budget had to be set at the 75th percentile of
 # the violators — ESLint's documented defaults are already within reach here.
-# Measured over the 161 files this file selects, on 2026-09-10, the budget
-# below leaves 214 entities over it, and each rule catches only the tail:
+# Measured over the 168 files this file selects, on 2026-09-10, the budget
+# below leaves 217 entities over it, and each rule catches only the tail:
 #
 #   rule                     budget   entities   over budget
-#   complexity               13       3,083      88   (2.9%)
-#   max-depth                3        3,402      19   (0.6%)
-#   max-lines                300      161        21   (13.0%)
-#   max-lines-per-function   50       3,036      78   (2.6%)
-#   max-nested-callbacks     10       1,001      0    (0.0%)
-#   max-params               4        1,880      8    (0.4%)
+#   complexity               13       3,189      88   (2.8%)
+#   max-depth                3        3,405      19   (0.6%)
+#   max-lines                300      168        23   (13.7%)
+#   max-lines-per-function   50       3,142      78   (2.5%)
+#   max-nested-callbacks     10       999        0    (0.0%)
+#   max-params               4        1,933      9    (0.5%)
 #
-# Those 214 are grandfathered by the ratchet — they may shrink but not grow.
+# Those 217 are grandfathered by the ratchet — they may shrink but not grow.
 # The budget is what NEW code has to fit, and ordinary Stimulus controllers and
 # modules already fit it.
 

--- a/.eslint_metrics.yml
+++ b/.eslint_metrics.yml
@@ -38,6 +38,9 @@
 include:
   - "engines/collavre/**/*.js"
   - "engines/collavre/**/*.jsx"
+  # The measurement holds itself to the budget it enforces, the way the Ruby
+  # half's own lib/complexity_ratchet is measured by RuboCop's Metrics cops.
+  - "lib/js_complexity/**/*.js"
 
 exclude:
   # Tests are excluded for the same reason as on the Ruby side: a 2,000-line

--- a/.eslint_metrics.yml
+++ b/.eslint_metrics.yml
@@ -4,10 +4,10 @@
 # shared. See docs/complexity_budget.md.
 #
 # There is no ESLint in this repository — no config file, no lint job, no
-# devDependency — so until now none of the core engine's ~34,000 lines of
-# non-test JavaScript were measured by anything. That is more code than the
-# 40,000 lines of core Ruby the ratchet already covers, and it holds the two
-# largest source files in the engine.
+# devDependency — so until now none of the core engine's 35,390 lines of
+# non-test JavaScript, across 161 files, were measured by anything. That sits
+# beside 40,153 lines of core Ruby the ratchet already covers, and it holds the
+# two largest source files in the engine.
 #
 # This file holds ONLY thresholds. Rule options that are not thresholds
 # (skipBlankLines, IIFEs) are fixed in lib/js_complexity/measure.js, and there
@@ -17,16 +17,16 @@
 # Why these numbers: unlike the Ruby side — where RuboCop's defaults put ~90% of
 # entities in violation and the budget had to be set at the 75th percentile of
 # the violators — ESLint's documented defaults are already within reach here.
-# Measured over the 162 non-test files on 2026-09-10, the budget below leaves
-# 214 entities over it, and each rule catches only the tail:
+# Measured over the 163 files this file selects, on 2026-09-10, the budget
+# below leaves 214 entities over it, and each rule catches only the tail:
 #
 #   rule                     budget   entities   over budget
-#   complexity               13       3,108      88   (2.8%)
-#   max-depth                3        3,402      19   (0.6%)
-#   max-lines                300      162        21   (13.0%)
-#   max-lines-per-function   50       3,038      78   (2.6%)
-#   max-nested-callbacks     10       1,001      0    (0.0%)
-#   max-params               4        1,881      8    (0.4%)
+#   complexity               13       3,123      88   (2.8%)
+#   max-depth                3        3,448      19   (0.6%)
+#   max-lines                300      163        21   (12.9%)
+#   max-lines-per-function   50       3,076      78   (2.5%)
+#   max-nested-callbacks     10       1,006      0    (0.0%)
+#   max-params               4        1,920      8    (0.4%)
 #
 # Those 214 are grandfathered by the ratchet — they may shrink but not grow.
 # The budget is what NEW code has to fit, and ordinary Stimulus controllers and
@@ -53,7 +53,7 @@ exclude:
   - "**/node_modules/**"
 
 # Only satellite-free core JavaScript is measured. The satellites hold about
-# 3,200 lines between them against the core's 34,000, and adding them here is a
+# 2,800 lines between them against the core's 35,000, and adding them here is a
 # two-line change once someone wants it.
 rules:
   complexity: 13

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,9 +77,11 @@ jobs:
       - name: Test shell script helpers
         run: bash script/test/lightsail_launch_test.sh
 
-  # Entity-level complexity ratchet: RuboCop's Metrics department over app code,
-  # run twice — once on this branch, once on a detached checkout of the merge
-  # base — and compared entity by entity. Adds ~5s. See docs/complexity_budget.md.
+  # Entity-level complexity ratchet: RuboCop's Metrics department over Ruby app
+  # code and ESLint's size and complexity rules over the core engine's
+  # JavaScript, run twice — once on this branch, once on a detached checkout of
+  # the merge base — and compared entity by entity. The two measurements take
+  # about 8s together. See docs/complexity_budget.md.
   complexity:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
@@ -98,8 +100,20 @@ jobs:
           ruby-version: .ruby-version
           bundler-cache: true
 
-      # The budget in .rubocop_metrics.yml may only tighten. The
-      # `complexity-baseline-reset` label is the way past that, for the case it
+      - name: Set up Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      # ESLint only. The merge-base worktree gets no install of its own — it is
+      # measured with this checkout's ESLint and this branch's budget, which is
+      # the same rule the Ruby half follows for .rubocop_metrics.yml.
+      - name: Install dependencies
+        run: npm ci
+
+      # The budgets in .rubocop_metrics.yml and .eslint_metrics.yml may only
+      # tighten. The `complexity-baseline-reset` label is the way past that, for the case it
       # was written for: a deliberate, reviewed budget change. Applying a label
       # does not re-trigger CI, so re-run this job afterwards.
       - name: Check the complexity ratchet

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,11 +116,22 @@ jobs:
       # tighten. The `complexity-baseline-reset` label is the way past that, for the case it
       # was written for: a deliberate, reviewed budget change. Applying a label
       # does not re-trigger CI, so re-run this job afterwards.
+      # The baseline is the base *branch*, not `pull_request.base.sha`. That
+      # field is the base tip as of the last open/synchronize event on this PR
+      # and does not move when the base branch does, while the checkout above
+      # is `refs/pull/N/merge`, which GitHub recomputes against the current
+      # base tip. Measuring the second against the first attributes every
+      # sibling PR that landed in between to this one: PR #1651 saw eight such
+      # reports, all of them other branches' code. Resolving the ref here makes
+      # the baseline `merge-base(HEAD, base tip)`, which is the base tip
+      # itself, so the diff measured is exactly this branch's.
       - name: Check the complexity ratchet
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
           ALLOW_BUDGET_CHANGE: ${{ contains(github.event.pull_request.labels.*.name, 'complexity-baseline-reset') && '--allow-budget-change' || '' }}
-        run: bin/complexity_check --base "$BASE_SHA" $ALLOW_BUDGET_CHANGE
+        run: |
+          git fetch --no-tags --quiet origin "+refs/heads/$BASE_REF:refs/remotes/origin/$BASE_REF"
+          bin/complexity_check --base "origin/$BASE_REF" $ALLOW_BUDGET_CHANGE
 
   # Production runs PostgreSQL while dev/test run SQLite, so db/schema.rb is
   # dumped from SQLite and can silently pick up SQLite-only constructs (e.g.

--- a/bin/complexity_check
+++ b/bin/complexity_check
@@ -1,8 +1,11 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-# Entity-level complexity ratchet. See lib/complexity_ratchet.rb for why this
-# exists and docs/complexity_budget.md for how to work with it.
+# Entity-level complexity ratchet, over Ruby (RuboCop's Metrics department) and
+# the core engine's JavaScript (ESLint's size and complexity rules). See
+# lib/complexity_ratchet.rb for why this exists, lib/complexity_ratchet/
+# javascript.rb for the JavaScript half, and docs/complexity_budget.md for how
+# to work with it.
 #
 #   bin/complexity_check                  # gate: fail on growth or new debt vs the merge base
 #   bin/complexity_check --base <ref>     # compare against something other than origin/main
@@ -18,6 +21,7 @@ require "optparse"
 ROOT = File.expand_path("..", __dir__)
 require File.join(ROOT, "lib", "complexity_ratchet")
 require File.join(ROOT, "lib", "complexity_ratchet", "base_tree")
+require File.join(ROOT, "lib", "complexity_ratchet", "javascript")
 
 options = { mode: :check, base: ENV.fetch("COMPLEXITY_BASE_REF", "origin/main") }
 OptionParser.new do |parser|
@@ -33,8 +37,9 @@ OptionParser.new do |parser|
   end
 end.parse!
 
-WAIVERS = File.join(ROOT, ComplexityRatchet::WAIVERS_PATH)
-CONFIG  = File.join(ROOT, ComplexityRatchet::CONFIG_PATH)
+WAIVERS   = File.join(ROOT, ComplexityRatchet::WAIVERS_PATH)
+CONFIG    = File.join(ROOT, ComplexityRatchet::CONFIG_PATH)
+JS_CONFIG = File.join(ROOT, ComplexityRatchet::Javascript::CONFIG_PATH)
 
 def abort_with(message)
   warn message
@@ -59,13 +64,26 @@ def budget_problems(base_sha, options)
   ComplexityRatchet.verify_budget(
     file_at(base_sha, ComplexityRatchet::CONFIG_PATH)&.then { |yaml| YAML.safe_load(yaml) || {} },
     YAML.safe_load_file(CONFIG) || {}
-  )
+  ) +
+    ComplexityRatchet::Javascript.verify_budget(
+      file_at(base_sha, ComplexityRatchet::Javascript::CONFIG_PATH)&.then { |yaml| YAML.safe_load(yaml) || {} },
+      YAML.safe_load_file(JS_CONFIG) || {}
+    )
 end
 
-actual = ComplexityRatchet::Measurement.call(root: ROOT)
+# Ruby and JavaScript entities share one hash, one waiver list and one
+# comparison: the key carries the path and the rule, so the two cannot collide,
+# and everything downstream of here is language-agnostic.
+def measure(root:, env: {})
+  ComplexityRatchet::Measurement.call(root: root, env: env)
+    .merge(ComplexityRatchet::Javascript::Measurement.call(root: root, tool_root: ROOT))
+end
+
+actual = measure(root: ROOT)
 
 if options[:mode] == :report
-  puts "#{actual.size} entities over the budget in #{ComplexityRatchet::CONFIG_PATH}:"
+  puts "#{actual.size} entities over the budgets in #{ComplexityRatchet::CONFIG_PATH} " \
+       "and #{ComplexityRatchet::Javascript::CONFIG_PATH}:"
   actual.sort.each { |key, value| puts "  #{value}\t#{key}" }
   exit 0
 end
@@ -74,9 +92,7 @@ base_measurement = nil
 base_sha = nil
 ComplexityRatchet::BaseTree.at_merge_base(root: ROOT, ref: options[:base]) do |tree, sha|
   base_sha = sha
-  base_measurement = ComplexityRatchet::Measurement.call(
-    root: tree, env: { "BUNDLE_GEMFILE" => File.join(ROOT, "Gemfile") }
-  )
+  base_measurement = measure(root: tree, env: { "BUNDLE_GEMFILE" => File.join(ROOT, "Gemfile") })
 end
 
 if base_measurement.nil?

--- a/bin/js_complexity.mjs
+++ b/bin/js_complexity.mjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+// JavaScript measurement for the complexity ratchet. Prints
+// {"path | rule | entity": value} as JSON on stdout; bin/complexity_check
+// merges it with the Ruby measurement and does the comparing.
+//
+//   node bin/js_complexity.mjs --root . --config .eslint_metrics.yml
+//
+// --root is the tree to measure, which for the base side of the ratchet is a
+// detached worktree with no node_modules of its own. Nothing is resolved out of
+// it: the rules come from --config and ESLint comes from this script's own
+// node_modules, so both sides are measured with this branch's budget.
+import path from "node:path";
+
+import { loadBudget, measure } from "../lib/js_complexity/measure.js";
+
+function parseArgv(argv) {
+  const options = { root: process.cwd(), config: ".eslint_metrics.yml" };
+  for (let i = 0; i < argv.length; i += 1) {
+    const flag = argv[i];
+    if (flag === "--root" || flag === "--config") {
+      const value = argv[i + 1];
+      if (value === undefined) throw new Error(`${flag} needs a value`);
+      options[flag.slice(2)] = value;
+      i += 1;
+    } else if (flag === "-h" || flag === "--help") {
+      options.help = true;
+    } else {
+      throw new Error(`unknown option ${flag}`);
+    }
+  }
+  return options;
+}
+
+const options = parseArgv(process.argv.slice(2));
+
+if (options.help) {
+  console.log("Usage: node bin/js_complexity.mjs [--root DIR] [--config FILE]");
+  process.exit(0);
+}
+
+const budget = loadBudget(path.resolve(options.config));
+const measured = await measure({ root: path.resolve(options.root), budget });
+
+process.stdout.write(`${JSON.stringify(measured, null, 2)}\n`);

--- a/config/application.rb
+++ b/config/application.rb
@@ -60,8 +60,11 @@ module Collavre
     # Common ones are `templates`, `generators`, or `middleware`, for example.
     # complexity_ratchet.rb and its directory back bin/complexity_check, a
     # CI-only lint tool. They have no business being eager loaded into a booted
-    # app, and bin/ runs them outside Rails anyway.
-    config.autoload_lib(ignore: %w[assets tasks middleware omniauth complexity_ratchet complexity_ratchet.rb])
+    # app, and bin/ runs them outside Rails anyway. js_complexity is the same
+    # tool's JavaScript half and holds no Ruby at all.
+    config.autoload_lib(
+      ignore: %w[assets tasks middleware omniauth complexity_ratchet complexity_ratchet.rb js_complexity]
+    )
 
     config.app_version = Collavre::VERSION
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,8 +25,8 @@ thin agent entry point that indexes into this directory.
 - [rails8_patterns.md](rails8_patterns.md) — Rails 8 idioms used across the
   codebase (auth, Current, encryption, Hotwire, Solid Queue, Propshaft).
 - [complexity_budget.md](complexity_budget.md) — the three CI gates that keep
-  the codebase from diverging as it grows (complexity ratchet, engine boundary,
-  coverage patch gate) and how to work with them.
+  the codebase from diverging as it grows (Ruby + JavaScript complexity ratchet,
+  engine boundary, coverage patch gate) and how to work with them.
 - [testing.md](testing.md) — automated-test conventions.
 - [test.md](test.md) — manual QA of the live site (test accounts, credentials).
 

--- a/docs/complexity_budget.md
+++ b/docs/complexity_budget.md
@@ -1,12 +1,12 @@
 # Complexity budget
 
 Three CI gates keep the codebase from diverging as it grows. They are cheap on
-purpose — together they add roughly six seconds of CI time — because a gate that
-slows everyone down gets removed.
+purpose — the ratchet measures two languages twice each in about ten seconds —
+because a gate that slows everyone down gets removed.
 
 | Gate | What it stops | Where |
 |------|---------------|-------|
-| Complexity ratchet | Any class, module, method or block growing past the size it has at the merge base | `complexity` job, `bin/complexity_check` |
+| Complexity ratchet | Any class, module, function, method or block — Ruby or JavaScript — growing past the size it has at the merge base | `complexity` job, `bin/complexity_check` |
 | Engine boundary | The core engine taking a dependency on a satellite engine | `EngineBoundaryTest`, runs with `rake test` |
 | Coverage patch gate | Ruby diffs landing under 80% covered | Codecov, `codecov.yml` |
 
@@ -23,6 +23,17 @@ Measured on 2026-08-11, before any of this existed:
 - Not one CI gate constrained any of it: RuboCop runs omakase, which disables
   every `Metrics` cop, and Codecov was informational.
 
+The Ruby ratchet landed first and left half the engine unmeasured. Measured on
+2026-09-10:
+
+- The core engine ships **34,000 lines of non-test JavaScript** across 162 files,
+  against 40,000 lines of core Ruby — and the two largest source files in the
+  engine are both JavaScript.
+- There was **no ESLint in the repository at all**: no config file, no lint job,
+  no devDependency. Nothing measured any of it, and "no explicit configuration"
+  is not the same as "no rules" only when there is a default to fall back on.
+  There was none.
+
 The divergence is *inside* the core, not across engine boundaries — the
 `collavre` → `collavre_*` rule is clean in application code, with one recorded
 exception in a migration. So the ratchet is the primary gate and the boundary
@@ -37,11 +48,16 @@ bin/complexity_check --report     # just list what is over budget right now
 ```
 
 There is nothing to commit and nothing to keep in sync. `bin/complexity_check`
-checks out the merge base into a throwaway `git worktree`, runs RuboCop's
-`Metrics` department over both trees, and compares them entity by entity. One
-file drives it: **`.rubocop_metrics.yml`**, the budget that decides which
-entities are worth measuring. It is not used by `bin/rubocop`; the omakase house
-style stays as it is.
+checks out the merge base into a throwaway `git worktree`, measures both trees,
+and compares them entity by entity. Two files drive it:
+
+- **`.rubocop_metrics.yml`** — RuboCop's `Metrics` department over Ruby app code.
+  It is not used by `bin/rubocop`; the omakase house style stays as it is.
+- **`.eslint_metrics.yml`** — ESLint's size and complexity rules over the core
+  engine's JavaScript. See [The JavaScript half](#the-javascript-half).
+
+Both languages land in one hash of `path | rule | entity` keys, so the waiver
+format, the comparison and the reporting below are the same code for both.
 
 The rules:
 
@@ -50,7 +66,8 @@ The rules:
    New code gets no amnesty from old debt.
 3. The budget cannot be loosened. Exactly two edits to `.rubocop_metrics.yml`
    pass — lowering a `Max`, and shrinking `AllCops/Exclude` — and every other
-   change to it is reported.
+   change to it is reported. `.eslint_metrics.yml` allows three: lowering a
+   threshold, widening `include`, and shrinking `exclude`.
 4. The only escape hatch is a waiver in `.complexity_waivers.yml`, which needs a
    non-blank owner, a non-blank reason, and an expiry no more than 90 days out.
    An expired or blank-field waiver fails CI.
@@ -184,6 +201,111 @@ callers, holds no shared mutable state, and splitting it buys nothing. Test bloa
 is real, but it is a coverage-quality problem, not a coupling one, and mixing it
 in would bury the app-code signal under thousands of block-length offenses.
 
+## The JavaScript half
+
+`.eslint_metrics.yml` is the budget; `bin/js_complexity.mjs` and
+`lib/js_complexity/` are the measurement. It prints the same
+`{"path | rule | entity": value}` shape the Ruby measurement produces, and
+`bin/complexity_check` merges the two before comparing, so everything above —
+the merge base, the waivers, rules 1 to 4 — applies unchanged.
+
+### The budget
+
+Unlike the Ruby side, where RuboCop's defaults put ~90% of entities in violation
+and the budget had to be set at the 75th percentile of the violators, ESLint's
+documented defaults were already within reach. Measured over the 162 non-test
+files on 2026-09-10:
+
+| Rule | Budget | Entities | Over budget | Ruby counterpart |
+|------|--------|----------|-------------|------------------|
+| `complexity` | 13 | 3,108 | 88 (2.8%) | `Metrics/CyclomaticComplexity` |
+| `max-depth` | 3 | 3,402 | 19 (0.6%) | `Metrics/BlockNesting` |
+| `max-lines` | 300 | 162 | 21 (13.0%) | `Metrics/ClassLength` |
+| `max-lines-per-function` | 50 | 3,038 | 78 (2.6%) | `Metrics/MethodLength` |
+| `max-nested-callbacks` | 10 | 1,001 | 0 (0.0%) | — |
+| `max-params` | 4 | 1,881 | 8 (0.4%) | `Metrics/ParameterLists` |
+
+214 entities are over it, against 394 on the Ruby side. They are grandfathered:
+they may shrink but not grow. The budget is what *new* code has to fit, and
+ordinary Stimulus controllers and modules already fit it.
+
+`max-nested-callbacks` sits at ESLint's default because nothing violates it —
+the same reasoning that keeps `Metrics/BlockNesting` at RuboCop's default.
+`max-lines` and `max-lines-per-function` skip blank lines and comments, because
+RuboCop's counters do; otherwise the same file measures differently on the two
+sides and a comment block reads as growth.
+
+### The budget file holds only numbers
+
+`.eslint_metrics.yml` has three keys — `include`, `exclude` and `rules` — and
+`rules` maps a rule name to an integer. Rule options that are not thresholds
+(`skipBlankLines`, `IIFEs`) live in `lib/js_complexity/measure.js`, and there is
+no per-file override syntax at all.
+
+That is the difference between this budget and a real `eslint.config.js`, and it
+is the point. Rule 3 on the Ruby side needs a long allowlist because a `Metrics`
+cop can be silenced through `Exclude`, `Include`, `AllowedMethods`,
+`AllowedPatterns` or `CountAsOne` while its `Max` still reads as strict. Here
+there is nothing to silence a rule *with*: three keys, and all three are
+compared. Inline `eslint-disable` comments are refused as well
+(`noInlineConfig`), so a directive cannot switch the gate off from inside a
+source file either.
+
+### Why ESLint's `Linter` and not the `ESLint` class
+
+The base side of the ratchet is a detached worktree of the merge base. It has no
+`node_modules` and no ESLint config of its own, and it must not have one:
+measuring each side with its own budget is what makes a PR that *tightens* a
+threshold report every pre-existing entity as brand-new debt. `Linter#verify`
+takes the config as a value and resolves nothing from the tree it is reading, so
+this branch's ESLint and this branch's budget are applied to both sides. The
+`ESLint` class would search the measured tree for a config file.
+
+### Entity keys in JavaScript
+
+Same problem as the Ruby side, same shape of answer, different parser. Names are
+built from an ESTree walk (`lib/js_complexity/entity_map.js`):
+
+```
+engines/collavre/app/javascript/controllers/comments/topics_controller.js | max-lines | (file)
+engines/collavre/app/javascript/modules/creative_row_editor.js | max-lines-per-function | setupEditorSession
+engines/collavre/app/javascript/components/InlineLexicalEditor.jsx | max-lines-per-function | Toolbar>[useCallback](10)
+```
+
+- A class member reads `Editor#save`, a static `Editor.create`, and a getter
+  `Editor#get draft` — without the kind, a `get`/`set` pair would collide into an
+  ordinal pair that reads as two unrelated members.
+- An anonymous function takes the name it is bound to (`const submit = …` →
+  `submit`), or, if it is bound to nothing, the call it is passed to
+  (`[addEventListener]`). This is what the Ruby side does for blocks.
+- `export default class extends Controller` — every Stimulus controller in the
+  engine — is named `default`. "(anonymous class)" would be accurate and
+  useless.
+- Siblings that share a name are numbered from the second on, so a second
+  over-budget `[map]` callback in one method cannot hide behind the first. As on
+  the Ruby side, an ordinal is a position and not an identity; the trade-off is
+  discussed under [Entity keys](#entity-keys) above and is the same here.
+- `max-lines` belongs to `(file)`: it reports on the first line past the limit,
+  which belongs to no entity in particular.
+- `max-depth` reports on a statement, so it falls back to the enclosing scope
+  plus the normalised source line with a leading `~` — the same fallback the
+  Ruby side uses for `Metrics/BlockNesting`.
+
+Lookup is by containment rather than by start position, because ESLint does not
+report an offense at the node it is about: `getFunctionHeadLoc` puts a method
+offense on the method name and an arrow offense on the `=>` token. All of them
+are *inside* the entity, so the innermost scope containing the offense is the
+right answer in every case.
+
+### Scope
+
+`engines/collavre/**/*.{js,jsx}`, minus `__tests__` and `engines/collavre/test`.
+Tests are excluded for the reason they are excluded on the Ruby side, spelled
+out under [Entity keys](#entity-keys). The satellite engines hold about 3,200
+lines of JavaScript between them against the core's 34,000 and are not measured;
+adding them is a two-line change to `include`, which the budget check allows in
+that direction.
+
 ## The engine boundary
 
 `EngineBoundaryTest` fails when a core engine Ruby file names a satellite
@@ -255,8 +377,8 @@ instead: expose a hook from `collavre` and let the satellite register itself.
 
 ## What this does not do
 
-The ratchet stops *growth*. It does not shrink the 430 entities already over
-budget, and it can be routed around by adding a hundred small files instead of
+The ratchet stops *growth*. It does not shrink the 608 entities already over
+budget (394 Ruby, 214 JavaScript), and it can be routed around by adding a hundred small files instead of
 one big one. Neither is a gap a PR gate can close.
 
 For that, use the churn×complexity data — files that are both large and
@@ -269,6 +391,16 @@ blocking gate cannot make anyone delete code.
 - **A committed baseline snapshot.** Tried first, and it is what the "Why the
   merge base" section above is about. It goes stale the moment `main` moves and
   its only escape hatch launders regressions.
+- **`max-statements`.** A genuine rule, and 384 entities exceed ESLint's default
+  of 10 — but it measures nearly the same thing as `max-lines-per-function`, and
+  adding it would have nearly tripled the over-budget list for a signal already
+  covered. The gate is cheap because it is small.
+- **A standalone ESLint lint job.** ESLint is in this repository for exactly one
+  reason: it is the only thing here that can parse modern JS and JSX well enough
+  to measure it. Turning on its correctness or style rules is a separate
+  decision with a separate cost — ~34,000 lines of unlinted JavaScript would
+  produce thousands of offenses on day one — and bundling it into a complexity
+  gate is how a gate gets switched off in week two.
 - **A test-to-app LOC ratio floor.** The core already has a healthy 1.51 ratio
   *and* the god objects. Test LOC is trivially gamed with fixture style, mocks,
   and duplicated setup — it is a lagging indicator dressed as a leading one.

--- a/docs/complexity_budget.md
+++ b/docs/complexity_budget.md
@@ -507,6 +507,11 @@ Byte-identical and same-named, those two shared an anchor and took an ordinal.
 that type at all, so it neither pushes nor pops, and anchoring on something the
 measurement cannot see would separate twins for no reason.
 
+If distinct bodies still collide after all three digest widths, measurement
+raises an error and blocks the gate. It never falls back to positional keys
+for different bodies; identical bodies with identical rule context may still
+use ordinals.
+
 The general statement, which is what the next rule added to the budget should be
 checked against: **a key must determine its measurement.** For each rule, either
 the value is a function of the entity's own text, or whatever else it depends on

--- a/docs/complexity_budget.md
+++ b/docs/complexity_budget.md
@@ -299,12 +299,14 @@ right answer in every case.
 
 ### Scope
 
-`engines/collavre/**/*.{js,jsx}`, minus `__tests__` and `engines/collavre/test`.
-Tests are excluded for the reason they are excluded on the Ruby side, spelled
-out under [Entity keys](#entity-keys). The satellite engines hold about 3,200
-lines of JavaScript between them against the core's 34,000 and are not measured;
-adding them is a two-line change to `include`, which the budget check allows in
-that direction.
+`engines/collavre/**/*.{js,jsx}`, minus `__tests__` and `engines/collavre/test`,
+plus `lib/js_complexity` — the measurement holds itself to the budget it
+enforces, the way `lib/complexity_ratchet` is measured by the Metrics cops it
+runs. Tests are excluded for the reason they are excluded on the Ruby side,
+spelled out under [Entity keys](#entity-keys). The satellite engines hold about
+3,200 lines of JavaScript between them against the core's 34,000 and are not
+measured; adding them is a two-line change to `include`, which the budget check
+allows in that direction.
 
 ## The engine boundary
 

--- a/docs/complexity_budget.md
+++ b/docs/complexity_budget.md
@@ -113,6 +113,42 @@ back to its earlier size without tripping. Requiring branches to be current with
 That is a much smaller hole than a gate the team switches off in week two
 because it reddens unrelated PRs.
 
+### Which base the CI job passes
+
+The `complexity` job passes the base **branch**, not `github.event.pull_request.base.sha`.
+
+The two are not the same thing, and the difference is not academic. `base.sha`
+is the base tip as of the last `opened`/`synchronize` event on the PR: it is a
+snapshot of the base at the moment *this* branch last pushed, and it does not
+move when the base branch does. `actions/checkout` on a pull request checks out
+`refs/pull/N/merge`, which GitHub *does* recompute whenever the base moves.
+Measuring the second against the first blames this PR for every sibling PR that
+landed in between.
+
+That is not a hypothetical either. On the branch that introduced this file, the
+job reported eight offenses in `creative_row_editor.js`, `popup_fullscreen.js`
+and `creative_save_state.js` — three files it had never touched — because two
+sibling PRs had merged into the integration branch since its last push. It
+happened twice, and on an integration branch collecting eight parallel PRs it
+would have happened on nearly every run.
+
+Passing `origin/$BASE_REF` makes the baseline `merge-base(HEAD, base tip)`.
+Since the checkout has the base tip as an ancestor, that *is* the base tip, so
+what gets measured is exactly what this branch adds to the base as it stands
+right now. The branch no longer has to keep merging the base in to stay green.
+
+To reproduce a CI result locally, build the same tree the job sees:
+
+```sh
+git fetch origin "refs/pull/$PR/merge:refs/ci-merge" && git checkout refs/ci-merge
+bin/complexity_check --base origin/<base branch>
+```
+
+Note that `--base` is resolved through `git merge-base`, so running it on a
+branch that has *not* merged the base in compares against the fork point and
+reports base-side entities as new. That is the local mirror of the same
+mismatch, and checking out the merge ref is what removes it.
+
 ### Rule 3: why the budget still needs its own check
 
 Both trees are measured with **this branch's** `.rubocop_metrics.yml`, on

--- a/docs/complexity_budget.md
+++ b/docs/complexity_budget.md
@@ -392,6 +392,27 @@ slot identity:
   bucket, collapsing two callbacks that measured 5 and 4 onto one anchor. The
   set now matches ESLint's. `\v` and `\f` are not in it and stay horizontal.
 
+One more, in the statement fallback rather than the digest: **`max-depth` is the
+only measurement here that is not a property of the entity's own text.** Two
+byte-identical `if (a) { y() }` statements in one function sit at different
+depths when one of them is inside another guard, so they measure differently —
+and being byte-identical, they shared an anchor and fell back on the ordinal.
+The justification for the ordinal did not hold for statements. A statement's
+identity carries its nesting depth now:
+
+```js
+function handle(p, q, a) {
+  if (p) { if (p) { if (a) { y() } } }   // ~if (a) { y() } at depth 3
+  if (q) { if (a) { y() } }              // ~if (a) { y() } at depth 2
+}
+```
+
+Those are two keys, not two slots. The number only has to *change* when ESLint's
+depth changes, not to equal it, so it counts enclosing nesting statements and
+does not model ESLint's exceptions (an `else if` chain does not count twice for
+ESLint; here it does). Over-counting keeps entities apart, which is the property
+wanted.
+
 Comments are the one thing left that moves a digest without moving a measurement
 — `skipComments` is on — so editing a comment inside an over-budget twin re-keys
 it. That is the loud direction, and telling comments from their look-alikes

--- a/docs/complexity_budget.md
+++ b/docs/complexity_budget.md
@@ -350,8 +350,8 @@ above) between them name all but a handful: of the engine's 214 over-budget
 entities, thirteen needed a position before those rules and four after — the
 worst being an eleven-way `useCallback` group in one component.
 
-What is left is anchored to an **FNV digest of its own source**, whitespace
-collapsed, so reindenting does not move a key but editing does:
+What is left is anchored to an **FNV digest of its own source**, normalised so
+that reindenting does not move a key but editing does:
 
 ```
 Row#connect>[items.map]#2842ca41
@@ -368,6 +368,30 @@ Only **byte-identical** twins still take an ordinal — `#2842ca41(1/2)` — and
 those measure identically, so any permutation of them is a no-op. One entity in
 the engine is in that position; the other three are distinct and now keyed
 apart.
+
+"Byte-identical" has to be meant literally, and two rounds of review on #1651
+found it was not. Both holes ended the same way — two entities that measure
+differently sharing an anchor, falling back on an ordinal, and landing back on
+slot identity:
+
+- **The digest was the grouping key.** One 32-bit FNV word collides often enough
+  that a brute-force search turns up a pair of ordinary-looking callbacks in
+  seconds; `(row) => { total += 91098 }` and `(row) => { total += 802942 }` are
+  one such pair. Twins are grouped by their **source text** now, and the digest
+  widens a word at a time until distinct bodies have distinct anchors. The first
+  width is a plain FNV-1a, so a group that does not actually collide keeps
+  exactly the key it always had.
+- **Normalisation collapsed newlines.** `max-lines-per-function` counts lines,
+  so two callbacks differing only in where a template literal's text wraps
+  measured 5 and 4 while normalising to the same string. Normalisation now
+  collapses only what the rules cannot see: runs of horizontal whitespace, any
+  horizontal whitespace around a newline, and runs of newlines (the rules run
+  with `skipBlankLines`). Every newline that separates content survives.
+
+Comments are the one thing left that moves a digest without moving a measurement
+— `skipComments` is on — so editing a comment inside an over-budget twin re-keys
+it. That is the loud direction, and telling comments from their look-alikes
+inside strings needs the token stream, which is a lot of machinery for a twin.
 
 The costs, both of which are the gate being loud about something it cannot
 attribute rather than quiet about something it can:

--- a/docs/complexity_budget.md
+++ b/docs/complexity_budget.md
@@ -26,7 +26,7 @@ Measured on 2026-08-11, before any of this existed:
 The Ruby ratchet landed first and left half the engine unmeasured. Measured on
 2026-09-10:
 
-- The core engine ships **35,390 lines of non-test JavaScript** across 161
+- The core engine ships **35,978 lines of non-test JavaScript** across 168
   files, against 40,153 lines of core Ruby — and the two largest source files in
   the engine are both JavaScript.
 - There was **no ESLint in the repository at all**: no config file, no lint job,
@@ -249,19 +249,19 @@ the merge base, the waivers, rules 1 to 4 — applies unchanged.
 
 Unlike the Ruby side, where RuboCop's defaults put ~90% of entities in violation
 and the budget had to be set at the 75th percentile of the violators, ESLint's
-documented defaults were already within reach. Measured over the 161 files the
+documented defaults were already within reach. Measured over the 168 files the
 budget selects, on 2026-09-10:
 
 | Rule | Budget | Entities | Over budget | Ruby counterpart |
 |------|--------|----------|-------------|------------------|
-| `complexity` | 13 | 3,083 | 88 (2.9%) | `Metrics/CyclomaticComplexity` |
-| `max-depth` | 3 | 3,402 | 19 (0.6%) | `Metrics/BlockNesting` |
-| `max-lines` | 300 | 161 | 21 (13.0%) | `Metrics/ClassLength` |
-| `max-lines-per-function` | 50 | 3,036 | 78 (2.6%) | `Metrics/MethodLength` |
-| `max-nested-callbacks` | 10 | 1,001 | 0 (0.0%) | — |
-| `max-params` | 4 | 1,880 | 8 (0.4%) | `Metrics/ParameterLists` |
+| `complexity` | 13 | 3,189 | 88 (2.8%) | `Metrics/CyclomaticComplexity` |
+| `max-depth` | 3 | 3,405 | 19 (0.6%) | `Metrics/BlockNesting` |
+| `max-lines` | 300 | 168 | 23 (13.7%) | `Metrics/ClassLength` |
+| `max-lines-per-function` | 50 | 3,142 | 78 (2.5%) | `Metrics/MethodLength` |
+| `max-nested-callbacks` | 10 | 999 | 0 (0.0%) | — |
+| `max-params` | 4 | 1,933 | 9 (0.5%) | `Metrics/ParameterLists` |
 
-214 entities are over it, against 394 on the Ruby side. They are grandfathered:
+217 entities are over it, against 388 on the Ruby side. They are grandfathered:
 they may shrink but not grow. The budget is what *new* code has to fit, and
 ordinary Stimulus controllers and modules already fit it.
 
@@ -551,7 +551,7 @@ direction.
 ### What this change touches outside the engine
 
 The guard's *target* is `engines/collavre`. Nothing under `engines/` is modified
-by this change — the gate is new, and the 214 entities already over budget are
+by this change — the gate is new, and the 217 entities already over budget are
 grandfathered. What it does add lives outside the engine, because that is where
 a repository-wide gate has to live:
 

--- a/docs/complexity_budget.md
+++ b/docs/complexity_budget.md
@@ -385,8 +385,12 @@ slot identity:
   so two callbacks differing only in where a template literal's text wraps
   measured 5 and 4 while normalising to the same string. Normalisation now
   collapses only what the rules cannot see: runs of horizontal whitespace, any
-  horizontal whitespace around a newline, and runs of newlines (the rules run
-  with `skipBlankLines`). Every newline that separates content survives.
+  horizontal whitespace around a line break, and runs of line breaks (the rules
+  run with `skipBlankLines`). Every line break that separates content survives.
+- **"Line break" meant `\n`.** ESLint splits lines on `\r\n`, `\r`, U+2028 and
+  U+2029 as well, so those count too — and U+2028 fell in the "horizontal"
+  bucket, collapsing two callbacks that measured 5 and 4 onto one anchor. The
+  set now matches ESLint's. `\v` and `\f` are not in it and stay horizontal.
 
 Comments are the one thing left that moves a digest without moving a measurement
 — `skipComments` is on — so editing a comment inside an over-budget twin re-keys

--- a/docs/complexity_budget.md
+++ b/docs/complexity_budget.md
@@ -512,6 +512,14 @@ raises an error and blocks the gate. It never falls back to positional keys
 for different bodies; identical bodies with identical rule context may still
 use ordinals.
 
+ESLint also measures implicit code paths: each class field initializer and
+each static block has its own complexity. These have separate entities, such
+as `Editor#draft(initializer)` and `Editor.(static block)`, with the same twin
+disambiguation as functions. A function created by a field initializer remains
+a separate nested entity. Computed field keys stay outside the initializer's
+scope. Complexity messages select the code-path kind explicitly because an
+initializer and the function it creates may start at the same position.
+
 The general statement, which is what the next rule added to the budget should be
 checked against: **a key must determine its measurement.** For each rule, either
 the value is a function of the entity's own text, or whatever else it depends on

--- a/docs/complexity_budget.md
+++ b/docs/complexity_budget.md
@@ -213,17 +213,17 @@ the merge base, the waivers, rules 1 to 4 — applies unchanged.
 
 Unlike the Ruby side, where RuboCop's defaults put ~90% of entities in violation
 and the budget had to be set at the 75th percentile of the violators, ESLint's
-documented defaults were already within reach. Measured over the 163 files the
+documented defaults were already within reach. Measured over the 161 files the
 budget selects, on 2026-09-10:
 
 | Rule | Budget | Entities | Over budget | Ruby counterpart |
 |------|--------|----------|-------------|------------------|
-| `complexity` | 13 | 3,123 | 88 (2.8%) | `Metrics/CyclomaticComplexity` |
-| `max-depth` | 3 | 3,448 | 19 (0.6%) | `Metrics/BlockNesting` |
-| `max-lines` | 300 | 163 | 21 (12.9%) | `Metrics/ClassLength` |
-| `max-lines-per-function` | 50 | 3,076 | 78 (2.5%) | `Metrics/MethodLength` |
-| `max-nested-callbacks` | 10 | 1,006 | 0 (0.0%) | — |
-| `max-params` | 4 | 1,920 | 8 (0.4%) | `Metrics/ParameterLists` |
+| `complexity` | 13 | 3,083 | 88 (2.9%) | `Metrics/CyclomaticComplexity` |
+| `max-depth` | 3 | 3,402 | 19 (0.6%) | `Metrics/BlockNesting` |
+| `max-lines` | 300 | 161 | 21 (13.0%) | `Metrics/ClassLength` |
+| `max-lines-per-function` | 50 | 3,036 | 78 (2.6%) | `Metrics/MethodLength` |
+| `max-nested-callbacks` | 10 | 1,001 | 0 (0.0%) | — |
+| `max-params` | 4 | 1,880 | 8 (0.4%) | `Metrics/ParameterLists` |
 
 214 entities are over it, against 394 on the Ruby side. They are grandfathered:
 they may shrink but not grow. The budget is what *new* code has to fit, and
@@ -269,22 +269,24 @@ built from an ESTree walk (`lib/js_complexity/entity_map.js`):
 ```
 engines/collavre/app/javascript/controllers/comments/topics_controller.js | max-lines | (file)
 engines/collavre/app/javascript/modules/creative_row_editor.js | max-lines-per-function | setupEditorSession
-engines/collavre/app/javascript/components/InlineLexicalEditor.jsx | max-lines-per-function | Toolbar>[useCallback](10)
+engines/collavre/app/javascript/components/InlineLexicalEditor.jsx | max-lines-per-function | Toolbar>[useCallback](10/11)
 ```
 
 - A class member reads `Editor#save`, a static `Editor.create`, and a getter
   `Editor#get draft` — without the kind, a `get`/`set` pair would collide into an
   ordinal pair that reads as two unrelated members.
 - An anonymous function takes the name it is bound to (`const submit = …` →
-  `submit`), or, if it is bound to nothing, the call it is passed to
-  (`[addEventListener]`). This is what the Ruby side does for blocks.
+  `submit`), or, if it is bound to nothing, the *whole callee* of the call it is
+  passed to (`[this.element.addEventListener]`, `[rows.map]`). This is what the
+  Ruby side does for blocks, with the receiver kept: `[map]` on its own turns
+  every `.map` in a method into a twin of every other, and twins are the only
+  case where identity has to fall back on source position.
 - `export default class extends Controller` — every Stimulus controller in the
   engine — is named `default`. "(anonymous class)" would be accurate and
   useless.
-- Siblings that share a name are numbered from the second on, so a second
-  over-budget `[map]` callback in one method cannot hide behind the first. As on
-  the Ruby side, an ordinal is a position and not an identity; the trade-off is
-  discussed under [Entity keys](#entity-keys) above and is the same here.
+- Entities in one scope that still share a name after all of that are **twins**,
+  and each carries its position *and* the size of its group: `[rows.map](2/3)`.
+  See [Twins](#twins) below for why the size is there.
 - `max-lines` belongs to `(file)`: it reports on the first line past the limit,
   which belongs to no entity in particular.
 - `max-depth` reports on a statement, so it falls back to the enclosing scope
@@ -297,16 +299,76 @@ offense on the method name and an arrow offense on the `=>` token. All of them
 are *inside* the entity, so the innermost scope containing the offense is the
 right answer in every case.
 
+### Twins
+
+Two entities in one scope can end up with the same name however good the naming
+is: two `items.map(…)` callbacks in one method, two identical `if` lines. The
+obvious fix is an ordinal — first one bare, second one `(2)` — and it is not
+enough, because **the bare name is inherited**:
+
+```js
+// before                               // after
+connect() {                             connect() {
+  items.map((row) => { …60 lines… })      items.map((row) => { …58 lines… })
+  items.map((row) => { …55 lines… })    }
+}
+```
+
+Under a plain ordinal the survivor is renamed from `>[items.map](2)` to
+`>[items.map]`, which is the key the *deleted* callback held at 60. Its growth
+from 55 to 58 is then measured against 60 and the gate says nothing. That is a
+silent bypass, and a silent bypass is the one failure mode this whole design
+exists to avoid.
+
+So every member of a group of twins carries the group's size as well as its
+position — `(1/2)`, `(2/2)` — and a lone entity carries neither. Adding or
+removing a twin changes the size, which changes every key in the group at once,
+and the ratchet reports the survivors as new debt rather than comparing them
+against somebody else's baseline. Reordering twins moves a larger value into a
+smaller slot, which reports as growth. The statement fallback (`~if (a) {`) is
+counted the same way, over every nesting statement in the scope rather than only
+the offending ones, which is what the Ruby side does for `Metrics/BlockNesting`.
+
+The cost is a false alarm: delete the larger of two twins and the survivor reads
+as new debt even though the file improved. That is recoverable three ways —
+give the callback a name (`const renderRow = (row) => …`, which ends the tie for
+good), get it under budget, or write a dated waiver. The reverse trade is not
+recoverable, because nobody finds out.
+
+The Ruby half still uses a plain ordinal and still has the hole, with the
+smaller blast radius its own section describes. Changing it would move every
+Ruby entity key at once, which is not this change's business.
+
 ### Scope
 
-`engines/collavre/**/*.{js,jsx}`, minus `__tests__` and `engines/collavre/test`,
-plus `lib/js_complexity` — the measurement holds itself to the budget it
-enforces, the way `lib/complexity_ratchet` is measured by the Metrics cops it
-runs. Tests are excluded for the reason they are excluded on the Ruby side,
-spelled out under [Entity keys](#entity-keys). The satellite engines hold about
-2,800 lines of JavaScript between them against the core's 35,000 and are not
-measured; adding them is a two-line change to `include`, which the budget check
-allows in that direction.
+`engines/collavre/**/*.{js,jsx}`, minus `__tests__` and `engines/collavre/test`.
+The core engine and nothing else: this gate is being introduced *for* the core
+engine, and `lib/js_complexity` — the measurement itself — is deliberately not
+in `include`, so a change to the tool cannot read as engine debt. Adding it is a
+one-line change whenever someone wants it, and the tool's own tests live in
+`lib/js_complexity/__tests__` either way. Tests are excluded for the reason they
+are excluded on the Ruby side, spelled out under
+[Entity keys](#entity-keys). The satellite engines hold about 2,800 lines of
+JavaScript between them against the core's 35,000 and are not measured; adding
+them is a two-line change to `include`, which the budget check allows in that
+direction.
+
+### What this change touches outside the engine
+
+The guard's *target* is `engines/collavre`. Nothing under `engines/` is modified
+by this change — the gate is new, and the 214 entities already over budget are
+grandfathered. What it does add lives outside the engine, because that is where
+a repository-wide gate has to live:
+
+| Path | Why it has to change |
+|------|----------------------|
+| `.eslint_metrics.yml` | The budget. New file. |
+| `lib/js_complexity/`, `bin/js_complexity.mjs` | The measurement. New files. |
+| `lib/complexity_ratchet/javascript.rb` | Runs the measurement and checks the budget can only tighten. New file. |
+| `bin/complexity_check` | Merges the JavaScript measurement into the existing Ruby one; the comparison, the waivers and the reporting are shared rather than duplicated. |
+| `.github/workflows/ci.yml` | The existing `complexity` job needs Node and `npm ci` to run the measurement. |
+| `package.json`, `jest.config.cjs` | ESLint as a devDependency, and the measurement's unit tests in the existing Jest run. |
+| `config/application.rb`, `docs/` | Keeps the CI-only tool out of the autoload path, and documents the above. |
 
 ## The engine boundary
 

--- a/docs/complexity_budget.md
+++ b/docs/complexity_budget.md
@@ -269,7 +269,8 @@ built from an ESTree walk (`lib/js_complexity/entity_map.js`):
 ```
 engines/collavre/app/javascript/controllers/comments/topics_controller.js | max-lines | (file)
 engines/collavre/app/javascript/modules/creative_row_editor.js | max-lines-per-function | setupEditorSession
-engines/collavre/app/javascript/components/InlineLexicalEditor.jsx | max-lines-per-function | Toolbar>[useCallback](10/11)
+engines/collavre/app/javascript/components/InlineLexicalEditor.jsx | max-lines-per-function | Toolbar>clearFormatting[useCallback]
+engines/collavre/app/javascript/controllers/comments/form_controller.js | complexity | default#handleSend>[doFetch().then().then]
 ```
 
 - A class member reads `Editor#save`, a static `Editor.create`, and a getter
@@ -280,13 +281,21 @@ engines/collavre/app/javascript/components/InlineLexicalEditor.jsx | max-lines-p
   passed to (`[this.element.addEventListener]`, `[rows.map]`). This is what the
   Ruby side does for blocks, with the receiver kept: `[map]` on its own turns
   every `.map` in a method into a twin of every other, and twins are the only
-  case where identity has to fall back on source position.
+  case where identity has to fall back on something other than a name.
+- A callee keeps its chain, rendered as `foo()`: the two callbacks in
+  `load().then(a).then(b)` are `[load().then]` and `[load().then().then]`, so
+  appending a third link leaves both of them where they were.
+- A callback whose call is itself bound to something takes that binding too:
+  `const handleFiles = useCallback(…)` is `handleFiles[useCallback]`. Every
+  callback in a React component is `useCallback`, so without this a component
+  with eleven of them has eleven twins, and adding a twelfth moves all eleven
+  keys.
 - `export default class extends Controller` — every Stimulus controller in the
   engine — is named `default`. "(anonymous class)" would be accurate and
   useless.
 - Entities in one scope that still share a name after all of that are **twins**,
-  and each carries its position *and* the size of its group: `[rows.map](2/3)`.
-  See [Twins](#twins) below for why the size is there.
+  and each is anchored to a digest of its own source: `[rows.map]#2842ca41`.
+  See [Twins](#twins) below.
 - `max-lines` belongs to `(file)`: it reports on the first line past the limit,
   which belongs to no entity in particular.
 - `max-depth` reports on a statement, so it falls back to the enclosing scope
@@ -303,8 +312,13 @@ right answer in every case.
 
 Two entities in one scope can end up with the same name however good the naming
 is: two `items.map(…)` callbacks in one method, two identical `if` lines. The
-obvious fix is an ordinal — first one bare, second one `(2)` — and it is not
-enough, because **the bare name is inherited**:
+obvious fix is a **position** — first one bare, second one `(2)`, or `(1/2)` and
+`(2/2)` to make the group's size part of it. Every version of that idea is
+wrong for the same reason: it makes a *slot* the identity, and the entity in
+slot 2 after an edit need not be the entity that was in slot 2 before it.
+
+Both ways of reaching that were found by Codex review on PR #1651. Deleting a
+twin:
 
 ```js
 // before                               // after
@@ -314,25 +328,58 @@ connect() {                             connect() {
 }
 ```
 
-Under a plain ordinal the survivor is renamed from `>[items.map](2)` to
-`>[items.map]`, which is the key the *deleted* callback held at 60. Its growth
-from 55 to 58 is then measured against 60 and the gate says nothing. That is a
-silent bypass, and a silent bypass is the one failure mode this whole design
-exists to avoid.
+Under a bare ordinal the survivor is renamed from `>[items.map](2)` to
+`>[items.map]`, the key the *deleted* callback held at 60, so its growth from 55
+to 58 is measured against 60 and the gate says nothing. Carrying the group's
+size fixes that one — and leaves reordering, which is the same bug wearing a
+different hat:
 
-So every member of a group of twins carries the group's size as well as its
-position — `(1/2)`, `(2/2)` — and a lone entity carries neither. Adding or
-removing a twin changes the size, which changes every key in the group at once,
-and the ratchet reports the survivors as new debt rather than comparing them
-against somebody else's baseline. Reordering twins moves a larger value into a
-smaller slot, which reports as growth. The statement fallback (`~if (a) {`) is
-counted the same way, over every nesting statement in the scope rather than only
-the offending ones, which is what the Ruby side does for `Metrics/BlockNesting`.
+```js
+// before: (1/2) = 12, (2/2) = 6       // after: (1/2) = 9, (2/2) = 5
+```
 
-The cost is a false alarm: delete the larger of two twins and the survivor reads
-as new debt even though the file improved. That is recoverable three ways —
-give the callback a name (`const renderRow = (row) => …`, which ends the tie for
-good), get it under budget, or write a dated waiver. The reverse trade is not
+Slot 1 reads `9 <= 12` and slot 2 reads `5 <= 6`, so nothing is reported, and
+yet the 6-line callback has grown to 9. Concealing growth this way costs an
+equal shrink somewhere else in the group, which is a low price for a silent
+bypass — and a silent bypass is the one failure mode this whole design exists to
+avoid.
+
+So the first move is to **have fewer twins**. Keeping the whole callee, keeping
+the call chain, and borrowing the binding a call sits in (see the naming rules
+above) between them name all but a handful: of the engine's 214 over-budget
+entities, thirteen needed a position before those rules and four after — the
+worst being an eleven-way `useCallback` group in one component.
+
+What is left is anchored to an **FNV digest of its own source**, whitespace
+collapsed, so reindenting does not move a key but editing does:
+
+```
+Row#connect>[items.map]#2842ca41
+Row#connect>[items.map]#5655f759
+```
+
+A twin's key now depends on the twin and on nothing around it. Siblings can be
+added, deleted or reordered without touching it, and an edit that changes its
+measurement changes its key, so growth surfaces as new debt instead of slipping
+into a neighbour's baseline. The statement fallback (`~if (a) {`) is anchored
+the same way, over the statement's whole span rather than its first line.
+
+Only **byte-identical** twins still take an ordinal — `#2842ca41(1/2)` — and
+those measure identically, so any permutation of them is a no-op. One entity in
+the engine is in that position; the other three are distinct and now keyed
+apart.
+
+The costs, both of which are the gate being loud about something it cannot
+attribute rather than quiet about something it can:
+
+- An over-budget twin that shrinks *without getting under budget* has a new
+  body, so it has a new key and reads as new debt.
+- The digest is only spelled out when a name is shared, so going from one such
+  entity to two — or back — renames it.
+
+Both are recoverable three ways: give the callback a name (`const renderRow =
+(row) => …`, which ends the tie for good and is usually the right change
+anyway), get it under budget, or write a dated waiver. The reverse trade is not
 recoverable, because nobody finds out.
 
 The Ruby half still uses a plain ordinal and still has the hole, with the

--- a/docs/complexity_budget.md
+++ b/docs/complexity_budget.md
@@ -428,8 +428,19 @@ slot identity:
   bucket, collapsing two callbacks that measured 5 and 4 onto one anchor. The
   set now matches ESLint's. `\v` and `\f` are not in it and stay horizontal.
 
-One more, in the statement fallback rather than the digest: **`max-depth` is the
-only measurement here that is not a property of the entity's own text.** Two
+Two more, in what the digest covers rather than in how it normalises. **Two of
+these rules do not measure what the entity says.** Every other one — `complexity`,
+`max-params`, `max-lines-per-function` — is a function of the entity's own text,
+so a digest of that text determines it. These two are not, and each of them
+produced a pair of byte-identical same-named twins that shared an anchor while
+measuring differently:
+
+| Rule | What it actually measures | Carried in the anchor by |
+|---|---|---|
+| `max-depth` | where a statement *sits* | `depthsOf` |
+| `max-nested-callbacks` | how deep a function is in callbacks | `callbackDepthsOf` |
+
+Taking `max-depth` first: **it is not a property of the entity's own text.** Two
 byte-identical `if (a) { y() }` statements in one function sit at different
 depths when one of them is inside another guard, so they measure differently —
 and being byte-identical, they shared an anchor and fell back on the ordinal.
@@ -474,6 +485,32 @@ and everything after it measures too shallow. Reproducing that is the point —
 the key has to match the number ESLint actually reported, not the one it should
 have. `depthsOf` is a single pass written to read like the rule, so an ESLint
 upgrade that fixes the quirk is a diff against one function.
+
+`max-nested-callbacks` is the same shape, and it is the one I argued could not
+have the problem: twins sit in one scope by construction, so surely they nest
+identically. They do not. The rule pops on **every** function exit but pushes
+only for a function whose parent is a call, so a function expression that is
+not a callback pops a level it never added, and everything after it in the
+scope counts one lower:
+
+```js
+a(function () {
+  items.map((row) => { total += row.n })   // 2
+  const helper = function () { return 1 }  // pops without having pushed
+  items.map((row) => { total += row.n })   // 1 — same name, same source
+})
+```
+
+Byte-identical and same-named, those two shared an anchor and took an ordinal.
+`callbackDepthsOf` mirrors the rule and the height goes into the digest.
+`FunctionDeclaration` is deliberately absent from it — the rule does not handle
+that type at all, so it neither pushes nor pops, and anchoring on something the
+measurement cannot see would separate twins for no reason.
+
+The general statement, which is what the next rule added to the budget should be
+checked against: **a key must determine its measurement.** For each rule, either
+the value is a function of the entity's own text, or whatever else it depends on
+belongs in the anchor.
 
 Comments are the one thing left that moves a digest without moving a measurement
 — `skipComments` is on — so editing a comment inside an over-budget twin re-keys

--- a/docs/complexity_budget.md
+++ b/docs/complexity_budget.md
@@ -443,11 +443,37 @@ function handle(p, q, a) {
 }
 ```
 
-Those are two keys, not two slots. The number only has to *change* when ESLint's
-depth changes, not to equal it, so it counts enclosing nesting statements and
-does not model ESLint's exceptions (an `else if` chain does not count twice for
-ESLint; here it does). Over-counting keeps entities apart, which is the property
-wanted.
+Those are two keys, not two slots.
+
+The depth in the key is **ESLint's own**, mirrored from the rule. A first
+attempt merely counted enclosing nesting statements, on the argument that the
+number only had to *change* when ESLint's changed and that over-counting keeps
+entities apart. That was the fifth variant of the same bug. A key has to
+*determine* its measurement, and a count that is merely correlated with
+ESLint's does not: both `if (a) { y() }` below sit under three enclosing
+statements, yet measure 3 and 2, because ESLint does not count an `if` whose
+parent is an `if`.
+
+```js
+function handle(p, q, a) {
+  if (p) { if (p) { if (a) { y() } } }              // enclosing 3, measures 3
+  if (q) { x() } else if (q) { if (a) { y() } }     // enclosing 3, measures 2
+}
+```
+
+Byte-identical and equal-count, they shared an anchor and took an ordinal — and
+each was then compared against the other's baseline. On the engine as it stands,
+4 of the 19 real `max-depth` offenses had a key whose depth disagreed with the
+number ESLint printed.
+
+Mirroring means mirroring the rule's arithmetic rather than a tidied-up version
+of it, including one upstream quirk: every nesting statement decrements the
+counter on exit, but an `if` under an `if` never incremented it, so an
+`if`/`else if`/`else if` chain leaves the counter two *below* where it started
+and everything after it measures too shallow. Reproducing that is the point —
+the key has to match the number ESLint actually reported, not the one it should
+have. `depthsOf` is a single pass written to read like the rule, so an ESLint
+upgrade that fixes the quirk is a diff against one function.
 
 Comments are the one thing left that moves a digest without moving a measurement
 — `skipComments` is on — so editing a comment inside an over-budget twin re-keys

--- a/docs/complexity_budget.md
+++ b/docs/complexity_budget.md
@@ -26,9 +26,9 @@ Measured on 2026-08-11, before any of this existed:
 The Ruby ratchet landed first and left half the engine unmeasured. Measured on
 2026-09-10:
 
-- The core engine ships **34,000 lines of non-test JavaScript** across 162 files,
-  against 40,000 lines of core Ruby — and the two largest source files in the
-  engine are both JavaScript.
+- The core engine ships **35,390 lines of non-test JavaScript** across 161
+  files, against 40,153 lines of core Ruby — and the two largest source files in
+  the engine are both JavaScript.
 - There was **no ESLint in the repository at all**: no config file, no lint job,
   no devDependency. Nothing measured any of it, and "no explicit configuration"
   is not the same as "no rules" only when there is a default to fall back on.
@@ -213,17 +213,17 @@ the merge base, the waivers, rules 1 to 4 — applies unchanged.
 
 Unlike the Ruby side, where RuboCop's defaults put ~90% of entities in violation
 and the budget had to be set at the 75th percentile of the violators, ESLint's
-documented defaults were already within reach. Measured over the 162 non-test
-files on 2026-09-10:
+documented defaults were already within reach. Measured over the 163 files the
+budget selects, on 2026-09-10:
 
 | Rule | Budget | Entities | Over budget | Ruby counterpart |
 |------|--------|----------|-------------|------------------|
-| `complexity` | 13 | 3,108 | 88 (2.8%) | `Metrics/CyclomaticComplexity` |
-| `max-depth` | 3 | 3,402 | 19 (0.6%) | `Metrics/BlockNesting` |
-| `max-lines` | 300 | 162 | 21 (13.0%) | `Metrics/ClassLength` |
-| `max-lines-per-function` | 50 | 3,038 | 78 (2.6%) | `Metrics/MethodLength` |
-| `max-nested-callbacks` | 10 | 1,001 | 0 (0.0%) | — |
-| `max-params` | 4 | 1,881 | 8 (0.4%) | `Metrics/ParameterLists` |
+| `complexity` | 13 | 3,123 | 88 (2.8%) | `Metrics/CyclomaticComplexity` |
+| `max-depth` | 3 | 3,448 | 19 (0.6%) | `Metrics/BlockNesting` |
+| `max-lines` | 300 | 163 | 21 (12.9%) | `Metrics/ClassLength` |
+| `max-lines-per-function` | 50 | 3,076 | 78 (2.5%) | `Metrics/MethodLength` |
+| `max-nested-callbacks` | 10 | 1,006 | 0 (0.0%) | — |
+| `max-params` | 4 | 1,920 | 8 (0.4%) | `Metrics/ParameterLists` |
 
 214 entities are over it, against 394 on the Ruby side. They are grandfathered:
 they may shrink but not grow. The budget is what *new* code has to fit, and
@@ -304,7 +304,7 @@ plus `lib/js_complexity` — the measurement holds itself to the budget it
 enforces, the way `lib/complexity_ratchet` is measured by the Metrics cops it
 runs. Tests are excluded for the reason they are excluded on the Ruby side,
 spelled out under [Entity keys](#entity-keys). The satellite engines hold about
-3,200 lines of JavaScript between them against the core's 34,000 and are not
+2,800 lines of JavaScript between them against the core's 35,000 and are not
 measured; adding them is a two-line change to `include`, which the budget check
 allows in that direction.
 
@@ -400,7 +400,7 @@ blocking gate cannot make anyone delete code.
 - **A standalone ESLint lint job.** ESLint is in this repository for exactly one
   reason: it is the only thing here that can parse modern JS and JSX well enough
   to measure it. Turning on its correctness or style rules is a separate
-  decision with a separate cost — ~34,000 lines of unlinted JavaScript would
+  decision with a separate cost — ~35,000 lines of unlinted JavaScript would
   produce thousands of offenses on day one — and bundling it into a complexity
   gate is how a gate gets switched off in week two.
 - **A test-to-app LOC ratio floor.** The core already has a healthy 1.51 ratio

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -125,7 +125,7 @@ engines/collavre_openclaw/config/locales/
 ```bash
 # Required before every PR
 ./bin/rubocop -a          # Auto-fix style issues
-bin/complexity_check      # Complexity ratchet (~2s)
+bin/complexity_check      # Complexity ratchet, Ruby + JavaScript (~8s, needs `npm ci`)
 bin/rails test            # Unit/integration tests
 bin/rails test:system     # System tests
 ```
@@ -135,11 +135,12 @@ conventions.
 
 ### Complexity Ratchet
 
-No class, module, method, or block may grow past the size it has at the merge
-base, and anything new must fit the budget in `.rubocop_metrics.yml`. CI measures
-both sides in one run, so there is no file to keep in sync and a refactor that
-shrinks something needs no bookkeeping. The budget itself may only tighten. Run
-`bin/complexity_check` locally to see what a PR would report. See
+No class, module, function, method, or block may grow past the size it has at
+the merge base, and anything new must fit the budget — `.rubocop_metrics.yml`
+for Ruby app code, `.eslint_metrics.yml` for the core engine's JavaScript. CI
+measures both sides in one run, so there is no file to keep in sync and a
+refactor that shrinks something needs no bookkeeping. Both budgets may only
+tighten. Run `bin/complexity_check` locally to see what a PR would report. See
 [complexity_budget.md](complexity_budget.md).
 
 ## PR Merge Principles (CTO Perspective)

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -7,6 +7,11 @@ module.exports = {
   roots: [
     "<rootDir>/app/javascript",
     "<rootDir>/engines",
+    // The complexity ratchet's JavaScript measurement (lib/js_complexity). It
+    // is tooling rather than app code, so it is deliberately absent from
+    // collectCoverageFrom below — but its entity naming is what keeps ratchet
+    // keys stable across commits, and that is worth unit tests.
+    "<rootDir>/lib",
     // Served production JS outside app/javascript (PWA service worker). Needed so
     // Jest's file crawler discovers it for coverage; no tests live here.
     "<rootDir>/app/views/pwa"

--- a/lib/complexity_ratchet/javascript.rb
+++ b/lib/complexity_ratchet/javascript.rb
@@ -7,7 +7,7 @@ module ComplexityRatchet
   # The JavaScript half of the ratchet.
   #
   # The Ruby half has been gating the core engine's ~40,000 lines of app code
-  # since the `complexity` job landed. The same engine ships ~34,000 lines of
+  # since the `complexity` job landed. The same engine ships ~35,000 lines of
   # non-test JavaScript that nothing measured at all: the repository has no
   # ESLint config, no lint job for it and no devDependency, and RuboCop
   # obviously does not read `.js`. That is where the two largest source files in

--- a/lib/complexity_ratchet/javascript.rb
+++ b/lib/complexity_ratchet/javascript.rb
@@ -1,0 +1,156 @@
+# frozen_string_literal: true
+
+require "json"
+require "open3"
+
+module ComplexityRatchet
+  # The JavaScript half of the ratchet.
+  #
+  # The Ruby half has been gating the core engine's ~40,000 lines of app code
+  # since the `complexity` job landed. The same engine ships ~34,000 lines of
+  # non-test JavaScript that nothing measured at all: the repository has no
+  # ESLint config, no lint job for it and no devDependency, and RuboCop
+  # obviously does not read `.js`. That is where the two largest source files in
+  # the engine live.
+  #
+  # Rather than a second gate with its own semantics, this produces the same
+  # {entity key => value} hash ComplexityRatchet::Measurement produces, so the
+  # merge-base comparison, the waiver format and the reporting are literally the
+  # same code. The measuring is delegated to Node (see bin/js_complexity.mjs)
+  # because ESLint is the only thing here that can parse modern JS and JSX.
+  module Javascript
+    CONFIG_PATH = ".eslint_metrics.yml"
+    SCRIPT_PATH = "bin/js_complexity.mjs"
+
+    INSTALL_HINT = "run `npm ci` first — the JavaScript ratchet needs ESLint from the repository's node_modules"
+
+    # Measures a tree with the *tool root's* ESLint and budget. The base side of
+    # the ratchet is a detached worktree with neither, and mixing the two would
+    # reintroduce the bug the Ruby half documents at length: measuring each side
+    # with its own budget makes a PR that tightens a limit report every
+    # pre-existing entity as brand-new debt.
+    class Measurement
+      def self.call(root:, tool_root:, config: nil)
+        new(root: root, tool_root: tool_root, config: config).call
+      end
+
+      def initialize(root:, tool_root:, config: nil)
+        @root = root
+        @tool_root = tool_root
+        @config = config || File.join(tool_root, CONFIG_PATH)
+      end
+
+      def call
+        JSON.parse(run)
+      end
+
+      private
+
+      attr_reader :root, :tool_root, :config
+
+      def run
+        command = [ "node", File.join(tool_root, SCRIPT_PATH), "--root", root, "--config", config ]
+        stdout, stderr, status = Open3.capture3(*command, chdir: tool_root)
+        raise Error, failure_message(status, stderr) unless status.success?
+
+        # Open3 tags the pipe with Encoding.default_external, which a shell
+        # without LANG set leaves as US-ASCII — and the first entity name
+        # carrying an em dash then dies inside JSON.parse. The script always
+        # writes UTF-8. (ComplexityRatchet::Measurement reads source files with
+        # the same explicit encoding, for the same reason.)
+        stdout.force_encoding(Encoding::UTF_8)
+      end
+
+      def failure_message(status, stderr)
+        hint = stderr.include?("Cannot find package") ? " — #{INSTALL_HINT}" : ""
+        "#{SCRIPT_PATH} failed (#{status.exitstatus})#{hint}: #{stderr.strip}"
+      end
+    end
+
+    # The budget file is compared against the merge base's copy for the same
+    # reason .rubocop_metrics.yml is: both trees are measured with this branch's
+    # copy, so raising a threshold silences the same entities on both sides at
+    # once and the comparison sees nothing.
+    #
+    # It is an allowlist. Exactly three edits pass — lowering a threshold,
+    # widening `include`, and shrinking `exclude` — and anything else is
+    # reported, including keys that do not exist yet. The budget file holds
+    # nothing but numbers and globs by design (rule options live in
+    # lib/js_complexity/measure.js), which is what makes an allowlist this short
+    # possible; the RuboCop side needs a much longer one because a cop can be
+    # silenced through Exclude, Include, AllowedMethods, AllowedPatterns or
+    # CountAsOne without its Max moving at all.
+    KNOWN_KEYS = %w[include exclude rules].freeze
+
+    class << self
+      def verify_budget(before, after)
+        return [] if before.nil?
+
+        rule_problems(before, after) +
+          scope_problems(before, after) +
+          unknown_key_problems(before, after)
+      end
+
+      private
+
+      def rule_problems(before, after)
+        rules(before).filter_map do |rule, limit|
+          current = rules(after)[rule]
+
+          if current.nil?
+            problem(:js_budget_disabled, rule,
+              "was in #{CONFIG_PATH} and is gone — dropping a rule silences every entity it holds")
+          elsif !current.is_a?(Integer) || current.negative?
+            problem(:js_budget_invalid_max, rule,
+              "threshold must be a non-negative integer in #{CONFIG_PATH} (got #{current.inspect})")
+          elsif current > limit
+            problem(:js_budget_loosened, rule,
+              "budget raised from #{limit} to #{current} in #{CONFIG_PATH} — the ratchet only turns one way")
+          end
+        end
+      end
+
+      # `include` may grow and `exclude` may shrink: both widen what is measured.
+      # The opposite of each hides code from the gate, which is the amnesty this
+      # design exists to avoid.
+      def scope_problems(before, after)
+        dropped = (list(before, "include") - list(after, "include")).map do |pattern|
+          problem(:js_budget_scope_narrowed, pattern,
+            "removed from `include` in #{CONFIG_PATH} — unmeasured code can grow without limit")
+        end
+
+        added = (list(after, "exclude") - list(before, "exclude")).map do |pattern|
+          problem(:js_budget_scope_narrowed, pattern,
+            "added to `exclude` in #{CONFIG_PATH} — excluded code is invisible to the ratchet")
+        end
+
+        dropped + added
+      end
+
+      # A key this checker does not know about cannot be judged, and an
+      # unjudged key in a budget file is a bypass waiting to be written. The
+      # next version of the measurement script may add one; adding it here is
+      # the deliberate step that makes it reviewable.
+      def unknown_key_problems(before, after)
+        ((before.keys | after.keys) - KNOWN_KEYS).sort.filter_map do |key|
+          next if before[key] == after[key]
+
+          problem(:js_budget_unknown_key, key,
+            "#{key} changed in #{CONFIG_PATH} and is not a key the ratchet knows how to compare")
+        end
+      end
+
+      def rules(config)
+        config["rules"].is_a?(Hash) ? config["rules"] : {}
+      end
+
+      def list(config, key)
+        Array(config[key])
+      end
+
+      def problem(kind, key, message)
+        Problem.new(kind: kind, key: key, message: message, blocking: true)
+      end
+    end
+  end
+end

--- a/lib/js_complexity/__tests__/measure.test.js
+++ b/lib/js_complexity/__tests__/measure.test.js
@@ -388,6 +388,45 @@ ${bodies.map((tag) => `          if (x) {\n            if (x) {\n              i
   test("says nothing when statement twins are reordered and neither one changed", () => {
     expect(reported(guards(1, 2), guards(2, 1))).toEqual([]);
   });
+
+  // Unlike every other measurement here, `max-depth`'s is NOT a property of the
+  // entity's own text: two byte-identical `if (a) { y() }` statements sit at
+  // different depths when one of them is inside another guard, and measure
+  // differently. They shared an anchor and fell back on the ordinal, so the
+  // "byte-identical twins measure identically" that justifies the ordinal did
+  // not hold for statements. A statement's identity carries its depth now.
+  function nested(...guards) {
+    const bodies = guards.map(([ guard, deep ]) => deep
+      ? `        if (${guard}) {\n          if (${guard}) {\n            if (a) { y() }\n          }\n        }`
+      : `        if (${guard}) {\n          if (a) { y() }\n        }`);
+
+    return measure(`
+      function handle(p, q, a) {
+${bodies.join("\n")}
+      }
+    `, { "max-depth": 1 });
+  }
+
+  const DEEP_P = [ "p", true ], SHALLOW_Q = [ "q", false ];
+
+  test("gives byte-identical statements at different depths distinct keys", () => {
+    const keys = entities(nested(DEEP_P, SHALLOW_Q), "max-depth").filter((key) => key.includes("if (a)"));
+
+    expect(new Set(keys).size).toBe(2);
+    for (const key of keys) expect(key).not.toMatch(/\(\d+\/\d+\)$/);
+  });
+
+  test("says nothing when statements at different depths swap source order", () => {
+    expect(reported(nested(DEEP_P, SHALLOW_Q), nested(SHALLOW_Q, DEEP_P))).toEqual([]);
+  });
+
+  // The over-correction to guard against: depth is in the key, so a statement
+  // that genuinely deepens has to still be reported.
+  test("reports a statement that gets deeper", () => {
+    const deeper = reported(nested(SHALLOW_Q), nested([ "q", true ]));
+
+    expect(deeper).toContain("handle~if (a) { y() }");
+  });
 });
 
 describe("offense shapes", () => {

--- a/lib/js_complexity/__tests__/measure.test.js
+++ b/lib/js_complexity/__tests__/measure.test.js
@@ -37,7 +37,7 @@ function reported(before, after) {
 // unrelated character moves inside a fixture.
 function labelled(keys) {
   const seen = new Map();
-  return keys.map((key) => key.replace(/#[0-9a-f]{8}/g, (digest) => {
+  return keys.map((key) => key.replace(/#(?:[0-9a-f]{8})+/g, (digest) => {
     if (!seen.has(digest)) seen.set(digest, `#${String.fromCharCode(97 + seen.size)}`);
     return seen.get(digest);
   }));
@@ -239,6 +239,96 @@ ${calls}
 
   test("says nothing when a twin is deleted and the rest are untouched", () => {
     expect(reported(twins(12, 8, 6), twins(12, 8))).toEqual([]);
+  });
+
+  // A 32-bit FNV word is small enough to collide on plausible input: these two
+  // markers were found by brute force in a few seconds, and under a single word
+  // both callbacks below digest to 299effeb. Grouping twins by that digest put
+  // two DIFFERENT callbacks back on one ordinal — the slot identity the whole
+  // scheme exists to remove — and a pure reorder of them reported growth that
+  // had not happened. Twins are grouped by source text instead, and the digest
+  // widens until it separates them.
+  const COLLIDING = { big: [ 12, 3893 ], small: [ 6, 250530 ] };
+
+  function collidingTwins(...pairs) {
+    const calls = pairs
+      .map(([ size, marker ]) => `        items.map((row) => {\n${body(size)}\n        const pad = ${marker}\n        })`)
+      .join("\n");
+    const measured = measure(`
+      class Row {
+        connect() {
+${calls}
+        }
+      }
+    `, { "max-lines-per-function": 2 });
+
+    return Object.fromEntries(Object.entries(measured).filter(([key]) => key.includes("[items.map]")));
+  }
+
+  test("separates twins whose bodies collide on a single digest word", () => {
+    const keys = Object.keys(collidingTwins(COLLIDING.big, COLLIDING.small)).map((key) => key.split(" | ")[2]);
+
+    expect(keys).toHaveLength(2);
+    expect(new Set(keys).size).toBe(2);
+    // No survivor fell back on a slot.
+    for (const key of keys) expect(key).not.toMatch(/\(\d+\/\d+\)$/);
+  });
+
+  test("says nothing when colliding twins are reordered and neither one changed", () => {
+    const before = collidingTwins(COLLIDING.big, COLLIDING.small);
+    const after = collidingTwins(COLLIDING.small, COLLIDING.big);
+
+    expect(reported(before, after)).toEqual([]);
+  });
+
+  // The digest normalises whitespace so that reindenting does not move a key.
+  // Collapsing NEWLINES along with the rest was a hole: `max-lines-per-function`
+  // counts lines, so two callbacks differing only in where a template literal's
+  // text wraps measure 5 and 4 while normalising to the same string. They shared
+  // an anchor, fell back on a slot, and a reorder compared each against the
+  // other's baseline.
+  function wrapping(...bodies) {
+    const calls = bodies.map((cb) => `        items.map((row) => {\n${cb}\n          use(t)\n        })`).join("\n");
+    const measured = measure(`
+      class Row {
+        connect() {
+${calls}
+        }
+      }
+    `, { "max-lines-per-function": 2 });
+
+    return Object.fromEntries(Object.entries(measured).filter(([key]) => key.includes("[items.map]")));
+  }
+
+  const WRAPPED = "          const t = `aaa\nbbb`";
+  const ONE_LINE = "          const t = `aaa bbb`";
+
+  test("separates twins that differ only in how a template literal wraps", () => {
+    const keys = Object.keys(wrapping(WRAPPED, ONE_LINE)).map((key) => key.split(" | ")[2]);
+
+    expect(new Set(keys).size).toBe(2);
+    for (const key of keys) expect(key).not.toMatch(/\(\d+\/\d+\)$/);
+  });
+
+  test("says nothing when twins that wrap differently are reordered", () => {
+    expect(reported(wrapping(WRAPPED, ONE_LINE), wrapping(ONE_LINE, WRAPPED))).toEqual([]);
+  });
+
+  // The other half of the same trade: whitespace the rules cannot measure must
+  // NOT move a key, or every reformat reads as new debt.
+  test("keeps a twin's key when it is reindented", () => {
+    const indented = (text) => text.replace(/^ +/gm, (run) => `${run}    `);
+
+    expect(reported(
+      wrapping(WRAPPED, ONE_LINE),
+      wrapping(indented(WRAPPED), indented(ONE_LINE)),
+    )).toEqual([]);
+  });
+
+  // `skipBlankLines` is on, so a blank line cannot change a measurement and
+  // must not change a key either.
+  test("keeps a twin's key when a blank line is added inside it", () => {
+    expect(reported(wrapping(WRAPPED, ONE_LINE), wrapping(`${WRAPPED}\n`, ONE_LINE))).toEqual([]);
   });
 
   // Statements that share a source line are the same problem in the max-depth

--- a/lib/js_complexity/__tests__/measure.test.js
+++ b/lib/js_complexity/__tests__/measure.test.js
@@ -427,6 +427,68 @@ ${bodies.join("\n")}
 
     expect(deeper).toContain("handle~if (a) { y() }");
   });
+
+  // An earlier version counted enclosing nesting statements instead of taking
+  // ESLint's number, arguing that the key only had to CHANGE when the
+  // measurement changed. It does not: a key has to DETERMINE its measurement.
+  // Both `if (a) { y() }` below sit under three enclosing statements, but the
+  // second hangs off an `else if`, which ESLint does not count — so they
+  // measured 3 and 2 while sharing an anchor and falling back on the ordinal,
+  // and each was compared against the other's baseline.
+  const PLAIN_REGION = `        if (p) {
+          if (p) {
+            if (a) { y() }
+          }
+        }`;
+  const ELSE_IF_REGION = `        if (q) {
+          x()
+        } else if (q) {
+          if (a) { y() }
+        }`;
+
+  function regions(...bodies) {
+    return measure(`
+      function handle(p, q, a) {
+${bodies.join("\n")}
+      }
+    `, { "max-depth": 1 });
+  }
+
+  test("separates byte-identical statements an else-if exempts from a depth level", () => {
+    const measured = regions(PLAIN_REGION, ELSE_IF_REGION);
+    const keys = entities(measured, "max-depth").filter((key) => key.includes("if (a)"));
+
+    expect(new Set(keys).size).toBe(2);
+    // No ordinal: an ordinal here would mean two different measurements
+    // sharing one anchor, which is the defect.
+    for (const key of keys) expect(key).not.toMatch(/\(\d+\/\d+\)$/);
+    expect(new Set(keys.map((key) => measured[`engines/collavre/app/javascript/x.js | max-depth | ${key}`]))).toEqual(new Set([ 3, 2 ]));
+  });
+
+  test("does not compare an else-if-exempt statement against an ordinarily nested one", () => {
+    // Same two statements, swapped. Under the ordinal each inherited the
+    // other's baseline and the swap was silent.
+    expect(reported(regions(PLAIN_REGION, ELSE_IF_REGION), regions(ELSE_IF_REGION, PLAIN_REGION)))
+      .not.toEqual([]);
+  });
+
+  // ESLint decrements on every one of these statements but only increments on
+  // some, so an if/else-if chain leaves its counter BELOW where it started and
+  // what follows measures too shallow. Mirroring the rule means reproducing
+  // that, not correcting it — the key has to match the number ESLint printed.
+  test("reproduces the depth ESLint reports after an else-if chain", () => {
+    const measured = measure(`
+      function f(a, b, c) {
+        if (a) { g() } else if (b) { g() } else if (c) { g() }
+        while (a) {
+          while (b) { g() }
+        }
+      }
+    `, { "max-depth": 0 });
+
+    // Only the chain's head counts; the two `while`s land at -1 and 0.
+    expect(entities(measured, "max-depth")).toEqual([ "f~if (a) { g() } else if (b) { g() } else if (c) { g() }" ]);
+  });
 });
 
 describe("offense shapes", () => {

--- a/lib/js_complexity/__tests__/measure.test.js
+++ b/lib/js_complexity/__tests__/measure.test.js
@@ -99,6 +99,51 @@ describe("entity naming", () => {
     ]);
   });
 
+  test("keeps computed-key functions outside a field value function", () => {
+    const source = "class C { [(() => a || b)()] = () => c || d; }";
+    expect(entities(measure(source, { complexity: 1 }), "complexity")).toEqual([
+      "C#(computed)(initializer)>(function)", "C>[anonymous]",
+    ]);
+  });
+
+  test("reports computed-key growth below a larger value function baseline", () => {
+    const before = measure("class C { [(() => a || b)()] = () => p || q || r || s; }", { complexity: 1 });
+    const after = measure("class C { [(() => a || b || c)()] = () => p || q || r || s; }", { complexity: 1 });
+    expect(reported(before, after)).toEqual(["C>[anonymous]"]);
+  });
+
+  test("reports computed-key depth below a field value function baseline", () => {
+    const value = [
+      "  })()] = () => {",
+      "    if (a) {",
+      "      if (b) {",
+      "        if (c) { run() }",
+      "      }",
+      "    }",
+      "  }",
+      "}",
+    ];
+    const before = measure([
+      "class C {",
+      "  [(function () {",
+      "    if (a) {",
+      "      if (c) { run() }",
+      "    }",
+      ...value,
+    ].join("\n"), { "max-depth": 2 });
+    const after = measure([
+      "class C {",
+      "  [(function () {",
+      "    if (a) {",
+      "      if (b) {",
+      "        if (c) { run() }",
+      "      }",
+      "    }",
+      ...value,
+    ].join("\n"), { "max-depth": 2 });
+    expect(reported(before, after)).toEqual(["C>[anonymous]~if (c) { run() }"]);
+  });
+
   test("attributes depth inside a field function to that function", () => {
     const source = `class C {
       fn = () => {

--- a/lib/js_complexity/__tests__/measure.test.js
+++ b/lib/js_complexity/__tests__/measure.test.js
@@ -30,6 +30,19 @@ function reported(before, after) {
     .map(([key]) => key.split(" | ")[2]);
 }
 
+// Content anchors are FNV digests; the tests care that two entities got
+// DIFFERENT anchors, not what the digest of any one of them is. Rewrite each
+// distinct digest to `#a`, `#b`, ... in first-seen order so an assertion reads
+// as the property it is making and does not have to be rewritten when an
+// unrelated character moves inside a fixture.
+function labelled(keys) {
+  const seen = new Map();
+  return keys.map((key) => key.replace(/#[0-9a-f]{8}/g, (digest) => {
+    if (!seen.has(digest)) seen.set(digest, `#${String.fromCharCode(97 + seen.size)}`);
+    return seen.get(digest);
+  }));
+}
+
 // A function body of `count` distinct statements, so max-lines-per-function
 // measures a value this test chose rather than one it has to look up.
 function body(count) {
@@ -88,7 +101,24 @@ describe("entity naming", () => {
     ]);
   });
 
-  test("gives twins their position and their group's size", () => {
+  test("anchors same-named siblings to a digest of their own source", () => {
+    const source = `
+      class Row {
+        connect() {
+          items.map((a, b, c) => { return a })
+          items.map((a, b, c) => { return b })
+        }
+      }
+    `;
+    expect(labelled(entities(measure(source, { "max-params": 2 }), "max-params"))).toEqual([
+      "Row#connect>[items.map]#a",
+      "Row#connect>[items.map]#b",
+    ]);
+  });
+
+  // Siblings that are byte-identical measure identically, so any permutation of
+  // them is a no-op and a plain ordinal is enough to keep them apart.
+  test("falls back to an ordinal only for byte-identical siblings", () => {
     const source = `
       class Row {
         connect() {
@@ -97,9 +127,40 @@ describe("entity naming", () => {
         }
       }
     `;
+    expect(labelled(entities(measure(source, { "max-params": 2 }), "max-params"))).toEqual([
+      "Row#connect>[items.map]#a(1/2)",
+      "Row#connect>[items.map]#a(2/2)",
+    ]);
+  });
+
+  // The name a reader would use is one level out from the call: every callback
+  // in a React component is `useCallback`, and a component with eleven of them
+  // had eleven entities whose keys all moved when a twelfth was added.
+  test("names a callback by the binding its call sits in", () => {
+    const source = `
+      function Toolbar() {
+        const handleFiles = useCallback((a, b, c) => {}, [])
+        const openPicker = useCallback((a, b, c) => {}, [])
+      }
+    `;
     expect(entities(measure(source, { "max-params": 2 }), "max-params")).toEqual([
-      "Row#connect>[items.map](1/2)",
-      "Row#connect>[items.map](2/2)",
+      "Toolbar>handleFiles[useCallback]",
+      "Toolbar>openPicker[useCallback]",
+    ]);
+  });
+
+  // A `.then` chain has no binding to borrow, so the callee carries the chain
+  // instead. Appending a fourth link leaves the first three keys alone.
+  test("names a chained callback by its position in the chain", () => {
+    const source = `
+      function save() {
+        load().then((a, b, c) => {}).then((a, b, c) => {}).catch((a, b, c) => {})
+      }
+    `;
+    expect(entities(measure(source, { "max-params": 2 }), "max-params")).toEqual([
+      "save>[load().then]",
+      "save>[load().then().then]",
+      "save>[load().then().then().catch]",
     ]);
   });
 
@@ -113,10 +174,11 @@ describe("entity naming", () => {
 });
 
 describe("twin identity across commits", () => {
-  // Two callbacks the naming cannot tell apart, sized independently. The
-  // measurements below stand in for the two sides of the merge-base comparison;
-  // only the callbacks are kept, because the method wrapping them changes size
-  // whenever the fixture does and that is not what these tests are about.
+  // Two callbacks the naming cannot tell apart by name, sized independently.
+  // The measurements below stand in for the two sides of the merge-base
+  // comparison; only the callbacks are kept, because the method wrapping them
+  // changes size whenever the fixture does and that is not what these tests are
+  // about.
   function twins(...sizes) {
     const calls = sizes.map((size) => `        items.map((row) => {\n${body(size)}\n        })`).join("\n");
     const measured = measure(`
@@ -130,10 +192,21 @@ ${calls}
     return Object.fromEntries(Object.entries(measured).filter(([key]) => key.includes("[items.map]")));
   }
 
-  // The hole this shape exists to close. Under a plain ordinal the survivor is
-  // renamed onto the deleted twin's key — `>[items.map](2)` becomes
-  // `>[items.map]` — so 6 growing to 9 is compared against the 12 that was
-  // deleted, and the ratchet says nothing.
+  // The hole this shape exists to close, in the form Codex found it: a plain
+  // ordinal compares SLOTS, so a twin that moved into a smaller slot is checked
+  // against the twin that used to be there. Baselines 12 and 6 against a
+  // reordered 9 and 5 passed — slot 1 read `9 <= 12` and slot 2 read `5 <= 6` —
+  // while the 6-line callback had in fact grown to 9.
+  test("does not hide growth behind a reorder and a compensating shrink", () => {
+    expect(labelled(reported(twins(12, 6), twins(9, 5)))).toEqual([
+      "Row#connect>[items.map]#a",
+      "Row#connect>[items.map]#b",
+    ]);
+  });
+
+  // A deleted twin cannot hand its measurement to a survivor either: the
+  // survivor is anchored to its own body, so growth is measured against its own
+  // baseline rather than the deleted twin's 12.
   test("does not hand a deleted twin's key to the survivor", () => {
     const before = twins(12, 6);
     const after = twins(9);
@@ -142,46 +215,60 @@ ${calls}
     expect(reported(before, after)).toEqual(["Row#connect>[items.map]"]);
   });
 
-  // The same edit without the growth still reports. That is the deliberate
-  // cost: the group's size is part of every key in it, so removing a twin
-  // invalidates the survivors' baselines and they read as new debt. A gate that
-  // is loud about an improvement is recoverable — a waiver, a name, or getting
-  // the survivor under budget. A gate that is quiet about growth is not.
-  test("reports the survivor as new debt even when nothing grew", () => {
+  // The anchor is only spelled out when it has to be, so an entity's key does
+  // not carry a digest it does not need. Crossing between "one" and "two" is
+  // therefore a rename, and a rename reads as new debt. That direction is safe
+  // — it is loud about an improvement, never quiet about growth — and it is the
+  // one place a twin's identity still depends on its siblings.
+  test("reports the survivor when deleting a twin leaves it alone in its scope", () => {
     expect(reported(twins(12, 6), twins(6))).toEqual(["Row#connect>[items.map]"]);
   });
 
-  test("does not hide growth when twins are reordered", () => {
-    // 12/6 becomes 6-grown-to-9 first, 12 second. Slot 2 held 6 and now holds
-    // 12, which reports — the growth cannot cross into the larger baseline.
-    expect(reported(twins(12, 6), twins(9, 12))).toEqual(["Row#connect>[items.map](2/2)"]);
+  // What the old ordinal got wrong in the other direction: moving twins around
+  // is not a change, and the gate should not say it is.
+  test("says nothing when twins are reordered and neither one changed", () => {
+    expect(reported(twins(12, 6), twins(6, 12))).toEqual([]);
   });
 
-  test("says nothing when a twin shrinks and nothing else moves", () => {
-    expect(reported(twins(12, 6), twins(10, 6))).toEqual([]);
+  // The cost of anchoring: an over-budget twin that shrinks but stays over
+  // budget has a new body, so it has a new key and reads as new debt. Recover
+  // by naming the callback, by getting it under budget, or with a waiver.
+  test("reports a twin that shrinks without getting under budget", () => {
+    expect(labelled(reported(twins(12, 6), twins(10, 6)))).toEqual(["Row#connect>[items.map]#a"]);
   });
 
-  // Identical `if` lines in one method are the same problem in the statement
-  // fallback, and get the same treatment: the group's size is part of the key,
-  // so the survivor of a deleted twin cannot inherit its measurement.
-  test("does not hand a deleted statement twin's key to the survivor", () => {
-    const guards = (count) => measure(`
+  test("says nothing when a twin is deleted and the rest are untouched", () => {
+    expect(reported(twins(12, 8, 6), twins(12, 8))).toEqual([]);
+  });
+
+  // Statements that share a source line are the same problem in the max-depth
+  // fallback, and go through the same `discriminate` the definitions above do:
+  // two `if (x) {` lines with different bodies are two keys, so neither can be
+  // measured against the other's baseline.
+  function guards(...bodies) {
+    return measure(`
       class Row {
         render() {
-${Array.from({ length: count }, () => "          if (a) { if (b) { return 1 } }").join("\n")}
+${bodies.map((tag) => `          if (x) {\n            if (x) {\n              if (y) { return ${tag} }\n            }\n          }`).join("\n")}
         }
       }
     `, { "max-depth": 1 });
+  }
 
-    const before = guards(2);
-    const after = guards(1);
-
-    expect(entities(before, "max-depth")).toEqual([
-      "Row#render~if (a) { if (b) { return 1 } }(2/4)",
-      "Row#render~if (a) { if (b) { return 1 } }(4/4)",
+  test("gives statements that share a source line but not a body distinct keys", () => {
+    // The two reported `if (x) {` lines are byte-different only in the `return`
+    // buried inside them, and that is enough: they are separate keys, not two
+    // slots in one.
+    expect(labelled(entities(guards(1, 2), "max-depth"))).toEqual([
+      "Row#render~if (x) {#a",
+      "Row#render~if (y) { return 1 }",
+      "Row#render~if (x) {#b",
+      "Row#render~if (y) { return 2 }",
     ]);
-    expect(entities(after, "max-depth")).toEqual(["Row#render~if (a) { if (b) { return 1 } }(2/2)"]);
-    expect(Object.keys(after).some((key) => key in before)).toBe(false);
+  });
+
+  test("says nothing when statement twins are reordered and neither one changed", () => {
+    expect(reported(guards(1, 2), guards(2, 1))).toEqual([]);
   });
 });
 
@@ -201,13 +288,13 @@ describe("offense shapes", () => {
         }
       }
     `;
-    // Three `if`s share the line, so the two offending ones are twins 2 and 3
-    // of a group of three — the outermost `if` is inside the budget and still
-    // counts towards the group, exactly as the Ruby side counts below-budget
-    // statements.
-    expect(entities(measure(source, { "max-depth": 1 }), "max-depth")).toEqual([
-      "Row#render~if (a) { if (b) { if (c) { return 1 } } }(2/3)",
-      "Row#render~if (a) { if (b) { if (c) { return 1 } } }(3/3)",
+    // Three `if`s share the line, so all three record the same text and each is
+    // anchored to its own span. The outermost is inside the budget and reports
+    // nothing; the two that do report are distinct keys rather than two slots
+    // in one group, so neither can be measured against the other's baseline.
+    expect(labelled(entities(measure(source, { "max-depth": 1 }), "max-depth"))).toEqual([
+      "Row#render~if (a) { if (b) { if (c) { return 1 } } }#a",
+      "Row#render~if (a) { if (b) { if (c) { return 1 } } }#b",
     ]);
   });
 

--- a/lib/js_complexity/__tests__/measure.test.js
+++ b/lib/js_complexity/__tests__/measure.test.js
@@ -20,6 +20,22 @@ function entities(measured, rule) {
     .map((key) => key.split(" | ")[2]);
 }
 
+// What ComplexityRatchet::Check does with the two measurements: an entity the
+// merge base does not have is new debt, and one that got bigger is growth.
+// Both block. Written here so the identity tests can assert the property that
+// actually matters — that an edit is REPORTED — rather than a key spelling.
+function reported(before, after) {
+  return Object.entries(after)
+    .filter(([key, value]) => !(key in before) || value > before[key])
+    .map(([key]) => key.split(" | ")[2]);
+}
+
+// A function body of `count` distinct statements, so max-lines-per-function
+// measures a value this test chose rather than one it has to look up.
+function body(count) {
+  return Array.from({ length: count }, (_, index) => `        const v${index} = ${index}`).join("\n");
+}
+
 describe("entity naming", () => {
   test("names class methods, statics and accessors by their member", () => {
     const source = `
@@ -54,20 +70,25 @@ describe("entity naming", () => {
     expect(entities(measure(source, { "max-params": 2 }), "max-params")).toEqual(["outer>inner"]);
   });
 
-  test("names an anonymous callback after the call it is passed to", () => {
+  test("names an anonymous callback after the whole call it is passed to", () => {
+    // The receiver is part of the name: `[addEventListener]` alone would make
+    // twins out of two listeners on different elements, and twins are the one
+    // case where identity has to fall back on source position.
     const source = `
       class Row {
         connect() {
           this.el.addEventListener("click", (a, b, c) => {})
+          document.addEventListener("keydown", (a, b, c) => {})
         }
       }
     `;
     expect(entities(measure(source, { "max-params": 2 }), "max-params")).toEqual([
-      "Row#connect>[addEventListener]",
+      "Row#connect>[this.el.addEventListener]",
+      "Row#connect>[document.addEventListener]",
     ]);
   });
 
-  test("numbers siblings that share a name from the second on", () => {
+  test("gives twins their position and their group's size", () => {
     const source = `
       class Row {
         connect() {
@@ -77,8 +98,8 @@ describe("entity naming", () => {
       }
     `;
     expect(entities(measure(source, { "max-params": 2 }), "max-params")).toEqual([
-      "Row#connect>[map]",
-      "Row#connect>[map](2)",
+      "Row#connect>[items.map](1/2)",
+      "Row#connect>[items.map](2/2)",
     ]);
   });
 
@@ -88,6 +109,79 @@ describe("entity naming", () => {
       const handlers = { retry: function (a, b, c) {} }
     `;
     expect(entities(measure(source, { "max-params": 2 }), "max-params")).toEqual(["submit", "retry"]);
+  });
+});
+
+describe("twin identity across commits", () => {
+  // Two callbacks the naming cannot tell apart, sized independently. The
+  // measurements below stand in for the two sides of the merge-base comparison;
+  // only the callbacks are kept, because the method wrapping them changes size
+  // whenever the fixture does and that is not what these tests are about.
+  function twins(...sizes) {
+    const calls = sizes.map((size) => `        items.map((row) => {\n${body(size)}\n        })`).join("\n");
+    const measured = measure(`
+      class Row {
+        connect() {
+${calls}
+        }
+      }
+    `, { "max-lines-per-function": 2 });
+
+    return Object.fromEntries(Object.entries(measured).filter(([key]) => key.includes("[items.map]")));
+  }
+
+  // The hole this shape exists to close. Under a plain ordinal the survivor is
+  // renamed onto the deleted twin's key — `>[items.map](2)` becomes
+  // `>[items.map]` — so 6 growing to 9 is compared against the 12 that was
+  // deleted, and the ratchet says nothing.
+  test("does not hand a deleted twin's key to the survivor", () => {
+    const before = twins(12, 6);
+    const after = twins(9);
+
+    expect(Object.keys(after).some((key) => key in before)).toBe(false);
+    expect(reported(before, after)).toEqual(["Row#connect>[items.map]"]);
+  });
+
+  // The same edit without the growth still reports. That is the deliberate
+  // cost: the group's size is part of every key in it, so removing a twin
+  // invalidates the survivors' baselines and they read as new debt. A gate that
+  // is loud about an improvement is recoverable — a waiver, a name, or getting
+  // the survivor under budget. A gate that is quiet about growth is not.
+  test("reports the survivor as new debt even when nothing grew", () => {
+    expect(reported(twins(12, 6), twins(6))).toEqual(["Row#connect>[items.map]"]);
+  });
+
+  test("does not hide growth when twins are reordered", () => {
+    // 12/6 becomes 6-grown-to-9 first, 12 second. Slot 2 held 6 and now holds
+    // 12, which reports — the growth cannot cross into the larger baseline.
+    expect(reported(twins(12, 6), twins(9, 12))).toEqual(["Row#connect>[items.map](2/2)"]);
+  });
+
+  test("says nothing when a twin shrinks and nothing else moves", () => {
+    expect(reported(twins(12, 6), twins(10, 6))).toEqual([]);
+  });
+
+  // Identical `if` lines in one method are the same problem in the statement
+  // fallback, and get the same treatment: the group's size is part of the key,
+  // so the survivor of a deleted twin cannot inherit its measurement.
+  test("does not hand a deleted statement twin's key to the survivor", () => {
+    const guards = (count) => measure(`
+      class Row {
+        render() {
+${Array.from({ length: count }, () => "          if (a) { if (b) { return 1 } }").join("\n")}
+        }
+      }
+    `, { "max-depth": 1 });
+
+    const before = guards(2);
+    const after = guards(1);
+
+    expect(entities(before, "max-depth")).toEqual([
+      "Row#render~if (a) { if (b) { return 1 } }(2/4)",
+      "Row#render~if (a) { if (b) { return 1 } }(4/4)",
+    ]);
+    expect(entities(after, "max-depth")).toEqual(["Row#render~if (a) { if (b) { return 1 } }(2/2)"]);
+    expect(Object.keys(after).some((key) => key in before)).toBe(false);
   });
 });
 
@@ -107,9 +201,13 @@ describe("offense shapes", () => {
         }
       }
     `;
+    // Three `if`s share the line, so the two offending ones are twins 2 and 3
+    // of a group of three — the outermost `if` is inside the budget and still
+    // counts towards the group, exactly as the Ruby side counts below-budget
+    // statements.
     expect(entities(measure(source, { "max-depth": 1 }), "max-depth")).toEqual([
-      "Row#render~if (a) { if (b) { if (c) { return 1 } } }",
-      "Row#render~if (a) { if (b) { if (c) { return 1 } } }[fallback:2]",
+      "Row#render~if (a) { if (b) { if (c) { return 1 } } }(2/3)",
+      "Row#render~if (a) { if (b) { if (c) { return 1 } } }(3/3)",
     ]);
   });
 
@@ -120,8 +218,9 @@ describe("offense shapes", () => {
       }
     `;
     const measured = measure(source, { "max-depth": 1 });
-    // Three nested offenses on one line: depths 2, 3 and 4 all report at the
-    // same normalised source line, so they share a key after the ordinal.
+    // Three nested offenses on one line, at depths 2, 3 and 4. They are twins
+    // of one group rather than one collapsed key, so the deepest is recorded
+    // rather than being the only one recorded.
     expect(Math.max(...Object.values(measured))).toBe(4);
   });
 

--- a/lib/js_complexity/__tests__/measure.test.js
+++ b/lib/js_complexity/__tests__/measure.test.js
@@ -278,6 +278,64 @@ describe("entity naming", () => {
     `;
     expect(entities(measure(source, { "max-params": 2 }), "max-params")).toEqual(["submit", "retry"]);
   });
+
+  test("keeps an object method at its key inside an enclosing function", () => {
+    const source = `
+function attachTouchBridge(a, b) {
+  if (a) use(a)
+  if (b) use(b)
+  const bridge = {
+    canStart(a, b, c) {
+      if (a) use(a)
+    }
+  }
+  return bridge
+}
+    `;
+    const measured = measure(source, {
+      complexity: 1,
+      "max-lines-per-function": 1,
+      "max-params": 1,
+    });
+
+    for (const rule of [ "complexity", "max-lines-per-function", "max-params" ]) {
+      expect(entities(measured, rule)).toEqual(["attachTouchBridge", "attachTouchBridge>canStart"]);
+    }
+  });
+
+  test("reports object-method growth below its enclosing function's baseline", () => {
+    const before = measure(`
+function setup(a, b) {
+  if (a) use(a)
+  if (b) use(b)
+  const bridge = { canStart(v) { return v ? 1 : 0 } }
+  return bridge
+}
+    `, { complexity: 1 });
+    const after = measure(`
+function setup(a, b) {
+  if (a) use(a)
+  if (b) use(b)
+  const bridge = { canStart(v) { return v ? 1 : v === 0 ? 0 : -1 } }
+  return bridge
+}
+    `, { complexity: 1 });
+
+    expect(reported(before, after)).toEqual(["setup>canStart"]);
+  });
+
+  test("names an identifier-assigned function by its target", () => {
+    const source = `function setup() { handler = (a, b, c) => {} }`;
+    expect(entities(measure(source, { "max-params": 2 }), "max-params"))
+      .toEqual(["setup>handler"]);
+  });
+
+  test("reports a replacement identifier assignment as new debt", () => {
+    const before = measure("function setup() { first = (a, b, c, d) => {} }", { "max-params": 2 });
+    const after = measure("function setup() { second = (a, b, c) => {} }", { "max-params": 2 });
+
+    expect(reported(before, after)).toEqual(["setup>second"]);
+  });
 });
 
 describe("twin identity across commits", () => {

--- a/lib/js_complexity/__tests__/measure.test.js
+++ b/lib/js_complexity/__tests__/measure.test.js
@@ -472,6 +472,62 @@ ${bodies.join("\n")}
       .not.toEqual([]);
   });
 
+  // The sixth variant, and the rule I had argued could not have it: twins sit
+  // in one scope by construction, so surely they nest identically. They do not.
+  // max-nested-callbacks pops on EVERY function exit but pushes only for
+  // functions whose parent is a call, so a function expression that is not a
+  // callback pops a level it never added and everything after it counts lower.
+  function separated(middle) {
+    return measure(`
+a(function () {
+  items.map((row) => { total += row.n })
+${middle}
+  items.map((row) => { total += row.n })
+})
+`, { "max-nested-callbacks": 0 });
+  }
+
+  const NON_CALLBACK = "  const helper = function () { return 1 }";
+
+  test("separates twins a non-callback function expression deflates the count for", () => {
+    const measured = separated(NON_CALLBACK);
+    const keys = entities(measured, "max-nested-callbacks").filter((key) => key.includes("items.map"));
+
+    expect(new Set(keys).size).toBe(2);
+    for (const key of keys) expect(key).not.toMatch(/\(\d+\/\d+\)$/);
+    expect(new Set(keys.map((key) => measured[`engines/collavre/app/javascript/x.js | max-nested-callbacks | ${key}`])))
+      .toEqual(new Set([ 2, 1 ]));
+  });
+
+  test("reports the twin whose callback nesting deepens", () => {
+    // Moving the non-callback above both twins takes the second from 1 to 2.
+    const before = separated(NON_CALLBACK);
+    const after = measure(`
+a(function () {
+${NON_CALLBACK}
+  items.map((row) => { total += row.n })
+  items.map((row) => { total += row.n })
+})
+`, { "max-nested-callbacks": 0 });
+
+    expect(reported(before, after)).not.toEqual([]);
+  });
+
+  // A FunctionDeclaration is not handled by the rule at all, so it neither
+  // pushes nor pops and must NOT separate the twins — the over-correction to
+  // guard against is anchoring on something the measurement does not see.
+  test("keeps twins together across a function declaration, which the rule ignores", () => {
+    const measured = separated("  function helper() { return 1 }");
+    const keys = entities(measured, "max-nested-callbacks").filter((key) => key.includes("items.map"));
+
+    // Nothing separates them: one anchor, and the ordinal that byte-identical
+    // twins are entitled to precisely because they measure identically.
+    expect(new Set(keys.map((key) => key.replace(/\(\d+\/\d+\)$/, ""))).size).toBe(1);
+    for (const key of keys) expect(key).toMatch(/\(\d+\/\d+\)$/);
+    expect(new Set(keys.map((key) => measured[`engines/collavre/app/javascript/x.js | max-nested-callbacks | ${key}`])))
+      .toEqual(new Set([ 2 ]));
+  });
+
   // ESLint decrements on every one of these statements but only increments on
   // some, so an if/else-if chain leaves its counter BELOW where it started and
   // what follows measures too shallow. Mirroring the rule means reproducing

--- a/lib/js_complexity/__tests__/measure.test.js
+++ b/lib/js_complexity/__tests__/measure.test.js
@@ -1,0 +1,192 @@
+import { Linter } from "eslint";
+
+import { eslintConfig, foldMessages, parseBudget, RULES } from "../measure.js";
+
+// Measure a source string the way lib/js_complexity/measure.js measures a file,
+// and return the ratchet keys it produces. Going through Linter rather than
+// hand-building an AST keeps the tests honest about the thing that actually
+// varies between ESLint versions: where a rule reports its offense.
+function measure(source, rules, filename = "engines/collavre/app/javascript/x.js") {
+  const budget = { include: [], exclude: [], rules };
+  const linter = new Linter();
+  const messages = linter.verify(source, eslintConfig(budget), filename);
+  return foldMessages(filename, source, linter.getSourceCode()?.ast, messages);
+}
+
+// Keys are `path | rule | entity`; the tests below care about the entity.
+function entities(measured, rule) {
+  return Object.keys(measured)
+    .filter((key) => key.split(" | ")[1] === rule)
+    .map((key) => key.split(" | ")[2]);
+}
+
+describe("entity naming", () => {
+  test("names class methods, statics and accessors by their member", () => {
+    const source = `
+      class Editor {
+        save(a, b, c) {}
+        static create(a, b, c) {}
+        get draft() { return this._d(1, 2, 3) }
+        set draft(v) {}
+      }
+      Editor.prototype.x = function (a, b, c) {}
+    `;
+    expect(entities(measure(source, { "max-params": 2 }), "max-params")).toEqual([
+      "Editor#save",
+      "Editor.create",
+      "Editor.prototype.x",
+    ]);
+  });
+
+  test("names an anonymous default-exported class `default`", () => {
+    // Every Stimulus controller in the engine is written this way.
+    const source = `export default class extends Controller { connect(a, b, c) {} }`;
+    expect(entities(measure(source, { "max-params": 2 }), "max-params")).toEqual(["default#connect"]);
+  });
+
+  test("names a nested function by its path through the enclosing scopes", () => {
+    const source = `
+      function outer() {
+        function inner(a, b, c) {}
+        return inner
+      }
+    `;
+    expect(entities(measure(source, { "max-params": 2 }), "max-params")).toEqual(["outer>inner"]);
+  });
+
+  test("names an anonymous callback after the call it is passed to", () => {
+    const source = `
+      class Row {
+        connect() {
+          this.el.addEventListener("click", (a, b, c) => {})
+        }
+      }
+    `;
+    expect(entities(measure(source, { "max-params": 2 }), "max-params")).toEqual([
+      "Row#connect>[addEventListener]",
+    ]);
+  });
+
+  test("numbers siblings that share a name from the second on", () => {
+    const source = `
+      class Row {
+        connect() {
+          items.map((a, b, c) => {})
+          items.map((a, b, c) => {})
+        }
+      }
+    `;
+    expect(entities(measure(source, { "max-params": 2 }), "max-params")).toEqual([
+      "Row#connect>[map]",
+      "Row#connect>[map](2)",
+    ]);
+  });
+
+  test("names a function by the binding it is assigned to", () => {
+    const source = `
+      const submit = (a, b, c) => {}
+      const handlers = { retry: function (a, b, c) {} }
+    `;
+    expect(entities(measure(source, { "max-params": 2 }), "max-params")).toEqual(["submit", "retry"]);
+  });
+});
+
+describe("offense shapes", () => {
+  test("max-lines belongs to the file, not to whatever sits on the overflowing line", () => {
+    const source = `const a = 1\nconst b = 2\nfunction c() { return 3 }\n`;
+    const measured = measure(source, { "max-lines": 1 });
+    expect(entities(measured, "max-lines")).toEqual(["(file)"]);
+    expect(Object.values(measured)).toEqual([3]);
+  });
+
+  test("max-depth falls back to the enclosing scope plus the source line", () => {
+    const source = `
+      class Row {
+        render() {
+          if (a) { if (b) { if (c) { return 1 } } }
+        }
+      }
+    `;
+    expect(entities(measure(source, { "max-depth": 1 }), "max-depth")).toEqual([
+      "Row#render~if (a) { if (b) { if (c) { return 1 } } }",
+      "Row#render~if (a) { if (b) { if (c) { return 1 } } }[fallback:2]",
+    ]);
+  });
+
+  test("records the largest value when one entity trips a rule twice", () => {
+    const source = `
+      function render() {
+        if (a) { if (b) { if (c) { if (d) { return 1 } } } }
+      }
+    `;
+    const measured = measure(source, { "max-depth": 1 });
+    // Three nested offenses on one line: depths 2, 3 and 4 all report at the
+    // same normalised source line, so they share a key after the ordinal.
+    expect(Math.max(...Object.values(measured))).toBe(4);
+  });
+
+  test("reads the measured value out of every rule in the budget", () => {
+    const source = `
+      class Editor {
+        save(a, b, c, d) {
+          if (a) { if (b) { if (c) { return 1 } } }
+          return a && b || c && d ? 1 : 2
+        }
+      }
+      setTimeout(() => { setTimeout(() => { setTimeout(() => {}) }) })
+    `;
+    const measured = measure(source, {
+      complexity: 1,
+      "max-depth": 1,
+      "max-lines": 1,
+      "max-lines-per-function": 1,
+      "max-nested-callbacks": 1,
+      "max-params": 1,
+    });
+    const seen = new Set(Object.keys(measured).map((key) => key.split(" | ")[1]));
+    expect([...seen].sort()).toEqual(Object.keys(RULES).sort());
+    expect(Object.values(measured).every((value) => Number.isInteger(value) && value > 0)).toBe(true);
+  });
+
+  test("throws rather than guessing when a source file does not parse", () => {
+    expect(() => measure("class {", { "max-params": 1 })).toThrow(/could not be parsed/);
+  });
+
+  test("ignores ESLint's notice that an inline disable comment was refused", () => {
+    // noInlineConfig is on, so `eslint-disable` comments cannot switch the gate
+    // off; ESLint reports that as a rule-less warning, which is not an entity.
+    const source = `/* eslint-disable max-params */\nfunction f(a, b, c) {}\n`;
+    expect(entities(measure(source, { "max-params": 2 }), "max-params")).toEqual(["f"]);
+  });
+});
+
+describe("budget parsing", () => {
+  test("rejects a rule the entity mapping does not cover", () => {
+    expect(() => parseBudget("rules:\n  no-unused-vars: 3\n")).toThrow(/no entity mapping/);
+  });
+
+  test("rejects a threshold that is not a non-negative integer", () => {
+    expect(() => parseBudget("rules:\n  complexity: 2.5\n")).toThrow(/non-negative integers/);
+    expect(() => parseBudget("rules:\n  complexity: -1\n")).toThrow(/non-negative integers/);
+  });
+
+  test("reads include, exclude and rules", () => {
+    const budget = parseBudget(`
+include:
+  - "engines/collavre/**/*.js"
+exclude:
+  - "**/__tests__/**"
+rules:
+  complexity: 13
+`);
+    expect(budget).toEqual({
+      include: ["engines/collavre/**/*.js"],
+      exclude: ["**/__tests__/**"],
+      rules: { complexity: 13 },
+    });
+  });
+
+  test("refuses to honour an inline directive that would silence the gate", () => {
+    expect(eslintConfig({ rules: {} }).linterOptions.noInlineConfig).toBe(true);
+  });
+});

--- a/lib/js_complexity/__tests__/measure.test.js
+++ b/lib/js_complexity/__tests__/measure.test.js
@@ -51,6 +51,67 @@ function body(count) {
 }
 
 describe("entity naming", () => {
+  test("separates field initializers from each other and from field functions", () => {
+    const source = `class C {
+      first = a || b || c;
+      static first = a || b;
+      #hidden = a || b;
+      fn = () => a || b;
+    }`;
+    const measured = measure(source, { complexity: 0 });
+    expect(entities(measured, "complexity")).toEqual([
+      "C#first(initializer)", "C.first(initializer)",
+      "C##hidden(initializer)", "C#fn(initializer)>(function)",
+      "C#fn(initializer)",
+    ]);
+    expect(Object.values(measured)).toEqual([3, 2, 2, 2, 1]);
+  });
+
+  test("reports a new field below a larger initializer's baseline", () => {
+    const before = measure("class C { first = a || b || c || d; }", { complexity: 1 });
+    const after = measure("class C { first = a || b || c || d; second = a || b; }", { complexity: 1 });
+    expect(reported(before, after)).toEqual(["C#second(initializer)"]);
+  });
+
+  test("reports field growth below a larger initializer's baseline", () => {
+    const before = measure("class C { first = a || b || c || d; second = a || b; }", { complexity: 1 });
+    const after = measure("class C { first = a || b || c || d; second = a || b || c; }", { complexity: 1 });
+    expect(reported(before, after)).toEqual(["C#second(initializer)"]);
+  });
+
+  test("reports static block growth masked by a larger shrinking block", () => {
+    const before = measure("class C { static { a || b || c || d; } static { a || b; } }", { complexity: 1 });
+    const after = measure("class C { static { a || b || c; } static { a || b || c; } }", { complexity: 1 });
+    expect(reported(before, after)).toHaveLength(2);
+  });
+
+  test("keeps static block identities across pure reorder", () => {
+    const before = measure("class C { static { a || b || c; } static { x || y; } }", { complexity: 1 });
+    const after = measure("class C { static { x || y; } static { a || b || c; } }", { complexity: 1 });
+    expect(entities(before, "complexity")).toHaveLength(2);
+    expect(reported(before, after)).toEqual([]);
+  });
+
+  test("keeps computed-key functions outside the field initializer scope", () => {
+    const source = "class C { [(() => a || b)()] = c || d; }";
+    expect(entities(measure(source, { complexity: 1 }), "complexity")).toEqual([
+      "C>[anonymous]", "C#(computed)(initializer)",
+    ]);
+  });
+
+  test("attributes depth inside a field function to that function", () => {
+    const source = `class C {
+      fn = () => {
+        if (a) {
+          if (b) { run() }
+        }
+      }
+    }`;
+    expect(entities(measure(source, { "max-depth": 1 }), "max-depth")).toEqual([
+      "C#fn(initializer)>(function)~if (b) { run() }",
+    ]);
+  });
+
   test("names class methods, statics and accessors by their member", () => {
     const source = `
       class Editor {

--- a/lib/js_complexity/__tests__/measure.test.js
+++ b/lib/js_complexity/__tests__/measure.test.js
@@ -331,6 +331,34 @@ ${calls}
     expect(reported(wrapping(WRAPPED, ONE_LINE), wrapping(`${WRAPPED}\n`, ONE_LINE))).toEqual([]);
   });
 
+  // "Line break" has to mean what ESLint means by it. It splits lines on
+  // `\r\n`, `\r`, U+2028 and U+2029 as well as `\n`, so all of them are lines
+  // that `max-lines-per-function` counts. Treating U+2028 as ordinary
+  // whitespace collapsed two callbacks measuring 5 and 4 onto one anchor.
+  const SEPARATED = "          const t = `aaa\u2028bbb`";
+
+  test("separates twins that differ by a Unicode line separator", () => {
+    const keys = Object.keys(wrapping(SEPARATED, ONE_LINE)).map((key) => key.split(" | ")[2]);
+
+    expect(new Set(keys).size).toBe(2);
+    for (const key of keys) expect(key).not.toMatch(/\(\d+\/\d+\)$/);
+  });
+
+  test("says nothing when twins differing by a Unicode line separator are reordered", () => {
+    expect(reported(wrapping(SEPARATED, ONE_LINE), wrapping(ONE_LINE, SEPARATED))).toEqual([]);
+  });
+
+  // The stability side of the same rule: a line ending is not something a rule
+  // can measure, so rewriting the file CRLF must leave every key alone.
+  test("keeps a twin's key when line endings change to CRLF", () => {
+    const crlf = (text) => text.replace(/\n/g, "\r\n");
+
+    expect(reported(
+      wrapping(WRAPPED, ONE_LINE),
+      wrapping(crlf(WRAPPED), crlf(ONE_LINE)),
+    )).toEqual([]);
+  });
+
   // Statements that share a source line are the same problem in the max-depth
   // fallback, and go through the same `discriminate` the definitions above do:
   // two `if (x) {` lines with different bodies are two keys, so neither can be

--- a/lib/js_complexity/__tests__/measure.test.js
+++ b/lib/js_complexity/__tests__/measure.test.js
@@ -1,4 +1,5 @@
 import { Linter } from "eslint";
+import { jest } from "@jest/globals";
 
 import { eslintConfig, foldMessages, parseBudget, RULES } from "../measure.js";
 
@@ -279,6 +280,27 @@ ${calls}
     const after = collidingTwins(COLLIDING.small, COLLIDING.big);
 
     expect(reported(before, after)).toEqual([]);
+  });
+
+  test("refuses to measure distinct twins when every digest width collides", () => {
+    // Force every FNV word to zero, exercising exhaustion without relying on
+    // finding a 96-bit collision. The real measurement must fail closed.
+    const multiply = jest.spyOn(Math, "imul").mockReturnValue(0);
+    try {
+      expect(() => collidingTwins(COLLIDING.big, COLLIDING.small))
+        .toThrow("Cannot distinguish complexity entities: [items.map]");
+    } finally {
+      multiply.mockRestore();
+    }
+  });
+
+  test("still measures identical twins when every digest width collides", () => {
+    const multiply = jest.spyOn(Math, "imul").mockReturnValue(0);
+    try {
+      expect(Object.keys(collidingTwins(COLLIDING.big, COLLIDING.big))).toHaveLength(2);
+    } finally {
+      multiply.mockRestore();
+    }
   });
 
   // The digest normalises whitespace so that reindenting does not move a key.

--- a/lib/js_complexity/entity_map.js
+++ b/lib/js_complexity/entity_map.js
@@ -163,6 +163,55 @@ function byRange(left, right) {
   return left.range[0] - right.range[0] || left.range[1] - right.range[1];
 }
 
+// The functions max-nested-callbacks counts. It pushes a function whose PARENT
+// is a call — that is its whole definition of "callback" — and reports the
+// stack's height.
+const CALLBACK_TYPES = new Set(["ArrowFunctionExpression", "FunctionExpression"]);
+
+// The callback-nesting height ESLint would report for every function, mirrored
+// from that rule for the same reason `depthsOf` mirrors max-depth: it is the
+// second measurement here that is not a property of the entity's own text, so a
+// twin's anchor has to carry it or two twins can share an anchor while
+// measuring differently.
+//
+// It was tempting to argue this one away — twins sit in one scope by
+// construction, so surely they nest identically. They do not, because the rule
+// pops on EVERY function exit while pushing only for callbacks. A function
+// expression that is not a callback therefore pops a level it never added, and
+// everything after it in the scope counts one lower:
+//
+//   a(function () {
+//     items.map((row) => { ... })            // 2
+//     const helper = function () { ... }      // pops without having pushed
+//     items.map((row) => { ... })            // 1  — same name, same source
+//   })
+//
+// Byte-identical and same-named, those two shared an anchor and took an
+// ordinal, each compared against the other's baseline. As with `depthsOf` the
+// quirk is reproduced rather than corrected: the key has to match the number
+// ESLint printed. FunctionDeclaration is deliberately absent — the rule does
+// not handle it, so it neither pushes nor pops.
+function callbackDepthsOf(ast) {
+  const depths = new Map();
+  let height = 0;
+
+  const visit = (node, parent) => {
+    const callback = CALLBACK_TYPES.has(node.type);
+    if (callback) {
+      if (parent?.type === "CallExpression") height++;
+      depths.set(node, height);
+    }
+
+    for (const child of [ ...childNodes(node) ].sort(byRange)) visit(child, node);
+
+    // `Array#pop` on an empty stack is a no-op, so the height floors at zero.
+    if (callback) height = Math.max(0, height - 1);
+  };
+
+  visit(ast, null);
+  return depths;
+}
+
 // `parent` is a back-reference ESLint adds while traversing; following it would
 // loop forever. `loc` and `range` hold no nodes, and skipping them keeps the
 // walk off every position object in the file.
@@ -183,6 +232,9 @@ class Scope {
     // known once the walk is finished.
     this.name = null;
     this.anchor = null;
+    // Set for function scopes by the walk; classes and the root never carry a
+    // callback height because no rule reports one on them.
+    this.callbackDepth = 0;
     this.keyed = false;
   }
 
@@ -215,6 +267,7 @@ export class EntityMap {
     this.source = source;
     this.scopes = [];
     this.depths = depthsOf(ast);
+    this.callbackDepths = callbackDepthsOf(ast);
     this.walk(ast, null, null, this.root);
     nameChildren(this.root, source);
   }
@@ -267,6 +320,7 @@ export class EntityMap {
     if (segment !== null) {
       const owner = rangeOwner(node, parent);
       scope = new Scope(segment, owner.loc, owner.range);
+      scope.callbackDepth = this.callbackDepths.get(node) ?? 0;
       enclosing.children.push(scope);
       this.scopes.push(scope);
     } else if (this.depths.has(node)) {
@@ -289,7 +343,7 @@ export class EntityMap {
 // ordinal read off a non-source order would move when nothing moved.
 function nameChildren(scope, source) {
   for (const [ segment, group ] of groupBy(scope.children, (child) => child.segment)) {
-    for (const [ , twins ] of discriminate(group, segment, (child) => sourceOf(source, child))) {
+    for (const [ , twins ] of discriminate(group, segment, (child) => definitionBody(source, child))) {
       twins.forEach((child, index) => {
         child.name = join(scope.name, ordinal(child.anchor, index, twins.length));
         nameChildren(child, source);
@@ -390,6 +444,14 @@ function normalise(text) {
 
 function sourceOf(source, node) {
   return normalise(source.slice(node.range[0], node.range[1]));
+}
+
+// A definition carries its CALLBACK-NESTING HEIGHT as well as its source, for
+// the same reason a statement carries its depth: `max-nested-callbacks` does
+// not measure what the function says, and two byte-identical same-named
+// callbacks in one scope can measure differently. See `callbackDepthsOf`.
+function definitionBody(source, scope) {
+  return `${scope.callbackDepth}\n${sourceOf(source, scope)}`;
 }
 
 // A statement carries its NESTING DEPTH as well as its source, because unlike

--- a/lib/js_complexity/entity_map.js
+++ b/lib/js_complexity/entity_map.js
@@ -191,25 +191,30 @@ export class EntityMap {
   // also built in tests straight from a parse. The grandparent comes along
   // because an anonymous callback's best name is usually one level further
   // out than its call — see `anonymousName`.
-  walk(node, parent, grandparent, enclosing) {
+  walk(node, parent, grandparent, enclosing, depth = 0) {
     const segment = segmentFor(node, parent, grandparent);
     let scope = enclosing;
+    let nesting = depth;
 
     if (segment !== null) {
       const owner = rangeOwner(node, parent);
       scope = new Scope(segment, owner.loc, owner.range);
       enclosing.children.push(scope);
       this.scopes.push(scope);
+      // max-depth counts nesting within a function, so each one starts over.
+      nesting = 0;
     } else if (NESTING_STATEMENT_TYPES.has(node.type)) {
+      nesting = depth + 1;
       enclosing.statements.push({
         line: node.loc.start.line,
         column: node.loc.start.column,
         range: node.range,
+        depth: nesting,
         text: normaliseLine(this.lines[node.loc.start.line - 1] ?? ""),
       });
     }
 
-    for (const child of childNodes(node)) this.walk(child, node, parent, scope);
+    for (const child of childNodes(node)) this.walk(child, node, parent, scope, nesting);
   }
 }
 
@@ -219,7 +224,7 @@ export class EntityMap {
 // ordinal read off a non-source order would move when nothing moved.
 function nameChildren(scope, source) {
   for (const [ segment, group ] of groupBy(scope.children, (child) => child.segment)) {
-    for (const [ , twins ] of discriminate(group, segment, source)) {
+    for (const [ , twins ] of discriminate(group, segment, (child) => sourceOf(source, child))) {
       twins.forEach((child, index) => {
         child.name = join(scope.name, ordinal(child.anchor, index, twins.length));
         nameChildren(child, source);
@@ -240,13 +245,13 @@ function nameChildren(scope, source) {
 // word at a time until distinct bodies have distinct anchors. The first width
 // is a plain FNV-1a, so a group that does not actually collide keeps exactly
 // the key it would have had.
-function discriminate(group, name, source) {
+function discriminate(group, name, bodyOf) {
   if (group.length < 2) {
     if (group.length === 1) group[0].anchor = name;
     return groupBy(group, () => name);
   }
 
-  for (const member of group) member.body = normalise(source.slice(member.range[0], member.range[1]));
+  for (const member of group) member.body = bodyOf(member);
 
   let groups;
   for (const width of DIGEST_WIDTHS) {
@@ -318,6 +323,27 @@ function normalise(text) {
   return text.replace(BREAK_RUN, "\n").replace(HORIZONTAL_RUN, " ");
 }
 
+function sourceOf(source, node) {
+  return normalise(source.slice(node.range[0], node.range[1]));
+}
+
+// A statement carries its NESTING DEPTH as well as its source, because unlike
+// every other measurement here, `max-depth`'s is not a property of the entity's
+// own text: two byte-identical `if (a) { y() }` statements in one function sit
+// at different depths if one of them is inside another guard, and measure
+// differently. Sharing an anchor, they fell back on the ordinal, which is the
+// slot identity the anchor exists to replace — a reorder then reported offenses
+// that had not happened, and a restructure that genuinely deepened one of them
+// left both their keys unchanged.
+//
+// The number only has to CHANGE when ESLint's depth changes, not to equal it,
+// so it counts enclosing nesting statements and does not model the exceptions
+// ESLint makes (an `else if` chain does not count twice for ESLint; here it
+// does). Over-counting keeps entities apart, which is the property wanted.
+function statementBody(source, statement) {
+  return `${statement.depth}\n${sourceOf(source, statement)}`;
+}
+
 // "Newline" has to mean what ESLint means by it, not `\n`: it splits a file on
 // `\r\n`, `\r`, `\u2028` and `\u2029` too, so all of them are countable lines to
 // `max-lines-per-function`. Treating U+2028 as horizontal whitespace collapsed
@@ -347,7 +373,7 @@ function keyStatements(scope, source) {
   scope.keyed = true;
 
   for (const [ text, group ] of groupBy(scope.statements, (statement) => statement.text)) {
-    for (const [ , twins ] of discriminate(group, text, source)) {
+    for (const [ , twins ] of discriminate(group, text, (statement) => statementBody(source, statement))) {
       twins.forEach((statement, index) => {
         statement.key = ordinal(statement.anchor, index, twins.length);
       });

--- a/lib/js_complexity/entity_map.js
+++ b/lib/js_complexity/entity_map.js
@@ -227,6 +227,7 @@ class Scope {
     this.end = loc.end;
     this.children = [];
     this.statements = [];
+    this.level = 0;
     // Filled in by the naming pass, which runs after the whole tree is known:
     // a scope's key depends on how many twins it has, and the last twin is only
     // known once the walk is finished.
@@ -249,6 +250,10 @@ class Scope {
   // nested". Comparing widths instead would need the source to convert a
   // line/column span into a length.
   innerThan(other) {
+    // A field function includes its member key for ESLint's function-head
+    // location, so its range can contain its own initializer parent's range.
+    // Prefer lexical nesting before comparing these overlapping locations.
+    if (this.level !== other.level) return this.level > other.level;
     if (this.start.line !== other.start.line) return this.start.line > other.start.line;
     if (this.start.column !== other.start.column) return this.start.column > other.start.column;
     if (this.end.line !== other.end.line) return this.end.line < other.end.line;
@@ -275,7 +280,16 @@ export class EntityMap {
   // Fully-qualified name of the innermost class or function containing the
   // offense, or null when the offense sits at file scope.
   nameAt(line, column) {
-    return this.enclosing(line, column - 1).name;
+    return this.enclosing(line, column - 1, (scope) => !scope.implicitKind).name;
+  }
+
+  // A field initializer may start at exactly the same position as the
+  // function or class it creates. Select ESLint's code-path kind explicitly
+  // rather than letting containment merge their independent measurements.
+  implicitNameAt(line, column, kind) {
+    const scope = this.enclosing(line, column - 1, (candidate) => candidate.implicitKind === kind);
+    if (scope === this.root) throw new Error(`Cannot locate ${kind} complexity entity at ${line}:${column}`);
+    return scope.name;
   }
 
   // Name for an offense that does not sit on a definition. Twins inside one
@@ -299,9 +313,10 @@ export class EntityMap {
 
   // ESLint message columns are 1-based; node columns are 0-based. Callers pass
   // the message column, so this takes the converted one.
-  enclosing(line, column) {
+  enclosing(line, column, accepts = () => true) {
     let best = this.root;
     for (const scope of this.scopes) {
+      if (!accepts(scope)) continue;
       if (!scope.contains(line, column)) continue;
       if (best === this.root || scope.innerThan(best)) best = scope;
     }
@@ -314,12 +329,24 @@ export class EntityMap {
   // because an anonymous callback's best name is usually one level further
   // out than its call — see `anonymousName`.
   walk(node, parent, grandparent, enclosing) {
+    // Only the value is an implicit code path. A computed field key executes
+    // in the enclosing context and must not be absorbed into this scope.
+    if (parent?.type === "PropertyDefinition" && parent.value === node) {
+      const initializer = new Scope(`${parent.static ? "." : "#"}${memberName(parent)}(initializer)`, node.loc, node.range);
+      initializer.implicitKind = "class-field-initializer";
+      initializer.level = enclosing.level + 1;
+      enclosing.children.push(initializer);
+      this.scopes.push(initializer);
+      enclosing = initializer;
+    }
     const segment = segmentFor(node, parent, grandparent);
     let scope = enclosing;
 
     if (segment !== null) {
       const owner = rangeOwner(node, parent);
       scope = new Scope(segment, owner.loc, owner.range);
+      scope.level = enclosing.level + 1;
+      if (node.type === "StaticBlock") scope.implicitKind = "class-static-block";
       scope.callbackDepth = this.callbackDepths.get(node) ?? 0;
       enclosing.children.push(scope);
       this.scopes.push(scope);
@@ -544,6 +571,7 @@ function isMember(node, parent) {
 
 function segmentFor(node, parent, grandparent) {
   if (CLASS_TYPES.has(node.type)) return className(node, parent);
+  if (node.type === "StaticBlock") return ".(static block)";
   if (!FUNCTION_TYPES.has(node.type)) return null;
 
   return functionName(node, parent, grandparent);
@@ -554,7 +582,8 @@ function className(node, parent) {
 }
 
 function functionName(node, parent, grandparent) {
-  if (parent?.type === "MethodDefinition" || parent?.type === "PropertyDefinition") {
+  if (parent?.type === "PropertyDefinition") return "(function)";
+  if (parent?.type === "MethodDefinition") {
     // `get x()` and `set x()` share a name; without the kind they would collide
     // into a twin pair that reads as two unrelated members.
     const kind = parent.kind === "get" || parent.kind === "set" ? `${parent.kind} ` : "";

--- a/lib/js_complexity/entity_map.js
+++ b/lib/js_complexity/entity_map.js
@@ -53,7 +53,11 @@
 // its measurement changes its key, so growth surfaces as new debt instead of
 // slipping into a neighbour's baseline. Only byte-identical twins still need an
 // ordinal, and those measure identically, so any permutation of them is a
-// no-op.
+// no-op. "Byte-identical" is meant literally: twins are grouped by their source
+// text and not by the digest of it, because one 32-bit FNV word collides often
+// enough to find a pair by brute force in seconds, and a collision would put
+// two different entities back on one ordinal. The digest widens a word at a
+// time until it separates them.
 //
 // The digest is spelled out only when a name is shared, so keys stay readable
 // and an ordinary entity does not carry a hash it has no use for. That leaves
@@ -227,14 +231,38 @@ function nameChildren(scope, source) {
 // Splits a group that shares a name into subgroups that do not, by anchoring
 // each member to a digest of its own source. A lone member keeps the clean
 // name. See the TWINS note in the header for why anchoring beats counting.
+//
+// The subgroups are the distinct BODIES, not the distinct digests. One 32-bit
+// FNV word is small enough that two different bodies really do collide — a
+// brute-force search finds a pair of plausible callbacks in seconds — and two
+// members that share an anchor go on to be told apart by `ordinal`, which is
+// the slot identity the anchor exists to replace. So the digest is widened a
+// word at a time until distinct bodies have distinct anchors. The first width
+// is a plain FNV-1a, so a group that does not actually collide keeps exactly
+// the key it would have had.
 function discriminate(group, name, source) {
   if (group.length < 2) {
     if (group.length === 1) group[0].anchor = name;
     return groupBy(group, () => name);
   }
 
-  for (const member of group) member.anchor = `${name}#${digest(source, member.range)}`;
-  return groupBy(group, (member) => member.anchor);
+  for (const member of group) member.body = normalise(source.slice(member.range[0], member.range[1]));
+
+  let groups;
+  for (const width of DIGEST_WIDTHS) {
+    for (const member of group) member.anchor = `${name}#${digest(member.body, width)}`;
+    groups = groupBy(group, (member) => member.anchor);
+    if (separated(groups)) break;
+  }
+  return groups;
+}
+
+// Whether every anchor group holds one body — the property that makes the
+// ordinal below safe. Three words is 96 bits; a pair of bodies that collides
+// under all three is not something to carry more machinery for, and lands back
+// on the ordinal, which is where every twin used to be.
+function separated(groups) {
+  return [ ...groups.values() ].every((group) => group.every((member) => member.body === group[0].body));
 }
 
 // Members that are still indistinguishable after anchoring are byte-identical,
@@ -244,18 +272,51 @@ function ordinal(anchor, index, size) {
   return size === 1 ? anchor : `${anchor}(${index + 1}/${size})`;
 }
 
-// FNV-1a over the entity's source with runs of whitespace collapsed, so
-// reindenting does not move a key but editing does. Written out rather than
-// taken from node:crypto because this has to produce the same digest on both
-// sides of the ratchet and on every Node version that runs it.
-function digest(source, range) {
-  const text = source.slice(range[0], range[1]).replace(/\s+/g, " ");
-  let hash = 0x811c9dc5;
-  for (let index = 0; index < text.length; index += 1) {
-    hash ^= text.charCodeAt(index);
-    hash = Math.imul(hash, 0x01000193) >>> 0;
+const DIGEST_WIDTHS = [ 1, 2, 3 ];
+
+// `width` FNV-1a runs over the entity's normalised source, each under its own
+// offset basis, concatenated. Written out rather than taken from node:crypto
+// because this has to produce the same digest on both sides of the ratchet and
+// on every Node version that runs it — and because the widths have to nest, so
+// that widening a colliding group cannot disturb one that does not collide.
+function digest(text, width) {
+  let out = "";
+  for (let word = 0; word < width; word += 1) {
+    let hash = (0x811c9dc5 ^ Math.imul(word, 0x9e3779b9)) >>> 0;
+    for (let index = 0; index < text.length; index += 1) {
+      hash ^= text.charCodeAt(index);
+      hash = Math.imul(hash, 0x01000193) >>> 0;
+    }
+    out += hash.toString(16).padStart(8, "0");
   }
-  return hash.toString(16).padStart(8, "0");
+  return out;
+}
+
+// Reindenting must not move a key, but anything the budget's rules can MEASURE
+// has to move it, or two entities that measure differently end up sharing an
+// anchor and fall back on a slot. So this collapses the whitespace the rules
+// cannot see and keeps the whitespace they can:
+//
+//   - horizontal whitespace never reaches a measurement, so runs of it collapse
+//     to one space and any of it around a newline goes away entirely. Reindent,
+//     retab, trailing spaces and CRLF all leave the digest alone.
+//   - a NEWLINE does reach one: `max-lines-per-function` counts lines. It is
+//     kept. Collapsing it was a real hole — two callbacks differing only in
+//     where a template literal's text wraps normalised to the same string while
+//     measuring 5 and 4, so they shared an anchor and a reorder compared each
+//     against the other's baseline.
+//   - runs of newlines collapse to one, because the rules run with
+//     `skipBlankLines`, so a blank line cannot change a measurement either.
+//
+// Comments are the one thing left that moves a digest without moving a
+// measurement (`skipComments` is on), so editing a comment inside an
+// over-budget twin re-keys it and reads as new debt. That is the loud
+// direction, and separating comments from their look-alikes inside strings
+// needs the token stream, which is a lot of machinery for a twin.
+function normalise(text) {
+  return text
+    .replace(/[^\S\n]*\n(?:[^\S\n]*\n)*[^\S\n]*/g, "\n")
+    .replace(/[^\S\n]+/g, " ");
 }
 
 function groupBy(items, key) {
@@ -417,7 +478,7 @@ function memberName(node) {
 }
 
 function normaliseLine(text) {
-  const collapsed = text.trim().replace(/\s+/g, " ");
+  const collapsed = normalise(text.trim());
   return collapsed.length > MAX_FALLBACK_TEXT
     ? `${collapsed.slice(0, MAX_FALLBACK_TEXT - 3)}...`
     : collapsed;

--- a/lib/js_complexity/entity_map.js
+++ b/lib/js_complexity/entity_map.js
@@ -372,19 +372,17 @@ function discriminate(group, name, bodyOf) {
 
   for (const member of group) member.body = bodyOf(member);
 
-  let groups;
   for (const width of DIGEST_WIDTHS) {
     for (const member of group) member.anchor = `${name}#${digest(member.body, width)}`;
-    groups = groupBy(group, (member) => member.anchor);
-    if (separated(groups)) break;
+    const groups = groupBy(group, (member) => member.anchor);
+    if (separated(groups)) return groups;
   }
-  return groups;
+  throw new Error(`Cannot distinguish complexity entities: ${name} (digest collision at every supported width)`);
 }
 
 // Whether every anchor group holds one body — the property that makes the
-// ordinal below safe. Three words is 96 bits; a pair of bodies that collides
-// under all three is not something to carry more machinery for, and lands back
-// on the ordinal, which is where every twin used to be.
+// ordinal below safe. If distinct bodies collide at all three widths, abort
+// measurement rather than compare different entities through positional keys.
 function separated(groups) {
   return [ ...groups.values() ].every((group) => group.every((member) => member.body === group[0].body));
 }

--- a/lib/js_complexity/entity_map.js
+++ b/lib/js_complexity/entity_map.js
@@ -300,11 +300,12 @@ function digest(text, width) {
 //   - horizontal whitespace never reaches a measurement, so runs of it collapse
 //     to one space and any of it around a newline goes away entirely. Reindent,
 //     retab, trailing spaces and CRLF all leave the digest alone.
-//   - a NEWLINE does reach one: `max-lines-per-function` counts lines. It is
+//   - a LINE BREAK does reach one: `max-lines-per-function` counts lines. It is
 //     kept. Collapsing it was a real hole — two callbacks differing only in
 //     where a template literal's text wraps normalised to the same string while
 //     measuring 5 and 4, so they shared an anchor and a reorder compared each
-//     against the other's baseline.
+//     against the other's baseline. A line break is everything ESLint splits
+//     lines on, U+2028 and U+2029 included, not just `\n`.
 //   - runs of newlines collapse to one, because the rules run with
 //     `skipBlankLines`, so a blank line cannot change a measurement either.
 //
@@ -314,10 +315,18 @@ function digest(text, width) {
 // direction, and separating comments from their look-alikes inside strings
 // needs the token stream, which is a lot of machinery for a twin.
 function normalise(text) {
-  return text
-    .replace(/[^\S\n]*\n(?:[^\S\n]*\n)*[^\S\n]*/g, "\n")
-    .replace(/[^\S\n]+/g, " ");
+  return text.replace(BREAK_RUN, "\n").replace(HORIZONTAL_RUN, " ");
 }
+
+// "Newline" has to mean what ESLint means by it, not `\n`: it splits a file on
+// `\r\n`, `\r`, `\u2028` and `\u2029` too, so all of them are countable lines to
+// `max-lines-per-function`. Treating U+2028 as horizontal whitespace collapsed
+// two callbacks that measured 5 and 4 onto one anchor. `\v` and `\f` are NOT in
+// ESLint's set, so they stay horizontal.
+const LINE_BREAK = String.raw`\r\n|[\n\r\u2028\u2029]`;
+const HORIZONTAL = String.raw`[^\S\n\r\u2028\u2029]`;
+const BREAK_RUN = new RegExp(`${HORIZONTAL}*(?:${LINE_BREAK})(?:${HORIZONTAL}*(?:${LINE_BREAK}))*${HORIZONTAL}*`, "gu");
+const HORIZONTAL_RUN = new RegExp(`${HORIZONTAL}+`, "gu");
 
 function groupBy(items, key) {
   const groups = new Map();

--- a/lib/js_complexity/entity_map.js
+++ b/lib/js_complexity/entity_map.js
@@ -14,8 +14,11 @@
 //   TopicsController.observed                   static class member
 //   CommentForm#submit>[this.el.addEventListener]  anonymous callback, named by
 //                                                  the call it is passed to
+//   Toolbar>handleFiles[useCallback]            callback named by its binding
+//   save>[load().then().then]                   callback named by its chain
 //   parseDraft>normalise                        function nested in a function
 //   CommentForm#submit~if (a) {                 statement fallback (see below)
+//   Row#connect>[items.map]#2842ca41            twin, anchored to its own source
 //
 // Lookup is by CONTAINMENT, not by start position, because ESLint does not
 // report an offense at the node it is about: `getFunctionHeadLoc` puts a method
@@ -32,17 +35,31 @@
 // Metrics/BlockNesting.
 //
 // TWINS. Two entities in one scope can still end up with the same name: two
-// `items.map(...)` callbacks in one method, or two identical `if` lines. A
-// plain ordinal — first one bare, second one `(2)` — is NOT enough, because the
-// bare name is inherited: delete the first twin and the survivor is renamed
-// onto the deleted twin's key, so its growth is compared against a measurement
-// that was never its own. Instead every member of a group of twins carries its
-// position AND the group's size, `(2/3)`. Adding or removing a twin changes the
-// size, which changes every key in the group at once, and the ratchet reports
-// the survivors as new debt rather than silently comparing them against
-// somebody else's baseline. Reordering twins likewise moves a larger value into
-// a smaller slot, which reports as growth. The gate stays loud in both cases;
-// what it must never do is stay quiet. See docs/complexity_budget.md.
+// `items.map(...)` callbacks in one method, or two identical `if` lines. Any
+// scheme that separates them BY POSITION — `(2)`, or `(2/3)` — makes a slot the
+// identity, and a slot is not an identity: the entity in slot 2 after an edit
+// need not be the entity that was in slot 2 before it, so its measurement is
+// compared against somebody else's baseline. Deleting a twin and reordering
+// twins are both ways to reach that, and the second can conceal real growth —
+// baselines 12 and 6 against a reordered 9 and 5 read `9 <= 12` and `5 <= 6`
+// and say nothing, while the 6-line callback has in fact grown to 9.
+//
+// So the first move is to have fewer twins: a callback takes the WHOLE callee
+// including any chain (`[load().then().then]`) and the binding its call sits in
+// (`handleFiles[useCallback]`), which is enough to name all but a handful.
+// What is left is anchored to a digest of its own source — `[items.map]#2842ca41`
+// — so a twin's key depends on the twin and on nothing around it. Siblings can
+// be added, deleted or reordered without touching it, and an edit that changes
+// its measurement changes its key, so growth surfaces as new debt instead of
+// slipping into a neighbour's baseline. Only byte-identical twins still need an
+// ordinal, and those measure identically, so any permutation of them is a
+// no-op.
+//
+// The digest is spelled out only when a name is shared, so keys stay readable
+// and an ordinary entity does not carry a hash it has no use for. That leaves
+// one seam: going from one such entity to two, or back, renames it. That
+// direction is safe — the gate is loud about a change it cannot attribute,
+// never quiet about growth. See docs/complexity_budget.md.
 
 const FUNCTION_TYPES = new Set([
   "FunctionDeclaration",
@@ -82,8 +99,9 @@ const SKIPPED_KEYS = new Set(["parent", "loc", "range"]);
 const MAX_FALLBACK_TEXT = 100;
 
 class Scope {
-  constructor(segment, loc) {
+  constructor(segment, loc, range) {
     this.segment = segment;
+    this.range = range;
     this.start = loc.start;
     this.end = loc.end;
     this.children = [];
@@ -92,7 +110,8 @@ class Scope {
     // a scope's key depends on how many twins it has, and the last twin is only
     // known once the walk is finished.
     this.name = null;
-    this.groups = null;
+    this.anchor = null;
+    this.keyed = false;
   }
 
   contains(line, column) {
@@ -120,10 +139,11 @@ export class EntityMap {
 
   constructor(ast, source) {
     this.lines = source.split("\n");
-    this.root = new Scope(null, ast.loc);
+    this.root = new Scope(null, ast.loc, ast.range);
+    this.source = source;
     this.scopes = [];
-    this.walk(ast, null, this.root);
-    nameChildren(this.root);
+    this.walk(ast, null, null, this.root);
+    nameChildren(this.root, source);
   }
 
   // Fully-qualified name of the innermost class or function containing the
@@ -138,18 +158,17 @@ export class EntityMap {
   // one key, and neither may inherit the other's.
   fallbackAt(line, column) {
     const scope = this.enclosing(line, column - 1);
-    const text = normaliseLine(this.lines[line - 1] ?? "");
-    const base = `${scope.name ?? ""}~${text}`;
+    keyStatements(scope, this.source);
 
-    const twins = statementGroup(scope, text);
-    if (twins.length < 2) return base;
+    // Columns are 0-based on nodes and 1-based in messages.
+    const statement = scope.statements.find((candidate) => candidate.line === line && candidate.column === column - 1)
+      ?? scope.statements.find((candidate) => candidate.line === line);
 
-    // Columns are 0-based on nodes and 1-based in messages. An offense that
-    // matches no recorded statement — a rule reporting somewhere this walk does
-    // not model — keeps the unqualified name rather than guessing a position.
-    const index = twins.findIndex((statement) => statement.line === line && statement.column === column - 1);
-    const position = index === -1 ? twins.findIndex((statement) => statement.line === line) : index;
-    return position === -1 ? base : `${base}(${position + 1}/${twins.length})`;
+    // An offense that matches no recorded statement — a rule reporting
+    // somewhere this walk does not model — keeps the unqualified name rather
+    // than guessing which statement it belongs to.
+    const text = statement?.key ?? normaliseLine(this.lines[line - 1] ?? "");
+    return `${scope.name ?? ""}~${text}`;
   }
 
   // ESLint message columns are 1-based; node columns are 0-based. Callers pass
@@ -165,24 +184,28 @@ export class EntityMap {
 
   // `parent` is threaded explicitly rather than read from `node.parent`:
   // ESLint only sets that back-reference while it traverses, and this map is
-  // also built in tests straight from a parse.
-  walk(node, parent, enclosing) {
-    const segment = segmentFor(node, parent);
+  // also built in tests straight from a parse. The grandparent comes along
+  // because an anonymous callback's best name is usually one level further
+  // out than its call — see `anonymousName`.
+  walk(node, parent, grandparent, enclosing) {
+    const segment = segmentFor(node, parent, grandparent);
     let scope = enclosing;
 
     if (segment !== null) {
-      scope = new Scope(segment, rangeOwner(node, parent).loc);
+      const owner = rangeOwner(node, parent);
+      scope = new Scope(segment, owner.loc, owner.range);
       enclosing.children.push(scope);
       this.scopes.push(scope);
     } else if (NESTING_STATEMENT_TYPES.has(node.type)) {
       enclosing.statements.push({
         line: node.loc.start.line,
         column: node.loc.start.column,
+        range: node.range,
         text: normaliseLine(this.lines[node.loc.start.line - 1] ?? ""),
       });
     }
 
-    for (const child of childNodes(node)) this.walk(child, node, scope);
+    for (const child of childNodes(node)) this.walk(child, node, parent, scope);
   }
 }
 
@@ -190,40 +213,76 @@ export class EntityMap {
 // than taken from the walk: `childNodes` follows object keys, and a class's
 // `superClass` is visited before its `body` whatever the source says. An
 // ordinal read off a non-source order would move when nothing moved.
-function nameChildren(scope) {
-  const groups = new Map();
-  for (const child of [ ...scope.children ].sort(byPosition)) {
-    const group = groups.get(child.segment);
-    if (group) group.push(child);
-    else groups.set(child.segment, [ child ]);
-  }
-
-  for (const [ segment, twins ] of groups) {
-    twins.forEach((child, index) => {
-      child.name = join(scope.name, qualify(segment, index, twins.length));
-      nameChildren(child);
-    });
-  }
-}
-
-// A lone entity keeps a clean key. Twins carry `(position/size)` — see the
-// header: the size is what stops a survivor from inheriting a deleted twin's
-// key, and the position is what stops twins from collapsing into one.
-function qualify(segment, index, size) {
-  return size === 1 ? segment : `${segment}(${index + 1}/${size})`;
-}
-
-function statementGroup(scope, text) {
-  if (scope.groups === null) {
-    scope.groups = new Map();
-    for (const statement of [ ...scope.statements ].sort(byPosition)) {
-      const group = scope.groups.get(statement.text);
-      if (group) group.push(statement);
-      else scope.groups.set(statement.text, [ statement ]);
+function nameChildren(scope, source) {
+  for (const [ segment, group ] of groupBy(scope.children, (child) => child.segment)) {
+    for (const [ , twins ] of discriminate(group, segment, source)) {
+      twins.forEach((child, index) => {
+        child.name = join(scope.name, ordinal(child.anchor, index, twins.length));
+        nameChildren(child, source);
+      });
     }
   }
+}
 
-  return scope.groups.get(text) ?? [];
+// Splits a group that shares a name into subgroups that do not, by anchoring
+// each member to a digest of its own source. A lone member keeps the clean
+// name. See the TWINS note in the header for why anchoring beats counting.
+function discriminate(group, name, source) {
+  if (group.length < 2) {
+    if (group.length === 1) group[0].anchor = name;
+    return groupBy(group, () => name);
+  }
+
+  for (const member of group) member.anchor = `${name}#${digest(source, member.range)}`;
+  return groupBy(group, (member) => member.anchor);
+}
+
+// Members that are still indistinguishable after anchoring are byte-identical,
+// so they measure identically and any permutation of them is a no-op. A plain
+// ordinal separates them; nothing can hide behind it.
+function ordinal(anchor, index, size) {
+  return size === 1 ? anchor : `${anchor}(${index + 1}/${size})`;
+}
+
+// FNV-1a over the entity's source with runs of whitespace collapsed, so
+// reindenting does not move a key but editing does. Written out rather than
+// taken from node:crypto because this has to produce the same digest on both
+// sides of the ratchet and on every Node version that runs it.
+function digest(source, range) {
+  const text = source.slice(range[0], range[1]).replace(/\s+/g, " ");
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < text.length; index += 1) {
+    hash ^= text.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return hash.toString(16).padStart(8, "0");
+}
+
+function groupBy(items, key) {
+  const groups = new Map();
+  for (const item of [ ...items ].sort(byPosition)) {
+    const group = groups.get(key(item));
+    if (group) group.push(item);
+    else groups.set(key(item), [ item ]);
+  }
+  return groups;
+}
+
+// Gives every statement in a scope its final key, the same way nameChildren
+// does for nested definitions: statements sharing a source line are anchored to
+// a digest of their own body, and only byte-identical ones fall back on an
+// ordinal. Done once per scope, on first use.
+function keyStatements(scope, source) {
+  if (scope.keyed) return;
+  scope.keyed = true;
+
+  for (const [ text, group ] of groupBy(scope.statements, (statement) => statement.text)) {
+    for (const [ , twins ] of discriminate(group, text, source)) {
+      twins.forEach((statement, index) => {
+        statement.key = ordinal(statement.anchor, index, twins.length);
+      });
+    }
+  }
 }
 
 function byPosition(left, right) {
@@ -260,18 +319,18 @@ function isMember(node, parent) {
   return FUNCTION_TYPES.has(node.type) && parent !== null && MEMBER_TYPES.has(parent.type) && parent.value === node;
 }
 
-function segmentFor(node, parent) {
+function segmentFor(node, parent, grandparent) {
   if (CLASS_TYPES.has(node.type)) return className(node, parent);
   if (!FUNCTION_TYPES.has(node.type)) return null;
 
-  return functionName(node, parent);
+  return functionName(node, parent, grandparent);
 }
 
 function className(node, parent) {
   return node.id?.name ?? inferredName(parent) ?? "(anonymous class)";
 }
 
-function functionName(node, parent) {
+function functionName(node, parent, grandparent) {
   if (parent?.type === "MethodDefinition" || parent?.type === "PropertyDefinition") {
     // `get x()` and `set x()` share a name; without the kind they would collide
     // into a twin pair that reads as two unrelated members.
@@ -280,7 +339,7 @@ function functionName(node, parent) {
   }
   if (node.type === "FunctionDeclaration" && node.id?.name) return node.id.name;
 
-  return inferredName(parent) ?? anonymousName(parent);
+  return inferredName(parent) ?? anonymousName(parent, grandparent);
 }
 
 // `const submit = () => {}` and `{ submit: function () {} }` are named by what
@@ -305,6 +364,14 @@ function inferredName(parent) {
 function memberPath(node) {
   if (node.type === "Identifier") return node.name;
   if (node.type === "ThisExpression") return "this";
+  // A call in the middle of a chain is rendered but not descended into for its
+  // arguments: `load(a, b).then` is `load().then` whatever it was passed, so
+  // editing an argument does not move the key of a callback further down the
+  // chain.
+  if (node.type === "CallExpression") {
+    const callee = node.callee ? memberPath(node.callee) : null;
+    return callee ? `${callee}()` : null;
+  }
   if (node.type !== "MemberExpression") return null;
 
   const object = memberPath(node.object);
@@ -312,15 +379,32 @@ function memberPath(node) {
   return object ? `${object}.${property}` : property;
 }
 
-// An anonymous callback is identified by the call it is passed to. The WHOLE
-// callee is kept — `[this.element.addEventListener]`, `[rows.map]` — not just
-// its last segment: `[map]` alone makes twins out of every `.map` in a method,
-// and twins are the one case where identity has to fall back on position.
-function anonymousName(parent) {
+// An anonymous callback is identified by the call it is passed to, plus the
+// binding that call sits in when there is one. Both halves exist to keep the
+// callback OUT of a twin group, because a twin's identity has to fall back on
+// its position among its siblings and a position is not a stable identity —
+// see the TWINS note in the header.
+//
+// The whole callee is kept, not just its last segment: `[map]` alone makes
+// twins out of every `.map` in a method. A chained call renders its object as
+// `foo()`, so the two callbacks in `load().then(a).then(b)` read
+// `[load().then]` and `[load().then().then]` rather than one `[then]` pair —
+// and appending a third `.then` leaves both of them alone.
+//
+// The binding is what makes React components tractable. Every callback in a
+// component is `useCallback`, so a component with eleven of them had eleven
+// twins whose keys all moved the moment a twelfth was added. `const handleFiles
+// = useCallback(...)` is really named `handleFiles`, one level out from the
+// call, and that name survives its siblings.
+function anonymousName(parent, grandparent) {
   if (parent?.type !== "CallExpression" && parent?.type !== "NewExpression") return "[anonymous]";
 
   const callee = parent.callee ? memberPath(parent.callee) : null;
-  return callee ? `[${callee}]` : "[anonymous]";
+  const call = callee ? `[${callee}]` : "[anonymous]";
+  // A CallExpression can only sit in the positions inferredName reads from as
+  // the bound value, so no further check that the binding is really this call.
+  const binding = inferredName(grandparent);
+  return binding ? `${binding}${call}` : call;
 }
 
 function memberName(node) {

--- a/lib/js_complexity/entity_map.js
+++ b/lib/js_complexity/entity_map.js
@@ -10,11 +10,12 @@
 //
 // Names read as a path from the outermost scope inward:
 //
-//   TopicsController#connect                 class method
-//   TopicsController.observed                static class member
-//   CommentForm#submit>[addEventListener]    anonymous callback, named by its call
-//   parseDraft>normalise                     function nested in a function
-//   CommentForm#submit~if (a) {              statement fallback (see below)
+//   TopicsController#connect                    class method
+//   TopicsController.observed                   static class member
+//   CommentForm#submit>[this.el.addEventListener]  anonymous callback, named by
+//                                                  the call it is passed to
+//   parseDraft>normalise                        function nested in a function
+//   CommentForm#submit~if (a) {                 statement fallback (see below)
 //
 // Lookup is by CONTAINMENT, not by start position, because ESLint does not
 // report an offense at the node it is about: `getFunctionHeadLoc` puts a method
@@ -29,6 +30,19 @@
 // one in the budget — get the enclosing scope plus the normalised source line,
 // written with a leading `~`. That is the fallback shape the Ruby side uses for
 // Metrics/BlockNesting.
+//
+// TWINS. Two entities in one scope can still end up with the same name: two
+// `items.map(...)` callbacks in one method, or two identical `if` lines. A
+// plain ordinal — first one bare, second one `(2)` — is NOT enough, because the
+// bare name is inherited: delete the first twin and the survivor is renamed
+// onto the deleted twin's key, so its growth is compared against a measurement
+// that was never its own. Instead every member of a group of twins carries its
+// position AND the group's size, `(2/3)`. Adding or removing a twin changes the
+// size, which changes every key in the group at once, and the ratchet reports
+// the survivors as new debt rather than silently comparing them against
+// somebody else's baseline. Reordering twins likewise moves a larger value into
+// a smaller slot, which reports as growth. The gate stays loud in both cases;
+// what it must never do is stay quiet. See docs/complexity_budget.md.
 
 const FUNCTION_TYPES = new Set([
   "FunctionDeclaration",
@@ -43,6 +57,23 @@ const CLASS_TYPES = new Set(["ClassDeclaration", "ClassExpression"]);
 // containment still finds it.
 const MEMBER_TYPES = new Set(["MethodDefinition", "PropertyDefinition", "Property"]);
 
+// The statements max-depth reports on — ESLint counts a block as nested when it
+// hangs off one of these, and reports the offense at the statement's own start
+// position. Recording them while walking is what lets a `~source line` fallback
+// know how many twins it is one of, the same way the Ruby side records every
+// statement in a scope rather than only the offending ones.
+const NESTING_STATEMENT_TYPES = new Set([
+  "DoWhileStatement",
+  "ForInStatement",
+  "ForOfStatement",
+  "ForStatement",
+  "IfStatement",
+  "SwitchStatement",
+  "TryStatement",
+  "WhileStatement",
+  "WithStatement",
+]);
+
 // `parent` is a back-reference ESLint adds while traversing; following it would
 // loop forever. `loc` and `range` hold no nodes, and skipping them keeps the
 // walk off every position object in the file.
@@ -51,16 +82,17 @@ const SKIPPED_KEYS = new Set(["parent", "loc", "range"]);
 const MAX_FALLBACK_TEXT = 100;
 
 class Scope {
-  constructor(name, loc) {
-    this.name = name;
+  constructor(segment, loc) {
+    this.segment = segment;
     this.start = loc.start;
     this.end = loc.end;
-    // Sibling entities that share a name are numbered from the second on, so a
-    // second over-budget `[map]` callback in one method cannot hide behind the
-    // first. Counting happens per parent scope, so an edit elsewhere in the
-    // file leaves the ordinal alone.
-    this.children = new Map();
-    this.fallbacks = new Map();
+    this.children = [];
+    this.statements = [];
+    // Filled in by the naming pass, which runs after the whole tree is known:
+    // a scope's key depends on how many twins it has, and the last twin is only
+    // known once the walk is finished.
+    this.name = null;
+    this.groups = null;
   }
 
   contains(line, column) {
@@ -91,6 +123,7 @@ export class EntityMap {
     this.root = new Scope(null, ast.loc);
     this.scopes = [];
     this.walk(ast, null, this.root);
+    nameChildren(this.root);
   }
 
   // Fully-qualified name of the innermost class or function containing the
@@ -100,14 +133,23 @@ export class EntityMap {
   }
 
   // Name for an offense that does not sit on a definition. Twins inside one
-  // scope get an ordinal, so two identical `if` lines in the same method do not
-  // collapse into one key where only the larger would be recorded.
+  // scope carry their position and their group's size, for the reason the
+  // header gives: two identical `if` lines in one method must not collapse into
+  // one key, and neither may inherit the other's.
   fallbackAt(line, column) {
     const scope = this.enclosing(line, column - 1);
-    const base = `${scope.name ?? ""}~${normaliseLine(this.lines[line - 1] ?? "")}`;
-    const seen = (scope.fallbacks.get(base) ?? 0) + 1;
-    scope.fallbacks.set(base, seen);
-    return seen > 1 ? `${base}[fallback:${seen}]` : base;
+    const text = normaliseLine(this.lines[line - 1] ?? "");
+    const base = `${scope.name ?? ""}~${text}`;
+
+    const twins = statementGroup(scope, text);
+    if (twins.length < 2) return base;
+
+    // Columns are 0-based on nodes and 1-based in messages. An offense that
+    // matches no recorded statement — a rule reporting somewhere this walk does
+    // not model — keeps the unqualified name rather than guessing a position.
+    const index = twins.findIndex((statement) => statement.line === line && statement.column === column - 1);
+    const position = index === -1 ? twins.findIndex((statement) => statement.line === line) : index;
+    return position === -1 ? base : `${base}(${position + 1}/${twins.length})`;
   }
 
   // ESLint message columns are 1-based; node columns are 0-based. Callers pass
@@ -129,16 +171,65 @@ export class EntityMap {
     let scope = enclosing;
 
     if (segment !== null) {
-      const ordinal = (enclosing.children.get(segment) ?? 0) + 1;
-      enclosing.children.set(segment, ordinal);
-      const numbered = ordinal > 1 ? `${segment}(${ordinal})` : segment;
-
-      scope = new Scope(join(enclosing.name, numbered), rangeOwner(node, parent).loc);
+      scope = new Scope(segment, rangeOwner(node, parent).loc);
+      enclosing.children.push(scope);
       this.scopes.push(scope);
+    } else if (NESTING_STATEMENT_TYPES.has(node.type)) {
+      enclosing.statements.push({
+        line: node.loc.start.line,
+        column: node.loc.start.column,
+        text: normaliseLine(this.lines[node.loc.start.line - 1] ?? ""),
+      });
     }
 
     for (const child of childNodes(node)) this.walk(child, node, scope);
   }
+}
+
+// Names a scope's children, then theirs. Source order is imposed here rather
+// than taken from the walk: `childNodes` follows object keys, and a class's
+// `superClass` is visited before its `body` whatever the source says. An
+// ordinal read off a non-source order would move when nothing moved.
+function nameChildren(scope) {
+  const groups = new Map();
+  for (const child of [ ...scope.children ].sort(byPosition)) {
+    const group = groups.get(child.segment);
+    if (group) group.push(child);
+    else groups.set(child.segment, [ child ]);
+  }
+
+  for (const [ segment, twins ] of groups) {
+    twins.forEach((child, index) => {
+      child.name = join(scope.name, qualify(segment, index, twins.length));
+      nameChildren(child);
+    });
+  }
+}
+
+// A lone entity keeps a clean key. Twins carry `(position/size)` — see the
+// header: the size is what stops a survivor from inheriting a deleted twin's
+// key, and the position is what stops twins from collapsing into one.
+function qualify(segment, index, size) {
+  return size === 1 ? segment : `${segment}(${index + 1}/${size})`;
+}
+
+function statementGroup(scope, text) {
+  if (scope.groups === null) {
+    scope.groups = new Map();
+    for (const statement of [ ...scope.statements ].sort(byPosition)) {
+      const group = scope.groups.get(statement.text);
+      if (group) group.push(statement);
+      else scope.groups.set(statement.text, [ statement ]);
+    }
+  }
+
+  return scope.groups.get(text) ?? [];
+}
+
+function byPosition(left, right) {
+  const leftStart = left.start ?? left;
+  const rightStart = right.start ?? right;
+  return leftStart.line - rightStart.line || leftStart.column - rightStart.column;
 }
 
 function* childNodes(node) {
@@ -183,7 +274,7 @@ function className(node, parent) {
 function functionName(node, parent) {
   if (parent?.type === "MethodDefinition" || parent?.type === "PropertyDefinition") {
     // `get x()` and `set x()` share a name; without the kind they would collide
-    // into an ordinal pair that reads as two unrelated members.
+    // into a twin pair that reads as two unrelated members.
     const kind = parent.kind === "get" || parent.kind === "set" ? `${parent.kind} ` : "";
     return `${parent.static ? "." : "#"}${kind}${memberName(parent)}`;
   }
@@ -210,7 +301,7 @@ function inferredName(parent) {
 
 // `Editor.prototype.render = function () {}` keeps the whole chain: two classes
 // in one file both assigning `.render` would otherwise share a name, and the
-// ordinal that separated them would depend on which was written first.
+// position that separated them would depend on which was written first.
 function memberPath(node) {
   if (node.type === "Identifier") return node.name;
   if (node.type === "ThisExpression") return "this";
@@ -221,15 +312,15 @@ function memberPath(node) {
   return object ? `${object}.${property}` : property;
 }
 
-// An anonymous callback is identified by the call it is passed to —
-// `[addEventListener]`, `[map]` — which is how the Ruby side anchors blocks.
+// An anonymous callback is identified by the call it is passed to. The WHOLE
+// callee is kept — `[this.element.addEventListener]`, `[rows.map]` — not just
+// its last segment: `[map]` alone makes twins out of every `.map` in a method,
+// and twins are the one case where identity has to fall back on position.
 function anonymousName(parent) {
   if (parent?.type !== "CallExpression" && parent?.type !== "NewExpression") return "[anonymous]";
 
-  const callee = parent.callee;
-  if (callee?.type === "Identifier") return `[${callee.name}]`;
-  if (callee?.type === "MemberExpression") return `[${memberName(callee)}]`;
-  return "[anonymous]";
+  const callee = parent.callee ? memberPath(parent.callee) : null;
+  return callee ? `[${callee}]` : "[anonymous]";
 }
 
 function memberName(node) {

--- a/lib/js_complexity/entity_map.js
+++ b/lib/js_complexity/entity_map.js
@@ -236,14 +236,20 @@ class Scope {
     // Set for function scopes by the walk; classes and the root never carry a
     // callback height because no rule reports one on them.
     this.callbackDepth = 0;
+    // Function scopes may have a wider lookup range than their own node: ESLint
+    // reports a member function at the member key. Keep the lexical range too,
+    // so a function inside a computed key beats the widened value-function
+    // range that overlaps it.
+    this.functionLoc = null;
     this.keyed = false;
   }
 
   contains(line, column) {
-    if (line < this.start.line || line > this.end.line) return false;
-    if (line === this.start.line && column < this.start.column) return false;
-    if (line === this.end.line && column > this.end.column) return false;
-    return true;
+    return locationContains({ start: this.start, end: this.end }, line, column);
+  }
+
+  lexicallyContains(line, column) {
+    return this.functionLoc !== null && locationContains(this.functionLoc, line, column);
   }
 
   // Later start wins, and on a tie the earlier end: both mean "more deeply
@@ -314,10 +320,17 @@ export class EntityMap {
   // ESLint message columns are 1-based; node columns are 0-based. Callers pass
   // the message column, so this takes the converted one.
   enclosing(line, column, accepts = () => true) {
+    const candidates = this.scopes.filter((scope) => accepts(scope) && scope.contains(line, column));
+    const insideFunction = candidates.some((scope) => scope.lexicallyContains(line, column));
     let best = this.root;
-    for (const scope of this.scopes) {
-      if (!accepts(scope)) continue;
-      if (!scope.contains(line, column)) continue;
+    for (const scope of candidates) {
+      // A member function's lookup range includes its key because some ESLint
+      // offenses are reported there. For a computed field, that widened range
+      // also overlaps functions executed by the key. When the position is
+      // lexically inside a function, discard widened-only function matches;
+      // otherwise the field value function can absorb the key function merely
+      // because the initializer gives it a deeper synthetic level.
+      if (insideFunction && scope.functionLoc !== null && !scope.lexicallyContains(line, column)) continue;
       if (best === this.root || scope.innerThan(best)) best = scope;
     }
     return best;
@@ -347,6 +360,7 @@ export class EntityMap {
       scope = new Scope(segment, owner.loc, owner.range);
       scope.level = enclosing.level + 1;
       if (node.type === "StaticBlock") scope.implicitKind = "class-static-block";
+      if (FUNCTION_TYPES.has(node.type)) scope.functionLoc = node.loc;
       scope.callbackDepth = this.callbackDepths.get(node) ?? 0;
       enclosing.children.push(scope);
       this.scopes.push(scope);
@@ -362,6 +376,13 @@ export class EntityMap {
 
     for (const child of childNodes(node)) this.walk(child, node, parent, scope);
   }
+}
+
+function locationContains(loc, line, column) {
+  if (line < loc.start.line || line > loc.end.line) return false;
+  if (line === loc.start.line && column < loc.start.column) return false;
+  if (line === loc.end.line && column > loc.end.column) return false;
+  return true;
 }
 
 // Names a scope's children, then theirs. Source order is imposed here rather

--- a/lib/js_complexity/entity_map.js
+++ b/lib/js_complexity/entity_map.js
@@ -145,14 +145,14 @@ function* childNodes(node) {
   for (const [name, value] of Object.entries(node)) {
     if (SKIPPED_KEYS.has(name) || value === null || typeof value !== "object") continue;
 
-    if (Array.isArray(value)) {
-      for (const item of value) {
-        if (item && typeof item === "object" && typeof item.type === "string") yield item;
-      }
-    } else if (typeof value.type === "string") {
-      yield value;
+    for (const candidate of Array.isArray(value) ? value : [ value ]) {
+      if (isNode(candidate)) yield candidate;
     }
   }
+}
+
+function isNode(value) {
+  return value !== null && typeof value === "object" && typeof value.type === "string";
 }
 
 function join(prefix, segment) {

--- a/lib/js_complexity/entity_map.js
+++ b/lib/js_complexity/entity_map.js
@@ -1,0 +1,249 @@
+// Resolves an ESLint offense position to the fully-qualified name of the entity
+// it sits on.
+//
+// The complexity ratchet compares two measurements of the same tree taken at
+// different commits, so an entity has to keep its identity across ordinary
+// editing. A line number does not survive an insertion above it, and a bare
+// function name is not unique inside a file, so neither works as a key on its
+// own. The Ruby half of the ratchet solves this with a Prism walk
+// (ComplexityRatchet::EntityMap); this is the same idea over an ESTree AST.
+//
+// Names read as a path from the outermost scope inward:
+//
+//   TopicsController#connect                 class method
+//   TopicsController.observed                static class member
+//   CommentForm#submit>[addEventListener]    anonymous callback, named by its call
+//   parseDraft>normalise                     function nested in a function
+//   CommentForm#submit~if (a) {              statement fallback (see below)
+//
+// Lookup is by CONTAINMENT, not by start position, because ESLint does not
+// report an offense at the node it is about: `getFunctionHeadLoc` puts a method
+// offense on the method name, an arrow offense on the `=>` token, and a
+// max-depth offense on a statement somewhere in the middle. All three are
+// inside the entity, so the innermost scope containing the offense is the
+// answer in every case — as long as a class member's scope carries the
+// MethodDefinition's range rather than the inner FunctionExpression's, which
+// starts after the name.
+//
+// Rules that report on a statement rather than a definition — max-depth is the
+// one in the budget — get the enclosing scope plus the normalised source line,
+// written with a leading `~`. That is the fallback shape the Ruby side uses for
+// Metrics/BlockNesting.
+
+const FUNCTION_TYPES = new Set([
+  "FunctionDeclaration",
+  "FunctionExpression",
+  "ArrowFunctionExpression",
+]);
+
+const CLASS_TYPES = new Set(["ClassDeclaration", "ClassExpression"]);
+
+// A function written as a class member or an object value is reported at its
+// key, which lies outside the function node. Take the range from the member so
+// containment still finds it.
+const MEMBER_TYPES = new Set(["MethodDefinition", "PropertyDefinition", "Property"]);
+
+// `parent` is a back-reference ESLint adds while traversing; following it would
+// loop forever. `loc` and `range` hold no nodes, and skipping them keeps the
+// walk off every position object in the file.
+const SKIPPED_KEYS = new Set(["parent", "loc", "range"]);
+
+const MAX_FALLBACK_TEXT = 100;
+
+class Scope {
+  constructor(name, loc) {
+    this.name = name;
+    this.start = loc.start;
+    this.end = loc.end;
+    // Sibling entities that share a name are numbered from the second on, so a
+    // second over-budget `[map]` callback in one method cannot hide behind the
+    // first. Counting happens per parent scope, so an edit elsewhere in the
+    // file leaves the ordinal alone.
+    this.children = new Map();
+    this.fallbacks = new Map();
+  }
+
+  contains(line, column) {
+    if (line < this.start.line || line > this.end.line) return false;
+    if (line === this.start.line && column < this.start.column) return false;
+    if (line === this.end.line && column > this.end.column) return false;
+    return true;
+  }
+
+  // Later start wins, and on a tie the earlier end: both mean "more deeply
+  // nested". Comparing widths instead would need the source to convert a
+  // line/column span into a length.
+  innerThan(other) {
+    if (this.start.line !== other.start.line) return this.start.line > other.start.line;
+    if (this.start.column !== other.start.column) return this.start.column > other.start.column;
+    if (this.end.line !== other.end.line) return this.end.line < other.end.line;
+    return this.end.column < other.end.column;
+  }
+}
+
+export class EntityMap {
+  static for(ast, source) {
+    return new EntityMap(ast, source);
+  }
+
+  constructor(ast, source) {
+    this.lines = source.split("\n");
+    this.root = new Scope(null, ast.loc);
+    this.scopes = [];
+    this.walk(ast, null, this.root);
+  }
+
+  // Fully-qualified name of the innermost class or function containing the
+  // offense, or null when the offense sits at file scope.
+  nameAt(line, column) {
+    return this.enclosing(line, column - 1).name;
+  }
+
+  // Name for an offense that does not sit on a definition. Twins inside one
+  // scope get an ordinal, so two identical `if` lines in the same method do not
+  // collapse into one key where only the larger would be recorded.
+  fallbackAt(line, column) {
+    const scope = this.enclosing(line, column - 1);
+    const base = `${scope.name ?? ""}~${normaliseLine(this.lines[line - 1] ?? "")}`;
+    const seen = (scope.fallbacks.get(base) ?? 0) + 1;
+    scope.fallbacks.set(base, seen);
+    return seen > 1 ? `${base}[fallback:${seen}]` : base;
+  }
+
+  // ESLint message columns are 1-based; node columns are 0-based. Callers pass
+  // the message column, so this takes the converted one.
+  enclosing(line, column) {
+    let best = this.root;
+    for (const scope of this.scopes) {
+      if (!scope.contains(line, column)) continue;
+      if (best === this.root || scope.innerThan(best)) best = scope;
+    }
+    return best;
+  }
+
+  // `parent` is threaded explicitly rather than read from `node.parent`:
+  // ESLint only sets that back-reference while it traverses, and this map is
+  // also built in tests straight from a parse.
+  walk(node, parent, enclosing) {
+    const segment = segmentFor(node, parent);
+    let scope = enclosing;
+
+    if (segment !== null) {
+      const ordinal = (enclosing.children.get(segment) ?? 0) + 1;
+      enclosing.children.set(segment, ordinal);
+      const numbered = ordinal > 1 ? `${segment}(${ordinal})` : segment;
+
+      scope = new Scope(join(enclosing.name, numbered), rangeOwner(node, parent).loc);
+      this.scopes.push(scope);
+    }
+
+    for (const child of childNodes(node)) this.walk(child, node, scope);
+  }
+}
+
+function* childNodes(node) {
+  for (const [name, value] of Object.entries(node)) {
+    if (SKIPPED_KEYS.has(name) || value === null || typeof value !== "object") continue;
+
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        if (item && typeof item === "object" && typeof item.type === "string") yield item;
+      }
+    } else if (typeof value.type === "string") {
+      yield value;
+    }
+  }
+}
+
+function join(prefix, segment) {
+  if (!prefix) return segment;
+
+  return segment.startsWith("#") || segment.startsWith(".") ? `${prefix}${segment}` : `${prefix}>${segment}`;
+}
+
+function rangeOwner(node, parent) {
+  return isMember(node, parent) ? parent : node;
+}
+
+function isMember(node, parent) {
+  return FUNCTION_TYPES.has(node.type) && parent !== null && MEMBER_TYPES.has(parent.type) && parent.value === node;
+}
+
+function segmentFor(node, parent) {
+  if (CLASS_TYPES.has(node.type)) return className(node, parent);
+  if (!FUNCTION_TYPES.has(node.type)) return null;
+
+  return functionName(node, parent);
+}
+
+function className(node, parent) {
+  return node.id?.name ?? inferredName(parent) ?? "(anonymous class)";
+}
+
+function functionName(node, parent) {
+  if (parent?.type === "MethodDefinition" || parent?.type === "PropertyDefinition") {
+    // `get x()` and `set x()` share a name; without the kind they would collide
+    // into an ordinal pair that reads as two unrelated members.
+    const kind = parent.kind === "get" || parent.kind === "set" ? `${parent.kind} ` : "";
+    return `${parent.static ? "." : "#"}${kind}${memberName(parent)}`;
+  }
+  if (node.type === "FunctionDeclaration" && node.id?.name) return node.id.name;
+
+  return inferredName(parent) ?? anonymousName(parent);
+}
+
+// `const submit = () => {}` and `{ submit: function () {} }` are named by what
+// they are bound to: that is the name a reader would use for them.
+function inferredName(parent) {
+  if (!parent) return null;
+  // `export default class extends Controller {}` is the shape every Stimulus
+  // controller in this engine uses. "(anonymous class)" would be accurate and
+  // useless; `default` is what the importing side calls it.
+  if (parent.type === "ExportDefaultDeclaration") return "default";
+  if (parent.type === "VariableDeclarator" && parent.id?.type === "Identifier") return parent.id.name;
+  if (parent.type === "Property") return memberName(parent);
+  if (parent.type === "AssignmentExpression" && parent.left?.type === "MemberExpression") {
+    return memberPath(parent.left);
+  }
+  return null;
+}
+
+// `Editor.prototype.render = function () {}` keeps the whole chain: two classes
+// in one file both assigning `.render` would otherwise share a name, and the
+// ordinal that separated them would depend on which was written first.
+function memberPath(node) {
+  if (node.type === "Identifier") return node.name;
+  if (node.type === "ThisExpression") return "this";
+  if (node.type !== "MemberExpression") return null;
+
+  const object = memberPath(node.object);
+  const property = memberName(node);
+  return object ? `${object}.${property}` : property;
+}
+
+// An anonymous callback is identified by the call it is passed to —
+// `[addEventListener]`, `[map]` — which is how the Ruby side anchors blocks.
+function anonymousName(parent) {
+  if (parent?.type !== "CallExpression" && parent?.type !== "NewExpression") return "[anonymous]";
+
+  const callee = parent.callee;
+  if (callee?.type === "Identifier") return `[${callee.name}]`;
+  if (callee?.type === "MemberExpression") return `[${memberName(callee)}]`;
+  return "[anonymous]";
+}
+
+function memberName(node) {
+  const named = node.key ?? node.property;
+  if (!named) return "(computed)";
+  if (named.type === "Identifier") return named.name;
+  if (named.type === "Literal") return String(named.value);
+  if (named.type === "PrivateIdentifier") return `#${named.name}`;
+  return "(computed)";
+}
+
+function normaliseLine(text) {
+  const collapsed = text.trim().replace(/\s+/g, " ");
+  return collapsed.length > MAX_FALLBACK_TEXT
+    ? `${collapsed.slice(0, MAX_FALLBACK_TEXT - 3)}...`
+    : collapsed;
+}

--- a/lib/js_complexity/entity_map.js
+++ b/lib/js_complexity/entity_map.js
@@ -227,6 +227,7 @@ class Scope {
     this.end = loc.end;
     this.children = [];
     this.statements = [];
+    this.parent = null;
     this.level = 0;
     // Filled in by the naming pass, which runs after the whole tree is known:
     // a scope's key depends on how many twins it has, and the last twin is only
@@ -250,6 +251,13 @@ class Scope {
 
   lexicallyContains(line, column) {
     return this.functionLoc !== null && locationContains(this.functionLoc, line, column);
+  }
+
+  descendsFrom(other) {
+    for (let scope = this.parent; scope !== null; scope = scope.parent) {
+      if (scope === other) return true;
+    }
+    return false;
   }
 
   // Later start wins, and on a tie the earlier end: both mean "more deeply
@@ -321,16 +329,17 @@ export class EntityMap {
   // the message column, so this takes the converted one.
   enclosing(line, column, accepts = () => true) {
     const candidates = this.scopes.filter((scope) => accepts(scope) && scope.contains(line, column));
-    const insideFunction = candidates.some((scope) => scope.lexicallyContains(line, column));
+    const lexicalOwners = candidates.filter((scope) => scope.lexicallyContains(line, column));
     let best = this.root;
     for (const scope of candidates) {
       // A member function's lookup range includes its key because some ESLint
       // offenses are reported there. For a computed field, that widened range
-      // also overlaps functions executed by the key. When the position is
-      // lexically inside a function, discard widened-only function matches;
-      // otherwise the field value function can absorb the key function merely
-      // because the initializer gives it a deeper synthetic level.
-      if (insideFunction && scope.functionLoc !== null && !scope.lexicallyContains(line, column)) continue;
+      // also overlaps functions executed by the key. Discard a widened-only
+      // match when a lexical function owner is not its ancestor; otherwise an
+      // enclosing function would incorrectly hide an object method whose
+      // offense is reported at the method key.
+      const unrelatedOwner = lexicalOwners.some((owner) => !scope.descendsFrom(owner));
+      if (unrelatedOwner && scope.functionLoc !== null && !scope.lexicallyContains(line, column)) continue;
       if (best === this.root || scope.innerThan(best)) best = scope;
     }
     return best;
@@ -348,6 +357,7 @@ export class EntityMap {
       const initializer = new Scope(`${parent.static ? "." : "#"}${memberName(parent)}(initializer)`, node.loc, node.range);
       initializer.implicitKind = "class-field-initializer";
       initializer.level = enclosing.level + 1;
+      initializer.parent = enclosing;
       enclosing.children.push(initializer);
       this.scopes.push(initializer);
       enclosing = initializer;
@@ -359,6 +369,7 @@ export class EntityMap {
       const owner = rangeOwner(node, parent);
       scope = new Scope(segment, owner.loc, owner.range);
       scope.level = enclosing.level + 1;
+      scope.parent = enclosing;
       if (node.type === "StaticBlock") scope.implicitKind = "class-static-block";
       if (FUNCTION_TYPES.has(node.type)) scope.functionLoc = node.loc;
       scope.callbackDepth = this.callbackDepths.get(node) ?? 0;
@@ -625,8 +636,9 @@ function inferredName(parent) {
   if (parent.type === "ExportDefaultDeclaration") return "default";
   if (parent.type === "VariableDeclarator" && parent.id?.type === "Identifier") return parent.id.name;
   if (parent.type === "Property") return memberName(parent);
-  if (parent.type === "AssignmentExpression" && parent.left?.type === "MemberExpression") {
-    return memberPath(parent.left);
+  if (parent.type === "AssignmentExpression") {
+    if (parent.left?.type === "Identifier") return parent.left.name;
+    if (parent.left?.type === "MemberExpression") return memberPath(parent.left);
   }
   return null;
 }

--- a/lib/js_complexity/entity_map.js
+++ b/lib/js_complexity/entity_map.js
@@ -53,7 +53,10 @@
 // its measurement changes its key, so growth surfaces as new debt instead of
 // slipping into a neighbour's baseline. Only byte-identical twins still need an
 // ordinal, and those measure identically, so any permutation of them is a
-// no-op. "Byte-identical" is meant literally: twins are grouped by their source
+// no-op — which holds only because the digested text covers everything that
+// feeds the measurement. A statement's therefore includes its DEPTH, and that
+// depth has to be the number ESLint reports rather than an approximation of
+// it; see `depthsOf`. "Byte-identical" is meant literally: twins are grouped by their source
 // text and not by the digest of it, because one 32-bit FNV word collides often
 // enough to find a pair by brute force in seconds, and a collision would put
 // two different entities back on one ordinal. The digest widens a word at a
@@ -94,6 +97,71 @@ const NESTING_STATEMENT_TYPES = new Set([
   "WhileStatement",
   "WithStatement",
 ]);
+
+// max-depth resets its counter inside a function, and inside a static block.
+const DEPTH_ROOTS = new Set([
+  "ArrowFunctionExpression",
+  "FunctionDeclaration",
+  "FunctionExpression",
+  "Program",
+  "StaticBlock",
+]);
+
+// The depth ESLint would report for every statement it counts, mirrored from
+// the rule rather than approximated.
+//
+// An earlier version counted enclosing nesting statements and argued that it
+// only had to CHANGE when ESLint's depth changed, so the exceptions did not
+// need modelling. That was wrong, and it is the same defect as the twin
+// ordinal one level down: a key has to DETERMINE its measurement, and a count
+// that is merely correlated with ESLint's does not. Two byte-identical
+// `if (a) { y() }` statements can both sit under three enclosing statements
+// while measuring 3 and 2, because one of them hangs off an `else if` — so
+// they shared an anchor, fell back on the ordinal, and each was compared
+// against the other's baseline.
+//
+// Mirroring means mirroring the rule's arithmetic, not a tidied-up version of
+// it, because the number that has to match is the one ESLint prints:
+//
+//   * an IfStatement whose PARENT is an IfStatement does not count. That is
+//     broader than `else if` — an unbraced `if (a) if (b) {}` is exempt too.
+//   * every one of these types decrements on exit, including the ones that
+//     never incremented, so an `if`/`else if`/`else if` chain leaves the
+//     counter two BELOW where it started and the statements after it measure
+//     too shallow. That is an upstream quirk; reproducing it is the point,
+//     since the ratchet's job is to key what ESLint actually reported.
+//
+// Statements that do not count get no entry: max-depth cannot report one, so
+// nothing ever needs its key.
+function depthsOf(ast) {
+  const depths = new Map();
+  const counters = [];
+
+  const visit = (node, parent) => {
+    const root = DEPTH_ROOTS.has(node.type);
+    if (root) counters.push(0);
+
+    const nesting = NESTING_STATEMENT_TYPES.has(node.type);
+    if (nesting && !(node.type === "IfStatement" && parent?.type === "IfStatement")) {
+      depths.set(node, ++counters[counters.length - 1]);
+    }
+
+    // Source order, because the counter is sequential rather than lexical: the
+    // drift an if-chain leaves behind applies to whatever is visited next, and
+    // `childNodes` follows object keys.
+    for (const child of [ ...childNodes(node) ].sort(byRange)) visit(child, node);
+
+    if (nesting) counters[counters.length - 1]--;
+    if (root) counters.pop();
+  };
+
+  visit(ast, null);
+  return depths;
+}
+
+function byRange(left, right) {
+  return left.range[0] - right.range[0] || left.range[1] - right.range[1];
+}
 
 // `parent` is a back-reference ESLint adds while traversing; following it would
 // loop forever. `loc` and `range` hold no nodes, and skipping them keeps the
@@ -146,6 +214,7 @@ export class EntityMap {
     this.root = new Scope(null, ast.loc, ast.range);
     this.source = source;
     this.scopes = [];
+    this.depths = depthsOf(ast);
     this.walk(ast, null, null, this.root);
     nameChildren(this.root, source);
   }
@@ -191,30 +260,26 @@ export class EntityMap {
   // also built in tests straight from a parse. The grandparent comes along
   // because an anonymous callback's best name is usually one level further
   // out than its call — see `anonymousName`.
-  walk(node, parent, grandparent, enclosing, depth = 0) {
+  walk(node, parent, grandparent, enclosing) {
     const segment = segmentFor(node, parent, grandparent);
     let scope = enclosing;
-    let nesting = depth;
 
     if (segment !== null) {
       const owner = rangeOwner(node, parent);
       scope = new Scope(segment, owner.loc, owner.range);
       enclosing.children.push(scope);
       this.scopes.push(scope);
-      // max-depth counts nesting within a function, so each one starts over.
-      nesting = 0;
-    } else if (NESTING_STATEMENT_TYPES.has(node.type)) {
-      nesting = depth + 1;
+    } else if (this.depths.has(node)) {
       enclosing.statements.push({
         line: node.loc.start.line,
         column: node.loc.start.column,
         range: node.range,
-        depth: nesting,
+        depth: this.depths.get(node),
         text: normaliseLine(this.lines[node.loc.start.line - 1] ?? ""),
       });
     }
 
-    for (const child of childNodes(node)) this.walk(child, node, parent, scope, nesting);
+    for (const child of childNodes(node)) this.walk(child, node, parent, scope);
   }
 }
 
@@ -336,10 +401,12 @@ function sourceOf(source, node) {
 // that had not happened, and a restructure that genuinely deepened one of them
 // left both their keys unchanged.
 //
-// The number only has to CHANGE when ESLint's depth changes, not to equal it,
-// so it counts enclosing nesting statements and does not model the exceptions
-// ESLint makes (an `else if` chain does not count twice for ESLint; here it
-// does). Over-counting keeps entities apart, which is the property wanted.
+// The depth is ESLint's own, computed by `depthsOf`. Approximating it is not
+// enough and was the fifth variant of this bug: a key has to DETERMINE its
+// measurement, and a count that merely moves when ESLint's moves does not.
+// Two byte-identical statements under three enclosing statements measure 3 and
+// 2 when one hangs off an `else if`, which put them back on a shared anchor
+// and an ordinal — the slot identity this whole scheme exists to remove.
 function statementBody(source, statement) {
   return `${statement.depth}\n${sourceOf(source, statement)}`;
 }

--- a/lib/js_complexity/measure.js
+++ b/lib/js_complexity/measure.js
@@ -30,11 +30,13 @@ import { EntityMap } from "./entity_map.js";
 //               first line past the limit, which belongs to no entity).
 //   function  — the offense is about a definition; the innermost scope
 //               containing it is that definition.
+//   code-path — a function, class field initializer, or class static block;
+//               ESLint's message distinguishes coincident code paths.
 //   statement — the offense is about a statement inside a definition, so it
 //               falls back to "enclosing scope + source line".
 export const RULES = {
   complexity: {
-    scope: "function",
+    scope: "code-path",
     options: (max) => ["error", max],
     value: /has a complexity of (\d+)\. Maximum/,
   },
@@ -153,6 +155,14 @@ export function foldMessages(relativePath, source, ast, messages) {
 function entityName(scope, entities, message) {
   if (scope === "file") return FILE_ENTITY;
   if (scope === "statement") return entities.fallbackAt(message.line, message.column);
+  if (scope === "code-path") {
+    if (message.message.startsWith("Class field initializer ")) {
+      return entities.implicitNameAt(message.line, message.column, "class-field-initializer");
+    }
+    if (message.message.startsWith("Class static block ")) {
+      return entities.implicitNameAt(message.line, message.column, "class-static-block");
+    }
+  }
 
   return entities.nameAt(message.line, message.column) ?? FILE_ENTITY;
 }

--- a/lib/js_complexity/measure.js
+++ b/lib/js_complexity/measure.js
@@ -1,0 +1,196 @@
+// The JavaScript half of the complexity ratchet: runs ESLint's size and
+// complexity rules over a tree and folds the offenses into
+// {entity key => measured value}, the same shape ComplexityRatchet::Measurement
+// produces for Ruby. bin/complexity_check merges the two and compares them
+// against the merge base entity by entity.
+//
+// Why ESLint's Linter rather than the ESLint class: the ratchet measures a
+// detached checkout of the merge base, which has no node_modules and no
+// eslint.config file of its own. `Linter#verify` takes the config as a value,
+// so nothing is resolved from the tree being measured — this branch's budget is
+// applied to both sides, which is exactly the rule the Ruby half follows.
+//
+// The budget lives in .eslint_metrics.yml and holds ONLY numbers. Rule options
+// that are not thresholds (skipBlankLines, IIFEs) are fixed here on purpose:
+// a budget file that could carry arbitrary rule options would carry the
+// bypasses with them — `max-lines: { max: 300 }` next to an `overrides` entry
+// that silences a directory reads as a budget and acts as an exemption.
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { Linter } from "eslint";
+import { glob } from "glob";
+import yaml from "js-yaml";
+
+import { EntityMap } from "./entity_map.js";
+
+// scope: how an offense maps back to an entity.
+//   file      — the offense is about the whole file (max-lines reports on the
+//               first line past the limit, which belongs to no entity).
+//   function  — the offense is about a definition; the innermost scope
+//               containing it is that definition.
+//   statement — the offense is about a statement inside a definition, so it
+//               falls back to "enclosing scope + source line".
+export const RULES = {
+  complexity: {
+    scope: "function",
+    options: (max) => ["error", max],
+    value: /has a complexity of (\d+)\. Maximum/,
+  },
+  "max-depth": {
+    scope: "statement",
+    options: (max) => ["error", max],
+    value: /\((\d+)\)\. Maximum/,
+  },
+  "max-lines": {
+    scope: "file",
+    // Blank lines and comments are skipped to match RuboCop's Metrics counters,
+    // which ignore both. Otherwise the same file measures differently on the
+    // two sides of the ratchet and a comment block reads as growth.
+    options: (max) => ["error", { max, skipBlankLines: true, skipComments: true }],
+    value: /\((\d+)\)\. Maximum/,
+  },
+  "max-lines-per-function": {
+    scope: "function",
+    options: (max) => ["error", { max, skipBlankLines: true, skipComments: true, IIFEs: true }],
+    value: /\((\d+)\)\. Maximum/,
+  },
+  "max-nested-callbacks": {
+    scope: "function",
+    options: (max) => ["error", max],
+    value: /\((\d+)\)\. Maximum/,
+  },
+  "max-params": {
+    scope: "function",
+    options: (max) => ["error", max],
+    value: /\((\d+)\)\. Maximum/,
+  },
+};
+
+export const SEPARATOR = " | ";
+
+// The entity name used for a file-scoped offense. Parenthesised so it cannot
+// collide with a real identifier.
+export const FILE_ENTITY = "(file)";
+
+export class BudgetError extends Error {}
+
+export function parseBudget(text) {
+  const budget = yaml.load(text) ?? {};
+  const rules = budget.rules ?? {};
+  const unknown = Object.keys(rules).filter((rule) => !(rule in RULES));
+  if (unknown.length > 0) {
+    throw new BudgetError(
+      `.eslint_metrics.yml enables rules this tool has no entity mapping for: ${unknown.join(", ")}. ` +
+        "Add them to RULES in lib/js_complexity/measure.js first."
+    );
+  }
+  const bad = Object.entries(rules).filter(([, max]) => !Number.isInteger(max) || max < 0);
+  if (bad.length > 0) {
+    throw new BudgetError(
+      `.eslint_metrics.yml thresholds must be non-negative integers: ${bad.map(([rule]) => rule).join(", ")}`
+    );
+  }
+
+  return {
+    include: budget.include ?? [],
+    exclude: budget.exclude ?? [],
+    rules,
+  };
+}
+
+export function eslintConfig(budget) {
+  return {
+    files: ["**/*.js", "**/*.jsx"],
+    languageOptions: {
+      ecmaVersion: "latest",
+      sourceType: "module",
+      parserOptions: { ecmaFeatures: { jsx: true } },
+    },
+    // A file that turns the budget off with an inline comment is the bypass
+    // this gate exists to prevent, so directives are not honoured.
+    linterOptions: { noInlineConfig: true, reportUnusedDisableDirectives: "off" },
+    rules: Object.fromEntries(
+      Object.entries(budget.rules).map(([rule, max]) => [rule, RULES[rule].options(max)])
+    ),
+  };
+}
+
+// Exported for the unit tests: the fold from ESLint messages to ratchet keys is
+// where the entity naming rules live, and it is worth testing without a lint.
+export function foldMessages(relativePath, source, ast, messages) {
+  // A syntax error is worth crashing on: a file that silently fails to parse
+  // measures as zero offenses, which reads as "clean" rather than "unread".
+  // ESLint also hands back no SourceCode at all in that case, so this has to
+  // come before the entity map is built.
+  const fatal = messages.find((message) => message.fatal);
+  if (fatal) {
+    throw new Error(`${relativePath}:${fatal.line ?? "?"} could not be parsed: ${fatal.message}`);
+  }
+
+  const entities = EntityMap.for(ast, source);
+  const measured = {};
+
+  for (const message of messages) {
+    // Rule-less, non-fatal messages are ESLint talking about itself — the one
+    // this config produces is the notice that an `eslint-disable-line` comment
+    // had no effect under noInlineConfig, which is the intended outcome.
+    if (!message.ruleId) continue;
+
+    const rule = RULES[message.ruleId];
+    if (!rule) throw new Error(`unexpected rule ${message.ruleId} in ${relativePath}`);
+
+    const name = entityName(rule.scope, entities, message);
+    const key = [relativePath, message.ruleId, name].join(SEPARATOR);
+    const value = extractValue(rule, message, relativePath);
+    measured[key] = Math.max(measured[key] ?? 0, value);
+  }
+
+  return measured;
+}
+
+function entityName(scope, entities, message) {
+  if (scope === "file") return FILE_ENTITY;
+  if (scope === "statement") return entities.fallbackAt(message.line, message.column);
+
+  return entities.nameAt(message.line, message.column) ?? FILE_ENTITY;
+}
+
+function extractValue(rule, message, relativePath) {
+  const match = rule.value.exec(message.message);
+  // Silently counting an unreadable message as 1 would turn a rule whose
+  // wording changed in an ESLint upgrade into an entity that can never grow.
+  if (!match) {
+    throw new Error(`cannot read a measured value out of "${message.message}" (${relativePath})`);
+  }
+  return Number(match[1]);
+}
+
+export async function measure({ root, budget }) {
+  const files = await glob(budget.include, {
+    cwd: root,
+    ignore: budget.exclude,
+    nodir: true,
+    posix: true,
+    dot: false,
+  });
+
+  const linter = new Linter();
+  const config = eslintConfig(budget);
+  const measured = {};
+
+  for (const relativePath of files.sort()) {
+    const source = readFileSync(path.join(root, relativePath), "utf8");
+    const messages = linter.verify(source, config, relativePath);
+    if (messages.length === 0) continue;
+
+    Object.assign(measured, foldMessages(relativePath, source, linter.getSourceCode()?.ast, messages));
+  }
+
+  return measured;
+}
+
+export function loadBudget(configPath) {
+  return parseBudget(readFileSync(configPath, "utf8"));
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
       "devDependencies": {
         "@testing-library/dom": "^10.4.1",
         "esbuild": "^0.28.1",
+        "eslint": "^9.39.5",
         "glob": "^13.0.0",
         "jest": "^30.4.0",
         "jest-environment-jsdom": "^30.4.0",
@@ -1323,6 +1324,232 @@
         "node": ">=18"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+      "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.7.tgz",
+      "integrity": "sha512-F42g89Qd5oAWtp0k0nnSrjziAKza7w8SVT4mStc18LZMaRb4J1HQAHLCalEtDCxrTuksx7NU9qsmeLwpOfPqWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.3.2",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
     "node_modules/@firebase/ai": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@firebase/ai/-/ai-2.2.1.tgz",
@@ -2048,6 +2275,72 @@
       "dependencies": {
         "@hotwired/turbo": "^8.0.13",
         "@rails/actioncable": ">=7.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@iconify/types": {
@@ -3605,6 +3898,13 @@
         "@types/d3-selection": "*"
       }
     },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/geojson": {
       "version": "7946.0.16",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
@@ -3662,6 +3962,13 @@
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "24.4.0",
@@ -4083,6 +4390,16 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/agent-base": {
@@ -5252,6 +5569,13 @@
         }
       }
     },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deepmerge": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
@@ -5444,6 +5768,285 @@
         "node": ">=8"
       }
     },
+    "node_modules/eslint": {
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.5.tgz",
+      "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
+      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.6",
+        "@eslint/js": "9.39.5",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/eslint/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/eslint/node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/eslint/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint/node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/eslint/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/eslint/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -5456,6 +6059,52 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/execa": {
@@ -5545,6 +6194,13 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
     },
@@ -5863,6 +6519,19 @@
       },
       "bin": {
         "which": "bin/which"
+      }
+    },
+    "node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/globby": {
@@ -7680,6 +8349,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -7691,6 +8367,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
     },
@@ -7778,6 +8461,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/lexical": {
@@ -7869,6 +8566,13 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.truncate": {
@@ -8245,6 +8949,24 @@
       "integrity": "sha512-+xyrJmxV9QUBFbSwPROYhOg/FLXry+uuPr4R+B5EaE4556Oc18/8ZC/fL5A+/lbRSwNvA0Alh+C0KpyFWLmLZg==",
       "license": "MIT"
     },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -8573,6 +9295,16 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/pretty-format": {
       "version": "27.5.1",
@@ -9690,6 +10422,19 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -9805,6 +10550,16 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -9955,6 +10710,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "devDependencies": {
     "@testing-library/dom": "^10.4.1",
     "esbuild": "^0.28.1",
+    "eslint": "^9.39.5",
     "glob": "^13.0.0",
     "jest": "^30.4.0",
     "jest-environment-jsdom": "^30.4.0",

--- a/test/lib/complexity_ratchet_eager_loading_test.rb
+++ b/test/lib/complexity_ratchet_eager_loading_test.rb
@@ -3,9 +3,10 @@
 require "test_helper"
 
 class ComplexityRatchetEagerLoadingTest < ActiveSupport::TestCase
-  test "excludes the CI-only complexity ratchet directory from eager loading" do
+  test "excludes the CI-only complexity ratchet directories from eager loading" do
     ignored_paths = Rails.autoloaders.main.instance_variable_get(:@ignored_paths)
 
     assert_includes ignored_paths, Rails.root.join("lib/complexity_ratchet").to_s
+    assert_includes ignored_paths, Rails.root.join("lib/js_complexity").to_s
   end
 end

--- a/test/lib/complexity_ratchet_javascript_test.rb
+++ b/test/lib/complexity_ratchet_javascript_test.rb
@@ -133,11 +133,12 @@ class ComplexityRatchetJavascriptMeasurementTest < ActiveSupport::TestCase
     end
   end
 
-  # The Codex review on PR #1651 named this exactly: with an order-only ordinal,
-  # deleting the first of two same-named callbacks renames the survivor onto the
-  # deleted one's key, and the survivor's growth is then compared against a
-  # measurement that was never its own. The JavaScript unit tests pin the naming;
-  # this pins the thing that actually matters, which is that the gate reports it.
+  # The Codex reviews on PR #1651 named both halves of this. With an order-only
+  # ordinal a same-named callback is identified by its SLOT, so deleting the
+  # first of two renames the survivor onto the deleted one's key, and reordering
+  # two of them measures each against the other's baseline. The JavaScript unit
+  # tests pin the naming; these pin the thing that actually matters, which is
+  # what the gate does with it.
   test "reports a surviving twin's growth after its sibling is deleted" do
     before = measure_twins(12, 6)
     after  = measure_twins(9)
@@ -146,15 +147,39 @@ class ComplexityRatchetJavascriptMeasurementTest < ActiveSupport::TestCase
     assert_equal [ :new_offense ], check(actual: after, base: before).map(&:kind)
   end
 
+  # Codex's second case: under a slot ordinal this passed, because slot 1 read
+  # `9 <= 12` and slot 2 read `5 <= 6` while the 6-line callback had grown to 9.
+  test "reports growth hidden behind a reorder and a compensating shrink" do
+    problems = check(actual: measure_twins(9, 5), base: measure_twins(12, 6))
+
+    assert_equal [ :new_offense, :new_offense ], problems.map(&:kind)
+  end
+
   test "reports growth that moves between reordered twins" do
     problems = check(actual: measure_twins(9, 12), base: measure_twins(12, 6))
 
-    assert_equal [ :regression ], problems.map(&:kind)
-    assert_includes problems.sole.key, "(2/2)"
+    assert_equal [ :new_offense ], problems.map(&:kind)
   end
 
-  test "says nothing when a twin shrinks and nothing else moves" do
-    assert_empty check(actual: measure_twins(10, 6), base: measure_twins(12, 6))
+  # A twin is anchored to its own body, so its siblings can come and go around
+  # it without touching its baseline. Under the ordinal this reported.
+  test "says nothing when a twin is deleted and the rest are untouched" do
+    assert_empty check(actual: measure_twins(12, 8), base: measure_twins(12, 8, 6))
+  end
+
+  test "says nothing when twins are reordered and neither one changed" do
+    assert_empty check(actual: measure_twins(6, 12), base: measure_twins(12, 6))
+  end
+
+  # The cost of anchoring, stated as a test so it cannot drift into folklore: an
+  # over-budget twin that shrinks without getting under budget has a new body,
+  # so it has a new key and reads as new debt. Loud about an improvement is
+  # recoverable — name the callback, finish the job, or waive it. Quiet about
+  # growth is not.
+  test "reports a twin that shrinks without getting under budget" do
+    problems = check(actual: measure_twins(10, 6), base: measure_twins(12, 6))
+
+    assert_equal [ :new_offense ], problems.map(&:kind)
   end
 
   test "raises with the file and the reason when a tree cannot be measured" do

--- a/test/lib/complexity_ratchet_javascript_test.rb
+++ b/test/lib/complexity_ratchet_javascript_test.rb
@@ -1,0 +1,175 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "tmpdir"
+
+# Not autoloaded: config/application.rb keeps this CI-only tool out of the app's
+# object graph, so the test has to require it by path.
+require Rails.root.join("lib/complexity_ratchet").to_s
+require Rails.root.join("lib/complexity_ratchet/javascript").to_s
+
+# The JavaScript budget is the same ratchet as the Ruby one and needs the same
+# two properties pinned: a measurement that produces stable entity keys, and a
+# budget that can only tighten. The entity naming itself is tested where it
+# lives, in lib/js_complexity/__tests__/measure.test.js.
+class ComplexityRatchetJavascriptBudgetTest < ActiveSupport::TestCase
+  BEFORE = {
+    "include" => [ "engines/collavre/**/*.js" ],
+    "exclude" => [ "**/__tests__/**" ],
+    "rules" => { "complexity" => 13, "max-lines" => 300 }
+  }.freeze
+
+  def verify(after)
+    ComplexityRatchet::Javascript.verify_budget(BEFORE, BEFORE.merge(after))
+  end
+
+  test "accepts an unchanged budget" do
+    assert_empty verify({})
+  end
+
+  test "accepts a tightened threshold and a newly added rule" do
+    assert_empty verify("rules" => { "complexity" => 10, "max-lines" => 300, "max-params" => 4 })
+  end
+
+  # The bypass this exists to catch: both trees are measured with this branch's
+  # budget, so raising a threshold stops the offenses on both sides at once and
+  # the entity-by-entity comparison sees nothing at all.
+  test "rejects a raised threshold" do
+    problem = verify("rules" => { "complexity" => 40, "max-lines" => 300 }).sole
+
+    assert_equal :js_budget_loosened, problem.kind
+    assert_equal "complexity", problem.key
+    assert problem.blocking?
+  end
+
+  test "rejects a rule that is deleted outright" do
+    problem = verify("rules" => { "complexity" => 13 }).sole
+
+    assert_equal :js_budget_disabled, problem.kind
+    assert_equal "max-lines", problem.key
+  end
+
+  test "rejects a threshold that is not a non-negative integer" do
+    assert_equal :js_budget_invalid_max, verify("rules" => BEFORE["rules"].merge("complexity" => -1)).sole.kind
+    assert_equal :js_budget_invalid_max, verify("rules" => BEFORE["rules"].merge("complexity" => 13.5)).sole.kind
+    assert_equal :js_budget_invalid_max, verify("rules" => BEFORE["rules"].merge("complexity" => "13")).sole.kind
+  end
+
+  test "rejects narrowing the measured scope from either side" do
+    dropped = verify("include" => []).sole
+    assert_equal :js_budget_scope_narrowed, dropped.kind
+    assert_includes dropped.message, "include"
+
+    excluded = verify("exclude" => [ "**/__tests__/**", "engines/collavre/app/javascript/controllers/**" ]).sole
+    assert_equal :js_budget_scope_narrowed, excluded.kind
+    assert_includes excluded.message, "exclude"
+  end
+
+  test "accepts widening the measured scope from either side" do
+    assert_empty verify("include" => BEFORE["include"] + [ "engines/collavre/**/*.jsx" ])
+    assert_empty verify("exclude" => [])
+  end
+
+  # An allowlist, not a list of known tricks: a key the comparison cannot judge
+  # is a bypass waiting to be written into it.
+  test "rejects a key the ratchet does not know how to compare" do
+    problem = verify("overrides" => [ { "files" => "**/*", "rules" => {} } ]).sole
+
+    assert_equal :js_budget_unknown_key, problem.kind
+    assert_equal "overrides", problem.key
+  end
+
+  test "has nothing to say when the budget file is new" do
+    assert_empty ComplexityRatchet::Javascript.verify_budget(nil, BEFORE)
+  end
+end
+
+class ComplexityRatchetJavascriptMeasurementTest < ActiveSupport::TestCase
+  BUDGET = <<~YAML
+    include:
+      - "**/*.js"
+    exclude:
+      - "**/__tests__/**"
+    rules:
+      complexity: 2
+      max-params: 2
+  YAML
+
+  # Runs the real Node script against a throwaway tree, which is the part that
+  # cannot be unit-tested from either side: the Ruby half has to survive the
+  # script's actual output, and the script has to measure a tree that has no
+  # node_modules and no config of its own.
+  test "measures a tree with this checkout's tooling and budget" do
+    Dir.mktmpdir do |tree|
+      File.write(File.join(tree, "widget.js"), <<~JS)
+        export class Widget {
+          render(a, b, c) {
+            return a && b || c ? 1 : 2
+          }
+        }
+      JS
+      FileUtils.mkdir_p(File.join(tree, "__tests__"))
+      File.write(File.join(tree, "__tests__", "widget.test.js"), "const f = (a, b, c) => a\n")
+
+      measured = with_budget do |config|
+        ComplexityRatchet::Javascript::Measurement.call(root: tree, tool_root: Rails.root.to_s, config: config)
+      end
+
+      assert_equal(
+        {
+          "widget.js | complexity | Widget#render" => 4,
+          "widget.js | max-params | Widget#render" => 3
+        },
+        measured
+      )
+    end
+  end
+
+  test "raises with the file and the reason when a tree cannot be measured" do
+    Dir.mktmpdir do |tree|
+      File.write(File.join(tree, "broken.js"), "class {\n")
+
+      error = assert_raises(ComplexityRatchet::Error) do
+        with_budget do |config|
+          ComplexityRatchet::Javascript::Measurement.call(root: tree, tool_root: Rails.root.to_s, config: config)
+        end
+      end
+
+      assert_includes error.message, "broken.js"
+      assert_includes error.message, "could not be parsed"
+    end
+  end
+
+  private
+
+  def with_budget
+    Dir.mktmpdir do |dir|
+      config = File.join(dir, "budget.yml")
+      File.write(config, BUDGET)
+      yield config
+    end
+  end
+end
+
+# The include globs are the whole scope of the gate. A typo in one of them
+# measures nothing at all and reports success, which is the failure mode this
+# design is otherwise built to avoid.
+class ComplexityRatchetJavascriptScopeTest < ActiveSupport::TestCase
+  setup do
+    @budget = YAML.safe_load_file(Rails.root.join(ComplexityRatchet::Javascript::CONFIG_PATH))
+  end
+
+  test "the shipped include globs match the core engine's JavaScript" do
+    matched = Dir.glob(@budget["include"], base: Rails.root.to_s)
+
+    assert_operator matched.size, :>, 100
+    assert_includes matched, "engines/collavre/app/javascript/controllers/index.js"
+  end
+
+  test "every shipped threshold is a rule the measurement can map to an entity" do
+    known = File.read(Rails.root.join("lib/js_complexity/measure.js")).scan(/^  "?([a-z-]+)"?: \{$/).flatten
+
+    assert_includes known, "complexity"
+    assert_empty @budget["rules"].keys - known
+  end
+end

--- a/test/lib/complexity_ratchet_javascript_test.rb
+++ b/test/lib/complexity_ratchet_javascript_test.rb
@@ -95,6 +95,14 @@ class ComplexityRatchetJavascriptMeasurementTest < ActiveSupport::TestCase
       max-params: 2
   YAML
 
+  TWIN_BUDGET = <<~YAML
+    include:
+      - "**/*.js"
+    exclude: []
+    rules:
+      max-lines-per-function: 2
+  YAML
+
   # Runs the real Node script against a throwaway tree, which is the part that
   # cannot be unit-tested from either side: the Ruby half has to survive the
   # script's actual output, and the script has to measure a tree that has no
@@ -125,6 +133,30 @@ class ComplexityRatchetJavascriptMeasurementTest < ActiveSupport::TestCase
     end
   end
 
+  # The Codex review on PR #1651 named this exactly: with an order-only ordinal,
+  # deleting the first of two same-named callbacks renames the survivor onto the
+  # deleted one's key, and the survivor's growth is then compared against a
+  # measurement that was never its own. The JavaScript unit tests pin the naming;
+  # this pins the thing that actually matters, which is that the gate reports it.
+  test "reports a surviving twin's growth after its sibling is deleted" do
+    before = measure_twins(12, 6)
+    after  = measure_twins(9)
+
+    assert_empty before.keys & after.keys, "a survivor must not inherit a deleted twin's key"
+    assert_equal [ :new_offense ], check(actual: after, base: before).map(&:kind)
+  end
+
+  test "reports growth that moves between reordered twins" do
+    problems = check(actual: measure_twins(9, 12), base: measure_twins(12, 6))
+
+    assert_equal [ :regression ], problems.map(&:kind)
+    assert_includes problems.sole.key, "(2/2)"
+  end
+
+  test "says nothing when a twin shrinks and nothing else moves" do
+    assert_empty check(actual: measure_twins(10, 6), base: measure_twins(12, 6))
+  end
+
   test "raises with the file and the reason when a tree cannot be measured" do
     Dir.mktmpdir do |tree|
       File.write(File.join(tree, "broken.js"), "class {\n")
@@ -142,10 +174,32 @@ class ComplexityRatchetJavascriptMeasurementTest < ActiveSupport::TestCase
 
   private
 
-  def with_budget
+  # A method holding `sizes.length` callbacks that the entity naming cannot tell
+  # apart, each `sizes[i]` statements long. Only the callbacks are returned: the
+  # enclosing method changes size whenever the fixture does, and that is not what
+  # these tests are about.
+  def measure_twins(*sizes)
+    calls = sizes.map { |size| "  items.map((row) => {\n#{Array.new(size) { |i| "    const v#{i} = #{i}" }.join("\n")}\n  })" }
+
+    Dir.mktmpdir do |tree|
+      File.write(File.join(tree, "row.js"), "class Row {\n connect() {\n#{calls.join("\n")}\n }\n}\n")
+
+      measured = with_budget(TWIN_BUDGET) do |config|
+        ComplexityRatchet::Javascript::Measurement.call(root: tree, tool_root: Rails.root.to_s, config: config)
+      end
+
+      measured.select { |key, _value| key.include?("[items.map]") }
+    end
+  end
+
+  def check(actual:, base:)
+    ComplexityRatchet::Check.new(actual: actual, base: base).problems
+  end
+
+  def with_budget(budget = BUDGET)
     Dir.mktmpdir do |dir|
       config = File.join(dir, "budget.yml")
-      File.write(config, BUDGET)
+      File.write(config, budget)
       yield config
     end
   end


### PR DESCRIPTION
## Change

Extend the existing Ruby complexity ratchet to production JavaScript in `engines/collavre`. Existing over-budget entities may shrink but cannot grow; new entities must fit the budget. Both trees are measured with the same tool and current budget.

The existing RuboCop configuration and inherited defaults already provide Ruby checks. The integration base has no ESLint dependency/configuration or JavaScript complexity CI job. This PR adds six ESLint metrics to the existing comparison and waiver mechanism.

## Scope and budget

Only `engines/collavre/**/*.js` and `**/*.jsx` are measured, excluding tests and dependencies. No engine source files are modified.

Measured against integration base `9b8d2cf1c993`: 168 files, 35,978 lines, 217 JavaScript over-budget entries.

| Rule | Budget | Over budget |
| --- | ---: | ---: |
| complexity | 13 | 88 |
| max-depth | 3 | 19 |
| max-lines | 300 | 23 |
| max-lines-per-function | 50 | 78 |
| max-nested-callbacks | 10 | 0 |
| max-params | 4 | 9 |

Thresholds are centralized and may only tighten. Inline ESLint configuration is disabled. `.complexity_waivers.yml` remains `waivers: []`.

Supporting changes outside the engine:

| Files | Purpose |
| --- | --- |
| `.eslint_metrics.yml` | Engine-only selection and thresholds |
| `lib/js_complexity/`, `bin/js_complexity.mjs` | ESLint measurement and entity naming, with regression tests |
| `lib/complexity_ratchet/javascript.rb`, `bin/complexity_check`, `test/lib/` | Integrate measurements and validate budgets using the existing ratchet |
| `.github/workflows/ci.yml` | Install Node dependencies; compare against the fetched integration base ref |
| `package.json`, `package-lock.json`, `jest.config.cjs` | Dependencies and test discovery |
| `config/application.rb` | Exclude the CI-only JavaScript tool directory from Rails autoloading |
| `docs/` | Usage, baseline reproduction, budget rationale, limitations |

## Entity identity

Callbacks use their callee chain and available binding. Remaining same-named entities use source digests that preserve measurable line breaks, including Unicode line separators. Statement and callback anchors include the effective context reported by ESLint, including its current counter behavior.

Distinct bodies are separated by progressively wider digests. If every supported width collides, measurement throws and blocks the gate. Positional suffixes are reserved for indistinguishable bodies with identical encoded context.

Class field initializers and static blocks have distinct entity scopes so their measurements cannot be folded into a shared class baseline.

Regression coverage includes implicit class paths, deletion, reorder with compensating shrink, literal line breaks, hash collisions and exhaustion, effective statement depth, and callback nesting.

Limitations: editing an over-budget twin, including a comment-only edit or a shrink that remains over budget, can change its key and report new debt. Crossing between a unique name and a duplicate group can also change keys. Moves between files are reported as new entities.

## CI baseline

CI checks out GitHub's PR merge tree and fetches the base branch ref before invoking the ratchet. The ratchet resolves its merge base with that ref. This avoids attributing already integrated sibling changes to this PR because of an older event payload SHA. Local reproduction is documented in `docs/complexity_budget.md`.

## Validation

Latest head: `6915641f6ae5f5a0f386901aa19fbcf438b87c7b`.

- Full local Jest: **162 suites / 2,330 tests pass**.
- Measurement suite: **54 tests pass**. Digest-exhaustion regression fails before the fix; identical-twin control passes in both versions.
- Local JavaScript comparison against `9b8d2cf1c993`: **217 / 217**, zero new offenses or regressions.
- This continuation environment lacks Ruby; current-head RuboCop, combined ratchet, Rails and system tests must be verified through CI.
- Latest-head Codex review and CI are pending. Earlier resolved threads do not count as current-head review approval.

Target is `feature/refactor-reduce-dupl`; do not merge directly to `main`. The integration-to-main findings are recorded in the PR conversation for the final integration owner to assess.
