### PR TITLE
Refactor creative row editor save state

### DIFF
--- a/engines/collavre/app/javascript/modules/__tests__/creative_row_editor_save_paths.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/creative_row_editor_save_paths.test.js
@@ -1,0 +1,184 @@
+/**
+ * @jest-environment jsdom
+ */
+import { jest } from '@jest/globals'
+
+let editorOptions = null
+const save = jest.fn()
+const enqueue = jest.fn()
+
+jest.unstable_mockModule('../lexical_inline_editor', () => ({
+  createInlineEditor: jest.fn((_container, options) => {
+    editorOptions = options
+    return {
+      destroy: jest.fn(),
+      load: jest.fn(),
+      focus: jest.fn(),
+      reset: jest.fn(),
+      getDeletedAttachments: jest.fn(() => []),
+    }
+  }),
+}))
+jest.unstable_mockModule('../creative_row_editor_delegated_clicks', () => ({
+  createDelegatedClickHandler: jest.fn(() => jest.fn()),
+}))
+jest.unstable_mockModule('../../lib/api/creatives', () => ({
+  default: {
+    save,
+    get: jest.fn(() => Promise.resolve({})),
+    loadChildren: jest.fn(() => Promise.resolve({ creatives: [] })),
+  },
+}))
+jest.unstable_mockModule('../../lib/api/queue_manager', () => ({
+  default: {
+    initialize: jest.fn(),
+    start: jest.fn(),
+    enqueue,
+  },
+}))
+
+const { initializeCreativeRowEditor } = await import('../creative_row_editor')
+const {
+  appendExistingRow, buildEditorDom, defineTreeRowStub, flush,
+} = await import('./support/inline_editor_dom')
+
+function response(data = {}) {
+  return Promise.resolve({
+    ok: true,
+    text: () => Promise.resolve(JSON.stringify(data)),
+  })
+}
+
+function openRow(tree) {
+  document.dispatchEvent(new CustomEvent('creative-edit-click', {
+    detail: { treeElement: tree },
+  }))
+}
+
+async function flushPromises() {
+  for (let i = 0; i < 10; i += 1) await Promise.resolve()
+}
+
+function appendMarkdownRow(id, source, editor = 'source') {
+  const result = appendExistingRow(id)
+  result.rowComponent.dataset.contentType = 'markdown'
+  result.rowComponent.dataset.markdownSource = source
+  result.rowComponent.dataset.markdownEditor = editor
+  result.rowComponent.dataset.descriptionRawHtml = `<p>${source}</p>`
+  return result
+}
+
+beforeAll(() => defineTreeRowStub())
+
+beforeEach(() => {
+  document.body.innerHTML = '<div id="creatives"></div><div id="center-frame"></div>'
+  buildEditorDom(document.getElementById('center-frame'))
+  save.mockReset()
+  enqueue.mockReset()
+  save.mockImplementation(() => response())
+  initializeCreativeRowEditor()
+  document.getElementById('metadata-popup').style.display = 'none'
+})
+
+afterEach(() => {
+  jest.clearAllTimers()
+  jest.useRealTimers()
+  editorOptions = null
+})
+
+test('direct save keeps FormData semantics, applies a markdown rewrite, and clears dirty state', async () => {
+  jest.useFakeTimers()
+  const { tree } = appendMarkdownRow('42', 'before')
+  openRow(tree)
+
+  const textarea = document.getElementById('markdown-editor-textarea')
+  textarea.value = 'draft ![image](data:old)'
+  textarea.dispatchEvent(new Event('input'))
+  let submitted
+  save.mockImplementation((_path, _method, form) => {
+    submitted = new FormData(form)
+    return response({
+      markdown_source: 'draft ![image](/rails/active_storage/blobs/image.png)',
+    })
+  })
+
+  const progress = document.getElementById('inline-creative-progress')
+  progress.checked = true
+  progress.dispatchEvent(new Event('change'))
+  await flushPromises()
+
+  expect(save).toHaveBeenCalledTimes(1)
+  expect(save.mock.calls[0][0]).toMatch(/\/creatives\/42$/)
+  expect(save.mock.calls[0][1]).toBe('PATCH')
+  expect(submitted.get('creative[markdown_source]')).toBe('draft ![image](data:old)')
+  expect(submitted.getAll('creative[progress]')).toEqual(['0', '1'])
+  expect(textarea.value).toBe('draft ![image](/rails/active_storage/blobs/image.png)')
+  expect(document.getElementById('inline-markdown-source').value)
+    .toBe('draft ![image](/rails/active_storage/blobs/image.png)')
+
+  document.getElementById('inline-close').click()
+  await Promise.resolve()
+  expect(save).toHaveBeenCalledTimes(1)
+})
+
+test('persistent queue snapshots the outgoing row, keeps its object body, applies response data, and clears dirty state', async () => {
+  jest.useFakeTimers()
+  const first = appendMarkdownRow('42', 'before', 'rich')
+  const second = appendMarkdownRow('43', 'second', 'rich')
+  openRow(first.tree)
+
+  editorOptions.onChange({ html: '<p>outgoing edit</p>', markdown: 'outgoing edit' })
+  document.getElementById('inline-move-down').click()
+  await Promise.resolve()
+  await Promise.resolve()
+
+  expect(enqueue).toHaveBeenCalledTimes(1)
+  const queued = enqueue.mock.calls[0][0]
+  expect(queued.path).toBe('/creatives/42')
+  expect(queued.method).toBe('PATCH')
+  expect(queued.body).toEqual(expect.objectContaining({
+    'creative[description]': '<p>outgoing edit</p>',
+    'creative[content_type_input]': 'markdown',
+    'creative[markdown_source]': 'outgoing edit',
+    'creative[markdown_editor]': 'rich',
+  }))
+  expect(queued.body).not.toBeInstanceOf(FormData)
+  expect(document.getElementById('inline-edit-form-element').dataset.creativeId).toBe('43')
+
+  queued.onSuccess({ markdown_source: 'server rewrite' })
+  expect(first.rowComponent.dataset.markdownSource).toBe('server rewrite')
+
+  document.getElementById('inline-move-up').click()
+  await Promise.resolve()
+  document.getElementById('inline-move-down').click()
+  await Promise.resolve()
+  expect(enqueue).toHaveBeenCalledTimes(1)
+  expect(second.rowComponent.dataset.markdownSource).toBe('second')
+})
+
+test('direct save skips an empty buffer', async () => {
+  const { rowComponent, tree } = appendExistingRow('42')
+  rowComponent.dataset.descriptionRawHtml = ''
+  openRow(tree)
+
+  const progress = document.getElementById('inline-creative-progress')
+  progress.checked = true
+  progress.dispatchEvent(new Event('change'))
+  await Promise.resolve()
+
+  expect(save).not.toHaveBeenCalled()
+})
+
+test('persistent queue skips an empty buffer', async () => {
+  const first = appendExistingRow('42')
+  first.rowComponent.dataset.descriptionRawHtml = ''
+  appendExistingRow('43')
+  openRow(first.tree)
+
+  editorOptions.onChange({ html: '', markdown: '' })
+  document.getElementById('inline-move-down').click()
+  await Promise.resolve()
+  await Promise.resolve()
+
+  expect(enqueue).not.toHaveBeenCalled()
+})

--- a/engines/collavre/app/javascript/modules/__tests__/creative_row_editor_save_paths.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/creative_row_editor_save_paths.test.js
@@ -182,3 +182,65 @@ test('persistent queue skips an empty buffer', async () => {
 
   expect(enqueue).not.toHaveBeenCalled()
 })
+
+test('persistent queue carries an unacknowledged progress toggle into the body and row dataset', async () => {
+  jest.useFakeTimers()
+  const first = appendMarkdownRow('42', 'before', 'rich')
+  appendMarkdownRow('43', 'second', 'rich')
+  openRow(first.tree)
+
+  // The checkbox fires a direct save; hold it in flight so the progress
+  // baseline is still stale when the move queues the outgoing row.
+  let settleDirectSave
+  save.mockImplementation(() => new Promise((resolve) => { settleDirectSave = resolve }))
+  editorOptions.onChange({ html: '<p>outgoing edit</p>', markdown: 'outgoing edit' })
+  const progress = document.getElementById('inline-creative-progress')
+  progress.checked = true
+  progress.dispatchEvent(new Event('change'))
+  await Promise.resolve()
+
+  document.getElementById('inline-move-down').click()
+  await flushPromises()
+
+  expect(enqueue).toHaveBeenCalledTimes(1)
+  expect(enqueue.mock.calls[0][0].body['creative[progress]']).toBe(1)
+  expect(first.rowComponent.dataset.progressValue).toBe('1')
+
+  settleDirectSave({ ok: true, text: () => Promise.resolve('{}') })
+  await flushPromises()
+})
+
+test('queued response rewrites the live textarea when the row is reopened before the ack', async () => {
+  jest.useFakeTimers()
+  const dataUri = 'data:image/png;base64,abc123'
+  const first = appendMarkdownRow('42', `before ${dataUri}`)
+  appendMarkdownRow('43', 'second')
+  openRow(first.tree)
+
+  const textarea = document.getElementById('markdown-editor-textarea')
+  textarea.value = `draft ${dataUri}`
+  textarea.dispatchEvent(new Event('input'))
+
+  document.getElementById('inline-move-down').click()
+  await flushPromises()
+  expect(enqueue).toHaveBeenCalledTimes(1)
+  const queued = enqueue.mock.calls[0][0]
+
+  // Back on the same row before the queued PATCH is acknowledged.
+  document.getElementById('inline-move-up').click()
+  await flushPromises()
+  expect(document.getElementById('inline-edit-form-element').dataset.creativeId).toBe('42')
+
+  queued.onSuccess({ markdown_source: 'draft /blob/image.png' })
+
+  expect(textarea.value).toBe('draft /blob/image.png')
+  expect(document.getElementById('inline-markdown-source').value).toBe('draft /blob/image.png')
+  expect(first.rowComponent.dataset.markdownSource).toBe('draft /blob/image.png')
+
+  // The rewrite also moved the dirty baseline (originalContent), so simply
+  // reopening and leaving the row must not queue a second save.
+  enqueue.mockClear()
+  document.getElementById('inline-move-down').click()
+  await flushPromises()
+  expect(enqueue).not.toHaveBeenCalled()
+})

--- a/engines/collavre/app/javascript/modules/__tests__/creative_save_state.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/creative_save_state.test.js
@@ -67,3 +67,33 @@ test('resets baselines and keeps a newer buffer dirty', () => {
   })
   expect(resetCreativeSaveState(snapshot).isDirty).toBe(false)
 })
+
+test('leaves the live buffer alone when the rewrite cannot be reconciled', () => {
+  const dataUri = 'data:image/png;base64,abc123'
+  const snapshot = captureCreativeSaveSnapshot({
+    content: `before ${dataUri}`,
+    emptyContentType: 'markdown',
+    contentType: 'markdown',
+    markdownSource: `before ${dataUri}`,
+  })
+  const applyCurrent = jest.fn()
+  const applyCached = jest.fn()
+
+  const result = applyCreativeSaveResponse(
+    snapshot,
+    { markdown_source: 'before /blob/image' },
+    {
+      // The user dropped the uploaded image while the save was in flight, so
+      // the substitution has nowhere to land in the live buffer.
+      currentMarkdownSource: 'rewritten from scratch',
+      applyCurrentMarkdownSource: applyCurrent,
+      applyCachedMarkdownSource: applyCached,
+    }
+  )
+
+  expect(applyCached).toHaveBeenCalledWith('before /blob/image', `before ${dataUri}`)
+  expect(applyCurrent).not.toHaveBeenCalled()
+  expect(result.snapshot).toBe(snapshot)
+  expect(result.currentMarkdownSource).toBe('rewritten from scratch')
+  expect(result.currentApplied).toBe(false)
+})

--- a/engines/collavre/app/javascript/modules/__tests__/creative_save_state.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/creative_save_state.test.js
@@ -1,0 +1,69 @@
+/**
+ * @jest-environment jsdom
+ */
+import { jest } from '@jest/globals'
+import {
+  applyCreativeSaveResponse,
+  captureCreativeSaveSnapshot,
+  creativeSaveSnapshotIsEmpty,
+  resetCreativeSaveState,
+} from '../creative_save_state'
+
+test('tests emptiness using the snapshot content format', () => {
+  const html = captureCreativeSaveSnapshot({
+    content: '<p><br></p>',
+    emptyContentType: 'html',
+  })
+  const markdown = captureCreativeSaveSnapshot({
+    content: '<p>rendered</p>',
+    emptyContent: '   ',
+    emptyContentType: 'markdown',
+  })
+
+  expect(creativeSaveSnapshotIsEmpty(html)).toBe(true)
+  expect(creativeSaveSnapshotIsEmpty(markdown)).toBe(true)
+})
+
+test('applies server markdown substitutions to cached and live content', () => {
+  const dataUri = 'data:image/png;base64,abc123'
+  const snapshot = captureCreativeSaveSnapshot({
+    content: `before ${dataUri}`,
+    emptyContentType: 'markdown',
+    contentType: 'markdown',
+    markdownSource: `before ${dataUri}`,
+  })
+  const applyCurrent = jest.fn()
+  const applyCached = jest.fn()
+
+  const result = applyCreativeSaveResponse(
+    snapshot,
+    { markdown_source: 'before /blob/image' },
+    {
+      currentMarkdownSource: `before ${dataUri} plus typing`,
+      applyCurrentMarkdownSource: applyCurrent,
+      applyCachedMarkdownSource: applyCached,
+    }
+  )
+
+  expect(applyCached).toHaveBeenCalledWith('before /blob/image', `before ${dataUri}`)
+  expect(applyCurrent).toHaveBeenCalledWith('before /blob/image plus typing')
+  expect(result.snapshot.content).toBe('before /blob/image')
+  expect(result.currentApplied).toBe(true)
+})
+
+test('resets baselines and keeps a newer buffer dirty', () => {
+  const snapshot = captureCreativeSaveSnapshot({
+    content: 'saved', progress: 1, persistProgress: true, originId: '7',
+  })
+
+  expect(resetCreativeSaveState(snapshot, {
+    content: 'newer', progress: 1, originId: '7',
+  })).toEqual({
+    originalContent: 'saved',
+    originalProgress: 1,
+    originalOriginId: '7',
+    isDirty: true,
+    pendingSave: false,
+  })
+  expect(resetCreativeSaveState(snapshot).isDirty).toBe(false)
+})

--- a/engines/collavre/app/javascript/modules/__tests__/support/inline_editor_dom.js
+++ b/engines/collavre/app/javascript/modules/__tests__/support/inline_editor_dom.js
@@ -28,6 +28,21 @@ export const DIV_IDS = [
   'inline-save-status', 'metadata-popup',
 ]
 
+const INPUT_NAMES = {
+  'inline-method': '_method',
+  'inline-creative-description': 'creative[description]',
+  'inline-content-type': 'creative[content_type_input]',
+  'inline-markdown-editor': 'creative[markdown_editor]',
+  'inline-markdown-source': 'creative[markdown_source]',
+  'inline-parent-id': 'creative[parent_id]',
+  'inline-before-id': 'before_id',
+  'inline-after-id': 'after_id',
+  'inline-child-id': 'child_id',
+  'inline-origin-id': 'creative[origin_id]',
+  'inline-history-anchor-id': 'history_anchor_id',
+  'inline-change-group-token': 'change_group_token',
+}
+
 export function buildEditorDom(container, {
   saveFailedMessage,
   archiveFailedMessage,
@@ -49,13 +64,19 @@ export function buildEditorDom(container, {
     const input = document.createElement('input')
     input.type = 'hidden'
     input.id = id
-    if (id === 'inline-history-anchor-id') input.name = 'history_anchor_id'
-    if (id === 'inline-change-group-token') input.name = 'change_group_token'
+    input.name = INPUT_NAMES[id]
     form.appendChild(input)
   })
+  const hiddenProgress = document.createElement('input')
+  hiddenProgress.type = 'hidden'
+  hiddenProgress.name = 'creative[progress]'
+  hiddenProgress.value = '0'
+  form.appendChild(hiddenProgress)
   const progress = document.createElement('input')
   progress.type = 'checkbox'
   progress.id = 'inline-creative-progress'
+  progress.name = 'creative[progress]'
+  progress.value = '1'
   form.appendChild(progress)
 
   const editorRoot = document.createElement('div')

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -7,9 +7,14 @@ import { markdownCreativeCommandRange, openCreativeLinkPicker } from './creative
 import { renderCreativeTree, dispatchCreativeTreeUpdated } from '../creatives/tree_renderer'
 import { isProgressComplete, progressBaselineValueFrom, progressValueChangedFrom } from './creative_progress'
 import { renderMarkdown } from '../lib/utils/markdown'
-import { reconcileMarkdownSource } from './markdown_source_reconcile'
-import { isHtmlEmpty } from './html_content_empty'
 import { CreativeSaveQueue } from './creative_save_queue'
+import { isHtmlEmpty } from './html_content_empty'
+import {
+  applyCreativeSaveResponse,
+  captureCreativeSaveSnapshot,
+  creativeSaveSnapshotIsEmpty,
+  resetCreativeSaveState,
+} from './creative_save_state'
 import { createListenerRegistry } from './dom_listener_registry'
 import { createDelegatedClickHandler } from './creative_row_editor_delegated_clicks'
 import { confirmDialog, alertDialog } from '../lib/utils/dialog'
@@ -18,7 +23,6 @@ import yaml from 'js-yaml'
 import {
   treeRowElement,
   hasDatasetValue,
-  isMarkdownEmpty,
   readRowLevel,
   editorPaddingForLevel,
 } from './creative_row_editor_helpers'
@@ -756,10 +760,17 @@ function setupEditorSession() {
         // Sync markdown form fields before saving
         if (markdownMode) syncMarkdownToForm();
 
-        const isEmpty = markdownMode
-          ? isMarkdownEmpty(markdownTextarea?.value)
-          : isHtmlEmpty(descriptionInput.value);
-        if (isEmpty) {
+        let snapshot = captureCreativeSaveSnapshot({
+          content: markdownMode ? (markdownTextarea?.value || '') : descriptionInput.value,
+          emptyContentType: markdownMode ? 'markdown' : 'html',
+          contentType: contentTypeInput?.value || 'html',
+          markdownSource: markdownSourceInput?.value || '',
+          markdownEditor: markdownEditorInput?.value || '',
+          progress: progressValueChanged() ? readProgressValue() : progressBaselineValueFrom(originalProgress),
+          persistProgress: progressValueChanged(),
+          originId: originIdInput?.value || '',
+        });
+        if (creativeSaveSnapshotIsEmpty(snapshot)) {
           pendingSave = false;
           // Nothing to persist — don't strand the "pending" label set above.
           if (tree === currentTree) setSaveStatus('');
@@ -778,13 +789,7 @@ function setupEditorSession() {
         };
         applySaveStatus('saving');
 
-        // Capture values being saved to update dirty state on success
-        // NOTE: `let` (not `const`) — when the server rewrites markdown_source
-        // (e.g. data: URI → blob path) we reassign below.
-        let savedContent = markdownMode ? (markdownTextarea?.value || '') : descriptionInput.value;
-        const shouldPersistProgress = progressValueChanged();
-        const savedProgress = shouldPersistProgress ? readProgressValue() : progressBaselineValueFrom(originalProgress);
-        const savedOriginId = originIdInput ? originIdInput.value : '';
+        const shouldPersistProgress = snapshot.persistProgress;
         const cascadeProgressUpdate = completionCascadePending;
         const progressInputsDisabled = progressInput?.disabled ?? false;
         const hiddenProgressDisabled = progressHiddenInput?.disabled ?? false;
@@ -802,39 +807,24 @@ function setupEditorSession() {
           return r.text().then(function (text) {
             try { return text ? JSON.parse(text) : {}; } catch (e) { return {}; }
           }).then(function (data) {
-            // Sync rewritten markdown source back into the textarea/hidden input.
-            // Server rewrites inline data: URIs in markdown_source to blob paths so
-            // re-saves don't re-import the same image. If the user typed during the
-            // request, merge the substitutions into the live textarea so the next
-            // save still carries blob paths instead of re-importing the data URI.
-            if (markdownMode && data && typeof data.markdown_source === 'string'
-                && data.markdown_source !== savedContent && markdownTextarea) {
-              const reconciled = reconcileMarkdownSource(
-                savedContent, data.markdown_source, markdownTextarea.value
-              );
-              if (reconciled !== null && reconciled !== markdownTextarea.value) {
-                markdownTextarea.value = reconciled;
+            const applied = applyCreativeSaveResponse(snapshot, data, {
+              currentMarkdownSource: markdownMode ? markdownTextarea?.value : undefined,
+              applyCurrentMarkdownSource: (source) => {
+                markdownTextarea.value = source;
                 syncMarkdownToForm();
-              }
-              if (reconciled !== null) {
-                savedContent = data.markdown_source;
-              }
-            }
+              },
+            });
+            snapshot = applied.snapshot;
 
-            // Update dirty state to reflect successful save
-            originalContent = savedContent;
-            if (shouldPersistProgress) {
-              originalProgress = savedProgress;
-            }
-            originalOriginId = savedOriginId;
-
-            // If current values match what was just saved, clear dirty flag
-            const currentContent = markdownMode ? (markdownTextarea?.value || '') : descriptionInput.value;
-            if (currentContent === savedContent &&
-              readProgressValue() === savedProgress &&
-              originIdInput.value === savedOriginId) {
-              isDirty = false;
-            }
+            const reset = resetCreativeSaveState(snapshot, {
+              content: markdownMode ? (markdownTextarea?.value || '') : descriptionInput.value,
+              progress: readProgressValue(),
+              originId: originIdInput?.value || '',
+            });
+            originalContent = reset.originalContent;
+            if (reset.originalProgress !== undefined) originalProgress = reset.originalProgress;
+            originalOriginId = reset.originalOriginId;
+            isDirty = reset.isDirty;
 
             if (method === 'POST' && data.id) {
               form.action = `/creatives/${data.id}`;
@@ -1143,22 +1133,22 @@ function setupEditorSession() {
       if (markdownMode) syncMarkdownToForm();
       const capturedContentType = contentTypeInput ? contentTypeInput.value : 'html';
       const isMarkdownSave = capturedContentType === 'markdown';
-      let currentContent = descriptionInput.value;
-      let currentProgress = readProgressValue();
-      let shouldPersistProgress = progressValueChanged();
+      let snapshot = captureCreativeSaveSnapshot({
+        content: descriptionInput.value,
+        emptyContent: isMarkdownSave ? markdownSourceInput?.value : descriptionInput.value,
+        emptyContentType: isMarkdownSave ? 'markdown' : 'html',
+        contentType: capturedContentType,
+        markdownSource: isMarkdownSave ? markdownSourceInput?.value : '',
+        markdownEditor: markdownEditorInput?.value || '',
+        progress: readProgressValue(),
+        persistProgress: progressValueChanged(),
+        originId: originIdInput?.value || '',
+      });
       const currentParentId = tree.dataset.parentId || '';
       const currentBeforeId = tree.previousElementSibling ? creativeIdFrom(tree.previousElementSibling) : '';
       const currentAfterId = tree.nextElementSibling ? creativeIdFrom(tree.nextElementSibling) : '';
       const startCreativeId = creativeId;
-      let capturedMarkdownSource = isMarkdownSave ? (markdownSourceInput ? markdownSourceInput.value : '') : '';
-      const capturedMarkdownEditor = markdownEditorInput ? markdownEditorInput.value : '';
-
-      // Prevent saving empty content, matching saveForm behavior
-      // This avoids overwriting existing descriptions with empty strings during quick navigation
-      const isEmpty = isMarkdownSave
-        ? isMarkdownEmpty(capturedMarkdownSource)
-        : isHtmlEmpty(currentContent);
-      if (isEmpty) {
+      if (creativeSaveSnapshotIsEmpty(snapshot)) {
         pendingSave = false;
         return;
       }
@@ -1173,34 +1163,36 @@ function setupEditorSession() {
       // so we must re-sync and re-capture the latest textarea value too — otherwise edits
       // made during the upload wait get overwritten by the stale pre-wait source.
       if (form.dataset.creativeId === startCreativeId) {
-        if (markdownMode) {
-          syncMarkdownToForm();
-          capturedMarkdownSource = markdownSourceInput ? markdownSourceInput.value : '';
-        } else if (isMarkdownSave && markdownSourceInput) {
-          // Rich surface: re-capture any Markdown produced by edits during the wait.
-          capturedMarkdownSource = markdownSourceInput.value;
-        }
-        currentContent = descriptionInput.value;
-        currentProgress = readProgressValue();
-        shouldPersistProgress = progressValueChanged();
+        if (markdownMode) syncMarkdownToForm();
+        snapshot = captureCreativeSaveSnapshot({
+          content: descriptionInput.value,
+          emptyContent: isMarkdownSave ? markdownSourceInput?.value : descriptionInput.value,
+          emptyContentType: isMarkdownSave ? 'markdown' : 'html',
+          contentType: capturedContentType,
+          markdownSource: isMarkdownSave ? markdownSourceInput?.value : '',
+          markdownEditor: markdownEditorInput?.value || '',
+          progress: readProgressValue(),
+          persistProgress: progressValueChanged(),
+          originId: originIdInput?.value || '',
+        });
       }
 
       // Build request body
       // Note: before_id and after_id must be top-level params, not nested under creative[]
       // because CreativesController reads params[:before_id] and params[:after_id] for positioning
       const body = {
-        'creative[description]': currentContent,
-        'creative[content_type_input]': capturedContentType
+        'creative[description]': snapshot.content,
+        'creative[content_type_input]': snapshot.contentType
       };
       if (isMarkdownSave) {
-        body['creative[markdown_source]'] = capturedMarkdownSource;
-        if (capturedMarkdownEditor) {
-          body['creative[markdown_editor]'] = capturedMarkdownEditor;
+        body['creative[markdown_source]'] = snapshot.markdownSource;
+        if (snapshot.markdownEditor) {
+          body['creative[markdown_editor]'] = snapshot.markdownEditor;
         }
       }
 
-      if (shouldPersistProgress) {
-        body['creative[progress]'] = currentProgress;
+      if (snapshot.persistProgress) {
+        body['creative[progress]'] = snapshot.progress;
       }
 
       // Always include parent_id, even if empty (for moving to root)
@@ -1221,18 +1213,18 @@ function setupEditorSession() {
       if (tree) {
         const row = treeRowElement(tree);
         if (row) {
-          row.dataset.descriptionHtml = currentContent;
-          row.descriptionHtml = currentContent;
-          row.dataset.descriptionRawHtml = currentContent;
-          if (shouldPersistProgress) {
-            row.dataset.progressValue = String(currentProgress);
+          row.dataset.descriptionHtml = snapshot.content;
+          row.descriptionHtml = snapshot.content;
+          row.dataset.descriptionRawHtml = snapshot.content;
+          if (snapshot.persistProgress) {
+            row.dataset.progressValue = String(snapshot.progress);
           }
-          row.dataset.contentType = capturedContentType;
-          row.dataset.markdownSource = isMarkdownSave ? capturedMarkdownSource : '';
+          row.dataset.contentType = snapshot.contentType;
+          row.dataset.markdownSource = isMarkdownSave ? snapshot.markdownSource : '';
           // Persist which surface authored this save so a row re-opened from this
           // cached payload (before any full GET refresh) reopens in the right
           // editor — without it, rich-authored Markdown falls back to the textarea.
-          row.dataset.markdownEditor = isMarkdownSave ? capturedMarkdownEditor : '';
+          row.dataset.markdownEditor = isMarkdownSave ? snapshot.markdownEditor : '';
           if (currentParentId) {
             tree.dataset.parentId = currentParentId;
             row.parentId = currentParentId;
@@ -1258,8 +1250,8 @@ function setupEditorSession() {
       // Capture per-enqueue values for the onSuccess closure so concurrent edits
       // on a different creative don't get clobbered when the response comes back.
       const onSuccessCreativeId = startCreativeId;
-      const onSuccessSavedMarkdown = isMarkdownSave ? capturedMarkdownSource : null;
       const onSuccessTree = tree;
+      const onSuccessSnapshot = snapshot;
       apiQueue.enqueue({
         path: `/creatives/${creativeId}`,
         method: 'PATCH',
@@ -1267,47 +1259,36 @@ function setupEditorSession() {
         dedupeKey: `creative_${creativeId}`,
         deletedAttachmentIds: deletedAttachmentIds,  // Store as data for serialization
         onSuccess: function (data) {
-          if (!isMarkdownSave || !data || typeof data.markdown_source !== 'string') return;
-          if (data.markdown_source === onSuccessSavedMarkdown) return;
-
-          // Update the row dataset cache regardless of which creative is active now,
-          // so a later loadCreative() for this row picks up the rewritten source.
-          if (onSuccessTree) {
-            const row = treeRowElement(onSuccessTree);
-            if (row && row.dataset.markdownSource === onSuccessSavedMarkdown) {
-              row.dataset.markdownSource = data.markdown_source;
-              row.requestUpdate?.();
-            }
-          }
-
-          // Merge the data: URI -> blob path substitutions into the live textarea,
-          // even if the user typed during the queued save. We still require the
-          // same creative to be open (race-safe across editor switches).
-          if (form.dataset.creativeId === onSuccessCreativeId
-              && markdownMode
-              && markdownTextarea) {
-            const reconciled = reconcileMarkdownSource(
-              onSuccessSavedMarkdown, data.markdown_source, markdownTextarea.value
-            );
-            if (reconciled !== null && reconciled !== markdownTextarea.value) {
-              markdownTextarea.value = reconciled;
+          if (!isMarkdownSave) return;
+          const canApplyToCurrentEditor = form.dataset.creativeId === onSuccessCreativeId
+            && markdownMode
+            && markdownTextarea;
+          const applied = applyCreativeSaveResponse(onSuccessSnapshot, data, {
+            currentMarkdownSource: canApplyToCurrentEditor ? markdownTextarea.value : undefined,
+            applyCurrentMarkdownSource: (source) => {
+              markdownTextarea.value = source;
               syncMarkdownToForm();
-            }
-            if (reconciled !== null) {
-              originalContent = data.markdown_source;
-            }
+            },
+            applyCachedMarkdownSource: (source, savedSource) => {
+              const row = onSuccessTree ? treeRowElement(onSuccessTree) : null;
+              if (row && row.dataset.markdownSource === savedSource) {
+                row.dataset.markdownSource = source;
+                row.requestUpdate?.();
+              }
+            },
+          });
+          if (canApplyToCurrentEditor && applied.currentApplied) {
+            originalContent = applied.snapshot.content;
           }
         }
       });
       // console.warn('apiQueue.enqueue disabled for debugging');
 
-      // Reset dirty state
-      originalContent = currentContent;
-      if (shouldPersistProgress) {
-        originalProgress = currentProgress;
-      }
-      isDirty = false;
-      pendingSave = false;
+      const reset = resetCreativeSaveState(snapshot);
+      originalContent = reset.originalContent;
+      if (reset.originalProgress !== undefined) originalProgress = reset.originalProgress;
+      isDirty = reset.isDirty;
+      pendingSave = reset.pendingSave;
       saveQueue.cancelTimer();
     }
 

--- a/engines/collavre/app/javascript/modules/creative_save_state.js
+++ b/engines/collavre/app/javascript/modules/creative_save_state.js
@@ -1,0 +1,84 @@
+import { isHtmlEmpty } from './html_content_empty'
+import { isMarkdownEmpty } from './creative_row_editor_helpers'
+import { reconcileMarkdownSource } from './markdown_source_reconcile'
+
+export function captureCreativeSaveSnapshot({
+  content,
+  emptyContent = content,
+  emptyContentType = 'html',
+  contentType = 'html',
+  markdownSource = '',
+  markdownEditor = '',
+  progress = 0,
+  persistProgress = false,
+  originId = '',
+}) {
+  return {
+    content: content || '',
+    emptyContent: emptyContent || '',
+    emptyContentType,
+    contentType,
+    markdownSource: markdownSource || '',
+    markdownEditor: markdownEditor || '',
+    progress,
+    persistProgress,
+    originId: originId || '',
+  }
+}
+
+export function creativeSaveSnapshotIsEmpty(snapshot) {
+  return snapshot.emptyContentType === 'markdown'
+    ? isMarkdownEmpty(snapshot.emptyContent)
+    : isHtmlEmpty(snapshot.emptyContent)
+}
+
+export function applyCreativeSaveResponse(snapshot, data, {
+  currentMarkdownSource,
+  applyCurrentMarkdownSource,
+  applyCachedMarkdownSource,
+} = {}) {
+  const serverSource = data?.markdown_source
+  if (typeof serverSource !== 'string' || serverSource === snapshot.markdownSource) {
+    return { snapshot, currentMarkdownSource, currentApplied: false }
+  }
+
+  applyCachedMarkdownSource?.(serverSource, snapshot.markdownSource)
+  if (typeof currentMarkdownSource !== 'string') {
+    return { snapshot, currentMarkdownSource, currentApplied: false }
+  }
+
+  const reconciled = reconcileMarkdownSource(
+    snapshot.markdownSource, serverSource, currentMarkdownSource
+  )
+  if (reconciled === null) {
+    return { snapshot, currentMarkdownSource, currentApplied: false }
+  }
+
+  if (reconciled !== currentMarkdownSource) applyCurrentMarkdownSource?.(reconciled)
+  return {
+    snapshot: {
+      ...snapshot,
+      content: snapshot.emptyContentType === 'markdown' ? serverSource : snapshot.content,
+      emptyContent: snapshot.emptyContentType === 'markdown' ? serverSource : snapshot.emptyContent,
+      markdownSource: serverSource,
+    },
+    currentMarkdownSource: reconciled,
+    currentApplied: true,
+  }
+}
+
+export function resetCreativeSaveState(snapshot, current = null) {
+  const matchesSnapshot = !current || (
+    current.content === snapshot.content &&
+    current.progress === snapshot.progress &&
+    current.originId === snapshot.originId
+  )
+
+  return {
+    originalContent: snapshot.content,
+    originalProgress: snapshot.persistProgress ? snapshot.progress : undefined,
+    originalOriginId: snapshot.originId,
+    isDirty: !matchesSnapshot,
+    pendingSave: false,
+  }
+}


### PR DESCRIPTION
## Summary

- characterize the direct FormData and persistent queue save paths
- extract shared empty-content, snapshot, response-application, and dirty-reset responsibilities
- preserve separate request bodies and execution strategies for both paths

## Verification

- `npm test -- --runInBand` (2,254 tests)
- `mise exec ruby@3.4.4 -- bin/complexity_check`
- `mise exec ruby@3.4.4 -- ./bin/rubocop -a engines/collavre`
- targeted host regression tests for GitHub encryption-dependent cases (11 tests)

Full parallel `bin/rails test` is currently affected by a pre-existing Active Record encryption configuration failure in 11 GitHub tests; the same tests pass sequentially.