### PR TITLE
refactor(collavre): extract trigger action command

### DIFF
--- a/engines/collavre/app/controllers/collavre/creatives_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creatives_controller.rb
@@ -455,87 +455,17 @@ module Collavre
 
     def trigger_action
       action = params[:action_name] || (request.content_type&.include?("json") ? request.request_parameters["action"] : params[:action])
+      enabled = request.content_type&.include?("json") ? request.request_parameters["enabled"] : params[:enabled]
+      result = Creatives::TriggerActionCommand.new(
+        creative: @creative,
+        user: Current.user,
+        action: action,
+        enabled: enabled
+      ).call
 
-      case action
-      when "toggle_container"
-        # Container toggle operates on effective_origin (where trigger config lives)
-        creative = @creative.effective_origin(Set.new)
-        unless creative.has_permission?(Current.user, :write)
-          render json: { error: t("collavre.creatives.errors.no_permission") }, status: :forbidden
-          return
-        end
+      return head :ok if result.success?
 
-        enabled = ActiveModel::Type::Boolean.new.cast(
-          request.content_type&.include?("json") ? request.request_parameters["enabled"] : params[:enabled]
-        )
-        data = creative.data || {}
-        trigger = data["trigger"] || {}
-        trigger["on_child_enter"] = enabled
-        data["trigger"] = trigger
-        previous_enabled = creative.drop_trigger_enabled?
-        creative.update!(data: data)
-        notify_drop_trigger_missing_agent!(creative) if !previous_enabled && creative.drop_trigger_enabled?
-      when "start"
-        # Start trigger: fires DropTriggerJob as if the child was just dropped into the container
-        creative = @creative
-        unless creative.has_permission?(Current.user, :write)
-          render json: { error: t("collavre.creatives.errors.no_permission") }, status: :forbidden
-          return
-        end
-
-        parent = creative.parent
-        unless parent&.drop_trigger_enabled?
-          render json: { error: t("collavre.drop_trigger.not_a_container") }, status: :unprocessable_entity
-          return
-        end
-
-        DropTriggerJob.perform_later(parent.id, creative.id)
-
-      when "pause", "resume", "restart"
-        # Loop actions operate on the creative itself (where loop state lives)
-        creative = @creative
-        unless creative.has_permission?(Current.user, :write)
-          render json: { error: t("collavre.creatives.errors.no_permission") }, status: :forbidden
-          return
-        end
-
-        data = creative.data || {}
-        trigger = data["trigger"] || {}
-        loop_data = trigger["loop"]
-
-        case action
-        when "pause"
-          if loop_data && %w[running pending_verification].include?(loop_data["state"])
-            loop_data["state"] = "paused"
-            trigger["loop"] = loop_data
-            data["trigger"] = trigger
-            creative.update!(data: data)
-          end
-        when "resume"
-          if loop_data && %w[paused idle stuck awaiting_user].include?(loop_data["state"])
-            loop_data["state"] = "running"
-            trigger["loop"] = loop_data
-            data["trigger"] = trigger
-            creative.update!(data: data)
-            post_continue_to_agent(creative, loop_data)
-          end
-        when "restart"
-          if loop_data && %w[completed max_reached stuck].include?(loop_data["state"])
-            loop_data["state"] = "running"
-            loop_data["current_iteration"] = 0
-            loop_data["infra_retry_count"] = 0
-            trigger["loop"] = loop_data
-            data["trigger"] = trigger
-            creative.update!(data: data)
-            post_restart_trigger(creative)
-          end
-        end
-      else
-        render json: { error: "Unknown action" }, status: :unprocessable_entity
-        return
-      end
-
-      head :ok
+      render json: { error: result.error }, status: result.status
     end
 
     def archive
@@ -726,93 +656,8 @@ module Collavre
         @reorderer ||= ::Creatives::Reorderer.new(user: Current.user)
       end
 
-      # Resume: post a continue instruction so the agent picks up where it left off.
-      # Creates a comment that triggers dispatch via after_create_commit.
-      def post_continue_to_agent(creative, loop_data)
-        parent = creative.parent
-        unless parent
-          Rails.logger.warn("[TriggerAction] resume: no parent for creative #{creative.id}")
-          return
-        end
-
-        topic = creative.topics.find_by(name: "Drop Trigger")
-        agent = parent.find_ai_agent(:write)
-        unless topic && agent
-          Rails.logger.warn("[TriggerAction] resume: missing topic=#{topic&.id} or agent for creative #{creative.id}")
-          return
-        end
-
-        iteration = loop_data["current_iteration"] || 0
-        max = loop_data["max_iterations"] || 10
-        content = "@#{agent.name}: #{t(
-          'collavre.trigger_loop.continue',
-          iteration: iteration,
-          max: max
-        )}"
-
-        # Use Current.user (human who clicked resume) as comment author
-        # so dispatch_to_orchestration doesn't skip it (it skips ai_user? authors)
-        comment = creative.comments.create!(
-          content: content,
-          topic_id: topic.id,
-          private: false,
-          user: Current.user,
-          skip_dispatch: false
-        )
-        Rails.logger.info("[TriggerAction] resume: posted continue comment #{comment.id} for creative #{creative.id}")
-      end
-
-      # Restart: create a fresh trigger comment and dispatch it explicitly.
-      # Uses skip_dispatch:true + manual SystemEvents dispatch to bypass
-      # after_create_commit (which would skip if user is ai_user?).
-      def post_restart_trigger(creative)
-        parent = creative.parent
-        unless parent
-          Rails.logger.warn("[TriggerAction] restart: no parent for creative #{creative.id}")
-          return
-        end
-
-        topic = creative.topics.find_by(name: "Drop Trigger")
-        agent = parent.find_ai_agent(:write)
-        unless topic && agent
-          Rails.logger.warn("[TriggerAction] restart: missing topic=#{topic&.id} or agent for creative #{creative.id}")
-          return
-        end
-
-        trigger_text = t(
-          "collavre.drop_trigger.child_entered",
-          child_description: creative.creative_snippet,
-          child_id: creative.id,
-          parent_description: parent.creative_snippet
-        )
-        loop_instructions = t("collavre.trigger_loop.instructions")
-        content = "@#{agent.name}: #{trigger_text}\n\n#{loop_instructions}"
-
-        comment = creative.comments.create!(
-          content: content,
-          topic_id: topic.id,
-          private: false,
-          user: Current.user,
-          skip_dispatch: true
-        )
-
-        scheduled = SystemEvents::Dispatcher.dispatch("comment_created", comment.dispatch_payload, source: "trigger_restart")
-        Rails.logger.info("[TriggerAction] restart: posted trigger comment #{comment.id}, dispatched to #{scheduled&.size || 0} agents")
-      end
-
       def notify_drop_trigger_missing_agent!(creative)
-        return if creative.find_ai_agent(:write)
-
-        topic = creative.topics.find_or_create_by!(name: "Drop Trigger") do |t|
-          t.user = creative.user
-        end
-
-        creative.comments.create!(
-          content: t("collavre.drop_trigger.no_agent", parent_description: creative.creative_snippet),
-          topic_id: topic.id,
-          private: false,
-          skip_default_user: true
-        )
+        Creatives::DropTriggerMissingAgentNotifier.new(creative: creative).call
       end
 
       def enforce_creatives_login_policy

--- a/engines/collavre/app/services/collavre/creatives/drop_trigger_missing_agent_notifier.rb
+++ b/engines/collavre/app/services/collavre/creatives/drop_trigger_missing_agent_notifier.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Collavre
+  module Creatives
+    # Records a visible warning when an enabled trigger has no writable agent.
+    class DropTriggerMissingAgentNotifier
+      def initialize(creative:)
+        @creative = creative
+      end
+
+      def call
+        return if creative.find_ai_agent(:write)
+
+        topic = creative.topics.find_or_create_by!(name: "Drop Trigger") do |record|
+          record.user = creative.user
+        end
+
+        creative.comments.create!(
+          content: I18n.t("collavre.drop_trigger.no_agent", parent_description: creative.creative_snippet),
+          topic_id: topic.id,
+          private: false,
+          skip_default_user: true
+        )
+      end
+
+      private
+
+      attr_reader :creative
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/creatives/trigger_action_command.rb
+++ b/engines/collavre/app/services/collavre/creatives/trigger_action_command.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+module Collavre
+  module Creatives
+    # Executes one trigger UI command after authorizing its target creative.
+    class TriggerActionCommand
+      ACTIONS = %w[toggle_container start pause resume restart].freeze
+      PAUSABLE_STATES = %w[running pending_verification].freeze
+      RESUMABLE_STATES = %w[paused idle stuck awaiting_user].freeze
+      RESTARTABLE_STATES = %w[completed max_reached stuck].freeze
+
+      Result = Struct.new(:error, :status, keyword_init: true) do
+        def success?
+          error.nil?
+        end
+      end
+
+      def initialize(creative:, user:, action:, enabled: nil)
+        @creative = creative
+        @user = user
+        @action = action
+        @enabled = enabled
+      end
+
+      def call
+        return failure(:unprocessable_entity, "collavre.drop_trigger.unknown_action") unless ACTIONS.include?(action)
+        return failure(:forbidden, "collavre.creatives.errors.no_permission") unless target.has_permission?(user, :write)
+
+        @transitioned_loop_data = nil
+        outcome = send(action)
+        outcome.is_a?(Result) ? outcome : Result.new
+      end
+
+      private
+
+      attr_reader :creative, :user, :action, :enabled
+
+      def target
+        @target ||= action == "toggle_container" ? creative.effective_origin(Set.new) : creative
+      end
+
+      def toggle_container
+        previous_enabled = target.drop_trigger_enabled?
+        data = (target.data || {}).deep_dup
+        data["trigger"] ||= {}
+        data["trigger"]["on_child_enter"] = ActiveModel::Type::Boolean.new.cast(enabled)
+        target.update!(data: data)
+        notify_missing_agent if !previous_enabled && target.drop_trigger_enabled?
+      end
+
+      def start
+        parent = creative.parent
+        return failure(:unprocessable_entity, "collavre.drop_trigger.not_a_container") unless parent&.drop_trigger_enabled?
+
+        DropTriggerJob.perform_later(parent.id, creative.id)
+      end
+
+      def pause
+        transition_loop(PAUSABLE_STATES) { |loop_data| loop_data["state"] = "paused" }
+      end
+
+      def resume
+        transition_loop(RESUMABLE_STATES) { |loop_data| loop_data["state"] = "running" }
+        post_continue_to_agent if @transitioned_loop_data
+      end
+
+      def restart
+        transition_loop(RESTARTABLE_STATES) do |loop_data|
+          loop_data.merge!("state" => "running", "current_iteration" => 0, "infra_retry_count" => 0)
+        end
+        post_restart_trigger if @transitioned_loop_data
+      end
+
+      def transition_loop(allowed_states)
+        data = (creative.data || {}).deep_dup
+        loop_data = data.dig("trigger", "loop")
+        return unless loop_data && allowed_states.include?(loop_data["state"])
+
+        yield loop_data
+        creative.update!(data: data)
+        @transitioned_loop_data = loop_data
+      end
+
+      def post_continue_to_agent
+        parent, topic, agent = trigger_context
+        return log_missing_context("resume", topic) unless parent && topic && agent
+
+        content = "@#{agent.name}: #{I18n.t(
+          'collavre.trigger_loop.continue',
+          iteration: @transitioned_loop_data["current_iteration"] || 0,
+          max: @transitioned_loop_data["max_iterations"] || 10
+        )}"
+        comment = create_trigger_comment(topic, content, skip_dispatch: false)
+        Rails.logger.info("[TriggerAction] resume: posted continue comment #{comment.id} for creative #{creative.id}")
+      end
+
+      def post_restart_trigger
+        parent, topic, agent = trigger_context
+        return log_missing_context("restart", topic) unless parent && topic && agent
+
+        content = "@#{agent.name}: #{restart_message(parent)}"
+        comment = create_trigger_comment(topic, content, skip_dispatch: true)
+        scheduled = SystemEvents::Dispatcher.dispatch("comment_created", comment.dispatch_payload, source: "trigger_restart")
+        Rails.logger.info("[TriggerAction] restart: posted trigger comment #{comment.id}, dispatched to #{scheduled&.size || 0} agents")
+      end
+
+      def restart_message(parent)
+        trigger_text = I18n.t(
+          "collavre.drop_trigger.child_entered",
+          child_description: creative.creative_snippet,
+          child_id: creative.id,
+          parent_description: parent.creative_snippet
+        )
+        "#{trigger_text}\n\n#{I18n.t('collavre.trigger_loop.instructions')}"
+      end
+
+      def trigger_context
+        parent = creative.parent
+        [ parent, creative.topics.find_by(name: "Drop Trigger"), parent&.find_ai_agent(:write) ]
+      end
+
+      def create_trigger_comment(topic, content, skip_dispatch:)
+        creative.comments.create!(
+          content: content,
+          topic_id: topic.id,
+          private: false,
+          user: user,
+          skip_dispatch: skip_dispatch
+        )
+      end
+
+      def log_missing_context(operation, topic)
+        Rails.logger.warn("[TriggerAction] #{operation}: missing topic=#{topic&.id} or agent for creative #{creative.id}")
+      end
+
+      def notify_missing_agent
+        DropTriggerMissingAgentNotifier.new(creative: target).call
+      end
+
+      def failure(status, key)
+        Result.new(error: I18n.t(key), status: status)
+      end
+    end
+  end
+end

--- a/engines/collavre/config/locales/drop_trigger.en.yml
+++ b/engines/collavre/config/locales/drop_trigger.en.yml
@@ -5,6 +5,7 @@ en:
       no_agent: "⚠️ Drop Trigger failed — No AI agent with write permission found on '%{parent_description}'. Please share an AI agent with write permission to enable automatic processing."
 
       not_a_container: "Parent is not a trigger container"
+      unknown_action: "Unknown action"
       toggle_on: "Drop Trigger enabled"
       toggle_off: "Drop Trigger disabled"
     trigger_loop:

--- a/engines/collavre/config/locales/drop_trigger.ko.yml
+++ b/engines/collavre/config/locales/drop_trigger.ko.yml
@@ -5,6 +5,7 @@ ko:
       no_agent: "⚠️ 드롭 트리거 실패 — '%{parent_description}'에 쓰기 권한을 가진 AI 에이전트가 없습니다. 자동 처리를 위해 AI 에이전트에 쓰기 권한을 부여해주세요."
 
       not_a_container: "부모가 트리거 컨테이너가 아닙니다"
+      unknown_action: "알 수 없는 작업입니다"
       toggle_on: "드롭 트리거 활성화됨"
       toggle_off: "드롭 트리거 비활성화됨"
     trigger_loop:

--- a/engines/collavre/test/controllers/creatives_controller_event_source_test.rb
+++ b/engines/collavre/test/controllers/creatives_controller_event_source_test.rb
@@ -7,7 +7,12 @@ module Collavre
       Current.session = OpenStruct.new(user: @user)
       @agent = users(:ai_bot)
       @parent = Creative.create!(user: @user, description: "Trigger parent")
-      @child = Creative.create!(user: @user, parent: @parent, description: "Trigger child")
+      @child = Creative.create!(
+        user: @user,
+        parent: @parent,
+        description: "Trigger child",
+        data: { "trigger" => { "loop" => { "state" => "completed" } } }
+      )
       CreativeShare.create!(creative: @parent, user: @agent, permission: :write)
       @child.topics.create!(name: "Drop Trigger", user: @user)
     end
@@ -22,7 +27,12 @@ module Collavre
         dispatch_options = options
         []
       }) do
-        CreativesController.new.send(:post_restart_trigger, @child)
+        result = Creatives::TriggerActionCommand.new(
+          creative: @child,
+          user: @user,
+          action: "restart"
+        ).call
+        assert result.success?
       end
 
       assert_equal "trigger_restart", dispatch_options[:source]

--- a/engines/collavre/test/services/creatives/trigger_action_command_test.rb
+++ b/engines/collavre/test/services/creatives/trigger_action_command_test.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  module Creatives
+    class TriggerActionCommandTest < ActiveSupport::TestCase
+      setup do
+        @user = users(:one)
+        @other_user = users(:two)
+        @container = Creative.create!(
+          user: @user,
+          description: "Trigger Container",
+          data: { "trigger" => { "on_child_enter" => true } }
+        )
+        @child = Creative.create!(user: @user, parent: @container, description: "Trigger Task")
+        clear_enqueued_jobs
+      end
+
+      test "rejects unknown actions" do
+        result = command(action: "invalid").call
+
+        refute result.success?
+        assert_equal :unprocessable_entity, result.status
+        assert_equal I18n.t("collavre.drop_trigger.unknown_action"), result.error
+      end
+
+      test "rejects actions without write permission" do
+        result = command(action: "pause", user: @other_user).call
+
+        refute result.success?
+        assert_equal :forbidden, result.status
+        assert_equal I18n.t("collavre.creatives.errors.no_permission"), result.error
+      end
+
+      test "toggle_container updates the effective origin" do
+        shell = Creative.create!(user: @other_user, origin: @container)
+        command = command(creative: shell, action: "toggle_container", enabled: false)
+
+        assert command.call.success?
+        refute @container.reload.drop_trigger_enabled?
+        assert_nil shell.reload.data&.dig("trigger", "on_child_enter")
+      end
+
+      test "toggle_container notifies only when enabling" do
+        @container.update!(data: { "trigger" => { "on_child_enter" => false } })
+
+        assert_difference -> { @container.comments.count }, 1 do
+          assert command(action: "toggle_container", enabled: true, creative: @container).call.success?
+        end
+        assert_equal "Drop Trigger", @container.comments.order(:id).last.topic.name
+
+        assert_no_difference -> { @container.comments.count } do
+          assert command(action: "toggle_container", enabled: true, creative: @container).call.success?
+        end
+      end
+
+      test "start enqueues the trigger job" do
+        previous_adapter = ActiveJob::Base.queue_adapter
+        ActiveJob::Base.queue_adapter = :test
+        begin
+          assert_enqueued_with(job: DropTriggerJob, args: [ @container.id, @child.id ]) do
+            assert command(action: "start").call.success?
+          end
+        ensure
+          ActiveJob::Base.queue_adapter = previous_adapter
+        end
+      end
+
+      test "start rejects a child outside a trigger container" do
+        parent = Creative.create!(user: @user, description: "Normal Parent")
+        child = Creative.create!(user: @user, parent: parent, description: "Normal Child")
+
+        result = command(creative: child, action: "start").call
+
+        refute result.success?
+        assert_equal :unprocessable_entity, result.status
+        assert_equal I18n.t("collavre.drop_trigger.not_a_container"), result.error
+      end
+
+      test "pause transitions running loop state" do
+        set_loop_state("running", "current_iteration" => 2)
+
+        assert command(action: "pause").call.success?
+        assert_equal "paused", @child.reload.data.dig("trigger", "loop", "state")
+        assert_equal 2, @child.data.dig("trigger", "loop", "current_iteration")
+      end
+
+      test "pause leaves an ineligible loop state unchanged" do
+        set_loop_state("completed")
+
+        assert command(action: "pause").call.success?
+        assert_equal "completed", @child.reload.data.dig("trigger", "loop", "state")
+      end
+
+      test "resume transitions eligible state and posts continuation" do
+        set_loop_state("awaiting_user", "current_iteration" => 3)
+        command = command(action: "resume")
+        posted = false
+        command.define_singleton_method(:post_continue_to_agent) { posted = true }
+
+        assert command.call.success?
+        assert posted
+        assert_equal "running", @child.reload.data.dig("trigger", "loop", "state")
+      end
+
+      test "restart resets loop counters and posts a fresh trigger" do
+        set_loop_state("max_reached", "current_iteration" => 8, "infra_retry_count" => 2)
+        command = command(action: "restart")
+        posted = false
+        command.define_singleton_method(:post_restart_trigger) { posted = true }
+
+        assert command.call.success?
+        assert posted
+        loop_data = @child.reload.data.dig("trigger", "loop")
+        assert_equal "running", loop_data["state"]
+        assert_equal 0, loop_data["current_iteration"]
+        assert_equal 0, loop_data["infra_retry_count"]
+      end
+
+      private
+
+      def command(creative: @child, user: @user, action:, enabled: nil)
+        TriggerActionCommand.new(creative: creative, user: user, action: action, enabled: enabled)
+      end
+
+      def set_loop_state(state, attributes = {})
+        @child.update!(data: { "trigger" => { "loop" => attributes.merge("state" => state) } })
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- extract trigger action authorization and state transitions from `CreativesController` into `Creatives::TriggerActionCommand`
- share missing-agent notification behavior through a dedicated notifier
- preserve trigger restart event-source coverage and add command-level regression tests

## Validation
- `./bin/rubocop -a`
- `bin/complexity_check --base origin/feature/refactor-reduce-dupl`
- `bin/rails test engines/collavre/test/services/creatives/trigger_action_command_test.rb engines/collavre/test/controllers/creatives_controller_trigger_task_test.rb engines/collavre/test/controllers/creatives_controller_event_source_test.rb`

## Local baseline limitations
- `bin/rails test` reaches 171 tests but 11 unrelated GitHub engine tests error without Active Record encryption credentials in this checkout.
- `bin/rails test:system` cannot load the absent host `test/system` directory. CI is the authoritative full-suite check.