### PR TITLE
Refactor comments popup fullscreen lifecycle

### DIFF
--- a/engines/collavre/app/javascript/controllers/comments/__tests__/popup_fullscreen.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/popup_fullscreen.test.js
@@ -123,4 +123,173 @@ describe('PopupFullscreen', () => {
     expect(callbacks.syncDockedUi).toHaveBeenCalledTimes(1)
     expect(manager.savedStyles).toBeNull()
   })
+
+  test('enters fullscreen without animation or history for auto-fullscreen', () => {
+    element.style.position = 'fixed'
+    element.style.top = '12px'
+    element.style.width = '300px'
+
+    manager.enterImmediate()
+
+    expect(element.dataset.fullscreen).toBe('true')
+    expect(document.body.classList.contains('chat-fullscreen')).toBe(true)
+    expect(callbacks.syncUi).toHaveBeenCalledWith(true)
+    expect(element.style.position).toBe('')
+    expect(element.style.top).toBe('')
+    expect(element.style.width).toBe('')
+    expect(window.location.pathname).toBe('/creatives/42')
+    expect(listController.scrollToBottom).toHaveBeenCalledTimes(1)
+  })
+
+  test('drops the entry animation styles once the transition settles', () => {
+    jest.spyOn(element, 'getBoundingClientRect').mockReturnValue({
+      top: 12,
+      left: 704,
+      width: 300,
+      height: 400,
+    })
+
+    manager.enter()
+    expect(element.style.position).toBe('fixed')
+
+    jest.advanceTimersByTime(300)
+
+    expect(element.style.position).toBe('')
+    expect(element.style.top).toBe('')
+    expect(element.style.height).toBe('')
+    expect(manager.enterCleanupTimer).toBeNull()
+    expect(manager.enterCleanupFn).toBeNull()
+  })
+
+  test('returns the docked popup to its dock without animation', () => {
+    callbacks.isDocked.mockReturnValue(true)
+    element.dataset.fullscreen = 'true'
+    element.style.position = 'fixed'
+    element.style.top = '0'
+    document.body.classList.add('chat-fullscreen')
+    manager.savedStyles = { width: '320px', height: '480px' }
+
+    manager.exit()
+
+    expect(element.dataset.fullscreen).toBe('false')
+    expect(element.style.position).toBe('')
+    expect(element.style.top).toBe('')
+    expect(document.body.classList.contains('chat-fullscreen')).toBe(false)
+    expect(callbacks.syncUi).toHaveBeenCalledWith(false)
+    expect(callbacks.syncDockedUi).toHaveBeenCalledTimes(1)
+    expect(manager.savedStyles).toBeNull()
+    expect(window.location.pathname).toBe('/creatives/42')
+    expect(new URLSearchParams(window.location.search).get('open_comments')).toBe('true')
+    expect(listController.scrollToBottom).toHaveBeenCalledTimes(1)
+  })
+
+  test('lands the desktop popup to the right of its trigger button when there is room', () => {
+    const button = document.createElement('button')
+    document.body.appendChild(button)
+    jest.spyOn(button, 'getBoundingClientRect').mockReturnValue({
+      top: 30,
+      bottom: 50,
+      left: 60,
+      right: 100,
+      width: 40,
+      height: 20,
+    })
+    callbacks.getCurrentButton.mockReturnValue(button)
+    jest.spyOn(element, 'getBoundingClientRect').mockReturnValue({
+      top: 0,
+      left: 0,
+      width: 1024,
+      height: 768,
+    })
+    element.dataset.fullscreen = 'true'
+    document.body.classList.add('chat-fullscreen')
+    manager.savedStyles = { top: '', right: '', left: '', width: '300px', height: '400px' }
+
+    manager.exit()
+
+    expect(callbacks.setCurrentButton).toHaveBeenCalledWith(button)
+    expect(element.dataset.fullscreen).toBe('false')
+    expect(element.style.left).toBe('108px')
+
+    jest.advanceTimersByTime(300)
+
+    expect(element.style.top).toBe('54px')
+    expect(element.style.width).toBe('300px')
+    expect(element.style.height).toBe('400px')
+    expect(element.style.left).toBe('108px')
+    expect(element.style.right).toBe('')
+  })
+
+  test('anchors to the right edge and clamps the top when the button sits low and far right', () => {
+    const button = document.createElement('button')
+    document.body.appendChild(button)
+    jest.spyOn(button, 'getBoundingClientRect').mockReturnValue({
+      top: 580,
+      bottom: 600,
+      left: 960,
+      right: 1000,
+      width: 40,
+      height: 20,
+    })
+    callbacks.getCurrentButton.mockReturnValue(button)
+    jest.spyOn(element, 'getBoundingClientRect').mockReturnValue({
+      top: 0,
+      left: 0,
+      width: 1024,
+      height: 768,
+    })
+    element.dataset.fullscreen = 'true'
+    manager.savedStyles = { top: '', right: '', left: '', width: '300px', height: '400px' }
+
+    manager.exit()
+    jest.advanceTimersByTime(300)
+
+    // 600 + 4 + 400 overflows 768, so the top clamps to innerHeight - height - 4.
+    expect(element.style.top).toBe('364px')
+    expect(element.style.right).toBe('48px')
+    expect(element.style.left).toBe('')
+    expect(element.style.width).toBe('300px')
+  })
+
+  test('falls back to default popup geometry when no button or saved styles exist', () => {
+    const topicsController = { scrollToActiveTopic: jest.fn() }
+    callbacks.getTopicsController.mockReturnValue(topicsController)
+    jest.spyOn(element, 'getBoundingClientRect').mockReturnValue({
+      top: 0,
+      left: 0,
+      width: 1024,
+      height: 768,
+    })
+    element.dataset.fullscreen = 'true'
+    manager.savedStyles = null
+
+    manager.exit()
+
+    expect(element.style.left).toBe('572px')
+    expect(element.style.width).toBe('420px')
+    expect(element.style.height).toBe('640px')
+
+    jest.advanceTimersByTime(300)
+
+    expect(element.style.position).toBe('')
+    expect(element.style.left).toBe('')
+    expect(element.style.width).toBe('')
+    expect(topicsController.scrollToActiveTopic).toHaveBeenCalledTimes(1)
+  })
+
+  test('toggle enters when windowed and exits when already fullscreen', () => {
+    jest.spyOn(element, 'getBoundingClientRect').mockReturnValue({
+      top: 12,
+      left: 704,
+      width: 300,
+      height: 400,
+    })
+
+    manager.toggle()
+    expect(manager.active).toBe(true)
+    expect(window.location.pathname).toBe('/creatives/42/comments/fullscreen')
+
+    manager.toggle()
+    expect(manager.active).toBe(false)
+  })
 })

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/popup_fullscreen.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/popup_fullscreen.test.js
@@ -1,0 +1,126 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { jest } from '@jest/globals'
+import PopupFullscreen from '../popup_fullscreen'
+
+describe('PopupFullscreen', () => {
+  let element
+  let manager
+  let callbacks
+  let requestAnimationFrame
+  let listController
+
+  beforeEach(() => {
+    jest.useFakeTimers()
+    document.body.innerHTML = '<div id="popup"></div>'
+    document.body.className = ''
+    element = document.getElementById('popup')
+    element.dataset.creativeId = '42'
+    requestAnimationFrame = jest
+      .spyOn(globalThis, 'requestAnimationFrame')
+      .mockImplementation(callback => {
+        callback()
+        return 1
+      })
+    listController = { scrollToBottom: jest.fn() }
+    callbacks = {
+      isMobile: jest.fn(() => false),
+      isDocked: jest.fn(() => false),
+      syncUi: jest.fn(),
+      syncDockedUi: jest.fn(),
+      getListController: jest.fn(() => listController),
+      getTopicsController: jest.fn(() => ({ scrollToActiveTopic: jest.fn() })),
+      getCurrentButton: jest.fn(() => null),
+      setCurrentButton: jest.fn(),
+    }
+    manager = new PopupFullscreen({ element, ...callbacks })
+    window.history.replaceState({}, '', '/creatives/42')
+  })
+
+  afterEach(() => {
+    manager.cancelEnterCleanup()
+    requestAnimationFrame.mockRestore()
+    jest.useRealTimers()
+  })
+
+  test('owns fullscreen entry state and browser history', () => {
+    element.style.top = '12px'
+    element.style.right = '20px'
+    element.style.width = '300px'
+    element.style.height = '400px'
+    jest.spyOn(element, 'getBoundingClientRect').mockReturnValue({
+      top: 12,
+      left: 704,
+      width: 300,
+      height: 400,
+    })
+
+    manager.enter()
+
+    expect(manager.savedStyles).toEqual({
+      top: '12px',
+      right: '20px',
+      left: '',
+      width: '300px',
+      height: '400px',
+    })
+    expect(element.dataset.fullscreen).toBe('true')
+    expect(document.body.classList.contains('chat-fullscreen')).toBe(true)
+    expect(callbacks.syncUi).toHaveBeenCalledWith(true)
+    expect(window.location.pathname).toBe('/creatives/42/comments/fullscreen')
+  })
+
+  test('restores the mobile popup and keeps it open in the URL', () => {
+    callbacks.isMobile.mockReturnValue(true)
+    element.dataset.fullscreen = 'true'
+    element.style.position = 'fixed'
+    element.style.transform = 'scale(1)'
+    document.body.classList.add('chat-fullscreen')
+    manager.previousUrl = '/creatives/42?comment_id=7'
+
+    manager.exit()
+
+    expect(element.dataset.fullscreen).toBe('false')
+    expect(element.style.position).toBe('')
+    expect(element.style.transform).toBe('')
+    expect(document.body.classList.contains('chat-fullscreen')).toBe(false)
+    expect(callbacks.syncUi).toHaveBeenCalledWith(false)
+    expect(window.location.pathname).toBe('/creatives/42')
+    expect(new URLSearchParams(window.location.search).get('open_comments')).toBe('true')
+    expect(new URLSearchParams(window.location.search).get('comment_id')).toBe('7')
+    expect(listController.scrollToBottom).toHaveBeenCalledTimes(1)
+  })
+
+  test('cleans deep-link markers when fullscreen is closed', () => {
+    element.dataset.fullscreen = 'true'
+    document.body.classList.add('chat-fullscreen')
+    manager.previousUrl = '/creatives/42/comments/77?open_comments=true&comment_id=77#comment_77'
+
+    manager.exitState()
+
+    expect(element.dataset.fullscreen).toBe('false')
+    expect(document.body.classList.contains('chat-fullscreen')).toBe(false)
+    expect(window.location.pathname).toBe('/creatives/42')
+    expect(window.location.search).toBe('')
+    expect(window.location.hash).toBe('')
+    expect(manager.previousUrl).toBeNull()
+  })
+
+  test('restores docked UI when browser navigation exits fullscreen', () => {
+    callbacks.isDocked.mockReturnValue(true)
+    element.dataset.fullscreen = 'true'
+    element.style.display = 'none'
+    manager.savedStyles = { width: '320px', height: '480px' }
+
+    manager.handlePopState({ state: { fullscreen: false } })
+
+    expect(element.dataset.fullscreen).toBe('false')
+    expect(element.style.display).toBe('flex')
+    expect(element.style.width).toBe('320px')
+    expect(element.style.height).toBe('480px')
+    expect(callbacks.syncDockedUi).toHaveBeenCalledTimes(1)
+    expect(manager.savedStyles).toBeNull()
+  })
+})

--- a/engines/collavre/app/javascript/controllers/comments/popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_controller.js
@@ -1,6 +1,7 @@
 import { Controller } from '@hotwired/stimulus'
 import chatHistory from '../../lib/chat_history'
 import chatDrafts from '../../lib/chat_drafts'
+import PopupFullscreen from './popup_fullscreen'
 
 const SIZE_STORAGE_KEY = 'commentsPopupSize'
 const CREATIVE_CLICK_EVENT = 'creative-comments-click'
@@ -26,6 +27,20 @@ export default class extends Controller {
     'header',
     'typingIndicator',
   ]
+
+  initialize() {
+    this.fullscreen = new PopupFullscreen({
+      element: this.element,
+      isMobile: () => this.isMobile(),
+      isDocked: () => this.isDocked(),
+      syncUi: entering => this._syncFullscreenUI(entering),
+      syncDockedUi: () => this.syncDockedUI(),
+      getListController: () => this.listController,
+      getTopicsController: () => this.topicsController,
+      getCurrentButton: () => this.currentButton,
+      setCurrentButton: button => { this.currentButton = button },
+    })
+  }
 
   connect() {
     this.currentButton = null
@@ -60,7 +75,6 @@ export default class extends Controller {
     this._isNavigating = false
     this._headerSwipeStartX = null
     this._headerSwipeStartY = null
-
     document.addEventListener(CREATIVE_CLICK_EVENT, this.handleCreativeClick)
     document.addEventListener(CREATIVE_DESTROYED_EVENT, this.handleCreativeDestroyed)
     document.addEventListener('creative-editing:start', this.handleEditingStart)
@@ -522,44 +536,7 @@ export default class extends Controller {
   }
 
   _exitFullscreenState() {
-    if (!this.isFullscreen()) return
-
-    if (this._enterCleanupTimer) {
-      window.clearTimeout(this._enterCleanupTimer)
-      this._enterCleanupTimer = null
-    }
-    if (this._enterCleanupFn) {
-      this.element.removeEventListener('transitionend', this._enterCleanupFn)
-      this._enterCleanupFn = null
-    }
-
-    this.element.dataset.fullscreen = 'false'
-    document.body.classList.remove('chat-fullscreen')
-    this._syncFullscreenUI(false)
-    this._savedStyles = null
-    this.element.style.transition = ''
-    this.element.style.position = ''
-    this.element.style.top = ''
-    this.element.style.left = ''
-    this.element.style.right = ''
-    this.element.style.bottom = ''
-    this.element.style.width = ''
-    this.element.style.height = ''
-    this.element.style.transform = ''
-
-    // Consume the fullscreen history entry and remove markers that could
-    // reopen the invalidated chat after a reset or close.
-    const creativeId = this.element.dataset.creativeId
-    const backUrl = this._previousUrl || (creativeId ? `/creatives/${creativeId}` : null)
-    if (backUrl) {
-      const url = new URL(backUrl, window.location.origin)
-      url.searchParams.delete('open_comments')
-      url.searchParams.delete('comment_id')
-      const cleanPath = url.pathname.replace(/\/comments\/\d+$/, '')
-      url.hash = url.hash.replace(/^#comment_\d+$/, '')
-      window.history.replaceState({ fullscreen: false }, '', cleanPath + url.search + url.hash)
-    }
-    this._previousUrl = null
+    this.fullscreen.exitState()
   }
 
   closeChildControllers() {
@@ -612,6 +589,22 @@ export default class extends Controller {
 
   isFullscreen() {
     return this.element.dataset.fullscreen === 'true'
+  }
+
+  get _savedStyles() {
+    return this.fullscreen?.savedStyles
+  }
+
+  set _savedStyles(value) {
+    if (this.fullscreen) this.fullscreen.savedStyles = value
+  }
+
+  get _previousUrl() {
+    return this.fullscreen?.previousUrl
+  }
+
+  set _previousUrl(value) {
+    if (this.fullscreen) this.fullscreen.previousUrl = value
   }
 
   isMobile() {
@@ -910,387 +903,15 @@ export default class extends Controller {
 
   // Enter fullscreen immediately without animation (for auto-fullscreen on page load)
   _enterFullscreenImmediate() {
-    const el = this.element
-
-    // Save current inline styles so exit-fullscreen can restore them
-    this._savedStyles = {
-      top: el.style.top,
-      right: el.style.right,
-      left: el.style.left,
-      width: el.style.width,
-      height: el.style.height,
-    }
-
-    el.style.transition = 'none'
-    el.dataset.fullscreen = 'true'
-    document.body.classList.add('chat-fullscreen')
-    this._syncFullscreenUI(true)
-    // Clear any inline position styles so CSS fullscreen rules apply
-    el.style.top = ''
-    el.style.left = ''
-    el.style.right = ''
-    el.style.bottom = ''
-    el.style.width = ''
-    el.style.height = ''
-    el.style.position = ''
-    // Force layout then restore transition
-    el.offsetHeight // eslint-disable-line no-unused-expressions
-    el.style.transition = ''
-
-    // URL is already /comments/fullscreen, no pushState needed
-    requestAnimationFrame(() => this.listController?.scrollToBottom())
+    this.fullscreen.enterImmediate()
   }
 
   toggleFullscreen() {
-    const entering = !this.isFullscreen()
-    const el = this.element
-
-    if (entering) {
-      // Save current inline styles for later restore
-      this._savedStyles = {
-        top: el.style.top,
-        right: el.style.right,
-        left: el.style.left,
-        width: el.style.width,
-        height: el.style.height,
-      }
-
-      // Capture current visual position
-      const rect = el.getBoundingClientRect()
-
-      // Disable transition, pin to current position as fixed
-      el.style.transition = 'none'
-      el.style.position = 'fixed'
-      el.style.top = `${rect.top}px`
-      el.style.left = `${rect.left}px`
-      el.style.right = 'auto'
-      el.style.width = `${rect.width}px`
-      el.style.height = `${rect.height}px`
-
-      // Force layout so the pinned position is applied
-      el.offsetHeight // eslint-disable-line no-unused-expressions
-
-      // Now enable transition and expand to fullscreen
-      el.style.transition = ''
-      el.dataset.fullscreen = 'true'
-      document.body.classList.add('chat-fullscreen')
-      this._syncFullscreenUI(true)
-
-      // Clear inline position so CSS fullscreen rules take over
-      el.style.top = '0'
-      el.style.left = '0'
-      el.style.right = '0'
-      el.style.bottom = '0'
-      el.style.width = '100%'
-      el.style.height = '100%'
-
-      // Update URL
-      const creativeId = el.dataset.creativeId
-      if (creativeId) {
-        this._previousUrl = window.location.href
-        const fullscreenPath = `/creatives/${creativeId}/comments/fullscreen`
-        window.history.pushState({ fullscreen: true }, '', fullscreenPath)
-      }
-
-      // Clean up inline styles after transition ends
-      this._enterCleanupFn = () => {
-        el.removeEventListener('transitionend', this._enterCleanupFn)
-        this._enterCleanupTimer = null
-        this._enterCleanupFn = null
-        el.style.top = ''
-        el.style.left = ''
-        el.style.right = ''
-        el.style.bottom = ''
-        el.style.width = ''
-        el.style.height = ''
-        el.style.position = ''
-      }
-      el.addEventListener('transitionend', this._enterCleanupFn, { once: true })
-      // Fallback if transitionend doesn't fire
-      this._enterCleanupTimer = setTimeout(this._enterCleanupFn, 300)
-
-    } else {
-      // Cancel any pending enter-fullscreen cleanup to prevent it from
-      // wiping inline styles mid-exit animation (race condition fix)
-      if (this._enterCleanupTimer) {
-        clearTimeout(this._enterCleanupTimer)
-        this._enterCleanupTimer = null
-      }
-      if (this._enterCleanupFn) {
-        el.removeEventListener('transitionend', this._enterCleanupFn)
-        this._enterCleanupFn = null
-      }
-
-      const savedStyles = this._savedStyles
-      this._savedStyles = null
-      const creativeId = el.dataset.creativeId
-
-      // Mobile: skip animation, just clear inline styles and let CSS handle positioning
-      if (this.isMobile()) {
-        el.style.transition = 'none'
-        el.dataset.fullscreen = 'false'
-        document.body.classList.remove('chat-fullscreen')
-        this._syncFullscreenUI(false)
-
-        // Clear all inline styles so CSS media query rules apply
-        el.style.position = ''
-        el.style.top = ''
-        el.style.left = ''
-        el.style.right = ''
-        el.style.bottom = ''
-        el.style.width = ''
-        el.style.height = ''
-        el.style.transform = ''
-
-        // Force layout then restore transitions
-        el.offsetHeight // eslint-disable-line no-unused-expressions
-        el.style.transition = ''
-
-        // Update URL
-        let backUrl = this._previousUrl || (creativeId ? `/creatives/${creativeId}` : null)
-        if (backUrl) {
-          const url = new URL(backUrl, window.location.origin)
-          url.searchParams.set('open_comments', 'true')
-          window.history.pushState({ fullscreen: false }, '', url.pathname + url.search)
-        }
-        this._previousUrl = null
-
-        // Scroll to bottom after layout change
-        requestAnimationFrame(() => {
-          this.listController?.scrollToBottom()
-        })
-        return
-      }
-
-      if (this.isDocked()) {
-        el.style.transition = 'none'
-        el.dataset.fullscreen = 'false'
-        document.body.classList.remove('chat-fullscreen')
-        el.style.position = ''
-        el.style.top = ''
-        el.style.left = ''
-        el.style.right = ''
-        el.style.bottom = ''
-        el.style.width = ''
-        el.style.height = ''
-        this._savedStyles = null
-        this._syncFullscreenUI(false)
-        this.syncDockedUI()
-        el.offsetHeight // eslint-disable-line no-unused-expressions
-        el.style.transition = ''
-
-        let backUrl = this._previousUrl || (creativeId ? `/creatives/${creativeId}` : null)
-        if (backUrl) {
-          const url = new URL(backUrl, window.location.origin)
-          url.searchParams.set('open_comments', 'true')
-          window.history.pushState({ fullscreen: false }, '', url.pathname + url.search)
-        }
-        this._previousUrl = null
-        requestAnimationFrame(() => this.listController?.scrollToBottom())
-        return
-      }
-
-      // Desktop: animated exit to target position
-      // Calculate target position using viewport-relative coords (popup is position: fixed)
-      let finalTop = ''      // px string (viewport-relative)
-      let finalRight = ''    // px string
-      let finalWidth = savedStyles?.width || ''
-      let finalHeight = savedStyles?.height || ''
-
-      // Animation targets (viewport-relative, same as final since popup is fixed)
-      let animTop, animLeft, animWidth, animHeight
-
-      // Try to find the comment button for precise positioning
-      let targetButton = this.currentButton
-      if (!targetButton && creativeId) {
-        const row = document.querySelector(`creative-tree-row[creative-id="${creativeId}"]`)
-        targetButton = row?.querySelector('.comments-btn')
-      }
-
-      // Scroll the creative row into view instantly BEFORE calculating positions,
-      // so getBoundingClientRect returns viewport-visible coordinates
-      if (targetButton) {
-        const row = targetButton.closest('creative-tree-row')
-        if (row) {
-          row.scrollIntoView({ behavior: 'instant', block: 'center' })
-        }
-      }
-
-      if (targetButton) {
-        this.currentButton = targetButton
-        const btnRect = targetButton.getBoundingClientRect()
-        const gap = 8
-
-        animWidth = parseFloat(finalWidth) || 420
-        animHeight = parseFloat(finalHeight) || 640
-
-        // Calculate top in viewport coords — same as updatePosition
-        let top = btnRect.bottom + 4
-        const bottom = top + animHeight
-        if (bottom > window.innerHeight) {
-          top = Math.max(4, window.innerHeight - animHeight - 4)
-        }
-
-        finalTop = `${top}px`
-
-        // Right-align if enough space to the right of the button
-        const spaceRight = window.innerWidth - btnRect.right - gap
-        if (spaceRight >= animWidth) {
-          this._exitToRight = true
-          animLeft = btnRect.right + gap
-          animTop = top
-        } else {
-          this._exitToRight = false
-          const rightPx = window.innerWidth - btnRect.right + 24
-          finalRight = `${rightPx}px`
-          animTop = top
-          animLeft = window.innerWidth - rightPx - animWidth
-        }
-      } else if (savedStyles && Object.values(savedStyles).some(v => v)) {
-        // Fallback to saved styles (already viewport-relative since popup is fixed)
-        const rightVal = parseFloat(savedStyles.right) || 32
-        animWidth = parseFloat(savedStyles.width) || 420
-        animHeight = parseFloat(savedStyles.height) || 640
-        animLeft = savedStyles.left ? parseFloat(savedStyles.left) : (window.innerWidth - rightVal - animWidth)
-        animTop = parseFloat(savedStyles.top) || 100
-
-        finalTop = savedStyles.top || ''
-        finalRight = savedStyles.right || ''
-      } else {
-        // No reference at all: use CSS defaults
-        animWidth = 420
-        animHeight = 640
-        animLeft = window.innerWidth - 32 - animWidth  // right: 2em
-        animTop = 100
-      }
-
-      // Animated exit: pin at fullscreen position, then shrink to target
-      const fsRect = el.getBoundingClientRect()
-
-      el.style.transition = 'none'
-      el.style.position = 'fixed'
-      el.style.top = `${fsRect.top}px`
-      el.style.left = `${fsRect.left}px`
-      el.style.right = 'auto'
-      el.style.bottom = 'auto'
-      el.style.width = `${fsRect.width}px`
-      el.style.height = `${fsRect.height}px`
-
-      el.dataset.fullscreen = 'false'
-      document.body.classList.remove('chat-fullscreen')
-      this._syncFullscreenUI(false)
-
-      // Force layout so the pinned position is applied
-      el.offsetHeight // eslint-disable-line no-unused-expressions
-
-      // Animate to target position (fixed coordinates)
-      el.style.transition = ''
-      el.style.top = `${animTop}px`
-      el.style.left = `${animLeft}px`
-      el.style.width = `${animWidth}px`
-      el.style.height = `${animHeight}px`
-
-      let cleanupTimer = null
-      let cleanedUp = false
-      const cleanup = () => {
-        if (cleanedUp) return
-        cleanedUp = true
-        if (cleanupTimer !== null) {
-          clearTimeout(cleanupTimer)
-          cleanupTimer = null
-        }
-        el.removeEventListener('transitionend', cleanup)
-        // Popup is always position: fixed — just apply final coords
-        el.style.transition = 'none'
-        el.style.position = ''
-        el.style.bottom = ''
-
-        if (targetButton) {
-          el.style.top = finalTop
-          el.style.width = finalWidth
-          el.style.height = finalHeight
-          if (this._exitToRight) {
-            el.style.left = `${animLeft}px`
-            el.style.right = ''
-          } else {
-            el.style.right = finalRight
-            el.style.left = ''
-          }
-        } else if (savedStyles) {
-          el.style.top = ''
-          el.style.left = ''
-          el.style.right = ''
-          el.style.width = ''
-          el.style.height = ''
-          Object.assign(el.style, savedStyles)
-        } else {
-          el.style.top = ''
-          el.style.left = ''
-          el.style.right = ''
-          el.style.width = ''
-          el.style.height = ''
-        }
-
-        // Force layout then restore transitions
-        el.offsetHeight // eslint-disable-line no-unused-expressions
-        el.style.transition = ''
-
-        // Scroll active topic into view after popup has settled at final size
-        this.topicsController?.scrollToActiveTopic()
-      }
-      el.addEventListener('transitionend', cleanup, { once: true })
-      cleanupTimer = setTimeout(cleanup, 300)
-
-      // Update URL — append open_comments=true so the popup stays open on refresh
-      let backUrl = this._previousUrl || (creativeId ? `/creatives/${creativeId}` : null)
-      if (backUrl) {
-        const url = new URL(backUrl, window.location.origin)
-        url.searchParams.set('open_comments', 'true')
-        window.history.pushState({ fullscreen: false }, '', url.pathname + url.search)
-      }
-      this._previousUrl = null
-
-    }
-
-    // Scroll to bottom after layout change
-    requestAnimationFrame(() => {
-      this.listController?.scrollToBottom()
-    })
+    this.fullscreen.toggle()
   }
 
   handlePopState(event) {
-    const isFs = event.state?.fullscreen === true
-    if (isFs !== this.isFullscreen()) {
-      const el = this.element
-      // Clear any animation inline styles to avoid stale positions
-      el.style.transition = 'none'
-      el.style.position = ''
-      el.style.top = ''
-      el.style.left = ''
-      el.style.right = ''
-      el.style.bottom = ''
-      el.style.width = ''
-      el.style.height = ''
-
-      el.dataset.fullscreen = isFs ? 'true' : 'false'
-      document.body.classList.toggle('chat-fullscreen', isFs)
-      this._syncFullscreenUI(isFs)
-      if (!isFs && this.isDocked()) {
-        el.style.display = 'flex'
-        this.syncDockedUI()
-      }
-
-      if (!isFs && this._savedStyles) {
-        Object.assign(el.style, this._savedStyles)
-        this._savedStyles = null
-      }
-
-      // Restore transition
-      el.offsetHeight // eslint-disable-line no-unused-expressions
-      el.style.transition = ''
-
-      requestAnimationFrame(() => this.listController?.scrollToBottom())
-    }
+    this.fullscreen.handlePopState(event)
   }
 
   _syncFullscreenUI(entering) {

--- a/engines/collavre/app/javascript/controllers/comments/popup_fullscreen.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_fullscreen.js
@@ -1,0 +1,414 @@
+export default class PopupFullscreen {
+  constructor({
+    element,
+    isMobile,
+    isDocked,
+    syncUi,
+    syncDockedUi,
+    getListController,
+    getTopicsController,
+    getCurrentButton,
+    setCurrentButton,
+  }) {
+    this.element = element
+    this.isMobile = isMobile
+    this.isDocked = isDocked
+    this.syncUi = syncUi
+    this.syncDockedUi = syncDockedUi
+    this.getListController = getListController
+    this.getTopicsController = getTopicsController
+    this.getCurrentButton = getCurrentButton
+    this.setCurrentButton = setCurrentButton
+    this.savedStyles = null
+    this.previousUrl = null
+    this.enterCleanupTimer = null
+    this.enterCleanupFn = null
+    this.exitToRight = false
+  }
+
+  get active() {
+    return this.element.dataset.fullscreen === 'true'
+  }
+
+  toggle() {
+    if (this.active) {
+      this.exit()
+    } else {
+      this.enter()
+    }
+  }
+
+  enterImmediate() {
+    const el = this.element
+    this.savedStyles = this.captureStyles()
+
+    el.style.transition = 'none'
+    el.dataset.fullscreen = 'true'
+    document.body.classList.add('chat-fullscreen')
+    this.syncUi(true)
+    this.clearPositionStyles()
+    el.offsetHeight // eslint-disable-line no-unused-expressions
+    el.style.transition = ''
+
+    requestAnimationFrame(() => this.getListController()?.scrollToBottom())
+  }
+
+  enter() {
+    const el = this.element
+    this.savedStyles = this.captureStyles()
+    const rect = el.getBoundingClientRect()
+
+    el.style.transition = 'none'
+    el.style.position = 'fixed'
+    el.style.top = `${rect.top}px`
+    el.style.left = `${rect.left}px`
+    el.style.right = 'auto'
+    el.style.width = `${rect.width}px`
+    el.style.height = `${rect.height}px`
+    el.offsetHeight // eslint-disable-line no-unused-expressions
+
+    el.style.transition = ''
+    el.dataset.fullscreen = 'true'
+    document.body.classList.add('chat-fullscreen')
+    this.syncUi(true)
+
+    el.style.top = '0'
+    el.style.left = '0'
+    el.style.right = '0'
+    el.style.bottom = '0'
+    el.style.width = '100%'
+    el.style.height = '100%'
+
+    const creativeId = el.dataset.creativeId
+    if (creativeId) {
+      this.previousUrl = window.location.href
+      window.history.pushState(
+        { fullscreen: true },
+        '',
+        `/creatives/${creativeId}/comments/fullscreen`,
+      )
+    }
+
+    this.scheduleEnterCleanup()
+  }
+
+  exit() {
+    this.cancelEnterCleanup()
+
+    const savedStyles = this.savedStyles
+    this.savedStyles = null
+    const creativeId = this.element.dataset.creativeId
+
+    if (this.isMobile()) {
+      this.exitWithoutAnimation()
+      this.pushExitUrl(creativeId)
+      this.scrollToBottom()
+      return
+    }
+
+    if (this.isDocked()) {
+      this.exitDocked()
+      this.pushExitUrl(creativeId)
+      this.scrollToBottom()
+      return
+    }
+
+    this.exitDesktop(savedStyles, creativeId)
+    this.scrollToBottom()
+  }
+
+  exitState() {
+    if (!this.active) return
+
+    this.cancelEnterCleanup()
+
+    const el = this.element
+    el.dataset.fullscreen = 'false'
+    document.body.classList.remove('chat-fullscreen')
+    this.syncUi(false)
+    this.savedStyles = null
+    el.style.transition = ''
+    this.clearPositionStyles({ includeTransform: true })
+
+    const creativeId = el.dataset.creativeId
+    const backUrl = this.previousUrl || (creativeId ? `/creatives/${creativeId}` : null)
+    if (backUrl) {
+      const url = new URL(backUrl, window.location.origin)
+      url.searchParams.delete('open_comments')
+      url.searchParams.delete('comment_id')
+      const cleanPath = url.pathname.replace(/\/comments\/\d+$/, '')
+      url.hash = url.hash.replace(/^#comment_\d+$/, '')
+      window.history.replaceState(
+        { fullscreen: false },
+        '',
+        cleanPath + url.search + url.hash,
+      )
+    }
+    this.previousUrl = null
+  }
+
+  handlePopState(event) {
+    const isFullscreen = event.state?.fullscreen === true
+    if (isFullscreen === this.active) return
+
+    const el = this.element
+    el.style.transition = 'none'
+    this.clearPositionStyles()
+
+    el.dataset.fullscreen = isFullscreen ? 'true' : 'false'
+    document.body.classList.toggle('chat-fullscreen', isFullscreen)
+    this.syncUi(isFullscreen)
+    if (!isFullscreen && this.isDocked()) {
+      el.style.display = 'flex'
+      this.syncDockedUi()
+    }
+
+    if (!isFullscreen && this.savedStyles) {
+      Object.assign(el.style, this.savedStyles)
+      this.savedStyles = null
+    }
+
+    el.offsetHeight // eslint-disable-line no-unused-expressions
+    el.style.transition = ''
+    this.scrollToBottom()
+  }
+
+  captureStyles() {
+    const { style } = this.element
+    return {
+      top: style.top,
+      right: style.right,
+      left: style.left,
+      width: style.width,
+      height: style.height,
+    }
+  }
+
+  scheduleEnterCleanup() {
+    const el = this.element
+    this.enterCleanupFn = () => {
+      el.removeEventListener('transitionend', this.enterCleanupFn)
+      this.enterCleanupTimer = null
+      this.enterCleanupFn = null
+      this.clearPositionStyles()
+    }
+    el.addEventListener('transitionend', this.enterCleanupFn, { once: true })
+    this.enterCleanupTimer = setTimeout(this.enterCleanupFn, 300)
+  }
+
+  cancelEnterCleanup() {
+    if (this.enterCleanupTimer) {
+      clearTimeout(this.enterCleanupTimer)
+      this.enterCleanupTimer = null
+    }
+    if (this.enterCleanupFn) {
+      this.element.removeEventListener('transitionend', this.enterCleanupFn)
+      this.enterCleanupFn = null
+    }
+  }
+
+  exitWithoutAnimation() {
+    const el = this.element
+    el.style.transition = 'none'
+    el.dataset.fullscreen = 'false'
+    document.body.classList.remove('chat-fullscreen')
+    this.syncUi(false)
+    this.clearPositionStyles({ includeTransform: true })
+    el.offsetHeight // eslint-disable-line no-unused-expressions
+    el.style.transition = ''
+  }
+
+  exitDocked() {
+    const el = this.element
+    el.style.transition = 'none'
+    el.dataset.fullscreen = 'false'
+    document.body.classList.remove('chat-fullscreen')
+    this.clearPositionStyles()
+    this.savedStyles = null
+    this.syncUi(false)
+    this.syncDockedUi()
+    el.offsetHeight // eslint-disable-line no-unused-expressions
+    el.style.transition = ''
+  }
+
+  exitDesktop(savedStyles, creativeId) {
+    const target = this.desktopExitTarget(savedStyles, creativeId)
+    const el = this.element
+    const fullscreenRect = el.getBoundingClientRect()
+
+    el.style.transition = 'none'
+    el.style.position = 'fixed'
+    el.style.top = `${fullscreenRect.top}px`
+    el.style.left = `${fullscreenRect.left}px`
+    el.style.right = 'auto'
+    el.style.bottom = 'auto'
+    el.style.width = `${fullscreenRect.width}px`
+    el.style.height = `${fullscreenRect.height}px`
+
+    el.dataset.fullscreen = 'false'
+    document.body.classList.remove('chat-fullscreen')
+    this.syncUi(false)
+    el.offsetHeight // eslint-disable-line no-unused-expressions
+
+    el.style.transition = ''
+    el.style.top = `${target.animTop}px`
+    el.style.left = `${target.animLeft}px`
+    el.style.width = `${target.animWidth}px`
+    el.style.height = `${target.animHeight}px`
+
+    this.scheduleExitCleanup(target, savedStyles)
+    this.pushExitUrl(creativeId)
+  }
+
+  desktopExitTarget(savedStyles, creativeId) {
+    const targetButton = this.findTargetButton(creativeId)
+    let finalTop = ''
+    let finalRight = ''
+    const finalWidth = savedStyles?.width || ''
+    const finalHeight = savedStyles?.height || ''
+    let animTop
+    let animLeft
+    let animWidth
+    let animHeight
+
+    if (targetButton) {
+      this.setCurrentButton(targetButton)
+      const btnRect = targetButton.getBoundingClientRect()
+      const gap = 8
+      animWidth = parseFloat(finalWidth) || 420
+      animHeight = parseFloat(finalHeight) || 640
+
+      let top = btnRect.bottom + 4
+      if (top + animHeight > window.innerHeight) {
+        top = Math.max(4, window.innerHeight - animHeight - 4)
+      }
+      finalTop = `${top}px`
+
+      if (window.innerWidth - btnRect.right - gap >= animWidth) {
+        this.exitToRight = true
+        animLeft = btnRect.right + gap
+      } else {
+        this.exitToRight = false
+        const rightPx = window.innerWidth - btnRect.right + 24
+        finalRight = `${rightPx}px`
+        animLeft = window.innerWidth - rightPx - animWidth
+      }
+      animTop = top
+    } else if (savedStyles && Object.values(savedStyles).some(value => value)) {
+      const right = parseFloat(savedStyles.right) || 32
+      animWidth = parseFloat(savedStyles.width) || 420
+      animHeight = parseFloat(savedStyles.height) || 640
+      animLeft = savedStyles.left
+        ? parseFloat(savedStyles.left)
+        : window.innerWidth - right - animWidth
+      animTop = parseFloat(savedStyles.top) || 100
+      finalTop = savedStyles.top || ''
+      finalRight = savedStyles.right || ''
+    } else {
+      animWidth = 420
+      animHeight = 640
+      animLeft = window.innerWidth - 32 - animWidth
+      animTop = 100
+    }
+
+    return {
+      targetButton,
+      finalTop,
+      finalRight,
+      finalWidth,
+      finalHeight,
+      animTop,
+      animLeft,
+      animWidth,
+      animHeight,
+    }
+  }
+
+  findTargetButton(creativeId) {
+    let targetButton = this.getCurrentButton()
+    if (!targetButton && creativeId) {
+      const row = document.querySelector(`creative-tree-row[creative-id="${creativeId}"]`)
+      targetButton = row?.querySelector('.comments-btn')
+    }
+    const row = targetButton?.closest('creative-tree-row')
+    row?.scrollIntoView({ behavior: 'instant', block: 'center' })
+    return targetButton
+  }
+
+  scheduleExitCleanup(target, savedStyles) {
+    const el = this.element
+    let cleanupTimer = null
+    let cleanedUp = false
+    const cleanup = () => {
+      if (cleanedUp) return
+      cleanedUp = true
+      if (cleanupTimer !== null) {
+        clearTimeout(cleanupTimer)
+        cleanupTimer = null
+      }
+      el.removeEventListener('transitionend', cleanup)
+      el.style.transition = 'none'
+      el.style.position = ''
+      el.style.bottom = ''
+
+      if (target.targetButton) {
+        this.restoreTargetButtonStyles(target)
+      } else if (savedStyles) {
+        this.clearPositionStyles()
+        Object.assign(el.style, savedStyles)
+      } else {
+        this.clearPositionStyles()
+      }
+
+      el.offsetHeight // eslint-disable-line no-unused-expressions
+      el.style.transition = ''
+      this.getTopicsController()?.scrollToActiveTopic()
+    }
+    el.addEventListener('transitionend', cleanup, { once: true })
+    cleanupTimer = setTimeout(cleanup, 300)
+  }
+
+  restoreTargetButtonStyles(target) {
+    const { style } = this.element
+    style.top = target.finalTop
+    style.width = target.finalWidth
+    style.height = target.finalHeight
+    if (this.exitToRight) {
+      style.left = `${target.animLeft}px`
+      style.right = ''
+    } else {
+      style.right = target.finalRight
+      style.left = ''
+    }
+  }
+
+  pushExitUrl(creativeId) {
+    const backUrl = this.previousUrl || (creativeId ? `/creatives/${creativeId}` : null)
+    if (backUrl) {
+      const url = new URL(backUrl, window.location.origin)
+      url.searchParams.set('open_comments', 'true')
+      window.history.pushState(
+        { fullscreen: false },
+        '',
+        url.pathname + url.search,
+      )
+    }
+    this.previousUrl = null
+  }
+
+  clearPositionStyles({ includeTransform = false } = {}) {
+    const { style } = this.element
+    style.position = ''
+    style.top = ''
+    style.left = ''
+    style.right = ''
+    style.bottom = ''
+    style.width = ''
+    style.height = ''
+    if (includeTransform) style.transform = ''
+  }
+
+  scrollToBottom() {
+    requestAnimationFrame(() => this.getListController()?.scrollToBottom())
+  }
+}


### PR DESCRIPTION
## Summary

- verify the 1,732-line comments popup controller has multiple independent responsibilities
- extract fullscreen state, browser history, animation, and responsive exit behavior into PopupFullscreen
- preserve the existing Stimulus action surface and add focused fullscreen regression coverage

## Complexity impact

- comments popup controller: 1,732 to 1,351 lines
- toggleFullscreen: 316 lines to a one-line delegate
- complexity ratchet: no entity growth

## Verification

- npm run test:coverage -- --runInBand (157 suites, 2,251 tests)
- npm run build
- bin/rubocop -a (1,351 files)
- bin/complexity_check --base origin/feature/refactor-reduce-dupl
- core engine system tests (131 runs, 875 assertions, 0 failures, 1 skip)
- focused Rails tests for the local pre-existing encryption-order failure (11 runs, 74 assertions, 0 failures)

Creative: 20941