### PR TITLE
Extract waiting notice management out of AgentOrchestrator

### DIFF
--- a/engines/collavre/app/jobs/collavre/ai_agent_job.rb
+++ b/engines/collavre/app/jobs/collavre/ai_agent_job.rb
@@ -362,7 +362,7 @@ module Collavre
       if waiter.waiting_notice_scope == Comment::WAITING_NOTICE_TOPIC
         Orchestration::TaskCoalescer.coalesce!(waiter)
       end
-      Orchestration::AgentOrchestrator.post_topic_concurrency_notice(
+      Orchestration::WaitingNoticeManager.post_topic_concurrency_notice(
         creative_id, topic_id, context, agent: agent, waiter: waiter
       )
 

--- a/engines/collavre/app/models/collavre/comment.rb
+++ b/engines/collavre/app/models/collavre/comment.rb
@@ -4,7 +4,7 @@ module Collavre
 
     STREAMING_PLACEHOLDER_CONTENT = "..."
     # Authorless "⏳" waiting-notice system messages posted when an agent is
-    # deferred for topic concurrency. AgentOrchestrator.cleanup_waiting_notices!
+    # deferred for topic concurrency. WaitingNoticeManager.cleanup_waiting_notices!
     # matches the same prefix to remove them once the waiter is dequeued.
     WAITING_NOTICE_PREFIX = "⏳"
 
@@ -29,7 +29,7 @@ module Collavre
     #
     # It therefore comes down wherever the waiter leaves, which is why this
     # lives here beside the columns rather than in one of those callers: the
-    # promotion (AgentOrchestrator.cleanup_waiter_notice!) and the fold
+    # promotion (WaitingNoticeManager.cleanup_waiter_notice!) and the fold
     # (Orchestration::TaskCoalescer) are two doors onto the same rule, and a
     # third would otherwise write its own copy or forget.
     #
@@ -176,7 +176,7 @@ module Collavre
     attribute :skip_dispatch, :boolean, default: false
     attribute :skip_link_preview, :boolean, default: false
     attribute :skip_notification_revision, :boolean, default: false
-    # Set by AgentOrchestrator.cleanup_waiting_notices! so destroying a notice as
+    # Set by WaitingNoticeManager.cleanup_waiting_notices! so destroying a notice as
     # part of *promoting* a waiter does not run the user-delete cancel cascade
     # (which would cancel other still-queued waiters in the same topic).
     attribute :suppress_waiter_cancellation, :boolean, default: false
@@ -426,7 +426,7 @@ module Collavre
     # Cancelling one was right while each deferral posted its own notice: the
     # newest queued task was the one that notice belonged to. A topic now gets
     # exactly one deduplicated notice
-    # (Orchestration::AgentOrchestrator.with_deduped_topic_notice), and with
+    # (Orchestration::WaitingNoticeManager.with_deduped_topic_notice), and with
     # topic_max_concurrent_jobs > 1 it can stand for waiters from several agents
     # — coalescing folds same-agent siblings only. Deleting it while cancelling
     # one of them leaves the rest queued with nothing on screen representing

--- a/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
+++ b/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
@@ -43,7 +43,7 @@ module Collavre
           # bottom would enqueue it, where AiAgentJob reloads and returns
           # without draining. Re-read once, here, rather than at each of them.
           unless task.reload.status == "cancelled"
-            cleanup_waiting_notices_if_drained!(task)
+            WaitingNoticeManager.cleanup_waiting_notices_if_drained!(task)
             refresh_deferred_context!(task)
             revalidate_assignment!(task) unless task.status == "cancelled"
           end
@@ -97,127 +97,6 @@ module Collavre
       end
       private_class_method :claim_next_waiter
 
-      # Human-readable reason for the "⏳" waiting notice. For topic-concurrency
-      # deferrals, name the agent(s) actually holding the topic's running slot so
-      # a waiting user can see *who* is blocking them (and reach that task's stop
-      # button) rather than an anonymous "another task is running" dead end.
-      def self.waiting_reason_text(reason_key, topic_id, creative_id)
-        if reason_key == :topic_concurrency && topic_id
-          names = Task.running_for_topic(topic_id, creative_id)
-                      .includes(:agent).filter_map { |t| t.agent&.name }.uniq
-          if names.any?
-            return I18n.t(
-              "collavre.orchestration.waiting_reasons.topic_concurrency_with_agent",
-              agent: names.join(", ")
-            )
-          end
-        end
-
-        I18n.t(
-          "collavre.orchestration.waiting_reasons.#{reason_key}",
-          default: reason_key.to_s.humanize
-        )
-      end
-
-      # Is there already a "⏳" topic-concurrency waiting notice on this
-      # creative/topic that stands for the topic as a whole? Shared with
-      # AiAgentJob's late slot check so both defer paths post at most one shared
-      # notice per topic.
-      #
-      # A per-deferral notice does not count. It speaks for one waiter, so
-      # letting it suppress the shared one would leave a coalescing agent's
-      # waiters with no notice at all whenever an opted-out agent happened to
-      # defer into the topic first. Notices from before the mode was recorded do
-      # count: they are the topic's only signal, and posting a second one beside
-      # them is the duplication this guard exists to prevent.
-      def self.topic_concurrency_notice_exists?(creative_id, topic_id)
-        Comment.where(creative_id: creative_id, topic_id: topic_id, user_id: nil,
-                      topic_concurrency_defer: true)
-               .where(waiting_notice_scope: [ nil, Comment::WAITING_NOTICE_TOPIC ])
-               .where("content LIKE ?", "#{Comment::WAITING_NOTICE_PREFIX}%")
-               .exists?
-      end
-
-      # Check-then-insert the one waiting notice a topic is allowed, as a single
-      # step. Both defer paths run for a *burst* — the case where every worker
-      # reads "no notice yet" before any of them inserts — so an unserialized
-      # check leaves N dead-end notices pointing at one blocker, and deleting one
-      # of them cancels the waiters while the others linger.
-      #
-      # Serialize on the same row admission locks (TopicSlot.lock!): the workers
-      # that compete for a notice are exactly the ones that competed for the
-      # slot, so the loser reads the winner's committed notice.
-      #
-      # The same lock also decides whether a notice is still warranted at all.
-      # The waiter commits before its notice goes up, so the blocker can finish
-      # in between, promote it, and run cleanup_waiting_notices! before any
-      # notice exists. A notice posted after that cleanup describes a wait that
-      # is already over, and nothing will ever take it down: removal only
-      # happens when a promotion drains a *queued* waiter, and there is none
-      # left. Promotion takes this same row, so "still queued" read here is the
-      # promotion's own before-or-after, not a guess.
-      #
-      # Yields only when a waiter is still queued and no notice exists yet;
-      # returns nil otherwise.
-      def self.with_deduped_topic_notice(creative_id, topic_id)
-        with_live_topic_wait(creative_id, topic_id) do
-          next nil if topic_concurrency_notice_exists?(creative_id, topic_id)
-
-          yield
-        end
-      end
-
-      # The "is anyone still waiting?" half on its own, without the "only one
-      # notice per topic" half.
-      #
-      # With coalesce_pending_tasks off, each deferral keeps its own waiter, so
-      # each one needs its own notice: a single notice standing for N
-      # independent waiters turns its stop button into "cancel everyone's work"
-      # (Comment#cancel_queued_tasks_for_waiting_notice reads "no sibling notice
-      # left" as "this notice spoke for the topic"). The drain guard still
-      # applies either way — a notice explaining a wait that is already over is
-      # never removed by anything.
-      def self.with_live_topic_wait(creative_id, topic_id)
-        Comment.transaction do
-          TopicSlot.lock!(topic_id, creative_id)
-          next nil unless Task.queued_for_topic(topic_id, creative_id).exists?
-
-          yield
-        end
-      end
-
-      # The same guard for a notice that speaks for exactly one waiter.
-      #
-      # "Is anyone still waiting?" is the *shared* notice's question, and it
-      # stays true for as long as any waiter is queued. A per-deferral notice
-      # answers for one — and that one can be promoted between its row
-      # committing and this lock, since the waiter is created and the notice
-      # posted in two steps on both doors. With another deferral parked in the
-      # same burst the topic-wide question then says yes while this waiter's
-      # says no, and the notice goes up offering a stop button for a turn that
-      # is already running.
-      #
-      # Nothing takes it back down. cleanup_waiter_notice! is the only path that
-      # removes one, it runs during the promotion that just happened, and it
-      # matched nothing because the notice did not exist yet; deleting it by
-      # hand cancels nothing either, since a task-scoped notice selects its own
-      # waiter and that waiter is no longer queued.
-      #
-      # Asked under the admission lock, so "still queued" is the promotion's own
-      # before-or-after rather than a guess.
-      def self.with_live_waiter(waiter, creative_id, topic_id, &block)
-        # No waiter to speak for: the topic-wide question is all a caller
-        # without one can be asked.
-        return with_live_topic_wait(creative_id, topic_id, &block) if waiter.nil?
-
-        Comment.transaction do
-          TopicSlot.lock!(topic_id, creative_id)
-          next nil unless Task.where(id: waiter.id, status: "queued").exists?
-
-          yield
-        end
-      end
-
       def self.coalesce_promoted!(task)
         return unless PolicyResolver.new(task.trigger_event_payload || {})
                         .coalesce_pending_tasks_for?(task.agent)
@@ -266,124 +145,8 @@ module Collavre
         # The folded waiters may have been everything the topic's "⏳" notice
         # described, and nothing else will take it down: removal happens when a
         # promotion drains a *queued* waiter, and this fold left none.
-        cleanup_waiting_notices_if_drained!(task)
+        WaitingNoticeManager.cleanup_waiting_notices_if_drained!(task)
       end
-
-      # Take the topic's "⏳" notice down, but only once nothing is waiting on
-      # the slot any more.
-      #
-      # "A waiter left the queue" is not the same question. A topic gets exactly
-      # one deduplicated notice, and with topic_max > 1 a promotion can leave
-      # other agents queued — coalesce_promoted! absorbs same-agent siblings
-      # only, and the queue head may be ineligible while a later waiter runs. So
-      # an unconditional cleanup strips the wait/stop signal off a wait that is
-      # still real, and nothing reposts it until the next deferral happens by.
-      #
-      # Asked under the lock post_waiting_notice takes, so "nobody is queued" is
-      # that path's own before-or-after rather than a guess: a deferral either
-      # commits its waiter before this reads, and keeps its notice, or after, and
-      # posts its own.
-      # …but that guard is about the *shared* notice, which is still describing a
-      # real wait for as long as anyone is queued. A per-deferral notice speaks
-      # for one waiter, so it comes down when that waiter leaves the queue and
-      # not a moment later: with the opt-out and two waiters, promoting one
-      # leaves the queue non-empty, and the notice for the task now running would
-      # stay on screen with a stop button for a wait that is over.
-      def self.cleanup_waiting_notices_if_drained!(task)
-        Comment.transaction do
-          TopicSlot.lock!(task.topic_id, task.creative_id)
-          cleanup_waiter_notice!(task)
-
-          # "Is anyone queued?" is the topic's question, not any one notice's.
-          # A shared notice speaks for the queued waiters no per-deferral notice
-          # claims, so a promotion that leaves only claimed waiters behind
-          # leaves it representing nobody — a second "⏳" line whose stop button
-          # selects nothing, kept up by the very waiter that is not its to
-          # speak for. Ask each notice what it still stands for.
-          Comment.remove_stranded_waiting_notices!(
-            creative_id: task.creative_id, topic_id: task.topic_id
-          )
-          next if Task.queued_for_topic(task.topic_id, task.creative_id).exists?
-
-          cleanup_waiting_notices!(task)
-        end
-      end
-      private_class_method :cleanup_waiting_notices_if_drained!
-
-      # Remove the per-deferral notice posted for this particular waiter, if it
-      # had one. A shared notice is left alone — it is not this task's to take
-      # down, and the drained check above is the question that governs it.
-      def self.cleanup_waiter_notice!(task)
-        Comment.remove_waiter_notices!(
-          creative_id: task.creative_id, topic_id: task.topic_id, task_ids: task.id
-        )
-      end
-      private_class_method :cleanup_waiter_notice!
-
-      # Post the "⏳ waiting on the topic slot" notice for a deferral raised
-      # outside #enqueue_jobs — AiAgentJob's late slot check, which catches
-      # dispatches that passed the Scheduler before any Task row existed.
-      # No-op when a notice for this creative/topic is already up — unless
-      # coalescing is off for this dispatch, in which case its waiter is nobody
-      # else's to speak for and gets a notice of its own, exactly as
-      # #post_waiting_notice does on the enqueue door. Leaving one door
-      # deduplicated and the other not is what breaks the opt-out's 1:1.
-      def self.post_topic_concurrency_notice(creative_id, topic_id, context = nil, agent: nil, waiter: nil)
-        return if creative_id.nil?
-
-        creative = Creative.find_by(id: creative_id)
-        return unless creative
-
-        reason_text = waiting_reason_text(:topic_concurrency, topic_id, creative_id)
-        # The waiter recorded this when it was parked. Reading it back rather than
-        # resolving the policy again keeps the notice, the fold and the shared
-        # notice's stop button on one answer even if the policy changes mid-wait.
-        # Falling back for a caller without a waiter: there is no row to ask.
-        shared =
-          if waiter
-            waiter.waiting_notice_scope == Comment::WAITING_NOTICE_TOPIC
-          else
-            PolicyResolver.new(context || {}).coalesce_pending_tasks_for?(agent)
-          end
-        post = lambda do
-          creative.comments.create!(
-            content: I18n.t("collavre.orchestration.waiting_notice", reason: reason_text),
-            topic_id: topic_id,
-            private: false,
-            skip_default_user: true,
-            topic_concurrency_defer: true,
-            # What this notice speaks for, recorded rather than reconstructed
-            # later from whichever siblings survive. See
-            # Comment#cancel_queued_tasks_for_waiting_notice.
-            waiting_notice_scope: shared ? Comment::WAITING_NOTICE_TOPIC : Comment::WAITING_NOTICE_TASK,
-            waiting_notice_task_id: shared ? nil : waiter&.id
-          )
-        end
-
-        if shared
-          with_deduped_topic_notice(creative_id, topic_id, &post)
-        else
-          with_live_waiter(waiter, creative_id, topic_id, &post)
-        end
-      end
-
-      # Remove waiting notice comments (system messages) for this task's creative/topic.
-      def self.cleanup_waiting_notices!(task)
-        context = task.trigger_event_payload
-        creative_id = context&.dig("creative", "id")
-        topic_id = context&.dig("topic", "id")
-        return unless creative_id
-
-        Comment.where(creative_id: creative_id, topic_id: topic_id, user_id: nil)
-               .where("content LIKE ?", "#{Comment::WAITING_NOTICE_PREFIX}%")
-               .find_each do |notice|
-          # System promotion, not user abandonment: do not let the destroy
-          # callback cancel other still-queued waiters in this topic.
-          notice.suppress_waiter_cancellation = true
-          notice.destroy
-        end
-      end
-      private_class_method :cleanup_waiting_notices!
 
       # Refresh trigger_event_payload so the deferred agent sees the latest
       # conversation state instead of the stale snapshot from enqueue time.
@@ -847,76 +610,15 @@ module Collavre
       end
 
       def post_waiting_notice(agent, decision, waiter: nil)
-        creative_id = @context.dig("creative", "id")
-        topic_id = @context.dig("topic", "id")
-        return unless creative_id
-
-        creative = Creative.find_by(id: creative_id)
-        return unless creative
-
-        reason_text = waiting_reason_text(decision[:reason] || :unknown, topic_id, creative_id)
-        deferred = decision[:timing] == :deferred
-
-        # Coalescing collapses a burst of deferrals into one waiter, so a notice
-        # per deferral would leave N-1 dead ends pointing at the same blocker.
-        # Keep exactly one topic-concurrency notice per creative/topic — and take
-        # the check and the insert under one lock, since a burst is precisely
-        # when an unserialized check reads stale.
-        #
-        # Taken from the waiter, which recorded it under the admission lock when
-        # park_waiter created it. One answer for the fold, the notice and the
-        # shared notice's stop button, rather than the same question asked at
-        # three moments a policy change can fall between. :delayed has no waiter.
-        shared = deferred && (waiter ? waiter.waiting_notice_scope == Comment::WAITING_NOTICE_TOPIC
-                                     : policy_resolver.coalesce_pending_tasks_for?(agent))
-        if shared
-          self.class.with_deduped_topic_notice(creative_id, topic_id) do
-            create_waiting_notice(creative, topic_id, reason_text, deferred: deferred,
-                                  shared: true, waiter: waiter)
-          end
-        elsif deferred
-          # park_waiter commits the row and this posts its notice afterwards, so
-          # the same window with_live_waiter closes on the late-admission door is
-          # open here too — see that method.
-          self.class.with_live_waiter(waiter, creative_id, topic_id) do
-            create_waiting_notice(creative, topic_id, reason_text, deferred: deferred,
-                                  shared: false, waiter: waiter)
-          end
-        else
-          # :delayed. The dispatch is still going to run, so there is no waiter
-          # for this notice to speak for and nothing for the guard to ask about.
-          create_waiting_notice(creative, topic_id, reason_text, deferred: deferred,
-                                shared: false, waiter: waiter)
-        end
-      end
-
-      def create_waiting_notice(creative, topic_id, reason_text, deferred:, shared:, waiter:)
-        creative.comments.build(
-          content: I18n.t("collavre.orchestration.waiting_notice", reason: reason_text),
-          topic_id: topic_id,
-          private: false,
-          skip_default_user: true,
-          # Only :deferred queues a topic waiter; mark it so its stop button can
-          # target the blocker. :delayed (busy / rate_limited) notices stay false.
-          topic_concurrency_defer: deferred,
-          # …and only a :deferred notice speaks for a waiter at all, so only that
-          # one records which. A :delayed notice never reaches
-          # Comment#cancel_queued_tasks_for_waiting_notice.
-          waiting_notice_scope: deferred ? (shared ? Comment::WAITING_NOTICE_TOPIC : Comment::WAITING_NOTICE_TASK) : nil,
-          waiting_notice_task_id: (waiter&.id unless shared)
-        ).tap(&:save!)
-      rescue ActiveRecord::RecordNotSaved => error
-        # A delayed job is already queued when this notice is posted. Topic
-        # relocation may invalidate only the stale notice in that gap.
-        raise unless error.record.errors.include?(:topic)
-      end
-
-      # Human-readable reason for the "⏳" waiting notice. For topic-concurrency
-      # deferrals, name the agent(s) actually holding the topic's running slot so
-      # a waiting user can see *who* is blocking them (and reach that task's stop
-      # button) rather than an anonymous "another task is running" dead end.
-      def waiting_reason_text(reason_key, topic_id, creative_id)
-        self.class.waiting_reason_text(reason_key, topic_id, creative_id)
+        WaitingNoticeManager.post(
+          @context.dig("creative", "id"), @context.dig("topic", "id"),
+          decision[:reason] || :unknown,
+          deferred: decision[:timing] == :deferred,
+          waiter: waiter,
+          # No waiter to read the scope off means :delayed, which never parks
+          # one; ask the policy the same question park_waiter asked.
+          shared_without_waiter: -> { policy_resolver.coalesce_pending_tasks_for?(agent) }
+        )
       end
     end
   end

--- a/engines/collavre/app/services/collavre/orchestration/waiting_notice_manager.rb
+++ b/engines/collavre/app/services/collavre/orchestration/waiting_notice_manager.rb
@@ -1,0 +1,289 @@
+# frozen_string_literal: true
+
+module Collavre
+  module Orchestration
+    # Owns the "⏳ waiting on the topic slot" notices: the reason text a waiting
+    # user reads, the locks that decide whether a notice is still warranted, the
+    # single row each door is allowed to write, and the cleanup that takes it
+    # down again.
+    #
+    # Two doors defer a dispatch — AgentOrchestrator#enqueue_jobs, and
+    # AiAgentJob's late slot check for dispatches that passed the Scheduler
+    # before any Task row existed — and they have to agree about when a burst
+    # becomes one notice, which waiter a notice speaks for, and when it comes
+    # back down. Both arrive here so that agreement is one implementation rather
+    # than two that drift.
+    class WaitingNoticeManager
+      # Human-readable reason for the "⏳" waiting notice. For topic-concurrency
+      # deferrals, name the agent(s) actually holding the topic's running slot so
+      # a waiting user can see *who* is blocking them (and reach that task's stop
+      # button) rather than an anonymous "another task is running" dead end.
+      def self.waiting_reason_text(reason_key, topic_id, creative_id)
+        if reason_key == :topic_concurrency && topic_id
+          names = Task.running_for_topic(topic_id, creative_id)
+                      .includes(:agent).filter_map { |t| t.agent&.name }.uniq
+          if names.any?
+            return I18n.t(
+              "collavre.orchestration.waiting_reasons.topic_concurrency_with_agent",
+              agent: names.join(", ")
+            )
+          end
+        end
+
+        I18n.t(
+          "collavre.orchestration.waiting_reasons.#{reason_key}",
+          default: reason_key.to_s.humanize
+        )
+      end
+
+      # Is there already a "⏳" topic-concurrency waiting notice on this
+      # creative/topic that stands for the topic as a whole? Shared with
+      # AiAgentJob's late slot check so both defer paths post at most one shared
+      # notice per topic.
+      #
+      # A per-deferral notice does not count. It speaks for one waiter, so
+      # letting it suppress the shared one would leave a coalescing agent's
+      # waiters with no notice at all whenever an opted-out agent happened to
+      # defer into the topic first. Notices from before the mode was recorded do
+      # count: they are the topic's only signal, and posting a second one beside
+      # them is the duplication this guard exists to prevent.
+      def self.topic_concurrency_notice_exists?(creative_id, topic_id)
+        Comment.where(creative_id: creative_id, topic_id: topic_id, user_id: nil,
+                      topic_concurrency_defer: true)
+               .where(waiting_notice_scope: [ nil, Comment::WAITING_NOTICE_TOPIC ])
+               .where("content LIKE ?", "#{Comment::WAITING_NOTICE_PREFIX}%")
+               .exists?
+      end
+
+      # Check-then-insert the one waiting notice a topic is allowed, as a single
+      # step. Both defer paths run for a *burst* — the case where every worker
+      # reads "no notice yet" before any of them inserts — so an unserialized
+      # check leaves N dead-end notices pointing at one blocker, and deleting one
+      # of them cancels the waiters while the others linger.
+      #
+      # Serialize on the same row admission locks (TopicSlot.lock!): the workers
+      # that compete for a notice are exactly the ones that competed for the
+      # slot, so the loser reads the winner's committed notice.
+      #
+      # The same lock also decides whether a notice is still warranted at all.
+      # The waiter commits before its notice goes up, so the blocker can finish
+      # in between, promote it, and run cleanup_waiting_notices! before any
+      # notice exists. A notice posted after that cleanup describes a wait that
+      # is already over, and nothing will ever take it down: removal only
+      # happens when a promotion drains a *queued* waiter, and there is none
+      # left. Promotion takes this same row, so "still queued" read here is the
+      # promotion's own before-or-after, not a guess.
+      #
+      # Yields only when a waiter is still queued and no notice exists yet;
+      # returns nil otherwise.
+      def self.with_deduped_topic_notice(creative_id, topic_id)
+        with_live_topic_wait(creative_id, topic_id) do
+          next nil if topic_concurrency_notice_exists?(creative_id, topic_id)
+
+          yield
+        end
+      end
+
+      # The "is anyone still waiting?" half on its own, without the "only one
+      # notice per topic" half.
+      #
+      # With coalesce_pending_tasks off, each deferral keeps its own waiter, so
+      # each one needs its own notice: a single notice standing for N
+      # independent waiters turns its stop button into "cancel everyone's work"
+      # (Comment#cancel_queued_tasks_for_waiting_notice reads "no sibling notice
+      # left" as "this notice spoke for the topic"). The drain guard still
+      # applies either way — a notice explaining a wait that is already over is
+      # never removed by anything.
+      def self.with_live_topic_wait(creative_id, topic_id)
+        Comment.transaction do
+          TopicSlot.lock!(topic_id, creative_id)
+          next nil unless Task.queued_for_topic(topic_id, creative_id).exists?
+
+          yield
+        end
+      end
+
+      # The same guard for a notice that speaks for exactly one waiter.
+      #
+      # "Is anyone still waiting?" is the *shared* notice's question, and it
+      # stays true for as long as any waiter is queued. A per-deferral notice
+      # answers for one — and that one can be promoted between its row
+      # committing and this lock, since the waiter is created and the notice
+      # posted in two steps on both doors. With another deferral parked in the
+      # same burst the topic-wide question then says yes while this waiter's
+      # says no, and the notice goes up offering a stop button for a turn that
+      # is already running.
+      #
+      # Nothing takes it back down. cleanup_waiter_notice! is the only path that
+      # removes one, it runs during the promotion that just happened, and it
+      # matched nothing because the notice did not exist yet; deleting it by
+      # hand cancels nothing either, since a task-scoped notice selects its own
+      # waiter and that waiter is no longer queued.
+      #
+      # Asked under the admission lock, so "still queued" is the promotion's own
+      # before-or-after rather than a guess.
+      def self.with_live_waiter(waiter, creative_id, topic_id, &block)
+        # No waiter to speak for: the topic-wide question is all a caller
+        # without one can be asked.
+        return with_live_topic_wait(creative_id, topic_id, &block) if waiter.nil?
+
+        Comment.transaction do
+          TopicSlot.lock!(topic_id, creative_id)
+          next nil unless Task.where(id: waiter.id, status: "queued").exists?
+
+          yield
+        end
+      end
+
+      # Take the topic's "⏳" notice down, but only once nothing is waiting on
+      # the slot any more.
+      #
+      # "A waiter left the queue" is not the same question. A topic gets exactly
+      # one deduplicated notice, and with topic_max > 1 a promotion can leave
+      # other agents queued — coalesce_promoted! absorbs same-agent siblings
+      # only, and the queue head may be ineligible while a later waiter runs. So
+      # an unconditional cleanup strips the wait/stop signal off a wait that is
+      # still real, and nothing reposts it until the next deferral happens by.
+      #
+      # Asked under the lock .post takes, so "nobody is queued" is
+      # that path's own before-or-after rather than a guess: a deferral either
+      # commits its waiter before this reads, and keeps its notice, or after, and
+      # posts its own.
+      # …but that guard is about the *shared* notice, which is still describing a
+      # real wait for as long as anyone is queued. A per-deferral notice speaks
+      # for one waiter, so it comes down when that waiter leaves the queue and
+      # not a moment later: with the opt-out and two waiters, promoting one
+      # leaves the queue non-empty, and the notice for the task now running would
+      # stay on screen with a stop button for a wait that is over.
+      def self.cleanup_waiting_notices_if_drained!(task)
+        Comment.transaction do
+          TopicSlot.lock!(task.topic_id, task.creative_id)
+          cleanup_waiter_notice!(task)
+
+          # "Is anyone queued?" is the topic's question, not any one notice's.
+          # A shared notice speaks for the queued waiters no per-deferral notice
+          # claims, so a promotion that leaves only claimed waiters behind
+          # leaves it representing nobody — a second "⏳" line whose stop button
+          # selects nothing, kept up by the very waiter that is not its to
+          # speak for. Ask each notice what it still stands for.
+          Comment.remove_stranded_waiting_notices!(
+            creative_id: task.creative_id, topic_id: task.topic_id
+          )
+          next if Task.queued_for_topic(task.topic_id, task.creative_id).exists?
+
+          cleanup_waiting_notices!(task)
+        end
+      end
+
+      # Remove the per-deferral notice posted for this particular waiter, if it
+      # had one. A shared notice is left alone — it is not this task's to take
+      # down, and the drained check above is the question that governs it.
+      def self.cleanup_waiter_notice!(task)
+        Comment.remove_waiter_notices!(
+          creative_id: task.creative_id, topic_id: task.topic_id, task_ids: task.id
+        )
+      end
+      private_class_method :cleanup_waiter_notice!
+
+      # Post the "⏳ waiting on the topic slot" notice for a deferral raised
+      # outside AgentOrchestrator#enqueue_jobs — AiAgentJob's late slot check,
+      # which catches dispatches that passed the Scheduler before any Task row
+      # existed.
+      # No-op when a notice for this creative/topic is already up — unless
+      # coalescing is off for this dispatch, in which case its waiter is nobody
+      # else's to speak for and gets a notice of its own, exactly as the enqueue
+      # door does. Leaving one door deduplicated and the other not is what breaks
+      # the opt-out's 1:1.
+      def self.post_topic_concurrency_notice(creative_id, topic_id, context = nil, agent: nil, waiter: nil)
+        post(
+          creative_id, topic_id, :topic_concurrency, deferred: true, waiter: waiter,
+          # Falling back for a caller without a waiter: there is no row to ask.
+          shared_without_waiter: -> { PolicyResolver.new(context || {}).coalesce_pending_tasks_for?(agent) }
+        )
+      end
+
+      # Post the one "⏳" notice a deferred or delayed dispatch is entitled to,
+      # under whichever guard its scope calls for.
+      #
+      # Coalescing collapses a burst of deferrals into one waiter, so a notice
+      # per deferral would leave N-1 dead ends pointing at the same blocker.
+      # Keep exactly one topic-concurrency notice per creative/topic — and take
+      # the check and the insert under one lock, since a burst is precisely when
+      # an unserialized check reads stale.
+      #
+      # The scope is taken from the waiter, which recorded it under the admission
+      # lock when it was parked. One answer for the fold, the notice and the
+      # shared notice's stop button, rather than the same question asked at three
+      # moments a policy change can fall between. `shared_without_waiter` is the
+      # fallback for a caller that has no waiter to ask — a :delayed dispatch
+      # never parks one — and is called only then.
+      def self.post(creative_id, topic_id, reason_key, deferred:, shared_without_waiter:, waiter: nil)
+        return if creative_id.nil?
+
+        creative = Creative.find_by(id: creative_id)
+        return unless creative
+
+        reason_text = waiting_reason_text(reason_key, topic_id, creative_id)
+        shared = deferred && (waiter ? waiter.waiting_notice_scope == Comment::WAITING_NOTICE_TOPIC
+                                     : shared_without_waiter.call)
+        write = lambda do
+          create_notice!(creative, topic_id, reason_text,
+                         deferred: deferred, shared: shared, waiter: waiter)
+        end
+
+        if shared
+          with_deduped_topic_notice(creative_id, topic_id, &write)
+        elsif deferred
+          # The waiter is committed and its notice posted afterwards, so the
+          # window with_live_waiter closes is open on both doors — see that
+          # method.
+          with_live_waiter(waiter, creative_id, topic_id, &write)
+        else
+          # :delayed. The dispatch is still going to run, so there is no waiter
+          # for this notice to speak for and nothing for the guard to ask about.
+          write.call
+        end
+      end
+
+      def self.create_notice!(creative, topic_id, reason_text, deferred:, shared:, waiter:)
+        creative.comments.build(
+          content: I18n.t("collavre.orchestration.waiting_notice", reason: reason_text),
+          topic_id: topic_id,
+          private: false,
+          skip_default_user: true,
+          # Only :deferred queues a topic waiter; mark it so its stop button can
+          # target the blocker. :delayed (busy / rate_limited) notices stay false.
+          topic_concurrency_defer: deferred,
+          # …and only a :deferred notice speaks for a waiter at all, so only that
+          # one records which. A :delayed notice never reaches
+          # Comment#cancel_queued_tasks_for_waiting_notice.
+          waiting_notice_scope: deferred ? (shared ? Comment::WAITING_NOTICE_TOPIC : Comment::WAITING_NOTICE_TASK) : nil,
+          waiting_notice_task_id: (waiter&.id unless shared)
+        ).tap(&:save!)
+      rescue ActiveRecord::RecordNotSaved => error
+        # A delayed job is already queued when this notice is posted. Topic
+        # relocation may invalidate only the stale notice in that gap.
+        raise unless error.record.errors.include?(:topic)
+      end
+      private_class_method :create_notice!
+
+      # Remove waiting notice comments (system messages) for this task's creative/topic.
+      def self.cleanup_waiting_notices!(task)
+        context = task.trigger_event_payload
+        creative_id = context&.dig("creative", "id")
+        topic_id = context&.dig("topic", "id")
+        return unless creative_id
+
+        Comment.where(creative_id: creative_id, topic_id: topic_id, user_id: nil)
+               .where("content LIKE ?", "#{Comment::WAITING_NOTICE_PREFIX}%")
+               .find_each do |notice|
+          # System promotion, not user abandonment: do not let the destroy
+          # callback cancel other still-queued waiters in this topic.
+          notice.suppress_waiter_cancellation = true
+          notice.destroy
+        end
+      end
+      private_class_method :cleanup_waiting_notices!
+    end
+  end
+end

--- a/engines/collavre/test/jobs/collavre/ai_agent_job_topic_slot_test.rb
+++ b/engines/collavre/test/jobs/collavre/ai_agent_job_topic_slot_test.rb
@@ -141,7 +141,7 @@ module Collavre
       }
 
       assert_no_difference notices do
-        Orchestration::AgentOrchestrator.post_topic_concurrency_notice(@creative.id, @topic.id)
+        Orchestration::WaitingNoticeManager.post_topic_concurrency_notice(@creative.id, @topic.id)
       end
     end
 
@@ -514,7 +514,7 @@ module Collavre
         "another task is running"
       end
 
-      Orchestration::AgentOrchestrator.stub :waiting_reason_text, delete_shared_in_window do
+      Orchestration::WaitingNoticeManager.stub :waiting_reason_text, delete_shared_in_window do
         AiAgentJob.new.perform(second_agent.id, "comment_created", context_for(comment("opt-out")))
       end
 
@@ -544,7 +544,7 @@ module Collavre
         "another task is running"
       end
 
-      Orchestration::AgentOrchestrator.stub :waiting_reason_text, delete_anchor_in_window do
+      Orchestration::WaitingNoticeManager.stub :waiting_reason_text, delete_anchor_in_window do
         AiAgentJob.new.perform(second_agent.id, "comment_created", context_for(anchor))
       end
 
@@ -652,7 +652,7 @@ module Collavre
         "another task is running"
       end
 
-      Orchestration::AgentOrchestrator.stub :waiting_reason_text, promote_in_window do
+      Orchestration::WaitingNoticeManager.stub :waiting_reason_text, promote_in_window do
         AiAgentJob.new.perform(@agent.id, "comment_created", context_for(comment("mine")))
       end
 

--- a/engines/collavre/test/services/collavre/orchestration/agent_orchestrator_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/agent_orchestrator_test.rb
@@ -268,11 +268,11 @@ module Collavre
         check_depth = nil
 
         Topic.stub(:lock, lock_relation) do
-          AgentOrchestrator.stub(:topic_concurrency_notice_exists?, ->(*) {
+          WaitingNoticeManager.stub(:topic_concurrency_notice_exists?, ->(*) {
             check_depth ||= Comment.connection.open_transactions
             false
           }) do
-            AgentOrchestrator.post_topic_concurrency_notice(@creative.id, topic.id)
+            WaitingNoticeManager.post_topic_concurrency_notice(@creative.id, topic.id)
           end
         end
 
@@ -289,7 +289,7 @@ module Collavre
         Task.create!(name: "Waiter", status: "queued", trigger_event_name: "e",
                      agent: @ai_agent, topic_id: topic.id, creative: @creative)
 
-        2.times { AgentOrchestrator.post_topic_concurrency_notice(@creative.id, topic.id) }
+        2.times { WaitingNoticeManager.post_topic_concurrency_notice(@creative.id, topic.id) }
 
         notices = @creative.comments.where(topic_id: topic.id, topic_concurrency_defer: true)
                            .select { |c| c.content.start_with?(Comment::WAITING_NOTICE_PREFIX) }

--- a/engines/collavre/test/services/collavre/orchestration/claim_to_execution_window_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/claim_to_execution_window_test.rb
@@ -174,7 +174,7 @@ module Collavre
       test "the waiting notice comes down when the fold drains the queue" do
         claimed = task_for(comment("@#{@agent.name}: first"), status: "pending")
         task_for(comment("@#{@agent.name}: later"), status: "queued")
-        AgentOrchestrator.post_topic_concurrency_notice(@creative.id, @topic.id)
+        WaitingNoticeManager.post_topic_concurrency_notice(@creative.id, @topic.id)
         assert_equal 1, notices.count, "fixture precondition: the late waiter posted a notice"
 
         AgentOrchestrator.coalesce_at_start!(claimed)
@@ -195,7 +195,7 @@ module Collavre
         task_for(comment("@#{@agent.name}: later"), status: "queued")
         other_waiter = task_for(comment("@#{other_agent.name}: hello"), status: "queued",
                                 agent: other_agent)
-        AgentOrchestrator.post_topic_concurrency_notice(@creative.id, @topic.id)
+        WaitingNoticeManager.post_topic_concurrency_notice(@creative.id, @topic.id)
         assert_equal 1, notices.count
 
         AgentOrchestrator.coalesce_at_start!(claimed)

--- a/engines/collavre/test/services/collavre/orchestration/waiting_notice_manager_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/waiting_notice_manager_test.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  module Orchestration
+    # The "⏳" notice has two doors — AgentOrchestrator#enqueue_jobs and
+    # AiAgentJob's late slot check — and one owner. These are the invariants
+    # that owner exists to hold: one answer about what a notice speaks for, one
+    # guard per scope, and a notice only while the wait it describes is real.
+    class WaitingNoticeManagerTest < ActiveSupport::TestCase
+      setup do
+        @user = users(:one)
+        @agent = users(:ai_bot)
+        @creative = creatives(:tshirt)
+        @topic = Topic.create!(name: "Notice owner", creative: @creative, user: @user)
+      end
+
+      def notices
+        Comment.where(creative_id: @creative.id, topic_id: @topic.id, user_id: nil)
+               .select { |c| c.content.start_with?(Comment::WAITING_NOTICE_PREFIX) }
+      end
+
+      def waiter!(scope, status: "queued")
+        Task.create!(
+          name: "Waiter", status: status, trigger_event_name: "comment_created",
+          agent: @agent, topic_id: @topic.id, creative_id: @creative.id,
+          waiting_notice_scope: scope
+        )
+      end
+
+      def never = ->(*) { flunk("the policy fallback must not be consulted") }
+
+      # The waiter recorded its scope under the admission lock when it was
+      # parked. Resolving the policy again here is how the notice, the fold and
+      # the stop button come to disagree about a wait whose policy changed
+      # mid-flight — so a waiter is the only thing asked when one exists.
+      test "the policy fallback is not consulted when a waiter carries the scope" do
+        waiter = waiter!(Comment::WAITING_NOTICE_TASK)
+
+        WaitingNoticeManager.post(@creative.id, @topic.id, :topic_concurrency,
+                                  deferred: true, waiter: waiter,
+                                  shared_without_waiter: never)
+
+        assert_equal [ waiter.id ], notices.map(&:waiting_notice_task_id),
+                     "a TASK-scoped waiter gets the per-deferral notice its row asked for"
+      end
+
+      # A shared notice speaks for the topic, so it carries no task id and the
+      # second deferral in a burst adds nothing beside it.
+      test "a topic-scoped waiter gets one shared notice for the whole burst" do
+        first = waiter!(Comment::WAITING_NOTICE_TOPIC)
+        second = waiter!(Comment::WAITING_NOTICE_TOPIC)
+
+        [ first, second ].each do |waiter|
+          WaitingNoticeManager.post(@creative.id, @topic.id, :topic_concurrency,
+                                    deferred: true, waiter: waiter,
+                                    shared_without_waiter: never)
+        end
+
+        assert_equal 1, notices.size, "one waiting notice per topic, not one per deferral"
+        assert_equal [ Comment::WAITING_NOTICE_TOPIC ], notices.map(&:waiting_notice_scope)
+        assert_nil notices.sole.waiting_notice_task_id
+      end
+
+      # The waiter commits before its notice goes up, so the blocker can finish
+      # and promote it in between. A notice posted after that describes a wait
+      # that is already over, and nothing would ever take it back down.
+      test "no notice goes up for a waiter that left the queue first" do
+        promoted = waiter!(Comment::WAITING_NOTICE_TASK, status: "pending")
+
+        WaitingNoticeManager.post(@creative.id, @topic.id, :topic_concurrency,
+                                  deferred: true, waiter: promoted,
+                                  shared_without_waiter: never)
+
+        assert_empty notices, "a stop button for a turn that is already running"
+      end
+
+      # :delayed is not a deferral. The dispatch is still going to run, so there
+      # is no waiter for the notice to speak for — and the queued-waiter guard
+      # must not be what decides whether it appears.
+      test "a delayed notice is posted with no waiter and no guard" do
+        WaitingNoticeManager.post(@creative.id, @topic.id, :busy,
+                                  deferred: false, waiter: nil,
+                                  shared_without_waiter: never)
+
+        notice = notices.sole
+        assert_not notice.topic_concurrency_defer, "only :deferred parks a topic waiter"
+        assert_nil notice.waiting_notice_scope, "a :delayed notice speaks for nobody"
+      end
+
+      # Without a waiter the policy is the only thing left to ask, and its
+      # answer picks the scope.
+      test "the policy fallback decides the scope for a waiterless deferral" do
+        waiter!(Comment::WAITING_NOTICE_TOPIC)
+
+        WaitingNoticeManager.post(@creative.id, @topic.id, :topic_concurrency,
+                                  deferred: true, waiter: nil,
+                                  shared_without_waiter: -> { true })
+
+        assert_equal [ Comment::WAITING_NOTICE_TOPIC ], notices.map(&:waiting_notice_scope)
+      end
+
+      # Name the agent holding the slot so a waiting user can reach its stop
+      # button rather than an anonymous "another task is running" dead end.
+      test "the reason text names the agent holding the topic slot" do
+        Task.create!(name: "Running", status: "running", trigger_event_name: "e",
+                     agent: @agent, topic_id: @topic.id, creative_id: @creative.id)
+
+        text = WaitingNoticeManager.waiting_reason_text(:topic_concurrency, @topic.id, @creative.id)
+
+        assert_includes text, @agent.name
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What

`AgentOrchestrator` owned the "⏳ waiting on the topic slot" notice alongside routing and scheduling: the reason text, the three locks that decide whether a notice is still warranted, the row each defer door writes, and the cleanup that takes it back down.

Two doors defer a dispatch — `AgentOrchestrator#enqueue_jobs` and `AiAgentJob`'s late slot check — and each carried its own copy of the scope decision and the insert. The invariant that they agree (one notice per topic when coalescing is on, 1:1 when it is off) lived in two places and was held by convention.

This moves the responsibility to `Collavre::Orchestration::WaitingNoticeManager` and routes both doors through one `.post`. `AgentOrchestrator` drops 320 lines.

## Ordering preserved

The relocated methods keep their names, bodies and comments. The lock / cancel / dedup ordering they exist to hold is unchanged:

- The scope is still read off the waiter — recorded under the admission lock in `park_waiter` — whenever there is one. The policy fallback is consulted only for a caller with no waiter, and is now passed as a lambda so it is still not evaluated when a waiter answers.
- A shared notice still goes up under `with_deduped_topic_notice` (check and insert on the same `TopicSlot.lock!` the admission takes), a per-deferral notice under `with_live_waiter`, and a `:delayed` notice under neither.
- Cleanup still runs waiter notice → stranded sweep → drained check inside one transaction on the admission lock.

## Behavior change

One, deliberate: the late-admission door now shares the enqueue door's `rescue ActiveRecord::RecordNotSaved` for an error aborted on `:topic`. A notice lost to a topic relocation mid-flight no longer fails the job. Previously only the enqueue door tolerated it, for the same reason.

## Tests

- Existing race-condition tests injected at `AgentOrchestrator.waiting_reason_text` and `.topic_concurrency_notice_exists?`; they now inject at the new owner. Same single method, same call count.
- New `WaitingNoticeManagerTest` covers the unified door directly, including that the policy fallback is **not** consulted when a waiter carries the scope — the invariant the extraction is there to make structural.

Local: `./bin/rubocop -a` clean, targeted orchestration/notice suites green (118 runs), full `bin/rails test` and `bin/rails test:system` reported in a comment below.

Base is `feature/refactor-reduce-dupl` (integration branch), not `main`.