### PR TITLE
fix(crons): display next run in user time zone

### DIFF
--- a/engines/collavre/app/components/collavre/cron_badge_component.rb
+++ b/engines/collavre/app/components/collavre/cron_badge_component.rb
@@ -28,7 +28,7 @@ module Collavre
     end
 
     def next_run_label(time)
-      time ? helpers.l(time, format: :short) : t("collavre.crons.not_available")
+      time ? helpers.l(time.in_time_zone, format: :short) : t("collavre.crons.not_available")
     end
 
     def destroy_path(task)

--- a/engines/collavre/test/components/cron_badge_component_test.rb
+++ b/engines/collavre/test/components/cron_badge_component_test.rb
@@ -36,4 +36,15 @@ class CronBadgeComponentTest < ViewComponent::TestCase
     assert_text "Not available", count: 2
     assert_no_selector ".cron-task-delete"
   end
+
+  test "renders the next run in the current user's time zone" do
+    time = Time.utc(2026, 9, 5, 9)
+    task = Task.new("cron_42_daily", "0 9 * * *", time, [ { message: "Daily summary" } ])
+
+    Time.use_zone("Asia/Seoul") do
+      render_inline(Collavre::CronBadgeComponent.new(tasks: [ task ], creative_id: 42))
+
+      assert_selector "time[datetime='#{time.iso8601}']", text: "5 Sep 18:00"
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- convert recurring task next-run timestamps to the current user time zone before formatting
- preserve the UTC instant in the `<time datetime>` attribute
- add a regression test for UTC-to-Asia/Seoul display conversion

## Testing

- `mise exec -- ./bin/rubocop -a`
- `mise exec -- bin/complexity_check`
- `mise exec -- bin/rails test engines/collavre/test/components/cron_badge_component_test.rb engines/collavre/test/helpers/creatives_helper_test.rb engines/collavre/test/controllers/topics_controller_test.rb engines/collavre/test/integration/creative_cron_filter_test.rb`
- `mise exec -- bin/rails test engines/collavre/test/system/creative_cron_badge_alignment_test.rb`

## Local suite notes

- The full host suite has 11 pre-existing Active Record encryption configuration errors; the two affected test files pass in isolation.
- The full engine system suite has one unrelated creative move-menu failure and one MCP SSE timeout; the cron badge system test passes in isolation.