### PR TITLE
Edit messages from scheduled job popups

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/creatives.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/creatives.css
@@ -1109,16 +1109,49 @@ creative-tree-row.is-being-edited .creative-tree {
     white-space: pre-wrap;
 }
 
+.cron-task-message-input {
+    box-sizing: border-box;
+    width: 100%;
+    min-height: 5em;
+    padding: var(--space-2);
+    border: var(--border-1) solid var(--border-color);
+    border-radius: var(--radius-2);
+    background: var(--surface-input);
+    color: var(--text-primary);
+    font: inherit;
+    font-size: var(--text-0);
+    resize: vertical;
+}
+
+.cron-task-actions {
+    display: flex;
+    gap: var(--space-2);
+}
+
+.cron-task-save,
 .cron-task-delete {
     display: inline-flex;
+    flex: 1;
     justify-content: center;
-    width: 100%;
     padding: var(--space-2);
-    border: var(--border-1) solid var(--color-danger);
     border-radius: var(--radius-2);
     background: transparent;
-    color: var(--color-danger);
     cursor: pointer;
+}
+
+.cron-task-save {
+    border: var(--border-1) solid var(--color-active);
+    color: var(--color-active);
+}
+
+.cron-task-save:hover,
+.cron-task-save:focus-visible {
+    background: color-mix(in srgb, var(--color-active) 12%, transparent);
+}
+
+.cron-task-delete {
+    border: var(--border-1) solid var(--color-danger);
+    color: var(--color-danger);
 }
 
 .cron-task-delete:hover,

--- a/engines/collavre/app/components/collavre/cron_badge_component.html.erb
+++ b/engines/collavre/app/components/collavre/cron_badge_component.html.erb
@@ -2,6 +2,7 @@
       data-controller="popup-menu cron-badge"
       data-cron-badge-delete-confirm-value="<%= t('collavre.crons.delete_confirm') %>"
       data-cron-badge-delete-error-value="<%= t('collavre.crons.delete_error') %>"
+      data-cron-badge-update-error-value="<%= t('collavre.crons.update_error') %>"
       data-cron-badge-count-one-value="<%= t('collavre.crons.count_one') %>"
       data-cron-badge-count-other-value="<%= t('collavre.crons.count_other') %>">
   <button type="button"
@@ -30,10 +31,20 @@
           <span class="cron-task-label"><%= t('collavre.crons.schedule') %></span>
           <code><%= task.schedule %></code>
         </span>
-        <span class="cron-task-field">
-          <span class="cron-task-label"><%= t('collavre.crons.message') %></span>
-          <span class="cron-task-message"><%= task_message(task) %></span>
-        </span>
+        <% if can_manage? %>
+          <label class="cron-task-field">
+            <span class="cron-task-label"><%= t('collavre.crons.message') %></span>
+            <textarea class="cron-task-message-input"
+                      rows="3"
+                      data-cron-badge-target="messageInput"
+                      data-cron-saved-message="<%= task_message_value(task) %>"><%= task_message_value(task) %></textarea>
+          </label>
+        <% else %>
+          <span class="cron-task-field">
+            <span class="cron-task-label"><%= t('collavre.crons.message') %></span>
+            <span class="cron-task-message"><%= task_message(task) %></span>
+          </span>
+        <% end %>
         <span class="cron-task-field">
           <span class="cron-task-label"><%= t('collavre.crons.next_run') %></span>
           <% if task_next_run %>
@@ -42,13 +53,21 @@
             <span><%= next_run_label(task_next_run) %></span>
           <% end %>
         </span>
-        <% if can_delete? %>
-          <button type="button"
-                  class="cron-task-delete"
-                  data-action="click->cron-badge#destroy"
-                  data-cron-delete-url="<%= destroy_path(task) %>">
-            <%= t('collavre.crons.delete') %>
-          </button>
+        <% if can_manage? %>
+          <span class="cron-task-actions">
+            <button type="button"
+                    class="cron-task-save"
+                    data-action="click->cron-badge#saveMessage"
+                    data-cron-update-url="<%= update_path(task) %>">
+              <%= t('app.save') %>
+            </button>
+            <button type="button"
+                    class="cron-task-delete"
+                    data-action="click->cron-badge#destroy"
+                    data-cron-delete-url="<%= destroy_path(task) %>">
+              <%= t('collavre.crons.delete') %>
+            </button>
+          </span>
         <% end %>
       </span>
     <% end %>

--- a/engines/collavre/app/components/collavre/cron_badge_component.html.erb
+++ b/engines/collavre/app/components/collavre/cron_badge_component.html.erb
@@ -37,7 +37,7 @@
             <textarea class="cron-task-message-input"
                       rows="3"
                       data-cron-badge-target="messageInput"
-                      data-cron-saved-message="<%= task_message_value(task) %>"><%= task_message_value(task) %></textarea>
+                      data-cron-saved-message="<%= task_message_value(task) %>"><%= textarea_message(task) %></textarea>
           </label>
         <% else %>
           <span class="cron-task-field">

--- a/engines/collavre/app/components/collavre/cron_badge_component.rb
+++ b/engines/collavre/app/components/collavre/cron_badge_component.rb
@@ -13,7 +13,7 @@ module Collavre
 
     attr_reader :tasks, :creative_id, :menu_id
 
-    def can_delete? = @can_delete
+    def can_manage? = @can_delete
 
     def count_label
       t("collavre.creatives.index.cron_count", count: tasks.size)
@@ -21,6 +21,10 @@ module Collavre
 
     def task_message(task)
       parse_arguments(task)["message"].presence || t("collavre.crons.not_available")
+    end
+
+    def task_message_value(task)
+      parse_arguments(task)["message"].to_s
     end
 
     def next_run(task)
@@ -32,6 +36,10 @@ module Collavre
     end
 
     def destroy_path(task)
+      helpers.collavre.creative_cron_path(creative_id, task.key)
+    end
+
+    def update_path(task)
       helpers.collavre.creative_cron_path(creative_id, task.key)
     end
   end

--- a/engines/collavre/app/components/collavre/cron_badge_component.rb
+++ b/engines/collavre/app/components/collavre/cron_badge_component.rb
@@ -27,6 +27,10 @@ module Collavre
       parse_arguments(task)["message"].to_s
     end
 
+    def textarea_message(task)
+      "\n#{task_message_value(task)}"
+    end
+
     def next_run(task)
       task.next_time
     end

--- a/engines/collavre/app/controllers/collavre/crons_controller.rb
+++ b/engines/collavre/app/controllers/collavre/crons_controller.rb
@@ -7,8 +7,23 @@ module Collavre
     before_action :set_creative
     before_action :require_creative_write!
 
+    def update
+      task = find_recurring_task
+      return head :not_found unless task
+
+      message = params[:message].to_s
+      if message.blank?
+        return render json: { error: t("collavre.crons.message_required") }, status: :unprocessable_entity
+      end
+
+      result = Tools::CronUpdateService.new.call(key: task.key, message: message)
+      return render json: result, status: :unprocessable_entity if result[:error]
+
+      render json: { message: message }
+    end
+
     def destroy
-      task = recurring_tasks.find { |candidate| candidate.key == params[:key] }
+      task = find_recurring_task
       return head :not_found unless task
 
       task.destroy!
@@ -24,6 +39,10 @@ module Collavre
 
     def recurring_tasks
       Crons::RecurringTaskIndex.for_creative_family(@creative).tasks_for(@creative.id)
+    end
+
+    def find_recurring_task
+      recurring_tasks.find { |candidate| candidate.key == params[:key] }
     end
   end
 end

--- a/engines/collavre/app/javascript/components/__tests__/creative_tree_row_progress_toggle.test.js
+++ b/engines/collavre/app/javascript/components/__tests__/creative_tree_row_progress_toggle.test.js
@@ -203,8 +203,8 @@ test('preserves a dirty cron message after toggling progress on the same row', a
   const input = row.querySelector('textarea')
   expect(input.value).toBe('\nHalf-typed message')
   expect(input.dataset.cronSavedMessage).toBe('Saved message')
-  expect(input.disabled).toBe(false)
-  expect(row.querySelector('.cron-task-save').disabled).toBe(false)
+  expect(input.disabled).toBe(true)
+  expect(row.querySelector('.cron-task-save').disabled).toBe(true)
 })
 
 test('preserves an ancestor cron draft after a descendant progress toggle', async () => {

--- a/engines/collavre/app/javascript/components/__tests__/creative_tree_row_progress_toggle.test.js
+++ b/engines/collavre/app/javascript/components/__tests__/creative_tree_row_progress_toggle.test.js
@@ -15,10 +15,11 @@ beforeAll(() => {
   }
 })
 
-async function mountRow(progressHtml) {
+async function mountRow(progressHtml, creativeId = '7') {
   await import('../creative_tree_row.js')
   const row = document.createElement('creative-tree-row')
-  row.creativeId = '7'
+  row.creativeId = creativeId
+  row.setAttribute('creative-id', creativeId)
   row.progressHtml = progressHtml
   document.body.appendChild(row)
   await row.updateComplete
@@ -32,6 +33,16 @@ const COMPLETE_TOGGLE = INCOMPLETE_TOGGLE
   .replace('title="Mark complete"', 'title="Mark incomplete"')
   .replace('<input type="checkbox"', '<input type="checkbox" checked')
   .replace('aria-label="Mark complete"', 'aria-label="Mark incomplete"')
+
+const progressWithCron = (control, message = 'Saved message') => `
+  <div class="creative-row-end">
+    <span data-cron-key="cron-42">
+      <textarea data-cron-badge-target="messageInput"
+                data-cron-saved-message="${message}">\n${message}</textarea>
+    </span>
+    ${control}
+  </div>
+`
 
 afterEach(() => {
   csrfFetch.mockReset()
@@ -166,6 +177,58 @@ test('keeps focus on the checkbox after the server re-renders the toggle', async
   const rendered = row.querySelector('.progress-toggle-checkbox')
   expect(document.activeElement).toBe(rendered)
   expect(rendered.checked).toBe(true)
+})
+
+test('preserves a dirty cron message after toggling progress on the same row', async () => {
+  csrfFetch.mockResolvedValue({
+    ok: true,
+    json: async () => ({
+      progress: 1,
+      progress_html: `<div class="creative-row-end">${COMPLETE_TOGGLE}</div>`,
+    }),
+  })
+  const row = await mountRow(progressWithCron(INCOMPLETE_TOGGLE))
+  row.querySelector('textarea').value = '\nHalf-typed message'
+
+  row.querySelector('[data-progress-toggle]').click()
+  await Promise.resolve()
+  await row.updateComplete
+  await row.updateComplete
+
+  const input = row.querySelector('textarea')
+  expect(input.value).toBe('\nHalf-typed message')
+  expect(input.dataset.cronSavedMessage).toBe('Saved message')
+})
+
+test('preserves an ancestor cron draft after a descendant progress toggle', async () => {
+  csrfFetch.mockResolvedValue({
+    ok: true,
+    json: async () => ({
+      progress: 1,
+      ancestors: [{
+        id: '42',
+        progress: 0.5,
+        progress_html: '<div class="creative-row-end"><span class="creative-progress-incomplete">50%</span></div>',
+      }],
+    }),
+  })
+  const ancestor = await mountRow(
+    progressWithCron('<span class="creative-progress-incomplete">0%</span>'),
+    '42'
+  )
+  ancestor.querySelector('textarea').value = 'Half-typed ancestor message'
+  const row = await mountRow(INCOMPLETE_TOGGLE)
+
+  row.querySelector('[data-progress-toggle]').click()
+  await new Promise(resolve => setTimeout(resolve, 0))
+  await row.updateComplete
+  await ancestor.updateComplete
+
+  const input = ancestor.querySelector('textarea')
+  expect(input.value).toBe('Half-typed ancestor message')
+  expect(input.dataset.cronSavedMessage).toBe('Saved message')
+  expect(ancestor.progressHtml).toContain('50%')
+  expect(ancestor.querySelector('.creative-progress-incomplete').textContent).toBe('50%')
 })
 
 test('restores checkbox metadata when a toggle request fails', async () => {

--- a/engines/collavre/app/javascript/components/__tests__/creative_tree_row_progress_toggle.test.js
+++ b/engines/collavre/app/javascript/components/__tests__/creative_tree_row_progress_toggle.test.js
@@ -36,9 +36,10 @@ const COMPLETE_TOGGLE = INCOMPLETE_TOGGLE
 
 const progressWithCron = (control, message = 'Saved message') => `
   <div class="creative-row-end">
-    <span data-cron-key="cron-42">
+    <span data-cron-badge-target="task" data-cron-key="cron-42">
       <textarea data-cron-badge-target="messageInput"
                 data-cron-saved-message="${message}">\n${message}</textarea>
+      <button class="cron-task-save">Save</button>
     </span>
     ${control}
   </div>
@@ -188,7 +189,11 @@ test('preserves a dirty cron message after toggling progress on the same row', a
     }),
   })
   const row = await mountRow(progressWithCron(INCOMPLETE_TOGGLE))
-  row.querySelector('textarea').value = '\nHalf-typed message'
+  const savingInput = row.querySelector('textarea')
+  const savingButton = row.querySelector('.cron-task-save')
+  savingInput.value = '\nHalf-typed message'
+  savingInput.disabled = true
+  savingButton.disabled = true
 
   row.querySelector('[data-progress-toggle]').click()
   await Promise.resolve()
@@ -198,6 +203,8 @@ test('preserves a dirty cron message after toggling progress on the same row', a
   const input = row.querySelector('textarea')
   expect(input.value).toBe('\nHalf-typed message')
   expect(input.dataset.cronSavedMessage).toBe('Saved message')
+  expect(input.disabled).toBe(false)
+  expect(row.querySelector('.cron-task-save').disabled).toBe(false)
 })
 
 test('preserves an ancestor cron draft after a descendant progress toggle', async () => {

--- a/engines/collavre/app/javascript/components/creative_tree_row.js
+++ b/engines/collavre/app/javascript/components/creative_tree_row.js
@@ -6,6 +6,7 @@ import { highlightCodeBlocks } from "../lib/utils/markdown";
 import { addCreativeTableDownloadButtons } from "../lib/utils/table_download";
 import { sanitizeDescriptionHtml } from "../lib/utils/sanitize_description";
 import csrfFetch from "../lib/api/csrf_fetch";
+import { replaceProgressControl, syncProgressHtmlFromDom } from "../creatives/tree_renderer";
 
 const BULLET_STARTING_LEVEL = 3;
 
@@ -606,8 +607,7 @@ class CreativeTreeRow extends LitElement {
       const data = await response.json();
       // Update this row's progressHtml from server response
       if (data.progress_html) {
-        this.progressHtml = data.progress_html;
-        this.dataset.progressHtml = data.progress_html;
+        this._applyProgressHtml(this, data.progress_html);
       }
       // Update progressValue for inline editor
       if (data.progress != null) {
@@ -623,8 +623,7 @@ class CreativeTreeRow extends LitElement {
           const row = document.querySelector(`creative-tree-row[creative-id="${ancestor.id}"]`);
           if (row) {
             if (ancestor.progress_html) {
-              row.progressHtml = ancestor.progress_html;
-              row.dataset.progressHtml = ancestor.progress_html;
+              this._applyProgressHtml(row, ancestor.progress_html);
             }
             if (ancestor.progress != null) {
               row.dataset.progressValue = String(ancestor.progress);
@@ -643,6 +642,14 @@ class CreativeTreeRow extends LitElement {
     } finally {
       wrap.classList.remove("progress-toggle-saving");
     }
+  }
+
+  _applyProgressHtml(row, serverHtml) {
+    syncProgressHtmlFromDom(row);
+    row.progressHtml = row.progressHtml
+      ? replaceProgressControl(row.progressHtml, serverHtml)
+      : serverHtml;
+    row.dataset.progressHtml = row.progressHtml;
   }
 
   _handleContentClick(event) {

--- a/engines/collavre/app/javascript/controllers/__tests__/cron_badge_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/cron_badge_controller.test.js
@@ -262,6 +262,33 @@ describe('CronBadgeController', () => {
     expect(treeController.endReloadHold).toHaveBeenCalledTimes(1)
   })
 
+	test('holds full tree reloads until an in-flight deletion settles', async () => {
+		let resolveDelete
+		confirmDialog.mockResolvedValue(true)
+		csrfFetch.mockReturnValue(new Promise(resolve => { resolveDelete = resolve }))
+		const tree = document.createElement('div')
+		tree.setAttribute('data-controller', 'creatives--tree')
+		element.before(tree)
+		tree.appendChild(element)
+		const treeController = {
+			beginReloadHold: jest.fn(),
+			endReloadHold: jest.fn(),
+		}
+		jest.spyOn(application, 'getControllerForElementAndIdentifier')
+			.mockReturnValue(treeController)
+
+		element.querySelector('[data-cron-delete-url$="/one"]').click()
+		await new Promise(resolve => setTimeout(resolve, 0))
+
+		expect(treeController.beginReloadHold).toHaveBeenCalledTimes(1)
+		expect(treeController.endReloadHold).not.toHaveBeenCalled()
+
+		resolveDelete({ ok: true, status: 204 })
+		await new Promise(resolve => setTimeout(resolve, 0))
+
+		expect(treeController.endReloadHold).toHaveBeenCalledTimes(1)
+	})
+
   test('ignores stale save tasks and missing controls when finishing', () => {
     const task = document.createElement('span')
     task.dataset.cronSaveOperation = 'current'

--- a/engines/collavre/app/javascript/controllers/__tests__/cron_badge_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/cron_badge_controller.test.js
@@ -175,6 +175,45 @@ describe('CronBadgeController', () => {
     expect(replacementTask.querySelector('[data-cron-update-url]').disabled).toBe(false)
   })
 
+  test('updates the saved message baseline on replacement controls after a successful update', async () => {
+    let resolveUpdate
+    csrfFetch.mockReturnValue(new Promise(resolve => { resolveUpdate = resolve }))
+    const task = element.querySelector('[data-cron-badge-target="task"]')
+    const input = task.querySelector('textarea')
+    const button = task.querySelector('[data-cron-update-url]')
+    input.dataset.cronSavedMessage = 'First message'
+    input.value = 'Updated message'
+
+    button.click()
+    const replacement = element.cloneNode(true)
+    element.replaceWith(replacement)
+    const replacementInput = replacement.querySelector('textarea')
+
+    expect(replacementInput.dataset.cronSavedMessage).toBe('First message')
+
+    resolveUpdate({ ok: true, status: 200 })
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(replacementInput.dataset.cronSavedMessage).toBe('Updated message')
+    expect(replacementInput.disabled).toBe(false)
+  })
+
+  test('ignores stale save tasks and missing controls when finishing', () => {
+    const task = document.createElement('span')
+    task.dataset.cronSaveOperation = 'current'
+
+    controller.finishMessageSave(task, 'stale')
+    expect(task.dataset.cronSaveOperation).toBe('current')
+
+    expect(() => controller.finishMessageSave(task, 'current')).not.toThrow()
+    expect(task.hasAttribute('data-cron-save-operation')).toBe(false)
+
+    task.dataset.cronSaveOperation = 'current'
+    expect(() => {
+      controller.updateSavedMessage(task, 'current', 'Updated message')
+    }).not.toThrow()
+  })
+
   test('refreshes the CSRF token and retries a message update after a payload-less 422 response', async () => {
     csrfFetch
       .mockResolvedValueOnce(response({ ok: false, status: 422 }))

--- a/engines/collavre/app/javascript/controllers/__tests__/cron_badge_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/cron_badge_controller.test.js
@@ -285,6 +285,8 @@ describe('CronBadgeController', () => {
 		expect(treeController.endReloadHold).not.toHaveBeenCalled()
 		const replacement = element.cloneNode(true)
 		element.replaceWith(replacement)
+		const replacementTask = replacement.querySelector('[data-cron-delete-operation]')
+		expect(replacementTask.querySelector('[data-cron-delete-url]').disabled).toBe(true)
 		resolveConfirmation(true)
 		await new Promise(resolve => setTimeout(resolve, 0))
 
@@ -295,6 +297,7 @@ describe('CronBadgeController', () => {
 		await new Promise(resolve => setTimeout(resolve, 0))
 
 		expect(treeController.endReloadHold).toHaveBeenCalledTimes(1)
+		expect(replacement.querySelectorAll('[data-cron-badge-target="task"]')).toHaveLength(1)
 	})
 
   test('ignores stale save tasks and missing controls when finishing', () => {
@@ -387,6 +390,8 @@ describe('CronBadgeController', () => {
 
     expect(csrfFetch).not.toHaveBeenCalled()
     expect(controller.taskTargets).toHaveLength(2)
+		expect(element.querySelector('[data-cron-delete-url$="/one"]').disabled).toBe(false)
+		expect(element.querySelector('[data-cron-delete-operation]')).toBeNull()
 		expect(treeController.beginReloadHold).toHaveBeenCalledTimes(1)
 		expect(treeController.endReloadHold).toHaveBeenCalledTimes(1)
   })

--- a/engines/collavre/app/javascript/controllers/__tests__/cron_badge_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/cron_badge_controller.test.js
@@ -32,15 +32,20 @@ describe('CronBadgeController', () => {
       <span data-controller="cron-badge"
             data-cron-badge-delete-confirm-value="Delete it?"
             data-cron-badge-delete-error-value="Delete failed"
+            data-cron-badge-update-error-value="Update failed"
             data-cron-badge-count-one-value="__count__ scheduled job"
             data-cron-badge-count-other-value="__count__ scheduled jobs">
         <button data-cron-badge-target="badge" title="2 scheduled jobs" aria-label="2 scheduled jobs">
           <span data-cron-badge-target="count">2</span>
         </button>
         <span data-cron-badge-target="task">
+          <textarea data-cron-badge-target="messageInput">First message</textarea>
+          <button data-action="click->cron-badge#saveMessage" data-cron-update-url="/creatives/42/crons/one">Save</button>
           <button data-action="click->cron-badge#destroy" data-cron-delete-url="/creatives/42/crons/one">Delete</button>
         </span>
         <span data-cron-badge-target="task">
+          <textarea data-cron-badge-target="messageInput">Second message</textarea>
+          <button data-action="click->cron-badge#saveMessage" data-cron-update-url="/creatives/42/crons/two">Save</button>
           <button data-action="click->cron-badge#destroy" data-cron-delete-url="/creatives/42/crons/two">Delete</button>
         </span>
       </span>
@@ -76,6 +81,79 @@ describe('CronBadgeController', () => {
     expect(controller.countTarget.textContent).toBe('1')
     expect(controller.badgeTarget.title).toBe('1 scheduled job')
     expect(controller.badgeTarget.getAttribute('aria-label')).toBe('1 scheduled job')
+  })
+
+  test('refreshes the plural count label', () => {
+    controller.refreshCount()
+
+    expect(controller.countTarget.textContent).toBe('2')
+    expect(controller.badgeTarget.title).toBe('2 scheduled jobs')
+    expect(controller.badgeTarget.getAttribute('aria-label')).toBe('2 scheduled jobs')
+  })
+
+  test('updates a task message and refreshes creative trees', async () => {
+    const refetch = jest.fn()
+    const invalidate = jest.fn()
+    document.addEventListener('creative-sync:refetch', refetch)
+    document.addEventListener('workspace-tree:invalidate', invalidate)
+    csrfFetch.mockResolvedValue({ ok: true, status: 200 })
+
+    const task = element.querySelector('[data-cron-badge-target="task"]')
+    const input = task.querySelector('[data-cron-badge-target="messageInput"]')
+    const button = task.querySelector('[data-cron-update-url]')
+    input.value = 'Updated message'
+    button.click()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(csrfFetch).toHaveBeenCalledWith('/creatives/42/crons/one', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message: 'Updated message' }),
+    })
+    expect(refetch).toHaveBeenCalledTimes(1)
+    expect(invalidate).toHaveBeenCalledTimes(1)
+    expect(input.dataset.cronSavedMessage).toBe('Updated message')
+    expect(button.disabled).toBe(false)
+    expect(input.disabled).toBe(false)
+    document.removeEventListener('creative-sync:refetch', refetch)
+    document.removeEventListener('workspace-tree:invalidate', invalidate)
+  })
+
+  test('ignores a message update when its input is missing', async () => {
+    const task = element.querySelector('[data-cron-badge-target="task"]')
+    task.querySelector('[data-cron-badge-target="messageInput"]').remove()
+
+    task.querySelector('[data-cron-update-url]').click()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(csrfFetch).not.toHaveBeenCalled()
+  })
+
+  test('reports a failed message update and restores the controls', async () => {
+    csrfFetch.mockResolvedValue({ ok: false, status: 500 })
+    alertDialog.mockResolvedValue(undefined)
+    const task = element.querySelector('[data-cron-badge-target="task"]')
+    const input = task.querySelector('[data-cron-badge-target="messageInput"]')
+    const button = task.querySelector('[data-cron-update-url]')
+
+    button.click()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(alertDialog).toHaveBeenCalledWith('Update failed')
+    expect(button.disabled).toBe(false)
+    expect(input.disabled).toBe(false)
+  })
+
+  test('refreshes the CSRF token and retries a message update after a 422 response', async () => {
+    csrfFetch
+      .mockResolvedValueOnce({ ok: false, status: 422 })
+      .mockResolvedValueOnce({ ok: true, status: 200 })
+
+    element.querySelector('[data-cron-update-url]').click()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(refreshCsrfToken).toHaveBeenCalledTimes(1)
+    expect(csrfFetch).toHaveBeenCalledTimes(2)
   })
 
   test('removes the badge after deleting its last task', async () => {

--- a/engines/collavre/app/javascript/controllers/__tests__/cron_badge_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/cron_badge_controller.test.js
@@ -152,6 +152,29 @@ describe('CronBadgeController', () => {
     expect(input.disabled).toBe(false)
   })
 
+  test('keeps replacement controls disabled until an in-flight update settles', async () => {
+    let resolveUpdate
+    csrfFetch.mockReturnValue(new Promise(resolve => { resolveUpdate = resolve }))
+    alertDialog.mockResolvedValue(undefined)
+    const task = element.querySelector('[data-cron-badge-target="task"]')
+    const button = task.querySelector('[data-cron-update-url]')
+
+    button.click()
+    const replacement = element.cloneNode(true)
+    element.replaceWith(replacement)
+    const replacementTask = replacement.querySelector('[data-cron-badge-target="task"]')
+
+    expect(replacementTask.querySelector('textarea').disabled).toBe(true)
+    expect(replacementTask.querySelector('[data-cron-update-url]').disabled).toBe(true)
+
+    resolveUpdate({ ok: false, status: 500 })
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(replacementTask.hasAttribute('data-cron-save-operation')).toBe(false)
+    expect(replacementTask.querySelector('textarea').disabled).toBe(false)
+    expect(replacementTask.querySelector('[data-cron-update-url]').disabled).toBe(false)
+  })
+
   test('refreshes the CSRF token and retries a message update after a payload-less 422 response', async () => {
     csrfFetch
       .mockResolvedValueOnce(response({ ok: false, status: 422 }))

--- a/engines/collavre/app/javascript/controllers/__tests__/cron_badge_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/cron_badge_controller.test.js
@@ -91,6 +91,45 @@ describe('CronBadgeController', () => {
     expect(controller.badgeTarget.getAttribute('aria-label')).toBe('1 scheduled job')
   })
 
+  test('restores a replacement delete button after a failed deletion', async () => {
+		let resolveDelete
+		confirmDialog.mockResolvedValue(true)
+		csrfFetch.mockReturnValue(new Promise(resolve => { resolveDelete = resolve }))
+		alertDialog.mockResolvedValue(undefined)
+		const button = element.querySelector('[data-cron-delete-url$="/one"]')
+
+		button.click()
+		await new Promise(resolve => setTimeout(resolve, 0))
+		const replacement = element.cloneNode(true)
+		element.replaceWith(replacement)
+		const replacementTask = replacement.querySelector('[data-cron-delete-operation]')
+
+		expect(replacementTask.querySelector('[data-cron-delete-url]').disabled).toBe(true)
+		resolveDelete({ ok: false, status: 500 })
+		await new Promise(resolve => setTimeout(resolve, 0))
+
+		expect(replacementTask.hasAttribute('data-cron-delete-operation')).toBe(false)
+		expect(replacementTask.querySelector('[data-cron-delete-url]').disabled).toBe(false)
+  })
+
+  test('removes a replacement task after a successful deletion', async () => {
+		let resolveDelete
+		confirmDialog.mockResolvedValue(true)
+		csrfFetch.mockReturnValue(new Promise(resolve => { resolveDelete = resolve }))
+		const button = element.querySelector('[data-cron-delete-url$="/one"]')
+
+		button.click()
+		await new Promise(resolve => setTimeout(resolve, 0))
+		const replacement = element.cloneNode(true)
+		element.replaceWith(replacement)
+		resolveDelete({ ok: true, status: 204 })
+		await new Promise(resolve => setTimeout(resolve, 0))
+
+		expect(replacement.querySelectorAll('[data-cron-badge-target="task"]')).toHaveLength(1)
+		expect(replacement.querySelector('[data-cron-badge-target="count"]').textContent).toBe('1')
+		expect(replacement.querySelector('[data-cron-badge-target="badge"]').title).toBe('1 scheduled job')
+  })
+
   test('refreshes the plural count label', () => {
     controller.refreshCount()
 

--- a/engines/collavre/app/javascript/controllers/__tests__/cron_badge_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/cron_badge_controller.test.js
@@ -21,6 +21,14 @@ jest.unstable_mockModule('../../lib/api/csrf_fetch', () => ({
 
 const { default: CronBadgeController } = await import('../cron_badge_controller')
 
+function response({ ok, status, body = '' }) {
+  return {
+    ok,
+    status,
+    clone: () => ({ text: async () => body }),
+  }
+}
+
 describe('CronBadgeController', () => {
   let application
   let element
@@ -144,9 +152,9 @@ describe('CronBadgeController', () => {
     expect(input.disabled).toBe(false)
   })
 
-  test('refreshes the CSRF token and retries a message update after a 422 response', async () => {
+  test('refreshes the CSRF token and retries a message update after a payload-less 422 response', async () => {
     csrfFetch
-      .mockResolvedValueOnce({ ok: false, status: 422 })
+      .mockResolvedValueOnce(response({ ok: false, status: 422 }))
       .mockResolvedValueOnce({ ok: true, status: 200 })
 
     element.querySelector('[data-cron-update-url]').click()
@@ -154,6 +162,22 @@ describe('CronBadgeController', () => {
 
     expect(refreshCsrfToken).toHaveBeenCalledTimes(1)
     expect(csrfFetch).toHaveBeenCalledTimes(2)
+  })
+
+  test('does not retry a message update after a semantic 422 response', async () => {
+    csrfFetch.mockResolvedValue(response({
+      ok: false,
+      status: 422,
+      body: JSON.stringify({ error: 'Message cannot be blank' }),
+    }))
+    alertDialog.mockResolvedValue(undefined)
+
+    element.querySelector('[data-cron-update-url]').click()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(refreshCsrfToken).not.toHaveBeenCalled()
+    expect(csrfFetch).toHaveBeenCalledTimes(1)
+    expect(alertDialog).toHaveBeenCalledWith('Update failed')
   })
 
   test('removes the badge after deleting its last task', async () => {
@@ -208,10 +232,10 @@ describe('CronBadgeController', () => {
     expect(controller.taskTargets).toHaveLength(2)
   })
 
-  test('refreshes the CSRF token and retries once after a 422 response', async () => {
+  test('refreshes the CSRF token and retries once after a payload-less 422 response', async () => {
     confirmDialog.mockResolvedValue(true)
     csrfFetch
-      .mockResolvedValueOnce({ ok: false, status: 422 })
+      .mockResolvedValueOnce(response({ ok: false, status: 422 }))
       .mockResolvedValueOnce({ ok: true, status: 204 })
 
     element.querySelector('[data-cron-delete-url$="/one"]').click()

--- a/engines/collavre/app/javascript/controllers/__tests__/cron_badge_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/cron_badge_controller.test.js
@@ -263,8 +263,9 @@ describe('CronBadgeController', () => {
   })
 
 	test('holds full tree reloads until an in-flight deletion settles', async () => {
+		let resolveConfirmation
 		let resolveDelete
-		confirmDialog.mockResolvedValue(true)
+		confirmDialog.mockReturnValue(new Promise(resolve => { resolveConfirmation = resolve }))
 		csrfFetch.mockReturnValue(new Promise(resolve => { resolveDelete = resolve }))
 		const tree = document.createElement('div')
 		tree.setAttribute('data-controller', 'creatives--tree')
@@ -281,6 +282,13 @@ describe('CronBadgeController', () => {
 		await new Promise(resolve => setTimeout(resolve, 0))
 
 		expect(treeController.beginReloadHold).toHaveBeenCalledTimes(1)
+		expect(treeController.endReloadHold).not.toHaveBeenCalled()
+		const replacement = element.cloneNode(true)
+		element.replaceWith(replacement)
+		resolveConfirmation(true)
+		await new Promise(resolve => setTimeout(resolve, 0))
+
+		expect(csrfFetch).toHaveBeenCalledTimes(1)
 		expect(treeController.endReloadHold).not.toHaveBeenCalled()
 
 		resolveDelete({ ok: true, status: 204 })
@@ -363,12 +371,24 @@ describe('CronBadgeController', () => {
 
   test('does not request deletion when confirmation is cancelled', async () => {
     confirmDialog.mockResolvedValue(false)
+		const tree = document.createElement('div')
+		tree.setAttribute('data-controller', 'creatives--tree')
+		element.before(tree)
+		tree.appendChild(element)
+		const treeController = {
+			beginReloadHold: jest.fn(),
+			endReloadHold: jest.fn(),
+		}
+		jest.spyOn(application, 'getControllerForElementAndIdentifier')
+			.mockReturnValue(treeController)
 
     element.querySelector('[data-cron-delete-url$="/one"]').click()
     await new Promise(resolve => setTimeout(resolve, 0))
 
     expect(csrfFetch).not.toHaveBeenCalled()
     expect(controller.taskTargets).toHaveLength(2)
+		expect(treeController.beginReloadHold).toHaveBeenCalledTimes(1)
+		expect(treeController.endReloadHold).toHaveBeenCalledTimes(1)
   })
 
   test('reports a failed deletion and restores the button', async () => {

--- a/engines/collavre/app/javascript/controllers/__tests__/cron_badge_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/cron_badge_controller.test.js
@@ -198,6 +198,31 @@ describe('CronBadgeController', () => {
     expect(replacementInput.disabled).toBe(false)
   })
 
+  test('holds full tree reloads until an in-flight message update settles', async () => {
+    let resolveUpdate
+    csrfFetch.mockReturnValue(new Promise(resolve => { resolveUpdate = resolve }))
+    const tree = document.createElement('div')
+    tree.setAttribute('data-controller', 'creatives--tree')
+    element.before(tree)
+    tree.appendChild(element)
+    const treeController = {
+      beginReloadHold: jest.fn(),
+      endReloadHold: jest.fn(),
+    }
+    jest.spyOn(application, 'getControllerForElementAndIdentifier')
+      .mockReturnValue(treeController)
+
+    element.querySelector('[data-cron-update-url]').click()
+
+    expect(treeController.beginReloadHold).toHaveBeenCalledTimes(1)
+    expect(treeController.endReloadHold).not.toHaveBeenCalled()
+
+    resolveUpdate({ ok: true, status: 200 })
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(treeController.endReloadHold).toHaveBeenCalledTimes(1)
+  })
+
   test('ignores stale save tasks and missing controls when finishing', () => {
     const task = document.createElement('span')
     task.dataset.cronSaveOperation = 'current'

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_creation_container.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_creation_container.test.js
@@ -184,6 +184,31 @@ describe('TopicsController create-button placement', () => {
     expect(controller.listTarget.querySelector('textarea').value).toBe('Server message')
   })
 
+  test('preserves an in-flight cron message save across topic refreshes', () => {
+    const cronBadge = (message) => `
+      <span data-cron-key="topic-1">
+		<textarea data-cron-badge-target="messageInput"
+			data-cron-saved-message="${message}">${message}</textarea>
+		<button data-action="click->cron-badge#saveMessage">Save</button>
+      </span>
+    `
+    controller.renderTopics([{ id: 1, name: 'Main', cron_badge_html: cronBadge('Saved message') }], true, true)
+    const task = controller.listTarget.querySelector('[data-cron-key="topic-1"]')
+    const input = task.querySelector('textarea')
+    task.dataset.cronSaveOperation = '42'
+    input.value = 'Submitted message'
+    input.disabled = true
+    task.querySelector('button').disabled = true
+
+    controller.renderTopics([{ id: 1, name: 'Main', cron_badge_html: cronBadge('Server message') }], true, true)
+
+    const replacementTask = controller.listTarget.querySelector('[data-cron-key="topic-1"]')
+    expect(replacementTask.dataset.cronSaveOperation).toBe('42')
+    expect(replacementTask.querySelector('textarea').value).toBe('Submitted message')
+    expect(replacementTask.querySelector('textarea').disabled).toBe(true)
+    expect(replacementTask.querySelector('button').disabled).toBe(true)
+  })
+
   test('does not restore a dirty cron message after edit access is lost', () => {
     const editableBadge = `
       <span data-cron-key="topic-1">

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_creation_container.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_creation_container.test.js
@@ -151,6 +151,59 @@ describe('TopicsController create-button placement', () => {
     expect(controller.listTarget.querySelector('.topic-tag[data-id="1"] .creative-cron-badge')).not.toBeNull()
   })
 
+  test('preserves a dirty cron message when topics refresh', () => {
+    const cronBadge = (message) => `
+      <span class="cron-badge-wrapper">
+        <span data-cron-key="topic-1">
+          <textarea data-cron-badge-target="messageInput"
+                    data-cron-saved-message="${message}">${message}</textarea>
+        </span>
+      </span>
+    `
+    controller.renderTopics([{ id: 1, name: 'Main', cron_badge_html: cronBadge('Saved message') }], true, true)
+    controller.listTarget.querySelector('textarea').value = 'Half-typed message'
+
+    controller.renderTopics([{ id: 1, name: 'Main', cron_badge_html: cronBadge('Server message') }], true, true)
+
+    const input = controller.listTarget.querySelector('textarea')
+    expect(input.value).toBe('Half-typed message')
+    expect(input.dataset.cronSavedMessage).toBe('Server message')
+  })
+
+  test('uses a refreshed cron message when the local message is clean', () => {
+    const cronBadge = (message) => `
+      <span data-cron-key="topic-1">
+        <textarea data-cron-badge-target="messageInput"
+                  data-cron-saved-message="${message}">${message}</textarea>
+      </span>
+    `
+    controller.renderTopics([{ id: 1, name: 'Main', cron_badge_html: cronBadge('Saved message') }], true, true)
+
+    controller.renderTopics([{ id: 1, name: 'Main', cron_badge_html: cronBadge('Server message') }], true, true)
+
+    expect(controller.listTarget.querySelector('textarea').value).toBe('Server message')
+  })
+
+  test('does not restore a dirty cron message after edit access is lost', () => {
+    const editableBadge = `
+      <span data-cron-key="topic-1">
+        <textarea data-cron-badge-target="messageInput"
+                  data-cron-saved-message="Saved message">Saved message</textarea>
+      </span>
+    `
+    const readOnlyBadge = `
+      <span data-cron-key="topic-1"><span class="cron-task-message">Server message</span></span>
+    `
+    controller.renderTopics([{ id: 1, name: 'Main', cron_badge_html: editableBadge }], true, true)
+    controller.listTarget.querySelector('textarea').value = 'Half-typed message'
+
+    controller.renderTopics([{ id: 1, name: 'Main', cron_badge_html: readOnlyBadge }], false, false)
+    controller.renderTopics([{ id: 1, name: 'Main', cron_badge_html: readOnlyBadge }], false, false)
+
+    expect(controller.listTarget.querySelector('textarea')).toBeNull()
+    expect(controller.listTarget.querySelector('.cron-task-message').textContent).toBe('Server message')
+  })
+
   test('reloads topics when a cron change is broadcast', () => {
     const refetch = jest.fn()
     const invalidate = jest.fn()

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_creation_container.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_creation_container.test.js
@@ -209,6 +209,27 @@ describe('TopicsController create-button placement', () => {
     expect(replacementTask.querySelector('button').disabled).toBe(true)
   })
 
+  test('preserves an in-flight cron deletion across topic refreshes', () => {
+		const cronBadge = (message) => `
+			<span data-cron-key="topic-1">
+				<textarea data-cron-badge-target="messageInput"
+					data-cron-saved-message="${message}">${message}</textarea>
+				<button data-action="click->cron-badge#destroy">Delete</button>
+			</span>
+		`
+		controller.renderTopics([{ id: 1, name: 'Main', cron_badge_html: cronBadge('Saved message') }], true, true)
+		const task = controller.listTarget.querySelector('[data-cron-key="topic-1"]')
+		task.dataset.cronDeleteOperation = '84'
+		task.querySelector('button').disabled = true
+
+		controller.renderTopics([{ id: 1, name: 'Main', cron_badge_html: cronBadge('Server message') }], true, true)
+
+		const replacementTask = controller.listTarget.querySelector('[data-cron-key="topic-1"]')
+		expect(replacementTask.dataset.cronDeleteOperation).toBe('84')
+		expect(replacementTask.querySelector('textarea').value).toBe('Server message')
+		expect(replacementTask.querySelector('button').disabled).toBe(true)
+  })
+
   test('does not restore a dirty cron message after edit access is lost', () => {
     const editableBadge = `
       <span data-cron-key="topic-1">

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -572,11 +572,18 @@ export default class extends Controller {
     captureCronMessageDrafts() {
         const drafts = new Map()
         this.listTarget.querySelectorAll('[data-cron-key]').forEach(task => {
-            const input = task.querySelector('[data-cron-badge-target="messageInput"]')
-			const operationId = task.dataset.cronSaveOperation
-			if (!input || (input.value === input.dataset.cronSavedMessage && !operationId)) return
+			const input = task.querySelector('[data-cron-badge-target="messageInput"]')
+			const saveOperationId = task.dataset.cronSaveOperation
+			const deleteOperationId = task.dataset.cronDeleteOperation
+			const dirty = input && input.value !== input.dataset.cronSavedMessage
+			if (!input || (!dirty && !saveOperationId && !deleteOperationId)) return
 
-			drafts.set(task.dataset.cronKey, { message: input.value, operationId })
+			drafts.set(task.dataset.cronKey, {
+				message: input.value,
+				dirty,
+				saveOperationId,
+				deleteOperationId,
+			})
         })
         return drafts
     }
@@ -589,12 +596,16 @@ export default class extends Controller {
 			if (!input) return
 
 			const draft = drafts.get(task.dataset.cronKey)
-			input.value = draft.message
-			if (!draft.operationId) return
-
-			task.dataset.cronSaveOperation = draft.operationId
-			input.disabled = true
-			task.querySelector('[data-action~="click->cron-badge#saveMessage"]').disabled = true
+			if (draft.dirty || draft.saveOperationId) input.value = draft.message
+			if (draft.saveOperationId) {
+				task.dataset.cronSaveOperation = draft.saveOperationId
+				input.disabled = true
+				task.querySelector('[data-action~="click->cron-badge#saveMessage"]').disabled = true
+			}
+			if (draft.deleteOperationId) {
+				task.dataset.cronDeleteOperation = draft.deleteOperationId
+				task.querySelector('[data-action~="click->cron-badge#destroy"]').disabled = true
+			}
         })
     }
 

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -488,6 +488,7 @@ export default class extends Controller {
     }
 
     renderTopics(topics, canManage = false, canCreateTopic = canManage, canSetPrimaryAgent = canManage, sourceCreativeId = this._topicsCreativeId || this.creativeId) {
+        const cronMessageDrafts = this.captureCronMessageDrafts()
         const allMessagesLabel = this.element.dataset.topicMainText || 'All Messages'
 
         const mainTopic = this.mainTopicId ? topics.find(t => String(t.id) === String(this.mainTopicId)) : null
@@ -557,6 +558,7 @@ export default class extends Controller {
         }
 
         this.listTarget.innerHTML = html
+        this.restoreCronMessageDrafts(cronMessageDrafts)
         // Which creative the chips now on screen belong to. A click can only
         // ever be about this one, whatever this.creativeId has since become.
         this._renderedCreativeId = sourceCreativeId
@@ -565,6 +567,26 @@ export default class extends Controller {
         // The create button lives outside the scrolling strip so it stays reachable
         // without horizontal scrolling, no matter how many topics there are.
         this.renderCreationContainer(canCreateTopic)
+    }
+
+    captureCronMessageDrafts() {
+        const drafts = new Map()
+        this.listTarget.querySelectorAll('[data-cron-key]').forEach(task => {
+            const input = task.querySelector('[data-cron-badge-target="messageInput"]')
+            if (input && input.value !== input.dataset.cronSavedMessage) {
+                drafts.set(task.dataset.cronKey, input.value)
+            }
+        })
+        return drafts
+    }
+
+    restoreCronMessageDrafts(drafts) {
+        this.listTarget.querySelectorAll('[data-cron-key]').forEach(task => {
+            if (!drafts.has(task.dataset.cronKey)) return
+
+            const input = task.querySelector('[data-cron-badge-target="messageInput"]')
+            if (input) input.value = drafts.get(task.dataset.cronKey)
+        })
     }
 
     // Write permission is sufficient for topic creation.

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -573,9 +573,10 @@ export default class extends Controller {
         const drafts = new Map()
         this.listTarget.querySelectorAll('[data-cron-key]').forEach(task => {
             const input = task.querySelector('[data-cron-badge-target="messageInput"]')
-            if (input && input.value !== input.dataset.cronSavedMessage) {
-                drafts.set(task.dataset.cronKey, input.value)
-            }
+			const operationId = task.dataset.cronSaveOperation
+			if (!input || (input.value === input.dataset.cronSavedMessage && !operationId)) return
+
+			drafts.set(task.dataset.cronKey, { message: input.value, operationId })
         })
         return drafts
     }
@@ -585,7 +586,15 @@ export default class extends Controller {
             if (!drafts.has(task.dataset.cronKey)) return
 
             const input = task.querySelector('[data-cron-badge-target="messageInput"]')
-            if (input) input.value = drafts.get(task.dataset.cronKey)
+			if (!input) return
+
+			const draft = drafts.get(task.dataset.cronKey)
+			input.value = draft.message
+			if (!draft.operationId) return
+
+			task.dataset.cronSaveOperation = draft.operationId
+			input.disabled = true
+			task.querySelector('[data-action~="click->cron-badge#saveMessage"]').disabled = true
         })
     }
 

--- a/engines/collavre/app/javascript/controllers/creatives/__tests__/tree_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/creatives/__tests__/tree_controller.test.js
@@ -332,6 +332,86 @@ describe('CreativesTreeController cron message drafts', () => {
     application.stop()
   })
 
+  test('restores a dirty cron message after loading an expanded branch', async () => {
+    const { container, application, controller } = await installCachedTree(`
+      <creative-tree-row creative-id="1" has-children expanded></creative-tree-row>
+      <div id="creative-children-1" data-loaded="true">
+        <creative-tree-row creative-id="2">${cronTask('Saved message')}</creative-tree-row>
+      </div>
+    `)
+    const draftInput = container.querySelector('textarea')
+    draftInput.closest('[data-cron-key]').dataset.cronKey = 'creative-2'
+    draftInput.value = 'Half-typed child message'
+    let finishChildUpdate
+    global.fetch = jest.fn((url) => {
+      if (url === '/children/1') {
+        return Promise.resolve({
+          ok: true,
+          headers: new Headers(),
+          json: async () => ({ creatives: [{ id: 2 }] }),
+        })
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({ creatives: [{ id: 1 }] }),
+      })
+    })
+    renderCreativeTree
+      .mockImplementationOnce((element) => {
+        element.innerHTML = `
+          <creative-tree-row creative-id="1" has-children></creative-tree-row>
+          <div id="creative-children-1" data-loaded="false" data-load-url="/children/1"></div>
+        `
+      })
+      .mockImplementationOnce((element) => {
+        element.innerHTML = '<creative-tree-row creative-id="2"></creative-tree-row>'
+        const row = element.querySelector('creative-tree-row')
+        row.updateComplete = new Promise((resolve) => {
+          finishChildUpdate = () => {
+            row.innerHTML = cronTask('Server child message')
+            row.querySelector('[data-cron-key]').dataset.cronKey = 'creative-2'
+            resolve(true)
+          }
+        })
+      })
+
+    controller.load({ preserveView: true })
+    await flush()
+    await flush()
+
+    expect(container.querySelector('textarea')).toBeNull()
+    expect(controller._pendingCronMessageDrafts).toEqual(new Map([
+      ['creative-2', 'Half-typed child message'],
+    ]))
+
+    finishChildUpdate()
+    await flush()
+
+    const input = container.querySelector('textarea')
+    expect(input.value).toBe('Half-typed child message')
+    expect(input.dataset.cronSavedMessage).toBe('Server child message')
+    expect(controller._pendingCronMessageDrafts).toBeNull()
+    application.stop()
+  })
+
+  test('keeps deferred branch drafts when a newer preserved load starts', async () => {
+    const { container, application, controller } = await installCachedTree(cronRow('Saved message'))
+    container.querySelector('textarea').value = 'New root draft'
+    controller._pendingCronMessageDrafts = new Map([
+      ['creative-2', 'Deferred child draft'],
+    ])
+    global.fetch = jest.fn(() => new Promise(() => {}))
+
+    controller.load({ preserveView: true })
+
+    expect(controller._pendingCronMessageDrafts).toEqual(new Map([
+      ['creative-2', 'Deferred child draft'],
+      ['creative-1', 'New root draft'],
+    ]))
+    controller.stopAnimation()
+    application.stop()
+  })
+
   test('uses the refreshed cron message when the local message is clean', async () => {
     const { container, application, controller } = await installCachedTree(cronRow('Saved message'))
     renderCreativeTree.mockImplementationOnce((element) => {

--- a/engines/collavre/app/javascript/controllers/creatives/__tests__/tree_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/creatives/__tests__/tree_controller.test.js
@@ -157,6 +157,99 @@ describe('CreativesTreeController retry on transient network errors', () => {
   })
 })
 
+describe('CreativesTreeController cron message drafts', () => {
+  let originalFetch
+
+  const cronRow = (message, { editable = true } = {}) => `
+    <creative-tree-row creative-id="1">
+      <span data-cron-key="creative-1">
+        ${editable
+          ? `<textarea data-cron-badge-target="messageInput"
+                       data-cron-saved-message="${message}">${message}</textarea>`
+          : `<span class="cron-task-message">${message}</span>`}
+      </span>
+    </creative-tree-row>
+  `
+
+  const installCachedTree = async (html) => {
+    const container = document.createElement('div')
+    container.setAttribute('data-controller', 'creatives--tree')
+    container.setAttribute('data-creatives--tree-url-value', '/creatives?format=json&id=991')
+    container.setAttribute('data-creatives--tree-loading-text-value', 'Loading creatives')
+    container.dataset.loaded = 'true'
+    container.innerHTML = html
+    document.body.appendChild(container)
+
+    const application = Application.start()
+    application.register('creatives--tree', TreeController)
+    await flush()
+    const controller = application.getControllerForElementAndIdentifier(container, 'creatives--tree')
+    return { container, application, controller }
+  }
+
+  beforeEach(() => {
+    originalFetch = global.fetch
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ creatives: [{ id: 1 }] }),
+    })
+  })
+
+  afterEach(() => {
+    global.fetch = originalFetch
+    renderCreativeTree.mockReset()
+    document.body.innerHTML = ''
+    jest.restoreAllMocks()
+  })
+
+  test('preserves a dirty cron message across a preserved tree reload', async () => {
+    const { container, application, controller } = await installCachedTree(cronRow('Saved message'))
+    container.querySelector('textarea').value = 'Half-typed message'
+    renderCreativeTree.mockImplementationOnce((element) => {
+      element.innerHTML = cronRow('Server message')
+    })
+
+    controller.load({ preserveView: true })
+    await flush()
+    await flush()
+
+    const input = container.querySelector('textarea')
+    expect(input.value).toBe('Half-typed message')
+    expect(input.dataset.cronSavedMessage).toBe('Server message')
+    application.stop()
+  })
+
+  test('uses the refreshed cron message when the local message is clean', async () => {
+    const { container, application, controller } = await installCachedTree(cronRow('Saved message'))
+    renderCreativeTree.mockImplementationOnce((element) => {
+      element.innerHTML = cronRow('Server message')
+    })
+
+    controller.load({ preserveView: true })
+    await flush()
+    await flush()
+
+    expect(container.querySelector('textarea').value).toBe('Server message')
+    application.stop()
+  })
+
+  test('does not restore a dirty cron message after edit access is lost', async () => {
+    const { container, application, controller } = await installCachedTree(cronRow('Saved message'))
+    container.querySelector('textarea').value = 'Half-typed message'
+    renderCreativeTree.mockImplementationOnce((element) => {
+      element.innerHTML = cronRow('Server message', { editable: false })
+    })
+
+    controller.load({ preserveView: true })
+    await flush()
+    await flush()
+
+    expect(container.querySelector('textarea')).toBeNull()
+    expect(container.querySelector('.cron-task-message').textContent).toBe('Server message')
+    application.stop()
+  })
+})
+
 describe('CreativesTreeController Chats pagination (load more)', () => {
   let originalFetch
   let originalIO

--- a/engines/collavre/app/javascript/controllers/creatives/__tests__/tree_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/creatives/__tests__/tree_controller.test.js
@@ -536,6 +536,53 @@ describe('CreativesTreeController Chats pagination (load more)', () => {
     application.stop()
   })
 
+  test('restores a deferred cron draft when its paginated row is appended', async () => {
+    const page2Nodes = [{ id: 2 }]
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ creatives: [{ id: 1 }], pagination: { has_more: true, next_page: 2 } }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ creatives: page2Nodes, pagination: { has_more: false, next_page: null } }),
+      })
+    renderCreativeTree.mockImplementationOnce((container) => {
+      container.innerHTML = '<creative-tree-row creative-id="1"></creative-tree-row>'
+    })
+    appendCreativeNodes.mockImplementationOnce((container) => {
+      const row = document.createElement('creative-tree-row')
+      row.setAttribute('creative-id', '2')
+      row.innerHTML = `
+        <span data-cron-key="creative-2">
+          <textarea data-cron-badge-target="messageInput"
+                    data-cron-saved-message="Server message">Server message</textarea>
+        </span>
+      `
+      row.updateComplete = Promise.resolve(true)
+      container.appendChild(row)
+    })
+
+    const { container, application } = installController()
+    await flush()
+    await flush()
+    const controller = application.getControllerForElementAndIdentifier(container, 'creatives--tree')
+    controller._pendingCronMessageDrafts = new Map([
+      ['creative-2', 'Half-typed page 2 message'],
+    ])
+
+    MockIntersectionObserver.instances[0].triggerIntersect()
+    await flush()
+    await flush()
+
+    const input = container.querySelector('textarea')
+    expect(input.value).toBe('Half-typed page 2 message')
+    expect(input.dataset.cronSavedMessage).toBe('Server message')
+    expect(controller._pendingCronMessageDrafts).toBeNull()
+    application.stop()
+  })
+
   test('drops a stale load-more response that resolves after a fresh load', async () => {
     let resolvePage2
     const page2Nodes = [{ id: 2 }, { id: 3 }]

--- a/engines/collavre/app/javascript/controllers/creatives/__tests__/tree_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/creatives/__tests__/tree_controller.test.js
@@ -276,6 +276,62 @@ describe('CreativesTreeController cron message drafts', () => {
     application.stop()
   })
 
+  test('captures newer edits while view-state restoration is still pending', async () => {
+    const { container, application, controller } = await installCachedTree(cronRow('Saved message'))
+    let releaseChildren
+    global.fetch = jest.fn((url) => {
+      if (url === '/children/1') {
+        return new Promise((resolve) => {
+          releaseChildren = () => resolve({
+            ok: true,
+            headers: new Headers(),
+            json: async () => ({ creatives: [{ id: 2 }] }),
+          })
+        })
+      }
+      return new Promise(() => {})
+    })
+    const originalDrafts = new Map([['creative-1', 'First draft']])
+    controller._pendingCronMessageDrafts = originalDrafts
+    controller._pendingViewState = {
+      scrolling: document.documentElement,
+      scrollTop: 0,
+      focus: null,
+      expansion: [{ creativeId: '1', expanded: true }],
+    }
+    renderCreativeTree.mockImplementationOnce((element) => {
+      element.innerHTML = `
+        <creative-tree-row creative-id="1" has-children>
+          ${cronTask('Server message')}
+        </creative-tree-row>
+        <div id="creative-children-1" data-loaded="false" data-load-url="/children/1"></div>
+      `
+    })
+
+    const restoration = controller.renderData({ creatives: [{ id: 1 }] })
+    await flush()
+
+    const input = container.querySelector('textarea')
+    expect(input.value).toBe('First draft')
+    expect(controller._pendingCronMessageDrafts).toBeNull()
+
+    input.value = 'Newer draft'
+    controller.load({ preserveView: true })
+
+    expect(controller._pendingCronMessageDrafts).toEqual(new Map([
+      ['creative-1', 'Newer draft'],
+    ]))
+
+    releaseChildren()
+    await restoration
+
+    expect(controller._pendingCronMessageDrafts).toEqual(new Map([
+      ['creative-1', 'Newer draft'],
+    ]))
+    controller.stopAnimation()
+    application.stop()
+  })
+
   test('uses the refreshed cron message when the local message is clean', async () => {
     const { container, application, controller } = await installCachedTree(cronRow('Saved message'))
     renderCreativeTree.mockImplementationOnce((element) => {
@@ -1149,6 +1205,7 @@ describe('CreativesTreeController requestReload', () => {
         return new Promise((resolve) => {
           releaseChildren = () => resolve({
             ok: true,
+            headers: new Headers(),
             json: async () => ({ creatives: [{ id: 2 }] }),
           })
         })

--- a/engines/collavre/app/javascript/controllers/creatives/__tests__/tree_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/creatives/__tests__/tree_controller.test.js
@@ -160,15 +160,17 @@ describe('CreativesTreeController retry on transient network errors', () => {
 describe('CreativesTreeController cron message drafts', () => {
   let originalFetch
 
-  const cronRow = (message, { editable = true } = {}) => `
-    <creative-tree-row creative-id="1">
-      <span data-cron-key="creative-1">
-        ${editable
-          ? `<textarea data-cron-badge-target="messageInput"
-                       data-cron-saved-message="${message}">${message}</textarea>`
-          : `<span class="cron-task-message">${message}</span>`}
-      </span>
-    </creative-tree-row>
+  const cronTask = (message, { editable = true } = {}) => `
+    <span data-cron-key="creative-1">
+      ${editable
+        ? `<textarea data-cron-badge-target="messageInput"
+                     data-cron-saved-message="${message}">${message}</textarea>`
+        : `<span class="cron-task-message">${message}</span>`}
+    </span>
+  `
+
+  const cronRow = (message, options = {}) => `
+    <creative-tree-row creative-id="1">${cronTask(message, options)}</creative-tree-row>
   `
 
   const installCachedTree = async (html) => {
@@ -216,6 +218,61 @@ describe('CreativesTreeController cron message drafts', () => {
     const input = container.querySelector('textarea')
     expect(input.value).toBe('Half-typed message')
     expect(input.dataset.cronSavedMessage).toBe('Server message')
+    application.stop()
+  })
+
+  test('waits for Lit rows to render before restoring a dirty cron message', async () => {
+    const { container, application, controller } = await installCachedTree(cronRow('Saved message'))
+    container.querySelector('textarea').value = 'Half-typed message'
+    let finishRowUpdate
+    renderCreativeTree.mockImplementationOnce((element) => {
+      element.innerHTML = '<creative-tree-row creative-id="1"></creative-tree-row>'
+      const row = element.querySelector('creative-tree-row')
+      row.updateComplete = new Promise((resolve) => {
+        finishRowUpdate = () => {
+          row.innerHTML = cronTask('Server message')
+          resolve(true)
+        }
+      })
+    })
+
+    controller.load({ preserveView: true })
+    await flush()
+    await flush()
+
+    expect(container.querySelector('textarea')).toBeNull()
+    finishRowUpdate()
+    await flush()
+
+    const input = container.querySelector('textarea')
+    expect(input.value).toBe('Half-typed message')
+    expect(input.dataset.cronSavedMessage).toBe('Server message')
+    application.stop()
+  })
+
+  test('does not restore a dirty cron message into a superseded Lit render', async () => {
+    const { container, application, controller } = await installCachedTree(cronRow('Saved message'))
+    const drafts = new Map([['creative-1', 'Half-typed message']])
+    controller._pendingCronMessageDrafts = drafts
+    let finishRowUpdate
+    renderCreativeTree.mockImplementationOnce((element) => {
+      element.innerHTML = '<creative-tree-row creative-id="1"></creative-tree-row>'
+      const row = element.querySelector('creative-tree-row')
+      row.updateComplete = new Promise((resolve) => {
+        finishRowUpdate = () => {
+          row.innerHTML = cronTask('Server message')
+          resolve(true)
+        }
+      })
+    })
+
+    const rendering = controller.renderData({ creatives: [{ id: 1 }] })
+    controller._viewRestoreGeneration += 1
+    finishRowUpdate()
+    await rendering
+
+    expect(container.querySelector('textarea').value).toBe('Server message')
+    expect(controller._pendingCronMessageDrafts).toBe(drafts)
     application.stop()
   })
 
@@ -1125,6 +1182,7 @@ describe('CreativesTreeController requestReload', () => {
     })
 
     const restoration = controller.renderData({ creatives: [{ id: 1 }] })
+    await flush()
     expect(controller._pendingViewState).toBe(viewState)
 
     controller.load({ preserveView: true })

--- a/engines/collavre/app/javascript/controllers/creatives/tree_controller.js
+++ b/engines/collavre/app/javascript/controllers/creatives/tree_controller.js
@@ -307,15 +307,15 @@ export default class extends Controller {
     )
     if (!isCurrent()) return
     this.restoreCronMessageDrafts(cronMessageDrafts)
+    if (this._pendingCronMessageDrafts === cronMessageDrafts) {
+      this._pendingCronMessageDrafts = null
+    }
     this.markContentLoaded()
     dispatchCreativeTreeUpdated(this.element)
     this.queueAlignmentUpdate()
     this._setupPagination(data?.pagination)
     await restoreCreativeTreeViewState(this.element, viewState, { isCurrent })
     if (isCurrent() && this._pendingViewState === viewState) this._pendingViewState = null
-    if (isCurrent() && this._pendingCronMessageDrafts === cronMessageDrafts) {
-      this._pendingCronMessageDrafts = null
-    }
   }
 
   captureCronMessageDrafts() {

--- a/engines/collavre/app/javascript/controllers/creatives/tree_controller.js
+++ b/engines/collavre/app/javascript/controllers/creatives/tree_controller.js
@@ -316,9 +316,11 @@ export default class extends Controller {
     if (!isCurrent()) return
     await this.waitForCreativeTreeRows()
     if (!isCurrent()) return
-    this.restoreCronMessageDrafts(deferredCronMessageDrafts)
+    const remainingCronMessageDrafts = this.restoreCronMessageDrafts(deferredCronMessageDrafts)
     if (this._pendingCronMessageDrafts === deferredCronMessageDrafts) {
-      this._pendingCronMessageDrafts = null
+      this._pendingCronMessageDrafts = this._pagination?.has_more
+        ? remainingCronMessageDrafts
+        : null
     }
     if (isCurrent() && this._pendingViewState === viewState) this._pendingViewState = null
   }
@@ -414,7 +416,7 @@ export default class extends Controller {
         if (!response.ok) throw new Error(`Failed to load more chats: ${response.status}`)
         return response.json()
       })
-      .then((data) => {
+      .then(async (data) => {
         if (signal.aborted) return
         this._hideLoadMoreIndicator()
         const nodes = Array.isArray(data?.creatives) ? data.creatives : []
@@ -423,6 +425,11 @@ export default class extends Controller {
           // that slipped through must never sit above the rows being appended.
           hideTreeEmptyState(this.element)
           appendCreativeNodes(this.element, nodes)
+          await this.waitForCreativeTreeRows()
+          if (signal.aborted) return
+          this._pendingCronMessageDrafts = this.restoreCronMessageDrafts(
+            this._pendingCronMessageDrafts
+          )
           dispatchCreativeTreeUpdated(this.element)
           this.queueAlignmentUpdate()
         }
@@ -431,6 +438,7 @@ export default class extends Controller {
         if (this._pagination && this._pagination.has_more) {
           this._repositionSentinel()
         } else {
+          this._pendingCronMessageDrafts = null
           this._teardownPagination()
           // Last page in, and the rows that were on screen when it was requested
           // may since have been deleted. Nothing is pending any more, so an empty

--- a/engines/collavre/app/javascript/controllers/creatives/tree_controller.js
+++ b/engines/collavre/app/javascript/controllers/creatives/tree_controller.js
@@ -227,7 +227,10 @@ export default class extends Controller {
       ? (this._pendingViewState || captureCreativeTreeViewState(this.element))
       : null
     this._pendingCronMessageDrafts = preserveView
-      ? (this._pendingCronMessageDrafts || this.captureCronMessageDrafts())
+      ? new Map([
+        ...(this._pendingCronMessageDrafts || []),
+        ...this.captureCronMessageDrafts(),
+      ])
       : null
 
     // A fresh load replaces the whole list (filter change, archive toggle, sync
@@ -299,23 +302,34 @@ export default class extends Controller {
     }
 
     renderCreativeTree(this.element, nodes)
-    await Promise.all(
-      Array.from(
-        this.element.querySelectorAll('creative-tree-row'),
-        row => row.updateComplete
-      )
-    )
+    await this.waitForCreativeTreeRows()
     if (!isCurrent()) return
-    this.restoreCronMessageDrafts(cronMessageDrafts)
+    const deferredCronMessageDrafts = this.restoreCronMessageDrafts(cronMessageDrafts)
     if (this._pendingCronMessageDrafts === cronMessageDrafts) {
-      this._pendingCronMessageDrafts = null
+      this._pendingCronMessageDrafts = deferredCronMessageDrafts
     }
     this.markContentLoaded()
     dispatchCreativeTreeUpdated(this.element)
     this.queueAlignmentUpdate()
     this._setupPagination(data?.pagination)
     await restoreCreativeTreeViewState(this.element, viewState, { isCurrent })
+    if (!isCurrent()) return
+    await this.waitForCreativeTreeRows()
+    if (!isCurrent()) return
+    this.restoreCronMessageDrafts(deferredCronMessageDrafts)
+    if (this._pendingCronMessageDrafts === deferredCronMessageDrafts) {
+      this._pendingCronMessageDrafts = null
+    }
     if (isCurrent() && this._pendingViewState === viewState) this._pendingViewState = null
+  }
+
+  waitForCreativeTreeRows() {
+    return Promise.all(
+      Array.from(
+        this.element.querySelectorAll('creative-tree-row'),
+        row => row.updateComplete
+      )
+    )
   }
 
   captureCronMessageDrafts() {
@@ -330,14 +344,21 @@ export default class extends Controller {
   }
 
   restoreCronMessageDrafts(drafts) {
-    if (!drafts) return
+    if (!drafts) return null
+
+    const deferredDrafts = new Map(drafts)
 
     this.element.querySelectorAll('[data-cron-key]').forEach(task => {
       if (!drafts.has(task.dataset.cronKey)) return
 
       const input = task.querySelector('[data-cron-badge-target="messageInput"]')
-      if (input) input.value = drafts.get(task.dataset.cronKey)
+      if (!input) return
+
+      input.value = drafts.get(task.dataset.cronKey)
+      deferredDrafts.delete(task.dataset.cronKey)
     })
+
+    return deferredDrafts.size > 0 ? deferredDrafts : null
   }
 
   // --- Load-more (paginated "Chats" feed) -------------------------------------

--- a/engines/collavre/app/javascript/controllers/creatives/tree_controller.js
+++ b/engines/collavre/app/javascript/controllers/creatives/tree_controller.js
@@ -40,6 +40,7 @@ export default class extends Controller {
     this._loadMoreAbort = null
     this._loadMoreIndicator = null
     this._pendingViewState = null
+    this._pendingCronMessageDrafts = null
     this._viewRestoreGeneration = 0
     this.handleResize = this.updateAlignmentOffset.bind(this)
     this.handleTreeUpdated = () => this.queueAlignmentUpdate()
@@ -225,6 +226,9 @@ export default class extends Controller {
     this._pendingViewState = preserveView
       ? (this._pendingViewState || captureCreativeTreeViewState(this.element))
       : null
+    this._pendingCronMessageDrafts = preserveView
+      ? (this._pendingCronMessageDrafts || this.captureCronMessageDrafts())
+      : null
 
     // A fresh load replaces the whole list (filter change, archive toggle, sync
     // refetch), so any active load-more session is stale — tear it down before
@@ -280,6 +284,7 @@ export default class extends Controller {
   async renderData(data, viewRestoreGeneration = this._viewRestoreGeneration) {
     const nodes = Array.isArray(data?.creatives) ? data.creatives : []
     const viewState = this._pendingViewState
+    const cronMessageDrafts = this._pendingCronMessageDrafts
     const isCurrent = () => viewRestoreGeneration === this._viewRestoreGeneration
 
     if (nodes.length === 0) {
@@ -287,16 +292,45 @@ export default class extends Controller {
       dispatchCreativeTreeUpdated(this.element)
       await restoreCreativeTreeViewState(this.element, viewState, { isCurrent })
       if (isCurrent() && this._pendingViewState === viewState) this._pendingViewState = null
+      if (isCurrent() && this._pendingCronMessageDrafts === cronMessageDrafts) {
+        this._pendingCronMessageDrafts = null
+      }
       return
     }
 
     renderCreativeTree(this.element, nodes)
+    this.restoreCronMessageDrafts(cronMessageDrafts)
     this.markContentLoaded()
     dispatchCreativeTreeUpdated(this.element)
     this.queueAlignmentUpdate()
     this._setupPagination(data?.pagination)
     await restoreCreativeTreeViewState(this.element, viewState, { isCurrent })
     if (isCurrent() && this._pendingViewState === viewState) this._pendingViewState = null
+    if (isCurrent() && this._pendingCronMessageDrafts === cronMessageDrafts) {
+      this._pendingCronMessageDrafts = null
+    }
+  }
+
+  captureCronMessageDrafts() {
+    const drafts = new Map()
+    this.element.querySelectorAll('[data-cron-key]').forEach(task => {
+      const input = task.querySelector('[data-cron-badge-target="messageInput"]')
+      if (input && input.value !== input.dataset.cronSavedMessage) {
+        drafts.set(task.dataset.cronKey, input.value)
+      }
+    })
+    return drafts
+  }
+
+  restoreCronMessageDrafts(drafts) {
+    if (!drafts) return
+
+    this.element.querySelectorAll('[data-cron-key]').forEach(task => {
+      if (!drafts.has(task.dataset.cronKey)) return
+
+      const input = task.querySelector('[data-cron-badge-target="messageInput"]')
+      if (input) input.value = drafts.get(task.dataset.cronKey)
+    })
   }
 
   // --- Load-more (paginated "Chats" feed) -------------------------------------

--- a/engines/collavre/app/javascript/controllers/creatives/tree_controller.js
+++ b/engines/collavre/app/javascript/controllers/creatives/tree_controller.js
@@ -299,6 +299,13 @@ export default class extends Controller {
     }
 
     renderCreativeTree(this.element, nodes)
+    await Promise.all(
+      Array.from(
+        this.element.querySelectorAll('creative-tree-row'),
+        row => row.updateComplete
+      )
+    )
+    if (!isCurrent()) return
     this.restoreCronMessageDrafts(cronMessageDrafts)
     this.markContentLoaded()
     dispatchCreativeTreeUpdated(this.element)

--- a/engines/collavre/app/javascript/controllers/cron_badge_controller.js
+++ b/engines/collavre/app/javascript/controllers/cron_badge_controller.js
@@ -93,14 +93,15 @@ export default class extends Controller {
     event.stopPropagation()
     const button = event.currentTarget
     const releaseTreeReload = this.holdCreativeTreeReload()
-
-    try {
-      if (!(await confirmDialog(this.deleteConfirmValue, { danger: true }))) return
-
 		const task = button.closest('[data-cron-badge-target="task"]')
 		const operationId = String(++cronOperationSequence)
+		let confirmed = false
 		task.dataset.cronDeleteOperation = operationId
 		button.disabled = true
+
+    try {
+		confirmed = await confirmDialog(this.deleteConfirmValue, { danger: true })
+		if (!confirmed) return
 
 		try {
 			const response = await this.deleteCron(button.dataset.cronDeleteUrl)
@@ -118,6 +119,7 @@ export default class extends Controller {
 			await alertDialog(this.deleteErrorValue)
 		}
 		} finally {
+			if (!confirmed) this.finishCronDelete(task, operationId)
 			releaseTreeReload()
     }
   }

--- a/engines/collavre/app/javascript/controllers/cron_badge_controller.js
+++ b/engines/collavre/app/javascript/controllers/cron_badge_controller.js
@@ -4,16 +4,43 @@ import { invalidateCreativeTree } from '../lib/creative_tree_invalidation'
 import csrfFetch, { refreshCsrfToken } from '../lib/api/csrf_fetch'
 
 export default class extends Controller {
-  static targets = ['badge', 'count', 'task']
+  static targets = ['badge', 'count', 'task', 'messageInput']
   static values = {
     countOne: String,
     countOther: String,
     deleteConfirm: String,
     deleteError: String,
+    updateError: String,
   }
 
   stopPropagation(event) {
     event.stopPropagation()
+  }
+
+  async saveMessage(event) {
+    event.preventDefault()
+    event.stopPropagation()
+    const button = event.currentTarget
+    const input = button.closest('[data-cron-badge-target="task"]')
+      ?.querySelector('[data-cron-badge-target="messageInput"]')
+    if (!input) return
+
+    button.disabled = true
+    input.disabled = true
+
+    try {
+      const response = await this.updateCron(button.dataset.cronUpdateUrl, input.value)
+      if (!response.ok) throw new Error(`Cron update failed (${response.status})`)
+
+      input.dataset.cronSavedMessage = input.value
+      invalidateCreativeTree()
+    } catch (error) {
+      console.error(error)
+      await alertDialog(this.updateErrorValue)
+    } finally {
+      button.disabled = false
+      input.disabled = false
+    }
   }
 
   async destroy(event) {
@@ -41,6 +68,20 @@ export default class extends Controller {
 
   async deleteCron(url) {
     const options = { method: 'DELETE' }
+    let response = await csrfFetch(url, options)
+    if (response.status !== 422) return response
+
+    await refreshCsrfToken()
+    response = await csrfFetch(url, options)
+    return response
+  }
+
+  async updateCron(url, message) {
+    const options = {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message }),
+    }
     let response = await csrfFetch(url, options)
     if (response.status !== 422) return response
 

--- a/engines/collavre/app/javascript/controllers/cron_badge_controller.js
+++ b/engines/collavre/app/javascript/controllers/cron_badge_controller.js
@@ -95,6 +95,7 @@ export default class extends Controller {
 
     if (!(await confirmDialog(this.deleteConfirmValue, { danger: true }))) return
 
+		const releaseTreeReload = this.holdCreativeTreeReload()
 		const task = button.closest('[data-cron-badge-target="task"]')
 		const operationId = String(++cronOperationSequence)
 		task.dataset.cronDeleteOperation = operationId
@@ -114,6 +115,8 @@ export default class extends Controller {
       console.error(error)
 			this.finishCronDelete(task, operationId)
       await alertDialog(this.deleteErrorValue)
+		} finally {
+			releaseTreeReload()
     }
   }
 

--- a/engines/collavre/app/javascript/controllers/cron_badge_controller.js
+++ b/engines/collavre/app/javascript/controllers/cron_badge_controller.js
@@ -69,7 +69,7 @@ export default class extends Controller {
   async deleteCron(url) {
     const options = { method: 'DELETE' }
     let response = await csrfFetch(url, options)
-    if (response.status !== 422) return response
+    if (!(await this.shouldRetryCsrf(response))) return response
 
     await refreshCsrfToken()
     response = await csrfFetch(url, options)
@@ -83,11 +83,18 @@ export default class extends Controller {
       body: JSON.stringify({ message }),
     }
     let response = await csrfFetch(url, options)
-    if (response.status !== 422) return response
+    if (!(await this.shouldRetryCsrf(response))) return response
 
     await refreshCsrfToken()
     response = await csrfFetch(url, options)
     return response
+  }
+
+  async shouldRetryCsrf(response) {
+    if (response.status !== 422) return false
+
+    const body = await response.clone().text()
+    return body.trim() === ''
   }
 
   refreshCount() {

--- a/engines/collavre/app/javascript/controllers/cron_badge_controller.js
+++ b/engines/collavre/app/javascript/controllers/cron_badge_controller.js
@@ -27,6 +27,7 @@ export default class extends Controller {
     const input = task?.querySelector('[data-cron-badge-target="messageInput"]')
     if (!input) return
 
+    const releaseTreeReload = this.holdCreativeTreeReload()
     const operationId = String(++saveOperationSequence)
     const message = input.value
     task.dataset.cronSaveOperation = operationId
@@ -44,7 +45,21 @@ export default class extends Controller {
       await alertDialog(this.updateErrorValue)
     } finally {
       this.finishMessageSave(task, operationId)
+      releaseTreeReload()
     }
+  }
+
+  holdCreativeTreeReload() {
+    const tree = this.element.closest('[data-controller~="creatives--tree"]')
+    const controller = tree && this.application.getControllerForElementAndIdentifier(
+      tree,
+      'creatives--tree'
+    )
+    if (typeof controller?.beginReloadHold !== 'function' ||
+        typeof controller?.endReloadHold !== 'function') return () => {}
+
+    controller.beginReloadHold()
+    return () => controller.endReloadHold()
   }
 
   finishMessageSave(task, operationId) {

--- a/engines/collavre/app/javascript/controllers/cron_badge_controller.js
+++ b/engines/collavre/app/javascript/controllers/cron_badge_controller.js
@@ -92,29 +92,31 @@ export default class extends Controller {
     event.preventDefault()
     event.stopPropagation()
     const button = event.currentTarget
+    const releaseTreeReload = this.holdCreativeTreeReload()
 
-    if (!(await confirmDialog(this.deleteConfirmValue, { danger: true }))) return
+    try {
+      if (!(await confirmDialog(this.deleteConfirmValue, { danger: true }))) return
 
-		const releaseTreeReload = this.holdCreativeTreeReload()
 		const task = button.closest('[data-cron-badge-target="task"]')
 		const operationId = String(++cronOperationSequence)
 		task.dataset.cronDeleteOperation = operationId
 		button.disabled = true
 
-    try {
-      const response = await this.deleteCron(button.dataset.cronDeleteUrl)
-      if (!response.ok) throw new Error(`Cron delete failed (${response.status})`)
+		try {
+			const response = await this.deleteCron(button.dataset.cronDeleteUrl)
+			if (!response.ok) throw new Error(`Cron delete failed (${response.status})`)
 
 			this.deleteOperationTasks(task, operationId).forEach(candidate => {
 				const badge = candidate.closest('[data-controller~="cron-badge"]')
 				candidate.remove()
 				this.refreshCount(badge)
 			})
-      invalidateCreativeTree()
-    } catch (error) {
-      console.error(error)
+			invalidateCreativeTree()
+		} catch (error) {
+			console.error(error)
 			this.finishCronDelete(task, operationId)
-      await alertDialog(this.deleteErrorValue)
+			await alertDialog(this.deleteErrorValue)
+		}
 		} finally {
 			releaseTreeReload()
     }

--- a/engines/collavre/app/javascript/controllers/cron_badge_controller.js
+++ b/engines/collavre/app/javascript/controllers/cron_badge_controller.js
@@ -3,7 +3,7 @@ import { alertDialog, confirmDialog } from '../lib/utils/dialog'
 import { invalidateCreativeTree } from '../lib/creative_tree_invalidation'
 import csrfFetch, { refreshCsrfToken } from '../lib/api/csrf_fetch'
 
-let saveOperationSequence = 0
+let cronOperationSequence = 0
 
 export default class extends Controller {
   static targets = ['badge', 'count', 'task', 'messageInput']
@@ -28,7 +28,7 @@ export default class extends Controller {
     if (!input) return
 
     const releaseTreeReload = this.holdCreativeTreeReload()
-    const operationId = String(++saveOperationSequence)
+    const operationId = String(++cronOperationSequence)
     const message = input.value
     task.dataset.cronSaveOperation = operationId
     button.disabled = true
@@ -95,21 +95,43 @@ export default class extends Controller {
 
     if (!(await confirmDialog(this.deleteConfirmValue, { danger: true }))) return
 
-    button.disabled = true
+		const task = button.closest('[data-cron-badge-target="task"]')
+		const operationId = String(++cronOperationSequence)
+		task.dataset.cronDeleteOperation = operationId
+		button.disabled = true
 
     try {
       const response = await this.deleteCron(button.dataset.cronDeleteUrl)
       if (!response.ok) throw new Error(`Cron delete failed (${response.status})`)
 
-      button.closest('[data-cron-badge-target="task"]')?.remove()
-      this.refreshCount()
+			this.deleteOperationTasks(task, operationId).forEach(candidate => {
+				const badge = candidate.closest('[data-controller~="cron-badge"]')
+				candidate.remove()
+				this.refreshCount(badge)
+			})
       invalidateCreativeTree()
     } catch (error) {
       console.error(error)
-      button.disabled = false
+			this.finishCronDelete(task, operationId)
       await alertDialog(this.deleteErrorValue)
     }
   }
+
+	finishCronDelete(task, operationId) {
+		this.deleteOperationTasks(task, operationId).forEach(candidate => {
+			delete candidate.dataset.cronDeleteOperation
+			candidate.querySelector('[data-action~="click->cron-badge#destroy"]').disabled = false
+		})
+	}
+
+	deleteOperationTasks(task, operationId) {
+		const currentTask = document.querySelector(
+			`[data-cron-delete-operation="${operationId}"]`
+		)
+		return new Set([task, currentTask].filter(candidate => (
+			candidate?.dataset.cronDeleteOperation === operationId
+		)))
+	}
 
   async deleteCron(url) {
     const options = { method: 'DELETE' }
@@ -142,17 +164,20 @@ export default class extends Controller {
     return body.trim() === ''
   }
 
-  refreshCount() {
-    const count = this.taskTargets.length
+  refreshCount(element = this.element) {
+		const tasks = element.querySelectorAll('[data-cron-badge-target="task"]')
+		const count = tasks.length
     if (count === 0) {
-      this.element.remove()
+			element.remove()
       return
     }
 
-    this.countTarget.textContent = String(count)
+		const countTarget = element.querySelector('[data-cron-badge-target="count"]')
+		const badgeTarget = element.querySelector('[data-cron-badge-target="badge"]')
+		countTarget.textContent = String(count)
     const template = count === 1 ? this.countOneValue : this.countOtherValue
     const label = template.replace('__count__', String(count))
-    this.badgeTarget.title = label
-    this.badgeTarget.setAttribute('aria-label', label)
+		badgeTarget.title = label
+		badgeTarget.setAttribute('aria-label', label)
   }
 }

--- a/engines/collavre/app/javascript/controllers/cron_badge_controller.js
+++ b/engines/collavre/app/javascript/controllers/cron_badge_controller.js
@@ -3,6 +3,8 @@ import { alertDialog, confirmDialog } from '../lib/utils/dialog'
 import { invalidateCreativeTree } from '../lib/creative_tree_invalidation'
 import csrfFetch, { refreshCsrfToken } from '../lib/api/csrf_fetch'
 
+let saveOperationSequence = 0
+
 export default class extends Controller {
   static targets = ['badge', 'count', 'task', 'messageInput']
   static values = {
@@ -21,10 +23,12 @@ export default class extends Controller {
     event.preventDefault()
     event.stopPropagation()
     const button = event.currentTarget
-    const input = button.closest('[data-cron-badge-target="task"]')
-      ?.querySelector('[data-cron-badge-target="messageInput"]')
+    const task = button.closest('[data-cron-badge-target="task"]')
+    const input = task?.querySelector('[data-cron-badge-target="messageInput"]')
     if (!input) return
 
+    const operationId = String(++saveOperationSequence)
+    task.dataset.cronSaveOperation = operationId
     button.disabled = true
     input.disabled = true
 
@@ -38,9 +42,23 @@ export default class extends Controller {
       console.error(error)
       await alertDialog(this.updateErrorValue)
     } finally {
-      button.disabled = false
-      input.disabled = false
+      this.finishMessageSave(task, operationId)
     }
+  }
+
+  finishMessageSave(task, operationId) {
+    const currentTask = document.querySelector(
+      `[data-cron-save-operation="${operationId}"]`
+    )
+    new Set([task, currentTask]).forEach(candidate => {
+      if (!candidate || candidate.dataset.cronSaveOperation !== operationId) return
+
+      delete candidate.dataset.cronSaveOperation
+      const input = candidate.querySelector('[data-cron-badge-target="messageInput"]')
+      const button = candidate.querySelector('[data-action~="click->cron-badge#saveMessage"]')
+      if (input) input.disabled = false
+      if (button) button.disabled = false
+    })
   }
 
   async destroy(event) {

--- a/engines/collavre/app/javascript/controllers/cron_badge_controller.js
+++ b/engines/collavre/app/javascript/controllers/cron_badge_controller.js
@@ -28,15 +28,16 @@ export default class extends Controller {
     if (!input) return
 
     const operationId = String(++saveOperationSequence)
+    const message = input.value
     task.dataset.cronSaveOperation = operationId
     button.disabled = true
     input.disabled = true
 
     try {
-      const response = await this.updateCron(button.dataset.cronUpdateUrl, input.value)
+      const response = await this.updateCron(button.dataset.cronUpdateUrl, message)
       if (!response.ok) throw new Error(`Cron update failed (${response.status})`)
 
-      input.dataset.cronSavedMessage = input.value
+      this.updateSavedMessage(task, operationId, message)
       invalidateCreativeTree()
     } catch (error) {
       console.error(error)
@@ -47,18 +48,29 @@ export default class extends Controller {
   }
 
   finishMessageSave(task, operationId) {
-    const currentTask = document.querySelector(
-      `[data-cron-save-operation="${operationId}"]`
-    )
-    new Set([task, currentTask]).forEach(candidate => {
-      if (!candidate || candidate.dataset.cronSaveOperation !== operationId) return
-
+    this.messageSaveTasks(task, operationId).forEach(candidate => {
       delete candidate.dataset.cronSaveOperation
       const input = candidate.querySelector('[data-cron-badge-target="messageInput"]')
       const button = candidate.querySelector('[data-action~="click->cron-badge#saveMessage"]')
       if (input) input.disabled = false
       if (button) button.disabled = false
     })
+  }
+
+  updateSavedMessage(task, operationId, message) {
+    this.messageSaveTasks(task, operationId).forEach(candidate => {
+      const input = candidate.querySelector('[data-cron-badge-target="messageInput"]')
+      if (input) input.dataset.cronSavedMessage = message
+    })
+  }
+
+  messageSaveTasks(task, operationId) {
+    const currentTask = document.querySelector(
+      `[data-cron-save-operation="${operationId}"]`
+    )
+    return new Set([task, currentTask].filter(candidate => (
+      candidate?.dataset.cronSaveOperation === operationId
+    )))
   }
 
   async destroy(event) {

--- a/engines/collavre/app/javascript/creatives/__tests__/tree_renderer.test.js
+++ b/engines/collavre/app/javascript/creatives/__tests__/tree_renderer.test.js
@@ -62,6 +62,53 @@ test('keeps a broadcast progress template instead of restoring stale DOM markup'
   expect(row.requestUpdate).toHaveBeenCalledTimes(1)
 })
 
+test('preserves dirty cron state while reconciling a full progress template', () => {
+	const currentProgressHtml = `
+		${TOGGLE_HTML}
+		<span data-cron-key="cron-42">
+			<textarea data-cron-badge-target="messageInput"
+				data-cron-saved-message="Saved message">Saved message</textarea>
+			<button data-action="click->cron-badge#saveMessage">Save</button>
+			<button data-action="click->cron-badge#destroy">Delete</button>
+		</span>
+		<span class="comments-btn">1</span>
+	`
+	const serverProgressHtml = `
+		<span class="creative-progress-incomplete">50%</span>
+		<span data-cron-key="cron-42">
+			<textarea data-cron-badge-target="messageInput"
+				data-cron-saved-message="Server message">Server message</textarea>
+			<button data-action="click->cron-badge#saveMessage">Save</button>
+			<button data-action="click->cron-badge#destroy">Delete</button>
+		</span>
+		<span class="comments-btn">2</span>
+	`
+	const row = document.createElement('creative-tree-row')
+	row.progressHtml = currentProgressHtml
+	row.dataset.progressHtml = currentProgressHtml
+	row.innerHTML = `<span class="creative-progress-area">${currentProgressHtml}</span>`
+	row.requestUpdate = jest.fn()
+	const currentTask = row.querySelector('[data-cron-key="cron-42"]')
+	currentTask.querySelector('textarea').value = '\nDraft message'
+	currentTask.dataset.cronSaveOperation = '6'
+	currentTask.dataset.cronDeleteOperation = '7'
+	currentTask.querySelector('[data-action~="click->cron-badge#saveMessage"]').disabled = true
+	currentTask.querySelector('[data-action~="click->cron-badge#destroy"]').disabled = true
+
+	applyRowProperties(row, { templates: { progress_html: serverProgressHtml } })
+
+	const template = document.createElement('template')
+	template.innerHTML = row.progressHtml
+	const nextTask = template.content.querySelector('[data-cron-key="cron-42"]')
+	expect(template.content.querySelector('.creative-progress-incomplete').textContent).toBe('50%')
+	expect(template.content.querySelector('.comments-btn').textContent).toBe('2')
+	expect(nextTask.querySelector('textarea').value).toBe('\nDraft message')
+	expect(nextTask.dataset.cronSaveOperation).toBe('6')
+	expect(nextTask.dataset.cronDeleteOperation).toBe('7')
+	expect(nextTask.querySelector('[data-action~="click->cron-badge#saveMessage"]').disabled).toBe(true)
+	expect(nextTask.querySelector('[data-action~="click->cron-badge#destroy"]').disabled).toBe(true)
+})
+
 test('replaces the progress control when a remote update changes binary eligibility', () => {
   const row = document.createElement('creative-tree-row')
   row.progressHtml = TOGGLE_HTML

--- a/engines/collavre/app/javascript/creatives/__tests__/tree_renderer.test.js
+++ b/engines/collavre/app/javascript/creatives/__tests__/tree_renderer.test.js
@@ -3,7 +3,12 @@
  */
 import { jest } from '@jest/globals'
 
-import { applyRowProperties, replaceProgressControl, updateProgressHtml } from '../tree_renderer'
+import {
+  applyRowProperties,
+  replaceProgressControl,
+  syncProgressHtmlFromDom,
+  updateProgressHtml,
+} from '../tree_renderer'
 
 const TOGGLE_HTML = '<span class="progress-toggle-wrap" data-progress-toggle="true" data-current-progress="0" data-new-progress="1" data-mark-complete="Mark complete" data-mark-incomplete="Mark incomplete" title="Mark complete"><input type="checkbox" class="progress-toggle-checkbox" aria-label="Mark complete"></span>'
 
@@ -104,4 +109,32 @@ test('preserves a dirty cron message when an incremental progress update rerende
   const input = template.content.querySelector('textarea')
   expect(input.value).toBe('\nHalf-typed message')
   expect(input.dataset.cronSavedMessage).toBe('Saved message')
+})
+
+test('does not persist transient disabled cron controls during DOM synchronization', () => {
+  const progressHtml = `
+    <span data-cron-badge-target="task" data-cron-key="cron-42">
+      <textarea data-cron-badge-target="messageInput"
+                data-cron-saved-message="Saved message">Saved message</textarea>
+      <button data-action="click->cron-badge#saveMessage">Save</button>
+    </span>
+    ${TOGGLE_HTML}
+  `
+  const row = document.createElement('creative-tree-row')
+  row.progressHtml = progressHtml
+  row.dataset.progressHtml = progressHtml
+  row.innerHTML = `<span class="creative-progress-area">${progressHtml}</span>`
+  const input = row.querySelector('textarea')
+  const button = row.querySelector('button[data-action]')
+  input.value = 'Half-typed message'
+  input.disabled = true
+  button.disabled = true
+
+  syncProgressHtmlFromDom(row)
+
+  const template = document.createElement('template')
+  template.innerHTML = row.progressHtml
+  expect(template.content.querySelector('textarea').value).toBe('Half-typed message')
+  expect(template.content.querySelector('textarea').disabled).toBe(false)
+  expect(template.content.querySelector('button').disabled).toBe(false)
 })

--- a/engines/collavre/app/javascript/creatives/__tests__/tree_renderer.test.js
+++ b/engines/collavre/app/javascript/creatives/__tests__/tree_renderer.test.js
@@ -111,7 +111,7 @@ test('preserves a dirty cron message when an incremental progress update rerende
   expect(input.dataset.cronSavedMessage).toBe('Saved message')
 })
 
-test('does not persist transient disabled cron controls during DOM synchronization', () => {
+test('keeps in-flight cron controls disabled during DOM synchronization', () => {
   const progressHtml = `
     <span data-cron-badge-target="task" data-cron-key="cron-42">
       <textarea data-cron-badge-target="messageInput"
@@ -135,6 +135,6 @@ test('does not persist transient disabled cron controls during DOM synchronizati
   const template = document.createElement('template')
   template.innerHTML = row.progressHtml
   expect(template.content.querySelector('textarea').value).toBe('Half-typed message')
-  expect(template.content.querySelector('textarea').disabled).toBe(false)
-  expect(template.content.querySelector('button').disabled).toBe(false)
+  expect(template.content.querySelector('textarea').disabled).toBe(true)
+  expect(template.content.querySelector('button').disabled).toBe(true)
 })

--- a/engines/collavre/app/javascript/creatives/__tests__/tree_renderer.test.js
+++ b/engines/collavre/app/javascript/creatives/__tests__/tree_renderer.test.js
@@ -78,3 +78,30 @@ test('replaces the progress control when a remote update changes binary eligibil
 
   expect(row.progressHtml).toBe(TOGGLE_HTML)
 })
+
+test('preserves a dirty cron message when an incremental progress update rerenders the row', () => {
+  const progressHtml = `
+    <span data-cron-key="cron-42">
+      <textarea data-cron-badge-target="messageInput"
+                data-cron-saved-message="Saved message">Saved message</textarea>
+    </span>
+    ${TOGGLE_HTML}
+  `
+  const row = document.createElement('creative-tree-row')
+  row.progressHtml = progressHtml
+  row.dataset.progressHtml = progressHtml
+  row.innerHTML = `<span class="creative-progress-area">${progressHtml}</span>`
+  row.requestUpdate = jest.fn()
+  row.querySelector('textarea').value = '\nHalf-typed message'
+
+  applyRowProperties(row, {
+    inline_editor_payload: { progress: 0.5 },
+    progress_control_html: '<span class="creative-progress-incomplete">50%</span>',
+  })
+
+  const template = document.createElement('template')
+  template.innerHTML = row.progressHtml
+  const input = template.content.querySelector('textarea')
+  expect(input.value).toBe('\nHalf-typed message')
+  expect(input.dataset.cronSavedMessage).toBe('Saved message')
+})

--- a/engines/collavre/app/javascript/creatives/tree_renderer.js
+++ b/engines/collavre/app/javascript/creatives/tree_renderer.js
@@ -94,6 +94,46 @@ export function replaceProgressControl(html, controlHtml) {
   return serializeProgressHtml(template)
 }
 
+function restoreCronTaskState(currentTask, nextTask) {
+  const currentInput = currentTask.querySelector('[data-cron-badge-target="messageInput"]')
+  const nextInput = nextTask.querySelector('[data-cron-badge-target="messageInput"]')
+  if (!currentInput || !nextInput) return false
+
+  const saveOperationId = currentTask.dataset.cronSaveOperation
+  const deleteOperationId = currentTask.dataset.cronDeleteOperation
+  const dirty = currentInput.value !== currentInput.dataset.cronSavedMessage
+  if (dirty || saveOperationId) nextInput.value = currentInput.value
+  if (saveOperationId) {
+    nextTask.dataset.cronSaveOperation = saveOperationId
+    nextInput.disabled = true
+    nextTask.querySelector('[data-action~="click->cron-badge#saveMessage"]').disabled = true
+  }
+  if (deleteOperationId) {
+    nextTask.dataset.cronDeleteOperation = deleteOperationId
+    nextTask.querySelector('[data-action~="click->cron-badge#destroy"]').disabled = true
+  }
+  return dirty || Boolean(saveOperationId) || Boolean(deleteOperationId)
+}
+
+export function mergeCronTaskState(currentHtml, nextHtml) {
+  const currentTemplate = document.createElement('template')
+  currentTemplate.innerHTML = currentHtml
+  const nextTemplate = document.createElement('template')
+  nextTemplate.innerHTML = nextHtml
+  const nextTasks = new Map(Array.from(
+    nextTemplate.content.querySelectorAll('[data-cron-key]'),
+    task => [task.dataset.cronKey, task]
+  ))
+  let changed = false
+
+  currentTemplate.content.querySelectorAll('[data-cron-key]').forEach(currentTask => {
+    const nextTask = nextTasks.get(currentTask.dataset.cronKey)
+    if (nextTask && restoreCronTaskState(currentTask, nextTask)) changed = true
+  })
+
+  return changed ? serializeProgressHtml(nextTemplate) : nextHtml
+}
+
 function applyRowProperties(row, node) {
   if (!row || !node) return
   // Preserve Turbo-mutated child markup before accepting server-side templates.
@@ -171,10 +211,15 @@ function applyRowProperties(row, node) {
     setDatasetValue(row, 'descriptionHtml', templates.description_html)
     dirty = true
   }
-  if (templates.progress_html != null && row.progressHtml !== templates.progress_html) {
-    row.progressHtml = templates.progress_html
-    setDatasetValue(row, 'progressHtml', templates.progress_html)
-    dirty = true
+	if (templates.progress_html != null) {
+		const progressHtml = row.progressHtml
+			? mergeCronTaskState(row.progressHtml, templates.progress_html)
+			: templates.progress_html
+		if (row.progressHtml !== progressHtml) {
+			row.progressHtml = progressHtml
+			setDatasetValue(row, 'progressHtml', progressHtml)
+			dirty = true
+		}
   }
   if (templates.edit_icon_html != null && row.editIconHtml !== templates.edit_icon_html) {
     row.editIconHtml = templates.edit_icon_html

--- a/engines/collavre/app/javascript/creatives/tree_renderer.js
+++ b/engines/collavre/app/javascript/creatives/tree_renderer.js
@@ -30,9 +30,6 @@ export function syncProgressHtmlFromDom(row) {
   const wrapper = row.querySelector('.creative-progress-area')
   if (!wrapper) return
   const clone = wrapper.cloneNode(true)
-  clone.querySelectorAll('[data-cron-badge-target="task"] [disabled]').forEach(control => {
-    control.removeAttribute('disabled')
-  })
   const inputs = wrapper.querySelectorAll('[data-cron-badge-target="messageInput"]')
   const clonedInputs = clone.querySelectorAll('[data-cron-badge-target="messageInput"]')
   inputs.forEach((input, index) => {

--- a/engines/collavre/app/javascript/creatives/tree_renderer.js
+++ b/engines/collavre/app/javascript/creatives/tree_renderer.js
@@ -11,17 +11,31 @@ function setDatasetValue(element, key, value) {
   }
 }
 
+function serializeProgressHtml(element) {
+  const root = element.content || element
+  root.querySelectorAll('[data-cron-badge-target="messageInput"]').forEach(input => {
+    input.textContent = `\n${input.value}`
+  })
+  return element.innerHTML
+}
+
 // Capture current DOM state of the progress area back into Lit's progressHtml
 // so that Turbo Streams DOM mutations (e.g. badge count updates) survive Lit re-renders.
 // Lit renders progressHtml via unsafeHTML() inside a .creative-progress-area wrapper.
 // Turbo may directly replace child elements (e.g. comment-badge span) in the DOM,
 // but Lit's progressHtml string remains stale. On next re-render, Lit would overwrite
 // the Turbo-updated DOM with the stale string, losing badge updates.
-function syncProgressHtmlFromDom(row) {
+export function syncProgressHtmlFromDom(row) {
   if (!row.progressHtml) return
   const wrapper = row.querySelector('.creative-progress-area')
   if (!wrapper) return
-  const currentHtml = wrapper.innerHTML
+  const clone = wrapper.cloneNode(true)
+  const inputs = wrapper.querySelectorAll('[data-cron-badge-target="messageInput"]')
+  const clonedInputs = clone.querySelectorAll('[data-cron-badge-target="messageInput"]')
+  inputs.forEach((input, index) => {
+    clonedInputs[index].value = input.value
+  })
+  const currentHtml = serializeProgressHtml(clone)
   if (currentHtml && currentHtml !== row.progressHtml) {
     row.progressHtml = currentHtml
     row.dataset.progressHtml = currentHtml
@@ -48,7 +62,7 @@ export function updateProgressHtml(html, progress, displayText) {
         checkbox.setAttribute('aria-label', label)
       }
     }
-    return template.innerHTML
+    return serializeProgressHtml(template)
   }
 
   const progressElement = template.content.querySelector(
@@ -59,7 +73,7 @@ export function updateProgressHtml(html, progress, displayText) {
   progressElement.textContent = displayText
   progressElement.classList.toggle('creative-progress-complete', complete)
   progressElement.classList.toggle('creative-progress-incomplete', !complete)
-  return template.innerHTML
+  return serializeProgressHtml(template)
 }
 
 export function replaceProgressControl(html, controlHtml) {
@@ -77,7 +91,7 @@ export function replaceProgressControl(html, controlHtml) {
   if (!currentControl || !replacementControl) return html
 
   currentControl.replaceWith(replacementControl.cloneNode(true))
-  return template.innerHTML
+  return serializeProgressHtml(template)
 }
 
 function applyRowProperties(row, node) {

--- a/engines/collavre/app/javascript/creatives/tree_renderer.js
+++ b/engines/collavre/app/javascript/creatives/tree_renderer.js
@@ -30,6 +30,9 @@ export function syncProgressHtmlFromDom(row) {
   const wrapper = row.querySelector('.creative-progress-area')
   if (!wrapper) return
   const clone = wrapper.cloneNode(true)
+  clone.querySelectorAll('[data-cron-badge-target="task"] [disabled]').forEach(control => {
+    control.removeAttribute('disabled')
+  })
   const inputs = wrapper.querySelectorAll('[data-cron-badge-target="messageInput"]')
   const clonedInputs = clone.querySelectorAll('[data-cron-badge-target="messageInput"]')
   inputs.forEach((input, index) => {

--- a/engines/collavre/app/javascript/lib/__tests__/turbo_stream_actions.test.js
+++ b/engines/collavre/app/javascript/lib/__tests__/turbo_stream_actions.test.js
@@ -10,6 +10,7 @@ jest.unstable_mockModule('../../creatives/tree_renderer', () => ({
   createRow: jest.fn(),
   applyRowProperties: jest.fn(),
   replaceProgressControl: jest.fn((_html, controlHtml) => controlHtml),
+  syncProgressHtmlFromDom: jest.fn(),
   updateProgressHtml: jest.fn((html, progress) => progress === 1
     ? html.replace('class="progress-toggle-checkbox"', 'class="progress-toggle-checkbox" checked="checked"')
       .replace('data-current-progress="0"', 'data-current-progress="1"')
@@ -19,7 +20,7 @@ jest.unstable_mockModule('../../creatives/tree_renderer', () => ({
 }))
 
 await import('../turbo_stream_actions')
-const { createRow } = await import('../../creatives/tree_renderer')
+const { createRow, syncProgressHtmlFromDom } = await import('../../creatives/tree_renderer')
 const { updateProgressForRow } = await import('../turbo_stream_actions')
 
 const EMPTY_HTML = '<div data-creatives-empty-state=""><p>No sub-creatives found.</p></div>'
@@ -148,6 +149,7 @@ test('remote progress updates keep checkbox controls actionable', () => {
 
   updateProgressForRow(row, 1, '100%')
 
+  expect(syncProgressHtmlFromDom).toHaveBeenCalledWith(row)
   expect(row.progressHtml).toContain('checked="checked"')
   expect(row.progressHtml).toContain('data-current-progress="1"')
   expect(row.progressHtml).toContain('data-new-progress="0"')

--- a/engines/collavre/app/javascript/lib/turbo_stream_actions.js
+++ b/engines/collavre/app/javascript/lib/turbo_stream_actions.js
@@ -1,5 +1,11 @@
 import { Turbo } from "@hotwired/turbo-rails"
-import { createRow, applyRowProperties, replaceProgressControl, updateProgressHtml } from "../creatives/tree_renderer"
+import {
+    createRow,
+    applyRowProperties,
+    replaceProgressControl,
+    syncProgressHtmlFromDom,
+    updateProgressHtml,
+} from "../creatives/tree_renderer"
 import { hideTreeEmptyState, restoreTreeEmptyState } from "../modules/creative_tree_empty_state"
 import { invalidateCreativeTree } from "./creative_tree_invalidation"
 
@@ -338,6 +344,7 @@ function handleDestroyed(creative) {
 
 export function updateProgressForRow(row, progress, progressText, progressHtml = null) {
     if (progress == null) return
+    syncProgressHtmlFromDom(row)
     const pct = Math.round(progress * 100)
     // progressText from server: completion mark string, empty string (=complete but no mark), or null
     const displayText = progressText != null ? (progressText || '\u00a0\u00a0') : `${pct}%`

--- a/engines/collavre/app/javascript/modules/__tests__/creative_inline_payload.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/creative_inline_payload.test.js
@@ -149,6 +149,33 @@ describe('updateRowFromData', () => {
     expect(row2.dataset.progressHtml).toBeUndefined();
   });
 
+  test('progress_html preserves a dirty cron message from the rendered row', () => {
+		const { row } = makeRow('1');
+		const currentProgressHtml = `
+			<span data-progress-toggle="true"><input class="progress-toggle-checkbox"></span>
+			<span data-cron-key="cron-1">
+				<textarea data-cron-badge-target="messageInput"
+					data-cron-saved-message="Saved message">Saved message</textarea>
+			</span>
+		`;
+		row.progressHtml = currentProgressHtml;
+		row.dataset.progressHtml = currentProgressHtml;
+		row.innerHTML = `<span class="creative-progress-area">${currentProgressHtml}</span>`;
+		row.querySelector('textarea').value = '\nDraft message';
+
+		updateRowFromData(row, {
+			description: 'd',
+			progress_html: '<span class="creative-progress-complete">100%</span>',
+		});
+
+		const template = document.createElement('template');
+		template.innerHTML = row.progressHtml;
+		expect(template.content.querySelector('.creative-progress-complete').textContent).toBe('100%');
+		expect(template.content.querySelector('[data-cron-key="cron-1"]')).not.toBeNull();
+		expect(template.content.querySelector('textarea').value).toBe('\nDraft message');
+		expect(row.dataset.progressHtml).toBe(row.progressHtml);
+  });
+
   test('progress written from own key; null clears dataset value', () => {
     const { row } = makeRow('1');
     updateRowFromData(row, { description: 'd', progress: 30 });

--- a/engines/collavre/app/javascript/modules/creative_inline_payload.js
+++ b/engines/collavre/app/javascript/modules/creative_inline_payload.js
@@ -13,6 +13,7 @@ import {
   hasDatasetValue,
   setRowDatasetValue,
 } from './creative_row_editor_helpers'
+import { replaceProgressControl, syncProgressHtmlFromDom } from '../creatives/tree_renderer'
 
 export function updateRowFromData(row, data) {
   if (!row || !data) return;
@@ -22,8 +23,12 @@ export function updateRowFromData(row, data) {
   setRowDatasetValue(row, 'descriptionHtml', descriptionHtml);
   setRowDatasetValue(row, 'descriptionRawHtml', rawHtml);
   if (data.progress_html != null) {
-    row.progressHtml = data.progress_html;
-    setRowDatasetValue(row, 'progressHtml', data.progress_html);
+		syncProgressHtmlFromDom(row);
+		const progressHtml = row.progressHtml
+			? replaceProgressControl(row.progressHtml, data.progress_html)
+			: data.progress_html;
+		row.progressHtml = progressHtml;
+		setRowDatasetValue(row, 'progressHtml', progressHtml);
   }
   if (Object.prototype.hasOwnProperty.call(data, 'progress')) {
     setRowDatasetValue(row, 'progressValue', data.progress ?? '');

--- a/engines/collavre/config/locales/crons.en.yml
+++ b/engines/collavre/config/locales/crons.en.yml
@@ -11,4 +11,6 @@ en:
       delete: Delete scheduled job
       delete_confirm: Delete this scheduled job?
       delete_error: Could not delete the scheduled job. Please try again.
+      update_error: Could not update the scheduled message. Please try again.
+      message_required: Enter a message for the scheduled job.
       not_available: Not available

--- a/engines/collavre/config/locales/crons.ko.yml
+++ b/engines/collavre/config/locales/crons.ko.yml
@@ -11,4 +11,6 @@ ko:
       delete: 예약 작업 삭제
       delete_confirm: 이 예약 작업을 삭제하시겠습니까?
       delete_error: 예약 작업을 삭제하지 못했습니다. 다시 시도해 주세요.
+      update_error: 예약 작업 메시지를 수정하지 못했습니다. 다시 시도해 주세요.
+      message_required: 예약 작업 메시지를 입력해 주세요.
       not_available: 정보 없음

--- a/engines/collavre/config/routes.rb
+++ b/engines/collavre/config/routes.rb
@@ -94,7 +94,7 @@ Collavre::Engine.routes.draw do
     end
   end
   resources :creatives do
-    resources :crons, only: [ :destroy ], param: :key
+    resources :crons, only: %i[update destroy], param: :key
     post "history/:id/apply", to: "creative_change_sets#apply", as: :apply_change_set
     resources :attachments, only: [ :create ], module: :creatives
     resources :creative_shares, only: [ :index, :create, :update, :destroy ]

--- a/engines/collavre/test/components/cron_badge_component_test.rb
+++ b/engines/collavre/test/components/cron_badge_component_test.rb
@@ -21,8 +21,9 @@ class CronBadgeComponentTest < ViewComponent::TestCase
     assert_selector "[data-cron-badge-count-one-value='__count__ scheduled job']"
     assert_selector "button.creative-cron-badge[data-cron-badge-target='badge']", text: "1"
     assert_selector ".cron-task code", text: "0 9 * * *"
-    assert_selector ".cron-task-message", text: "Daily summary"
+    assert_selector "textarea.cron-task-message-input[data-cron-badge-target='messageInput'][data-cron-saved-message='Daily summary']", text: "Daily summary"
     assert_selector "time[datetime='#{time.iso8601}']"
+    assert_selector "button.cron-task-save[data-cron-update-url='/creatives/42/crons/cron_42_daily']", text: "Save"
     assert_selector "button.cron-task-delete[data-cron-delete-url='/creatives/42/crons/cron_42_daily']"
   end
 
@@ -34,6 +35,8 @@ class CronBadgeComponentTest < ViewComponent::TestCase
     )
 
     assert_text "Not available", count: 2
+    assert_no_selector ".cron-task-message-input"
+    assert_no_selector ".cron-task-save"
     assert_no_selector ".cron-task-delete"
   end
 

--- a/engines/collavre/test/components/cron_badge_component_test.rb
+++ b/engines/collavre/test/components/cron_badge_component_test.rb
@@ -40,6 +40,24 @@ class CronBadgeComponentTest < ViewComponent::TestCase
     assert_no_selector ".cron-task-delete"
   end
 
+  test "preserves a leading newline in an editable message" do
+    message = "\nDaily summary"
+    task = Task.new("cron_42_daily", "0 9 * * *", nil, [ { message: message } ])
+
+    render_inline(
+      Collavre::CronBadgeComponent.new(
+        tasks: [ task ],
+        creative_id: 42,
+        can_delete: true
+      )
+    )
+
+    textarea = Capybara.string(rendered_content).find("textarea.cron-task-message-input")
+
+    assert_equal message, textarea.value
+    assert_equal message, textarea["data-cron-saved-message"]
+  end
+
   test "renders the next run in the current user's time zone" do
     time = Time.utc(2026, 9, 5, 9)
     task = Task.new("cron_42_daily", "0 9 * * *", time, [ { message: "Daily summary" } ])

--- a/engines/collavre/test/controllers/crons_controller_test.rb
+++ b/engines/collavre/test/controllers/crons_controller_test.rb
@@ -24,6 +24,63 @@ class CronsControllerTest < ActionDispatch::IntegrationTest
     assert_not @task.class.exists?(@task.id)
   end
 
+  test "updates a cron message while preserving its other arguments" do
+    assert_broadcast_on(Collavre::TopicsChannel.broadcasting_for(@creative), action: "cron_changed") do
+      patch collavre.creative_cron_url(@creative, @task.key), params: { message: "Updated summary" }, as: :json
+    end
+
+    assert_response :success
+    assert_equal({ "message" => "Updated summary" }, response.parsed_body)
+
+    arguments = @task.reload.arguments.first.stringify_keys
+    assert_equal "Updated summary", arguments.fetch("message")
+    assert_equal @creative.id, arguments.fetch("creative_id")
+    assert_equal @topic.id, arguments.fetch("topic_id")
+  end
+
+  test "rejects an empty cron message" do
+    patch collavre.creative_cron_url(@creative, @task.key), params: { message: "" }, as: :json
+
+    assert_response :unprocessable_entity
+    assert_equal I18n.t("collavre.crons.message_required"), response.parsed_body.fetch("error")
+    assert_equal "Daily summary", @task.reload.arguments.first.stringify_keys.fetch("message")
+  end
+
+  test "returns an update service error" do
+    calls = []
+    service = Object.new
+    service.define_singleton_method(:call) do |**arguments|
+      calls << arguments
+      { error: "Cron update failed" }
+    end
+
+    Collavre::Tools::CronUpdateService.stub(:new, -> { service }) do
+      patch collavre.creative_cron_url(@creative, @task.key), params: { message: "Updated summary" }, as: :json
+    end
+
+    assert_response :unprocessable_entity
+    assert_equal "Cron update failed", response.parsed_body.fetch("error")
+    assert_equal [ { key: @task.key, message: "Updated summary" } ], calls
+  end
+
+  test "rejects message updates without write permission" do
+    sign_in_as users(:two), password: "password"
+
+    patch collavre.creative_cron_url(@creative, @task.key), params: { message: "Not allowed" }, as: :json
+
+    assert_response :forbidden
+    assert_equal "Daily summary", @task.reload.arguments.first.stringify_keys.fetch("message")
+  end
+
+  test "does not update a cron belonging to another creative" do
+    other_creative = Collavre::Creative.create!(user: @user, description: "Other work")
+
+    patch collavre.creative_cron_url(other_creative, @task.key), params: { message: "Wrong creative" }, as: :json
+
+    assert_response :not_found
+    assert_equal "Daily summary", @task.reload.arguments.first.stringify_keys.fetch("message")
+  end
+
   test "rejects deletion without write permission" do
     other_user = users(:two)
     sign_in_as other_user, password: "password"

--- a/engines/collavre/test/system/creative_cron_badge_alignment_test.rb
+++ b/engines/collavre/test/system/creative_cron_badge_alignment_test.rb
@@ -47,4 +47,16 @@ class CreativeCronBadgeAlignmentTest < ApplicationSystemTestCase
 
     assert_in_delta positions.fetch("checkbox"), positions.fetch("badge"), 1
   end
+
+  test "edits the scheduled message from the cron badge popup" do
+    visit collavre.creatives_path(has_cron: "true")
+    row_selector = "#creative-#{@creative.id}"
+
+    find("#{row_selector} .creative-cron-badge").click
+    find("#{row_selector} .cron-task-message-input").set("Updated scheduled message")
+    find("#{row_selector} .cron-task-save").click
+
+    assert_selector "#{row_selector} .cron-task-message-input[data-cron-saved-message='Updated scheduled message']", visible: :all
+    assert_equal "Updated scheduled message", @task.class.find(@task.id).arguments.first.stringify_keys.fetch("message")
+  end
 end


### PR DESCRIPTION
## Summary
- add a message editor and save action to the shared scheduled-job popup
- route updates through the existing cron update service while enforcing creative write access
- keep read-only popups unchanged and refresh topic/tree badges after updates
- add English and Korean UI messages

## Tests
- 116 related Ruby controller, component, helper, integration, and topic tests
- 2 Chrome system tests, including editing a scheduled message from the popup
- 12 Jest tests with 100% statement, branch, function, and line coverage for the cron badge controller
- 100% line and branch coverage for the changed Ruby controller and component
- RuboCop, i18n consistency check, CSS lint for the added rules, and asset build