### PR TITLE
Refactor Collavre core responsibilities and add complexity guards

### DIFF
--- a/.eslint_metrics.yml
+++ b/.eslint_metrics.yml
@@ -1,0 +1,67 @@
+# Complexity budget for the JavaScript half of the ratchet
+# (bin/complexity_check, lib/js_complexity/). The Ruby half is
+# .rubocop_metrics.yml; the rules, the waivers and the merge-base comparison are
+# shared. See docs/complexity_budget.md.
+#
+# There is no ESLint in this repository — no config file, no lint job, no
+# devDependency — so until now none of the core engine's 35,978 lines of
+# non-test JavaScript, across 168 files, were measured by anything. That sits
+# beside 40,153 lines of core Ruby the ratchet already covers, and it holds the
+# two largest source files in the engine.
+#
+# This file holds ONLY thresholds. Rule options that are not thresholds
+# (skipBlankLines, IIFEs) are fixed in lib/js_complexity/measure.js, and there
+# is no per-file override syntax at all, because every one of those is a way to
+# silence the gate while the number above it still reads like a budget.
+#
+# Why these numbers: unlike the Ruby side — where RuboCop's defaults put ~90% of
+# entities in violation and the budget had to be set at the 75th percentile of
+# the violators — ESLint's documented defaults are already within reach here.
+# Measured over the 168 files this file selects, on 2026-09-10, the budget
+# below leaves 217 entities over it, and each rule catches only the tail:
+#
+#   rule                     budget   entities   over budget
+#   complexity               13       3,189      88   (2.8%)
+#   max-depth                3        3,405      19   (0.6%)
+#   max-lines                300      168        23   (13.7%)
+#   max-lines-per-function   50       3,142      78   (2.5%)
+#   max-nested-callbacks     10       999        0    (0.0%)
+#   max-params               4        1,933      9    (0.5%)
+#
+# Those 217 are grandfathered by the ratchet — they may shrink but not grow.
+# The budget is what NEW code has to fit, and ordinary Stimulus controllers and
+# modules already fit it.
+
+# Everything the core engine ships, not a hand-written list of directories: a
+# glob and the real file set drift apart, and the half that drifts is always the
+# one nobody is looking at.
+#
+# The core engine and nothing else. lib/js_complexity — the measurement itself —
+# is deliberately NOT here: this gate is being introduced for engines/collavre,
+# and a tool that measures itself makes every change to the tool read as engine
+# debt. It is a two-line addition whenever someone wants it, and the tool's own
+# tests are in lib/js_complexity/__tests__ either way.
+include:
+  - "engines/collavre/**/*.js"
+  - "engines/collavre/**/*.jsx"
+
+exclude:
+  # Tests are excluded for the same reason as on the Ruby side: a 2,000-line
+  # test file is a list, not a god object. It has no callers and no shared
+  # mutable state, and splitting it buys nothing. Test bloat is real but it is a
+  # coverage-quality problem, and mixing it in here would bury the app-code
+  # signal under hundreds of function-length offenses.
+  - "**/__tests__/**"
+  - "engines/collavre/test/**"
+  - "**/node_modules/**"
+
+# Only satellite-free core JavaScript is measured. The satellites hold about
+# 2,800 lines between them against the core's 35,000, and adding them here is a
+# two-line change once someone wants it.
+rules:
+  complexity: 13
+  max-depth: 3
+  max-lines: 300
+  max-lines-per-function: 50
+  max-nested-callbacks: 10
+  max-params: 4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,9 +77,11 @@ jobs:
       - name: Test shell script helpers
         run: bash script/test/lightsail_launch_test.sh
 
-  # Entity-level complexity ratchet: RuboCop's Metrics department over app code,
-  # run twice — once on this branch, once on a detached checkout of the merge
-  # base — and compared entity by entity. Adds ~5s. See docs/complexity_budget.md.
+  # Entity-level complexity ratchet: RuboCop's Metrics department over Ruby app
+  # code and ESLint's size and complexity rules over the core engine's
+  # JavaScript, run twice — once on this branch, once on a detached checkout of
+  # the merge base — and compared entity by entity. The two measurements take
+  # about 8s together. See docs/complexity_budget.md.
   complexity:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
@@ -98,15 +100,38 @@ jobs:
           ruby-version: .ruby-version
           bundler-cache: true
 
-      # The budget in .rubocop_metrics.yml may only tighten. The
-      # `complexity-baseline-reset` label is the way past that, for the case it
+      - name: Set up Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      # ESLint only. The merge-base worktree gets no install of its own — it is
+      # measured with this checkout's ESLint and this branch's budget, which is
+      # the same rule the Ruby half follows for .rubocop_metrics.yml.
+      - name: Install dependencies
+        run: npm ci
+
+      # The budgets in .rubocop_metrics.yml and .eslint_metrics.yml may only
+      # tighten. The `complexity-baseline-reset` label is the way past that, for the case it
       # was written for: a deliberate, reviewed budget change. Applying a label
       # does not re-trigger CI, so re-run this job afterwards.
+      # The baseline is the base *branch*, not `pull_request.base.sha`. That
+      # field is the base tip as of the last open/synchronize event on this PR
+      # and does not move when the base branch does, while the checkout above
+      # is `refs/pull/N/merge`, which GitHub recomputes against the current
+      # base tip. Measuring the second against the first attributes every
+      # sibling PR that landed in between to this one: PR #1651 saw eight such
+      # reports, all of them other branches' code. Resolving the ref here makes
+      # the baseline `merge-base(HEAD, base tip)`, which is the base tip
+      # itself, so the diff measured is exactly this branch's.
       - name: Check the complexity ratchet
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
           ALLOW_BUDGET_CHANGE: ${{ contains(github.event.pull_request.labels.*.name, 'complexity-baseline-reset') && '--allow-budget-change' || '' }}
-        run: bin/complexity_check --base "$BASE_SHA" $ALLOW_BUDGET_CHANGE
+        run: |
+          git fetch --no-tags --quiet origin "+refs/heads/$BASE_REF:refs/remotes/origin/$BASE_REF"
+          bin/complexity_check --base "origin/$BASE_REF" $ALLOW_BUDGET_CHANGE
 
   # Production runs PostgreSQL while dev/test run SQLite, so db/schema.rb is
   # dumped from SQLite and can silently pick up SQLite-only constructs (e.g.

--- a/bin/complexity_check
+++ b/bin/complexity_check
@@ -1,8 +1,11 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-# Entity-level complexity ratchet. See lib/complexity_ratchet.rb for why this
-# exists and docs/complexity_budget.md for how to work with it.
+# Entity-level complexity ratchet, over Ruby (RuboCop's Metrics department) and
+# the core engine's JavaScript (ESLint's size and complexity rules). See
+# lib/complexity_ratchet.rb for why this exists, lib/complexity_ratchet/
+# javascript.rb for the JavaScript half, and docs/complexity_budget.md for how
+# to work with it.
 #
 #   bin/complexity_check                  # gate: fail on growth or new debt vs the merge base
 #   bin/complexity_check --base <ref>     # compare against something other than origin/main
@@ -18,6 +21,7 @@ require "optparse"
 ROOT = File.expand_path("..", __dir__)
 require File.join(ROOT, "lib", "complexity_ratchet")
 require File.join(ROOT, "lib", "complexity_ratchet", "base_tree")
+require File.join(ROOT, "lib", "complexity_ratchet", "javascript")
 
 options = { mode: :check, base: ENV.fetch("COMPLEXITY_BASE_REF", "origin/main") }
 OptionParser.new do |parser|
@@ -33,8 +37,9 @@ OptionParser.new do |parser|
   end
 end.parse!
 
-WAIVERS = File.join(ROOT, ComplexityRatchet::WAIVERS_PATH)
-CONFIG  = File.join(ROOT, ComplexityRatchet::CONFIG_PATH)
+WAIVERS   = File.join(ROOT, ComplexityRatchet::WAIVERS_PATH)
+CONFIG    = File.join(ROOT, ComplexityRatchet::CONFIG_PATH)
+JS_CONFIG = File.join(ROOT, ComplexityRatchet::Javascript::CONFIG_PATH)
 
 def abort_with(message)
   warn message
@@ -59,13 +64,26 @@ def budget_problems(base_sha, options)
   ComplexityRatchet.verify_budget(
     file_at(base_sha, ComplexityRatchet::CONFIG_PATH)&.then { |yaml| YAML.safe_load(yaml) || {} },
     YAML.safe_load_file(CONFIG) || {}
-  )
+  ) +
+    ComplexityRatchet::Javascript.verify_budget(
+      file_at(base_sha, ComplexityRatchet::Javascript::CONFIG_PATH)&.then { |yaml| YAML.safe_load(yaml) || {} },
+      YAML.safe_load_file(JS_CONFIG) || {}
+    )
 end
 
-actual = ComplexityRatchet::Measurement.call(root: ROOT)
+# Ruby and JavaScript entities share one hash, one waiver list and one
+# comparison: the key carries the path and the rule, so the two cannot collide,
+# and everything downstream of here is language-agnostic.
+def measure(root:, env: {})
+  ComplexityRatchet::Measurement.call(root: root, env: env)
+    .merge(ComplexityRatchet::Javascript::Measurement.call(root: root, tool_root: ROOT))
+end
+
+actual = measure(root: ROOT)
 
 if options[:mode] == :report
-  puts "#{actual.size} entities over the budget in #{ComplexityRatchet::CONFIG_PATH}:"
+  puts "#{actual.size} entities over the budgets in #{ComplexityRatchet::CONFIG_PATH} " \
+       "and #{ComplexityRatchet::Javascript::CONFIG_PATH}:"
   actual.sort.each { |key, value| puts "  #{value}\t#{key}" }
   exit 0
 end
@@ -74,9 +92,7 @@ base_measurement = nil
 base_sha = nil
 ComplexityRatchet::BaseTree.at_merge_base(root: ROOT, ref: options[:base]) do |tree, sha|
   base_sha = sha
-  base_measurement = ComplexityRatchet::Measurement.call(
-    root: tree, env: { "BUNDLE_GEMFILE" => File.join(ROOT, "Gemfile") }
-  )
+  base_measurement = measure(root: tree, env: { "BUNDLE_GEMFILE" => File.join(ROOT, "Gemfile") })
 end
 
 if base_measurement.nil?

--- a/bin/js_complexity.mjs
+++ b/bin/js_complexity.mjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+// JavaScript measurement for the complexity ratchet. Prints
+// {"path | rule | entity": value} as JSON on stdout; bin/complexity_check
+// merges it with the Ruby measurement and does the comparing.
+//
+//   node bin/js_complexity.mjs --root . --config .eslint_metrics.yml
+//
+// --root is the tree to measure, which for the base side of the ratchet is a
+// detached worktree with no node_modules of its own. Nothing is resolved out of
+// it: the rules come from --config and ESLint comes from this script's own
+// node_modules, so both sides are measured with this branch's budget.
+import path from "node:path";
+
+import { loadBudget, measure } from "../lib/js_complexity/measure.js";
+
+function parseArgv(argv) {
+  const options = { root: process.cwd(), config: ".eslint_metrics.yml" };
+  for (let i = 0; i < argv.length; i += 1) {
+    const flag = argv[i];
+    if (flag === "--root" || flag === "--config") {
+      const value = argv[i + 1];
+      if (value === undefined) throw new Error(`${flag} needs a value`);
+      options[flag.slice(2)] = value;
+      i += 1;
+    } else if (flag === "-h" || flag === "--help") {
+      options.help = true;
+    } else {
+      throw new Error(`unknown option ${flag}`);
+    }
+  }
+  return options;
+}
+
+const options = parseArgv(process.argv.slice(2));
+
+if (options.help) {
+  console.log("Usage: node bin/js_complexity.mjs [--root DIR] [--config FILE]");
+  process.exit(0);
+}
+
+const budget = loadBudget(path.resolve(options.config));
+const measured = await measure({ root: path.resolve(options.root), budget });
+
+process.stdout.write(`${JSON.stringify(measured, null, 2)}\n`);

--- a/config/application.rb
+++ b/config/application.rb
@@ -60,8 +60,11 @@ module Collavre
     # Common ones are `templates`, `generators`, or `middleware`, for example.
     # complexity_ratchet.rb and its directory back bin/complexity_check, a
     # CI-only lint tool. They have no business being eager loaded into a booted
-    # app, and bin/ runs them outside Rails anyway.
-    config.autoload_lib(ignore: %w[assets tasks middleware omniauth complexity_ratchet complexity_ratchet.rb])
+    # app, and bin/ runs them outside Rails anyway. js_complexity is the same
+    # tool's JavaScript half and holds no Ruby at all.
+    config.autoload_lib(
+      ignore: %w[assets tasks middleware omniauth complexity_ratchet complexity_ratchet.rb js_complexity]
+    )
 
     config.app_version = Collavre::VERSION
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,8 +25,8 @@ thin agent entry point that indexes into this directory.
 - [rails8_patterns.md](rails8_patterns.md) — Rails 8 idioms used across the
   codebase (auth, Current, encryption, Hotwire, Solid Queue, Propshaft).
 - [complexity_budget.md](complexity_budget.md) — the three CI gates that keep
-  the codebase from diverging as it grows (complexity ratchet, engine boundary,
-  coverage patch gate) and how to work with them.
+  the codebase from diverging as it grows (Ruby + JavaScript complexity ratchet,
+  engine boundary, coverage patch gate) and how to work with them.
 - [testing.md](testing.md) — automated-test conventions.
 - [test.md](test.md) — manual QA of the live site (test accounts, credentials).
 

--- a/docs/complexity_budget.md
+++ b/docs/complexity_budget.md
@@ -1,12 +1,12 @@
 # Complexity budget
 
 Three CI gates keep the codebase from diverging as it grows. They are cheap on
-purpose — together they add roughly six seconds of CI time — because a gate that
-slows everyone down gets removed.
+purpose — the ratchet measures two languages twice each in about ten seconds —
+because a gate that slows everyone down gets removed.
 
 | Gate | What it stops | Where |
 |------|---------------|-------|
-| Complexity ratchet | Any class, module, method or block growing past the size it has at the merge base | `complexity` job, `bin/complexity_check` |
+| Complexity ratchet | Any class, module, function, method or block — Ruby or JavaScript — growing past the size it has at the merge base | `complexity` job, `bin/complexity_check` |
 | Engine boundary | The core engine taking a dependency on a satellite engine | `EngineBoundaryTest`, runs with `rake test` |
 | Coverage patch gate | Ruby diffs landing under 80% covered | Codecov, `codecov.yml` |
 
@@ -23,6 +23,17 @@ Measured on 2026-08-11, before any of this existed:
 - Not one CI gate constrained any of it: RuboCop runs omakase, which disables
   every `Metrics` cop, and Codecov was informational.
 
+The Ruby ratchet landed first and left half the engine unmeasured. Measured on
+2026-09-10:
+
+- The core engine ships **35,978 lines of non-test JavaScript** across 168
+  files, against 40,153 lines of core Ruby — and the two largest source files in
+  the engine are both JavaScript.
+- There was **no ESLint in the repository at all**: no config file, no lint job,
+  no devDependency. Nothing measured any of it, and "no explicit configuration"
+  is not the same as "no rules" only when there is a default to fall back on.
+  There was none.
+
 The divergence is *inside* the core, not across engine boundaries — the
 `collavre` → `collavre_*` rule is clean in application code, with one recorded
 exception in a migration. So the ratchet is the primary gate and the boundary
@@ -37,11 +48,16 @@ bin/complexity_check --report     # just list what is over budget right now
 ```
 
 There is nothing to commit and nothing to keep in sync. `bin/complexity_check`
-checks out the merge base into a throwaway `git worktree`, runs RuboCop's
-`Metrics` department over both trees, and compares them entity by entity. One
-file drives it: **`.rubocop_metrics.yml`**, the budget that decides which
-entities are worth measuring. It is not used by `bin/rubocop`; the omakase house
-style stays as it is.
+checks out the merge base into a throwaway `git worktree`, measures both trees,
+and compares them entity by entity. Two files drive it:
+
+- **`.rubocop_metrics.yml`** — RuboCop's `Metrics` department over Ruby app code.
+  It is not used by `bin/rubocop`; the omakase house style stays as it is.
+- **`.eslint_metrics.yml`** — ESLint's size and complexity rules over the core
+  engine's JavaScript. See [The JavaScript half](#the-javascript-half).
+
+Both languages land in one hash of `path | rule | entity` keys, so the waiver
+format, the comparison and the reporting below are the same code for both.
 
 The rules:
 
@@ -50,7 +66,8 @@ The rules:
    New code gets no amnesty from old debt.
 3. The budget cannot be loosened. Exactly two edits to `.rubocop_metrics.yml`
    pass — lowering a `Max`, and shrinking `AllCops/Exclude` — and every other
-   change to it is reported.
+   change to it is reported. `.eslint_metrics.yml` allows three: lowering a
+   threshold, widening `include`, and shrinking `exclude`.
 4. The only escape hatch is a waiver in `.complexity_waivers.yml`, which needs a
    non-blank owner, a non-blank reason, and an expiry no more than 90 days out.
    An expired or blank-field waiver fails CI.
@@ -95,6 +112,42 @@ back to its earlier size without tripping. Requiring branches to be current with
 `main` before merge closes it, and the squash-merge workflow already rebases.
 That is a much smaller hole than a gate the team switches off in week two
 because it reddens unrelated PRs.
+
+### Which base the CI job passes
+
+The `complexity` job passes the base **branch**, not `github.event.pull_request.base.sha`.
+
+The two are not the same thing, and the difference is not academic. `base.sha`
+is the base tip as of the last `opened`/`synchronize` event on the PR: it is a
+snapshot of the base at the moment *this* branch last pushed, and it does not
+move when the base branch does. `actions/checkout` on a pull request checks out
+`refs/pull/N/merge`, which GitHub *does* recompute whenever the base moves.
+Measuring the second against the first blames this PR for every sibling PR that
+landed in between.
+
+That is not a hypothetical either. On the branch that introduced this file, the
+job reported eight offenses in `creative_row_editor.js`, `popup_fullscreen.js`
+and `creative_save_state.js` — three files it had never touched — because two
+sibling PRs had merged into the integration branch since its last push. It
+happened twice, and on an integration branch collecting eight parallel PRs it
+would have happened on nearly every run.
+
+Passing `origin/$BASE_REF` makes the baseline `merge-base(HEAD, base tip)`.
+Since the checkout has the base tip as an ancestor, that *is* the base tip, so
+what gets measured is exactly what this branch adds to the base as it stands
+right now. The branch no longer has to keep merging the base in to stay green.
+
+To reproduce a CI result locally, build the same tree the job sees:
+
+```sh
+git fetch origin "refs/pull/$PR/merge:refs/ci-merge" && git checkout refs/ci-merge
+bin/complexity_check --base origin/<base branch>
+```
+
+Note that `--base` is resolved through `git merge-base`, so running it on a
+branch that has *not* merged the base in compares against the fork point and
+reports base-side entities as new. That is the local mirror of the same
+mismatch, and checking out the merge ref is what removes it.
 
 ### Rule 3: why the budget still needs its own check
 
@@ -184,6 +237,347 @@ callers, holds no shared mutable state, and splitting it buys nothing. Test bloa
 is real, but it is a coverage-quality problem, not a coupling one, and mixing it
 in would bury the app-code signal under thousands of block-length offenses.
 
+## The JavaScript half
+
+`.eslint_metrics.yml` is the budget; `bin/js_complexity.mjs` and
+`lib/js_complexity/` are the measurement. It prints the same
+`{"path | rule | entity": value}` shape the Ruby measurement produces, and
+`bin/complexity_check` merges the two before comparing, so everything above —
+the merge base, the waivers, rules 1 to 4 — applies unchanged.
+
+### The budget
+
+Unlike the Ruby side, where RuboCop's defaults put ~90% of entities in violation
+and the budget had to be set at the 75th percentile of the violators, ESLint's
+documented defaults were already within reach. Measured over the 168 files the
+budget selects, on 2026-09-10:
+
+| Rule | Budget | Entities | Over budget | Ruby counterpart |
+|------|--------|----------|-------------|------------------|
+| `complexity` | 13 | 3,189 | 88 (2.8%) | `Metrics/CyclomaticComplexity` |
+| `max-depth` | 3 | 3,405 | 19 (0.6%) | `Metrics/BlockNesting` |
+| `max-lines` | 300 | 168 | 23 (13.7%) | `Metrics/ClassLength` |
+| `max-lines-per-function` | 50 | 3,142 | 78 (2.5%) | `Metrics/MethodLength` |
+| `max-nested-callbacks` | 10 | 999 | 0 (0.0%) | — |
+| `max-params` | 4 | 1,933 | 9 (0.5%) | `Metrics/ParameterLists` |
+
+217 entities are over it, against 388 on the Ruby side. They are grandfathered:
+they may shrink but not grow. The budget is what *new* code has to fit, and
+ordinary Stimulus controllers and modules already fit it.
+
+`max-nested-callbacks` sits at ESLint's default because nothing violates it —
+the same reasoning that keeps `Metrics/BlockNesting` at RuboCop's default.
+`max-lines` and `max-lines-per-function` skip blank lines and comments, because
+RuboCop's counters do; otherwise the same file measures differently on the two
+sides and a comment block reads as growth.
+
+### The budget file holds only numbers
+
+`.eslint_metrics.yml` has three keys — `include`, `exclude` and `rules` — and
+`rules` maps a rule name to an integer. Rule options that are not thresholds
+(`skipBlankLines`, `IIFEs`) live in `lib/js_complexity/measure.js`, and there is
+no per-file override syntax at all.
+
+That is the difference between this budget and a real `eslint.config.js`, and it
+is the point. Rule 3 on the Ruby side needs a long allowlist because a `Metrics`
+cop can be silenced through `Exclude`, `Include`, `AllowedMethods`,
+`AllowedPatterns` or `CountAsOne` while its `Max` still reads as strict. Here
+there is nothing to silence a rule *with*: three keys, and all three are
+compared. Inline `eslint-disable` comments are refused as well
+(`noInlineConfig`), so a directive cannot switch the gate off from inside a
+source file either.
+
+### Why ESLint's `Linter` and not the `ESLint` class
+
+The base side of the ratchet is a detached worktree of the merge base. It has no
+`node_modules` and no ESLint config of its own, and it must not have one:
+measuring each side with its own budget is what makes a PR that *tightens* a
+threshold report every pre-existing entity as brand-new debt. `Linter#verify`
+takes the config as a value and resolves nothing from the tree it is reading, so
+this branch's ESLint and this branch's budget are applied to both sides. The
+`ESLint` class would search the measured tree for a config file.
+
+### Entity keys in JavaScript
+
+Same problem as the Ruby side, same shape of answer, different parser. Names are
+built from an ESTree walk (`lib/js_complexity/entity_map.js`):
+
+```
+engines/collavre/app/javascript/controllers/comments/topics_controller.js | max-lines | (file)
+engines/collavre/app/javascript/modules/creative_row_editor.js | max-lines-per-function | setupEditorSession
+engines/collavre/app/javascript/components/InlineLexicalEditor.jsx | max-lines-per-function | Toolbar>clearFormatting[useCallback]
+engines/collavre/app/javascript/controllers/comments/form_controller.js | complexity | default#handleSend>[doFetch().then().then]
+```
+
+- A class member reads `Editor#save`, a static `Editor.create`, and a getter
+  `Editor#get draft` — without the kind, a `get`/`set` pair would collide into an
+  ordinal pair that reads as two unrelated members.
+- An anonymous function takes the name it is bound to (`const submit = …` →
+  `submit`), or, if it is bound to nothing, the *whole callee* of the call it is
+  passed to (`[this.element.addEventListener]`, `[rows.map]`). This is what the
+  Ruby side does for blocks, with the receiver kept: `[map]` on its own turns
+  every `.map` in a method into a twin of every other, and twins are the only
+  case where identity has to fall back on something other than a name.
+- A callee keeps its chain, rendered as `foo()`: the two callbacks in
+  `load().then(a).then(b)` are `[load().then]` and `[load().then().then]`, so
+  appending a third link leaves both of them where they were.
+- A callback whose call is itself bound to something takes that binding too:
+  `const handleFiles = useCallback(…)` is `handleFiles[useCallback]`. Every
+  callback in a React component is `useCallback`, so without this a component
+  with eleven of them has eleven twins, and adding a twelfth moves all eleven
+  keys.
+- `export default class extends Controller` — every Stimulus controller in the
+  engine — is named `default`. "(anonymous class)" would be accurate and
+  useless.
+- Entities in one scope that still share a name after all of that are **twins**,
+  and each is anchored to a digest of its own source: `[rows.map]#2842ca41`.
+  See [Twins](#twins) below.
+- `max-lines` belongs to `(file)`: it reports on the first line past the limit,
+  which belongs to no entity in particular.
+- `max-depth` reports on a statement, so it falls back to the enclosing scope
+  plus the normalised source line with a leading `~` — the same fallback the
+  Ruby side uses for `Metrics/BlockNesting`.
+
+Lookup is by containment rather than by start position, because ESLint does not
+report an offense at the node it is about: `getFunctionHeadLoc` puts a method
+offense on the method name and an arrow offense on the `=>` token. All of them
+are *inside* the entity, so the innermost scope containing the offense is the
+right answer in every case.
+
+### Twins
+
+Two entities in one scope can end up with the same name however good the naming
+is: two `items.map(…)` callbacks in one method, two identical `if` lines. The
+obvious fix is a **position** — first one bare, second one `(2)`, or `(1/2)` and
+`(2/2)` to make the group's size part of it. Every version of that idea is
+wrong for the same reason: it makes a *slot* the identity, and the entity in
+slot 2 after an edit need not be the entity that was in slot 2 before it.
+
+Both ways of reaching that were found by Codex review on PR #1651. Deleting a
+twin:
+
+```js
+// before                               // after
+connect() {                             connect() {
+  items.map((row) => { …60 lines… })      items.map((row) => { …58 lines… })
+  items.map((row) => { …55 lines… })    }
+}
+```
+
+Under a bare ordinal the survivor is renamed from `>[items.map](2)` to
+`>[items.map]`, the key the *deleted* callback held at 60, so its growth from 55
+to 58 is measured against 60 and the gate says nothing. Carrying the group's
+size fixes that one — and leaves reordering, which is the same bug wearing a
+different hat:
+
+```js
+// before: (1/2) = 12, (2/2) = 6       // after: (1/2) = 9, (2/2) = 5
+```
+
+Slot 1 reads `9 <= 12` and slot 2 reads `5 <= 6`, so nothing is reported, and
+yet the 6-line callback has grown to 9. Concealing growth this way costs an
+equal shrink somewhere else in the group, which is a low price for a silent
+bypass — and a silent bypass is the one failure mode this whole design exists to
+avoid.
+
+So the first move is to **have fewer twins**. Keeping the whole callee, keeping
+the call chain, and borrowing the binding a call sits in (see the naming rules
+above) between them name all but a handful: of the engine's 214 over-budget
+entities, thirteen needed a position before those rules and four after — the
+worst being an eleven-way `useCallback` group in one component.
+
+What is left is anchored to an **FNV digest of its own source**, normalised so
+that reindenting does not move a key but editing does:
+
+```
+Row#connect>[items.map]#2842ca41
+Row#connect>[items.map]#5655f759
+```
+
+A twin's key now depends on the twin and on nothing around it. Siblings can be
+added, deleted or reordered without touching it, and an edit that changes its
+measurement changes its key, so growth surfaces as new debt instead of slipping
+into a neighbour's baseline. The statement fallback (`~if (a) {`) is anchored
+the same way, over the statement's whole span rather than its first line.
+
+Only **byte-identical** twins still take an ordinal — `#2842ca41(1/2)` — and
+those measure identically, so any permutation of them is a no-op. One entity in
+the engine is in that position; the other three are distinct and now keyed
+apart.
+
+"Byte-identical" has to be meant literally, and two rounds of review on #1651
+found it was not. Both holes ended the same way — two entities that measure
+differently sharing an anchor, falling back on an ordinal, and landing back on
+slot identity:
+
+- **The digest was the grouping key.** One 32-bit FNV word collides often enough
+  that a brute-force search turns up a pair of ordinary-looking callbacks in
+  seconds; `(row) => { total += 91098 }` and `(row) => { total += 802942 }` are
+  one such pair. Twins are grouped by their **source text** now, and the digest
+  widens a word at a time until distinct bodies have distinct anchors. The first
+  width is a plain FNV-1a, so a group that does not actually collide keeps
+  exactly the key it always had.
+- **Normalisation collapsed newlines.** `max-lines-per-function` counts lines,
+  so two callbacks differing only in where a template literal's text wraps
+  measured 5 and 4 while normalising to the same string. Normalisation now
+  collapses only what the rules cannot see: runs of horizontal whitespace, any
+  horizontal whitespace around a line break, and runs of line breaks (the rules
+  run with `skipBlankLines`). Every line break that separates content survives.
+- **"Line break" meant `\n`.** ESLint splits lines on `\r\n`, `\r`, U+2028 and
+  U+2029 as well, so those count too — and U+2028 fell in the "horizontal"
+  bucket, collapsing two callbacks that measured 5 and 4 onto one anchor. The
+  set now matches ESLint's. `\v` and `\f` are not in it and stay horizontal.
+
+Two more, in what the digest covers rather than in how it normalises. **Two of
+these rules do not measure what the entity says.** Every other one — `complexity`,
+`max-params`, `max-lines-per-function` — is a function of the entity's own text,
+so a digest of that text determines it. These two are not, and each of them
+produced a pair of byte-identical same-named twins that shared an anchor while
+measuring differently:
+
+| Rule | What it actually measures | Carried in the anchor by |
+|---|---|---|
+| `max-depth` | where a statement *sits* | `depthsOf` |
+| `max-nested-callbacks` | how deep a function is in callbacks | `callbackDepthsOf` |
+
+Taking `max-depth` first: **it is not a property of the entity's own text.** Two
+byte-identical `if (a) { y() }` statements in one function sit at different
+depths when one of them is inside another guard, so they measure differently —
+and being byte-identical, they shared an anchor and fell back on the ordinal.
+The justification for the ordinal did not hold for statements. A statement's
+identity carries its nesting depth now:
+
+```js
+function handle(p, q, a) {
+  if (p) { if (p) { if (a) { y() } } }   // ~if (a) { y() } at depth 3
+  if (q) { if (a) { y() } }              // ~if (a) { y() } at depth 2
+}
+```
+
+Those are two keys, not two slots.
+
+The depth in the key is **ESLint's own**, mirrored from the rule. A first
+attempt merely counted enclosing nesting statements, on the argument that the
+number only had to *change* when ESLint's changed and that over-counting keeps
+entities apart. That was the fifth variant of the same bug. A key has to
+*determine* its measurement, and a count that is merely correlated with
+ESLint's does not: both `if (a) { y() }` below sit under three enclosing
+statements, yet measure 3 and 2, because ESLint does not count an `if` whose
+parent is an `if`.
+
+```js
+function handle(p, q, a) {
+  if (p) { if (p) { if (a) { y() } } }              // enclosing 3, measures 3
+  if (q) { x() } else if (q) { if (a) { y() } }     // enclosing 3, measures 2
+}
+```
+
+Byte-identical and equal-count, they shared an anchor and took an ordinal — and
+each was then compared against the other's baseline. On the engine as it stands,
+4 of the 19 real `max-depth` offenses had a key whose depth disagreed with the
+number ESLint printed.
+
+Mirroring means mirroring the rule's arithmetic rather than a tidied-up version
+of it, including one upstream quirk: every nesting statement decrements the
+counter on exit, but an `if` under an `if` never incremented it, so an
+`if`/`else if`/`else if` chain leaves the counter two *below* where it started
+and everything after it measures too shallow. Reproducing that is the point —
+the key has to match the number ESLint actually reported, not the one it should
+have. `depthsOf` is a single pass written to read like the rule, so an ESLint
+upgrade that fixes the quirk is a diff against one function.
+
+`max-nested-callbacks` is the same shape, and it is the one I argued could not
+have the problem: twins sit in one scope by construction, so surely they nest
+identically. They do not. The rule pops on **every** function exit but pushes
+only for a function whose parent is a call, so a function expression that is
+not a callback pops a level it never added, and everything after it in the
+scope counts one lower:
+
+```js
+a(function () {
+  items.map((row) => { total += row.n })   // 2
+  const helper = function () { return 1 }  // pops without having pushed
+  items.map((row) => { total += row.n })   // 1 — same name, same source
+})
+```
+
+Byte-identical and same-named, those two shared an anchor and took an ordinal.
+`callbackDepthsOf` mirrors the rule and the height goes into the digest.
+`FunctionDeclaration` is deliberately absent from it — the rule does not handle
+that type at all, so it neither pushes nor pops, and anchoring on something the
+measurement cannot see would separate twins for no reason.
+
+If distinct bodies still collide after all three digest widths, measurement
+raises an error and blocks the gate. It never falls back to positional keys
+for different bodies; identical bodies with identical rule context may still
+use ordinals.
+
+ESLint also measures implicit code paths: each class field initializer and
+each static block has its own complexity. These have separate entities, such
+as `Editor#draft(initializer)` and `Editor.(static block)`, with the same twin
+disambiguation as functions. A function created by a field initializer remains
+a separate nested entity. Computed field keys stay outside the initializer's
+scope. Complexity messages select the code-path kind explicitly because an
+initializer and the function it creates may start at the same position.
+
+The general statement, which is what the next rule added to the budget should be
+checked against: **a key must determine its measurement.** For each rule, either
+the value is a function of the entity's own text, or whatever else it depends on
+belongs in the anchor.
+
+Comments are the one thing left that moves a digest without moving a measurement
+— `skipComments` is on — so editing a comment inside an over-budget twin re-keys
+it. That is the loud direction, and telling comments from their look-alikes
+inside strings needs the token stream, which is a lot of machinery for a twin.
+
+The costs, both of which are the gate being loud about something it cannot
+attribute rather than quiet about something it can:
+
+- An over-budget twin that shrinks *without getting under budget* has a new
+  body, so it has a new key and reads as new debt.
+- The digest is only spelled out when a name is shared, so going from one such
+  entity to two — or back — renames it.
+
+Both are recoverable three ways: give the callback a name (`const renderRow =
+(row) => …`, which ends the tie for good and is usually the right change
+anyway), get it under budget, or write a dated waiver. The reverse trade is not
+recoverable, because nobody finds out.
+
+The Ruby half still uses a plain ordinal and still has the hole, with the
+smaller blast radius its own section describes. Changing it would move every
+Ruby entity key at once, which is not this change's business.
+
+### Scope
+
+`engines/collavre/**/*.{js,jsx}`, minus `__tests__` and `engines/collavre/test`.
+The core engine and nothing else: this gate is being introduced *for* the core
+engine, and `lib/js_complexity` — the measurement itself — is deliberately not
+in `include`, so a change to the tool cannot read as engine debt. Adding it is a
+one-line change whenever someone wants it, and the tool's own tests live in
+`lib/js_complexity/__tests__` either way. Tests are excluded for the reason they
+are excluded on the Ruby side, spelled out under
+[Entity keys](#entity-keys). The satellite engines hold about 2,800 lines of
+JavaScript between them against the core's 35,000 and are not measured; adding
+them is a two-line change to `include`, which the budget check allows in that
+direction.
+
+### What this change touches outside the engine
+
+The guard's *target* is `engines/collavre`. Nothing under `engines/` is modified
+by this change — the gate is new, and the 217 entities already over budget are
+grandfathered. What it does add lives outside the engine, because that is where
+a repository-wide gate has to live:
+
+| Path | Why it has to change |
+|------|----------------------|
+| `.eslint_metrics.yml` | The budget. New file. |
+| `lib/js_complexity/`, `bin/js_complexity.mjs` | The measurement. New files. |
+| `lib/complexity_ratchet/javascript.rb` | Runs the measurement and checks the budget can only tighten. New file. |
+| `bin/complexity_check` | Merges the JavaScript measurement into the existing Ruby one; the comparison, the waivers and the reporting are shared rather than duplicated. |
+| `.github/workflows/ci.yml` | The existing `complexity` job needs Node and `npm ci` to run the measurement. |
+| `package.json`, `jest.config.cjs` | ESLint as a devDependency, and the measurement's unit tests in the existing Jest run. |
+| `config/application.rb`, `docs/` | Keeps the CI-only tool out of the autoload path, and documents the above. |
+
 ## The engine boundary
 
 `EngineBoundaryTest` fails when a core engine Ruby file names a satellite
@@ -255,8 +649,8 @@ instead: expose a hook from `collavre` and let the satellite register itself.
 
 ## What this does not do
 
-The ratchet stops *growth*. It does not shrink the 430 entities already over
-budget, and it can be routed around by adding a hundred small files instead of
+The ratchet stops *growth*. It does not shrink the 608 entities already over
+budget (394 Ruby, 214 JavaScript), and it can be routed around by adding a hundred small files instead of
 one big one. Neither is a gap a PR gate can close.
 
 For that, use the churn×complexity data — files that are both large and
@@ -269,6 +663,16 @@ blocking gate cannot make anyone delete code.
 - **A committed baseline snapshot.** Tried first, and it is what the "Why the
   merge base" section above is about. It goes stale the moment `main` moves and
   its only escape hatch launders regressions.
+- **`max-statements`.** A genuine rule, and 384 entities exceed ESLint's default
+  of 10 — but it measures nearly the same thing as `max-lines-per-function`, and
+  adding it would have nearly tripled the over-budget list for a signal already
+  covered. The gate is cheap because it is small.
+- **A standalone ESLint lint job.** ESLint is in this repository for exactly one
+  reason: it is the only thing here that can parse modern JS and JSX well enough
+  to measure it. Turning on its correctness or style rules is a separate
+  decision with a separate cost — ~35,000 lines of unlinted JavaScript would
+  produce thousands of offenses on day one — and bundling it into a complexity
+  gate is how a gate gets switched off in week two.
 - **A test-to-app LOC ratio floor.** The core already has a healthy 1.51 ratio
   *and* the god objects. Test LOC is trivially gamed with fixture style, mocks,
   and duplicated setup — it is a lagging indicator dressed as a leading one.

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -125,7 +125,7 @@ engines/collavre_openclaw/config/locales/
 ```bash
 # Required before every PR
 ./bin/rubocop -a          # Auto-fix style issues
-bin/complexity_check      # Complexity ratchet (~2s)
+bin/complexity_check      # Complexity ratchet, Ruby + JavaScript (~8s, needs `npm ci`)
 bin/rails test            # Unit/integration tests
 bin/rails test:system     # System tests
 ```
@@ -135,11 +135,12 @@ conventions.
 
 ### Complexity Ratchet
 
-No class, module, method, or block may grow past the size it has at the merge
-base, and anything new must fit the budget in `.rubocop_metrics.yml`. CI measures
-both sides in one run, so there is no file to keep in sync and a refactor that
-shrinks something needs no bookkeeping. The budget itself may only tighten. Run
-`bin/complexity_check` locally to see what a PR would report. See
+No class, module, function, method, or block may grow past the size it has at
+the merge base, and anything new must fit the budget — `.rubocop_metrics.yml`
+for Ruby app code, `.eslint_metrics.yml` for the core engine's JavaScript. CI
+measures both sides in one run, so there is no file to keep in sync and a
+refactor that shrinks something needs no bookkeeping. Both budgets may only
+tighten. Run `bin/complexity_check` locally to see what a PR would report. See
 [complexity_budget.md](complexity_budget.md).
 
 ## PR Merge Principles (CTO Perspective)

--- a/engines/collavre/app/controllers/collavre/creatives_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creatives_controller.rb
@@ -455,87 +455,17 @@ module Collavre
 
     def trigger_action
       action = params[:action_name] || (request.content_type&.include?("json") ? request.request_parameters["action"] : params[:action])
+      enabled = request.content_type&.include?("json") ? request.request_parameters["enabled"] : params[:enabled]
+      result = Creatives::TriggerActionCommand.new(
+        creative: @creative,
+        user: Current.user,
+        action: action,
+        enabled: enabled
+      ).call
 
-      case action
-      when "toggle_container"
-        # Container toggle operates on effective_origin (where trigger config lives)
-        creative = @creative.effective_origin(Set.new)
-        unless creative.has_permission?(Current.user, :write)
-          render json: { error: t("collavre.creatives.errors.no_permission") }, status: :forbidden
-          return
-        end
+      return head :ok if result.success?
 
-        enabled = ActiveModel::Type::Boolean.new.cast(
-          request.content_type&.include?("json") ? request.request_parameters["enabled"] : params[:enabled]
-        )
-        data = creative.data || {}
-        trigger = data["trigger"] || {}
-        trigger["on_child_enter"] = enabled
-        data["trigger"] = trigger
-        previous_enabled = creative.drop_trigger_enabled?
-        creative.update!(data: data)
-        notify_drop_trigger_missing_agent!(creative) if !previous_enabled && creative.drop_trigger_enabled?
-      when "start"
-        # Start trigger: fires DropTriggerJob as if the child was just dropped into the container
-        creative = @creative
-        unless creative.has_permission?(Current.user, :write)
-          render json: { error: t("collavre.creatives.errors.no_permission") }, status: :forbidden
-          return
-        end
-
-        parent = creative.parent
-        unless parent&.drop_trigger_enabled?
-          render json: { error: t("collavre.drop_trigger.not_a_container") }, status: :unprocessable_entity
-          return
-        end
-
-        DropTriggerJob.perform_later(parent.id, creative.id)
-
-      when "pause", "resume", "restart"
-        # Loop actions operate on the creative itself (where loop state lives)
-        creative = @creative
-        unless creative.has_permission?(Current.user, :write)
-          render json: { error: t("collavre.creatives.errors.no_permission") }, status: :forbidden
-          return
-        end
-
-        data = creative.data || {}
-        trigger = data["trigger"] || {}
-        loop_data = trigger["loop"]
-
-        case action
-        when "pause"
-          if loop_data && %w[running pending_verification].include?(loop_data["state"])
-            loop_data["state"] = "paused"
-            trigger["loop"] = loop_data
-            data["trigger"] = trigger
-            creative.update!(data: data)
-          end
-        when "resume"
-          if loop_data && %w[paused idle stuck awaiting_user].include?(loop_data["state"])
-            loop_data["state"] = "running"
-            trigger["loop"] = loop_data
-            data["trigger"] = trigger
-            creative.update!(data: data)
-            post_continue_to_agent(creative, loop_data)
-          end
-        when "restart"
-          if loop_data && %w[completed max_reached stuck].include?(loop_data["state"])
-            loop_data["state"] = "running"
-            loop_data["current_iteration"] = 0
-            loop_data["infra_retry_count"] = 0
-            trigger["loop"] = loop_data
-            data["trigger"] = trigger
-            creative.update!(data: data)
-            post_restart_trigger(creative)
-          end
-        end
-      else
-        render json: { error: "Unknown action" }, status: :unprocessable_entity
-        return
-      end
-
-      head :ok
+      render json: { error: result.error }, status: result.status
     end
 
     def archive
@@ -726,93 +656,8 @@ module Collavre
         @reorderer ||= ::Creatives::Reorderer.new(user: Current.user)
       end
 
-      # Resume: post a continue instruction so the agent picks up where it left off.
-      # Creates a comment that triggers dispatch via after_create_commit.
-      def post_continue_to_agent(creative, loop_data)
-        parent = creative.parent
-        unless parent
-          Rails.logger.warn("[TriggerAction] resume: no parent for creative #{creative.id}")
-          return
-        end
-
-        topic = creative.topics.find_by(name: "Drop Trigger")
-        agent = parent.find_ai_agent(:write)
-        unless topic && agent
-          Rails.logger.warn("[TriggerAction] resume: missing topic=#{topic&.id} or agent for creative #{creative.id}")
-          return
-        end
-
-        iteration = loop_data["current_iteration"] || 0
-        max = loop_data["max_iterations"] || 10
-        content = "@#{agent.name}: #{t(
-          'collavre.trigger_loop.continue',
-          iteration: iteration,
-          max: max
-        )}"
-
-        # Use Current.user (human who clicked resume) as comment author
-        # so dispatch_to_orchestration doesn't skip it (it skips ai_user? authors)
-        comment = creative.comments.create!(
-          content: content,
-          topic_id: topic.id,
-          private: false,
-          user: Current.user,
-          skip_dispatch: false
-        )
-        Rails.logger.info("[TriggerAction] resume: posted continue comment #{comment.id} for creative #{creative.id}")
-      end
-
-      # Restart: create a fresh trigger comment and dispatch it explicitly.
-      # Uses skip_dispatch:true + manual SystemEvents dispatch to bypass
-      # after_create_commit (which would skip if user is ai_user?).
-      def post_restart_trigger(creative)
-        parent = creative.parent
-        unless parent
-          Rails.logger.warn("[TriggerAction] restart: no parent for creative #{creative.id}")
-          return
-        end
-
-        topic = creative.topics.find_by(name: "Drop Trigger")
-        agent = parent.find_ai_agent(:write)
-        unless topic && agent
-          Rails.logger.warn("[TriggerAction] restart: missing topic=#{topic&.id} or agent for creative #{creative.id}")
-          return
-        end
-
-        trigger_text = t(
-          "collavre.drop_trigger.child_entered",
-          child_description: creative.creative_snippet,
-          child_id: creative.id,
-          parent_description: parent.creative_snippet
-        )
-        loop_instructions = t("collavre.trigger_loop.instructions")
-        content = "@#{agent.name}: #{trigger_text}\n\n#{loop_instructions}"
-
-        comment = creative.comments.create!(
-          content: content,
-          topic_id: topic.id,
-          private: false,
-          user: Current.user,
-          skip_dispatch: true
-        )
-
-        scheduled = SystemEvents::Dispatcher.dispatch("comment_created", comment.dispatch_payload, source: "trigger_restart")
-        Rails.logger.info("[TriggerAction] restart: posted trigger comment #{comment.id}, dispatched to #{scheduled&.size || 0} agents")
-      end
-
       def notify_drop_trigger_missing_agent!(creative)
-        return if creative.find_ai_agent(:write)
-
-        topic = creative.topics.find_or_create_by!(name: "Drop Trigger") do |t|
-          t.user = creative.user
-        end
-
-        creative.comments.create!(
-          content: t("collavre.drop_trigger.no_agent", parent_description: creative.creative_snippet),
-          topic_id: topic.id,
-          private: false,
-          skip_default_user: true
-        )
+        Creatives::DropTriggerMissingAgentNotifier.new(creative: creative).call
       end
 
       def enforce_creatives_login_policy

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/comment_read_tracker.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/comment_read_tracker.test.js
@@ -1,0 +1,71 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { jest } from '@jest/globals'
+import CommentReadTracker from '../comment_read_tracker'
+
+describe('CommentReadTracker', () => {
+  let controller
+  let request
+  let tracker
+
+  beforeEach(() => {
+    jest.useFakeTimers()
+    request = jest.fn().mockResolvedValue({ ok: true })
+    controller = {
+      creativeId: '42',
+      currentTopicId: null,
+      element: document.createElement('div'),
+      popupController: { topicsController: { loadTopics: jest.fn() } },
+    }
+    document.body.appendChild(controller.element)
+    tracker = new CommentReadTracker(controller, { request })
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+    jest.useRealTimers()
+  })
+
+  test('owns the rendered All Messages snapshot lifecycle', () => {
+    tracker.captureRenderedSnapshot('1,2', '{"1":20,"2":21,"_legacy":19}')
+
+    expect(controller.renderedAllTopicIds).toEqual(['1', '2'])
+    expect(controller.renderedAllTopicWatermarks).toEqual({ 1: 20, 2: 21, _legacy: 19 })
+    expect(controller.renderedAllIncludesLegacy).toBe(true)
+
+    tracker.resetRenderedSnapshot()
+
+    expect(controller.renderedAllTopicIds).toBeNull()
+    expect(controller.renderedAllTopicWatermarks).toBeNull()
+    expect(controller.renderedAllIncludesLegacy).toBe(false)
+  })
+
+  test('keeps topic IDs while discarding a malformed watermark header', () => {
+    tracker.captureRenderedSnapshot('1,2', '{malformed')
+
+    expect(controller.renderedAllTopicIds).toEqual(['1', '2'])
+    expect(controller.renderedAllTopicWatermarks).toBeNull()
+    expect(controller.renderedAllIncludesLegacy).toBe(false)
+  })
+
+  test('flushes the captured snapshot with unload-safe request options', () => {
+    controller.renderedAllTopicIds = ['1', '2']
+    controller.renderedAllTopicWatermarks = { 1: 20, 2: 21 }
+    tracker.markCommentsRead()
+
+    tracker.flushPendingRead({ keepalive: true })
+
+    expect(request).toHaveBeenCalledWith('/comment_read_pointers/update', expect.objectContaining({
+      method: 'POST',
+      keepalive: true,
+      body: JSON.stringify({
+        creative_id: '42',
+        topic_id: null,
+        topic_ids: ['1', '2'],
+        topic_watermarks: { 1: 20, 2: 21 },
+      }),
+    }))
+  })
+})

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_draft.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_draft.test.js
@@ -253,7 +253,7 @@ describe('FormController - draft persistence', () => {
     controller.textareaTarget.value = 'still composing'
     dispatchTopicChange('77', '10074')
     expect(chatDrafts.get('77')).toBeNull()
-    expect(controller._activeDraftKey).toBe('77')
+    expect(controller._drafts._activeDraftKey).toBe('77')
   })
 
   test('switching linked creatives flushes before resetting a shared effective draft', () => {
@@ -275,7 +275,7 @@ describe('FormController - draft persistence', () => {
     popupEl.dispatchEvent(
       new CustomEvent('comments--topics:change', { detail: { topicId: '10073' } }),
     )
-    expect(controller._activeDraftKey).toBe('66')
+    expect(controller._drafts._activeDraftKey).toBe('66')
   })
 
   test('keeps the draft key empty when no creative id is available', () => {
@@ -284,7 +284,7 @@ describe('FormController - draft persistence', () => {
     popupEl.dispatchEvent(
       new CustomEvent('comments--topics:change', { detail: { topicId: '10073' } }),
     )
-    expect(controller._activeDraftKey).toBeNull()
+    expect(controller._drafts._activeDraftKey).toBeNull()
   })
 
   test('closing the popup flush-saves the draft; blank input deletes it', () => {
@@ -387,7 +387,7 @@ describe('FormController - draft persistence', () => {
     popupEl.dataset.creativeId = '88'
     dispatchTopicChange('88')
     controller.onPopupOpened({ creativeId: '88', canComment: true })
-    expect(controller._activeDraftKey).toBeNull()
+    expect(controller._drafts._activeDraftKey).toBeNull()
     typeInto(controller.textareaTarget, 'must not persist for the old user')
     controller.onPopupClosed()
     await new Promise((resolve) => setTimeout(resolve, 600))
@@ -484,14 +484,14 @@ describe('FormController - draft persistence', () => {
 
     expect(submissionBackup('77')).toBeNull()
     expect(freshController._draftPersistenceDisabled()).toBe(true)
-    expect(freshController._observedDraftClearNonces.has(namespace)).toBe(false)
+    expect(freshController._drafts._observedDraftClearNonces.has(namespace)).toBe(false)
 
     setItem.mockRestore()
     freshController.disconnect()
     freshController.connect()
 
     expect(freshController._draftPersistenceDisabled()).toBe(false)
-    expect(freshController._observedDraftClearNonces.get(namespace)).toBe('logout-2')
+    expect(freshController._drafts._observedDraftClearNonces.get(namespace)).toBe('logout-2')
     controller = freshController
   })
 
@@ -502,7 +502,7 @@ describe('FormController - draft persistence', () => {
       nonce: 'missed-logout',
     }))
     controller.disconnect()
-    controller._observedDraftClearNonces.clear()
+    controller._drafts._observedDraftClearNonces.clear()
     const storageGetter = jest.spyOn(window, 'sessionStorage', 'get').mockImplementation(() => {
       throw new DOMException('denied', 'SecurityError')
     })
@@ -521,7 +521,7 @@ describe('FormController - draft persistence', () => {
   test('storage recovery does not treat an existing clear marker as a new logout', () => {
     controller.disconnect()
     chatDrafts.clearAll()
-    controller._observedDraftClearNonces.clear()
+    controller._drafts._observedDraftClearNonces.clear()
     const storageGetter = jest.spyOn(window, 'localStorage', 'get').mockImplementation(() => {
       throw new DOMException('denied', 'SecurityError')
     })
@@ -1491,7 +1491,7 @@ describe('FormController - draft persistence', () => {
     delete popupEl.dataset.effectiveCreativeId
     controller.onChatWillOpen({ creativeId: '78' })
     chatDrafts.saveSubmissionBackup('78', 'failed submission restored after reload')
-    controller._pendingDraftSubmissions.clear()
+    controller._drafts._pendingDraftSubmissions.clear()
     controller.resetForm()
     controller._restoreDraft()
 
@@ -1614,15 +1614,15 @@ describe('FormController - draft persistence', () => {
     dispatchTopicChange('70')
     controller.onPopupOpened({ creativeId: '78', canComment: true })
 
-    expect(controller._activeDraftKey).toBe('78')
-    expect(controller._awaitingEffectiveDraftKeyFor).toBe('78')
+    expect(controller._drafts._activeDraftKey).toBe('78')
+    expect(controller._drafts._awaitingEffectiveDraftKeyFor).toBe('78')
     expect(controller.textareaTarget.value).toBe('latest raw draft')
 
     dispatchTopicChange('70')
     controller.onPopupOpened({ creativeId: '78', canComment: true })
 
-    expect(controller._activeDraftKey).toBe('70')
-    expect(controller._awaitingEffectiveDraftKeyFor).toBeNull()
+    expect(controller._drafts._activeDraftKey).toBe('70')
+    expect(controller._drafts._awaitingEffectiveDraftKeyFor).toBeNull()
     expect(controller.textareaTarget.value).toBe('latest raw draft')
     expect(chatDrafts.get('78')).toBeNull()
     expect(chatDrafts.get('70')).toBe('latest raw draft')
@@ -1642,8 +1642,8 @@ describe('FormController - draft persistence', () => {
     dispatchTopicChange('70')
     controller.onPopupOpened({ creativeId: '78', canComment: true })
 
-    expect(controller._activeDraftKey).toBe('70')
-    expect(controller._awaitingEffectiveDraftKeyFor).toBeNull()
+    expect(controller._drafts._activeDraftKey).toBe('70')
+    expect(controller._drafts._awaitingEffectiveDraftKeyFor).toBeNull()
     expect(controller.textareaTarget.value).toBe('newer canonical draft')
   })
 
@@ -1847,8 +1847,8 @@ describe('FormController - draft persistence', () => {
 
     controller.disconnect()
     controller.connect()
-    expect(controller._activeDraftKey).toBe('78')
-    expect(controller._awaitingEffectiveDraftKeyFor).toBe('78')
+    expect(controller._drafts._activeDraftKey).toBe('78')
+    expect(controller._drafts._awaitingEffectiveDraftKeyFor).toBe('78')
     typeInto(controller.textareaTarget, 'next message after reconnect')
 
     popupEl.dataset.creativeId = '78'

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_stashed_draft.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_stashed_draft.test.js
@@ -26,7 +26,7 @@ const buildController = () => {
 // The stash is tagged with the creative it was typed in, so tests build it the
 // way handleStashDraft does rather than assigning a bare string.
 const stash = (controller, draft) => {
-  controller._stashedDraft = { draft, creativeId: controller.creativeId }
+  controller._drafts._stashedDraft = { draft, creativeId: controller.creativeId }
 }
 
 describe('CommentsFormController stashed draft', () => {
@@ -37,7 +37,7 @@ describe('CommentsFormController stashed draft', () => {
       new CustomEvent('comments--form:stash-draft', { detail: { draft: 'roadmap notes' } }),
     )
 
-    expect(controller._stashedDraft).toEqual({ draft: 'roadmap notes', creativeId: '7' })
+    expect(controller._drafts._stashedDraft).toEqual({ draft: 'roadmap notes', creativeId: '7' })
   })
 
   test('receives the event dispatched on the textarea, which bubbles to the popup', () => {
@@ -58,7 +58,7 @@ describe('CommentsFormController stashed draft', () => {
       }),
     )
 
-    expect(controller._stashedDraft).toEqual({ draft: 'roadmap notes', creativeId: '7' })
+    expect(controller._drafts._stashedDraft).toEqual({ draft: 'roadmap notes', creativeId: '7' })
   })
 
   test('restores the draft into the textarea the send cleared', () => {
@@ -116,7 +116,7 @@ describe('CommentsFormController stashed draft', () => {
     stash(controller, 'roadmap notes')
 
     controller._restoreStashedDraft()
-    expect(controller._stashedDraft).toBeNull()
+    expect(controller._drafts._stashedDraft).toBeNull()
 
     textarea.value = ''
     controller._restoreStashedDraft()

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_stashed_draft_creative_switch.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_stashed_draft_creative_switch.test.js
@@ -106,7 +106,7 @@ describe('CommentsFormController stashed draft across a creative switch', () => 
     await flush()
 
     expect(textarea.value).toBe('')
-    expect(controller._stashedDraft).toBeNull()
+    expect(controller._drafts._stashedDraft).toBeNull()
   })
 
   test('still restores the draft when the same creative is reopened mid-flight', async () => {
@@ -161,6 +161,6 @@ describe('CommentsFormController stashed draft across a creative switch', () => 
     controller._restoreStashedDraft('')
 
     expect(textarea.value).toBe('')
-    expect(controller._stashedDraft).toBeNull()
+    expect(controller._drafts._stashedDraft).toBeNull()
   })
 })

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/form_draft_manager.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/form_draft_manager.test.js
@@ -1,0 +1,154 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { jest } from '@jest/globals'
+import FormDraftManager from '../form_draft_manager'
+import chatDrafts from '../../../lib/chat_drafts'
+
+// The draft lifecycle was extracted out of comments--form so it can be
+// exercised without Stimulus. These tests drive it through a plain host object
+// that offers only the form surface the manager is allowed to touch, which is
+// what keeps the seam honest: anything the manager reaches for that is not
+// listed here shows up as a failure rather than as accidental coupling.
+const buildManager = () => {
+  document.body.innerHTML = '<div id="host"><textarea></textarea></div>'
+  const element = document.getElementById('host')
+  const textarea = element.querySelector('textarea')
+  const host = {
+    element,
+    textareaTarget: textarea,
+    editingId: null,
+    creativeId: null,
+    _reviewStore: { isEmpty: true },
+    _autoResize: jest.fn(),
+    _updateSubmitButton: jest.fn(),
+    resetForm: jest.fn(() => { textarea.value = '' }),
+  }
+
+  return { host, element, textarea, manager: new FormDraftManager(host) }
+}
+
+describe('FormDraftManager', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    window.sessionStorage.clear()
+    document.body.dataset.currentUserId = '9'
+    if (typeof global.requestAnimationFrame !== 'function') {
+      global.requestAnimationFrame = (cb) => setTimeout(cb, 0)
+    }
+  })
+
+  test('debounce-saves typed input under the active chat key', () => {
+    jest.useFakeTimers()
+    try {
+      const { manager, textarea } = buildManager()
+      manager.connect()
+      manager._activeDraftKey = '42'
+
+      textarea.value = 'roadmap notes'
+      textarea.dispatchEvent(new Event('input', { bubbles: true }))
+      expect(chatDrafts.get('42')).toBeNull()
+
+      jest.advanceTimersByTime(500)
+      expect(chatDrafts.get('42')).toBe('roadmap notes')
+    } finally {
+      jest.useRealTimers()
+    }
+  })
+
+  test('restores the stored draft when its chat opens', () => {
+    chatDrafts.set('42', 'roadmap notes')
+    const { manager, textarea, host } = buildManager()
+    manager.connect()
+
+    manager.onChatWillOpen({ creativeId: '42' })
+
+    expect(textarea.value).toBe('roadmap notes')
+    expect(host.creativeId).toBe('42')
+    expect(manager._activeDraftKey).toBe('42')
+    // The topics event has not landed yet, so the raw id is still provisional.
+    expect(manager._awaitingEffectiveDraftKeyFor).toBe('42')
+  })
+
+  test('re-opening the chat it already owns leaves the in-progress text alone', () => {
+    const { manager, textarea, host } = buildManager()
+    manager.connect()
+    manager.onChatWillOpen({ creativeId: '42' })
+    host.resetForm.mockClear()
+
+    textarea.value = 'half-typed reply'
+    manager.onChatWillOpen({ creativeId: 42 })
+
+    // resetForm would have wiped the textarea; the repeat open must be a no-op.
+    expect(host.resetForm).not.toHaveBeenCalled()
+    expect(textarea.value).toBe('half-typed reply')
+  })
+
+  test('discarding a draft cancels the pending save instead of writing it back', () => {
+    jest.useFakeTimers()
+    try {
+      const { manager, textarea } = buildManager()
+      manager.connect()
+      manager._activeDraftKey = '42'
+
+      textarea.value = 'roadmap notes'
+      textarea.dispatchEvent(new Event('input', { bubbles: true }))
+      manager.discardDraft()
+      jest.advanceTimersByTime(500)
+
+      expect(chatDrafts.get('42')).toBeNull()
+      expect(manager._activeDraftKey).toBeNull()
+    } finally {
+      jest.useRealTimers()
+    }
+  })
+
+  test('disconnecting stops the textarea from feeding further saves', () => {
+    jest.useFakeTimers()
+    try {
+      const { manager, textarea } = buildManager()
+      manager.connect()
+      manager._activeDraftKey = '42'
+      manager.disconnect()
+
+      textarea.value = 'typed after teardown'
+      textarea.dispatchEvent(new Event('input', { bubbles: true }))
+      jest.advanceTimersByTime(500)
+
+      expect(chatDrafts.get('42')).toBeNull()
+    } finally {
+      jest.useRealTimers()
+    }
+  })
+
+  test('a partial key migration only tracks the plain draft that was sent', () => {
+    const { manager } = buildManager()
+    manager.connect()
+    const namespace = chatDrafts.namespace()
+    const sourceDraft = { text: 'roadmap notes', revision: 3, updatedAt: 10 }
+    const targetDraft = { text: 'roadmap notes', revision: 3, updatedAt: 10 }
+    const plainSubmission = {
+      namespace,
+      key: '42',
+      storedRevision: 3,
+      migratedSources: [],
+    }
+    // A stashed command carries text the user never meant to keep as a draft,
+    // so the migration must not adopt the new key on its behalf.
+    const stashedSubmission = {
+      namespace,
+      key: '42',
+      storedRevision: 3,
+      hadStash: true,
+      migratedSources: [],
+    }
+    manager._pendingDraftSubmissions.add(plainSubmission)
+    manager._pendingDraftSubmissions.add(stashedSubmission)
+
+    manager._trackPartialDraftMigration('42', '77', sourceDraft, targetDraft)
+
+    expect(plainSubmission.migratedSources).toEqual([{ key: '77', revision: 3 }])
+    expect(stashedSubmission.migratedSources).toEqual([])
+  })
+})

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/popup_exit_target.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/popup_exit_target.test.js
@@ -1,0 +1,118 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { jest } from '@jest/globals'
+import {
+  findPopupTargetButton,
+  popupExitTarget,
+  restorePopupTargetStyles,
+} from '../popup_exit_target'
+
+describe('popup exit target', () => {
+  test('finds and reveals the creative row button when the current button is missing', () => {
+    document.body.innerHTML = `
+      <creative-tree-row creative-id="42">
+        <button class="comments-btn"></button>
+      </creative-tree-row>
+    `
+    const row = document.querySelector('creative-tree-row')
+    row.scrollIntoView = jest.fn()
+
+    const button = findPopupTargetButton(null, '42')
+
+    expect(button).toBe(document.querySelector('.comments-btn'))
+    expect(row.scrollIntoView).toHaveBeenCalledWith({ behavior: 'instant', block: 'center' })
+  })
+
+  test('places the popup beside a button when the viewport has room', () => {
+    const targetButton = document.createElement('button')
+    targetButton.getBoundingClientRect = () => ({ bottom: 50, right: 100 })
+
+    const target = popupExitTarget({
+      targetButton,
+      savedStyles: { width: '300px', height: '400px' },
+      viewport: { width: 1024, height: 768 },
+    })
+
+    expect(target).toMatchObject({
+      finalTop: '54px',
+      finalRight: '',
+      animTop: 54,
+      animLeft: 108,
+      animWidth: 300,
+      animHeight: 400,
+      exitToRight: true,
+    })
+  })
+
+  test('anchors to the right edge and clamps a low button target', () => {
+    const targetButton = document.createElement('button')
+    targetButton.getBoundingClientRect = () => ({ bottom: 600, right: 1000 })
+
+    const target = popupExitTarget({
+      targetButton,
+      savedStyles: { width: '300px', height: '400px' },
+      viewport: { width: 1024, height: 768 },
+    })
+
+    expect(target).toMatchObject({
+      finalTop: '364px',
+      finalRight: '48px',
+      animTop: 364,
+      animLeft: 676,
+      exitToRight: false,
+    })
+  })
+
+  test('uses saved geometry when no target button is available', () => {
+    const target = popupExitTarget({
+      targetButton: null,
+      savedStyles: { top: '72px', right: '24px', left: '', width: '360px', height: '480px' },
+      viewport: { width: 1024, height: 768 },
+    })
+
+    expect(target).toMatchObject({
+      finalTop: '72px',
+      finalRight: '24px',
+      animTop: 72,
+      animLeft: 640,
+      animWidth: 360,
+      animHeight: 480,
+    })
+  })
+
+  test('falls back to the default popup geometry', () => {
+    const target = popupExitTarget({
+      targetButton: null,
+      savedStyles: null,
+      viewport: { width: 1024, height: 768 },
+    })
+
+    expect(target).toMatchObject({
+      finalTop: '',
+      finalRight: '',
+      finalWidth: '',
+      finalHeight: '',
+      animTop: 100,
+      animLeft: 572,
+      animWidth: 420,
+      animHeight: 640,
+    })
+  })
+
+  test.each([
+    [{ exitToRight: true, animLeft: 108, finalTop: '54px', finalWidth: '300px', finalHeight: '400px' }, { top: '54px', left: '108px', right: '' }],
+    [{ exitToRight: false, finalRight: '48px', finalTop: '364px', finalWidth: '300px', finalHeight: '400px' }, { top: '364px', left: '', right: '48px' }],
+  ])('restores target styles for either horizontal anchor', (target, expected) => {
+    const style = document.createElement('div').style
+
+    restorePopupTargetStyles(style, target)
+
+    expect(style.top).toBe(expected.top)
+    expect(style.left).toBe(expected.left)
+    expect(style.right).toBe(expected.right)
+    expect(style.width).toBe('300px')
+    expect(style.height).toBe('400px')
+  })
+})

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/popup_fullscreen.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/popup_fullscreen.test.js
@@ -1,0 +1,295 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { jest } from '@jest/globals'
+import PopupFullscreen from '../popup_fullscreen'
+
+describe('PopupFullscreen', () => {
+  let element
+  let manager
+  let callbacks
+  let requestAnimationFrame
+  let listController
+
+  beforeEach(() => {
+    jest.useFakeTimers()
+    document.body.innerHTML = '<div id="popup"></div>'
+    document.body.className = ''
+    element = document.getElementById('popup')
+    element.dataset.creativeId = '42'
+    requestAnimationFrame = jest
+      .spyOn(globalThis, 'requestAnimationFrame')
+      .mockImplementation(callback => {
+        callback()
+        return 1
+      })
+    listController = { scrollToBottom: jest.fn() }
+    callbacks = {
+      isMobile: jest.fn(() => false),
+      isDocked: jest.fn(() => false),
+      syncUi: jest.fn(),
+      syncDockedUi: jest.fn(),
+      getListController: jest.fn(() => listController),
+      getTopicsController: jest.fn(() => ({ scrollToActiveTopic: jest.fn() })),
+      getCurrentButton: jest.fn(() => null),
+      setCurrentButton: jest.fn(),
+    }
+    manager = new PopupFullscreen({ element, ...callbacks })
+    window.history.replaceState({}, '', '/creatives/42')
+  })
+
+  afterEach(() => {
+    manager.cancelEnterCleanup()
+    requestAnimationFrame.mockRestore()
+    jest.useRealTimers()
+  })
+
+  test('owns fullscreen entry state and browser history', () => {
+    element.style.top = '12px'
+    element.style.right = '20px'
+    element.style.width = '300px'
+    element.style.height = '400px'
+    jest.spyOn(element, 'getBoundingClientRect').mockReturnValue({
+      top: 12,
+      left: 704,
+      width: 300,
+      height: 400,
+    })
+
+    manager.enter()
+
+    expect(manager.savedStyles).toEqual({
+      top: '12px',
+      right: '20px',
+      left: '',
+      width: '300px',
+      height: '400px',
+    })
+    expect(element.dataset.fullscreen).toBe('true')
+    expect(document.body.classList.contains('chat-fullscreen')).toBe(true)
+    expect(callbacks.syncUi).toHaveBeenCalledWith(true)
+    expect(window.location.pathname).toBe('/creatives/42/comments/fullscreen')
+  })
+
+  test('restores the mobile popup and keeps it open in the URL', () => {
+    callbacks.isMobile.mockReturnValue(true)
+    element.dataset.fullscreen = 'true'
+    element.style.position = 'fixed'
+    element.style.transform = 'scale(1)'
+    document.body.classList.add('chat-fullscreen')
+    manager.previousUrl = '/creatives/42?comment_id=7'
+
+    manager.exit()
+
+    expect(element.dataset.fullscreen).toBe('false')
+    expect(element.style.position).toBe('')
+    expect(element.style.transform).toBe('')
+    expect(document.body.classList.contains('chat-fullscreen')).toBe(false)
+    expect(callbacks.syncUi).toHaveBeenCalledWith(false)
+    expect(window.location.pathname).toBe('/creatives/42')
+    expect(new URLSearchParams(window.location.search).get('open_comments')).toBe('true')
+    expect(new URLSearchParams(window.location.search).get('comment_id')).toBe('7')
+    expect(listController.scrollToBottom).toHaveBeenCalledTimes(1)
+  })
+
+  test('cleans deep-link markers when fullscreen is closed', () => {
+    element.dataset.fullscreen = 'true'
+    document.body.classList.add('chat-fullscreen')
+    manager.previousUrl = '/creatives/42/comments/77?open_comments=true&comment_id=77#comment_77'
+
+    manager.exitState()
+
+    expect(element.dataset.fullscreen).toBe('false')
+    expect(document.body.classList.contains('chat-fullscreen')).toBe(false)
+    expect(window.location.pathname).toBe('/creatives/42')
+    expect(window.location.search).toBe('')
+    expect(window.location.hash).toBe('')
+    expect(manager.previousUrl).toBeNull()
+  })
+
+  test('restores docked UI when browser navigation exits fullscreen', () => {
+    callbacks.isDocked.mockReturnValue(true)
+    element.dataset.fullscreen = 'true'
+    element.style.display = 'none'
+    manager.savedStyles = { width: '320px', height: '480px' }
+
+    manager.handlePopState({ state: { fullscreen: false } })
+
+    expect(element.dataset.fullscreen).toBe('false')
+    expect(element.style.display).toBe('flex')
+    expect(element.style.width).toBe('320px')
+    expect(element.style.height).toBe('480px')
+    expect(callbacks.syncDockedUi).toHaveBeenCalledTimes(1)
+    expect(manager.savedStyles).toBeNull()
+  })
+
+  test('enters fullscreen without animation or history for auto-fullscreen', () => {
+    element.style.position = 'fixed'
+    element.style.top = '12px'
+    element.style.width = '300px'
+
+    manager.enterImmediate()
+
+    expect(element.dataset.fullscreen).toBe('true')
+    expect(document.body.classList.contains('chat-fullscreen')).toBe(true)
+    expect(callbacks.syncUi).toHaveBeenCalledWith(true)
+    expect(element.style.position).toBe('')
+    expect(element.style.top).toBe('')
+    expect(element.style.width).toBe('')
+    expect(window.location.pathname).toBe('/creatives/42')
+    expect(listController.scrollToBottom).toHaveBeenCalledTimes(1)
+  })
+
+  test('drops the entry animation styles once the transition settles', () => {
+    jest.spyOn(element, 'getBoundingClientRect').mockReturnValue({
+      top: 12,
+      left: 704,
+      width: 300,
+      height: 400,
+    })
+
+    manager.enter()
+    expect(element.style.position).toBe('fixed')
+
+    jest.advanceTimersByTime(300)
+
+    expect(element.style.position).toBe('')
+    expect(element.style.top).toBe('')
+    expect(element.style.height).toBe('')
+    expect(manager.enterCleanupTimer).toBeNull()
+    expect(manager.enterCleanupFn).toBeNull()
+  })
+
+  test('returns the docked popup to its dock without animation', () => {
+    callbacks.isDocked.mockReturnValue(true)
+    element.dataset.fullscreen = 'true'
+    element.style.position = 'fixed'
+    element.style.top = '0'
+    document.body.classList.add('chat-fullscreen')
+    manager.savedStyles = { width: '320px', height: '480px' }
+
+    manager.exit()
+
+    expect(element.dataset.fullscreen).toBe('false')
+    expect(element.style.position).toBe('')
+    expect(element.style.top).toBe('')
+    expect(document.body.classList.contains('chat-fullscreen')).toBe(false)
+    expect(callbacks.syncUi).toHaveBeenCalledWith(false)
+    expect(callbacks.syncDockedUi).toHaveBeenCalledTimes(1)
+    expect(manager.savedStyles).toBeNull()
+    expect(window.location.pathname).toBe('/creatives/42')
+    expect(new URLSearchParams(window.location.search).get('open_comments')).toBe('true')
+    expect(listController.scrollToBottom).toHaveBeenCalledTimes(1)
+  })
+
+  test('lands the desktop popup to the right of its trigger button when there is room', () => {
+    const button = document.createElement('button')
+    document.body.appendChild(button)
+    jest.spyOn(button, 'getBoundingClientRect').mockReturnValue({
+      top: 30,
+      bottom: 50,
+      left: 60,
+      right: 100,
+      width: 40,
+      height: 20,
+    })
+    callbacks.getCurrentButton.mockReturnValue(button)
+    jest.spyOn(element, 'getBoundingClientRect').mockReturnValue({
+      top: 0,
+      left: 0,
+      width: 1024,
+      height: 768,
+    })
+    element.dataset.fullscreen = 'true'
+    document.body.classList.add('chat-fullscreen')
+    manager.savedStyles = { top: '', right: '', left: '', width: '300px', height: '400px' }
+
+    manager.exit()
+
+    expect(callbacks.setCurrentButton).toHaveBeenCalledWith(button)
+    expect(element.dataset.fullscreen).toBe('false')
+    expect(element.style.left).toBe('108px')
+
+    jest.advanceTimersByTime(300)
+
+    expect(element.style.top).toBe('54px')
+    expect(element.style.width).toBe('300px')
+    expect(element.style.height).toBe('400px')
+    expect(element.style.left).toBe('108px')
+    expect(element.style.right).toBe('')
+  })
+
+  test('anchors to the right edge and clamps the top when the button sits low and far right', () => {
+    const button = document.createElement('button')
+    document.body.appendChild(button)
+    jest.spyOn(button, 'getBoundingClientRect').mockReturnValue({
+      top: 580,
+      bottom: 600,
+      left: 960,
+      right: 1000,
+      width: 40,
+      height: 20,
+    })
+    callbacks.getCurrentButton.mockReturnValue(button)
+    jest.spyOn(element, 'getBoundingClientRect').mockReturnValue({
+      top: 0,
+      left: 0,
+      width: 1024,
+      height: 768,
+    })
+    element.dataset.fullscreen = 'true'
+    manager.savedStyles = { top: '', right: '', left: '', width: '300px', height: '400px' }
+
+    manager.exit()
+    jest.advanceTimersByTime(300)
+
+    // 600 + 4 + 400 overflows 768, so the top clamps to innerHeight - height - 4.
+    expect(element.style.top).toBe('364px')
+    expect(element.style.right).toBe('48px')
+    expect(element.style.left).toBe('')
+    expect(element.style.width).toBe('300px')
+  })
+
+  test('falls back to default popup geometry when no button or saved styles exist', () => {
+    const topicsController = { scrollToActiveTopic: jest.fn() }
+    callbacks.getTopicsController.mockReturnValue(topicsController)
+    jest.spyOn(element, 'getBoundingClientRect').mockReturnValue({
+      top: 0,
+      left: 0,
+      width: 1024,
+      height: 768,
+    })
+    element.dataset.fullscreen = 'true'
+    manager.savedStyles = null
+
+    manager.exit()
+
+    expect(element.style.left).toBe('572px')
+    expect(element.style.width).toBe('420px')
+    expect(element.style.height).toBe('640px')
+
+    jest.advanceTimersByTime(300)
+
+    expect(element.style.position).toBe('')
+    expect(element.style.left).toBe('')
+    expect(element.style.width).toBe('')
+    expect(topicsController.scrollToActiveTopic).toHaveBeenCalledTimes(1)
+  })
+
+  test('toggle enters when windowed and exits when already fullscreen', () => {
+    jest.spyOn(element, 'getBoundingClientRect').mockReturnValue({
+      top: 12,
+      left: 704,
+      width: 300,
+      height: 400,
+    })
+
+    manager.toggle()
+    expect(manager.active).toBe(true)
+    expect(window.location.pathname).toBe('/creatives/42/comments/fullscreen')
+
+    manager.toggle()
+    expect(manager.active).toBe(false)
+  })
+})

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/popup_fullscreen.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/popup_fullscreen.test.js
@@ -70,6 +70,7 @@ describe('PopupFullscreen', () => {
     expect(document.body.classList.contains('chat-fullscreen')).toBe(true)
     expect(callbacks.syncUi).toHaveBeenCalledWith(true)
     expect(window.location.pathname).toBe('/creatives/42/comments/fullscreen')
+    expect(listController.scrollToBottom).toHaveBeenCalledTimes(1)
   })
 
   test('restores the mobile popup and keeps it open in the URL', () => {

--- a/engines/collavre/app/javascript/controllers/comments/comment_read_tracker.js
+++ b/engines/collavre/app/javascript/controllers/comments/comment_read_tracker.js
@@ -1,0 +1,149 @@
+import csrfFetch from '../../lib/api/csrf_fetch'
+
+const READ_DEBOUNCE_MS = 2000
+
+export default class CommentReadTracker {
+  constructor(controller, { request = csrfFetch } = {}) {
+    this.controller = controller
+    this.request = request
+  }
+
+  resetRenderedSnapshot() {
+    this.controller.renderedAllTopicIds = null
+    this.controller.renderedAllTopicWatermarks = null
+    this.controller.renderedAllIncludesLegacy = false
+  }
+
+  captureRenderedSnapshot(topicIds, topicWatermarks) {
+    this.controller.renderedAllTopicIds = topicIds.split(',').filter(Boolean)
+    try {
+      this.controller.renderedAllTopicWatermarks = topicWatermarks ? JSON.parse(topicWatermarks) : null
+      this.controller.renderedAllIncludesLegacy = Boolean(
+        this.controller.renderedAllTopicWatermarks &&
+        Object.hasOwn(this.controller.renderedAllTopicWatermarks, '_legacy')
+      )
+    } catch (_error) {
+      this.controller.renderedAllTopicWatermarks = null
+      this.controller.renderedAllIncludesLegacy = false
+    }
+  }
+
+  markCommentsRead() {
+    const controller = this.controller
+    if (!controller.creativeId) return
+    if (controller.markReadTimeout) window.clearTimeout(controller.markReadTimeout)
+
+    const creativeId = controller.creativeId
+    const topicId = controller.currentTopicId || null
+    const topicIds = topicId ? null : controller.renderedAllTopicIds
+    const topicWatermarks = topicId ? null : controller.renderedAllTopicWatermarks
+    const pendingRead = { creativeId, topicId, topicIds, topicWatermarks }
+    controller.pendingRead = pendingRead
+    controller.markReadTimeout = window.setTimeout(() => {
+      controller.markReadTimeout = null
+      if (controller.pendingRead !== pendingRead) return
+      controller.pendingRead = null
+      if (!controller.element.isConnected || controller.creativeId !== creativeId ||
+          (controller.currentTopicId || null) !== topicId) return
+
+      this.updateReadPointer(creativeId, topicId, topicIds, topicWatermarks)
+    }, READ_DEBOUNCE_MS)
+  }
+
+  flushPendingRead({ keepalive = false } = {}) {
+    const controller = this.controller
+    const pendingRead = controller.pendingRead
+    if (!pendingRead) return
+
+    if (controller.markReadTimeout) window.clearTimeout(controller.markReadTimeout)
+    controller.markReadTimeout = null
+    controller.pendingRead = null
+    this.updateReadPointer(
+      pendingRead.creativeId,
+      pendingRead.topicId,
+      pendingRead.topicIds,
+      pendingRead.topicWatermarks,
+      { keepalive }
+    )
+  }
+
+  updateReadPointer(creativeId, topicId, topicIds = null, topicWatermarks = null, { keepalive = false } = {}) {
+    if (!creativeId) return
+
+    this.request('/comment_read_pointers/update', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      keepalive,
+      body: JSON.stringify({
+        creative_id: creativeId,
+        topic_id: topicId,
+        ...(topicIds ? { topic_ids: topicIds } : {}),
+        ...(topicWatermarks ? { topic_watermarks: topicWatermarks } : {}),
+      }),
+    }).then((response) => {
+      const controller = this.controller
+      if (!response.ok || !controller.element.isConnected || controller.creativeId !== creativeId ||
+          (controller.currentTopicId || null) !== topicId) return
+
+      controller.popupController?.topicsController?.loadTopics?.()
+    }).catch(() => { /* ignore — creative may have been deleted */ })
+  }
+
+  recordRenderedAllTopicWatermarks(comments, { includeNewTopics = false } = {}) {
+    const controller = this.controller
+    if (controller.currentTopicId || !Array.isArray(controller.renderedAllTopicIds)) return false
+
+    let addedTopic = false
+    const renderedComments = comments instanceof Element ? [comments] : Array.from(comments || [])
+    renderedComments.forEach((comment) => {
+      const topicId = comment.dataset.topicId
+      const commentId = Number.parseInt(comment.dataset.commentId, 10)
+      if (!Number.isSafeInteger(commentId) || commentId <= 0) return
+
+      const watermarkKey = topicId || '_legacy'
+      if (!topicId && !controller.renderedAllIncludesLegacy) {
+        if (!includeNewTopics) return
+
+        controller.renderedAllIncludesLegacy = true
+        addedTopic = true
+      }
+
+      if (topicId && !controller.renderedAllTopicIds.some((id) => String(id) === String(topicId))) {
+        if (!includeNewTopics) return
+
+        controller.renderedAllTopicIds.push(String(topicId))
+        addedTopic = true
+      }
+
+      controller.renderedAllTopicWatermarks ||= {}
+      const previousId = Number.parseInt(controller.renderedAllTopicWatermarks[watermarkKey], 10)
+      if (!Number.isSafeInteger(previousId) || commentId > previousId) {
+        controller.renderedAllTopicWatermarks[watermarkKey] = commentId
+      }
+    })
+
+    return addedTopic
+  }
+
+  reportRenderedAllTopics() {
+    const controller = this.controller
+    if (controller.currentTopicId || !Array.isArray(controller.renderedAllTopicIds)) return
+
+    controller.element.dispatchEvent(new CustomEvent('comments--list:rendered-all-topics', {
+      bubbles: true,
+      detail: {
+        creativeId: controller.creativeId,
+        topicIds: controller.renderedAllTopicIds,
+        includesLegacy: controller.renderedAllIncludesLegacy,
+      },
+    }))
+  }
+
+  isOutsideRenderedAllTopics(topicId) {
+    const topicIds = this.controller.renderedAllTopicIds
+    return Array.isArray(topicIds) &&
+      !topicIds.some((id) => String(id) === String(topicId))
+  }
+}

--- a/engines/collavre/app/javascript/controllers/comments/comment_read_tracker.js
+++ b/engines/collavre/app/javascript/controllers/comments/comment_read_tracker.js
@@ -46,7 +46,7 @@ export default class CommentReadTracker {
       if (!controller.element.isConnected || controller.creativeId !== creativeId ||
           (controller.currentTopicId || null) !== topicId) return
 
-      this.updateReadPointer(creativeId, topicId, topicIds, topicWatermarks)
+      this.updateReadPointer({ creativeId, topicId, topicIds, topicWatermarks })
     }, READ_DEBOUNCE_MS)
   }
 
@@ -58,16 +58,10 @@ export default class CommentReadTracker {
     if (controller.markReadTimeout) window.clearTimeout(controller.markReadTimeout)
     controller.markReadTimeout = null
     controller.pendingRead = null
-    this.updateReadPointer(
-      pendingRead.creativeId,
-      pendingRead.topicId,
-      pendingRead.topicIds,
-      pendingRead.topicWatermarks,
-      { keepalive }
-    )
+    this.updateReadPointer({ ...pendingRead, keepalive })
   }
 
-  updateReadPointer(creativeId, topicId, topicIds = null, topicWatermarks = null, { keepalive = false } = {}) {
+  updateReadPointer({ creativeId, topicId, topicIds = null, topicWatermarks = null, keepalive = false }) {
     if (!creativeId) return
 
     this.request('/comment_read_pointers/update', {

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -563,7 +563,7 @@ export default class extends Controller {
             this._autoResize()
             this._updateSubmitButton()
             chatDrafts.set(submittedDraftKey, newerDraft)
-            this._observeDraft(submittedDraftKey, newerDraft, submittedDraftNamespace)
+						this._observeDraft(submittedDraftKey, newerDraft, { namespace: submittedDraftNamespace })
           } else if (hasNewerStoredDraft && submittedChatStillActive) {
             this._restoreDraft()
           } else if (
@@ -573,7 +573,7 @@ export default class extends Controller {
             ownsSubmittedDraftNamespace
           ) {
             chatDrafts.clear(submittedDraftKey)
-            this._observeDraft(submittedDraftKey, null, submittedDraftNamespace)
+						this._observeDraft(submittedDraftKey, null, { namespace: submittedDraftNamespace })
           }
           if (ownsSubmittedDraftNamespace && !submittedHadReview) {
             this._clearMigratedSubmittedSources(submittedDraft)

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -6,6 +6,7 @@ import { renderMarkdownInContainer } from '../../lib/utils/markdown'
 import { wrapHtmlInCodeBlocks } from '../../lib/html_code_block_wrapper'
 import { refreshCsrfToken } from '../../lib/api/csrf_fetch'
 import ReviewQuotesStore from './review_quotes_store'
+import FormDraftManager from './form_draft_manager'
 import { alertDialog } from '../../lib/utils/dialog'
 import chatDrafts from '../../lib/chat_drafts'
 
@@ -37,6 +38,11 @@ export default class extends Controller {
     'reviewQuotesContainer',
     'quoteCancelButton',
   ]
+
+  get _drafts() {
+    this.__drafts ||= new FormDraftManager(this)
+    return this.__drafts
+  }
 
   connect() {
     this.dnd = createDragDropRegistry({ root: this.formTarget, getKind: getDragKind, readData: readDragData })
@@ -98,115 +104,7 @@ export default class extends Controller {
     }
     this.textareaTarget.addEventListener('input', this._autoResize)
 
-    // Draft persistence: debounce-save unsent input per chat.
-    // _activeDraftKey always identifies the chat whose text is in the textarea.
-    this._activeDraftKey ??= null
-    this._activeDraftCreativeId ??= null
-    this._awaitingEffectiveDraftKeyFor ??= null
-    this._draftSaveTimer = null
-    this._draftSaveSuspendedForPermission ??= false
-    // A cross-tab logout permanently retires the old user's namespace for this
-    // controller lifetime, including Stimulus reconnects in the stale tab.
-    this._disabledDraftNamespaces ||= new Set()
-    this._draftBackupCleanupPendingNamespaces ||= new Set()
-    this._observedDraftClearNonces ||= new Map()
-    // A pending send survives a Stimulus reconnect on this controller instance,
-    // so its completion must keep comparing against the same draft history.
-    this._draftRevisions ||= new Map()
-    this._observedDrafts ||= new Map()
-    this._observedDisplayedDrafts ||= new Map()
-    this._observedDraftRevisions ||= new Map()
-    this._observedStoredDraftRevisions ||= new Map()
-    // A linked chat can replace its temporary raw key while its request is in
-    // flight. Keep mutable submission state across that migration/reconnect.
-    this._pendingDraftSubmissions ||= new Set()
-    const draftNamespace = chatDrafts.namespace()
-    const draftClearNonce = chatDrafts.clearNonce(draftNamespace)
-    const draftClearNoncePending = chatDrafts.clearNoncePending(draftNamespace)
-    const observedDraftClearNonce = this._observedDraftClearNonces.has(draftNamespace)
-    let canObserveDraftClearNonce = true
-    if (draftClearNonce && !observedDraftClearNonce) {
-      canObserveDraftClearNonce = chatDrafts.clearSubmissionBackupsForClear(
-	draftNamespace,
-	draftClearNonce,
-      )
-      if (canObserveDraftClearNonce && !draftClearNoncePending) {
-	this._draftBackupCleanupPendingNamespaces.delete(draftNamespace)
-      } else {
-	this._draftBackupCleanupPendingNamespaces.add(draftNamespace)
-      }
-    }
-    if (
-      draftClearNonce &&
-      observedDraftClearNonce &&
-      this._observedDraftClearNonces.get(draftNamespace) !== draftClearNonce
-    ) {
-      this._disableDraftNamespace(draftNamespace)
-    }
-    if (
-      draftClearNonce !== undefined &&
-      canObserveDraftClearNonce &&
-      !draftClearNoncePending
-    ) {
-      this._observedDraftClearNonces.set(draftNamespace, draftClearNonce)
-    }
-    this._handlePageHide = () => {
-      if (!this.element.isConnected) return
-
-      this._flushDraftSave()
-    }
-    this._handleDraftStorage = (event) => {
-      if (!this.element.isConnected || !chatDrafts.wasCleared(event)) return
-
-      const clearedNamespace = chatDrafts.namespace()
-      this._disableDraftNamespace(clearedNamespace)
-    }
-    this._handleCompositionEnd = () => {
-      this._imeCommitPending = true
-    }
-    // Chrome fires the commit `input` after `compositionend`, but Firefox has
-    // shipped the reverse order, where the commit input consumes the latch
-    // before it is even set. Nothing would clear the leftover latch, so the
-    // next ordinary edit would be misread as a commit. The commit input always
-    // arrives before the user can act again, so any fresh gesture expires it.
-    this._expireImeCommitLatch = (event) => {
-      if (event?.isComposing || event?.keyCode === 229) return
-
-      this._imeCommitPending = false
-    }
-    this._handleDraftInput = (event) => {
-      // Consume the composition flag before any early return, so it can never
-      // outlive the `input` event that the commit itself fired. Firefox has
-      // shipped both orderings, so accept isComposing on the input event too.
-      const isImeCommit = Boolean(event?.isComposing) || this._imeCommitPending === true
-      this._imeCommitPending = false
-      if (
-        this.editingId ||
-	this._draftPersistenceDisabled() ||
-        this._draftSaveSuspendedForPermission ||
-        this._shouldSuppressDraftSaveForStash() ||
-        !this._reviewStore.isEmpty ||
-        !this._activeDraftKey
-      ) return
-      // An IME commit fires `input` after the keydown that started a send, so
-      // the textarea still holds exactly what went to the server. Counting it
-      // as a revision would defeat _currentPendingSubmission and make the sent
-      // message look like a draft typed mid-flight, restoring it on success.
-      // Text equality alone is not enough to suppress: re-entering the same
-      // string mid-flight (select-all + paste to send it twice) is a real edit.
-      if (isImeCommit && this._currentTextIsPendingSubmission()) return
-      const revisionKey = `${chatDrafts.namespace()}:${this._activeDraftKey}`
-      this._draftRevisions.set(revisionKey, (this._draftRevisions.get(revisionKey) || 0) + 1)
-      clearTimeout(this._draftSaveTimer)
-      this._draftSaveTimer = setTimeout(() => this._saveDraftNow(), 500)
-    }
-    this.textareaTarget.addEventListener('compositionend', this._handleCompositionEnd)
-    this.textareaTarget.addEventListener('keydown', this._expireImeCommitLatch)
-    this.textareaTarget.addEventListener('paste', this._expireImeCommitLatch)
-    this.textareaTarget.addEventListener('drop', this._expireImeCommitLatch)
-    this.textareaTarget.addEventListener('input', this._handleDraftInput)
-    window.addEventListener('pagehide', this._handlePageHide)
-    window.addEventListener('storage', this._handleDraftStorage)
+    this._drafts.connect()
 
     this.textareaTarget.addEventListener('keydown', (event) => {
       if (event.key === 'Escape') {
@@ -240,66 +138,7 @@ export default class extends Controller {
   }
 
   handleTopicChange(event) {
-    // This event fires before onPopupOpened during a chat switch, while the
-    // textarea still contains the outgoing chat's text. Flush before re-keying.
-    const draftPersistenceDisabled = this._draftPersistenceDisabled()
-    const nextDraftKey = draftPersistenceDisabled
-      ? null
-      : this.element.dataset.effectiveCreativeId || this.element.dataset.creativeId || null
-    const nextCreativeId = draftPersistenceDisabled
-      ? null
-      : this.element.dataset.creativeId || null
-    const draftKeyChanged = String(this._activeDraftKey || '') !== String(nextDraftKey || '')
-    const creativeChanged =
-      String(this._activeDraftCreativeId || '') !== String(nextCreativeId || '')
-    const resolvingIncomingDraftKey =
-      this._awaitingEffectiveDraftKeyFor &&
-      String(this._awaitingEffectiveDraftKeyFor) === String(nextCreativeId || '')
-    let keepAwaitingEffectiveDraftKey = false
-    if (draftKeyChanged || creativeChanged) {
-      const previousDraftKey = this._activeDraftKey
-      // onChatWillOpen already flushed the outgoing chat. While the effective
-      // key is loading, save only actual new input; rewriting a restored raw
-      // draft here would make stale text appear newer than the canonical draft.
-      if (!resolvingIncomingDraftKey || this._draftSaveTimer) this._flushDraftSave()
-      this._activeDraftKey = nextDraftKey ? String(nextDraftKey) : null
-      this._activeDraftCreativeId = nextCreativeId ? String(nextCreativeId) : null
-      if (
-        resolvingIncomingDraftKey &&
-        previousDraftKey &&
-        this._activeDraftKey
-      ) {
-        const sourceDraft = chatDrafts.snapshot(previousDraftKey)
-	const moveCompleted = chatDrafts.move(previousDraftKey, this._activeDraftKey)
-        const targetDraft = chatDrafts.snapshot(this._activeDraftKey)
-	const movedBackups = moveCompleted
-	  ? chatDrafts.moveSubmissionBackups(previousDraftKey, this._activeDraftKey)
-	  : new Map()
-	if (moveCompleted && (targetDraft.revision || !sourceDraft.revision)) {
-          this._rebindPendingDraftSubmissions(
-            previousDraftKey,
-            this._activeDraftKey,
-            sourceDraft,
-            targetDraft,
-            movedBackups,
-          )
-	} else if (!moveCompleted) {
-	  this._trackPartialDraftMigration(
-	    previousDraftKey,
-	    this._activeDraftKey,
-	    sourceDraft,
-	    targetDraft,
-	  )
-	  if (chatDrafts.isNewer(previousDraftKey, this._activeDraftKey)) {
-	    this._activeDraftKey = String(previousDraftKey)
-	    keepAwaitingEffectiveDraftKey = true
-	  }
-        }
-      }
-    }
-    if (resolvingIncomingDraftKey && !keepAwaitingEffectiveDraftKey) {
-      this._awaitingEffectiveDraftKeyFor = null
-    }
+    this._drafts.handleTopicChange()
     this.currentTopicId = event.detail.topicId
     this.readOnlyTopic = event.detail.readOnly || false
     this._isInbox = event.detail.isInbox || false
@@ -318,14 +157,7 @@ export default class extends Controller {
 
   disconnect() {
     this.dnd?.destroy()
-    this._flushDraftSave()
-    this.textareaTarget.removeEventListener('compositionend', this._handleCompositionEnd)
-    this.textareaTarget.removeEventListener('keydown', this._expireImeCommitLatch)
-    this.textareaTarget.removeEventListener('paste', this._expireImeCommitLatch)
-    this.textareaTarget.removeEventListener('drop', this._expireImeCommitLatch)
-    this.textareaTarget.removeEventListener('input', this._handleDraftInput)
-    window.removeEventListener('pagehide', this._handlePageHide)
-    window.removeEventListener('storage', this._handleDraftStorage)
+    this._drafts.disconnect()
     this.formTarget.removeEventListener('submit', this.handleSubmit)
     this.submitTarget.removeEventListener('click', this.handleSend)
     this.submitTarget.removeEventListener('pointerup', this.handlePointerSend)
@@ -356,7 +188,7 @@ export default class extends Controller {
   onPopupOpened({ creativeId, canComment }) {
     this.creativeId = creativeId
     this.element.dataset.creativeId = creativeId || ''
-    if (canComment) this._draftSaveSuspendedForPermission = false
+    if (canComment) this._drafts._draftSaveSuspendedForPermission = false
     // Stale topic ids from the previous creative are cleared by the popup
     // controller BEFORE topics loadTopics() dispatches comments--topics:change,
     // so by the time we get here, currentTopicId already reflects the new
@@ -366,9 +198,9 @@ export default class extends Controller {
     // Capture input entered while topics were loading before reset clears it.
     // Without a pending input timer, a blank textarea must not erase a draft
     // that is waiting in storage to be restored below.
-    if (this._draftSaveTimer) this._flushDraftSave()
+    if (this._drafts._draftSaveTimer) this._flushDraftSave()
     this.resetForm()
-    this._draftSaveSuspendedForPermission = !canComment
+    this._drafts._draftSaveSuspendedForPermission = !canComment
     if (canComment && this.shouldAutoFocusOnOpen()) {
       requestAnimationFrame(() => this.textareaTarget.focus())
     }
@@ -376,52 +208,20 @@ export default class extends Controller {
   }
 
   onChatWillOpen({ creativeId }) {
-    const nextCreativeId = creativeId ? String(creativeId) : null
-    if (
-      String(this._activeDraftCreativeId || '') === String(nextCreativeId || '')
-    ) return
-
-    // The popup publishes its raw creative id before awaiting topics. Flush the
-    // outgoing chat now, then give any input typed during that await a key owned
-    // by the incoming chat. The topics event replaces it with the effective id.
-    this._flushDraftSave()
-    if (this._draftPersistenceDisabled()) {
-      this._activeDraftKey = null
-      this._activeDraftCreativeId = null
-      this._awaitingEffectiveDraftKeyFor = null
-      this.creativeId = creativeId
-      this.resetForm()
-      return
-    }
-    this._activeDraftKey = nextCreativeId
-    this._activeDraftCreativeId = nextCreativeId
-    this._awaitingEffectiveDraftKeyFor = nextCreativeId
-    this.creativeId = creativeId
-    this.resetForm()
-    this._restoreDraft()
+    this._drafts.onChatWillOpen({ creativeId })
   }
 
   onPopupClosed() {
     this._flushDraftSave()
-    this._activeDraftKey = null
-    this._activeDraftCreativeId = null
-    this._awaitingEffectiveDraftKeyFor = null
+    this._drafts._activeDraftKey = null
+    this._drafts._activeDraftCreativeId = null
+    this._drafts._awaitingEffectiveDraftKeyFor = null
     this.stopSpeechRecognition()
     this.resetForm()
   }
 
   discardDraft() {
-    const namespace = chatDrafts.namespace()
-    this._pendingDraftSubmissions?.forEach((submission) => {
-      if (submission.namespace === namespace) submission.invalidated = true
-    })
-    clearTimeout(this._draftSaveTimer)
-    this._draftSaveTimer = null
-    this._activeDraftKey = null
-    this._activeDraftCreativeId = null
-    this._awaitingEffectiveDraftKeyFor = null
-    this._stashedDraft = null
-    this.resetForm()
+    this._drafts.discardDraft()
   }
 
   setCommentPermission(canComment) {
@@ -430,13 +230,13 @@ export default class extends Controller {
 
     if (!canComment) {
       this._flushDraftSave()
-      this._draftSaveSuspendedForPermission = true
+      this._drafts._draftSaveSuspendedForPermission = true
       this.stopSpeechRecognition()
       this.resetForm()
       return
     }
 
-    this._draftSaveSuspendedForPermission = false
+    this._drafts._draftSaveSuspendedForPermission = false
     this._restoreDraft()
     if (this.shouldAutoFocusOnOpen()) {
       requestAnimationFrame(() => this.textareaTarget.focus())
@@ -478,55 +278,15 @@ export default class extends Controller {
   }
 
   handleStashDraft(event) {
-    const draft = event.detail?.draft || null
-    if (draft) this._flushDraftSave()
-    // Tagged with the conversation it was typed in: the popup reuses this one
-    // controller for every creative, so a stash left over from another one must
-    // not be handed back here.
-    this._stashedDraft = draft ? { draft, creativeId: this.creativeId } : null
+    this._drafts.handleStashDraft(event)
   }
 
   _stashedDraftBelongsToCurrentCreative() {
-    return Boolean(
-      this._stashedDraft &&
-      String(this._stashedDraft.creativeId) === String(this.creativeId),
-    )
-  }
-
-  _shouldSuppressDraftSaveForStash() {
-    if (!this._stashedDraftBelongsToCurrentCreative()) return false
-
-    // Before handleSend captures the command, the command-menu input event
-    // must not replace the stashed ordinary draft. Once the send starts, only
-    // the submitted command remains suppressed; later input is a new draft.
-    return !this._stashedDraft.submittedText ||
-      this.textareaTarget.value === this._stashedDraft.submittedText
+    return this._drafts._stashedDraftBelongsToCurrentCreative()
   }
 
   _restoreStashedDraft(submittedText) {
-    const stashed = this._stashedDraft
-    this._stashedDraft = null
-    if (!stashed) return
-    // Switching creatives calls onPopupOpened on this same instance (there is
-    // no disconnect between conversations), so a send that settles after the
-    // switch would drop the previous conversation's draft into the new one.
-    // The draft belongs to a conversation that is no longer on screen; discard
-    // it rather than misfile it.
-    if (String(stashed.creativeId ?? '') !== String(this.creativeId ?? '')) return
-    const draft = stashed.draft
-    // Two boxes are safe to overwrite: an empty one (the success path runs
-    // resetForm) and one still holding exactly what we submitted (the failure
-    // path never clears it, so the command text is left sitting there). Any
-    // other content is text the user typed while the request was in flight, or
-    // a review quote the failure path restored, and must not be clobbered.
-    const current = this.textareaTarget.value
-    if (current.trim().length > 0 && current !== submittedText) return
-    this.textareaTarget.value = draft
-    // Resize and re-enable send directly rather than dispatching `input`, which
-    // would re-open the command menu for a draft that starts with "/".
-    this._autoResize()
-    this._updateSubmitButton()
-    this._saveDraftNow()
+    this._drafts._restoreStashedDraft(submittedText)
   }
 
   resetForm() {
@@ -545,279 +305,28 @@ export default class extends Controller {
     this.textareaTarget.style.height = 'auto'
   }
 
-  _saveDraftNow() {
-    if (
-      !this._activeDraftKey ||
-      this._draftPersistenceDisabled() ||
-      this._draftSaveSuspendedForPermission ||
-      this.editingId ||
-      this._shouldSuppressDraftSaveForStash() ||
-      !this._reviewStore.isEmpty
-    ) return
-    if (this._currentTextIsPendingSubmission()) return
-    const draftKey = this._activeDraftKey
-    const text = this.textareaTarget.value
-    const blank = !text.trim()
-    const storedDraft = chatDrafts.snapshot(draftKey)
-    const storedText = storedDraft.text
-    const hasStoredEntry = chatDrafts.updatedAt(draftKey) !== null
-    const observationKey = `${chatDrafts.namespace()}:${draftKey}`
-    const hasObservedDraft = this._observedDrafts?.has(observationKey)
-    const observedText = this._observedDrafts?.get(observationKey)
-    const hasObservedDisplayedDraft =
-      this._observedDisplayedDrafts?.has(observationKey)
-    const observedDisplayedText = hasObservedDisplayedDraft
-      ? this._observedDisplayedDrafts.get(observationKey)
-      : observedText
-    const observedRevision = this._observedDraftRevisions?.get(observationKey) || 0
-    const observedStoredRevision =
-      this._observedStoredDraftRevisions?.get(observationKey) || null
-    const currentRevision = this._draftRevisions?.get(observationKey) || 0
-    const inputChangedLocally = currentRevision !== observedRevision
-    const preserveBlank =
-      blank && Boolean(this._awaitingEffectiveDraftKeyFor) && inputChangedLocally
-    const displayedDraftChanged =
-      (hasObservedDisplayedDraft || hasObservedDraft) &&
-      (observedDisplayedText || '') !== text
-    const draftChangedLocally =
-      inputChangedLocally || displayedDraftChanged
-    const storedDraftChangedOutsideController = hasObservedDraft && (
-      observedText !== storedText || observedStoredRevision !== storedDraft.revision
-    )
-    // An idle tab can retain stale restored text after another tab updates the
-    // same draft. Closing or switching that idle tab must not write it back.
-    if (!draftChangedLocally && storedDraftChangedOutsideController) return
-    if (preserveBlank) {
-      if (storedText !== null || !hasStoredEntry) {
-        chatDrafts.set(draftKey, '', { preserveBlank: true })
-      }
-    } else if (blank) {
-      if (hasStoredEntry) {
-        chatDrafts.clear(draftKey)
-      }
-    } else if (storedText !== text) {
-      chatDrafts.set(draftKey, text)
-    }
-    if (blank && draftChangedLocally) chatDrafts.clearSubmissionBackups(draftKey)
-    this._observeDraft(draftKey)
-  }
-
   _flushDraftSave() {
-    clearTimeout(this._draftSaveTimer)
-    this._draftSaveTimer = null
-    this._saveDraftNow()
-  }
-
-  _currentTextIsPendingSubmission() {
-    return Boolean(this._currentPendingSubmission())
-  }
-
-  _currentPendingSubmission() {
-    const namespace = chatDrafts.namespace()
-    const key = String(this._activeDraftKey || '')
-
-    return [...(this._pendingDraftSubmissions || [])].find((submission) => (
-      !submission.invalidated &&
-      submission.namespace === namespace &&
-      String(submission.key || '') === key &&
-      !submission.hadStash &&
-      !submission.hadReview &&
-      !submission.editing &&
-      submission.text === this.textareaTarget.value &&
-      (this._draftRevisions?.get(submission.revisionKey) || 0) === submission.keyRevision
-    ))
+    this._drafts._flushDraftSave()
   }
 
   _restoreDraft() {
-    if (
-      !this._activeDraftKey ||
-      this._draftPersistenceDisabled() ||
-      this.editingId
-    ) return
-    if (this.textareaTarget.value.trim()) return
-
-    const draft = chatDrafts.snapshot(this._activeDraftKey)
-    const backup = chatDrafts.latestSubmissionBackup(this._activeDraftKey)
-    const restoreBackup = Boolean(
-      backup?.text &&
-      (draft.updatedAt === null || backup.updatedAt > draft.updatedAt),
-    )
-    if (backup && !restoreBackup) chatDrafts.removeSubmissionBackup(backup.key)
-    const restoredText = restoreBackup ? backup.text : draft.text
-    this._observeDraft(
-      this._activeDraftKey,
-      draft.text,
-      chatDrafts.namespace(),
-      draft.revision,
-      restoredText,
-    )
-    if (restoredText) {
-      this.textareaTarget.value = restoredText
-      requestAnimationFrame(() => this._autoResize())
-    } else if (draft.updatedAt === null) {
-      this._restorePendingSubmittedDraft()
-    }
+    this._drafts._restoreDraft()
   }
 
-  _restorePendingSubmittedDraft() {
-    const namespace = chatDrafts.namespace()
-    const pending = [...(this._pendingDraftSubmissions || [])].find((submission) => (
-      !submission.invalidated &&
-      submission.namespace === namespace &&
-      String(submission.key || '') === String(this._activeDraftKey || '') &&
-      !submission.hadStash &&
-      !submission.hadReview &&
-      !submission.editing
-    ))
-    if (!pending) return
-
-    this.textareaTarget.value = pending.text
-    requestAnimationFrame(() => this._autoResize())
-    this._updateSubmitButton()
+  _draftPersistenceDisabled(namespace) {
+    return this._drafts._draftPersistenceDisabled(namespace)
   }
 
-  _draftPersistenceDisabled(namespace = chatDrafts.namespace()) {
-    return this._disabledDraftNamespaces?.has(namespace) ||
-      this._draftBackupCleanupPendingNamespaces?.has(namespace) ||
-      false
-  }
-
-  _disableDraftNamespace(namespace) {
-    this._disabledDraftNamespaces.add(namespace)
-    this.discardDraft()
-    // A timer in this tab may have raced with the logout tab's first clear.
-    chatDrafts.clearAll({ broadcast: false })
-  }
-
-  _observeDraft(
-    draftKey,
-    text,
-    namespace = chatDrafts.namespace(),
-    storedRevision,
-    displayedText,
-  ) {
-    if (!draftKey) return
-    const storedDraft = storedRevision === undefined
-      ? chatDrafts.snapshot(draftKey)
-      : { text, revision: storedRevision }
-    const observationKey = `${namespace}:${draftKey}`
-    this._observedDrafts?.set(observationKey, storedDraft.text)
-    this._observedDisplayedDrafts?.set(
-      observationKey,
-      displayedText === undefined ? storedDraft.text : displayedText,
-    )
-    this._observedDraftRevisions?.set(
-      observationKey,
-      this._draftRevisions?.get(observationKey) || 0,
-    )
-    this._observedStoredDraftRevisions?.set(observationKey, storedDraft.revision)
-  }
-
-  _rebindPendingDraftSubmissions(
-    sourceKey,
-    targetKey,
-    sourceDraft,
-    targetDraft,
-    movedBackups = new Map(),
-  ) {
-    const namespace = chatDrafts.namespace()
-    const targetRevisionKey = `${namespace}:${targetKey}`
-
-    this._pendingDraftSubmissions?.forEach((submission) => {
-      if (
-        submission.namespace !== namespace ||
-        String(submission.key) !== String(sourceKey)
-      ) return
-
-      const targetMatchesStoredBaseline = submission.storedRevision && targetDraft.revision === submission.storedRevision
-      const sourceMatchesSubmission =
-        sourceDraft.revision &&
-        targetDraft.revision === sourceDraft.revision &&
-        targetDraft.text === submission.text
-      const submittedDraftWasUnstored =
-        !submission.storedRevision &&
-        !sourceDraft.revision &&
-        !targetDraft.revision
-      const submittedDraftWasMoved = targetMatchesStoredBaseline || sourceMatchesSubmission || submittedDraftWasUnstored
-      if (
-        sourceDraft.revision &&
-        sourceDraft.text === submission.text
-      ) {
-        submission.migratedSources.push({
-          key: String(sourceKey),
-          revision: sourceDraft.revision,
-        })
-      }
-      submission.key = String(targetKey)
-      submission.revisionKey = targetRevisionKey
-      submission.keyRevision = this._draftRevisions?.get(targetRevisionKey) || 0
-      submission.storedRevision = targetDraft.revision
-      submission.storedUpdatedAt = targetDraft.updatedAt
-      submission.storedChangedOutsideController ||=
-        !submittedDraftWasMoved
-      if (submission.backupKey && movedBackups.has(submission.backupKey)) {
-        submission.backupKey = movedBackups.get(submission.backupKey)
-      }
-    })
-  }
-
-  _trackPartialDraftMigration(sourceKey, targetKey, sourceDraft, targetDraft) {
-    if (
-      !sourceDraft.revision ||
-      targetDraft.revision !== sourceDraft.revision
-    ) return
-
-    const namespace = chatDrafts.namespace()
-    this._pendingDraftSubmissions?.forEach((submission) => {
-      if (
-	submission.namespace !== namespace ||
-	String(submission.key) !== String(sourceKey) ||
-	submission.hadStash ||
-	submission.hadReview ||
-	submission.editing ||
-	submission.storedRevision !== sourceDraft.revision
-      ) return
-
-      submission.migratedSources.push({
-	key: String(targetKey),
-	revision: targetDraft.revision,
-      })
-    })
+  _observeDraft(...args) {
+    this._drafts._observeDraft(...args)
   }
 
   _clearMigratedSubmittedSources(submission) {
-    submission.migratedSources.forEach(({ key, revision }) => {
-      if (chatDrafts.revision(key) !== revision) return
-
-      chatDrafts.clear(key)
-      this._observeDraft(key, null, submission.namespace)
-    })
+    this._drafts._clearMigratedSubmittedSources(submission)
   }
 
   _persistFailedSubmissionDraft(submission) {
-    if (
-      submission.invalidated ||
-      submission.hadStash ||
-      submission.hadReview ||
-      submission.editing ||
-      submission.namespace !== chatDrafts.namespace()
-    ) return
-
-    const currentDraft = chatDrafts.snapshot(submission.key)
-    const currentKeyRevision =
-      this._draftRevisions?.get(submission.revisionKey) || 0
-    const submittedChatAdvanced =
-      submission.storedChangedOutsideController ||
-      currentKeyRevision !== submission.keyRevision ||
-      currentDraft.revision !== submission.storedRevision ||
-      currentDraft.updatedAt !== submission.storedUpdatedAt
-    if (submittedChatAdvanced) return
-
-    submission.backupKey ||= chatDrafts.saveSubmissionBackup(
-      submission.key,
-      submission.text,
-      { updatedAt: submission.backupUpdatedAt },
-    )
+    this._drafts._persistFailedSubmissionDraft(submission)
   }
 
   setSendingState(isSending) {
@@ -872,9 +381,9 @@ export default class extends Controller {
     // Cancel any pending input debounce before capturing the submission. A
     // write while the request is in flight looks like a newer draft and can
     // restore the already-sent text on success. Failures persist below.
-    if (this._draftSaveTimer) {
-      clearTimeout(this._draftSaveTimer)
-      this._draftSaveTimer = null
+    if (this._drafts._draftSaveTimer) {
+      clearTimeout(this._drafts._draftSaveTimer)
+      this._drafts._draftSaveTimer = null
     }
 
     // Build final content from review quotes + user text
@@ -890,7 +399,7 @@ export default class extends Controller {
     // going to the server. _restoreStashedDraft compares against it to tell a
     // failure that left the command text behind from text typed mid-flight.
     const submittedText = this.textareaTarget.value
-    const initialSubmittedDraftKey = this._activeDraftKey
+    const initialSubmittedDraftKey = this._drafts._activeDraftKey
     const submittedDraftNamespace = chatDrafts.namespace()
     const initialSubmittedDraftRevisionKey =
       `${submittedDraftNamespace}:${initialSubmittedDraftKey}`
@@ -902,22 +411,22 @@ export default class extends Controller {
       (initialSubmittedDraft.updatedAt || 0) + 1,
     )
     const observedSubmittedText =
-      this._observedDrafts?.get(initialSubmittedDraftRevisionKey)
+      this._drafts._observedDrafts?.get(initialSubmittedDraftRevisionKey)
     const observedSubmittedStoredRevision =
-      this._observedStoredDraftRevisions?.get(initialSubmittedDraftRevisionKey) || null
+      this._drafts._observedStoredDraftRevisions?.get(initialSubmittedDraftRevisionKey) || null
     const submittedTextChangedOutsideController =
       observedSubmittedText !== initialSubmittedDraft.text
     const submittedRevisionChangedOutsideController =
       observedSubmittedStoredRevision !== initialSubmittedDraft.revision
     const submittedStoredDraftChangedOutsideController =
-      this._observedDrafts?.has(initialSubmittedDraftRevisionKey) &&
+      this._drafts._observedDrafts?.has(initialSubmittedDraftRevisionKey) &&
       (submittedTextChangedOutsideController || submittedRevisionChangedOutsideController)
     const submittedDraft = {
       key: initialSubmittedDraftKey,
       namespace: submittedDraftNamespace,
       revisionKey: initialSubmittedDraftRevisionKey,
       storedChangedOutsideController: submittedStoredDraftChangedOutsideController,
-      keyRevision: this._draftRevisions?.get(initialSubmittedDraftRevisionKey) || 0,
+      keyRevision: this._drafts._draftRevisions?.get(initialSubmittedDraftRevisionKey) || 0,
       storedRevision: initialSubmittedDraft.revision,
       storedUpdatedAt: initialSubmittedDraft.updatedAt,
       backupUpdatedAt: submittedBackupUpdatedAt,
@@ -926,14 +435,14 @@ export default class extends Controller {
       backupKey: submittedBackup?.text === submittedText ? submittedBackup.key : null,
       migratedSources: [],
     }
-    this._pendingDraftSubmissions ||= new Set()
-    this._pendingDraftSubmissions.add(submittedDraft)
+    this._drafts._pendingDraftSubmissions ||= new Set()
+    this._drafts._pendingDraftSubmissions.add(submittedDraft)
     const submittedEditingId = this.editingId
     const submittedHadReview = hasQuotes
     submittedDraft.editing = Boolean(submittedEditingId)
     submittedDraft.hadReview = submittedHadReview
     if (submittedHadStash) {
-      this._stashedDraft.submittedText = submittedText
+      this._drafts._stashedDraft.submittedText = submittedText
     }
 
     const formData = new FormData(this.formTarget)
@@ -1006,18 +515,18 @@ export default class extends Controller {
         const switchedChats =
           ownsSubmittedDraftNamespace &&
           submittedDraftKey &&
-          this._activeDraftKey &&
-          String(submittedDraftKey) !== String(this._activeDraftKey)
+          this._drafts._activeDraftKey &&
+          String(submittedDraftKey) !== String(this._drafts._activeDraftKey)
         const submittedChatStillActive =
           submittedDraftKey &&
-          this._activeDraftKey &&
-          String(submittedDraftKey) === String(this._activeDraftKey)
+          this._drafts._activeDraftKey &&
+          String(submittedDraftKey) === String(this._drafts._activeDraftKey)
         const hasNewerActiveDraft =
           ownsSubmittedDraftNamespace &&
           !submittedEditingId &&
           !submittedHadReview &&
           submittedChatStillActive &&
-          (this._draftRevisions?.get(submittedDraftRevisionKey) || 0) !==
+          (this._drafts._draftRevisions?.get(submittedDraftRevisionKey) || 0) !==
             submittedDraftKeyRevision
         const hasNewerStoredDraft =
           ownsSubmittedDraftNamespace &&
@@ -1025,7 +534,7 @@ export default class extends Controller {
           !submittedHadReview &&
           submittedDraftKey &&
           (
-            (this._draftRevisions?.get(submittedDraftRevisionKey) || 0) !==
+            (this._drafts._draftRevisions?.get(submittedDraftRevisionKey) || 0) !==
               submittedDraftKeyRevision ||
             submittedStoredDraftChangedOutsideController ||
             chatDrafts.revision(submittedDraftKey) !== submittedDraftStoredRevision
@@ -1033,14 +542,14 @@ export default class extends Controller {
         const hasNewerDraft = hasNewerActiveDraft || hasNewerStoredDraft
         const newerDraft = hasNewerActiveDraft
           ? (
-            this._draftSaveSuspendedForPermission
+            this._drafts._draftSaveSuspendedForPermission
               ? chatDrafts.get(submittedDraftKey)
               : this.textareaTarget.value
           )
           : null
         if (switchedChats) this._flushDraftSave()
-        clearTimeout(this._draftSaveTimer)
-        this._draftSaveTimer = null
+        clearTimeout(this._drafts._draftSaveTimer)
+        this._drafts._draftSaveTimer = null
         this.resetForm()
         if (submittedEditingId) {
           if (ownsSubmittedDraftNamespace) this._restoreDraft()
@@ -1117,7 +626,7 @@ export default class extends Controller {
         settlementUi = alertDialog(error?.message || 'Failed to submit comment')
       })
       .finally(() => {
-        this._pendingDraftSubmissions.delete(submittedDraft)
+        this._drafts._pendingDraftSubmissions.delete(submittedDraft)
         inFlightSends.delete(sendKey)
         this._hasRetried = false
         this.setSendingState(false)
@@ -1127,7 +636,7 @@ export default class extends Controller {
         ) {
           this._restoreStashedDraft(submittedText)
         } else {
-          this._stashedDraft = null
+          this._drafts._stashedDraft = null
         }
         const announceSettlement = () => {
           this.element.dispatchEvent(new CustomEvent('comments--form:submit-settled', {

--- a/engines/collavre/app/javascript/controllers/comments/form_draft_manager.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_draft_manager.js
@@ -1,8 +1,10 @@
 import chatDrafts from '../../lib/chat_drafts'
+import FormDraftMigration from './form_draft_migration'
 
 // Owns the stateful draft lifecycle while the Stimulus controller coordinates UI concerns.
-export default class FormDraftManager {
+export default class FormDraftManager extends FormDraftMigration {
   constructor(form) {
+    super()
     this.form = form
   }
 
@@ -26,28 +28,40 @@ export default class FormDraftManager {
   }
 
   connect() {
-    // Draft persistence: debounce-save unsent input per chat.
-    // _activeDraftKey always identifies the chat whose text is in the textarea.
+    this._initializeDraftState()
+    this._observeDraftClearState()
+    this._defineLifecycleHandlers()
+    this._defineImeHandlers()
+    this._defineDraftInputHandler()
+    this._addDraftEventListeners()
+  }
+
+  _initializeDraftState() {
+    this._initializeDraftIdentityState()
+    this._initializeDraftObservationState()
+  }
+
+  _initializeDraftIdentityState() {
     this._activeDraftKey ??= null
     this._activeDraftCreativeId ??= null
     this._awaitingEffectiveDraftKeyFor ??= null
     this._draftSaveTimer = null
     this._draftSaveSuspendedForPermission ??= false
-    // A cross-tab logout permanently retires the old user's namespace for this
-    // controller lifetime, including Stimulus reconnects in the stale tab.
     this._disabledDraftNamespaces ||= new Set()
     this._draftBackupCleanupPendingNamespaces ||= new Set()
     this._observedDraftClearNonces ||= new Map()
-    // A pending send survives a Stimulus reconnect on this controller instance,
-    // so its completion must keep comparing against the same draft history.
+  }
+
+  _initializeDraftObservationState() {
     this._draftRevisions ||= new Map()
     this._observedDrafts ||= new Map()
     this._observedDisplayedDrafts ||= new Map()
     this._observedDraftRevisions ||= new Map()
     this._observedStoredDraftRevisions ||= new Map()
-    // A linked chat can replace its temporary raw key while its request is in
-    // flight. Keep mutable submission state across that migration/reconnect.
     this._pendingDraftSubmissions ||= new Set()
+  }
+
+  _observeDraftClearState() {
     const draftNamespace = chatDrafts.namespace()
     const draftClearNonce = chatDrafts.clearNonce(draftNamespace)
     const draftClearNoncePending = chatDrafts.clearNoncePending(draftNamespace)
@@ -78,6 +92,9 @@ export default class FormDraftManager {
     ) {
       this._observedDraftClearNonces.set(draftNamespace, draftClearNonce)
     }
+  }
+
+  _defineLifecycleHandlers() {
     this._handlePageHide = () => {
       if (!this.element.isConnected) return
 
@@ -89,6 +106,9 @@ export default class FormDraftManager {
       const clearedNamespace = chatDrafts.namespace()
       this._disableDraftNamespace(clearedNamespace)
     }
+  }
+
+  _defineImeHandlers() {
     this._handleCompositionEnd = () => {
       this._imeCommitPending = true
     }
@@ -102,6 +122,9 @@ export default class FormDraftManager {
 
       this._imeCommitPending = false
     }
+  }
+
+  _defineDraftInputHandler() {
     this._handleDraftInput = (event) => {
       // Consume the composition flag before any early return, so it can never
       // outlive the `input` event that the commit itself fired. Firefox has
@@ -128,6 +151,9 @@ export default class FormDraftManager {
       clearTimeout(this._draftSaveTimer)
       this._draftSaveTimer = setTimeout(() => this._saveDraftNow(), 500)
     }
+  }
+
+  _addDraftEventListeners() {
     this.textareaTarget.addEventListener('compositionend', this._handleCompositionEnd)
     this.textareaTarget.addEventListener('keydown', this._expireImeCommitLatch)
     this.textareaTarget.addEventListener('paste', this._expireImeCommitLatch)
@@ -146,69 +172,6 @@ export default class FormDraftManager {
     this.textareaTarget.removeEventListener('input', this._handleDraftInput)
     window.removeEventListener('pagehide', this._handlePageHide)
     window.removeEventListener('storage', this._handleDraftStorage)
-  }
-
-  handleTopicChange() {
-    // This event fires before onPopupOpened during a chat switch, while the
-    // textarea still contains the outgoing chat's text. Flush before re-keying.
-    const draftPersistenceDisabled = this._draftPersistenceDisabled()
-    const nextDraftKey = draftPersistenceDisabled
-      ? null
-      : this.element.dataset.effectiveCreativeId || this.element.dataset.creativeId || null
-    const nextCreativeId = draftPersistenceDisabled
-      ? null
-      : this.element.dataset.creativeId || null
-    const draftKeyChanged = String(this._activeDraftKey || '') !== String(nextDraftKey || '')
-    const creativeChanged =
-      String(this._activeDraftCreativeId || '') !== String(nextCreativeId || '')
-    const resolvingIncomingDraftKey =
-      this._awaitingEffectiveDraftKeyFor &&
-      String(this._awaitingEffectiveDraftKeyFor) === String(nextCreativeId || '')
-    let keepAwaitingEffectiveDraftKey = false
-    if (draftKeyChanged || creativeChanged) {
-      const previousDraftKey = this._activeDraftKey
-      // onChatWillOpen already flushed the outgoing chat. While the effective
-      // key is loading, save only actual new input; rewriting a restored raw
-      // draft here would make stale text appear newer than the canonical draft.
-      if (!resolvingIncomingDraftKey || this._draftSaveTimer) this._flushDraftSave()
-      this._activeDraftKey = nextDraftKey ? String(nextDraftKey) : null
-      this._activeDraftCreativeId = nextCreativeId ? String(nextCreativeId) : null
-      if (
-	resolvingIncomingDraftKey &&
-	previousDraftKey &&
-	this._activeDraftKey
-      ) {
-	const sourceDraft = chatDrafts.snapshot(previousDraftKey)
-	const moveCompleted = chatDrafts.move(previousDraftKey, this._activeDraftKey)
-	const targetDraft = chatDrafts.snapshot(this._activeDraftKey)
-	const movedBackups = moveCompleted
-	  ? chatDrafts.moveSubmissionBackups(previousDraftKey, this._activeDraftKey)
-	  : new Map()
-	if (moveCompleted && (targetDraft.revision || !sourceDraft.revision)) {
-	  this._rebindPendingDraftSubmissions(
-	    previousDraftKey,
-	    this._activeDraftKey,
-	    sourceDraft,
-	    targetDraft,
-	    movedBackups,
-	  )
-	} else if (!moveCompleted) {
-	  this._trackPartialDraftMigration(
-	    previousDraftKey,
-	    this._activeDraftKey,
-	    sourceDraft,
-	    targetDraft,
-	  )
-	  if (chatDrafts.isNewer(previousDraftKey, this._activeDraftKey)) {
-	    this._activeDraftKey = String(previousDraftKey)
-	    keepAwaitingEffectiveDraftKey = true
-	  }
-	}
-      }
-    }
-    if (resolvingIncomingDraftKey && !keepAwaitingEffectiveDraftKey) {
-      this._awaitingEffectiveDraftKeyFor = null
-    }
   }
 
   onChatWillOpen({ creativeId }) {
@@ -303,278 +266,4 @@ export default class FormDraftManager {
     this._saveDraftNow()
   }
 
-  _saveDraftNow() {
-    if (
-      !this._activeDraftKey ||
-      this._draftPersistenceDisabled() ||
-      this._draftSaveSuspendedForPermission ||
-      this.editingId ||
-      this._shouldSuppressDraftSaveForStash() ||
-      !this._reviewStore.isEmpty
-    ) return
-    if (this._currentTextIsPendingSubmission()) return
-    const draftKey = this._activeDraftKey
-    const text = this.textareaTarget.value
-    const blank = !text.trim()
-    const storedDraft = chatDrafts.snapshot(draftKey)
-    const storedText = storedDraft.text
-    const hasStoredEntry = chatDrafts.updatedAt(draftKey) !== null
-    const observationKey = `${chatDrafts.namespace()}:${draftKey}`
-    const hasObservedDraft = this._observedDrafts?.has(observationKey)
-    const observedText = this._observedDrafts?.get(observationKey)
-    const hasObservedDisplayedDraft =
-      this._observedDisplayedDrafts?.has(observationKey)
-    const observedDisplayedText = hasObservedDisplayedDraft
-      ? this._observedDisplayedDrafts.get(observationKey)
-      : observedText
-    const observedRevision = this._observedDraftRevisions?.get(observationKey) || 0
-    const observedStoredRevision =
-      this._observedStoredDraftRevisions?.get(observationKey) || null
-    const currentRevision = this._draftRevisions?.get(observationKey) || 0
-    const inputChangedLocally = currentRevision !== observedRevision
-    const preserveBlank =
-      blank && Boolean(this._awaitingEffectiveDraftKeyFor) && inputChangedLocally
-    const displayedDraftChanged =
-      (hasObservedDisplayedDraft || hasObservedDraft) &&
-      (observedDisplayedText || '') !== text
-    const draftChangedLocally =
-      inputChangedLocally || displayedDraftChanged
-    const storedDraftChangedOutsideController = hasObservedDraft && (
-      observedText !== storedText || observedStoredRevision !== storedDraft.revision
-    )
-    // An idle tab can retain stale restored text after another tab updates the
-    // same draft. Closing or switching that idle tab must not write it back.
-    if (!draftChangedLocally && storedDraftChangedOutsideController) return
-    if (preserveBlank) {
-      if (storedText !== null || !hasStoredEntry) {
-	chatDrafts.set(draftKey, '', { preserveBlank: true })
-      }
-    } else if (blank) {
-      if (hasStoredEntry) {
-	chatDrafts.clear(draftKey)
-      }
-    } else if (storedText !== text) {
-      chatDrafts.set(draftKey, text)
-    }
-    if (blank && draftChangedLocally) chatDrafts.clearSubmissionBackups(draftKey)
-    this._observeDraft(draftKey)
-  }
-
-  _flushDraftSave() {
-    clearTimeout(this._draftSaveTimer)
-    this._draftSaveTimer = null
-    this._saveDraftNow()
-  }
-
-  _currentTextIsPendingSubmission() {
-    return Boolean(this._currentPendingSubmission())
-  }
-
-  _currentPendingSubmission() {
-    const namespace = chatDrafts.namespace()
-    const key = String(this._activeDraftKey || '')
-
-    return [...(this._pendingDraftSubmissions || [])].find((submission) => (
-      !submission.invalidated &&
-      submission.namespace === namespace &&
-      String(submission.key || '') === key &&
-      !submission.hadStash &&
-      !submission.hadReview &&
-      !submission.editing &&
-      submission.text === this.textareaTarget.value &&
-      (this._draftRevisions?.get(submission.revisionKey) || 0) === submission.keyRevision
-    ))
-  }
-
-  _restoreDraft() {
-    if (
-      !this._activeDraftKey ||
-      this._draftPersistenceDisabled() ||
-      this.editingId
-    ) return
-    if (this.textareaTarget.value.trim()) return
-
-    const draft = chatDrafts.snapshot(this._activeDraftKey)
-    const backup = chatDrafts.latestSubmissionBackup(this._activeDraftKey)
-    const restoreBackup = Boolean(
-      backup?.text &&
-      (draft.updatedAt === null || backup.updatedAt > draft.updatedAt),
-    )
-    if (backup && !restoreBackup) chatDrafts.removeSubmissionBackup(backup.key)
-    const restoredText = restoreBackup ? backup.text : draft.text
-    this._observeDraft(
-      this._activeDraftKey,
-      draft.text,
-      chatDrafts.namespace(),
-      draft.revision,
-      restoredText,
-    )
-    if (restoredText) {
-      this.textareaTarget.value = restoredText
-      requestAnimationFrame(() => this._autoResize())
-    } else if (draft.updatedAt === null) {
-      this._restorePendingSubmittedDraft()
-    }
-  }
-
-  _restorePendingSubmittedDraft() {
-    const namespace = chatDrafts.namespace()
-    const pending = [...(this._pendingDraftSubmissions || [])].find((submission) => (
-      !submission.invalidated &&
-      submission.namespace === namespace &&
-      String(submission.key || '') === String(this._activeDraftKey || '') &&
-      !submission.hadStash &&
-      !submission.hadReview &&
-      !submission.editing
-    ))
-    if (!pending) return
-
-    this.textareaTarget.value = pending.text
-    requestAnimationFrame(() => this._autoResize())
-    this._updateSubmitButton()
-  }
-
-  _draftPersistenceDisabled(namespace = chatDrafts.namespace()) {
-    return this._disabledDraftNamespaces?.has(namespace) ||
-      this._draftBackupCleanupPendingNamespaces?.has(namespace) ||
-      false
-  }
-
-  _disableDraftNamespace(namespace) {
-    this._disabledDraftNamespaces.add(namespace)
-    this.discardDraft()
-    // A timer in this tab may have raced with the logout tab's first clear.
-    chatDrafts.clearAll({ broadcast: false })
-  }
-
-  _observeDraft(
-    draftKey,
-    text,
-    namespace = chatDrafts.namespace(),
-    storedRevision,
-    displayedText,
-  ) {
-    if (!draftKey) return
-    const storedDraft = storedRevision === undefined
-      ? chatDrafts.snapshot(draftKey)
-      : { text, revision: storedRevision }
-    const observationKey = `${namespace}:${draftKey}`
-    this._observedDrafts?.set(observationKey, storedDraft.text)
-    this._observedDisplayedDrafts?.set(
-      observationKey,
-      displayedText === undefined ? storedDraft.text : displayedText,
-    )
-    this._observedDraftRevisions?.set(
-      observationKey,
-      this._draftRevisions?.get(observationKey) || 0,
-    )
-    this._observedStoredDraftRevisions?.set(observationKey, storedDraft.revision)
-  }
-
-  _rebindPendingDraftSubmissions(
-    sourceKey,
-    targetKey,
-    sourceDraft,
-    targetDraft,
-    movedBackups = new Map(),
-  ) {
-    const namespace = chatDrafts.namespace()
-    const targetRevisionKey = `${namespace}:${targetKey}`
-
-    this._pendingDraftSubmissions?.forEach((submission) => {
-      if (
-	submission.namespace !== namespace ||
-	String(submission.key) !== String(sourceKey)
-      ) return
-
-      const targetMatchesStoredBaseline = submission.storedRevision && targetDraft.revision === submission.storedRevision
-      const sourceMatchesSubmission =
-	sourceDraft.revision &&
-	targetDraft.revision === sourceDraft.revision &&
-	targetDraft.text === submission.text
-      const submittedDraftWasUnstored =
-	!submission.storedRevision &&
-	!sourceDraft.revision &&
-	!targetDraft.revision
-      const submittedDraftWasMoved = targetMatchesStoredBaseline || sourceMatchesSubmission || submittedDraftWasUnstored
-      if (
-	sourceDraft.revision &&
-	sourceDraft.text === submission.text
-      ) {
-	submission.migratedSources.push({
-	  key: String(sourceKey),
-	  revision: sourceDraft.revision,
-	})
-      }
-      submission.key = String(targetKey)
-      submission.revisionKey = targetRevisionKey
-      submission.keyRevision = this._draftRevisions?.get(targetRevisionKey) || 0
-      submission.storedRevision = targetDraft.revision
-      submission.storedUpdatedAt = targetDraft.updatedAt
-      submission.storedChangedOutsideController ||=
-	!submittedDraftWasMoved
-      if (submission.backupKey && movedBackups.has(submission.backupKey)) {
-	submission.backupKey = movedBackups.get(submission.backupKey)
-      }
-    })
-  }
-
-  _trackPartialDraftMigration(sourceKey, targetKey, sourceDraft, targetDraft) {
-    if (
-      !sourceDraft.revision ||
-      targetDraft.revision !== sourceDraft.revision
-    ) return
-
-    const namespace = chatDrafts.namespace()
-    this._pendingDraftSubmissions?.forEach((submission) => {
-      if (
-	submission.namespace !== namespace ||
-	String(submission.key) !== String(sourceKey) ||
-	submission.hadStash ||
-	submission.hadReview ||
-	submission.editing ||
-	submission.storedRevision !== sourceDraft.revision
-      ) return
-
-      submission.migratedSources.push({
-	key: String(targetKey),
-	revision: targetDraft.revision,
-      })
-    })
-  }
-
-  _clearMigratedSubmittedSources(submission) {
-    submission.migratedSources.forEach(({ key, revision }) => {
-      if (chatDrafts.revision(key) !== revision) return
-
-      chatDrafts.clear(key)
-      this._observeDraft(key, null, submission.namespace)
-    })
-  }
-
-  _persistFailedSubmissionDraft(submission) {
-    if (
-      submission.invalidated ||
-      submission.hadStash ||
-      submission.hadReview ||
-      submission.editing ||
-      submission.namespace !== chatDrafts.namespace()
-    ) return
-
-    const currentDraft = chatDrafts.snapshot(submission.key)
-    const currentKeyRevision =
-      this._draftRevisions?.get(submission.revisionKey) || 0
-    const submittedChatAdvanced =
-      submission.storedChangedOutsideController ||
-      currentKeyRevision !== submission.keyRevision ||
-      currentDraft.revision !== submission.storedRevision ||
-      currentDraft.updatedAt !== submission.storedUpdatedAt
-    if (submittedChatAdvanced) return
-
-    submission.backupKey ||= chatDrafts.saveSubmissionBackup(
-      submission.key,
-      submission.text,
-      { updatedAt: submission.backupUpdatedAt },
-    )
-  }
 }

--- a/engines/collavre/app/javascript/controllers/comments/form_draft_manager.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_draft_manager.js
@@ -1,0 +1,580 @@
+import chatDrafts from '../../lib/chat_drafts'
+
+// Owns the stateful draft lifecycle while the Stimulus controller coordinates UI concerns.
+export default class FormDraftManager {
+  constructor(form) {
+    this.form = form
+  }
+
+  get element() { return this.form.element }
+  get textareaTarget() { return this.form.textareaTarget }
+  get editingId() { return this.form.editingId }
+  get creativeId() { return this.form.creativeId }
+  set creativeId(value) { this.form.creativeId = value }
+  get _reviewStore() { return this.form._reviewStore }
+
+  _autoResize() {
+    this.form._autoResize()
+  }
+
+  _updateSubmitButton() {
+    this.form._updateSubmitButton()
+  }
+
+  resetForm() {
+    this.form.resetForm()
+  }
+
+  connect() {
+    // Draft persistence: debounce-save unsent input per chat.
+    // _activeDraftKey always identifies the chat whose text is in the textarea.
+    this._activeDraftKey ??= null
+    this._activeDraftCreativeId ??= null
+    this._awaitingEffectiveDraftKeyFor ??= null
+    this._draftSaveTimer = null
+    this._draftSaveSuspendedForPermission ??= false
+    // A cross-tab logout permanently retires the old user's namespace for this
+    // controller lifetime, including Stimulus reconnects in the stale tab.
+    this._disabledDraftNamespaces ||= new Set()
+    this._draftBackupCleanupPendingNamespaces ||= new Set()
+    this._observedDraftClearNonces ||= new Map()
+    // A pending send survives a Stimulus reconnect on this controller instance,
+    // so its completion must keep comparing against the same draft history.
+    this._draftRevisions ||= new Map()
+    this._observedDrafts ||= new Map()
+    this._observedDisplayedDrafts ||= new Map()
+    this._observedDraftRevisions ||= new Map()
+    this._observedStoredDraftRevisions ||= new Map()
+    // A linked chat can replace its temporary raw key while its request is in
+    // flight. Keep mutable submission state across that migration/reconnect.
+    this._pendingDraftSubmissions ||= new Set()
+    const draftNamespace = chatDrafts.namespace()
+    const draftClearNonce = chatDrafts.clearNonce(draftNamespace)
+    const draftClearNoncePending = chatDrafts.clearNoncePending(draftNamespace)
+    const observedDraftClearNonce = this._observedDraftClearNonces.has(draftNamespace)
+    let canObserveDraftClearNonce = true
+    if (draftClearNonce && !observedDraftClearNonce) {
+      canObserveDraftClearNonce = chatDrafts.clearSubmissionBackupsForClear(
+	draftNamespace,
+	draftClearNonce,
+      )
+      if (canObserveDraftClearNonce && !draftClearNoncePending) {
+	this._draftBackupCleanupPendingNamespaces.delete(draftNamespace)
+      } else {
+	this._draftBackupCleanupPendingNamespaces.add(draftNamespace)
+      }
+    }
+    if (
+      draftClearNonce &&
+      observedDraftClearNonce &&
+      this._observedDraftClearNonces.get(draftNamespace) !== draftClearNonce
+    ) {
+      this._disableDraftNamespace(draftNamespace)
+    }
+    if (
+      draftClearNonce !== undefined &&
+      canObserveDraftClearNonce &&
+      !draftClearNoncePending
+    ) {
+      this._observedDraftClearNonces.set(draftNamespace, draftClearNonce)
+    }
+    this._handlePageHide = () => {
+      if (!this.element.isConnected) return
+
+      this._flushDraftSave()
+    }
+    this._handleDraftStorage = (event) => {
+      if (!this.element.isConnected || !chatDrafts.wasCleared(event)) return
+
+      const clearedNamespace = chatDrafts.namespace()
+      this._disableDraftNamespace(clearedNamespace)
+    }
+    this._handleCompositionEnd = () => {
+      this._imeCommitPending = true
+    }
+    // Chrome fires the commit `input` after `compositionend`, but Firefox has
+    // shipped the reverse order, where the commit input consumes the latch
+    // before it is even set. Nothing would clear the leftover latch, so the
+    // next ordinary edit would be misread as a commit. The commit input always
+    // arrives before the user can act again, so any fresh gesture expires it.
+    this._expireImeCommitLatch = (event) => {
+      if (event?.isComposing || event?.keyCode === 229) return
+
+      this._imeCommitPending = false
+    }
+    this._handleDraftInput = (event) => {
+      // Consume the composition flag before any early return, so it can never
+      // outlive the `input` event that the commit itself fired. Firefox has
+      // shipped both orderings, so accept isComposing on the input event too.
+      const isImeCommit = Boolean(event?.isComposing) || this._imeCommitPending === true
+      this._imeCommitPending = false
+      if (
+	this.editingId ||
+	this._draftPersistenceDisabled() ||
+	this._draftSaveSuspendedForPermission ||
+	this._shouldSuppressDraftSaveForStash() ||
+	!this._reviewStore.isEmpty ||
+	!this._activeDraftKey
+      ) return
+      // An IME commit fires `input` after the keydown that started a send, so
+      // the textarea still holds exactly what went to the server. Counting it
+      // as a revision would defeat _currentPendingSubmission and make the sent
+      // message look like a draft typed mid-flight, restoring it on success.
+      // Text equality alone is not enough to suppress: re-entering the same
+      // string mid-flight (select-all + paste to send it twice) is a real edit.
+      if (isImeCommit && this._currentTextIsPendingSubmission()) return
+      const revisionKey = `${chatDrafts.namespace()}:${this._activeDraftKey}`
+      this._draftRevisions.set(revisionKey, (this._draftRevisions.get(revisionKey) || 0) + 1)
+      clearTimeout(this._draftSaveTimer)
+      this._draftSaveTimer = setTimeout(() => this._saveDraftNow(), 500)
+    }
+    this.textareaTarget.addEventListener('compositionend', this._handleCompositionEnd)
+    this.textareaTarget.addEventListener('keydown', this._expireImeCommitLatch)
+    this.textareaTarget.addEventListener('paste', this._expireImeCommitLatch)
+    this.textareaTarget.addEventListener('drop', this._expireImeCommitLatch)
+    this.textareaTarget.addEventListener('input', this._handleDraftInput)
+    window.addEventListener('pagehide', this._handlePageHide)
+    window.addEventListener('storage', this._handleDraftStorage)
+  }
+
+  disconnect() {
+    this._flushDraftSave()
+    this.textareaTarget.removeEventListener('compositionend', this._handleCompositionEnd)
+    this.textareaTarget.removeEventListener('keydown', this._expireImeCommitLatch)
+    this.textareaTarget.removeEventListener('paste', this._expireImeCommitLatch)
+    this.textareaTarget.removeEventListener('drop', this._expireImeCommitLatch)
+    this.textareaTarget.removeEventListener('input', this._handleDraftInput)
+    window.removeEventListener('pagehide', this._handlePageHide)
+    window.removeEventListener('storage', this._handleDraftStorage)
+  }
+
+  handleTopicChange() {
+    // This event fires before onPopupOpened during a chat switch, while the
+    // textarea still contains the outgoing chat's text. Flush before re-keying.
+    const draftPersistenceDisabled = this._draftPersistenceDisabled()
+    const nextDraftKey = draftPersistenceDisabled
+      ? null
+      : this.element.dataset.effectiveCreativeId || this.element.dataset.creativeId || null
+    const nextCreativeId = draftPersistenceDisabled
+      ? null
+      : this.element.dataset.creativeId || null
+    const draftKeyChanged = String(this._activeDraftKey || '') !== String(nextDraftKey || '')
+    const creativeChanged =
+      String(this._activeDraftCreativeId || '') !== String(nextCreativeId || '')
+    const resolvingIncomingDraftKey =
+      this._awaitingEffectiveDraftKeyFor &&
+      String(this._awaitingEffectiveDraftKeyFor) === String(nextCreativeId || '')
+    let keepAwaitingEffectiveDraftKey = false
+    if (draftKeyChanged || creativeChanged) {
+      const previousDraftKey = this._activeDraftKey
+      // onChatWillOpen already flushed the outgoing chat. While the effective
+      // key is loading, save only actual new input; rewriting a restored raw
+      // draft here would make stale text appear newer than the canonical draft.
+      if (!resolvingIncomingDraftKey || this._draftSaveTimer) this._flushDraftSave()
+      this._activeDraftKey = nextDraftKey ? String(nextDraftKey) : null
+      this._activeDraftCreativeId = nextCreativeId ? String(nextCreativeId) : null
+      if (
+	resolvingIncomingDraftKey &&
+	previousDraftKey &&
+	this._activeDraftKey
+      ) {
+	const sourceDraft = chatDrafts.snapshot(previousDraftKey)
+	const moveCompleted = chatDrafts.move(previousDraftKey, this._activeDraftKey)
+	const targetDraft = chatDrafts.snapshot(this._activeDraftKey)
+	const movedBackups = moveCompleted
+	  ? chatDrafts.moveSubmissionBackups(previousDraftKey, this._activeDraftKey)
+	  : new Map()
+	if (moveCompleted && (targetDraft.revision || !sourceDraft.revision)) {
+	  this._rebindPendingDraftSubmissions(
+	    previousDraftKey,
+	    this._activeDraftKey,
+	    sourceDraft,
+	    targetDraft,
+	    movedBackups,
+	  )
+	} else if (!moveCompleted) {
+	  this._trackPartialDraftMigration(
+	    previousDraftKey,
+	    this._activeDraftKey,
+	    sourceDraft,
+	    targetDraft,
+	  )
+	  if (chatDrafts.isNewer(previousDraftKey, this._activeDraftKey)) {
+	    this._activeDraftKey = String(previousDraftKey)
+	    keepAwaitingEffectiveDraftKey = true
+	  }
+	}
+      }
+    }
+    if (resolvingIncomingDraftKey && !keepAwaitingEffectiveDraftKey) {
+      this._awaitingEffectiveDraftKeyFor = null
+    }
+  }
+
+  onChatWillOpen({ creativeId }) {
+    const nextCreativeId = creativeId ? String(creativeId) : null
+    if (
+      String(this._activeDraftCreativeId || '') === String(nextCreativeId || '')
+    ) return
+
+    // The popup publishes its raw creative id before awaiting topics. Flush the
+    // outgoing chat now, then give any input typed during that await a key owned
+    // by the incoming chat. The topics event replaces it with the effective id.
+    this._flushDraftSave()
+    if (this._draftPersistenceDisabled()) {
+      this._activeDraftKey = null
+      this._activeDraftCreativeId = null
+      this._awaitingEffectiveDraftKeyFor = null
+      this.creativeId = creativeId
+      this.resetForm()
+      return
+    }
+    this._activeDraftKey = nextCreativeId
+    this._activeDraftCreativeId = nextCreativeId
+    this._awaitingEffectiveDraftKeyFor = nextCreativeId
+    this.creativeId = creativeId
+    this.resetForm()
+    this._restoreDraft()
+  }
+
+  discardDraft() {
+    const namespace = chatDrafts.namespace()
+    this._pendingDraftSubmissions?.forEach((submission) => {
+      if (submission.namespace === namespace) submission.invalidated = true
+    })
+    clearTimeout(this._draftSaveTimer)
+    this._draftSaveTimer = null
+    this._activeDraftKey = null
+    this._activeDraftCreativeId = null
+    this._awaitingEffectiveDraftKeyFor = null
+    this._stashedDraft = null
+    this.resetForm()
+  }
+
+  handleStashDraft(event) {
+    const draft = event.detail?.draft || null
+    if (draft) this._flushDraftSave()
+    // Tagged with the conversation it was typed in: the popup reuses this one
+    // controller for every creative, so a stash left over from another one must
+    // not be handed back here.
+    this._stashedDraft = draft ? { draft, creativeId: this.creativeId } : null
+  }
+
+  _stashedDraftBelongsToCurrentCreative() {
+    return Boolean(
+      this._stashedDraft &&
+      String(this._stashedDraft.creativeId) === String(this.creativeId),
+    )
+  }
+
+  _shouldSuppressDraftSaveForStash() {
+    if (!this._stashedDraftBelongsToCurrentCreative()) return false
+
+    // Before handleSend captures the command, the command-menu input event
+    // must not replace the stashed ordinary draft. Once the send starts, only
+    // the submitted command remains suppressed; later input is a new draft.
+    return !this._stashedDraft.submittedText ||
+      this.textareaTarget.value === this._stashedDraft.submittedText
+  }
+
+  _restoreStashedDraft(submittedText) {
+    const stashed = this._stashedDraft
+    this._stashedDraft = null
+    if (!stashed) return
+    // Switching creatives calls onPopupOpened on this same instance (there is
+    // no disconnect between conversations), so a send that settles after the
+    // switch would drop the previous conversation's draft into the new one.
+    // The draft belongs to a conversation that is no longer on screen; discard
+    // it rather than misfile it.
+    if (String(stashed.creativeId ?? '') !== String(this.creativeId ?? '')) return
+    const draft = stashed.draft
+    // Two boxes are safe to overwrite: an empty one (the success path runs
+    // resetForm) and one still holding exactly what we submitted (the failure
+    // path never clears it, so the command text is left sitting there). Any
+    // other content is text the user typed while the request was in flight, or
+    // a review quote the failure path restored, and must not be clobbered.
+    const current = this.textareaTarget.value
+    if (current.trim().length > 0 && current !== submittedText) return
+    this.textareaTarget.value = draft
+    // Resize and re-enable send directly rather than dispatching `input`, which
+    // would re-open the command menu for a draft that starts with "/".
+    this._autoResize()
+    this._updateSubmitButton()
+    this._saveDraftNow()
+  }
+
+  _saveDraftNow() {
+    if (
+      !this._activeDraftKey ||
+      this._draftPersistenceDisabled() ||
+      this._draftSaveSuspendedForPermission ||
+      this.editingId ||
+      this._shouldSuppressDraftSaveForStash() ||
+      !this._reviewStore.isEmpty
+    ) return
+    if (this._currentTextIsPendingSubmission()) return
+    const draftKey = this._activeDraftKey
+    const text = this.textareaTarget.value
+    const blank = !text.trim()
+    const storedDraft = chatDrafts.snapshot(draftKey)
+    const storedText = storedDraft.text
+    const hasStoredEntry = chatDrafts.updatedAt(draftKey) !== null
+    const observationKey = `${chatDrafts.namespace()}:${draftKey}`
+    const hasObservedDraft = this._observedDrafts?.has(observationKey)
+    const observedText = this._observedDrafts?.get(observationKey)
+    const hasObservedDisplayedDraft =
+      this._observedDisplayedDrafts?.has(observationKey)
+    const observedDisplayedText = hasObservedDisplayedDraft
+      ? this._observedDisplayedDrafts.get(observationKey)
+      : observedText
+    const observedRevision = this._observedDraftRevisions?.get(observationKey) || 0
+    const observedStoredRevision =
+      this._observedStoredDraftRevisions?.get(observationKey) || null
+    const currentRevision = this._draftRevisions?.get(observationKey) || 0
+    const inputChangedLocally = currentRevision !== observedRevision
+    const preserveBlank =
+      blank && Boolean(this._awaitingEffectiveDraftKeyFor) && inputChangedLocally
+    const displayedDraftChanged =
+      (hasObservedDisplayedDraft || hasObservedDraft) &&
+      (observedDisplayedText || '') !== text
+    const draftChangedLocally =
+      inputChangedLocally || displayedDraftChanged
+    const storedDraftChangedOutsideController = hasObservedDraft && (
+      observedText !== storedText || observedStoredRevision !== storedDraft.revision
+    )
+    // An idle tab can retain stale restored text after another tab updates the
+    // same draft. Closing or switching that idle tab must not write it back.
+    if (!draftChangedLocally && storedDraftChangedOutsideController) return
+    if (preserveBlank) {
+      if (storedText !== null || !hasStoredEntry) {
+	chatDrafts.set(draftKey, '', { preserveBlank: true })
+      }
+    } else if (blank) {
+      if (hasStoredEntry) {
+	chatDrafts.clear(draftKey)
+      }
+    } else if (storedText !== text) {
+      chatDrafts.set(draftKey, text)
+    }
+    if (blank && draftChangedLocally) chatDrafts.clearSubmissionBackups(draftKey)
+    this._observeDraft(draftKey)
+  }
+
+  _flushDraftSave() {
+    clearTimeout(this._draftSaveTimer)
+    this._draftSaveTimer = null
+    this._saveDraftNow()
+  }
+
+  _currentTextIsPendingSubmission() {
+    return Boolean(this._currentPendingSubmission())
+  }
+
+  _currentPendingSubmission() {
+    const namespace = chatDrafts.namespace()
+    const key = String(this._activeDraftKey || '')
+
+    return [...(this._pendingDraftSubmissions || [])].find((submission) => (
+      !submission.invalidated &&
+      submission.namespace === namespace &&
+      String(submission.key || '') === key &&
+      !submission.hadStash &&
+      !submission.hadReview &&
+      !submission.editing &&
+      submission.text === this.textareaTarget.value &&
+      (this._draftRevisions?.get(submission.revisionKey) || 0) === submission.keyRevision
+    ))
+  }
+
+  _restoreDraft() {
+    if (
+      !this._activeDraftKey ||
+      this._draftPersistenceDisabled() ||
+      this.editingId
+    ) return
+    if (this.textareaTarget.value.trim()) return
+
+    const draft = chatDrafts.snapshot(this._activeDraftKey)
+    const backup = chatDrafts.latestSubmissionBackup(this._activeDraftKey)
+    const restoreBackup = Boolean(
+      backup?.text &&
+      (draft.updatedAt === null || backup.updatedAt > draft.updatedAt),
+    )
+    if (backup && !restoreBackup) chatDrafts.removeSubmissionBackup(backup.key)
+    const restoredText = restoreBackup ? backup.text : draft.text
+    this._observeDraft(
+      this._activeDraftKey,
+      draft.text,
+      chatDrafts.namespace(),
+      draft.revision,
+      restoredText,
+    )
+    if (restoredText) {
+      this.textareaTarget.value = restoredText
+      requestAnimationFrame(() => this._autoResize())
+    } else if (draft.updatedAt === null) {
+      this._restorePendingSubmittedDraft()
+    }
+  }
+
+  _restorePendingSubmittedDraft() {
+    const namespace = chatDrafts.namespace()
+    const pending = [...(this._pendingDraftSubmissions || [])].find((submission) => (
+      !submission.invalidated &&
+      submission.namespace === namespace &&
+      String(submission.key || '') === String(this._activeDraftKey || '') &&
+      !submission.hadStash &&
+      !submission.hadReview &&
+      !submission.editing
+    ))
+    if (!pending) return
+
+    this.textareaTarget.value = pending.text
+    requestAnimationFrame(() => this._autoResize())
+    this._updateSubmitButton()
+  }
+
+  _draftPersistenceDisabled(namespace = chatDrafts.namespace()) {
+    return this._disabledDraftNamespaces?.has(namespace) ||
+      this._draftBackupCleanupPendingNamespaces?.has(namespace) ||
+      false
+  }
+
+  _disableDraftNamespace(namespace) {
+    this._disabledDraftNamespaces.add(namespace)
+    this.discardDraft()
+    // A timer in this tab may have raced with the logout tab's first clear.
+    chatDrafts.clearAll({ broadcast: false })
+  }
+
+  _observeDraft(
+    draftKey,
+    text,
+    namespace = chatDrafts.namespace(),
+    storedRevision,
+    displayedText,
+  ) {
+    if (!draftKey) return
+    const storedDraft = storedRevision === undefined
+      ? chatDrafts.snapshot(draftKey)
+      : { text, revision: storedRevision }
+    const observationKey = `${namespace}:${draftKey}`
+    this._observedDrafts?.set(observationKey, storedDraft.text)
+    this._observedDisplayedDrafts?.set(
+      observationKey,
+      displayedText === undefined ? storedDraft.text : displayedText,
+    )
+    this._observedDraftRevisions?.set(
+      observationKey,
+      this._draftRevisions?.get(observationKey) || 0,
+    )
+    this._observedStoredDraftRevisions?.set(observationKey, storedDraft.revision)
+  }
+
+  _rebindPendingDraftSubmissions(
+    sourceKey,
+    targetKey,
+    sourceDraft,
+    targetDraft,
+    movedBackups = new Map(),
+  ) {
+    const namespace = chatDrafts.namespace()
+    const targetRevisionKey = `${namespace}:${targetKey}`
+
+    this._pendingDraftSubmissions?.forEach((submission) => {
+      if (
+	submission.namespace !== namespace ||
+	String(submission.key) !== String(sourceKey)
+      ) return
+
+      const targetMatchesStoredBaseline = submission.storedRevision && targetDraft.revision === submission.storedRevision
+      const sourceMatchesSubmission =
+	sourceDraft.revision &&
+	targetDraft.revision === sourceDraft.revision &&
+	targetDraft.text === submission.text
+      const submittedDraftWasUnstored =
+	!submission.storedRevision &&
+	!sourceDraft.revision &&
+	!targetDraft.revision
+      const submittedDraftWasMoved = targetMatchesStoredBaseline || sourceMatchesSubmission || submittedDraftWasUnstored
+      if (
+	sourceDraft.revision &&
+	sourceDraft.text === submission.text
+      ) {
+	submission.migratedSources.push({
+	  key: String(sourceKey),
+	  revision: sourceDraft.revision,
+	})
+      }
+      submission.key = String(targetKey)
+      submission.revisionKey = targetRevisionKey
+      submission.keyRevision = this._draftRevisions?.get(targetRevisionKey) || 0
+      submission.storedRevision = targetDraft.revision
+      submission.storedUpdatedAt = targetDraft.updatedAt
+      submission.storedChangedOutsideController ||=
+	!submittedDraftWasMoved
+      if (submission.backupKey && movedBackups.has(submission.backupKey)) {
+	submission.backupKey = movedBackups.get(submission.backupKey)
+      }
+    })
+  }
+
+  _trackPartialDraftMigration(sourceKey, targetKey, sourceDraft, targetDraft) {
+    if (
+      !sourceDraft.revision ||
+      targetDraft.revision !== sourceDraft.revision
+    ) return
+
+    const namespace = chatDrafts.namespace()
+    this._pendingDraftSubmissions?.forEach((submission) => {
+      if (
+	submission.namespace !== namespace ||
+	String(submission.key) !== String(sourceKey) ||
+	submission.hadStash ||
+	submission.hadReview ||
+	submission.editing ||
+	submission.storedRevision !== sourceDraft.revision
+      ) return
+
+      submission.migratedSources.push({
+	key: String(targetKey),
+	revision: targetDraft.revision,
+      })
+    })
+  }
+
+  _clearMigratedSubmittedSources(submission) {
+    submission.migratedSources.forEach(({ key, revision }) => {
+      if (chatDrafts.revision(key) !== revision) return
+
+      chatDrafts.clear(key)
+      this._observeDraft(key, null, submission.namespace)
+    })
+  }
+
+  _persistFailedSubmissionDraft(submission) {
+    if (
+      submission.invalidated ||
+      submission.hadStash ||
+      submission.hadReview ||
+      submission.editing ||
+      submission.namespace !== chatDrafts.namespace()
+    ) return
+
+    const currentDraft = chatDrafts.snapshot(submission.key)
+    const currentKeyRevision =
+      this._draftRevisions?.get(submission.revisionKey) || 0
+    const submittedChatAdvanced =
+      submission.storedChangedOutsideController ||
+      currentKeyRevision !== submission.keyRevision ||
+      currentDraft.revision !== submission.storedRevision ||
+      currentDraft.updatedAt !== submission.storedUpdatedAt
+    if (submittedChatAdvanced) return
+
+    submission.backupKey ||= chatDrafts.saveSubmissionBackup(
+      submission.key,
+      submission.text,
+      { updatedAt: submission.backupUpdatedAt },
+    )
+  }
+}

--- a/engines/collavre/app/javascript/controllers/comments/form_draft_migration.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_draft_migration.js
@@ -1,0 +1,142 @@
+import chatDrafts from '../../lib/chat_drafts'
+import FormDraftPersistence from './form_draft_persistence'
+
+export default class FormDraftMigration extends FormDraftPersistence {
+	handleTopicChange() {
+		const context = this._nextDraftContext()
+		const resolvingIncomingDraftKey = this._isResolvingDraftKey(context.nextCreativeId)
+		let keepAwaitingEffectiveDraftKey = false
+
+		if (this._draftContextChanged(context)) {
+			keepAwaitingEffectiveDraftKey = this._changeDraftContext(context, resolvingIncomingDraftKey)
+		}
+		if (resolvingIncomingDraftKey && !keepAwaitingEffectiveDraftKey) {
+			this._awaitingEffectiveDraftKeyFor = null
+		}
+	}
+
+	_nextDraftContext() {
+		if (this._draftPersistenceDisabled()) return { nextDraftKey: null, nextCreativeId: null }
+
+		return {
+			nextDraftKey: this.element.dataset.effectiveCreativeId || this.element.dataset.creativeId || null,
+			nextCreativeId: this.element.dataset.creativeId || null,
+		}
+	}
+
+	_isResolvingDraftKey(nextCreativeId) {
+		return Boolean(
+			this._awaitingEffectiveDraftKeyFor &&
+			String(this._awaitingEffectiveDraftKeyFor) === String(nextCreativeId || ''),
+		)
+	}
+
+	_draftContextChanged({ nextDraftKey, nextCreativeId }) {
+		return String(this._activeDraftKey || '') !== String(nextDraftKey || '') ||
+			String(this._activeDraftCreativeId || '') !== String(nextCreativeId || '')
+	}
+
+	_changeDraftContext({ nextDraftKey, nextCreativeId }, resolvingIncomingDraftKey) {
+		const previousDraftKey = this._activeDraftKey
+		if (!resolvingIncomingDraftKey || this._draftSaveTimer) this._flushDraftSave()
+		this._activeDraftKey = nextDraftKey ? String(nextDraftKey) : null
+		this._activeDraftCreativeId = nextCreativeId ? String(nextCreativeId) : null
+		if (!resolvingIncomingDraftKey || !previousDraftKey || !this._activeDraftKey) return false
+
+		return this._migrateDraftKey(previousDraftKey)
+	}
+
+	_migrateDraftKey(sourceKey) {
+		const targetKey = this._activeDraftKey
+		const sourceDraft = chatDrafts.snapshot(sourceKey)
+		const moveCompleted = chatDrafts.move(sourceKey, targetKey)
+		const targetDraft = chatDrafts.snapshot(targetKey)
+		const movedBackups = moveCompleted
+			? chatDrafts.moveSubmissionBackups(sourceKey, targetKey)
+			: new Map()
+		const migration = { sourceKey, targetKey, sourceDraft, targetDraft, movedBackups }
+
+		if (moveCompleted && (targetDraft.revision || !sourceDraft.revision)) {
+			this._rebindPendingDraftSubmissions(migration)
+			return false
+		}
+		if (moveCompleted) return false
+
+		this._trackPartialDraftMigration(sourceKey, targetKey, sourceDraft, targetDraft)
+		if (!chatDrafts.isNewer(sourceKey, targetKey)) return false
+
+		this._activeDraftKey = String(sourceKey)
+		return true
+	}
+
+	_rebindPendingDraftSubmissions(migration) {
+		const namespace = chatDrafts.namespace()
+		const context = {
+			...migration,
+			namespace,
+			targetRevisionKey: `${namespace}:${migration.targetKey}`,
+		}
+		this._pendingDraftSubmissions?.forEach((submission) => {
+			this._rebindPendingDraftSubmission(submission, context)
+		})
+	}
+
+	_rebindPendingDraftSubmission(submission, context) {
+		const { namespace, sourceKey, targetKey, sourceDraft, targetDraft, movedBackups } = context
+		if (submission.namespace !== namespace || String(submission.key) !== String(sourceKey)) return
+
+		const submittedDraftWasMoved = this._submittedDraftWasMoved(submission, context)
+		this._recordMigratedSubmissionSource(submission, context)
+		submission.key = String(targetKey)
+		submission.revisionKey = context.targetRevisionKey
+		submission.keyRevision = this._draftRevisions?.get(context.targetRevisionKey) || 0
+		submission.storedRevision = targetDraft.revision
+		submission.storedUpdatedAt = targetDraft.updatedAt
+		submission.storedChangedOutsideController ||= !submittedDraftWasMoved
+		if (submission.backupKey && movedBackups.has(submission.backupKey)) {
+			submission.backupKey = movedBackups.get(submission.backupKey)
+		}
+	}
+
+	_submittedDraftWasMoved(submission, { sourceDraft, targetDraft }) {
+		const targetMatchesStoredBaseline = submission.storedRevision &&
+			targetDraft.revision === submission.storedRevision
+		const sourceMatchesSubmission = sourceDraft.revision &&
+			targetDraft.revision === sourceDraft.revision &&
+			targetDraft.text === submission.text
+		const submittedDraftWasUnstored = !submission.storedRevision &&
+			!sourceDraft.revision && !targetDraft.revision
+		return targetMatchesStoredBaseline ||
+			sourceMatchesSubmission || submittedDraftWasUnstored
+	}
+
+	_recordMigratedSubmissionSource(submission, { sourceKey, sourceDraft }) {
+		if (sourceDraft.revision && sourceDraft.text === submission.text) {
+			submission.migratedSources.push({
+				key: String(sourceKey),
+				revision: sourceDraft.revision,
+			})
+		}
+	}
+
+	_trackPartialDraftMigration(sourceKey, targetKey, sourceDraft, targetDraft) {
+		if (!sourceDraft.revision || targetDraft.revision !== sourceDraft.revision) return
+
+		const namespace = chatDrafts.namespace()
+		this._pendingDraftSubmissions?.forEach((submission) => {
+			if (
+				submission.namespace !== namespace ||
+				String(submission.key) !== String(sourceKey) ||
+				submission.hadStash ||
+				submission.hadReview ||
+				submission.editing ||
+				submission.storedRevision !== sourceDraft.revision
+			) return
+
+			submission.migratedSources.push({
+				key: String(targetKey),
+				revision: targetDraft.revision,
+			})
+		})
+	}
+}

--- a/engines/collavre/app/javascript/controllers/comments/form_draft_persistence.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_draft_persistence.js
@@ -1,0 +1,228 @@
+import chatDrafts from '../../lib/chat_drafts'
+
+export default class FormDraftPersistence {
+	_saveDraftNow() {
+		if (!this._canPersistCurrentDraft() || this._currentTextIsPendingSubmission()) return
+
+		const snapshot = this._draftSaveSnapshot()
+		if (!snapshot.draftChangedLocally && snapshot.storedDraftChangedOutsideController) return
+
+		this._persistDraftSnapshot(snapshot)
+		if (snapshot.blank && snapshot.draftChangedLocally) {
+			chatDrafts.clearSubmissionBackups(snapshot.draftKey)
+		}
+		this._observeDraft(snapshot.draftKey)
+	}
+
+	_canPersistCurrentDraft() {
+		return Boolean(
+			this._activeDraftKey &&
+			!this._draftPersistenceDisabled() &&
+			!this._draftSaveSuspendedForPermission &&
+			!this.editingId &&
+			!this._shouldSuppressDraftSaveForStash() &&
+			this._reviewStore.isEmpty,
+		)
+	}
+
+	_draftSaveSnapshot() {
+		const draftKey = this._activeDraftKey
+		const text = this.textareaTarget.value
+		const blank = !text.trim()
+		const storedDraft = chatDrafts.snapshot(draftKey)
+		const hasStoredEntry = chatDrafts.updatedAt(draftKey) !== null
+		const observationKey = `${chatDrafts.namespace()}:${draftKey}`
+		const observation = this._draftObservation(observationKey, text)
+
+		return {
+			draftKey,
+			text,
+			blank,
+			storedText: storedDraft.text,
+			hasStoredEntry,
+			preserveBlank: blank && Boolean(this._awaitingEffectiveDraftKeyFor) &&
+				observation.inputChangedLocally,
+			draftChangedLocally: observation.inputChangedLocally || observation.displayedDraftChanged,
+			storedDraftChangedOutsideController: observation.hasObservedDraft && (
+				observation.observedText !== storedDraft.text ||
+				observation.observedStoredRevision !== storedDraft.revision
+			),
+		}
+	}
+
+	_draftObservation(observationKey, text) {
+		const hasObservedDraft = this._observedDrafts?.has(observationKey)
+		const observedText = this._observedDrafts?.get(observationKey)
+		const hasObservedDisplayedDraft = this._observedDisplayedDrafts?.has(observationKey)
+		const observedDisplayedText = hasObservedDisplayedDraft
+			? this._observedDisplayedDrafts.get(observationKey)
+			: observedText
+		const { observedRevision, observedStoredRevision, currentRevision } =
+			this._draftObservationRevisions(observationKey)
+		const inputChangedLocally = currentRevision !== observedRevision
+		const displayedDraftChanged = (hasObservedDisplayedDraft || hasObservedDraft) &&
+			(observedDisplayedText || '') !== text
+
+		return {
+			hasObservedDraft,
+			observedText,
+			observedStoredRevision,
+			inputChangedLocally,
+			displayedDraftChanged,
+		}
+	}
+
+	_draftObservationRevisions(observationKey) {
+		return {
+			observedRevision: this._observedDraftRevisions?.get(observationKey) || 0,
+			observedStoredRevision: this._observedStoredDraftRevisions?.get(observationKey) || null,
+			currentRevision: this._draftRevisions?.get(observationKey) || 0,
+		}
+	}
+
+	_persistDraftSnapshot({ draftKey, text, blank, storedText, hasStoredEntry, preserveBlank }) {
+		if (preserveBlank) {
+			if (storedText !== null || !hasStoredEntry) {
+				chatDrafts.set(draftKey, '', { preserveBlank: true })
+			}
+		} else if (blank) {
+			if (hasStoredEntry) chatDrafts.clear(draftKey)
+		} else if (storedText !== text) {
+			chatDrafts.set(draftKey, text)
+		}
+	}
+
+	_flushDraftSave() {
+		clearTimeout(this._draftSaveTimer)
+		this._draftSaveTimer = null
+		this._saveDraftNow()
+	}
+
+	_currentTextIsPendingSubmission() {
+		return Boolean(this._currentPendingSubmission())
+	}
+
+	_currentPendingSubmission() {
+		const namespace = chatDrafts.namespace()
+		const key = String(this._activeDraftKey || '')
+
+		return [...(this._pendingDraftSubmissions || [])].find((submission) => (
+			!submission.invalidated &&
+			submission.namespace === namespace &&
+			String(submission.key || '') === key &&
+			!submission.hadStash &&
+			!submission.hadReview &&
+			!submission.editing &&
+			submission.text === this.textareaTarget.value &&
+			(this._draftRevisions?.get(submission.revisionKey) || 0) === submission.keyRevision
+		))
+	}
+
+	_restoreDraft() {
+		if (!this._activeDraftKey || this._draftPersistenceDisabled() || this.editingId) return
+		if (this.textareaTarget.value.trim()) return
+
+		const draft = chatDrafts.snapshot(this._activeDraftKey)
+		const backup = chatDrafts.latestSubmissionBackup(this._activeDraftKey)
+		const restoreBackup = Boolean(
+			backup?.text && (draft.updatedAt === null || backup.updatedAt > draft.updatedAt),
+		)
+		if (backup && !restoreBackup) chatDrafts.removeSubmissionBackup(backup.key)
+		const restoredText = restoreBackup ? backup.text : draft.text
+		this._observeDraft(this._activeDraftKey, draft.text, {
+			storedRevision: draft.revision,
+			displayedText: restoredText,
+		})
+		if (restoredText) {
+			this.textareaTarget.value = restoredText
+			requestAnimationFrame(() => this._autoResize())
+		} else if (draft.updatedAt === null) {
+			this._restorePendingSubmittedDraft()
+		}
+	}
+
+	_restorePendingSubmittedDraft() {
+		const namespace = chatDrafts.namespace()
+		const pending = [...(this._pendingDraftSubmissions || [])].find((submission) => (
+			!submission.invalidated &&
+			submission.namespace === namespace &&
+			String(submission.key || '') === String(this._activeDraftKey || '') &&
+			!submission.hadStash &&
+			!submission.hadReview &&
+			!submission.editing
+		))
+		if (!pending) return
+
+		this.textareaTarget.value = pending.text
+		requestAnimationFrame(() => this._autoResize())
+		this._updateSubmitButton()
+	}
+
+	_draftPersistenceDisabled(namespace = chatDrafts.namespace()) {
+		return this._disabledDraftNamespaces?.has(namespace) ||
+			this._draftBackupCleanupPendingNamespaces?.has(namespace) ||
+			false
+	}
+
+	_disableDraftNamespace(namespace) {
+		this._disabledDraftNamespaces.add(namespace)
+		this.discardDraft()
+		chatDrafts.clearAll({ broadcast: false })
+	}
+
+	_observeDraft(draftKey, text, options = {}) {
+		if (!draftKey) return
+		const {
+			namespace = chatDrafts.namespace(),
+			storedRevision,
+			displayedText,
+		} = options
+		const storedDraft = storedRevision === undefined
+			? chatDrafts.snapshot(draftKey)
+			: { text, revision: storedRevision }
+		const observationKey = `${namespace}:${draftKey}`
+		this._observedDrafts?.set(observationKey, storedDraft.text)
+		this._observedDisplayedDrafts?.set(
+			observationKey,
+			displayedText === undefined ? storedDraft.text : displayedText,
+		)
+		this._observedDraftRevisions?.set(
+			observationKey,
+			this._draftRevisions?.get(observationKey) || 0,
+		)
+		this._observedStoredDraftRevisions?.set(observationKey, storedDraft.revision)
+	}
+
+	_clearMigratedSubmittedSources(submission) {
+		submission.migratedSources.forEach(({ key, revision }) => {
+			if (chatDrafts.revision(key) !== revision) return
+
+			chatDrafts.clear(key)
+			this._observeDraft(key, null, { namespace: submission.namespace })
+		})
+	}
+
+	_persistFailedSubmissionDraft(submission) {
+		if (
+			submission.invalidated ||
+			submission.hadStash ||
+			submission.hadReview ||
+			submission.editing ||
+			submission.namespace !== chatDrafts.namespace()
+		) return
+
+		const currentDraft = chatDrafts.snapshot(submission.key)
+		const currentKeyRevision = this._draftRevisions?.get(submission.revisionKey) || 0
+		const submittedChatAdvanced = submission.storedChangedOutsideController ||
+			currentKeyRevision !== submission.keyRevision ||
+			currentDraft.revision !== submission.storedRevision ||
+			currentDraft.updatedAt !== submission.storedUpdatedAt
+		if (submittedChatAdvanced) return
+
+		submission.backupKey ||= chatDrafts.saveSubmissionBackup(
+			submission.key,
+			submission.text,
+			{ updatedAt: submission.backupUpdatedAt },
+		)
+	}
+}

--- a/engines/collavre/app/javascript/controllers/comments/list_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/list_controller.js
@@ -6,8 +6,9 @@ import { attachBundleDragImage } from '../../lib/dnd/bundle_image'
 import { renderMarkdownInContainer } from '../../lib/utils/markdown'
 import creativesApi from '../../lib/api/creatives'
 import { renderCreativeTree, dispatchCreativeTreeUpdated } from '../../creatives/tree_renderer'
-import csrfFetch, { updateCsrfTokenFromResponse } from '../../lib/api/csrf_fetch'
+import { updateCsrfTokenFromResponse } from '../../lib/api/csrf_fetch'
 import { alertDialog, confirmDialog } from '../../lib/utils/dialog'
+import CommentReadTracker from './comment_read_tracker'
 import PrevMessageNavigator from './prev_message_navigator'
 // CommonPopup is now used via TopicSearchController (Stimulus)
 
@@ -31,6 +32,7 @@ export default class extends Controller {
     this.highlightCreativeId = null
     this._loadCommentsVersion = 0
     this.markReadTimeout = null
+    this.commentReadTracker = new CommentReadTracker(this)
     this.prevMsgNavigator = new PrevMessageNavigator()
 
     this.handleScroll = this.handleScroll.bind(this)
@@ -144,9 +146,7 @@ export default class extends Controller {
       ? this.highlightAfterLoad
       : null
     this.creativeId = creativeId
-    this.renderedAllTopicIds = null
-    this.renderedAllTopicWatermarks = null
-    this.renderedAllIncludesLegacy = false
+    this.getCommentReadTracker().resetRenderedSnapshot()
     this.initialLoadComplete = false
     // highlightId from popup args takes precedence, else fallback to URL param if first load
     this.highlightAfterLoad = highlightId || pendingHighlight || this.deepLinkCommentId
@@ -169,9 +169,7 @@ export default class extends Controller {
     this.flushPendingRead()
     this._loadCommentsVersion += 1
     this.creativeId = null
-    this.renderedAllTopicIds = null
-    this.renderedAllTopicWatermarks = null
-    this.renderedAllIncludesLegacy = false
+    this.getCommentReadTracker().resetRenderedSnapshot()
     this.highlightAfterLoad = null
     this.highlightCreativeId = null
     this.suppressTopicChangeLoad = false
@@ -391,14 +389,10 @@ export default class extends Controller {
       // happen later and may observe a topic-strip archive change without
       // rendering that topic's existing history.
       if (loadVersion !== undefined && !pagination && !superseded && !this.currentTopicId && renderedTopicIds !== null) {
-        this.renderedAllTopicIds = renderedTopicIds.split(',').filter(Boolean)
-        try {
-          this.renderedAllTopicWatermarks = renderedTopicWatermarks ? JSON.parse(renderedTopicWatermarks) : null
-          this.renderedAllIncludesLegacy = Boolean(this.renderedAllTopicWatermarks && Object.hasOwn(this.renderedAllTopicWatermarks, '_legacy'))
-        } catch (_error) {
-          this.renderedAllTopicWatermarks = null
-          this.renderedAllIncludesLegacy = false
-        }
+        this.getCommentReadTracker().captureRenderedSnapshot(
+          renderedTopicIds,
+          renderedTopicWatermarks
+        )
       }
       // A load superseded while in flight must not retopic anything: its own HTML
       // is dropped, so moving currentTopicId (and the strip, and the form) to its
@@ -498,62 +492,21 @@ export default class extends Controller {
   }
 
   markCommentsRead() {
-    if (!this.creativeId) return
-    if (this.markReadTimeout) window.clearTimeout(this.markReadTimeout)
-    const creativeId = this.creativeId
-    const topicId = this.currentTopicId || null
-    const topicIds = topicId ? null : this.renderedAllTopicIds
-    const topicWatermarks = topicId ? null : this.renderedAllTopicWatermarks
-    const pendingRead = { creativeId, topicId, topicIds, topicWatermarks }
-    this.pendingRead = pendingRead
-    this.markReadTimeout = window.setTimeout(() => {
-      this.markReadTimeout = null
-      if (this.pendingRead !== pendingRead) return
-      this.pendingRead = null
-      if (!this.element.isConnected || this.creativeId !== creativeId || (this.currentTopicId || null) !== topicId) return
-
-      this.updateReadPointer(creativeId, topicId, topicIds, topicWatermarks)
-    }, 2000);
+    this.getCommentReadTracker().markCommentsRead()
   }
 
   flushPendingRead({ keepalive = false } = {}) {
-    const pendingRead = this.pendingRead
-    if (!pendingRead) return
-
-    if (this.markReadTimeout) window.clearTimeout(this.markReadTimeout)
-    this.markReadTimeout = null
-    this.pendingRead = null
-    this.updateReadPointer(
-      pendingRead.creativeId,
-      pendingRead.topicId,
-      pendingRead.topicIds,
-      pendingRead.topicWatermarks,
-      { keepalive }
-    )
+    this.getCommentReadTracker().flushPendingRead({ keepalive })
   }
 
   updateReadPointer(creativeId, topicId, topicIds = null, topicWatermarks = null, { keepalive = false } = {}) {
-    if (!creativeId) return
-
-    csrfFetch('/comment_read_pointers/update', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      keepalive,
-      body: JSON.stringify({
-        creative_id: creativeId,
-        topic_id: topicId,
-        ...(topicIds ? { topic_ids: topicIds } : {}),
-        ...(topicWatermarks ? { topic_watermarks: topicWatermarks } : {}),
-      }),
-    }).then((response) => {
-      if (!response.ok || !this.element.isConnected || this.creativeId !== creativeId || (this.currentTopicId || null) !== topicId) return
-
-      // A successful topic read changes its chip and the aggregate creative
-      // badge. Reload immediately instead of leaving stale counts on screen.
-      this.popupController?.topicsController?.loadTopics?.()
-    }).catch(() => { /* ignore — creative may have been deleted */ })
+    this.getCommentReadTracker().updateReadPointer(
+      creativeId,
+      topicId,
+      topicIds,
+      topicWatermarks,
+      { keepalive }
+    )
   }
 
   handlePrevMsgUserInput() {
@@ -676,56 +629,20 @@ export default class extends Controller {
   // visible in the DOM. Live streams still fence topics outside the initial
   // snapshot because older history for those topics may be unseen.
   recordRenderedAllTopicWatermarks(comments, { includeNewTopics = false } = {}) {
-    if (this.currentTopicId || !Array.isArray(this.renderedAllTopicIds)) return false
-
-    let addedTopic = false
-    const renderedComments = comments instanceof Element ? [comments] : Array.from(comments || [])
-    renderedComments.forEach((comment) => {
-      const topicId = comment.dataset.topicId
-      const commentId = Number.parseInt(comment.dataset.commentId, 10)
-      if (!Number.isSafeInteger(commentId) || commentId <= 0) return
-
-      const watermarkKey = topicId || '_legacy'
-      if (!topicId && !this.renderedAllIncludesLegacy) {
-        if (!includeNewTopics) return
-
-        this.renderedAllIncludesLegacy = true
-        addedTopic = true
-      }
-
-      if (topicId && !this.renderedAllTopicIds.some((id) => String(id) === String(topicId))) {
-        if (!includeNewTopics) return
-
-        this.renderedAllTopicIds.push(String(topicId))
-        addedTopic = true
-      }
-
-      this.renderedAllTopicWatermarks ||= {}
-      const previousId = Number.parseInt(this.renderedAllTopicWatermarks[watermarkKey], 10)
-      if (!Number.isSafeInteger(previousId) || commentId > previousId) {
-        this.renderedAllTopicWatermarks[watermarkKey] = commentId
-      }
-    })
-
-    return addedTopic
+    return this.getCommentReadTracker().recordRenderedAllTopicWatermarks(comments, { includeNewTopics })
   }
 
   reportRenderedAllTopics() {
-    if (this.currentTopicId || !Array.isArray(this.renderedAllTopicIds)) return
-
-    this.element.dispatchEvent(new CustomEvent('comments--list:rendered-all-topics', {
-      bubbles: true,
-      detail: {
-        creativeId: this.creativeId,
-        topicIds: this.renderedAllTopicIds,
-        includesLegacy: this.renderedAllIncludesLegacy,
-      },
-    }))
+    this.getCommentReadTracker().reportRenderedAllTopics()
   }
 
   isOutsideRenderedAllTopics(topicId) {
-    return Array.isArray(this.renderedAllTopicIds) &&
-      !this.renderedAllTopicIds.some((id) => String(id) === String(topicId))
+    return this.getCommentReadTracker().isOutsideRenderedAllTopics(topicId)
+  }
+
+  getCommentReadTracker() {
+    this.commentReadTracker ||= new CommentReadTracker(this)
+    return this.commentReadTracker
   }
 
   handleStreamRender(event) {

--- a/engines/collavre/app/javascript/controllers/comments/list_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/list_controller.js
@@ -500,13 +500,13 @@ export default class extends Controller {
   }
 
   updateReadPointer(creativeId, topicId, topicIds = null, topicWatermarks = null, { keepalive = false } = {}) {
-    this.getCommentReadTracker().updateReadPointer(
+    this.getCommentReadTracker().updateReadPointer({
       creativeId,
       topicId,
       topicIds,
       topicWatermarks,
-      { keepalive }
-    )
+      keepalive,
+    })
   }
 
   handlePrevMsgUserInput() {

--- a/engines/collavre/app/javascript/controllers/comments/popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_controller.js
@@ -1,6 +1,7 @@
 import { Controller } from '@hotwired/stimulus'
 import chatHistory from '../../lib/chat_history'
 import chatDrafts from '../../lib/chat_drafts'
+import PopupFullscreen from './popup_fullscreen'
 
 const SIZE_STORAGE_KEY = 'commentsPopupSize'
 const CREATIVE_CLICK_EVENT = 'creative-comments-click'
@@ -26,6 +27,20 @@ export default class extends Controller {
     'header',
     'typingIndicator',
   ]
+
+  initialize() {
+    this.fullscreen = new PopupFullscreen({
+      element: this.element,
+      isMobile: () => this.isMobile(),
+      isDocked: () => this.isDocked(),
+      syncUi: entering => this._syncFullscreenUI(entering),
+      syncDockedUi: () => this.syncDockedUI(),
+      getListController: () => this.listController,
+      getTopicsController: () => this.topicsController,
+      getCurrentButton: () => this.currentButton,
+      setCurrentButton: button => { this.currentButton = button },
+    })
+  }
 
   connect() {
     this.currentButton = null
@@ -60,7 +75,6 @@ export default class extends Controller {
     this._isNavigating = false
     this._headerSwipeStartX = null
     this._headerSwipeStartY = null
-
     document.addEventListener(CREATIVE_CLICK_EVENT, this.handleCreativeClick)
     document.addEventListener(CREATIVE_DESTROYED_EVENT, this.handleCreativeDestroyed)
     document.addEventListener('creative-editing:start', this.handleEditingStart)
@@ -522,44 +536,7 @@ export default class extends Controller {
   }
 
   _exitFullscreenState() {
-    if (!this.isFullscreen()) return
-
-    if (this._enterCleanupTimer) {
-      window.clearTimeout(this._enterCleanupTimer)
-      this._enterCleanupTimer = null
-    }
-    if (this._enterCleanupFn) {
-      this.element.removeEventListener('transitionend', this._enterCleanupFn)
-      this._enterCleanupFn = null
-    }
-
-    this.element.dataset.fullscreen = 'false'
-    document.body.classList.remove('chat-fullscreen')
-    this._syncFullscreenUI(false)
-    this._savedStyles = null
-    this.element.style.transition = ''
-    this.element.style.position = ''
-    this.element.style.top = ''
-    this.element.style.left = ''
-    this.element.style.right = ''
-    this.element.style.bottom = ''
-    this.element.style.width = ''
-    this.element.style.height = ''
-    this.element.style.transform = ''
-
-    // Consume the fullscreen history entry and remove markers that could
-    // reopen the invalidated chat after a reset or close.
-    const creativeId = this.element.dataset.creativeId
-    const backUrl = this._previousUrl || (creativeId ? `/creatives/${creativeId}` : null)
-    if (backUrl) {
-      const url = new URL(backUrl, window.location.origin)
-      url.searchParams.delete('open_comments')
-      url.searchParams.delete('comment_id')
-      const cleanPath = url.pathname.replace(/\/comments\/\d+$/, '')
-      url.hash = url.hash.replace(/^#comment_\d+$/, '')
-      window.history.replaceState({ fullscreen: false }, '', cleanPath + url.search + url.hash)
-    }
-    this._previousUrl = null
+    this.fullscreen.exitState()
   }
 
   closeChildControllers() {
@@ -612,6 +589,22 @@ export default class extends Controller {
 
   isFullscreen() {
     return this.element.dataset.fullscreen === 'true'
+  }
+
+  get _savedStyles() {
+    return this.fullscreen?.savedStyles
+  }
+
+  set _savedStyles(value) {
+    if (this.fullscreen) this.fullscreen.savedStyles = value
+  }
+
+  get _previousUrl() {
+    return this.fullscreen?.previousUrl
+  }
+
+  set _previousUrl(value) {
+    if (this.fullscreen) this.fullscreen.previousUrl = value
   }
 
   isMobile() {
@@ -910,387 +903,15 @@ export default class extends Controller {
 
   // Enter fullscreen immediately without animation (for auto-fullscreen on page load)
   _enterFullscreenImmediate() {
-    const el = this.element
-
-    // Save current inline styles so exit-fullscreen can restore them
-    this._savedStyles = {
-      top: el.style.top,
-      right: el.style.right,
-      left: el.style.left,
-      width: el.style.width,
-      height: el.style.height,
-    }
-
-    el.style.transition = 'none'
-    el.dataset.fullscreen = 'true'
-    document.body.classList.add('chat-fullscreen')
-    this._syncFullscreenUI(true)
-    // Clear any inline position styles so CSS fullscreen rules apply
-    el.style.top = ''
-    el.style.left = ''
-    el.style.right = ''
-    el.style.bottom = ''
-    el.style.width = ''
-    el.style.height = ''
-    el.style.position = ''
-    // Force layout then restore transition
-    el.offsetHeight // eslint-disable-line no-unused-expressions
-    el.style.transition = ''
-
-    // URL is already /comments/fullscreen, no pushState needed
-    requestAnimationFrame(() => this.listController?.scrollToBottom())
+    this.fullscreen.enterImmediate()
   }
 
   toggleFullscreen() {
-    const entering = !this.isFullscreen()
-    const el = this.element
-
-    if (entering) {
-      // Save current inline styles for later restore
-      this._savedStyles = {
-        top: el.style.top,
-        right: el.style.right,
-        left: el.style.left,
-        width: el.style.width,
-        height: el.style.height,
-      }
-
-      // Capture current visual position
-      const rect = el.getBoundingClientRect()
-
-      // Disable transition, pin to current position as fixed
-      el.style.transition = 'none'
-      el.style.position = 'fixed'
-      el.style.top = `${rect.top}px`
-      el.style.left = `${rect.left}px`
-      el.style.right = 'auto'
-      el.style.width = `${rect.width}px`
-      el.style.height = `${rect.height}px`
-
-      // Force layout so the pinned position is applied
-      el.offsetHeight // eslint-disable-line no-unused-expressions
-
-      // Now enable transition and expand to fullscreen
-      el.style.transition = ''
-      el.dataset.fullscreen = 'true'
-      document.body.classList.add('chat-fullscreen')
-      this._syncFullscreenUI(true)
-
-      // Clear inline position so CSS fullscreen rules take over
-      el.style.top = '0'
-      el.style.left = '0'
-      el.style.right = '0'
-      el.style.bottom = '0'
-      el.style.width = '100%'
-      el.style.height = '100%'
-
-      // Update URL
-      const creativeId = el.dataset.creativeId
-      if (creativeId) {
-        this._previousUrl = window.location.href
-        const fullscreenPath = `/creatives/${creativeId}/comments/fullscreen`
-        window.history.pushState({ fullscreen: true }, '', fullscreenPath)
-      }
-
-      // Clean up inline styles after transition ends
-      this._enterCleanupFn = () => {
-        el.removeEventListener('transitionend', this._enterCleanupFn)
-        this._enterCleanupTimer = null
-        this._enterCleanupFn = null
-        el.style.top = ''
-        el.style.left = ''
-        el.style.right = ''
-        el.style.bottom = ''
-        el.style.width = ''
-        el.style.height = ''
-        el.style.position = ''
-      }
-      el.addEventListener('transitionend', this._enterCleanupFn, { once: true })
-      // Fallback if transitionend doesn't fire
-      this._enterCleanupTimer = setTimeout(this._enterCleanupFn, 300)
-
-    } else {
-      // Cancel any pending enter-fullscreen cleanup to prevent it from
-      // wiping inline styles mid-exit animation (race condition fix)
-      if (this._enterCleanupTimer) {
-        clearTimeout(this._enterCleanupTimer)
-        this._enterCleanupTimer = null
-      }
-      if (this._enterCleanupFn) {
-        el.removeEventListener('transitionend', this._enterCleanupFn)
-        this._enterCleanupFn = null
-      }
-
-      const savedStyles = this._savedStyles
-      this._savedStyles = null
-      const creativeId = el.dataset.creativeId
-
-      // Mobile: skip animation, just clear inline styles and let CSS handle positioning
-      if (this.isMobile()) {
-        el.style.transition = 'none'
-        el.dataset.fullscreen = 'false'
-        document.body.classList.remove('chat-fullscreen')
-        this._syncFullscreenUI(false)
-
-        // Clear all inline styles so CSS media query rules apply
-        el.style.position = ''
-        el.style.top = ''
-        el.style.left = ''
-        el.style.right = ''
-        el.style.bottom = ''
-        el.style.width = ''
-        el.style.height = ''
-        el.style.transform = ''
-
-        // Force layout then restore transitions
-        el.offsetHeight // eslint-disable-line no-unused-expressions
-        el.style.transition = ''
-
-        // Update URL
-        let backUrl = this._previousUrl || (creativeId ? `/creatives/${creativeId}` : null)
-        if (backUrl) {
-          const url = new URL(backUrl, window.location.origin)
-          url.searchParams.set('open_comments', 'true')
-          window.history.pushState({ fullscreen: false }, '', url.pathname + url.search)
-        }
-        this._previousUrl = null
-
-        // Scroll to bottom after layout change
-        requestAnimationFrame(() => {
-          this.listController?.scrollToBottom()
-        })
-        return
-      }
-
-      if (this.isDocked()) {
-        el.style.transition = 'none'
-        el.dataset.fullscreen = 'false'
-        document.body.classList.remove('chat-fullscreen')
-        el.style.position = ''
-        el.style.top = ''
-        el.style.left = ''
-        el.style.right = ''
-        el.style.bottom = ''
-        el.style.width = ''
-        el.style.height = ''
-        this._savedStyles = null
-        this._syncFullscreenUI(false)
-        this.syncDockedUI()
-        el.offsetHeight // eslint-disable-line no-unused-expressions
-        el.style.transition = ''
-
-        let backUrl = this._previousUrl || (creativeId ? `/creatives/${creativeId}` : null)
-        if (backUrl) {
-          const url = new URL(backUrl, window.location.origin)
-          url.searchParams.set('open_comments', 'true')
-          window.history.pushState({ fullscreen: false }, '', url.pathname + url.search)
-        }
-        this._previousUrl = null
-        requestAnimationFrame(() => this.listController?.scrollToBottom())
-        return
-      }
-
-      // Desktop: animated exit to target position
-      // Calculate target position using viewport-relative coords (popup is position: fixed)
-      let finalTop = ''      // px string (viewport-relative)
-      let finalRight = ''    // px string
-      let finalWidth = savedStyles?.width || ''
-      let finalHeight = savedStyles?.height || ''
-
-      // Animation targets (viewport-relative, same as final since popup is fixed)
-      let animTop, animLeft, animWidth, animHeight
-
-      // Try to find the comment button for precise positioning
-      let targetButton = this.currentButton
-      if (!targetButton && creativeId) {
-        const row = document.querySelector(`creative-tree-row[creative-id="${creativeId}"]`)
-        targetButton = row?.querySelector('.comments-btn')
-      }
-
-      // Scroll the creative row into view instantly BEFORE calculating positions,
-      // so getBoundingClientRect returns viewport-visible coordinates
-      if (targetButton) {
-        const row = targetButton.closest('creative-tree-row')
-        if (row) {
-          row.scrollIntoView({ behavior: 'instant', block: 'center' })
-        }
-      }
-
-      if (targetButton) {
-        this.currentButton = targetButton
-        const btnRect = targetButton.getBoundingClientRect()
-        const gap = 8
-
-        animWidth = parseFloat(finalWidth) || 420
-        animHeight = parseFloat(finalHeight) || 640
-
-        // Calculate top in viewport coords — same as updatePosition
-        let top = btnRect.bottom + 4
-        const bottom = top + animHeight
-        if (bottom > window.innerHeight) {
-          top = Math.max(4, window.innerHeight - animHeight - 4)
-        }
-
-        finalTop = `${top}px`
-
-        // Right-align if enough space to the right of the button
-        const spaceRight = window.innerWidth - btnRect.right - gap
-        if (spaceRight >= animWidth) {
-          this._exitToRight = true
-          animLeft = btnRect.right + gap
-          animTop = top
-        } else {
-          this._exitToRight = false
-          const rightPx = window.innerWidth - btnRect.right + 24
-          finalRight = `${rightPx}px`
-          animTop = top
-          animLeft = window.innerWidth - rightPx - animWidth
-        }
-      } else if (savedStyles && Object.values(savedStyles).some(v => v)) {
-        // Fallback to saved styles (already viewport-relative since popup is fixed)
-        const rightVal = parseFloat(savedStyles.right) || 32
-        animWidth = parseFloat(savedStyles.width) || 420
-        animHeight = parseFloat(savedStyles.height) || 640
-        animLeft = savedStyles.left ? parseFloat(savedStyles.left) : (window.innerWidth - rightVal - animWidth)
-        animTop = parseFloat(savedStyles.top) || 100
-
-        finalTop = savedStyles.top || ''
-        finalRight = savedStyles.right || ''
-      } else {
-        // No reference at all: use CSS defaults
-        animWidth = 420
-        animHeight = 640
-        animLeft = window.innerWidth - 32 - animWidth  // right: 2em
-        animTop = 100
-      }
-
-      // Animated exit: pin at fullscreen position, then shrink to target
-      const fsRect = el.getBoundingClientRect()
-
-      el.style.transition = 'none'
-      el.style.position = 'fixed'
-      el.style.top = `${fsRect.top}px`
-      el.style.left = `${fsRect.left}px`
-      el.style.right = 'auto'
-      el.style.bottom = 'auto'
-      el.style.width = `${fsRect.width}px`
-      el.style.height = `${fsRect.height}px`
-
-      el.dataset.fullscreen = 'false'
-      document.body.classList.remove('chat-fullscreen')
-      this._syncFullscreenUI(false)
-
-      // Force layout so the pinned position is applied
-      el.offsetHeight // eslint-disable-line no-unused-expressions
-
-      // Animate to target position (fixed coordinates)
-      el.style.transition = ''
-      el.style.top = `${animTop}px`
-      el.style.left = `${animLeft}px`
-      el.style.width = `${animWidth}px`
-      el.style.height = `${animHeight}px`
-
-      let cleanupTimer = null
-      let cleanedUp = false
-      const cleanup = () => {
-        if (cleanedUp) return
-        cleanedUp = true
-        if (cleanupTimer !== null) {
-          clearTimeout(cleanupTimer)
-          cleanupTimer = null
-        }
-        el.removeEventListener('transitionend', cleanup)
-        // Popup is always position: fixed — just apply final coords
-        el.style.transition = 'none'
-        el.style.position = ''
-        el.style.bottom = ''
-
-        if (targetButton) {
-          el.style.top = finalTop
-          el.style.width = finalWidth
-          el.style.height = finalHeight
-          if (this._exitToRight) {
-            el.style.left = `${animLeft}px`
-            el.style.right = ''
-          } else {
-            el.style.right = finalRight
-            el.style.left = ''
-          }
-        } else if (savedStyles) {
-          el.style.top = ''
-          el.style.left = ''
-          el.style.right = ''
-          el.style.width = ''
-          el.style.height = ''
-          Object.assign(el.style, savedStyles)
-        } else {
-          el.style.top = ''
-          el.style.left = ''
-          el.style.right = ''
-          el.style.width = ''
-          el.style.height = ''
-        }
-
-        // Force layout then restore transitions
-        el.offsetHeight // eslint-disable-line no-unused-expressions
-        el.style.transition = ''
-
-        // Scroll active topic into view after popup has settled at final size
-        this.topicsController?.scrollToActiveTopic()
-      }
-      el.addEventListener('transitionend', cleanup, { once: true })
-      cleanupTimer = setTimeout(cleanup, 300)
-
-      // Update URL — append open_comments=true so the popup stays open on refresh
-      let backUrl = this._previousUrl || (creativeId ? `/creatives/${creativeId}` : null)
-      if (backUrl) {
-        const url = new URL(backUrl, window.location.origin)
-        url.searchParams.set('open_comments', 'true')
-        window.history.pushState({ fullscreen: false }, '', url.pathname + url.search)
-      }
-      this._previousUrl = null
-
-    }
-
-    // Scroll to bottom after layout change
-    requestAnimationFrame(() => {
-      this.listController?.scrollToBottom()
-    })
+    this.fullscreen.toggle()
   }
 
   handlePopState(event) {
-    const isFs = event.state?.fullscreen === true
-    if (isFs !== this.isFullscreen()) {
-      const el = this.element
-      // Clear any animation inline styles to avoid stale positions
-      el.style.transition = 'none'
-      el.style.position = ''
-      el.style.top = ''
-      el.style.left = ''
-      el.style.right = ''
-      el.style.bottom = ''
-      el.style.width = ''
-      el.style.height = ''
-
-      el.dataset.fullscreen = isFs ? 'true' : 'false'
-      document.body.classList.toggle('chat-fullscreen', isFs)
-      this._syncFullscreenUI(isFs)
-      if (!isFs && this.isDocked()) {
-        el.style.display = 'flex'
-        this.syncDockedUI()
-      }
-
-      if (!isFs && this._savedStyles) {
-        Object.assign(el.style, this._savedStyles)
-        this._savedStyles = null
-      }
-
-      // Restore transition
-      el.offsetHeight // eslint-disable-line no-unused-expressions
-      el.style.transition = ''
-
-      requestAnimationFrame(() => this.listController?.scrollToBottom())
-    }
+    this.fullscreen.handlePopState(event)
   }
 
   _syncFullscreenUI(entering) {

--- a/engines/collavre/app/javascript/controllers/comments/popup_exit_target.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_exit_target.js
@@ -1,0 +1,92 @@
+const DEFAULT_WIDTH = 420
+const DEFAULT_HEIGHT = 640
+const DEFAULT_TOP = 100
+
+function popupDimensions(savedStyles) {
+  const finalWidth = savedStyles?.width || ''
+  const finalHeight = savedStyles?.height || ''
+
+  return {
+    finalWidth,
+    finalHeight,
+    animWidth: parseFloat(finalWidth) || DEFAULT_WIDTH,
+    animHeight: parseFloat(finalHeight) || DEFAULT_HEIGHT,
+  }
+}
+
+function buttonTarget(targetButton, dimensions, viewport) {
+  const btnRect = targetButton.getBoundingClientRect()
+  const proposedTop = btnRect.bottom + 4
+  const animTop = proposedTop + dimensions.animHeight > viewport.height
+    ? Math.max(4, viewport.height - dimensions.animHeight - 4)
+    : proposedTop
+  const exitToRight = viewport.width - btnRect.right - 8 >= dimensions.animWidth
+  const rightPx = viewport.width - btnRect.right + 24
+
+  return {
+    ...dimensions,
+    targetButton,
+    finalTop: `${animTop}px`,
+    finalRight: exitToRight ? '' : `${rightPx}px`,
+    animTop,
+    animLeft: exitToRight ? btnRect.right + 8 : viewport.width - rightPx - dimensions.animWidth,
+    exitToRight,
+  }
+}
+
+function savedTarget(savedStyles, dimensions, viewport) {
+  const right = parseFloat(savedStyles.right) || 32
+
+  return {
+    ...dimensions,
+    targetButton: null,
+    finalTop: savedStyles.top || '',
+    finalRight: savedStyles.right || '',
+    animTop: parseFloat(savedStyles.top) || DEFAULT_TOP,
+    animLeft: savedStyles.left
+      ? parseFloat(savedStyles.left)
+      : viewport.width - right - dimensions.animWidth,
+    exitToRight: false,
+  }
+}
+
+export function findPopupTargetButton(currentButton, creativeId) {
+  let targetButton = currentButton
+  if (!targetButton && creativeId) {
+    const row = document.querySelector(`creative-tree-row[creative-id="${creativeId}"]`)
+    targetButton = row?.querySelector('.comments-btn')
+  }
+  targetButton?.closest('creative-tree-row')?.scrollIntoView({ behavior: 'instant', block: 'center' })
+  return targetButton
+}
+
+export function popupExitTarget({ targetButton, savedStyles, viewport }) {
+  const dimensions = popupDimensions(savedStyles)
+  if (targetButton) return buttonTarget(targetButton, dimensions, viewport)
+  if (savedStyles && Object.values(savedStyles).some(value => value)) {
+    return savedTarget(savedStyles, dimensions, viewport)
+  }
+
+  return {
+    ...dimensions,
+    targetButton: null,
+    finalTop: '',
+    finalRight: '',
+    animTop: DEFAULT_TOP,
+    animLeft: viewport.width - 32 - dimensions.animWidth,
+    exitToRight: false,
+  }
+}
+
+export function restorePopupTargetStyles(style, target) {
+  style.top = target.finalTop
+  style.width = target.finalWidth
+  style.height = target.finalHeight
+  if (target.exitToRight) {
+    style.left = `${target.animLeft}px`
+    style.right = ''
+  } else {
+    style.right = target.finalRight
+    style.left = ''
+  }
+}

--- a/engines/collavre/app/javascript/controllers/comments/popup_fullscreen.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_fullscreen.js
@@ -1,3 +1,9 @@
+import {
+  findPopupTargetButton,
+  popupExitTarget,
+  restorePopupTargetStyles,
+} from './popup_exit_target'
+
 export default class PopupFullscreen {
   constructor({
     element,
@@ -23,7 +29,6 @@ export default class PopupFullscreen {
     this.previousUrl = null
     this.enterCleanupTimer = null
     this.enterCleanupFn = null
-    this.exitToRight = false
   }
 
   get active() {
@@ -31,11 +36,9 @@ export default class PopupFullscreen {
   }
 
   toggle() {
-    if (this.active) {
-      this.exit()
-    } else {
-      this.enter()
-    }
+    if (this.active) return this.exit()
+
+    this.enter()
   }
 
   enterImmediate() {
@@ -90,6 +93,7 @@ export default class PopupFullscreen {
     }
 
     this.scheduleEnterCleanup()
+    this.scrollToBottom()
   }
 
   exit() {
@@ -232,7 +236,13 @@ export default class PopupFullscreen {
   }
 
   exitDesktop(savedStyles, creativeId) {
-    const target = this.desktopExitTarget(savedStyles, creativeId)
+    const targetButton = findPopupTargetButton(this.getCurrentButton(), creativeId)
+    if (targetButton) this.setCurrentButton(targetButton)
+    const target = popupExitTarget({
+      targetButton,
+      savedStyles,
+      viewport: { width: window.innerWidth, height: window.innerHeight },
+    })
     const el = this.element
     const fullscreenRect = el.getBoundingClientRect()
 
@@ -260,81 +270,6 @@ export default class PopupFullscreen {
     this.pushExitUrl(creativeId)
   }
 
-  desktopExitTarget(savedStyles, creativeId) {
-    const targetButton = this.findTargetButton(creativeId)
-    let finalTop = ''
-    let finalRight = ''
-    const finalWidth = savedStyles?.width || ''
-    const finalHeight = savedStyles?.height || ''
-    let animTop
-    let animLeft
-    let animWidth
-    let animHeight
-
-    if (targetButton) {
-      this.setCurrentButton(targetButton)
-      const btnRect = targetButton.getBoundingClientRect()
-      const gap = 8
-      animWidth = parseFloat(finalWidth) || 420
-      animHeight = parseFloat(finalHeight) || 640
-
-      let top = btnRect.bottom + 4
-      if (top + animHeight > window.innerHeight) {
-        top = Math.max(4, window.innerHeight - animHeight - 4)
-      }
-      finalTop = `${top}px`
-
-      if (window.innerWidth - btnRect.right - gap >= animWidth) {
-        this.exitToRight = true
-        animLeft = btnRect.right + gap
-      } else {
-        this.exitToRight = false
-        const rightPx = window.innerWidth - btnRect.right + 24
-        finalRight = `${rightPx}px`
-        animLeft = window.innerWidth - rightPx - animWidth
-      }
-      animTop = top
-    } else if (savedStyles && Object.values(savedStyles).some(value => value)) {
-      const right = parseFloat(savedStyles.right) || 32
-      animWidth = parseFloat(savedStyles.width) || 420
-      animHeight = parseFloat(savedStyles.height) || 640
-      animLeft = savedStyles.left
-        ? parseFloat(savedStyles.left)
-        : window.innerWidth - right - animWidth
-      animTop = parseFloat(savedStyles.top) || 100
-      finalTop = savedStyles.top || ''
-      finalRight = savedStyles.right || ''
-    } else {
-      animWidth = 420
-      animHeight = 640
-      animLeft = window.innerWidth - 32 - animWidth
-      animTop = 100
-    }
-
-    return {
-      targetButton,
-      finalTop,
-      finalRight,
-      finalWidth,
-      finalHeight,
-      animTop,
-      animLeft,
-      animWidth,
-      animHeight,
-    }
-  }
-
-  findTargetButton(creativeId) {
-    let targetButton = this.getCurrentButton()
-    if (!targetButton && creativeId) {
-      const row = document.querySelector(`creative-tree-row[creative-id="${creativeId}"]`)
-      targetButton = row?.querySelector('.comments-btn')
-    }
-    const row = targetButton?.closest('creative-tree-row')
-    row?.scrollIntoView({ behavior: 'instant', block: 'center' })
-    return targetButton
-  }
-
   scheduleExitCleanup(target, savedStyles) {
     const el = this.element
     let cleanupTimer = null
@@ -352,7 +287,7 @@ export default class PopupFullscreen {
       el.style.bottom = ''
 
       if (target.targetButton) {
-        this.restoreTargetButtonStyles(target)
+        restorePopupTargetStyles(el.style, target)
       } else if (savedStyles) {
         this.clearPositionStyles()
         Object.assign(el.style, savedStyles)
@@ -366,20 +301,6 @@ export default class PopupFullscreen {
     }
     el.addEventListener('transitionend', cleanup, { once: true })
     cleanupTimer = setTimeout(cleanup, 300)
-  }
-
-  restoreTargetButtonStyles(target) {
-    const { style } = this.element
-    style.top = target.finalTop
-    style.width = target.finalWidth
-    style.height = target.finalHeight
-    if (this.exitToRight) {
-      style.left = `${target.animLeft}px`
-      style.right = ''
-    } else {
-      style.right = target.finalRight
-      style.left = ''
-    }
   }
 
   pushExitUrl(creativeId) {

--- a/engines/collavre/app/javascript/controllers/comments/popup_fullscreen.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_fullscreen.js
@@ -1,0 +1,414 @@
+export default class PopupFullscreen {
+  constructor({
+    element,
+    isMobile,
+    isDocked,
+    syncUi,
+    syncDockedUi,
+    getListController,
+    getTopicsController,
+    getCurrentButton,
+    setCurrentButton,
+  }) {
+    this.element = element
+    this.isMobile = isMobile
+    this.isDocked = isDocked
+    this.syncUi = syncUi
+    this.syncDockedUi = syncDockedUi
+    this.getListController = getListController
+    this.getTopicsController = getTopicsController
+    this.getCurrentButton = getCurrentButton
+    this.setCurrentButton = setCurrentButton
+    this.savedStyles = null
+    this.previousUrl = null
+    this.enterCleanupTimer = null
+    this.enterCleanupFn = null
+    this.exitToRight = false
+  }
+
+  get active() {
+    return this.element.dataset.fullscreen === 'true'
+  }
+
+  toggle() {
+    if (this.active) {
+      this.exit()
+    } else {
+      this.enter()
+    }
+  }
+
+  enterImmediate() {
+    const el = this.element
+    this.savedStyles = this.captureStyles()
+
+    el.style.transition = 'none'
+    el.dataset.fullscreen = 'true'
+    document.body.classList.add('chat-fullscreen')
+    this.syncUi(true)
+    this.clearPositionStyles()
+    el.offsetHeight // eslint-disable-line no-unused-expressions
+    el.style.transition = ''
+
+    requestAnimationFrame(() => this.getListController()?.scrollToBottom())
+  }
+
+  enter() {
+    const el = this.element
+    this.savedStyles = this.captureStyles()
+    const rect = el.getBoundingClientRect()
+
+    el.style.transition = 'none'
+    el.style.position = 'fixed'
+    el.style.top = `${rect.top}px`
+    el.style.left = `${rect.left}px`
+    el.style.right = 'auto'
+    el.style.width = `${rect.width}px`
+    el.style.height = `${rect.height}px`
+    el.offsetHeight // eslint-disable-line no-unused-expressions
+
+    el.style.transition = ''
+    el.dataset.fullscreen = 'true'
+    document.body.classList.add('chat-fullscreen')
+    this.syncUi(true)
+
+    el.style.top = '0'
+    el.style.left = '0'
+    el.style.right = '0'
+    el.style.bottom = '0'
+    el.style.width = '100%'
+    el.style.height = '100%'
+
+    const creativeId = el.dataset.creativeId
+    if (creativeId) {
+      this.previousUrl = window.location.href
+      window.history.pushState(
+        { fullscreen: true },
+        '',
+        `/creatives/${creativeId}/comments/fullscreen`,
+      )
+    }
+
+    this.scheduleEnterCleanup()
+  }
+
+  exit() {
+    this.cancelEnterCleanup()
+
+    const savedStyles = this.savedStyles
+    this.savedStyles = null
+    const creativeId = this.element.dataset.creativeId
+
+    if (this.isMobile()) {
+      this.exitWithoutAnimation()
+      this.pushExitUrl(creativeId)
+      this.scrollToBottom()
+      return
+    }
+
+    if (this.isDocked()) {
+      this.exitDocked()
+      this.pushExitUrl(creativeId)
+      this.scrollToBottom()
+      return
+    }
+
+    this.exitDesktop(savedStyles, creativeId)
+    this.scrollToBottom()
+  }
+
+  exitState() {
+    if (!this.active) return
+
+    this.cancelEnterCleanup()
+
+    const el = this.element
+    el.dataset.fullscreen = 'false'
+    document.body.classList.remove('chat-fullscreen')
+    this.syncUi(false)
+    this.savedStyles = null
+    el.style.transition = ''
+    this.clearPositionStyles({ includeTransform: true })
+
+    const creativeId = el.dataset.creativeId
+    const backUrl = this.previousUrl || (creativeId ? `/creatives/${creativeId}` : null)
+    if (backUrl) {
+      const url = new URL(backUrl, window.location.origin)
+      url.searchParams.delete('open_comments')
+      url.searchParams.delete('comment_id')
+      const cleanPath = url.pathname.replace(/\/comments\/\d+$/, '')
+      url.hash = url.hash.replace(/^#comment_\d+$/, '')
+      window.history.replaceState(
+        { fullscreen: false },
+        '',
+        cleanPath + url.search + url.hash,
+      )
+    }
+    this.previousUrl = null
+  }
+
+  handlePopState(event) {
+    const isFullscreen = event.state?.fullscreen === true
+    if (isFullscreen === this.active) return
+
+    const el = this.element
+    el.style.transition = 'none'
+    this.clearPositionStyles()
+
+    el.dataset.fullscreen = isFullscreen ? 'true' : 'false'
+    document.body.classList.toggle('chat-fullscreen', isFullscreen)
+    this.syncUi(isFullscreen)
+    if (!isFullscreen && this.isDocked()) {
+      el.style.display = 'flex'
+      this.syncDockedUi()
+    }
+
+    if (!isFullscreen && this.savedStyles) {
+      Object.assign(el.style, this.savedStyles)
+      this.savedStyles = null
+    }
+
+    el.offsetHeight // eslint-disable-line no-unused-expressions
+    el.style.transition = ''
+    this.scrollToBottom()
+  }
+
+  captureStyles() {
+    const { style } = this.element
+    return {
+      top: style.top,
+      right: style.right,
+      left: style.left,
+      width: style.width,
+      height: style.height,
+    }
+  }
+
+  scheduleEnterCleanup() {
+    const el = this.element
+    this.enterCleanupFn = () => {
+      el.removeEventListener('transitionend', this.enterCleanupFn)
+      this.enterCleanupTimer = null
+      this.enterCleanupFn = null
+      this.clearPositionStyles()
+    }
+    el.addEventListener('transitionend', this.enterCleanupFn, { once: true })
+    this.enterCleanupTimer = setTimeout(this.enterCleanupFn, 300)
+  }
+
+  cancelEnterCleanup() {
+    if (this.enterCleanupTimer) {
+      clearTimeout(this.enterCleanupTimer)
+      this.enterCleanupTimer = null
+    }
+    if (this.enterCleanupFn) {
+      this.element.removeEventListener('transitionend', this.enterCleanupFn)
+      this.enterCleanupFn = null
+    }
+  }
+
+  exitWithoutAnimation() {
+    const el = this.element
+    el.style.transition = 'none'
+    el.dataset.fullscreen = 'false'
+    document.body.classList.remove('chat-fullscreen')
+    this.syncUi(false)
+    this.clearPositionStyles({ includeTransform: true })
+    el.offsetHeight // eslint-disable-line no-unused-expressions
+    el.style.transition = ''
+  }
+
+  exitDocked() {
+    const el = this.element
+    el.style.transition = 'none'
+    el.dataset.fullscreen = 'false'
+    document.body.classList.remove('chat-fullscreen')
+    this.clearPositionStyles()
+    this.savedStyles = null
+    this.syncUi(false)
+    this.syncDockedUi()
+    el.offsetHeight // eslint-disable-line no-unused-expressions
+    el.style.transition = ''
+  }
+
+  exitDesktop(savedStyles, creativeId) {
+    const target = this.desktopExitTarget(savedStyles, creativeId)
+    const el = this.element
+    const fullscreenRect = el.getBoundingClientRect()
+
+    el.style.transition = 'none'
+    el.style.position = 'fixed'
+    el.style.top = `${fullscreenRect.top}px`
+    el.style.left = `${fullscreenRect.left}px`
+    el.style.right = 'auto'
+    el.style.bottom = 'auto'
+    el.style.width = `${fullscreenRect.width}px`
+    el.style.height = `${fullscreenRect.height}px`
+
+    el.dataset.fullscreen = 'false'
+    document.body.classList.remove('chat-fullscreen')
+    this.syncUi(false)
+    el.offsetHeight // eslint-disable-line no-unused-expressions
+
+    el.style.transition = ''
+    el.style.top = `${target.animTop}px`
+    el.style.left = `${target.animLeft}px`
+    el.style.width = `${target.animWidth}px`
+    el.style.height = `${target.animHeight}px`
+
+    this.scheduleExitCleanup(target, savedStyles)
+    this.pushExitUrl(creativeId)
+  }
+
+  desktopExitTarget(savedStyles, creativeId) {
+    const targetButton = this.findTargetButton(creativeId)
+    let finalTop = ''
+    let finalRight = ''
+    const finalWidth = savedStyles?.width || ''
+    const finalHeight = savedStyles?.height || ''
+    let animTop
+    let animLeft
+    let animWidth
+    let animHeight
+
+    if (targetButton) {
+      this.setCurrentButton(targetButton)
+      const btnRect = targetButton.getBoundingClientRect()
+      const gap = 8
+      animWidth = parseFloat(finalWidth) || 420
+      animHeight = parseFloat(finalHeight) || 640
+
+      let top = btnRect.bottom + 4
+      if (top + animHeight > window.innerHeight) {
+        top = Math.max(4, window.innerHeight - animHeight - 4)
+      }
+      finalTop = `${top}px`
+
+      if (window.innerWidth - btnRect.right - gap >= animWidth) {
+        this.exitToRight = true
+        animLeft = btnRect.right + gap
+      } else {
+        this.exitToRight = false
+        const rightPx = window.innerWidth - btnRect.right + 24
+        finalRight = `${rightPx}px`
+        animLeft = window.innerWidth - rightPx - animWidth
+      }
+      animTop = top
+    } else if (savedStyles && Object.values(savedStyles).some(value => value)) {
+      const right = parseFloat(savedStyles.right) || 32
+      animWidth = parseFloat(savedStyles.width) || 420
+      animHeight = parseFloat(savedStyles.height) || 640
+      animLeft = savedStyles.left
+        ? parseFloat(savedStyles.left)
+        : window.innerWidth - right - animWidth
+      animTop = parseFloat(savedStyles.top) || 100
+      finalTop = savedStyles.top || ''
+      finalRight = savedStyles.right || ''
+    } else {
+      animWidth = 420
+      animHeight = 640
+      animLeft = window.innerWidth - 32 - animWidth
+      animTop = 100
+    }
+
+    return {
+      targetButton,
+      finalTop,
+      finalRight,
+      finalWidth,
+      finalHeight,
+      animTop,
+      animLeft,
+      animWidth,
+      animHeight,
+    }
+  }
+
+  findTargetButton(creativeId) {
+    let targetButton = this.getCurrentButton()
+    if (!targetButton && creativeId) {
+      const row = document.querySelector(`creative-tree-row[creative-id="${creativeId}"]`)
+      targetButton = row?.querySelector('.comments-btn')
+    }
+    const row = targetButton?.closest('creative-tree-row')
+    row?.scrollIntoView({ behavior: 'instant', block: 'center' })
+    return targetButton
+  }
+
+  scheduleExitCleanup(target, savedStyles) {
+    const el = this.element
+    let cleanupTimer = null
+    let cleanedUp = false
+    const cleanup = () => {
+      if (cleanedUp) return
+      cleanedUp = true
+      if (cleanupTimer !== null) {
+        clearTimeout(cleanupTimer)
+        cleanupTimer = null
+      }
+      el.removeEventListener('transitionend', cleanup)
+      el.style.transition = 'none'
+      el.style.position = ''
+      el.style.bottom = ''
+
+      if (target.targetButton) {
+        this.restoreTargetButtonStyles(target)
+      } else if (savedStyles) {
+        this.clearPositionStyles()
+        Object.assign(el.style, savedStyles)
+      } else {
+        this.clearPositionStyles()
+      }
+
+      el.offsetHeight // eslint-disable-line no-unused-expressions
+      el.style.transition = ''
+      this.getTopicsController()?.scrollToActiveTopic()
+    }
+    el.addEventListener('transitionend', cleanup, { once: true })
+    cleanupTimer = setTimeout(cleanup, 300)
+  }
+
+  restoreTargetButtonStyles(target) {
+    const { style } = this.element
+    style.top = target.finalTop
+    style.width = target.finalWidth
+    style.height = target.finalHeight
+    if (this.exitToRight) {
+      style.left = `${target.animLeft}px`
+      style.right = ''
+    } else {
+      style.right = target.finalRight
+      style.left = ''
+    }
+  }
+
+  pushExitUrl(creativeId) {
+    const backUrl = this.previousUrl || (creativeId ? `/creatives/${creativeId}` : null)
+    if (backUrl) {
+      const url = new URL(backUrl, window.location.origin)
+      url.searchParams.set('open_comments', 'true')
+      window.history.pushState(
+        { fullscreen: false },
+        '',
+        url.pathname + url.search,
+      )
+    }
+    this.previousUrl = null
+  }
+
+  clearPositionStyles({ includeTransform = false } = {}) {
+    const { style } = this.element
+    style.position = ''
+    style.top = ''
+    style.left = ''
+    style.right = ''
+    style.bottom = ''
+    style.width = ''
+    style.height = ''
+    if (includeTransform) style.transform = ''
+  }
+
+  scrollToBottom() {
+    requestAnimationFrame(() => this.getListController()?.scrollToBottom())
+  }
+}

--- a/engines/collavre/app/javascript/controllers/comments/topics/last_topic_save.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics/last_topic_save.js
@@ -1,0 +1,124 @@
+export default class LastTopicSave {
+	constructor(topics) {
+		this.topics = topics
+	}
+
+	enqueue(context) {
+		return this.topics.saveOrderState.enqueue(() => this._save(context))
+	}
+
+	async _save(context) {
+		const claimed = this._claimEcho(context)
+		const saveResult = await this.topics.saveLastTopicWithTimeout(
+			context.creativeId,
+			context.id || null,
+			context.clientId,
+		)
+		const outcome = this._outcome(context, saveResult)
+		if (claimed && outcome.saved) this._handleSaved(context, outcome)
+		this._finish(context, outcome, claimed)
+	}
+
+	_claimEcho({ id, effectiveCreativeId, clientId, generation }) {
+		const topics = this.topics
+		const claimed = generation === topics.subscriptionGenerationFor(effectiveCreativeId)
+		if (!claimed) return false
+
+		const previousTopicId = topics.lastKnownRemoteTopicIdFor(effectiveCreativeId)
+		topics.selfEchoState.claim(clientId, {
+			creativeId: effectiveCreativeId,
+			topicId: id,
+			previousTopicId: previousTopicId === undefined ? topics.serverLastTopicId : previousTopicId,
+			possiblyMissed: topics._popupClosed && !topics.topicsSubscription,
+		})
+		return true
+	}
+
+	_outcome(context, saveResult) {
+		const savedRevision = this.topics.normalizeLastTopicRevision(saveResult?.lastTopicRevision)
+		return {
+			saveResult,
+			savedRevision,
+			saved: saveResult === true || saveResult?.success === true,
+			savedRevisionIsCurrent: this.topics.observeLastTopicRevision(
+				context.effectiveCreativeId,
+				savedRevision,
+			),
+			topicId: context.id ? String(context.id) : "",
+			rejected: saveResult === false || saveResult?.success === false,
+			stale: saveResult?.staleLastTopicSave === true,
+		}
+	}
+
+	_handleSaved(context, outcome) {
+		const topics = this.topics
+		const hasPendingSelfEcho = this._recordAcknowledgement(context, outcome)
+		const echoState = this._echoState(context)
+		if (echoState.cannotArrive) {
+			topics.setLastKnownRemoteTopicId(context.effectiveCreativeId, outcome.topicId)
+			if (echoState.missedDuringDisconnect) {
+				topics.retirePendingSelfEcho(context.clientId)
+			} else {
+				topics.releasePendingSelfEcho(context.clientId)
+			}
+			return
+		}
+
+		if (hasPendingSelfEcho && outcome.savedRevisionIsCurrent) {
+			topics.setLastKnownRemoteTopicId(context.effectiveCreativeId, outcome.topicId)
+		}
+		topics.acknowledgePendingSelfEcho(context.clientId)
+	}
+
+	_recordAcknowledgement({ clientId }, { savedRevision }) {
+		const topics = this.topics
+		const hasPendingSelfEcho = topics.pendingSelfEchoes.includes(clientId)
+		if (!hasPendingSelfEcho) return false
+
+		topics.saveAcknowledgementVersion += 1
+		topics.pendingSelfEchoAcknowledgementVersions.set(
+			clientId,
+			topics.saveAcknowledgementVersion,
+		)
+		if (savedRevision) topics.pendingSelfEchoRemoteRevisions.set(clientId, savedRevision)
+		return true
+	}
+
+	_echoState({ effectiveCreativeId, clientId }) {
+		const topics = this.topics
+		const currentCreativeId = String(topics.creativeId)
+		const currentStreamIsResolved = topics.element.dataset.effectiveCreativeId ||
+			topics.knownEffectiveCreativeIds.has(currentCreativeId)
+		const subscribedToAnotherStream = topics.topicsSubscription && currentStreamIsResolved &&
+			String(topics.effectiveCreativeId) !== String(effectiveCreativeId)
+		const missedDuringDisconnect =
+			topics.possiblyMissedPendingSelfEchoesDuringDisconnect.has(clientId)
+		const missedWhileClosed =
+			topics.possiblyMissedPendingSelfEchoes.has(clientId) && !topics.topicsSubscription
+
+		return {
+			missedDuringDisconnect,
+			cannotArrive: missedWhileClosed || subscribedToAnotherStream || missedDuringDisconnect,
+		}
+	}
+
+	_finish(context, outcome, claimed) {
+		const topics = this.topics
+		if (claimed && outcome.rejected) topics.releasePendingSelfEcho(context.clientId)
+		if (claimed && outcome.saveResult === null) {
+			topics.scheduleAmbiguousPendingSelfEchoRetirement(context.clientId)
+		}
+		const pendingPickMatches = topics.selectionState.pendingPickMatches(
+			context.pendingPick,
+			context.creativeId,
+			outcome.topicId,
+		)
+		if (outcome.stale && pendingPickMatches) topics.selectionState.clearPendingPick()
+		if (outcome.saveResult !== null) {
+			topics.retryDeferredLastTopicReconciliation(context.effectiveCreativeId)
+		}
+		if (outcome.saveResult !== false && pendingPickMatches) {
+			topics.selectionState.clearPendingPick()
+		}
+	}
+}

--- a/engines/collavre/app/javascript/controllers/comments/topics/save_order_state.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics/save_order_state.js
@@ -1,0 +1,127 @@
+const LAST_TOPIC_SAVE_SESSION_STORAGE_KEY = "collavre:last-topic-save-session-id"
+const LAST_TOPIC_SAVE_SEQUENCE_STORAGE_KEY = "collavre:last-topic-save-sequence"
+const LAST_TOPIC_SAVE_WINDOW_NAME_PREFIX = "collavre:last-topic-save-session:"
+let fallbackClientIdSequence = 0
+
+function newClientId() {
+    if (typeof crypto !== 'undefined' && crypto.randomUUID) return crypto.randomUUID()
+
+    if (typeof crypto !== 'undefined' && crypto.getRandomValues) {
+        const bytes = crypto.getRandomValues(new Uint8Array(16))
+        return `save-${Array.from(bytes, byte => byte.toString(16).padStart(2, '0')).join('')}`
+    }
+
+    fallbackClientIdSequence += 1
+    return `save-${Date.now().toString(36)}-${fallbackClientIdSequence.toString(36)}`
+}
+
+export default class LastTopicSaveOrderState {
+    constructor() {
+        this.timer = null
+        this.chain = Promise.resolve()
+        this.sessionId = undefined
+        this.sequence = 0
+        this.lastKnownRemoteTopicIds = new Map()
+        this.highestRevisions = new Map()
+        this.knownEffectiveCreativeIds = new Map()
+        this.activeLoadAcknowledgementVersions = new Map()
+        this.acknowledgementVersion = 0
+        this.deferredReconciliations = new Set()
+        this.subscriptionGenerations = new Map()
+    }
+
+    enqueue(callback) {
+        this.chain = this.chain.then(callback)
+        return this.chain
+    }
+
+    nextClientId() {
+        this.sessionId ||= this.windowSessionId()
+        this.sequence = this.nextSequence()
+        return `${this.sessionId}.${this.sequence}.${newClientId()}`
+    }
+
+    windowSessionId() {
+        try {
+            const sessionId = this.currentWindowSessionId()
+            sessionStorage.setItem(LAST_TOPIC_SAVE_SESSION_STORAGE_KEY, sessionId)
+            return sessionId
+        } catch (_) {
+            return newClientId()
+        }
+    }
+
+    currentWindowSessionId() {
+        const currentName = window.name || ""
+        if (currentName.startsWith(LAST_TOPIC_SAVE_WINDOW_NAME_PREFIX)) {
+            const sessionId = currentName.slice(LAST_TOPIC_SAVE_WINDOW_NAME_PREFIX.length)
+            if (/^[A-Za-z0-9-]+$/.test(sessionId)) return sessionId
+        }
+
+        const sessionId = newClientId()
+        window.name = `${LAST_TOPIC_SAVE_WINDOW_NAME_PREFIX}${sessionId}`
+        return sessionId
+    }
+
+    nextSequence() {
+        try {
+            const stored = Number(sessionStorage.getItem(LAST_TOPIC_SAVE_SEQUENCE_STORAGE_KEY))
+            const previous = Number.isSafeInteger(stored) && stored >= 0 ? stored : 0
+            const sequence = Math.max(this.sequence, previous) + 1
+            sessionStorage.setItem(LAST_TOPIC_SAVE_SEQUENCE_STORAGE_KEY, String(sequence))
+            return sequence
+        } catch (_) {
+            return this.sequence + 1
+        }
+    }
+
+    lastKnownTopicIdFor(creativeId) {
+        return this.lastKnownRemoteTopicIds.get(String(creativeId))
+    }
+
+    setLastKnownTopicId(creativeId, value) {
+        this.lastKnownRemoteTopicIds.set(String(creativeId), value ? String(value) : "")
+    }
+
+    observeRevision(creativeId, revision) {
+        if (!revision) return true
+
+        const streamCreativeId = String(creativeId)
+        const previous = this.highestRevisions.get(streamCreativeId)
+        const comparison = this.compareRevisions(revision, previous)
+        if (comparison !== null && comparison < 0) return false
+        if (comparison === null || comparison > 0) {
+            this.highestRevisions.set(streamCreativeId, revision)
+        }
+        return true
+    }
+
+    normalizeRevision(value) {
+        if (!Array.isArray(value) || value.length !== 2) return null
+        const revision = value.map(Number)
+        return revision.every(Number.isSafeInteger) ? revision : null
+    }
+
+    compareRevisions(left, right) {
+        if (!left || !right) return null
+        return left[0] === right[0] ? left[1] - right[1] : left[0] - right[0]
+    }
+
+    subscriptionGenerationFor(creativeId) {
+        const streamCreativeId = String(creativeId)
+        if (!this.subscriptionGenerations.has(streamCreativeId)) {
+            this.subscriptionGenerations.set(streamCreativeId, 0)
+        }
+        return this.subscriptionGenerations.get(streamCreativeId)
+    }
+
+    bumpSubscriptionGeneration(creativeId) {
+        const streamCreativeId = String(creativeId)
+        this.subscriptionGenerations.set(
+            streamCreativeId,
+            this.subscriptionGenerationFor(streamCreativeId) + 1
+        )
+    }
+}
+
+export { LAST_TOPIC_SAVE_WINDOW_NAME_PREFIX }

--- a/engines/collavre/app/javascript/controllers/comments/topics/selection_restore_state.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics/selection_restore_state.js
@@ -1,0 +1,42 @@
+export default class TopicSelectionRestoreState {
+    constructor() {
+        this.epoch = 0
+        this.explicitAllMessagesSelection = false
+        this.pendingPick = undefined
+        this.pickCreativeId = undefined
+        this.pickTopicId = undefined
+    }
+
+    recordPick(creativeId, topicId, { pending = false } = {}) {
+        this.epoch += 1
+        this.pickCreativeId = creativeId
+        this.pickTopicId = topicId
+        if (pending) {
+            this.pendingPick = { creativeId, topicId }
+        }
+    }
+
+    outranks(epoch, creativeId, topics, archivedTopics) {
+        const hasNewerPick = this.epoch !== epoch
+        const hasUnsavedPick = this.pendingPick &&
+            String(this.pendingPick.creativeId) === String(creativeId)
+        if (!hasNewerPick && !hasUnsavedPick) return false
+        if (String(this.pickCreativeId) !== String(creativeId)) return false
+        if (!this.pickTopicId) return true
+
+        return [ ...(topics || []), ...(archivedTopics || []) ]
+            .some(topic => String(topic.id) === String(this.pickTopicId))
+    }
+
+    pendingPickMatches(pick, creativeId, topicId) {
+        return this.pendingPick === pick &&
+            String(pick?.creativeId) === String(creativeId) &&
+            pick?.topicId === topicId
+    }
+
+    clearPendingPick(topicId = undefined) {
+        if (topicId === undefined || String(this.pendingPick?.topicId) === String(topicId)) {
+            this.pendingPick = null
+        }
+    }
+}

--- a/engines/collavre/app/javascript/controllers/comments/topics/self_echo_state.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics/self_echo_state.js
@@ -1,0 +1,24 @@
+export default class LastTopicSelfEchoState {
+    constructor() {
+        this.pendingIds = []
+        this.creativeIds = new Map()
+        this.topicIds = new Map()
+        this.previousTopicIds = new Map()
+        this.acknowledgementVersions = new Map()
+        this.remoteRevisions = new Map()
+        this.acknowledgedIds = new Set()
+        this.settledIds = new Set()
+        this.possiblyMissedIds = new Set()
+        this.possiblyMissedDuringDisconnectIds = new Set()
+        this.ambiguousRetirementTimers = new Map()
+        this.retiredSequenceHighWaters = new Map()
+    }
+
+    claim(clientId, { creativeId, topicId, previousTopicId, possiblyMissed = false }) {
+        this.pendingIds.push(clientId)
+        this.creativeIds.set(clientId, String(creativeId))
+        this.topicIds.set(clientId, topicId ? String(topicId) : "")
+        this.previousTopicIds.set(clientId, previousTopicId ? String(previousTopicId) : "")
+        if (possiblyMissed) this.possiblyMissedIds.add(clientId)
+    }
+}

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -8,6 +8,7 @@ import { alertDialog, confirmDialog } from "../../lib/utils/dialog"
 import { invalidateCreativeTree } from '../../lib/creative_tree_invalidation'
 import PopupToggleGuard from '../../lib/popup_toggle_guard'
 import TopicSelectionRestoreState from './topics/selection_restore_state'
+import LastTopicSave from './topics/last_topic_save'
 import LastTopicSaveOrderState, { LAST_TOPIC_SAVE_WINDOW_NAME_PREFIX } from './topics/save_order_state'
 import LastTopicSelfEchoState from './topics/self_echo_state'
 
@@ -28,6 +29,10 @@ export default class extends Controller {
     get saveOrderState() {
         return this._saveOrderState || (this._saveOrderState = new LastTopicSaveOrderState())
     }
+
+	get lastTopicSave() {
+		return this._lastTopicSave || (this._lastTopicSave = new LastTopicSave(this))
+	}
 
     get selfEchoState() {
         return this._selfEchoState || (this._selfEchoState = new LastTopicSelfEchoState())
@@ -1583,115 +1588,11 @@ export default class extends Controller {
         // sticks need not be the last one picked. Waiting for the one in
         // flight is what makes the order they were picked in the order they
         // are written.
-        const save = this.saveOrderState.enqueue(async () => {
-            // update_last_topic broadcasts to every session of this user, this
-            // one included. Claim the echo here, before the request goes out —
-            // the broadcast is sent server-side before the response is
-            // rendered, so it can beat the save returning.
-            const claimed = generation === this.subscriptionGenerationFor(effectiveCreativeId)
-            if (claimed) {
-                this.selfEchoState.claim(clientId, {
-                    creativeId: effectiveCreativeId,
-                    topicId: id,
-                    previousTopicId: this.lastKnownRemoteTopicIdFor(effectiveCreativeId) === undefined
-                        ? this.serverLastTopicId
-                        : this.lastKnownRemoteTopicIdFor(effectiveCreativeId),
-                    possiblyMissed: this._popupClosed && !this.topicsSubscription,
-                })
-                // A save can wait behind another request while the popup closes. It
-                // takes its claim only when the queue reaches it, after the close
-                // handler has already marked the claims that existed then. Its echo
-                // will also be sent into that closed gap, so mark it at creation.
-            }
-            // A thrown fetch has an unknown outcome: the server may have saved
-            // and broadcast before the connection failed, so keep its claim for
-            // that delayed echo. An HTTP failure is definitive, however, and
-            // update_last_topic returns before broadcasting in that case.
-            const saveResult = await this.saveLastTopicWithTimeout(creativeId, id || null, clientId)
-            const saved = saveResult === true || saveResult?.success === true
-            const savedRevision = this.normalizeLastTopicRevision(saveResult?.lastTopicRevision)
-            const savedRevisionIsCurrent = this.observeLastTopicRevision(
-                effectiveCreativeId,
-                savedRevision
-            )
-            const topicId = id ? String(id) : ""
-            const saveRejected = saveResult === false || saveResult?.success === false
-            const staleLastTopicSave = saveResult?.staleLastTopicSave === true
-            if (claimed && saved) {
-                // The Action Cable echo can arrive before this response. In that
-                // case it has already consumed the claim and removed its metadata;
-                // do not recreate an acknowledgement entry for a completed save.
-                const hasPendingSelfEcho = this.pendingSelfEchoes.includes(clientId)
-                if (hasPendingSelfEcho) {
-                    this.saveAcknowledgementVersion += 1
-                    this.pendingSelfEchoAcknowledgementVersions.set(
-                        clientId,
-                        this.saveAcknowledgementVersion
-                    )
-                    // The response can beat its Action Cable echo. Preserve the
-                    // server-issued revision now so a delayed GET can order this
-                    // acknowledged claim against a newer ABA snapshot.
-                    if (savedRevision) {
-                        this.pendingSelfEchoRemoteRevisions.set(clientId, savedRevision)
-                    }
-                }
-                const currentCreativeId = String(this.creativeId)
-                const currentStreamIsResolved = this.element.dataset.effectiveCreativeId ||
-                    this.knownEffectiveCreativeIds.has(currentCreativeId)
-                const subscribedToAnotherStream = this.topicsSubscription && currentStreamIsResolved &&
-                    String(this.effectiveCreativeId) !== String(effectiveCreativeId)
-                const possiblyMissedDuringDisconnect =
-                    this.possiblyMissedPendingSelfEchoesDuringDisconnect.has(clientId)
-                if ((this.possiblyMissedPendingSelfEchoes.has(clientId) && !this.topicsSubscription) ||
-                    subscribedToAnotherStream ||
-                    possiblyMissedDuringDisconnect) {
-                    // update_last_topic broadcasts before it returns. With the popup
-                    // closed, or after its stream was replaced, that echo was necessarily
-                    // sent somewhere this controller can no longer receive it and cannot
-                    // settle this claim.
-                    // This completed save is also the remote baseline for the next
-                    // queued save, which may have claimed after the popup closed.
-                    this.setLastKnownRemoteTopicId(effectiveCreativeId, topicId)
-                    if (possiblyMissedDuringDisconnect) {
-                        this.retirePendingSelfEcho(clientId)
-                    } else {
-                        this.releasePendingSelfEcho(clientId)
-                    }
-                } else {
-                    // The replacement subscription may have been active before this
-                    // response beat the WebSocket message back to the browser. Keep the
-                    // id to consume that echo, but do not use this acknowledged claim to
-                    // override a later reopen snapshot.
-                    // A completed save establishes the server value that the
-                    // next claim was made from. Without moving this baseline,
-                    // a later closed save compares its reopen snapshot to a
-                    // value from before an earlier local save and mistakes the
-                    // legitimate previous value for another session's update.
-                    // Do not overwrite a newer Action Cable update after this
-                    // save's echo has already been consumed: that echo records
-                    // the baseline at broadcast time, and another message may
-                    // have advanced it before the HTTP response arrived.
-                    if (hasPendingSelfEcho && savedRevisionIsCurrent) {
-                        this.setLastKnownRemoteTopicId(effectiveCreativeId, topicId)
-                    }
-                    this.acknowledgePendingSelfEcho(clientId)
-                }
-            }
-            if (claimed && saveRejected) this.releasePendingSelfEcho(clientId)
-            if (claimed && saveResult === null) {
-                this.scheduleAmbiguousPendingSelfEchoRetirement(clientId)
-            }
-            const rejectedPendingPick = staleLastTopicSave &&
-                this.selectionState.pendingPickMatches(pendingPick, creativeId, topicId)
-            if (rejectedPendingPick) this.selectionState.clearPendingPick()
-            if (saveResult !== null) this.retryDeferredLastTopicReconciliation(effectiveCreativeId)
-            if (saveResult !== false &&
-                this.selectionState.pendingPickMatches(pendingPick, creativeId, topicId)) {
-                this.selectionState.clearPendingPick()
-            }
-        })
-        return save
-    }
+		const context = {
+			id, creativeId, effectiveCreativeId, clientId, pendingPick, generation,
+		}
+		return this.lastTopicSave.enqueue(context)
+	}
 
     // A timed-out fetch can still be running on Rails. Prefix each echo id with
     // a controller-local session and monotonically increasing sequence so Rails

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -7,6 +7,9 @@ import { fetchNextTopicName, createTopicWithComments, saveLastTopic } from "../.
 import { alertDialog, confirmDialog } from "../../lib/utils/dialog"
 import { invalidateCreativeTree } from '../../lib/creative_tree_invalidation'
 import PopupToggleGuard from '../../lib/popup_toggle_guard'
+import TopicSelectionRestoreState from './topics/selection_restore_state'
+import LastTopicSaveOrderState, { LAST_TOPIC_SAVE_WINDOW_NAME_PREFIX } from './topics/save_order_state'
+import LastTopicSelfEchoState from './topics/self_echo_state'
 
 const ICON_ARCHIVE = `<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="5" rx="1"/><path d="M4 8v11a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8"/><path d="M10 12h4"/></svg>`
 const ICON_RESTORE = `<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7v6h6"/><path d="M21 17a9 9 0 0 0-9-9 9 9 0 0 0-6.69 3L3 13"/></svg>`
@@ -14,28 +17,64 @@ const AMBIGUOUS_SAVE_CLAIM_TIMEOUT = 5_000
 const SAVE_REQUEST_TIMEOUT = 5_000
 const UNREAD_COUNT_REFRESH_DELAY = 250
 const TOPIC_SCROLL_DURATION = 250
-const LAST_TOPIC_SAVE_SESSION_STORAGE_KEY = "collavre:last-topic-save-session-id"
-const LAST_TOPIC_SAVE_SEQUENCE_STORAGE_KEY = "collavre:last-topic-save-sequence"
-const LAST_TOPIC_SAVE_WINDOW_NAME_PREFIX = "collavre:last-topic-save-session:"
-let fallbackClientIdSequence = 0
-
-// Names one save, so its broadcast can be told from a sibling session's. It
-// has to be unique across the user's tabs, not just within this one: two tabs
-// counting from zero would answer to each other's echoes.
-function newClientId() {
-    if (typeof crypto !== 'undefined' && crypto.randomUUID) return crypto.randomUUID()
-
-    if (typeof crypto !== 'undefined' && crypto.getRandomValues) {
-        const bytes = crypto.getRandomValues(new Uint8Array(16))
-        return `save-${Array.from(bytes, byte => byte.toString(16).padStart(2, '0')).join('')}`
-    }
-
-    fallbackClientIdSequence += 1
-    return `save-${Date.now().toString(36)}-${fallbackClientIdSequence.toString(36)}`
-}
 
 export default class extends Controller {
     static targets = ["list", "creationContainer", "topicListButton"]
+
+    get selectionState() {
+        return this._selectionState || (this._selectionState = new TopicSelectionRestoreState())
+    }
+
+    get saveOrderState() {
+        return this._saveOrderState || (this._saveOrderState = new LastTopicSaveOrderState())
+    }
+
+    get selfEchoState() {
+        return this._selfEchoState || (this._selfEchoState = new LastTopicSelfEchoState())
+    }
+
+    // Keep the controller's existing internal surface while the state itself is
+    // owned by focused collaborators. Existing lifecycle paths intentionally
+    // inspect these values while a request is in flight.
+    get _explicitAllMessagesSelection() {
+        return this.selectionState.explicitAllMessagesSelection
+    }
+
+    set _explicitAllMessagesSelection(value) {
+        this.selectionState.explicitAllMessagesSelection = value
+    }
+
+    get _pendingPick() {
+        return this.selectionState.pendingPick
+    }
+
+    set _pendingPick(value) {
+        this.selectionState.pendingPick = value
+    }
+
+    get _pickCreativeId() {
+        return this.selectionState.pickCreativeId
+    }
+
+    set _pickCreativeId(value) {
+        this.selectionState.pickCreativeId = value
+    }
+
+    get _pickTopicId() {
+        return this.selectionState.pickTopicId
+    }
+
+    set _pickTopicId(value) {
+        this.selectionState.pickTopicId = value
+    }
+
+    get _saveLastTopicTimer() {
+        return this.saveOrderState.timer
+    }
+
+    set _saveLastTopicTimer(value) {
+        this.saveOrderState.timer = value
+    }
 
     connect() {
         this._registerDragDrop()
@@ -1448,15 +1487,11 @@ export default class extends Controller {
             // resolved to the topic now being selected must keep outranking the
             // stale server last_topic_id for the rest of the popup session.
             this.releaseSelectionSourcesOtherThan(this.serverLastTopicId)
-            this.selectionEpoch += 1
-            this._pickCreativeId = this._renderedCreativeId
-            this._pickTopicId = this.serverLastTopicId
-            if (pending) {
-                this._pendingPick = {
-                    creativeId: this._pickCreativeId,
-                    topicId: this._pickTopicId,
-                }
-            }
+            this.selectionState.recordPick(
+                this._renderedCreativeId,
+                this.serverLastTopicId,
+                { pending }
+            )
         }
         if (persist) this.debounceSaveLastTopic(id)
     }
@@ -1464,11 +1499,11 @@ export default class extends Controller {
     // Bumped on every selection so an in-flight loadTopics() can tell whether
     // its answer predates a pick the user has since made.
     get selectionEpoch() {
-        return this._selectionEpoch || 0
+        return this.selectionState.epoch
     }
 
     set selectionEpoch(value) {
-        this._selectionEpoch = value
+        this.selectionState.epoch = value
     }
 
     // Did a pick land after the load at `epoch` started, or is there still an
@@ -1486,17 +1521,7 @@ export default class extends Controller {
     // made against a strip that predates a delete, and keeping it would fail the
     // lookup in restoreSelection() and persist Main in its place.
     pickOutranks(epoch, creativeId, topics, archivedTopics) {
-        const hasNewerPick = this.selectionEpoch !== epoch
-        const hasUnsavedPick = this._pendingPick &&
-            String(this._pendingPick.creativeId) === String(creativeId)
-        if (!hasNewerPick && !hasUnsavedPick) return false
-        // creativeId is always truthy here — loadTopics() returns without it —
-        // so a pick made before any strip was rendered fails this too.
-        if (String(this._pickCreativeId) !== String(creativeId)) return false
-        if (!this._pickTopicId) return true
-
-        return [ ...(topics || []), ...(archivedTopics || []) ]
-            .some(t => String(t.id) === String(this._pickTopicId))
+        return this.selectionState.outranks(epoch, creativeId, topics, archivedTopics)
     }
 
     releaseSelectionSourcesOtherThan(id) {
@@ -1558,29 +1583,25 @@ export default class extends Controller {
         // sticks need not be the last one picked. Waiting for the one in
         // flight is what makes the order they were picked in the order they
         // are written.
-        this._saveChain = (this._saveChain || Promise.resolve()).then(async () => {
+        const save = this.saveOrderState.enqueue(async () => {
             // update_last_topic broadcasts to every session of this user, this
             // one included. Claim the echo here, before the request goes out —
             // the broadcast is sent server-side before the response is
             // rendered, so it can beat the save returning.
             const claimed = generation === this.subscriptionGenerationFor(effectiveCreativeId)
             if (claimed) {
-                this.pendingSelfEchoes.push(clientId)
-                this.pendingSelfEchoCreativeIds.set(clientId, String(effectiveCreativeId))
-                this.pendingSelfEchoTopicIds.set(clientId, id ? String(id) : "")
-                this.pendingSelfEchoPreviousTopicIds.set(
-                    clientId,
-                    this.lastKnownRemoteTopicIdFor(effectiveCreativeId) === undefined
-                        ? (this.serverLastTopicId ? String(this.serverLastTopicId) : "")
-                        : this.lastKnownRemoteTopicIdFor(effectiveCreativeId)
-                )
+                this.selfEchoState.claim(clientId, {
+                    creativeId: effectiveCreativeId,
+                    topicId: id,
+                    previousTopicId: this.lastKnownRemoteTopicIdFor(effectiveCreativeId) === undefined
+                        ? this.serverLastTopicId
+                        : this.lastKnownRemoteTopicIdFor(effectiveCreativeId),
+                    possiblyMissed: this._popupClosed && !this.topicsSubscription,
+                })
                 // A save can wait behind another request while the popup closes. It
                 // takes its claim only when the queue reaches it, after the close
                 // handler has already marked the claims that existed then. Its echo
                 // will also be sent into that closed gap, so mark it at creation.
-                if (this._popupClosed && !this.topicsSubscription) {
-                    this.possiblyMissedPendingSelfEchoes.add(clientId)
-                }
             }
             // A thrown fetch has an unknown outcome: the server may have saved
             // and broadcast before the connection failed, so keep its claim for
@@ -1660,18 +1681,16 @@ export default class extends Controller {
             if (claimed && saveResult === null) {
                 this.scheduleAmbiguousPendingSelfEchoRetirement(clientId)
             }
-            const rejectedPendingPick = staleLastTopicSave && this._pendingPick === pendingPick &&
-                String(pendingPick?.creativeId) === String(creativeId) &&
-                pendingPick?.topicId === topicId
-            if (rejectedPendingPick) this._pendingPick = null
+            const rejectedPendingPick = staleLastTopicSave &&
+                this.selectionState.pendingPickMatches(pendingPick, creativeId, topicId)
+            if (rejectedPendingPick) this.selectionState.clearPendingPick()
             if (saveResult !== null) this.retryDeferredLastTopicReconciliation(effectiveCreativeId)
-            if (saveResult !== false && this._pendingPick === pendingPick &&
-                String(pendingPick?.creativeId) === String(creativeId) &&
-                pendingPick?.topicId === topicId) {
-                this._pendingPick = null
+            if (saveResult !== false &&
+                this.selectionState.pendingPickMatches(pendingPick, creativeId, topicId)) {
+                this.selectionState.clearPendingPick()
             }
         })
-        return this._saveChain
+        return save
     }
 
     // A timed-out fetch can still be running on Rails. Prefix each echo id with
@@ -1679,9 +1698,7 @@ export default class extends Controller {
     // can reject an older request if a later one from this controller commits
     // first. The trailing nonce keeps the Action Cable echo identifier unique.
     newLastTopicSaveClientId() {
-        this._lastTopicSaveSessionId ||= this.lastTopicSaveSessionId()
-        this._lastTopicSaveSequence = this.nextLastTopicSaveSequence()
-        return `${this._lastTopicSaveSessionId}.${this._lastTopicSaveSequence}.${newClientId()}`
+        return this.saveOrderState.nextClientId()
     }
 
     // A Turbo replacement creates a new controller while an earlier request can
@@ -1689,13 +1706,7 @@ export default class extends Controller {
     // browser tab so the server can reject that earlier request after the new
     // controller has saved a later selection.
     lastTopicSaveSessionId() {
-        try {
-            const sessionId = this.lastTopicSaveWindowSessionId()
-            sessionStorage.setItem(LAST_TOPIC_SAVE_SESSION_STORAGE_KEY, sessionId)
-            return sessionId
-        } catch (_) {
-            return newClientId()
-        }
+        return this.saveOrderState.windowSessionId()
     }
 
     // sessionStorage survives a reload, but browsers copy it into a duplicated
@@ -1703,27 +1714,11 @@ export default class extends Controller {
     // survives reloads, so it keeps Turbo replacements on one fence while a
     // copied tab starts a separate ordering stream.
     lastTopicSaveWindowSessionId() {
-        const currentName = window.name || ""
-        if (currentName.startsWith(LAST_TOPIC_SAVE_WINDOW_NAME_PREFIX)) {
-            const sessionId = currentName.slice(LAST_TOPIC_SAVE_WINDOW_NAME_PREFIX.length)
-            if (/^[A-Za-z0-9-]+$/.test(sessionId)) return sessionId
-        }
-
-        const sessionId = newClientId()
-        window.name = `${LAST_TOPIC_SAVE_WINDOW_NAME_PREFIX}${sessionId}`
-        return sessionId
+        return this.saveOrderState.currentWindowSessionId()
     }
 
     nextLastTopicSaveSequence() {
-        try {
-            const stored = Number(sessionStorage.getItem(LAST_TOPIC_SAVE_SEQUENCE_STORAGE_KEY))
-            const previous = Number.isSafeInteger(stored) && stored >= 0 ? stored : 0
-            const sequence = Math.max(this._lastTopicSaveSequence || 0, previous) + 1
-            sessionStorage.setItem(LAST_TOPIC_SAVE_SEQUENCE_STORAGE_KEY, String(sequence))
-            return sequence
-        } catch (_) {
-            return (this._lastTopicSaveSequence || 0) + 1
-        }
+        return this.saveOrderState.nextSequence()
     }
 
     // A request that never settles must not hold every later pick behind it.
@@ -1878,13 +1873,11 @@ export default class extends Controller {
     }
 
     get ambiguousPendingSelfEchoRetirements() {
-        return this._ambiguousPendingSelfEchoRetirements ||
-            (this._ambiguousPendingSelfEchoRetirements = new Map())
+        return this.selfEchoState.ambiguousRetirementTimers
     }
 
     get retiredSelfEchoSequenceHighWaters() {
-        return this._retiredSelfEchoSequenceHighWaters ||
-            (this._retiredSelfEchoSequenceHighWaters = new Map())
+        return this.selfEchoState.retiredSequenceHighWaters
     }
 
     // An early echo can be the only proof that an in-flight GET predates a
@@ -1907,15 +1900,15 @@ export default class extends Controller {
     // time it arrives the user may have picked something else — applying it
     // then reverts the newer pick and persists the older topic over it.
     get pendingSelfEchoes() {
-        return this._pendingSelfEchoes || (this._pendingSelfEchoes = [])
+        return this.selfEchoState.pendingIds
     }
 
     get pendingSelfEchoCreativeIds() {
-        return this._pendingSelfEchoCreativeIds || (this._pendingSelfEchoCreativeIds = new Map())
+        return this.selfEchoState.creativeIds
     }
 
     get pendingSelfEchoTopicIds() {
-        return this._pendingSelfEchoTopicIds || (this._pendingSelfEchoTopicIds = new Map())
+        return this.selfEchoState.topicIds
     }
 
     // The last preference observed from the server is the baseline for a save.
@@ -1931,50 +1924,41 @@ export default class extends Controller {
     }
 
     lastKnownRemoteTopicIdFor(creativeId) {
-        return this.lastKnownRemoteTopicIds.get(String(creativeId))
+        return this.saveOrderState.lastKnownTopicIdFor(creativeId)
     }
 
     setLastKnownRemoteTopicId(creativeId, value) {
-        this.lastKnownRemoteTopicIds.set(String(creativeId), value ? String(value) : "")
+        this.saveOrderState.setLastKnownTopicId(creativeId, value)
     }
 
     get lastKnownRemoteTopicIds() {
-        return this._lastKnownRemoteTopicIds || (this._lastKnownRemoteTopicIds = new Map())
+        return this.saveOrderState.lastKnownRemoteTopicIds
     }
 
     // Action Cable is ordered only within a connection. A delayed older message
     // can therefore arrive after a newer GET, response, or broadcast. Keep the
     // server-issued revision per effective stream and never apply it backward.
     observeLastTopicRevision(creativeId, revision) {
-        if (!revision) return true
-
-        const streamCreativeId = String(creativeId)
-        const previous = this.highestLastTopicRevisions.get(streamCreativeId)
-        const comparison = this.compareLastTopicRevisions(revision, previous)
-        if (comparison !== null && comparison < 0) return false
-        if (comparison === null || comparison > 0) {
-            this.highestLastTopicRevisions.set(streamCreativeId, revision)
-        }
-        return true
+        return this.saveOrderState.observeRevision(creativeId, revision)
     }
 
     get highestLastTopicRevisions() {
-        return this._highestLastTopicRevisions || (this._highestLastTopicRevisions = new Map())
+        return this.saveOrderState.highestRevisions
     }
 
     // The server resolves TopicsChannel subscriptions for linked shells to their
     // origin stream. Keep that result separately from the popup-scoped dataset:
     // the latter is deliberately cleared while a replacement load is pending.
     get knownEffectiveCreativeIds() {
-        return this._knownEffectiveCreativeIds || (this._knownEffectiveCreativeIds = new Map())
+        return this.saveOrderState.knownEffectiveCreativeIds
     }
 
     get pendingSelfEchoPreviousTopicIds() {
-        return this._pendingSelfEchoPreviousTopicIds || (this._pendingSelfEchoPreviousTopicIds = new Map())
+        return this.selfEchoState.previousTopicIds
     }
 
     get pendingSelfEchoAcknowledgementVersions() {
-        return this._pendingSelfEchoAcknowledgementVersions || (this._pendingSelfEchoAcknowledgementVersions = new Map())
+        return this.selfEchoState.acknowledgementVersions
     }
 
     // The preference row id distinguishes a record recreated after clearing the
@@ -1982,9 +1966,7 @@ export default class extends Controller {
     // they are a server-issued ordering token, rather than an inference from a
     // topic id that can repeat in an ABA change (Main -> Alpha -> Main).
     normalizeLastTopicRevision(value) {
-        if (!Array.isArray(value) || value.length !== 2) return null
-        const revision = value.map(Number)
-        return revision.every(Number.isSafeInteger) ? revision : null
+        return this.saveOrderState.normalizeRevision(value)
     }
 
     isPersistedAllMessagesSelection(topicId, allMessages) {
@@ -1992,30 +1974,29 @@ export default class extends Controller {
     }
 
     compareLastTopicRevisions(left, right) {
-        if (!left || !right) return null
-        return left[0] === right[0] ? left[1] - right[1] : left[0] - right[0]
+        return this.saveOrderState.compareRevisions(left, right)
     }
 
     get pendingSelfEchoRemoteRevisions() {
-        return this._pendingSelfEchoRemoteRevisions || (this._pendingSelfEchoRemoteRevisions = new Map())
+        return this.selfEchoState.remoteRevisions
     }
 
     // Echoes normally remove their claims. A short-lived tombstone retains the
     // save order for GETs already in progress when the echo arrived.
     get settledSelfEchoes() {
-        return this._settledSelfEchoes || (this._settledSelfEchoes = new Set())
+        return this.selfEchoState.settledIds
     }
 
     get activeLoadAcknowledgementVersions() {
-        return this._activeLoadAcknowledgementVersions || (this._activeLoadAcknowledgementVersions = new Map())
+        return this.saveOrderState.activeLoadAcknowledgementVersions
     }
 
     get saveAcknowledgementVersion() {
-        return this._saveAcknowledgementVersion || 0
+        return this.saveOrderState.acknowledgementVersion
     }
 
     set saveAcknowledgementVersion(value) {
-        this._saveAcknowledgementVersion = value
+        this.saveOrderState.acknowledgementVersion = value
     }
 
     // These claims were already in flight when the popup unsubscribed. If their
@@ -2023,7 +2004,7 @@ export default class extends Controller {
     // went into that gap. A replacement subscription can receive an echo when it
     // reopens before the response arrives, though.
     get possiblyMissedPendingSelfEchoes() {
-        return this._possiblyMissedPendingSelfEchoes || (this._possiblyMissedPendingSelfEchoes = new Set())
+        return this.selfEchoState.possiblyMissedIds
     }
 
     // A broadcast sent after Action Cable disconnects is not replayed after the
@@ -2031,8 +2012,7 @@ export default class extends Controller {
     // whether one could have been sent in that gap; acknowledged saves can be
     // retired immediately because their broadcast has already been sent.
     get possiblyMissedPendingSelfEchoesDuringDisconnect() {
-        return this._possiblyMissedPendingSelfEchoesDuringDisconnect ||
-            (this._possiblyMissedPendingSelfEchoesDuringDisconnect = new Set())
+        return this.selfEchoState.possiblyMissedDuringDisconnectIds
     }
 
     handleTopicsSubscriptionDisconnected() {
@@ -2094,7 +2074,7 @@ export default class extends Controller {
     // open popup keeps its id long enough to consume an echo still in flight,
     // without allowing it to override a later reopen snapshot.
     get acknowledgedPendingSelfEchoes() {
-        return this._acknowledgedPendingSelfEchoes || (this._acknowledgedPendingSelfEchoes = new Set())
+        return this.selfEchoState.acknowledgedIds
     }
 
     acknowledgePendingSelfEcho(clientId) {
@@ -2179,7 +2159,7 @@ export default class extends Controller {
     }
 
     get deferredLastTopicReconciliations() {
-        return this._deferredLastTopicReconciliations || (this._deferredLastTopicReconciliations = new Set())
+        return this.saveOrderState.deferredReconciliations
     }
 
     retryDeferredLastTopicReconciliation(creativeId) {
@@ -2196,23 +2176,15 @@ export default class extends Controller {
     // subscription must not prevent a queued save for the original stream from
     // claiming its own echo when the user returns to it.
     subscriptionGenerationFor(creativeId) {
-        const streamCreativeId = String(creativeId)
-        if (!this.subscriptionGenerations.has(streamCreativeId)) {
-            this.subscriptionGenerations.set(streamCreativeId, 0)
-        }
-        return this.subscriptionGenerations.get(streamCreativeId)
+        return this.saveOrderState.subscriptionGenerationFor(creativeId)
     }
 
     bumpSubscriptionGenerationFor(creativeId) {
-        const streamCreativeId = String(creativeId)
-        this.subscriptionGenerations.set(
-            streamCreativeId,
-            this.subscriptionGenerationFor(streamCreativeId) + 1
-        )
+        this.saveOrderState.bumpSubscriptionGeneration(creativeId)
     }
 
     get subscriptionGenerations() {
-        return this._subscriptionGenerations || (this._subscriptionGenerations = new Map())
+        return this.saveOrderState.subscriptionGenerations
     }
 
     // The legacy key is adopted only as a stand-in for a preference the server
@@ -2289,7 +2261,7 @@ export default class extends Controller {
             ...this.settledSelfEchoes,
         ].filter(clientId => this.pendingSelfEchoCreativeIds.get(clientId) === streamCreativeId))
 
-        this._pendingSelfEchoes = this.pendingSelfEchoes.filter(clientId => !clientIds.has(clientId))
+        this.selfEchoState.pendingIds = this.pendingSelfEchoes.filter(clientId => !clientIds.has(clientId))
         for (const clientId of clientIds) this.discardSelfEchoMetadata(clientId)
         this.bumpSubscriptionGenerationFor(streamCreativeId)
     }

--- a/engines/collavre/app/javascript/modules/__tests__/creative_row_editor_save_paths.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/creative_row_editor_save_paths.test.js
@@ -1,0 +1,246 @@
+/**
+ * @jest-environment jsdom
+ */
+import { jest } from '@jest/globals'
+
+let editorOptions = null
+const save = jest.fn()
+const enqueue = jest.fn()
+
+jest.unstable_mockModule('../lexical_inline_editor', () => ({
+  createInlineEditor: jest.fn((_container, options) => {
+    editorOptions = options
+    return {
+      destroy: jest.fn(),
+      load: jest.fn(),
+      focus: jest.fn(),
+      reset: jest.fn(),
+      getDeletedAttachments: jest.fn(() => []),
+    }
+  }),
+}))
+jest.unstable_mockModule('../creative_row_editor_delegated_clicks', () => ({
+  createDelegatedClickHandler: jest.fn(() => jest.fn()),
+}))
+jest.unstable_mockModule('../../lib/api/creatives', () => ({
+  default: {
+    save,
+    get: jest.fn(() => Promise.resolve({})),
+    loadChildren: jest.fn(() => Promise.resolve({ creatives: [] })),
+  },
+}))
+jest.unstable_mockModule('../../lib/api/queue_manager', () => ({
+  default: {
+    initialize: jest.fn(),
+    start: jest.fn(),
+    enqueue,
+  },
+}))
+
+const { initializeCreativeRowEditor } = await import('../creative_row_editor')
+const {
+  appendExistingRow, buildEditorDom, defineTreeRowStub, flush,
+} = await import('./support/inline_editor_dom')
+
+function response(data = {}) {
+  return Promise.resolve({
+    ok: true,
+    text: () => Promise.resolve(JSON.stringify(data)),
+  })
+}
+
+function openRow(tree) {
+  document.dispatchEvent(new CustomEvent('creative-edit-click', {
+    detail: { treeElement: tree },
+  }))
+}
+
+async function flushPromises() {
+  for (let i = 0; i < 10; i += 1) await Promise.resolve()
+}
+
+function appendMarkdownRow(id, source, editor = 'source') {
+  const result = appendExistingRow(id)
+  result.rowComponent.dataset.contentType = 'markdown'
+  result.rowComponent.dataset.markdownSource = source
+  result.rowComponent.dataset.markdownEditor = editor
+  result.rowComponent.dataset.descriptionRawHtml = `<p>${source}</p>`
+  return result
+}
+
+beforeAll(() => defineTreeRowStub())
+
+beforeEach(() => {
+  document.body.innerHTML = '<div id="creatives"></div><div id="center-frame"></div>'
+  buildEditorDom(document.getElementById('center-frame'))
+  save.mockReset()
+  enqueue.mockReset()
+  save.mockImplementation(() => response())
+  initializeCreativeRowEditor()
+  document.getElementById('metadata-popup').style.display = 'none'
+})
+
+afterEach(() => {
+  jest.clearAllTimers()
+  jest.useRealTimers()
+  editorOptions = null
+})
+
+test('direct save keeps FormData semantics, applies a markdown rewrite, and clears dirty state', async () => {
+  jest.useFakeTimers()
+  const { tree } = appendMarkdownRow('42', 'before')
+  openRow(tree)
+
+  const textarea = document.getElementById('markdown-editor-textarea')
+  textarea.value = 'draft ![image](data:old)'
+  textarea.dispatchEvent(new Event('input'))
+  let submitted
+  save.mockImplementation((_path, _method, form) => {
+    submitted = new FormData(form)
+    return response({
+      markdown_source: 'draft ![image](/rails/active_storage/blobs/image.png)',
+    })
+  })
+
+  const progress = document.getElementById('inline-creative-progress')
+  progress.checked = true
+  progress.dispatchEvent(new Event('change'))
+  await flushPromises()
+
+  expect(save).toHaveBeenCalledTimes(1)
+  expect(save.mock.calls[0][0]).toMatch(/\/creatives\/42$/)
+  expect(save.mock.calls[0][1]).toBe('PATCH')
+  expect(submitted.get('creative[markdown_source]')).toBe('draft ![image](data:old)')
+  expect(submitted.getAll('creative[progress]')).toEqual(['0', '1'])
+  expect(textarea.value).toBe('draft ![image](/rails/active_storage/blobs/image.png)')
+  expect(document.getElementById('inline-markdown-source').value)
+    .toBe('draft ![image](/rails/active_storage/blobs/image.png)')
+
+  document.getElementById('inline-close').click()
+  await Promise.resolve()
+  expect(save).toHaveBeenCalledTimes(1)
+})
+
+test('persistent queue snapshots the outgoing row, keeps its object body, applies response data, and clears dirty state', async () => {
+  jest.useFakeTimers()
+  const first = appendMarkdownRow('42', 'before', 'rich')
+  const second = appendMarkdownRow('43', 'second', 'rich')
+  openRow(first.tree)
+
+  editorOptions.onChange({ html: '<p>outgoing edit</p>', markdown: 'outgoing edit' })
+  document.getElementById('inline-move-down').click()
+  await Promise.resolve()
+  await Promise.resolve()
+
+  expect(enqueue).toHaveBeenCalledTimes(1)
+  const queued = enqueue.mock.calls[0][0]
+  expect(queued.path).toBe('/creatives/42')
+  expect(queued.method).toBe('PATCH')
+  expect(queued.body).toEqual(expect.objectContaining({
+    'creative[description]': '<p>outgoing edit</p>',
+    'creative[content_type_input]': 'markdown',
+    'creative[markdown_source]': 'outgoing edit',
+    'creative[markdown_editor]': 'rich',
+  }))
+  expect(queued.body).not.toBeInstanceOf(FormData)
+  expect(document.getElementById('inline-edit-form-element').dataset.creativeId).toBe('43')
+
+  queued.onSuccess({ markdown_source: 'server rewrite' })
+  expect(first.rowComponent.dataset.markdownSource).toBe('server rewrite')
+
+  document.getElementById('inline-move-up').click()
+  await Promise.resolve()
+  document.getElementById('inline-move-down').click()
+  await Promise.resolve()
+  expect(enqueue).toHaveBeenCalledTimes(1)
+  expect(second.rowComponent.dataset.markdownSource).toBe('second')
+})
+
+test('direct save skips an empty buffer', async () => {
+  const { rowComponent, tree } = appendExistingRow('42')
+  rowComponent.dataset.descriptionRawHtml = ''
+  openRow(tree)
+
+  const progress = document.getElementById('inline-creative-progress')
+  progress.checked = true
+  progress.dispatchEvent(new Event('change'))
+  await Promise.resolve()
+
+  expect(save).not.toHaveBeenCalled()
+})
+
+test('persistent queue skips an empty buffer', async () => {
+  const first = appendExistingRow('42')
+  first.rowComponent.dataset.descriptionRawHtml = ''
+  appendExistingRow('43')
+  openRow(first.tree)
+
+  editorOptions.onChange({ html: '', markdown: '' })
+  document.getElementById('inline-move-down').click()
+  await Promise.resolve()
+  await Promise.resolve()
+
+  expect(enqueue).not.toHaveBeenCalled()
+})
+
+test('persistent queue carries an unacknowledged progress toggle into the body and row dataset', async () => {
+  jest.useFakeTimers()
+  const first = appendMarkdownRow('42', 'before', 'rich')
+  appendMarkdownRow('43', 'second', 'rich')
+  openRow(first.tree)
+
+  // The checkbox fires a direct save; hold it in flight so the progress
+  // baseline is still stale when the move queues the outgoing row.
+  let settleDirectSave
+  save.mockImplementation(() => new Promise((resolve) => { settleDirectSave = resolve }))
+  editorOptions.onChange({ html: '<p>outgoing edit</p>', markdown: 'outgoing edit' })
+  const progress = document.getElementById('inline-creative-progress')
+  progress.checked = true
+  progress.dispatchEvent(new Event('change'))
+  await Promise.resolve()
+
+  document.getElementById('inline-move-down').click()
+  await flushPromises()
+
+  expect(enqueue).toHaveBeenCalledTimes(1)
+  expect(enqueue.mock.calls[0][0].body['creative[progress]']).toBe(1)
+  expect(first.rowComponent.dataset.progressValue).toBe('1')
+
+  settleDirectSave({ ok: true, text: () => Promise.resolve('{}') })
+  await flushPromises()
+})
+
+test('queued response rewrites the live textarea when the row is reopened before the ack', async () => {
+  jest.useFakeTimers()
+  const dataUri = 'data:image/png;base64,abc123'
+  const first = appendMarkdownRow('42', `before ${dataUri}`)
+  appendMarkdownRow('43', 'second')
+  openRow(first.tree)
+
+  const textarea = document.getElementById('markdown-editor-textarea')
+  textarea.value = `draft ${dataUri}`
+  textarea.dispatchEvent(new Event('input'))
+
+  document.getElementById('inline-move-down').click()
+  await flushPromises()
+  expect(enqueue).toHaveBeenCalledTimes(1)
+  const queued = enqueue.mock.calls[0][0]
+
+  // Back on the same row before the queued PATCH is acknowledged.
+  document.getElementById('inline-move-up').click()
+  await flushPromises()
+  expect(document.getElementById('inline-edit-form-element').dataset.creativeId).toBe('42')
+
+  queued.onSuccess({ markdown_source: 'draft /blob/image.png' })
+
+  expect(textarea.value).toBe('draft /blob/image.png')
+  expect(document.getElementById('inline-markdown-source').value).toBe('draft /blob/image.png')
+  expect(first.rowComponent.dataset.markdownSource).toBe('draft /blob/image.png')
+
+  // The rewrite also moved the dirty baseline (originalContent), so simply
+  // reopening and leaving the row must not queue a second save.
+  enqueue.mockClear()
+  document.getElementById('inline-move-down').click()
+  await flushPromises()
+  expect(enqueue).not.toHaveBeenCalled()
+})

--- a/engines/collavre/app/javascript/modules/__tests__/creative_save_state.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/creative_save_state.test.js
@@ -116,20 +116,21 @@ test('applies server markdown substitutions to cached and live content', () => {
   expect(result.currentApplied).toBe(true)
 })
 
-test('resets baselines and keeps a newer buffer dirty', () => {
+test('resets baselines and preserves dirty state for a newer buffer', () => {
   const snapshot = captureCreativeSaveSnapshot({
     content: 'saved', progress: 1, persistProgress: true, originId: '7',
   })
 
-  expect(resetCreativeSaveState(snapshot, {
-    content: 'newer', progress: 1, originId: '7',
-  })).toEqual({
+  const newerBuffer = { content: 'newer', progress: 1, originId: '7' }
+
+  expect(resetCreativeSaveState(snapshot, newerBuffer, true)).toEqual({
     originalContent: 'saved',
     originalProgress: 1,
     originalOriginId: '7',
     isDirty: true,
     pendingSave: false,
   })
+  expect(resetCreativeSaveState(snapshot, newerBuffer, false).isDirty).toBe(false)
   expect(resetCreativeSaveState(snapshot).isDirty).toBe(false)
 })
 

--- a/engines/collavre/app/javascript/modules/__tests__/creative_save_state.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/creative_save_state.test.js
@@ -1,0 +1,99 @@
+/**
+ * @jest-environment jsdom
+ */
+import { jest } from '@jest/globals'
+import {
+  applyCreativeSaveResponse,
+  captureCreativeSaveSnapshot,
+  creativeSaveSnapshotIsEmpty,
+  resetCreativeSaveState,
+} from '../creative_save_state'
+
+test('tests emptiness using the snapshot content format', () => {
+  const html = captureCreativeSaveSnapshot({
+    content: '<p><br></p>',
+    emptyContentType: 'html',
+  })
+  const markdown = captureCreativeSaveSnapshot({
+    content: '<p>rendered</p>',
+    emptyContent: '   ',
+    emptyContentType: 'markdown',
+  })
+
+  expect(creativeSaveSnapshotIsEmpty(html)).toBe(true)
+  expect(creativeSaveSnapshotIsEmpty(markdown)).toBe(true)
+})
+
+test('applies server markdown substitutions to cached and live content', () => {
+  const dataUri = 'data:image/png;base64,abc123'
+  const snapshot = captureCreativeSaveSnapshot({
+    content: `before ${dataUri}`,
+    emptyContentType: 'markdown',
+    contentType: 'markdown',
+    markdownSource: `before ${dataUri}`,
+  })
+  const applyCurrent = jest.fn()
+  const applyCached = jest.fn()
+
+  const result = applyCreativeSaveResponse(
+    snapshot,
+    { markdown_source: 'before /blob/image' },
+    {
+      currentMarkdownSource: `before ${dataUri} plus typing`,
+      applyCurrentMarkdownSource: applyCurrent,
+      applyCachedMarkdownSource: applyCached,
+    }
+  )
+
+  expect(applyCached).toHaveBeenCalledWith('before /blob/image', `before ${dataUri}`)
+  expect(applyCurrent).toHaveBeenCalledWith('before /blob/image plus typing')
+  expect(result.snapshot.content).toBe('before /blob/image')
+  expect(result.currentApplied).toBe(true)
+})
+
+test('resets baselines and keeps a newer buffer dirty', () => {
+  const snapshot = captureCreativeSaveSnapshot({
+    content: 'saved', progress: 1, persistProgress: true, originId: '7',
+  })
+
+  expect(resetCreativeSaveState(snapshot, {
+    content: 'newer', progress: 1, originId: '7',
+  })).toEqual({
+    originalContent: 'saved',
+    originalProgress: 1,
+    originalOriginId: '7',
+    isDirty: true,
+    pendingSave: false,
+  })
+  expect(resetCreativeSaveState(snapshot).isDirty).toBe(false)
+})
+
+test('leaves the live buffer alone when the rewrite cannot be reconciled', () => {
+  const dataUri = 'data:image/png;base64,abc123'
+  const snapshot = captureCreativeSaveSnapshot({
+    content: `before ${dataUri}`,
+    emptyContentType: 'markdown',
+    contentType: 'markdown',
+    markdownSource: `before ${dataUri}`,
+  })
+  const applyCurrent = jest.fn()
+  const applyCached = jest.fn()
+
+  const result = applyCreativeSaveResponse(
+    snapshot,
+    { markdown_source: 'before /blob/image' },
+    {
+      // The user dropped the uploaded image while the save was in flight, so
+      // the substitution has nowhere to land in the live buffer.
+      currentMarkdownSource: 'rewritten from scratch',
+      applyCurrentMarkdownSource: applyCurrent,
+      applyCachedMarkdownSource: applyCached,
+    }
+  )
+
+  expect(applyCached).toHaveBeenCalledWith('before /blob/image', `before ${dataUri}`)
+  expect(applyCurrent).not.toHaveBeenCalled()
+  expect(result.snapshot).toBe(snapshot)
+  expect(result.currentMarkdownSource).toBe('rewritten from scratch')
+  expect(result.currentApplied).toBe(false)
+})

--- a/engines/collavre/app/javascript/modules/__tests__/creative_save_state.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/creative_save_state.test.js
@@ -4,10 +4,75 @@
 import { jest } from '@jest/globals'
 import {
   applyCreativeSaveResponse,
+  captureDirectCreativeSaveSnapshot,
+  captureQueuedCreativeSaveSnapshot,
   captureCreativeSaveSnapshot,
   creativeSaveSnapshotIsEmpty,
   resetCreativeSaveState,
 } from '../creative_save_state'
+
+test('captures direct saves from the active editor surface', () => {
+  const markdown = captureDirectCreativeSaveSnapshot({
+    markdownMode: true,
+    markdownContent: '# live',
+    htmlContent: '<p>rendered</p>',
+    contentType: 'markdown',
+    markdownSource: '# live',
+    markdownEditor: 'textarea',
+    progress: 1,
+    persistProgress: true,
+    originId: '7',
+  })
+  const rich = captureDirectCreativeSaveSnapshot({
+    markdownMode: false,
+    markdownContent: '# cached',
+    htmlContent: '<p>live</p>',
+    contentType: 'html',
+    markdownSource: '# cached',
+    markdownEditor: 'rich',
+    progress: 0.5,
+    persistProgress: false,
+    originId: '8',
+  })
+
+  expect(markdown).toMatchObject({
+    content: '# live', emptyContent: '# live', emptyContentType: 'markdown', progress: 1,
+  })
+  expect(rich).toMatchObject({
+    content: '<p>live</p>', emptyContent: '<p>live</p>', emptyContentType: 'html', progress: 0.5,
+  })
+})
+
+test('captures queued saves using their persisted content type', () => {
+  const markdown = captureQueuedCreativeSaveSnapshot({
+    content: '<p>rendered</p>',
+    contentType: 'markdown',
+    markdownSource: '# source',
+    markdownEditor: 'rich',
+    progress: 0.5,
+    persistProgress: true,
+    originId: '9',
+  })
+  const html = captureQueuedCreativeSaveSnapshot({
+    content: '<p>live</p>',
+    contentType: 'html',
+    markdownSource: '# stale',
+  })
+
+  expect(markdown).toMatchObject({
+    content: '<p>rendered</p>', emptyContent: '# source', emptyContentType: 'markdown',
+    markdownSource: '# source',
+  })
+  expect(html).toMatchObject({
+    content: '<p>live</p>', emptyContent: '<p>live</p>', emptyContentType: 'html',
+    markdownSource: '',
+  })
+})
+
+test('normalizes falsy snapshot strings without changing other values', () => {
+  expect(captureCreativeSaveSnapshot({ content: false, markdownSource: 0, originId: null }))
+    .toMatchObject({ content: '', markdownSource: '', originId: '' })
+})
 
 test('tests emptiness using the snapshot content format', () => {
   const html = captureCreativeSaveSnapshot({

--- a/engines/collavre/app/javascript/modules/__tests__/html_content_empty.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/html_content_empty.test.js
@@ -38,4 +38,15 @@ describe('isHtmlEmpty', () => {
   test('returns false for [data-trix-attachment]-only HTML', () => {
     expect(isHtmlEmpty('<div data-trix-attachment=\'{"sgid":"x"}\'></div>')).toBe(false);
   });
+
+  test('parses untrusted HTML without assigning it to the active document', () => {
+    let activeDocumentSinkUsed = false;
+    const liveDocument = {
+      defaultView: { DOMParser },
+      createElement: () => { activeDocumentSinkUsed = true; }
+    };
+
+    expect(isHtmlEmpty('<img src="invalid" onerror="alert(1)">', liveDocument)).toBe(false);
+    expect(activeDocumentSinkUsed).toBe(false);
+  });
 });

--- a/engines/collavre/app/javascript/modules/__tests__/support/inline_editor_dom.js
+++ b/engines/collavre/app/javascript/modules/__tests__/support/inline_editor_dom.js
@@ -28,6 +28,21 @@ export const DIV_IDS = [
   'inline-save-status', 'metadata-popup',
 ]
 
+const INPUT_NAMES = {
+  'inline-method': '_method',
+  'inline-creative-description': 'creative[description]',
+  'inline-content-type': 'creative[content_type_input]',
+  'inline-markdown-editor': 'creative[markdown_editor]',
+  'inline-markdown-source': 'creative[markdown_source]',
+  'inline-parent-id': 'creative[parent_id]',
+  'inline-before-id': 'before_id',
+  'inline-after-id': 'after_id',
+  'inline-child-id': 'child_id',
+  'inline-origin-id': 'creative[origin_id]',
+  'inline-history-anchor-id': 'history_anchor_id',
+  'inline-change-group-token': 'change_group_token',
+}
+
 export function buildEditorDom(container, {
   saveFailedMessage,
   archiveFailedMessage,
@@ -49,13 +64,19 @@ export function buildEditorDom(container, {
     const input = document.createElement('input')
     input.type = 'hidden'
     input.id = id
-    if (id === 'inline-history-anchor-id') input.name = 'history_anchor_id'
-    if (id === 'inline-change-group-token') input.name = 'change_group_token'
+    input.name = INPUT_NAMES[id]
     form.appendChild(input)
   })
+  const hiddenProgress = document.createElement('input')
+  hiddenProgress.type = 'hidden'
+  hiddenProgress.name = 'creative[progress]'
+  hiddenProgress.value = '0'
+  form.appendChild(hiddenProgress)
   const progress = document.createElement('input')
   progress.type = 'checkbox'
   progress.id = 'inline-creative-progress'
+  progress.name = 'creative[progress]'
+  progress.value = '1'
   form.appendChild(progress)
 
   const editorRoot = document.createElement('div')

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -817,7 +817,7 @@ function setupEditorSession() {
               content: markdownMode ? (markdownTextarea?.value || '') : descriptionInput.value,
               progress: readProgressValue(),
               originId: originIdInput?.value || '',
-            });
+	    }, isDirty);
             originalContent = reset.originalContent;
             if (reset.originalProgress !== undefined) originalProgress = reset.originalProgress;
             originalOriginId = reset.originalOriginId;

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -7,9 +7,14 @@ import { markdownCreativeCommandRange, openCreativeLinkPicker } from './creative
 import { renderCreativeTree, dispatchCreativeTreeUpdated } from '../creatives/tree_renderer'
 import { isProgressComplete, progressBaselineValueFrom, progressValueChangedFrom } from './creative_progress'
 import { renderMarkdown } from '../lib/utils/markdown'
-import { reconcileMarkdownSource } from './markdown_source_reconcile'
-import { isHtmlEmpty } from './html_content_empty'
 import { CreativeSaveQueue } from './creative_save_queue'
+import { isHtmlEmpty } from './html_content_empty'
+import {
+  applyCreativeSaveResponse,
+  captureCreativeSaveSnapshot,
+  creativeSaveSnapshotIsEmpty,
+  resetCreativeSaveState,
+} from './creative_save_state'
 import { createListenerRegistry } from './dom_listener_registry'
 import { createDelegatedClickHandler } from './creative_row_editor_delegated_clicks'
 import { confirmDialog, alertDialog } from '../lib/utils/dialog'
@@ -18,7 +23,6 @@ import yaml from 'js-yaml'
 import {
   treeRowElement,
   hasDatasetValue,
-  isMarkdownEmpty,
   readRowLevel,
   editorPaddingForLevel,
 } from './creative_row_editor_helpers'
@@ -756,10 +760,17 @@ function setupEditorSession() {
         // Sync markdown form fields before saving
         if (markdownMode) syncMarkdownToForm();
 
-        const isEmpty = markdownMode
-          ? isMarkdownEmpty(markdownTextarea?.value)
-          : isHtmlEmpty(descriptionInput.value);
-        if (isEmpty) {
+        let snapshot = captureCreativeSaveSnapshot({
+          content: markdownMode ? (markdownTextarea?.value || '') : descriptionInput.value,
+          emptyContentType: markdownMode ? 'markdown' : 'html',
+          contentType: contentTypeInput?.value || 'html',
+          markdownSource: markdownSourceInput?.value || '',
+          markdownEditor: markdownEditorInput?.value || '',
+          progress: progressValueChanged() ? readProgressValue() : progressBaselineValueFrom(originalProgress),
+          persistProgress: progressValueChanged(),
+          originId: originIdInput?.value || '',
+        });
+        if (creativeSaveSnapshotIsEmpty(snapshot)) {
           pendingSave = false;
           // Nothing to persist — don't strand the "pending" label set above.
           if (tree === currentTree) setSaveStatus('');
@@ -778,13 +789,7 @@ function setupEditorSession() {
         };
         applySaveStatus('saving');
 
-        // Capture values being saved to update dirty state on success
-        // NOTE: `let` (not `const`) — when the server rewrites markdown_source
-        // (e.g. data: URI → blob path) we reassign below.
-        let savedContent = markdownMode ? (markdownTextarea?.value || '') : descriptionInput.value;
-        const shouldPersistProgress = progressValueChanged();
-        const savedProgress = shouldPersistProgress ? readProgressValue() : progressBaselineValueFrom(originalProgress);
-        const savedOriginId = originIdInput ? originIdInput.value : '';
+        const shouldPersistProgress = snapshot.persistProgress;
         const cascadeProgressUpdate = completionCascadePending;
         const progressInputsDisabled = progressInput?.disabled ?? false;
         const hiddenProgressDisabled = progressHiddenInput?.disabled ?? false;
@@ -802,39 +807,24 @@ function setupEditorSession() {
           return r.text().then(function (text) {
             try { return text ? JSON.parse(text) : {}; } catch (e) { return {}; }
           }).then(function (data) {
-            // Sync rewritten markdown source back into the textarea/hidden input.
-            // Server rewrites inline data: URIs in markdown_source to blob paths so
-            // re-saves don't re-import the same image. If the user typed during the
-            // request, merge the substitutions into the live textarea so the next
-            // save still carries blob paths instead of re-importing the data URI.
-            if (markdownMode && data && typeof data.markdown_source === 'string'
-                && data.markdown_source !== savedContent && markdownTextarea) {
-              const reconciled = reconcileMarkdownSource(
-                savedContent, data.markdown_source, markdownTextarea.value
-              );
-              if (reconciled !== null && reconciled !== markdownTextarea.value) {
-                markdownTextarea.value = reconciled;
+            const applied = applyCreativeSaveResponse(snapshot, data, {
+              currentMarkdownSource: markdownMode ? markdownTextarea?.value : undefined,
+              applyCurrentMarkdownSource: (source) => {
+                markdownTextarea.value = source;
                 syncMarkdownToForm();
-              }
-              if (reconciled !== null) {
-                savedContent = data.markdown_source;
-              }
-            }
+              },
+            });
+            snapshot = applied.snapshot;
 
-            // Update dirty state to reflect successful save
-            originalContent = savedContent;
-            if (shouldPersistProgress) {
-              originalProgress = savedProgress;
-            }
-            originalOriginId = savedOriginId;
-
-            // If current values match what was just saved, clear dirty flag
-            const currentContent = markdownMode ? (markdownTextarea?.value || '') : descriptionInput.value;
-            if (currentContent === savedContent &&
-              readProgressValue() === savedProgress &&
-              originIdInput.value === savedOriginId) {
-              isDirty = false;
-            }
+            const reset = resetCreativeSaveState(snapshot, {
+              content: markdownMode ? (markdownTextarea?.value || '') : descriptionInput.value,
+              progress: readProgressValue(),
+              originId: originIdInput?.value || '',
+            });
+            originalContent = reset.originalContent;
+            if (reset.originalProgress !== undefined) originalProgress = reset.originalProgress;
+            originalOriginId = reset.originalOriginId;
+            isDirty = reset.isDirty;
 
             if (method === 'POST' && data.id) {
               form.action = `/creatives/${data.id}`;
@@ -1143,22 +1133,22 @@ function setupEditorSession() {
       if (markdownMode) syncMarkdownToForm();
       const capturedContentType = contentTypeInput ? contentTypeInput.value : 'html';
       const isMarkdownSave = capturedContentType === 'markdown';
-      let currentContent = descriptionInput.value;
-      let currentProgress = readProgressValue();
-      let shouldPersistProgress = progressValueChanged();
+      let snapshot = captureCreativeSaveSnapshot({
+        content: descriptionInput.value,
+        emptyContent: isMarkdownSave ? markdownSourceInput?.value : descriptionInput.value,
+        emptyContentType: isMarkdownSave ? 'markdown' : 'html',
+        contentType: capturedContentType,
+        markdownSource: isMarkdownSave ? markdownSourceInput?.value : '',
+        markdownEditor: markdownEditorInput?.value || '',
+        progress: readProgressValue(),
+        persistProgress: progressValueChanged(),
+        originId: originIdInput?.value || '',
+      });
       const currentParentId = tree.dataset.parentId || '';
       const currentBeforeId = tree.previousElementSibling ? creativeIdFrom(tree.previousElementSibling) : '';
       const currentAfterId = tree.nextElementSibling ? creativeIdFrom(tree.nextElementSibling) : '';
       const startCreativeId = creativeId;
-      let capturedMarkdownSource = isMarkdownSave ? (markdownSourceInput ? markdownSourceInput.value : '') : '';
-      const capturedMarkdownEditor = markdownEditorInput ? markdownEditorInput.value : '';
-
-      // Prevent saving empty content, matching saveForm behavior
-      // This avoids overwriting existing descriptions with empty strings during quick navigation
-      const isEmpty = isMarkdownSave
-        ? isMarkdownEmpty(capturedMarkdownSource)
-        : isHtmlEmpty(currentContent);
-      if (isEmpty) {
+      if (creativeSaveSnapshotIsEmpty(snapshot)) {
         pendingSave = false;
         return;
       }
@@ -1173,34 +1163,36 @@ function setupEditorSession() {
       // so we must re-sync and re-capture the latest textarea value too — otherwise edits
       // made during the upload wait get overwritten by the stale pre-wait source.
       if (form.dataset.creativeId === startCreativeId) {
-        if (markdownMode) {
-          syncMarkdownToForm();
-          capturedMarkdownSource = markdownSourceInput ? markdownSourceInput.value : '';
-        } else if (isMarkdownSave && markdownSourceInput) {
-          // Rich surface: re-capture any Markdown produced by edits during the wait.
-          capturedMarkdownSource = markdownSourceInput.value;
-        }
-        currentContent = descriptionInput.value;
-        currentProgress = readProgressValue();
-        shouldPersistProgress = progressValueChanged();
+        if (markdownMode) syncMarkdownToForm();
+        snapshot = captureCreativeSaveSnapshot({
+          content: descriptionInput.value,
+          emptyContent: isMarkdownSave ? markdownSourceInput?.value : descriptionInput.value,
+          emptyContentType: isMarkdownSave ? 'markdown' : 'html',
+          contentType: capturedContentType,
+          markdownSource: isMarkdownSave ? markdownSourceInput?.value : '',
+          markdownEditor: markdownEditorInput?.value || '',
+          progress: readProgressValue(),
+          persistProgress: progressValueChanged(),
+          originId: originIdInput?.value || '',
+        });
       }
 
       // Build request body
       // Note: before_id and after_id must be top-level params, not nested under creative[]
       // because CreativesController reads params[:before_id] and params[:after_id] for positioning
       const body = {
-        'creative[description]': currentContent,
-        'creative[content_type_input]': capturedContentType
+        'creative[description]': snapshot.content,
+        'creative[content_type_input]': snapshot.contentType
       };
       if (isMarkdownSave) {
-        body['creative[markdown_source]'] = capturedMarkdownSource;
-        if (capturedMarkdownEditor) {
-          body['creative[markdown_editor]'] = capturedMarkdownEditor;
+        body['creative[markdown_source]'] = snapshot.markdownSource;
+        if (snapshot.markdownEditor) {
+          body['creative[markdown_editor]'] = snapshot.markdownEditor;
         }
       }
 
-      if (shouldPersistProgress) {
-        body['creative[progress]'] = currentProgress;
+      if (snapshot.persistProgress) {
+        body['creative[progress]'] = snapshot.progress;
       }
 
       // Always include parent_id, even if empty (for moving to root)
@@ -1221,18 +1213,18 @@ function setupEditorSession() {
       if (tree) {
         const row = treeRowElement(tree);
         if (row) {
-          row.dataset.descriptionHtml = currentContent;
-          row.descriptionHtml = currentContent;
-          row.dataset.descriptionRawHtml = currentContent;
-          if (shouldPersistProgress) {
-            row.dataset.progressValue = String(currentProgress);
+          row.dataset.descriptionHtml = snapshot.content;
+          row.descriptionHtml = snapshot.content;
+          row.dataset.descriptionRawHtml = snapshot.content;
+          if (snapshot.persistProgress) {
+            row.dataset.progressValue = String(snapshot.progress);
           }
-          row.dataset.contentType = capturedContentType;
-          row.dataset.markdownSource = isMarkdownSave ? capturedMarkdownSource : '';
+          row.dataset.contentType = snapshot.contentType;
+          row.dataset.markdownSource = isMarkdownSave ? snapshot.markdownSource : '';
           // Persist which surface authored this save so a row re-opened from this
           // cached payload (before any full GET refresh) reopens in the right
           // editor — without it, rich-authored Markdown falls back to the textarea.
-          row.dataset.markdownEditor = isMarkdownSave ? capturedMarkdownEditor : '';
+          row.dataset.markdownEditor = isMarkdownSave ? snapshot.markdownEditor : '';
           if (currentParentId) {
             tree.dataset.parentId = currentParentId;
             row.parentId = currentParentId;
@@ -1258,8 +1250,8 @@ function setupEditorSession() {
       // Capture per-enqueue values for the onSuccess closure so concurrent edits
       // on a different creative don't get clobbered when the response comes back.
       const onSuccessCreativeId = startCreativeId;
-      const onSuccessSavedMarkdown = isMarkdownSave ? capturedMarkdownSource : null;
       const onSuccessTree = tree;
+      const onSuccessSnapshot = snapshot;
       apiQueue.enqueue({
         path: `/creatives/${creativeId}`,
         method: 'PATCH',
@@ -1267,47 +1259,36 @@ function setupEditorSession() {
         dedupeKey: `creative_${creativeId}`,
         deletedAttachmentIds: deletedAttachmentIds,  // Store as data for serialization
         onSuccess: function (data) {
-          if (!isMarkdownSave || !data || typeof data.markdown_source !== 'string') return;
-          if (data.markdown_source === onSuccessSavedMarkdown) return;
-
-          // Update the row dataset cache regardless of which creative is active now,
-          // so a later loadCreative() for this row picks up the rewritten source.
-          if (onSuccessTree) {
-            const row = treeRowElement(onSuccessTree);
-            if (row && row.dataset.markdownSource === onSuccessSavedMarkdown) {
-              row.dataset.markdownSource = data.markdown_source;
-              row.requestUpdate?.();
-            }
-          }
-
-          // Merge the data: URI -> blob path substitutions into the live textarea,
-          // even if the user typed during the queued save. We still require the
-          // same creative to be open (race-safe across editor switches).
-          if (form.dataset.creativeId === onSuccessCreativeId
-              && markdownMode
-              && markdownTextarea) {
-            const reconciled = reconcileMarkdownSource(
-              onSuccessSavedMarkdown, data.markdown_source, markdownTextarea.value
-            );
-            if (reconciled !== null && reconciled !== markdownTextarea.value) {
-              markdownTextarea.value = reconciled;
+          if (!isMarkdownSave) return;
+          const canApplyToCurrentEditor = form.dataset.creativeId === onSuccessCreativeId
+            && markdownMode
+            && markdownTextarea;
+          const applied = applyCreativeSaveResponse(onSuccessSnapshot, data, {
+            currentMarkdownSource: canApplyToCurrentEditor ? markdownTextarea.value : undefined,
+            applyCurrentMarkdownSource: (source) => {
+              markdownTextarea.value = source;
               syncMarkdownToForm();
-            }
-            if (reconciled !== null) {
-              originalContent = data.markdown_source;
-            }
+            },
+            applyCachedMarkdownSource: (source, savedSource) => {
+              const row = onSuccessTree ? treeRowElement(onSuccessTree) : null;
+              if (row && row.dataset.markdownSource === savedSource) {
+                row.dataset.markdownSource = source;
+                row.requestUpdate?.();
+              }
+            },
+          });
+          if (canApplyToCurrentEditor && applied.currentApplied) {
+            originalContent = applied.snapshot.content;
           }
         }
       });
       // console.warn('apiQueue.enqueue disabled for debugging');
 
-      // Reset dirty state
-      originalContent = currentContent;
-      if (shouldPersistProgress) {
-        originalProgress = currentProgress;
-      }
-      isDirty = false;
-      pendingSave = false;
+      const reset = resetCreativeSaveState(snapshot);
+      originalContent = reset.originalContent;
+      if (reset.originalProgress !== undefined) originalProgress = reset.originalProgress;
+      isDirty = reset.isDirty;
+      pendingSave = reset.pendingSave;
       saveQueue.cancelTimer();
     }
 

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -10,10 +10,8 @@ import { renderMarkdown } from '../lib/utils/markdown'
 import { CreativeSaveQueue } from './creative_save_queue'
 import { isHtmlEmpty } from './html_content_empty'
 import {
-  applyCreativeSaveResponse,
-  captureCreativeSaveSnapshot,
-  creativeSaveSnapshotIsEmpty,
-  resetCreativeSaveState,
+  applyCreativeSaveResponse, captureDirectCreativeSaveSnapshot, captureQueuedCreativeSaveSnapshot,
+  creativeSaveSnapshotIsEmpty, resetCreativeSaveState,
 } from './creative_save_state'
 import { createListenerRegistry } from './dom_listener_registry'
 import { createDelegatedClickHandler } from './creative_row_editor_delegated_clicks'
@@ -757,18 +755,17 @@ function setupEditorSession() {
       // in-flight state until that request settles. Returning null keeps the
       // queue idle without ever flipping the in-flight flag.
       function performSave() {
-        // Sync markdown form fields before saving
         if (markdownMode) syncMarkdownToForm();
 
-        let snapshot = captureCreativeSaveSnapshot({
-          content: markdownMode ? (markdownTextarea?.value || '') : descriptionInput.value,
-          emptyContentType: markdownMode ? 'markdown' : 'html',
-          contentType: contentTypeInput?.value || 'html',
-          markdownSource: markdownSourceInput?.value || '',
-          markdownEditor: markdownEditorInput?.value || '',
-          progress: progressValueChanged() ? readProgressValue() : progressBaselineValueFrom(originalProgress),
-          persistProgress: progressValueChanged(),
-          originId: originIdInput?.value || '',
+        const persistProgress = progressValueChanged(), progress = persistProgress ? readProgressValue() : progressBaselineValueFrom(originalProgress);
+        let snapshot = captureDirectCreativeSaveSnapshot({
+          markdownMode, markdownContent: markdownTextarea?.value,
+          htmlContent: descriptionInput.value, contentType: contentTypeInput?.value,
+          markdownSource: markdownSourceInput?.value,
+          markdownEditor: markdownEditorInput?.value,
+          progress,
+          persistProgress,
+          originId: originIdInput?.value,
         });
         if (creativeSaveSnapshotIsEmpty(snapshot)) {
           pendingSave = false;
@@ -873,7 +870,6 @@ function setupEditorSession() {
               completionCascadePending = false;
             }
 
-            // Delete removed attachments after successful save
             if (lexicalEditor && typeof lexicalEditor.getDeletedAttachments === 'function') {
               const deletedIds = lexicalEditor.getDeletedAttachments();
               if (deletedIds && deletedIds.length > 0) {
@@ -1131,19 +1127,16 @@ function setupEditorSession() {
       // (markdownMode) syncs its value to the hidden fields here; the rich
       // surface already kept them current via onLexicalChange/applyCreativeData.
       if (markdownMode) syncMarkdownToForm();
-      const capturedContentType = contentTypeInput ? contentTypeInput.value : 'html';
-      const isMarkdownSave = capturedContentType === 'markdown';
-      let snapshot = captureCreativeSaveSnapshot({
+      let snapshot = captureQueuedCreativeSaveSnapshot({
         content: descriptionInput.value,
-        emptyContent: isMarkdownSave ? markdownSourceInput?.value : descriptionInput.value,
-        emptyContentType: isMarkdownSave ? 'markdown' : 'html',
-        contentType: capturedContentType,
-        markdownSource: isMarkdownSave ? markdownSourceInput?.value : '',
-        markdownEditor: markdownEditorInput?.value || '',
+        contentType: contentTypeInput?.value,
+        markdownSource: markdownSourceInput?.value,
+        markdownEditor: markdownEditorInput?.value,
         progress: readProgressValue(),
         persistProgress: progressValueChanged(),
-        originId: originIdInput?.value || '',
+        originId: originIdInput?.value,
       });
+      const isMarkdownSave = snapshot.contentType === 'markdown';
       const currentParentId = tree.dataset.parentId || '';
       const currentBeforeId = tree.previousElementSibling ? creativeIdFrom(tree.previousElementSibling) : '';
       const currentAfterId = tree.nextElementSibling ? creativeIdFrom(tree.nextElementSibling) : '';
@@ -1164,16 +1157,14 @@ function setupEditorSession() {
       // made during the upload wait get overwritten by the stale pre-wait source.
       if (form.dataset.creativeId === startCreativeId) {
         if (markdownMode) syncMarkdownToForm();
-        snapshot = captureCreativeSaveSnapshot({
+        snapshot = captureQueuedCreativeSaveSnapshot({
           content: descriptionInput.value,
-          emptyContent: isMarkdownSave ? markdownSourceInput?.value : descriptionInput.value,
-          emptyContentType: isMarkdownSave ? 'markdown' : 'html',
-          contentType: capturedContentType,
-          markdownSource: isMarkdownSave ? markdownSourceInput?.value : '',
-          markdownEditor: markdownEditorInput?.value || '',
+          contentType: snapshot.contentType,
+          markdownSource: markdownSourceInput?.value,
+          markdownEditor: markdownEditorInput?.value,
           progress: readProgressValue(),
           persistProgress: progressValueChanged(),
-          originId: originIdInput?.value || '',
+          originId: originIdInput?.value,
         });
       }
 

--- a/engines/collavre/app/javascript/modules/creative_save_state.js
+++ b/engines/collavre/app/javascript/modules/creative_save_state.js
@@ -117,7 +117,7 @@ export function applyCreativeSaveResponse(snapshot, data, {
   }
 }
 
-export function resetCreativeSaveState(snapshot, current = null) {
+export function resetCreativeSaveState(snapshot, current = null, currentDirty = false) {
   const matchesSnapshot = !current || (
     current.content === snapshot.content &&
     current.progress === snapshot.progress &&
@@ -128,7 +128,7 @@ export function resetCreativeSaveState(snapshot, current = null) {
     originalContent: snapshot.content,
     originalProgress: snapshot.persistProgress ? snapshot.progress : undefined,
     originalOriginId: snapshot.originId,
-    isDirty: !matchesSnapshot,
+    isDirty: matchesSnapshot ? false : currentDirty,
     pendingSave: false,
   }
 }

--- a/engines/collavre/app/javascript/modules/creative_save_state.js
+++ b/engines/collavre/app/javascript/modules/creative_save_state.js
@@ -1,0 +1,84 @@
+import { isHtmlEmpty } from './html_content_empty'
+import { isMarkdownEmpty } from './creative_row_editor_helpers'
+import { reconcileMarkdownSource } from './markdown_source_reconcile'
+
+export function captureCreativeSaveSnapshot({
+  content,
+  emptyContent = content,
+  emptyContentType = 'html',
+  contentType = 'html',
+  markdownSource = '',
+  markdownEditor = '',
+  progress = 0,
+  persistProgress = false,
+  originId = '',
+}) {
+  return {
+    content: content || '',
+    emptyContent: emptyContent || '',
+    emptyContentType,
+    contentType,
+    markdownSource: markdownSource || '',
+    markdownEditor: markdownEditor || '',
+    progress,
+    persistProgress,
+    originId: originId || '',
+  }
+}
+
+export function creativeSaveSnapshotIsEmpty(snapshot) {
+  return snapshot.emptyContentType === 'markdown'
+    ? isMarkdownEmpty(snapshot.emptyContent)
+    : isHtmlEmpty(snapshot.emptyContent)
+}
+
+export function applyCreativeSaveResponse(snapshot, data, {
+  currentMarkdownSource,
+  applyCurrentMarkdownSource,
+  applyCachedMarkdownSource,
+} = {}) {
+  const serverSource = data?.markdown_source
+  if (typeof serverSource !== 'string' || serverSource === snapshot.markdownSource) {
+    return { snapshot, currentMarkdownSource, currentApplied: false }
+  }
+
+  applyCachedMarkdownSource?.(serverSource, snapshot.markdownSource)
+  if (typeof currentMarkdownSource !== 'string') {
+    return { snapshot, currentMarkdownSource, currentApplied: false }
+  }
+
+  const reconciled = reconcileMarkdownSource(
+    snapshot.markdownSource, serverSource, currentMarkdownSource
+  )
+  if (reconciled === null) {
+    return { snapshot, currentMarkdownSource, currentApplied: false }
+  }
+
+  if (reconciled !== currentMarkdownSource) applyCurrentMarkdownSource?.(reconciled)
+  return {
+    snapshot: {
+      ...snapshot,
+      content: snapshot.emptyContentType === 'markdown' ? serverSource : snapshot.content,
+      emptyContent: snapshot.emptyContentType === 'markdown' ? serverSource : snapshot.emptyContent,
+      markdownSource: serverSource,
+    },
+    currentMarkdownSource: reconciled,
+    currentApplied: true,
+  }
+}
+
+export function resetCreativeSaveState(snapshot, current = null) {
+  const matchesSnapshot = !current || (
+    current.content === snapshot.content &&
+    current.progress === snapshot.progress &&
+    current.originId === snapshot.originId
+  )
+
+  return {
+    originalContent: snapshot.content,
+    originalProgress: snapshot.persistProgress ? snapshot.progress : undefined,
+    originalOriginId: snapshot.originId,
+    isDirty: !matchesSnapshot,
+    pendingSave: false,
+  }
+}

--- a/engines/collavre/app/javascript/modules/creative_save_state.js
+++ b/engines/collavre/app/javascript/modules/creative_save_state.js
@@ -2,6 +2,10 @@ import { isHtmlEmpty } from './html_content_empty'
 import { isMarkdownEmpty } from './creative_row_editor_helpers'
 import { reconcileMarkdownSource } from './markdown_source_reconcile'
 
+function stringOrEmpty(value) {
+  return value || ''
+}
+
 export function captureCreativeSaveSnapshot({
   content,
   emptyContent = content,
@@ -14,16 +18,62 @@ export function captureCreativeSaveSnapshot({
   originId = '',
 }) {
   return {
-    content: content || '',
-    emptyContent: emptyContent || '',
+    content: stringOrEmpty(content),
+    emptyContent: stringOrEmpty(emptyContent),
     emptyContentType,
     contentType,
-    markdownSource: markdownSource || '',
-    markdownEditor: markdownEditor || '',
+    markdownSource: stringOrEmpty(markdownSource),
+    markdownEditor: stringOrEmpty(markdownEditor),
     progress,
     persistProgress,
-    originId: originId || '',
+    originId: stringOrEmpty(originId),
   }
+}
+
+export function captureDirectCreativeSaveSnapshot({
+  markdownMode,
+  markdownContent,
+  htmlContent,
+  contentType,
+  markdownSource,
+  markdownEditor,
+  progress,
+  persistProgress,
+  originId,
+}) {
+  return captureCreativeSaveSnapshot({
+    content: markdownMode ? markdownContent : htmlContent,
+    emptyContentType: markdownMode ? 'markdown' : 'html',
+    contentType,
+    markdownSource,
+    markdownEditor,
+    progress,
+    persistProgress,
+    originId,
+  })
+}
+
+export function captureQueuedCreativeSaveSnapshot({
+  content,
+  contentType,
+  markdownSource,
+  markdownEditor,
+  progress,
+  persistProgress,
+  originId,
+}) {
+  const isMarkdown = contentType === 'markdown'
+  return captureCreativeSaveSnapshot({
+    content,
+    emptyContent: isMarkdown ? markdownSource : content,
+    emptyContentType: isMarkdown ? 'markdown' : 'html',
+    contentType,
+    markdownSource: isMarkdown ? markdownSource : '',
+    markdownEditor,
+    progress,
+    persistProgress,
+    originId,
+  })
 }
 
 export function creativeSaveSnapshotIsEmpty(snapshot) {

--- a/engines/collavre/app/javascript/modules/html_content_empty.js
+++ b/engines/collavre/app/javascript/modules/html_content_empty.js
@@ -4,9 +4,11 @@
 // don't get discarded silently when switching editor modes.
 export function isHtmlEmpty(html, doc = typeof document !== 'undefined' ? document : null) {
   if (!html) return true;
-  if (!doc) return html.replace(/<[^>]*>/g, '').trim().length === 0;
-  const temp = doc.createElement('div');
-  temp.innerHTML = html;
+  const Parser = doc?.defaultView?.DOMParser ?? globalThis.DOMParser;
+  if (!Parser) return html.replace(/<[^>]*>/g, '').trim().length === 0;
+  // Parse in an inert document: even a detached element in the active document
+  // can execute resource event handlers when untrusted HTML is assigned to it.
+  const temp = new Parser().parseFromString(html, 'text/html').body;
   if (temp.querySelector('img, action-text-attachment, figure.attachment, [data-trix-attachment]')) return false;
   return (temp.textContent || '').trim().length === 0;
 }

--- a/engines/collavre/app/jobs/collavre/ai_agent_job.rb
+++ b/engines/collavre/app/jobs/collavre/ai_agent_job.rb
@@ -362,7 +362,7 @@ module Collavre
       if waiter.waiting_notice_scope == Comment::WAITING_NOTICE_TOPIC
         Orchestration::TaskCoalescer.coalesce!(waiter)
       end
-      Orchestration::AgentOrchestrator.post_topic_concurrency_notice(
+      Orchestration::WaitingNoticeManager.post_topic_concurrency_notice(
         creative_id, topic_id, context, agent: agent, waiter: waiter
       )
 

--- a/engines/collavre/app/models/collavre/comment.rb
+++ b/engines/collavre/app/models/collavre/comment.rb
@@ -4,7 +4,7 @@ module Collavre
 
     STREAMING_PLACEHOLDER_CONTENT = "..."
     # Authorless "⏳" waiting-notice system messages posted when an agent is
-    # deferred for topic concurrency. AgentOrchestrator.cleanup_waiting_notices!
+    # deferred for topic concurrency. WaitingNoticeManager.cleanup_waiting_notices!
     # matches the same prefix to remove them once the waiter is dequeued.
     WAITING_NOTICE_PREFIX = "⏳"
 
@@ -29,7 +29,7 @@ module Collavre
     #
     # It therefore comes down wherever the waiter leaves, which is why this
     # lives here beside the columns rather than in one of those callers: the
-    # promotion (AgentOrchestrator.cleanup_waiter_notice!) and the fold
+    # promotion (WaitingNoticeManager.cleanup_waiter_notice!) and the fold
     # (Orchestration::TaskCoalescer) are two doors onto the same rule, and a
     # third would otherwise write its own copy or forget.
     #
@@ -176,7 +176,7 @@ module Collavre
     attribute :skip_dispatch, :boolean, default: false
     attribute :skip_link_preview, :boolean, default: false
     attribute :skip_notification_revision, :boolean, default: false
-    # Set by AgentOrchestrator.cleanup_waiting_notices! so destroying a notice as
+    # Set by WaitingNoticeManager.cleanup_waiting_notices! so destroying a notice as
     # part of *promoting* a waiter does not run the user-delete cancel cascade
     # (which would cancel other still-queued waiters in the same topic).
     attribute :suppress_waiter_cancellation, :boolean, default: false
@@ -426,7 +426,7 @@ module Collavre
     # Cancelling one was right while each deferral posted its own notice: the
     # newest queued task was the one that notice belonged to. A topic now gets
     # exactly one deduplicated notice
-    # (Orchestration::AgentOrchestrator.with_deduped_topic_notice), and with
+    # (Orchestration::WaitingNoticeManager.with_deduped_topic_notice), and with
     # topic_max_concurrent_jobs > 1 it can stand for waiters from several agents
     # — coalescing folds same-agent siblings only. Deleting it while cancelling
     # one of them leaves the rest queued with nothing on screen representing

--- a/engines/collavre/app/services/collavre/creatives/drop_trigger_missing_agent_notifier.rb
+++ b/engines/collavre/app/services/collavre/creatives/drop_trigger_missing_agent_notifier.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Collavre
+  module Creatives
+    # Records a visible warning when an enabled trigger has no writable agent.
+    class DropTriggerMissingAgentNotifier
+      def initialize(creative:)
+        @creative = creative
+      end
+
+      def call
+        return if creative.find_ai_agent(:write)
+
+        topic = creative.topics.find_or_create_by!(name: "Drop Trigger") do |record|
+          record.user = creative.user
+        end
+
+        creative.comments.create!(
+          content: I18n.t("collavre.drop_trigger.no_agent", parent_description: creative.creative_snippet),
+          topic_id: topic.id,
+          private: false,
+          skip_default_user: true
+        )
+      end
+
+      private
+
+      attr_reader :creative
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/creatives/trigger_action_command.rb
+++ b/engines/collavre/app/services/collavre/creatives/trigger_action_command.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+module Collavre
+  module Creatives
+    # Executes one trigger UI command after authorizing its target creative.
+    class TriggerActionCommand
+      ACTIONS = %w[toggle_container start pause resume restart].freeze
+      PAUSABLE_STATES = %w[running pending_verification].freeze
+      RESUMABLE_STATES = %w[paused idle stuck awaiting_user].freeze
+      RESTARTABLE_STATES = %w[completed max_reached stuck].freeze
+
+      Result = Struct.new(:error, :status, keyword_init: true) do
+        def success?
+          error.nil?
+        end
+      end
+
+      def initialize(creative:, user:, action:, enabled: nil)
+        @creative = creative
+        @user = user
+        @action = action
+        @enabled = enabled
+      end
+
+      def call
+        return failure(:unprocessable_entity, "collavre.drop_trigger.unknown_action") unless ACTIONS.include?(action)
+        return failure(:forbidden, "collavre.creatives.errors.no_permission") unless target.has_permission?(user, :write)
+
+        @transitioned_loop_data = nil
+        outcome = send(action)
+        outcome.is_a?(Result) ? outcome : Result.new
+      end
+
+      private
+
+      attr_reader :creative, :user, :action, :enabled
+
+      def target
+        @target ||= action == "toggle_container" ? creative.effective_origin(Set.new) : creative
+      end
+
+      def toggle_container
+        previous_enabled = target.drop_trigger_enabled?
+        data = (target.data || {}).deep_dup
+        data["trigger"] ||= {}
+        data["trigger"]["on_child_enter"] = ActiveModel::Type::Boolean.new.cast(enabled)
+        target.update!(data: data)
+        notify_missing_agent if !previous_enabled && target.drop_trigger_enabled?
+      end
+
+      def start
+        parent = creative.parent
+        return failure(:unprocessable_entity, "collavre.drop_trigger.not_a_container") unless parent&.drop_trigger_enabled?
+
+        DropTriggerJob.perform_later(parent.id, creative.id)
+      end
+
+      def pause
+        transition_loop(PAUSABLE_STATES) { |loop_data| loop_data["state"] = "paused" }
+      end
+
+      def resume
+        transition_loop(RESUMABLE_STATES) { |loop_data| loop_data["state"] = "running" }
+        post_continue_to_agent if @transitioned_loop_data
+      end
+
+      def restart
+        transition_loop(RESTARTABLE_STATES) do |loop_data|
+          loop_data.merge!("state" => "running", "current_iteration" => 0, "infra_retry_count" => 0)
+        end
+        post_restart_trigger if @transitioned_loop_data
+      end
+
+      def transition_loop(allowed_states)
+        data = (creative.data || {}).deep_dup
+        loop_data = data.dig("trigger", "loop")
+        return unless loop_data && allowed_states.include?(loop_data["state"])
+
+        yield loop_data
+        creative.update!(data: data)
+        @transitioned_loop_data = loop_data
+      end
+
+      def post_continue_to_agent
+        parent, topic, agent = trigger_context
+        return log_missing_context("resume", topic) unless parent && topic && agent
+
+        content = "@#{agent.name}: #{I18n.t(
+          'collavre.trigger_loop.continue',
+          iteration: @transitioned_loop_data["current_iteration"] || 0,
+          max: @transitioned_loop_data["max_iterations"] || 10
+        )}"
+        comment = create_trigger_comment(topic, content, skip_dispatch: false)
+        Rails.logger.info("[TriggerAction] resume: posted continue comment #{comment.id} for creative #{creative.id}")
+      end
+
+      def post_restart_trigger
+        parent, topic, agent = trigger_context
+        return log_missing_context("restart", topic) unless parent && topic && agent
+
+        content = "@#{agent.name}: #{restart_message(parent)}"
+        comment = create_trigger_comment(topic, content, skip_dispatch: true)
+        scheduled = SystemEvents::Dispatcher.dispatch("comment_created", comment.dispatch_payload, source: "trigger_restart")
+        Rails.logger.info("[TriggerAction] restart: posted trigger comment #{comment.id}, dispatched to #{scheduled&.size || 0} agents")
+      end
+
+      def restart_message(parent)
+        trigger_text = I18n.t(
+          "collavre.drop_trigger.child_entered",
+          child_description: creative.creative_snippet,
+          child_id: creative.id,
+          parent_description: parent.creative_snippet
+        )
+        "#{trigger_text}\n\n#{I18n.t('collavre.trigger_loop.instructions')}"
+      end
+
+      def trigger_context
+        parent = creative.parent
+        [ parent, creative.topics.find_by(name: "Drop Trigger"), parent&.find_ai_agent(:write) ]
+      end
+
+      def create_trigger_comment(topic, content, skip_dispatch:)
+        creative.comments.create!(
+          content: content,
+          topic_id: topic.id,
+          private: false,
+          user: user,
+          skip_dispatch: skip_dispatch
+        )
+      end
+
+      def log_missing_context(operation, topic)
+        Rails.logger.warn("[TriggerAction] #{operation}: missing topic=#{topic&.id} or agent for creative #{creative.id}")
+      end
+
+      def notify_missing_agent
+        DropTriggerMissingAgentNotifier.new(creative: target).call
+      end
+
+      def failure(status, key)
+        Result.new(error: I18n.t(key), status: status)
+      end
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
+++ b/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
@@ -43,7 +43,7 @@ module Collavre
           # bottom would enqueue it, where AiAgentJob reloads and returns
           # without draining. Re-read once, here, rather than at each of them.
           unless task.reload.status == "cancelled"
-            cleanup_waiting_notices_if_drained!(task)
+            WaitingNoticeManager.cleanup_waiting_notices_if_drained!(task)
             refresh_deferred_context!(task)
             revalidate_assignment!(task) unless task.status == "cancelled"
           end
@@ -97,127 +97,6 @@ module Collavre
       end
       private_class_method :claim_next_waiter
 
-      # Human-readable reason for the "⏳" waiting notice. For topic-concurrency
-      # deferrals, name the agent(s) actually holding the topic's running slot so
-      # a waiting user can see *who* is blocking them (and reach that task's stop
-      # button) rather than an anonymous "another task is running" dead end.
-      def self.waiting_reason_text(reason_key, topic_id, creative_id)
-        if reason_key == :topic_concurrency && topic_id
-          names = Task.running_for_topic(topic_id, creative_id)
-                      .includes(:agent).filter_map { |t| t.agent&.name }.uniq
-          if names.any?
-            return I18n.t(
-              "collavre.orchestration.waiting_reasons.topic_concurrency_with_agent",
-              agent: names.join(", ")
-            )
-          end
-        end
-
-        I18n.t(
-          "collavre.orchestration.waiting_reasons.#{reason_key}",
-          default: reason_key.to_s.humanize
-        )
-      end
-
-      # Is there already a "⏳" topic-concurrency waiting notice on this
-      # creative/topic that stands for the topic as a whole? Shared with
-      # AiAgentJob's late slot check so both defer paths post at most one shared
-      # notice per topic.
-      #
-      # A per-deferral notice does not count. It speaks for one waiter, so
-      # letting it suppress the shared one would leave a coalescing agent's
-      # waiters with no notice at all whenever an opted-out agent happened to
-      # defer into the topic first. Notices from before the mode was recorded do
-      # count: they are the topic's only signal, and posting a second one beside
-      # them is the duplication this guard exists to prevent.
-      def self.topic_concurrency_notice_exists?(creative_id, topic_id)
-        Comment.where(creative_id: creative_id, topic_id: topic_id, user_id: nil,
-                      topic_concurrency_defer: true)
-               .where(waiting_notice_scope: [ nil, Comment::WAITING_NOTICE_TOPIC ])
-               .where("content LIKE ?", "#{Comment::WAITING_NOTICE_PREFIX}%")
-               .exists?
-      end
-
-      # Check-then-insert the one waiting notice a topic is allowed, as a single
-      # step. Both defer paths run for a *burst* — the case where every worker
-      # reads "no notice yet" before any of them inserts — so an unserialized
-      # check leaves N dead-end notices pointing at one blocker, and deleting one
-      # of them cancels the waiters while the others linger.
-      #
-      # Serialize on the same row admission locks (TopicSlot.lock!): the workers
-      # that compete for a notice are exactly the ones that competed for the
-      # slot, so the loser reads the winner's committed notice.
-      #
-      # The same lock also decides whether a notice is still warranted at all.
-      # The waiter commits before its notice goes up, so the blocker can finish
-      # in between, promote it, and run cleanup_waiting_notices! before any
-      # notice exists. A notice posted after that cleanup describes a wait that
-      # is already over, and nothing will ever take it down: removal only
-      # happens when a promotion drains a *queued* waiter, and there is none
-      # left. Promotion takes this same row, so "still queued" read here is the
-      # promotion's own before-or-after, not a guess.
-      #
-      # Yields only when a waiter is still queued and no notice exists yet;
-      # returns nil otherwise.
-      def self.with_deduped_topic_notice(creative_id, topic_id)
-        with_live_topic_wait(creative_id, topic_id) do
-          next nil if topic_concurrency_notice_exists?(creative_id, topic_id)
-
-          yield
-        end
-      end
-
-      # The "is anyone still waiting?" half on its own, without the "only one
-      # notice per topic" half.
-      #
-      # With coalesce_pending_tasks off, each deferral keeps its own waiter, so
-      # each one needs its own notice: a single notice standing for N
-      # independent waiters turns its stop button into "cancel everyone's work"
-      # (Comment#cancel_queued_tasks_for_waiting_notice reads "no sibling notice
-      # left" as "this notice spoke for the topic"). The drain guard still
-      # applies either way — a notice explaining a wait that is already over is
-      # never removed by anything.
-      def self.with_live_topic_wait(creative_id, topic_id)
-        Comment.transaction do
-          TopicSlot.lock!(topic_id, creative_id)
-          next nil unless Task.queued_for_topic(topic_id, creative_id).exists?
-
-          yield
-        end
-      end
-
-      # The same guard for a notice that speaks for exactly one waiter.
-      #
-      # "Is anyone still waiting?" is the *shared* notice's question, and it
-      # stays true for as long as any waiter is queued. A per-deferral notice
-      # answers for one — and that one can be promoted between its row
-      # committing and this lock, since the waiter is created and the notice
-      # posted in two steps on both doors. With another deferral parked in the
-      # same burst the topic-wide question then says yes while this waiter's
-      # says no, and the notice goes up offering a stop button for a turn that
-      # is already running.
-      #
-      # Nothing takes it back down. cleanup_waiter_notice! is the only path that
-      # removes one, it runs during the promotion that just happened, and it
-      # matched nothing because the notice did not exist yet; deleting it by
-      # hand cancels nothing either, since a task-scoped notice selects its own
-      # waiter and that waiter is no longer queued.
-      #
-      # Asked under the admission lock, so "still queued" is the promotion's own
-      # before-or-after rather than a guess.
-      def self.with_live_waiter(waiter, creative_id, topic_id, &block)
-        # No waiter to speak for: the topic-wide question is all a caller
-        # without one can be asked.
-        return with_live_topic_wait(creative_id, topic_id, &block) if waiter.nil?
-
-        Comment.transaction do
-          TopicSlot.lock!(topic_id, creative_id)
-          next nil unless Task.where(id: waiter.id, status: "queued").exists?
-
-          yield
-        end
-      end
-
       def self.coalesce_promoted!(task)
         return unless PolicyResolver.new(task.trigger_event_payload || {})
                         .coalesce_pending_tasks_for?(task.agent)
@@ -266,124 +145,8 @@ module Collavre
         # The folded waiters may have been everything the topic's "⏳" notice
         # described, and nothing else will take it down: removal happens when a
         # promotion drains a *queued* waiter, and this fold left none.
-        cleanup_waiting_notices_if_drained!(task)
+        WaitingNoticeManager.cleanup_waiting_notices_if_drained!(task)
       end
-
-      # Take the topic's "⏳" notice down, but only once nothing is waiting on
-      # the slot any more.
-      #
-      # "A waiter left the queue" is not the same question. A topic gets exactly
-      # one deduplicated notice, and with topic_max > 1 a promotion can leave
-      # other agents queued — coalesce_promoted! absorbs same-agent siblings
-      # only, and the queue head may be ineligible while a later waiter runs. So
-      # an unconditional cleanup strips the wait/stop signal off a wait that is
-      # still real, and nothing reposts it until the next deferral happens by.
-      #
-      # Asked under the lock post_waiting_notice takes, so "nobody is queued" is
-      # that path's own before-or-after rather than a guess: a deferral either
-      # commits its waiter before this reads, and keeps its notice, or after, and
-      # posts its own.
-      # …but that guard is about the *shared* notice, which is still describing a
-      # real wait for as long as anyone is queued. A per-deferral notice speaks
-      # for one waiter, so it comes down when that waiter leaves the queue and
-      # not a moment later: with the opt-out and two waiters, promoting one
-      # leaves the queue non-empty, and the notice for the task now running would
-      # stay on screen with a stop button for a wait that is over.
-      def self.cleanup_waiting_notices_if_drained!(task)
-        Comment.transaction do
-          TopicSlot.lock!(task.topic_id, task.creative_id)
-          cleanup_waiter_notice!(task)
-
-          # "Is anyone queued?" is the topic's question, not any one notice's.
-          # A shared notice speaks for the queued waiters no per-deferral notice
-          # claims, so a promotion that leaves only claimed waiters behind
-          # leaves it representing nobody — a second "⏳" line whose stop button
-          # selects nothing, kept up by the very waiter that is not its to
-          # speak for. Ask each notice what it still stands for.
-          Comment.remove_stranded_waiting_notices!(
-            creative_id: task.creative_id, topic_id: task.topic_id
-          )
-          next if Task.queued_for_topic(task.topic_id, task.creative_id).exists?
-
-          cleanup_waiting_notices!(task)
-        end
-      end
-      private_class_method :cleanup_waiting_notices_if_drained!
-
-      # Remove the per-deferral notice posted for this particular waiter, if it
-      # had one. A shared notice is left alone — it is not this task's to take
-      # down, and the drained check above is the question that governs it.
-      def self.cleanup_waiter_notice!(task)
-        Comment.remove_waiter_notices!(
-          creative_id: task.creative_id, topic_id: task.topic_id, task_ids: task.id
-        )
-      end
-      private_class_method :cleanup_waiter_notice!
-
-      # Post the "⏳ waiting on the topic slot" notice for a deferral raised
-      # outside #enqueue_jobs — AiAgentJob's late slot check, which catches
-      # dispatches that passed the Scheduler before any Task row existed.
-      # No-op when a notice for this creative/topic is already up — unless
-      # coalescing is off for this dispatch, in which case its waiter is nobody
-      # else's to speak for and gets a notice of its own, exactly as
-      # #post_waiting_notice does on the enqueue door. Leaving one door
-      # deduplicated and the other not is what breaks the opt-out's 1:1.
-      def self.post_topic_concurrency_notice(creative_id, topic_id, context = nil, agent: nil, waiter: nil)
-        return if creative_id.nil?
-
-        creative = Creative.find_by(id: creative_id)
-        return unless creative
-
-        reason_text = waiting_reason_text(:topic_concurrency, topic_id, creative_id)
-        # The waiter recorded this when it was parked. Reading it back rather than
-        # resolving the policy again keeps the notice, the fold and the shared
-        # notice's stop button on one answer even if the policy changes mid-wait.
-        # Falling back for a caller without a waiter: there is no row to ask.
-        shared =
-          if waiter
-            waiter.waiting_notice_scope == Comment::WAITING_NOTICE_TOPIC
-          else
-            PolicyResolver.new(context || {}).coalesce_pending_tasks_for?(agent)
-          end
-        post = lambda do
-          creative.comments.create!(
-            content: I18n.t("collavre.orchestration.waiting_notice", reason: reason_text),
-            topic_id: topic_id,
-            private: false,
-            skip_default_user: true,
-            topic_concurrency_defer: true,
-            # What this notice speaks for, recorded rather than reconstructed
-            # later from whichever siblings survive. See
-            # Comment#cancel_queued_tasks_for_waiting_notice.
-            waiting_notice_scope: shared ? Comment::WAITING_NOTICE_TOPIC : Comment::WAITING_NOTICE_TASK,
-            waiting_notice_task_id: shared ? nil : waiter&.id
-          )
-        end
-
-        if shared
-          with_deduped_topic_notice(creative_id, topic_id, &post)
-        else
-          with_live_waiter(waiter, creative_id, topic_id, &post)
-        end
-      end
-
-      # Remove waiting notice comments (system messages) for this task's creative/topic.
-      def self.cleanup_waiting_notices!(task)
-        context = task.trigger_event_payload
-        creative_id = context&.dig("creative", "id")
-        topic_id = context&.dig("topic", "id")
-        return unless creative_id
-
-        Comment.where(creative_id: creative_id, topic_id: topic_id, user_id: nil)
-               .where("content LIKE ?", "#{Comment::WAITING_NOTICE_PREFIX}%")
-               .find_each do |notice|
-          # System promotion, not user abandonment: do not let the destroy
-          # callback cancel other still-queued waiters in this topic.
-          notice.suppress_waiter_cancellation = true
-          notice.destroy
-        end
-      end
-      private_class_method :cleanup_waiting_notices!
 
       # Refresh trigger_event_payload so the deferred agent sees the latest
       # conversation state instead of the stale snapshot from enqueue time.
@@ -847,76 +610,15 @@ module Collavre
       end
 
       def post_waiting_notice(agent, decision, waiter: nil)
-        creative_id = @context.dig("creative", "id")
-        topic_id = @context.dig("topic", "id")
-        return unless creative_id
-
-        creative = Creative.find_by(id: creative_id)
-        return unless creative
-
-        reason_text = waiting_reason_text(decision[:reason] || :unknown, topic_id, creative_id)
-        deferred = decision[:timing] == :deferred
-
-        # Coalescing collapses a burst of deferrals into one waiter, so a notice
-        # per deferral would leave N-1 dead ends pointing at the same blocker.
-        # Keep exactly one topic-concurrency notice per creative/topic — and take
-        # the check and the insert under one lock, since a burst is precisely
-        # when an unserialized check reads stale.
-        #
-        # Taken from the waiter, which recorded it under the admission lock when
-        # park_waiter created it. One answer for the fold, the notice and the
-        # shared notice's stop button, rather than the same question asked at
-        # three moments a policy change can fall between. :delayed has no waiter.
-        shared = deferred && (waiter ? waiter.waiting_notice_scope == Comment::WAITING_NOTICE_TOPIC
-                                     : policy_resolver.coalesce_pending_tasks_for?(agent))
-        if shared
-          self.class.with_deduped_topic_notice(creative_id, topic_id) do
-            create_waiting_notice(creative, topic_id, reason_text, deferred: deferred,
-                                  shared: true, waiter: waiter)
-          end
-        elsif deferred
-          # park_waiter commits the row and this posts its notice afterwards, so
-          # the same window with_live_waiter closes on the late-admission door is
-          # open here too — see that method.
-          self.class.with_live_waiter(waiter, creative_id, topic_id) do
-            create_waiting_notice(creative, topic_id, reason_text, deferred: deferred,
-                                  shared: false, waiter: waiter)
-          end
-        else
-          # :delayed. The dispatch is still going to run, so there is no waiter
-          # for this notice to speak for and nothing for the guard to ask about.
-          create_waiting_notice(creative, topic_id, reason_text, deferred: deferred,
-                                shared: false, waiter: waiter)
-        end
-      end
-
-      def create_waiting_notice(creative, topic_id, reason_text, deferred:, shared:, waiter:)
-        creative.comments.build(
-          content: I18n.t("collavre.orchestration.waiting_notice", reason: reason_text),
-          topic_id: topic_id,
-          private: false,
-          skip_default_user: true,
-          # Only :deferred queues a topic waiter; mark it so its stop button can
-          # target the blocker. :delayed (busy / rate_limited) notices stay false.
-          topic_concurrency_defer: deferred,
-          # …and only a :deferred notice speaks for a waiter at all, so only that
-          # one records which. A :delayed notice never reaches
-          # Comment#cancel_queued_tasks_for_waiting_notice.
-          waiting_notice_scope: deferred ? (shared ? Comment::WAITING_NOTICE_TOPIC : Comment::WAITING_NOTICE_TASK) : nil,
-          waiting_notice_task_id: (waiter&.id unless shared)
-        ).tap(&:save!)
-      rescue ActiveRecord::RecordNotSaved => error
-        # A delayed job is already queued when this notice is posted. Topic
-        # relocation may invalidate only the stale notice in that gap.
-        raise unless error.record.errors.include?(:topic)
-      end
-
-      # Human-readable reason for the "⏳" waiting notice. For topic-concurrency
-      # deferrals, name the agent(s) actually holding the topic's running slot so
-      # a waiting user can see *who* is blocking them (and reach that task's stop
-      # button) rather than an anonymous "another task is running" dead end.
-      def waiting_reason_text(reason_key, topic_id, creative_id)
-        self.class.waiting_reason_text(reason_key, topic_id, creative_id)
+        WaitingNoticeManager.post(
+          @context.dig("creative", "id"), @context.dig("topic", "id"),
+          decision[:reason] || :unknown,
+          deferred: decision[:timing] == :deferred,
+          waiter: waiter,
+          # No waiter to read the scope off means :delayed, which never parks
+          # one; ask the policy the same question park_waiter asked.
+          shared_without_waiter: -> { policy_resolver.coalesce_pending_tasks_for?(agent) }
+        )
       end
     end
   end

--- a/engines/collavre/app/services/collavre/orchestration/waiting_notice_manager.rb
+++ b/engines/collavre/app/services/collavre/orchestration/waiting_notice_manager.rb
@@ -1,0 +1,289 @@
+# frozen_string_literal: true
+
+module Collavre
+  module Orchestration
+    # Owns the "⏳ waiting on the topic slot" notices: the reason text a waiting
+    # user reads, the locks that decide whether a notice is still warranted, the
+    # single row each door is allowed to write, and the cleanup that takes it
+    # down again.
+    #
+    # Two doors defer a dispatch — AgentOrchestrator#enqueue_jobs, and
+    # AiAgentJob's late slot check for dispatches that passed the Scheduler
+    # before any Task row existed — and they have to agree about when a burst
+    # becomes one notice, which waiter a notice speaks for, and when it comes
+    # back down. Both arrive here so that agreement is one implementation rather
+    # than two that drift.
+    class WaitingNoticeManager
+      # Human-readable reason for the "⏳" waiting notice. For topic-concurrency
+      # deferrals, name the agent(s) actually holding the topic's running slot so
+      # a waiting user can see *who* is blocking them (and reach that task's stop
+      # button) rather than an anonymous "another task is running" dead end.
+      def self.waiting_reason_text(reason_key, topic_id, creative_id)
+        if reason_key == :topic_concurrency && topic_id
+          names = Task.running_for_topic(topic_id, creative_id)
+                      .includes(:agent).filter_map { |t| t.agent&.name }.uniq
+          if names.any?
+            return I18n.t(
+              "collavre.orchestration.waiting_reasons.topic_concurrency_with_agent",
+              agent: names.join(", ")
+            )
+          end
+        end
+
+        I18n.t(
+          "collavre.orchestration.waiting_reasons.#{reason_key}",
+          default: reason_key.to_s.humanize
+        )
+      end
+
+      # Is there already a "⏳" topic-concurrency waiting notice on this
+      # creative/topic that stands for the topic as a whole? Shared with
+      # AiAgentJob's late slot check so both defer paths post at most one shared
+      # notice per topic.
+      #
+      # A per-deferral notice does not count. It speaks for one waiter, so
+      # letting it suppress the shared one would leave a coalescing agent's
+      # waiters with no notice at all whenever an opted-out agent happened to
+      # defer into the topic first. Notices from before the mode was recorded do
+      # count: they are the topic's only signal, and posting a second one beside
+      # them is the duplication this guard exists to prevent.
+      def self.topic_concurrency_notice_exists?(creative_id, topic_id)
+        Comment.where(creative_id: creative_id, topic_id: topic_id, user_id: nil,
+                      topic_concurrency_defer: true)
+               .where(waiting_notice_scope: [ nil, Comment::WAITING_NOTICE_TOPIC ])
+               .where("content LIKE ?", "#{Comment::WAITING_NOTICE_PREFIX}%")
+               .exists?
+      end
+
+      # Check-then-insert the one waiting notice a topic is allowed, as a single
+      # step. Both defer paths run for a *burst* — the case where every worker
+      # reads "no notice yet" before any of them inserts — so an unserialized
+      # check leaves N dead-end notices pointing at one blocker, and deleting one
+      # of them cancels the waiters while the others linger.
+      #
+      # Serialize on the same row admission locks (TopicSlot.lock!): the workers
+      # that compete for a notice are exactly the ones that competed for the
+      # slot, so the loser reads the winner's committed notice.
+      #
+      # The same lock also decides whether a notice is still warranted at all.
+      # The waiter commits before its notice goes up, so the blocker can finish
+      # in between, promote it, and run cleanup_waiting_notices! before any
+      # notice exists. A notice posted after that cleanup describes a wait that
+      # is already over, and nothing will ever take it down: removal only
+      # happens when a promotion drains a *queued* waiter, and there is none
+      # left. Promotion takes this same row, so "still queued" read here is the
+      # promotion's own before-or-after, not a guess.
+      #
+      # Yields only when a waiter is still queued and no notice exists yet;
+      # returns nil otherwise.
+      def self.with_deduped_topic_notice(creative_id, topic_id)
+        with_live_topic_wait(creative_id, topic_id) do
+          next nil if topic_concurrency_notice_exists?(creative_id, topic_id)
+
+          yield
+        end
+      end
+
+      # The "is anyone still waiting?" half on its own, without the "only one
+      # notice per topic" half.
+      #
+      # With coalesce_pending_tasks off, each deferral keeps its own waiter, so
+      # each one needs its own notice: a single notice standing for N
+      # independent waiters turns its stop button into "cancel everyone's work"
+      # (Comment#cancel_queued_tasks_for_waiting_notice reads "no sibling notice
+      # left" as "this notice spoke for the topic"). The drain guard still
+      # applies either way — a notice explaining a wait that is already over is
+      # never removed by anything.
+      def self.with_live_topic_wait(creative_id, topic_id)
+        Comment.transaction do
+          TopicSlot.lock!(topic_id, creative_id)
+          next nil unless Task.queued_for_topic(topic_id, creative_id).exists?
+
+          yield
+        end
+      end
+
+      # The same guard for a notice that speaks for exactly one waiter.
+      #
+      # "Is anyone still waiting?" is the *shared* notice's question, and it
+      # stays true for as long as any waiter is queued. A per-deferral notice
+      # answers for one — and that one can be promoted between its row
+      # committing and this lock, since the waiter is created and the notice
+      # posted in two steps on both doors. With another deferral parked in the
+      # same burst the topic-wide question then says yes while this waiter's
+      # says no, and the notice goes up offering a stop button for a turn that
+      # is already running.
+      #
+      # Nothing takes it back down. cleanup_waiter_notice! is the only path that
+      # removes one, it runs during the promotion that just happened, and it
+      # matched nothing because the notice did not exist yet; deleting it by
+      # hand cancels nothing either, since a task-scoped notice selects its own
+      # waiter and that waiter is no longer queued.
+      #
+      # Asked under the admission lock, so "still queued" is the promotion's own
+      # before-or-after rather than a guess.
+      def self.with_live_waiter(waiter, creative_id, topic_id, &block)
+        # No waiter to speak for: the topic-wide question is all a caller
+        # without one can be asked.
+        return with_live_topic_wait(creative_id, topic_id, &block) if waiter.nil?
+
+        Comment.transaction do
+          TopicSlot.lock!(topic_id, creative_id)
+          next nil unless Task.where(id: waiter.id, status: "queued").exists?
+
+          yield
+        end
+      end
+
+      # Take the topic's "⏳" notice down, but only once nothing is waiting on
+      # the slot any more.
+      #
+      # "A waiter left the queue" is not the same question. A topic gets exactly
+      # one deduplicated notice, and with topic_max > 1 a promotion can leave
+      # other agents queued — coalesce_promoted! absorbs same-agent siblings
+      # only, and the queue head may be ineligible while a later waiter runs. So
+      # an unconditional cleanup strips the wait/stop signal off a wait that is
+      # still real, and nothing reposts it until the next deferral happens by.
+      #
+      # Asked under the lock .post takes, so "nobody is queued" is
+      # that path's own before-or-after rather than a guess: a deferral either
+      # commits its waiter before this reads, and keeps its notice, or after, and
+      # posts its own.
+      # …but that guard is about the *shared* notice, which is still describing a
+      # real wait for as long as anyone is queued. A per-deferral notice speaks
+      # for one waiter, so it comes down when that waiter leaves the queue and
+      # not a moment later: with the opt-out and two waiters, promoting one
+      # leaves the queue non-empty, and the notice for the task now running would
+      # stay on screen with a stop button for a wait that is over.
+      def self.cleanup_waiting_notices_if_drained!(task)
+        Comment.transaction do
+          TopicSlot.lock!(task.topic_id, task.creative_id)
+          cleanup_waiter_notice!(task)
+
+          # "Is anyone queued?" is the topic's question, not any one notice's.
+          # A shared notice speaks for the queued waiters no per-deferral notice
+          # claims, so a promotion that leaves only claimed waiters behind
+          # leaves it representing nobody — a second "⏳" line whose stop button
+          # selects nothing, kept up by the very waiter that is not its to
+          # speak for. Ask each notice what it still stands for.
+          Comment.remove_stranded_waiting_notices!(
+            creative_id: task.creative_id, topic_id: task.topic_id
+          )
+          next if Task.queued_for_topic(task.topic_id, task.creative_id).exists?
+
+          cleanup_waiting_notices!(task)
+        end
+      end
+
+      # Remove the per-deferral notice posted for this particular waiter, if it
+      # had one. A shared notice is left alone — it is not this task's to take
+      # down, and the drained check above is the question that governs it.
+      def self.cleanup_waiter_notice!(task)
+        Comment.remove_waiter_notices!(
+          creative_id: task.creative_id, topic_id: task.topic_id, task_ids: task.id
+        )
+      end
+      private_class_method :cleanup_waiter_notice!
+
+      # Post the "⏳ waiting on the topic slot" notice for a deferral raised
+      # outside AgentOrchestrator#enqueue_jobs — AiAgentJob's late slot check,
+      # which catches dispatches that passed the Scheduler before any Task row
+      # existed.
+      # No-op when a notice for this creative/topic is already up — unless
+      # coalescing is off for this dispatch, in which case its waiter is nobody
+      # else's to speak for and gets a notice of its own, exactly as the enqueue
+      # door does. Leaving one door deduplicated and the other not is what breaks
+      # the opt-out's 1:1.
+      def self.post_topic_concurrency_notice(creative_id, topic_id, context = nil, agent: nil, waiter: nil)
+        post(
+          creative_id, topic_id, :topic_concurrency, deferred: true, waiter: waiter,
+          # Falling back for a caller without a waiter: there is no row to ask.
+          shared_without_waiter: -> { PolicyResolver.new(context || {}).coalesce_pending_tasks_for?(agent) }
+        )
+      end
+
+      # Post the one "⏳" notice a deferred or delayed dispatch is entitled to,
+      # under whichever guard its scope calls for.
+      #
+      # Coalescing collapses a burst of deferrals into one waiter, so a notice
+      # per deferral would leave N-1 dead ends pointing at the same blocker.
+      # Keep exactly one topic-concurrency notice per creative/topic — and take
+      # the check and the insert under one lock, since a burst is precisely when
+      # an unserialized check reads stale.
+      #
+      # The scope is taken from the waiter, which recorded it under the admission
+      # lock when it was parked. One answer for the fold, the notice and the
+      # shared notice's stop button, rather than the same question asked at three
+      # moments a policy change can fall between. `shared_without_waiter` is the
+      # fallback for a caller that has no waiter to ask — a :delayed dispatch
+      # never parks one — and is called only then.
+      def self.post(creative_id, topic_id, reason_key, deferred:, shared_without_waiter:, waiter: nil)
+        return if creative_id.nil?
+
+        creative = Creative.find_by(id: creative_id)
+        return unless creative
+
+        reason_text = waiting_reason_text(reason_key, topic_id, creative_id)
+        shared = deferred && (waiter ? waiter.waiting_notice_scope == Comment::WAITING_NOTICE_TOPIC
+                                     : shared_without_waiter.call)
+        write = lambda do
+          create_notice!(creative, topic_id, reason_text,
+                         deferred: deferred, shared: shared, waiter: waiter)
+        end
+
+        if shared
+          with_deduped_topic_notice(creative_id, topic_id, &write)
+        elsif deferred
+          # The waiter is committed and its notice posted afterwards, so the
+          # window with_live_waiter closes is open on both doors — see that
+          # method.
+          with_live_waiter(waiter, creative_id, topic_id, &write)
+        else
+          # :delayed. The dispatch is still going to run, so there is no waiter
+          # for this notice to speak for and nothing for the guard to ask about.
+          write.call
+        end
+      end
+
+      def self.create_notice!(creative, topic_id, reason_text, deferred:, shared:, waiter:)
+        creative.comments.build(
+          content: I18n.t("collavre.orchestration.waiting_notice", reason: reason_text),
+          topic_id: topic_id,
+          private: false,
+          skip_default_user: true,
+          # Only :deferred queues a topic waiter; mark it so its stop button can
+          # target the blocker. :delayed (busy / rate_limited) notices stay false.
+          topic_concurrency_defer: deferred,
+          # …and only a :deferred notice speaks for a waiter at all, so only that
+          # one records which. A :delayed notice never reaches
+          # Comment#cancel_queued_tasks_for_waiting_notice.
+          waiting_notice_scope: deferred ? (shared ? Comment::WAITING_NOTICE_TOPIC : Comment::WAITING_NOTICE_TASK) : nil,
+          waiting_notice_task_id: (waiter&.id unless shared)
+        ).tap(&:save!)
+      rescue ActiveRecord::RecordNotSaved => error
+        # A delayed job is already queued when this notice is posted. Topic
+        # relocation may invalidate only the stale notice in that gap.
+        raise unless error.record.errors.include?(:topic)
+      end
+      private_class_method :create_notice!
+
+      # Remove waiting notice comments (system messages) for this task's creative/topic.
+      def self.cleanup_waiting_notices!(task)
+        context = task.trigger_event_payload
+        creative_id = context&.dig("creative", "id")
+        topic_id = context&.dig("topic", "id")
+        return unless creative_id
+
+        Comment.where(creative_id: creative_id, topic_id: topic_id, user_id: nil)
+               .where("content LIKE ?", "#{Comment::WAITING_NOTICE_PREFIX}%")
+               .find_each do |notice|
+          # System promotion, not user abandonment: do not let the destroy
+          # callback cancel other still-queued waiters in this topic.
+          notice.suppress_waiter_cancellation = true
+          notice.destroy
+        end
+      end
+      private_class_method :cleanup_waiting_notices!
+    end
+  end
+end

--- a/engines/collavre/config/locales/drop_trigger.en.yml
+++ b/engines/collavre/config/locales/drop_trigger.en.yml
@@ -5,6 +5,7 @@ en:
       no_agent: "⚠️ Drop Trigger failed — No AI agent with write permission found on '%{parent_description}'. Please share an AI agent with write permission to enable automatic processing."
 
       not_a_container: "Parent is not a trigger container"
+      unknown_action: "Unknown action"
       toggle_on: "Drop Trigger enabled"
       toggle_off: "Drop Trigger disabled"
     trigger_loop:

--- a/engines/collavre/config/locales/drop_trigger.ko.yml
+++ b/engines/collavre/config/locales/drop_trigger.ko.yml
@@ -5,6 +5,7 @@ ko:
       no_agent: "⚠️ 드롭 트리거 실패 — '%{parent_description}'에 쓰기 권한을 가진 AI 에이전트가 없습니다. 자동 처리를 위해 AI 에이전트에 쓰기 권한을 부여해주세요."
 
       not_a_container: "부모가 트리거 컨테이너가 아닙니다"
+      unknown_action: "알 수 없는 작업입니다"
       toggle_on: "드롭 트리거 활성화됨"
       toggle_off: "드롭 트리거 비활성화됨"
     trigger_loop:

--- a/engines/collavre/test/controllers/creatives_controller_event_source_test.rb
+++ b/engines/collavre/test/controllers/creatives_controller_event_source_test.rb
@@ -7,7 +7,12 @@ module Collavre
       Current.session = OpenStruct.new(user: @user)
       @agent = users(:ai_bot)
       @parent = Creative.create!(user: @user, description: "Trigger parent")
-      @child = Creative.create!(user: @user, parent: @parent, description: "Trigger child")
+      @child = Creative.create!(
+        user: @user,
+        parent: @parent,
+        description: "Trigger child",
+        data: { "trigger" => { "loop" => { "state" => "completed" } } }
+      )
       CreativeShare.create!(creative: @parent, user: @agent, permission: :write)
       @child.topics.create!(name: "Drop Trigger", user: @user)
     end
@@ -22,7 +27,12 @@ module Collavre
         dispatch_options = options
         []
       }) do
-        CreativesController.new.send(:post_restart_trigger, @child)
+        result = Creatives::TriggerActionCommand.new(
+          creative: @child,
+          user: @user,
+          action: "restart"
+        ).call
+        assert result.success?
       end
 
       assert_equal "trigger_restart", dispatch_options[:source]

--- a/engines/collavre/test/jobs/collavre/ai_agent_job_topic_slot_test.rb
+++ b/engines/collavre/test/jobs/collavre/ai_agent_job_topic_slot_test.rb
@@ -141,7 +141,7 @@ module Collavre
       }
 
       assert_no_difference notices do
-        Orchestration::AgentOrchestrator.post_topic_concurrency_notice(@creative.id, @topic.id)
+        Orchestration::WaitingNoticeManager.post_topic_concurrency_notice(@creative.id, @topic.id)
       end
     end
 
@@ -514,7 +514,7 @@ module Collavre
         "another task is running"
       end
 
-      Orchestration::AgentOrchestrator.stub :waiting_reason_text, delete_shared_in_window do
+      Orchestration::WaitingNoticeManager.stub :waiting_reason_text, delete_shared_in_window do
         AiAgentJob.new.perform(second_agent.id, "comment_created", context_for(comment("opt-out")))
       end
 
@@ -544,7 +544,7 @@ module Collavre
         "another task is running"
       end
 
-      Orchestration::AgentOrchestrator.stub :waiting_reason_text, delete_anchor_in_window do
+      Orchestration::WaitingNoticeManager.stub :waiting_reason_text, delete_anchor_in_window do
         AiAgentJob.new.perform(second_agent.id, "comment_created", context_for(anchor))
       end
 
@@ -652,7 +652,7 @@ module Collavre
         "another task is running"
       end
 
-      Orchestration::AgentOrchestrator.stub :waiting_reason_text, promote_in_window do
+      Orchestration::WaitingNoticeManager.stub :waiting_reason_text, promote_in_window do
         AiAgentJob.new.perform(@agent.id, "comment_created", context_for(comment("mine")))
       end
 

--- a/engines/collavre/test/services/collavre/orchestration/agent_orchestrator_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/agent_orchestrator_test.rb
@@ -268,11 +268,11 @@ module Collavre
         check_depth = nil
 
         Topic.stub(:lock, lock_relation) do
-          AgentOrchestrator.stub(:topic_concurrency_notice_exists?, ->(*) {
+          WaitingNoticeManager.stub(:topic_concurrency_notice_exists?, ->(*) {
             check_depth ||= Comment.connection.open_transactions
             false
           }) do
-            AgentOrchestrator.post_topic_concurrency_notice(@creative.id, topic.id)
+            WaitingNoticeManager.post_topic_concurrency_notice(@creative.id, topic.id)
           end
         end
 
@@ -289,7 +289,7 @@ module Collavre
         Task.create!(name: "Waiter", status: "queued", trigger_event_name: "e",
                      agent: @ai_agent, topic_id: topic.id, creative: @creative)
 
-        2.times { AgentOrchestrator.post_topic_concurrency_notice(@creative.id, topic.id) }
+        2.times { WaitingNoticeManager.post_topic_concurrency_notice(@creative.id, topic.id) }
 
         notices = @creative.comments.where(topic_id: topic.id, topic_concurrency_defer: true)
                            .select { |c| c.content.start_with?(Comment::WAITING_NOTICE_PREFIX) }

--- a/engines/collavre/test/services/collavre/orchestration/claim_to_execution_window_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/claim_to_execution_window_test.rb
@@ -174,7 +174,7 @@ module Collavre
       test "the waiting notice comes down when the fold drains the queue" do
         claimed = task_for(comment("@#{@agent.name}: first"), status: "pending")
         task_for(comment("@#{@agent.name}: later"), status: "queued")
-        AgentOrchestrator.post_topic_concurrency_notice(@creative.id, @topic.id)
+        WaitingNoticeManager.post_topic_concurrency_notice(@creative.id, @topic.id)
         assert_equal 1, notices.count, "fixture precondition: the late waiter posted a notice"
 
         AgentOrchestrator.coalesce_at_start!(claimed)
@@ -195,7 +195,7 @@ module Collavre
         task_for(comment("@#{@agent.name}: later"), status: "queued")
         other_waiter = task_for(comment("@#{other_agent.name}: hello"), status: "queued",
                                 agent: other_agent)
-        AgentOrchestrator.post_topic_concurrency_notice(@creative.id, @topic.id)
+        WaitingNoticeManager.post_topic_concurrency_notice(@creative.id, @topic.id)
         assert_equal 1, notices.count
 
         AgentOrchestrator.coalesce_at_start!(claimed)

--- a/engines/collavre/test/services/collavre/orchestration/waiting_notice_manager_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/waiting_notice_manager_test.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  module Orchestration
+    # The "⏳" notice has two doors — AgentOrchestrator#enqueue_jobs and
+    # AiAgentJob's late slot check — and one owner. These are the invariants
+    # that owner exists to hold: one answer about what a notice speaks for, one
+    # guard per scope, and a notice only while the wait it describes is real.
+    class WaitingNoticeManagerTest < ActiveSupport::TestCase
+      setup do
+        @user = users(:one)
+        @agent = users(:ai_bot)
+        @creative = creatives(:tshirt)
+        @topic = Topic.create!(name: "Notice owner", creative: @creative, user: @user)
+      end
+
+      def notices
+        Comment.where(creative_id: @creative.id, topic_id: @topic.id, user_id: nil)
+               .select { |c| c.content.start_with?(Comment::WAITING_NOTICE_PREFIX) }
+      end
+
+      def waiter!(scope, status: "queued")
+        Task.create!(
+          name: "Waiter", status: status, trigger_event_name: "comment_created",
+          agent: @agent, topic_id: @topic.id, creative_id: @creative.id,
+          waiting_notice_scope: scope
+        )
+      end
+
+      def never = ->(*) { flunk("the policy fallback must not be consulted") }
+
+      # The waiter recorded its scope under the admission lock when it was
+      # parked. Resolving the policy again here is how the notice, the fold and
+      # the stop button come to disagree about a wait whose policy changed
+      # mid-flight — so a waiter is the only thing asked when one exists.
+      test "the policy fallback is not consulted when a waiter carries the scope" do
+        waiter = waiter!(Comment::WAITING_NOTICE_TASK)
+
+        WaitingNoticeManager.post(@creative.id, @topic.id, :topic_concurrency,
+                                  deferred: true, waiter: waiter,
+                                  shared_without_waiter: never)
+
+        assert_equal [ waiter.id ], notices.map(&:waiting_notice_task_id),
+                     "a TASK-scoped waiter gets the per-deferral notice its row asked for"
+      end
+
+      # A shared notice speaks for the topic, so it carries no task id and the
+      # second deferral in a burst adds nothing beside it.
+      test "a topic-scoped waiter gets one shared notice for the whole burst" do
+        first = waiter!(Comment::WAITING_NOTICE_TOPIC)
+        second = waiter!(Comment::WAITING_NOTICE_TOPIC)
+
+        [ first, second ].each do |waiter|
+          WaitingNoticeManager.post(@creative.id, @topic.id, :topic_concurrency,
+                                    deferred: true, waiter: waiter,
+                                    shared_without_waiter: never)
+        end
+
+        assert_equal 1, notices.size, "one waiting notice per topic, not one per deferral"
+        assert_equal [ Comment::WAITING_NOTICE_TOPIC ], notices.map(&:waiting_notice_scope)
+        assert_nil notices.sole.waiting_notice_task_id
+      end
+
+      # The waiter commits before its notice goes up, so the blocker can finish
+      # and promote it in between. A notice posted after that describes a wait
+      # that is already over, and nothing would ever take it back down.
+      test "no notice goes up for a waiter that left the queue first" do
+        promoted = waiter!(Comment::WAITING_NOTICE_TASK, status: "pending")
+
+        WaitingNoticeManager.post(@creative.id, @topic.id, :topic_concurrency,
+                                  deferred: true, waiter: promoted,
+                                  shared_without_waiter: never)
+
+        assert_empty notices, "a stop button for a turn that is already running"
+      end
+
+      # :delayed is not a deferral. The dispatch is still going to run, so there
+      # is no waiter for the notice to speak for — and the queued-waiter guard
+      # must not be what decides whether it appears.
+      test "a delayed notice is posted with no waiter and no guard" do
+        WaitingNoticeManager.post(@creative.id, @topic.id, :busy,
+                                  deferred: false, waiter: nil,
+                                  shared_without_waiter: never)
+
+        notice = notices.sole
+        assert_not notice.topic_concurrency_defer, "only :deferred parks a topic waiter"
+        assert_nil notice.waiting_notice_scope, "a :delayed notice speaks for nobody"
+      end
+
+      # Without a waiter the policy is the only thing left to ask, and its
+      # answer picks the scope.
+      test "the policy fallback decides the scope for a waiterless deferral" do
+        waiter!(Comment::WAITING_NOTICE_TOPIC)
+
+        WaitingNoticeManager.post(@creative.id, @topic.id, :topic_concurrency,
+                                  deferred: true, waiter: nil,
+                                  shared_without_waiter: -> { true })
+
+        assert_equal [ Comment::WAITING_NOTICE_TOPIC ], notices.map(&:waiting_notice_scope)
+      end
+
+      # Name the agent holding the slot so a waiting user can reach its stop
+      # button rather than an anonymous "another task is running" dead end.
+      test "the reason text names the agent holding the topic slot" do
+        Task.create!(name: "Running", status: "running", trigger_event_name: "e",
+                     agent: @agent, topic_id: @topic.id, creative_id: @creative.id)
+
+        text = WaitingNoticeManager.waiting_reason_text(:topic_concurrency, @topic.id, @creative.id)
+
+        assert_includes text, @agent.name
+      end
+    end
+  end
+end

--- a/engines/collavre/test/services/creatives/trigger_action_command_test.rb
+++ b/engines/collavre/test/services/creatives/trigger_action_command_test.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  module Creatives
+    class TriggerActionCommandTest < ActiveSupport::TestCase
+      setup do
+        @user = users(:one)
+        @other_user = users(:two)
+        @container = Creative.create!(
+          user: @user,
+          description: "Trigger Container",
+          data: { "trigger" => { "on_child_enter" => true } }
+        )
+        @child = Creative.create!(user: @user, parent: @container, description: "Trigger Task")
+        clear_enqueued_jobs
+      end
+
+      test "rejects unknown actions" do
+        result = command(action: "invalid").call
+
+        refute result.success?
+        assert_equal :unprocessable_entity, result.status
+        assert_equal I18n.t("collavre.drop_trigger.unknown_action"), result.error
+      end
+
+      test "rejects actions without write permission" do
+        result = command(action: "pause", user: @other_user).call
+
+        refute result.success?
+        assert_equal :forbidden, result.status
+        assert_equal I18n.t("collavre.creatives.errors.no_permission"), result.error
+      end
+
+      test "toggle_container updates the effective origin" do
+        shell = Creative.create!(user: @other_user, origin: @container)
+        command = command(creative: shell, action: "toggle_container", enabled: false)
+
+        assert command.call.success?
+        refute @container.reload.drop_trigger_enabled?
+        assert_nil shell.reload.data&.dig("trigger", "on_child_enter")
+      end
+
+      test "toggle_container notifies only when enabling" do
+        @container.update!(data: { "trigger" => { "on_child_enter" => false } })
+
+        assert_difference -> { @container.comments.count }, 1 do
+          assert command(action: "toggle_container", enabled: true, creative: @container).call.success?
+        end
+        assert_equal "Drop Trigger", @container.comments.order(:id).last.topic.name
+
+        assert_no_difference -> { @container.comments.count } do
+          assert command(action: "toggle_container", enabled: true, creative: @container).call.success?
+        end
+      end
+
+      test "start enqueues the trigger job" do
+        previous_adapter = ActiveJob::Base.queue_adapter
+        ActiveJob::Base.queue_adapter = :test
+        begin
+          assert_enqueued_with(job: DropTriggerJob, args: [ @container.id, @child.id ]) do
+            assert command(action: "start").call.success?
+          end
+        ensure
+          ActiveJob::Base.queue_adapter = previous_adapter
+        end
+      end
+
+      test "start rejects a child outside a trigger container" do
+        parent = Creative.create!(user: @user, description: "Normal Parent")
+        child = Creative.create!(user: @user, parent: parent, description: "Normal Child")
+
+        result = command(creative: child, action: "start").call
+
+        refute result.success?
+        assert_equal :unprocessable_entity, result.status
+        assert_equal I18n.t("collavre.drop_trigger.not_a_container"), result.error
+      end
+
+      test "pause transitions running loop state" do
+        set_loop_state("running", "current_iteration" => 2)
+
+        assert command(action: "pause").call.success?
+        assert_equal "paused", @child.reload.data.dig("trigger", "loop", "state")
+        assert_equal 2, @child.data.dig("trigger", "loop", "current_iteration")
+      end
+
+      test "pause leaves an ineligible loop state unchanged" do
+        set_loop_state("completed")
+
+        assert command(action: "pause").call.success?
+        assert_equal "completed", @child.reload.data.dig("trigger", "loop", "state")
+      end
+
+      test "resume transitions eligible state and posts continuation" do
+        set_loop_state("awaiting_user", "current_iteration" => 3)
+        command = command(action: "resume")
+        posted = false
+        command.define_singleton_method(:post_continue_to_agent) { posted = true }
+
+        assert command.call.success?
+        assert posted
+        assert_equal "running", @child.reload.data.dig("trigger", "loop", "state")
+      end
+
+      test "restart resets loop counters and posts a fresh trigger" do
+        set_loop_state("max_reached", "current_iteration" => 8, "infra_retry_count" => 2)
+        command = command(action: "restart")
+        posted = false
+        command.define_singleton_method(:post_restart_trigger) { posted = true }
+
+        assert command.call.success?
+        assert posted
+        loop_data = @child.reload.data.dig("trigger", "loop")
+        assert_equal "running", loop_data["state"]
+        assert_equal 0, loop_data["current_iteration"]
+        assert_equal 0, loop_data["infra_retry_count"]
+      end
+
+      private
+
+      def command(creative: @child, user: @user, action:, enabled: nil)
+        TriggerActionCommand.new(creative: creative, user: user, action: action, enabled: enabled)
+      end
+
+      def set_loop_state(state, attributes = {})
+        @child.update!(data: { "trigger" => { "loop" => attributes.merge("state" => state) } })
+      end
+    end
+  end
+end

--- a/engines/collavre/test/system/creative_move_menu_system_test.rb
+++ b/engines/collavre/test/system/creative_move_menu_system_test.rb
@@ -292,11 +292,13 @@ class CreativeMoveMenuSystemTest < ApplicationSystemTestCase
 
     # The launcher falls back to the creative on screen, so the move has to land
     # on the source and leave the previously selected child where it is.
+    mark_row_before_tree_refresh(child)
     open_move_menu
     pick_destination
     find('[data-creative-move-target="confirm"]').click
 
     assert_no_selector "dialog[open][data-creative-move-target]"
+    assert_row_replaced_by_tree_refresh(child)
     assert_equal @destination, @source.reload.parent
     assert_equal @source, child.reload.parent
 
@@ -340,6 +342,16 @@ class CreativeMoveMenuSystemTest < ApplicationSystemTestCase
     find('[aria-controls="creative-overflow-menu"]').click
     find("#select-creative-btn").click
     creatives.each { |creative| find("#creative-#{creative.id} .select-creative-checkbox").click }
+  end
+
+  def mark_row_before_tree_refresh(creative)
+    page.execute_script(<<~JS, "#creative-#{creative.id}")
+      document.querySelector(arguments[0]).dataset.beforeMoveRefresh = 'true'
+    JS
+  end
+
+  def assert_row_replaced_by_tree_refresh(creative)
+    assert_no_selector "#creative-#{creative.id}[data-before-move-refresh]", visible: :all, wait: 10
   end
 
   # Fails only the tree JSON request (/creatives?format=json) so the rest of the

--- a/engines/collavre/test/system/creative_progress_toggle_keyboard_test.rb
+++ b/engines/collavre/test/system/creative_progress_toggle_keyboard_test.rb
@@ -60,6 +60,10 @@ class CreativeProgressToggleKeyboardTest < ApplicationSystemTestCase
     press_space
   end
 
+  def wait_for_progress_save
+    assert_no_selector "#{toggle_selector}.progress-toggle-saving", wait: 10
+  end
+
   test "space toggles a leaf between complete and incomplete" do
     assert_selector "#{toggle_selector}[data-current-progress='0']"
 
@@ -67,14 +71,14 @@ class CreativeProgressToggleKeyboardTest < ApplicationSystemTestCase
 
     assert_selector "#{toggle_selector}[data-current-progress='1']", wait: 5
     assert_selector "#{toggle_selector} .progress-toggle-checkbox:checked", visible: :all
-    wait_for_network_idle(timeout: 10)
+    wait_for_progress_save
     assert_equal 1, @leaf.reload.progress
 
     press_space_on_checkbox
 
     assert_selector "#{toggle_selector}[data-current-progress='0']", wait: 5
     assert_no_selector "#{toggle_selector} .progress-toggle-checkbox:checked", visible: :all
-    wait_for_network_idle(timeout: 10)
+    wait_for_progress_save
     assert_equal 0, @leaf.reload.progress
   end
 
@@ -100,7 +104,7 @@ class CreativeProgressToggleKeyboardTest < ApplicationSystemTestCase
     press_space
 
     assert_selector "#{toggle_selector}[data-current-progress='1']", wait: 5
-    wait_for_network_idle(timeout: 10)
+    wait_for_progress_save
     assert_equal 1, @leaf.reload.progress
     # The broadcast for this update re-renders the row a second time, after the
     # PATCH response already did, so focus has to survive both. Hold the
@@ -111,7 +115,7 @@ class CreativeProgressToggleKeyboardTest < ApplicationSystemTestCase
     press_space
 
     assert_selector "#{toggle_selector}[data-current-progress='0']", wait: 5
-    wait_for_network_idle(timeout: 10)
+    wait_for_progress_save
     assert_equal 0, @leaf.reload.progress
   end
 

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -7,6 +7,11 @@ module.exports = {
   roots: [
     "<rootDir>/app/javascript",
     "<rootDir>/engines",
+    // The complexity ratchet's JavaScript measurement (lib/js_complexity). It
+    // is tooling rather than app code, so it is deliberately absent from
+    // collectCoverageFrom below — but its entity naming is what keeps ratchet
+    // keys stable across commits, and that is worth unit tests.
+    "<rootDir>/lib",
     // Served production JS outside app/javascript (PWA service worker). Needed so
     // Jest's file crawler discovers it for coverage; no tests live here.
     "<rootDir>/app/views/pwa"

--- a/lib/complexity_ratchet/javascript.rb
+++ b/lib/complexity_ratchet/javascript.rb
@@ -1,0 +1,156 @@
+# frozen_string_literal: true
+
+require "json"
+require "open3"
+
+module ComplexityRatchet
+  # The JavaScript half of the ratchet.
+  #
+  # The Ruby half has been gating the core engine's ~40,000 lines of app code
+  # since the `complexity` job landed. The same engine ships ~35,000 lines of
+  # non-test JavaScript that nothing measured at all: the repository has no
+  # ESLint config, no lint job for it and no devDependency, and RuboCop
+  # obviously does not read `.js`. That is where the two largest source files in
+  # the engine live.
+  #
+  # Rather than a second gate with its own semantics, this produces the same
+  # {entity key => value} hash ComplexityRatchet::Measurement produces, so the
+  # merge-base comparison, the waiver format and the reporting are literally the
+  # same code. The measuring is delegated to Node (see bin/js_complexity.mjs)
+  # because ESLint is the only thing here that can parse modern JS and JSX.
+  module Javascript
+    CONFIG_PATH = ".eslint_metrics.yml"
+    SCRIPT_PATH = "bin/js_complexity.mjs"
+
+    INSTALL_HINT = "run `npm ci` first — the JavaScript ratchet needs ESLint from the repository's node_modules"
+
+    # Measures a tree with the *tool root's* ESLint and budget. The base side of
+    # the ratchet is a detached worktree with neither, and mixing the two would
+    # reintroduce the bug the Ruby half documents at length: measuring each side
+    # with its own budget makes a PR that tightens a limit report every
+    # pre-existing entity as brand-new debt.
+    class Measurement
+      def self.call(root:, tool_root:, config: nil)
+        new(root: root, tool_root: tool_root, config: config).call
+      end
+
+      def initialize(root:, tool_root:, config: nil)
+        @root = root
+        @tool_root = tool_root
+        @config = config || File.join(tool_root, CONFIG_PATH)
+      end
+
+      def call
+        JSON.parse(run)
+      end
+
+      private
+
+      attr_reader :root, :tool_root, :config
+
+      def run
+        command = [ "node", File.join(tool_root, SCRIPT_PATH), "--root", root, "--config", config ]
+        stdout, stderr, status = Open3.capture3(*command, chdir: tool_root)
+        raise Error, failure_message(status, stderr) unless status.success?
+
+        # Open3 tags the pipe with Encoding.default_external, which a shell
+        # without LANG set leaves as US-ASCII — and the first entity name
+        # carrying an em dash then dies inside JSON.parse. The script always
+        # writes UTF-8. (ComplexityRatchet::Measurement reads source files with
+        # the same explicit encoding, for the same reason.)
+        stdout.force_encoding(Encoding::UTF_8)
+      end
+
+      def failure_message(status, stderr)
+        hint = stderr.include?("Cannot find package") ? " — #{INSTALL_HINT}" : ""
+        "#{SCRIPT_PATH} failed (#{status.exitstatus})#{hint}: #{stderr.strip}"
+      end
+    end
+
+    # The budget file is compared against the merge base's copy for the same
+    # reason .rubocop_metrics.yml is: both trees are measured with this branch's
+    # copy, so raising a threshold silences the same entities on both sides at
+    # once and the comparison sees nothing.
+    #
+    # It is an allowlist. Exactly three edits pass — lowering a threshold,
+    # widening `include`, and shrinking `exclude` — and anything else is
+    # reported, including keys that do not exist yet. The budget file holds
+    # nothing but numbers and globs by design (rule options live in
+    # lib/js_complexity/measure.js), which is what makes an allowlist this short
+    # possible; the RuboCop side needs a much longer one because a cop can be
+    # silenced through Exclude, Include, AllowedMethods, AllowedPatterns or
+    # CountAsOne without its Max moving at all.
+    KNOWN_KEYS = %w[include exclude rules].freeze
+
+    class << self
+      def verify_budget(before, after)
+        return [] if before.nil?
+
+        rule_problems(before, after) +
+          scope_problems(before, after) +
+          unknown_key_problems(before, after)
+      end
+
+      private
+
+      def rule_problems(before, after)
+        rules(before).filter_map do |rule, limit|
+          current = rules(after)[rule]
+
+          if current.nil?
+            problem(:js_budget_disabled, rule,
+              "was in #{CONFIG_PATH} and is gone — dropping a rule silences every entity it holds")
+          elsif !current.is_a?(Integer) || current.negative?
+            problem(:js_budget_invalid_max, rule,
+              "threshold must be a non-negative integer in #{CONFIG_PATH} (got #{current.inspect})")
+          elsif current > limit
+            problem(:js_budget_loosened, rule,
+              "budget raised from #{limit} to #{current} in #{CONFIG_PATH} — the ratchet only turns one way")
+          end
+        end
+      end
+
+      # `include` may grow and `exclude` may shrink: both widen what is measured.
+      # The opposite of each hides code from the gate, which is the amnesty this
+      # design exists to avoid.
+      def scope_problems(before, after)
+        dropped = (list(before, "include") - list(after, "include")).map do |pattern|
+          problem(:js_budget_scope_narrowed, pattern,
+            "removed from `include` in #{CONFIG_PATH} — unmeasured code can grow without limit")
+        end
+
+        added = (list(after, "exclude") - list(before, "exclude")).map do |pattern|
+          problem(:js_budget_scope_narrowed, pattern,
+            "added to `exclude` in #{CONFIG_PATH} — excluded code is invisible to the ratchet")
+        end
+
+        dropped + added
+      end
+
+      # A key this checker does not know about cannot be judged, and an
+      # unjudged key in a budget file is a bypass waiting to be written. The
+      # next version of the measurement script may add one; adding it here is
+      # the deliberate step that makes it reviewable.
+      def unknown_key_problems(before, after)
+        ((before.keys | after.keys) - KNOWN_KEYS).sort.filter_map do |key|
+          next if before[key] == after[key]
+
+          problem(:js_budget_unknown_key, key,
+            "#{key} changed in #{CONFIG_PATH} and is not a key the ratchet knows how to compare")
+        end
+      end
+
+      def rules(config)
+        config["rules"].is_a?(Hash) ? config["rules"] : {}
+      end
+
+      def list(config, key)
+        Array(config[key])
+      end
+
+      def problem(kind, key, message)
+        Problem.new(kind: kind, key: key, message: message, blocking: true)
+      end
+    end
+  end
+end

--- a/lib/js_complexity/__tests__/measure.test.js
+++ b/lib/js_complexity/__tests__/measure.test.js
@@ -1,0 +1,839 @@
+import { Linter } from "eslint";
+import { jest } from "@jest/globals";
+
+import { eslintConfig, foldMessages, parseBudget, RULES } from "../measure.js";
+
+// Measure a source string the way lib/js_complexity/measure.js measures a file,
+// and return the ratchet keys it produces. Going through Linter rather than
+// hand-building an AST keeps the tests honest about the thing that actually
+// varies between ESLint versions: where a rule reports its offense.
+function measure(source, rules, filename = "engines/collavre/app/javascript/x.js") {
+  const budget = { include: [], exclude: [], rules };
+  const linter = new Linter();
+  const messages = linter.verify(source, eslintConfig(budget), filename);
+  return foldMessages(filename, source, linter.getSourceCode()?.ast, messages);
+}
+
+// Keys are `path | rule | entity`; the tests below care about the entity.
+function entities(measured, rule) {
+  return Object.keys(measured)
+    .filter((key) => key.split(" | ")[1] === rule)
+    .map((key) => key.split(" | ")[2]);
+}
+
+// What ComplexityRatchet::Check does with the two measurements: an entity the
+// merge base does not have is new debt, and one that got bigger is growth.
+// Both block. Written here so the identity tests can assert the property that
+// actually matters — that an edit is REPORTED — rather than a key spelling.
+function reported(before, after) {
+  return Object.entries(after)
+    .filter(([key, value]) => !(key in before) || value > before[key])
+    .map(([key]) => key.split(" | ")[2]);
+}
+
+// Content anchors are FNV digests; the tests care that two entities got
+// DIFFERENT anchors, not what the digest of any one of them is. Rewrite each
+// distinct digest to `#a`, `#b`, ... in first-seen order so an assertion reads
+// as the property it is making and does not have to be rewritten when an
+// unrelated character moves inside a fixture.
+function labelled(keys) {
+  const seen = new Map();
+  return keys.map((key) => key.replace(/#(?:[0-9a-f]{8})+/g, (digest) => {
+    if (!seen.has(digest)) seen.set(digest, `#${String.fromCharCode(97 + seen.size)}`);
+    return seen.get(digest);
+  }));
+}
+
+// A function body of `count` distinct statements, so max-lines-per-function
+// measures a value this test chose rather than one it has to look up.
+function body(count) {
+  return Array.from({ length: count }, (_, index) => `        const v${index} = ${index}`).join("\n");
+}
+
+describe("entity naming", () => {
+  test("separates field initializers from each other and from field functions", () => {
+    const source = `class C {
+      first = a || b || c;
+      static first = a || b;
+      #hidden = a || b;
+      fn = () => a || b;
+    }`;
+    const measured = measure(source, { complexity: 0 });
+    expect(entities(measured, "complexity")).toEqual([
+      "C#first(initializer)", "C.first(initializer)",
+      "C##hidden(initializer)", "C#fn(initializer)>(function)",
+      "C#fn(initializer)",
+    ]);
+    expect(Object.values(measured)).toEqual([3, 2, 2, 2, 1]);
+  });
+
+  test("reports a new field below a larger initializer's baseline", () => {
+    const before = measure("class C { first = a || b || c || d; }", { complexity: 1 });
+    const after = measure("class C { first = a || b || c || d; second = a || b; }", { complexity: 1 });
+    expect(reported(before, after)).toEqual(["C#second(initializer)"]);
+  });
+
+  test("reports field growth below a larger initializer's baseline", () => {
+    const before = measure("class C { first = a || b || c || d; second = a || b; }", { complexity: 1 });
+    const after = measure("class C { first = a || b || c || d; second = a || b || c; }", { complexity: 1 });
+    expect(reported(before, after)).toEqual(["C#second(initializer)"]);
+  });
+
+  test("reports static block growth masked by a larger shrinking block", () => {
+    const before = measure("class C { static { a || b || c || d; } static { a || b; } }", { complexity: 1 });
+    const after = measure("class C { static { a || b || c; } static { a || b || c; } }", { complexity: 1 });
+    expect(reported(before, after)).toHaveLength(2);
+  });
+
+  test("keeps static block identities across pure reorder", () => {
+    const before = measure("class C { static { a || b || c; } static { x || y; } }", { complexity: 1 });
+    const after = measure("class C { static { x || y; } static { a || b || c; } }", { complexity: 1 });
+    expect(entities(before, "complexity")).toHaveLength(2);
+    expect(reported(before, after)).toEqual([]);
+  });
+
+  test("keeps computed-key functions outside the field initializer scope", () => {
+    const source = "class C { [(() => a || b)()] = c || d; }";
+    expect(entities(measure(source, { complexity: 1 }), "complexity")).toEqual([
+      "C>[anonymous]", "C#(computed)(initializer)",
+    ]);
+  });
+
+  test("keeps computed-key functions outside a field value function", () => {
+    const source = "class C { [(() => a || b)()] = () => c || d; }";
+    expect(entities(measure(source, { complexity: 1 }), "complexity")).toEqual([
+      "C#(computed)(initializer)>(function)", "C>[anonymous]",
+    ]);
+  });
+
+  test("reports computed-key growth below a larger value function baseline", () => {
+    const before = measure("class C { [(() => a || b)()] = () => p || q || r || s; }", { complexity: 1 });
+    const after = measure("class C { [(() => a || b || c)()] = () => p || q || r || s; }", { complexity: 1 });
+    expect(reported(before, after)).toEqual(["C>[anonymous]"]);
+  });
+
+  test("reports computed-key depth below a field value function baseline", () => {
+    const value = [
+      "  })()] = () => {",
+      "    if (a) {",
+      "      if (b) {",
+      "        if (c) { run() }",
+      "      }",
+      "    }",
+      "  }",
+      "}",
+    ];
+    const before = measure([
+      "class C {",
+      "  [(function () {",
+      "    if (a) {",
+      "      if (c) { run() }",
+      "    }",
+      ...value,
+    ].join("\n"), { "max-depth": 2 });
+    const after = measure([
+      "class C {",
+      "  [(function () {",
+      "    if (a) {",
+      "      if (b) {",
+      "        if (c) { run() }",
+      "      }",
+      "    }",
+      ...value,
+    ].join("\n"), { "max-depth": 2 });
+    expect(reported(before, after)).toEqual(["C>[anonymous]~if (c) { run() }"]);
+  });
+
+  test("attributes depth inside a field function to that function", () => {
+    const source = `class C {
+      fn = () => {
+        if (a) {
+          if (b) { run() }
+        }
+      }
+    }`;
+    expect(entities(measure(source, { "max-depth": 1 }), "max-depth")).toEqual([
+      "C#fn(initializer)>(function)~if (b) { run() }",
+    ]);
+  });
+
+  test("names class methods, statics and accessors by their member", () => {
+    const source = `
+      class Editor {
+        save(a, b, c) {}
+        static create(a, b, c) {}
+        get draft() { return this._d(1, 2, 3) }
+        set draft(v) {}
+      }
+      Editor.prototype.x = function (a, b, c) {}
+    `;
+    expect(entities(measure(source, { "max-params": 2 }), "max-params")).toEqual([
+      "Editor#save",
+      "Editor.create",
+      "Editor.prototype.x",
+    ]);
+  });
+
+  test("names an anonymous default-exported class `default`", () => {
+    // Every Stimulus controller in the engine is written this way.
+    const source = `export default class extends Controller { connect(a, b, c) {} }`;
+    expect(entities(measure(source, { "max-params": 2 }), "max-params")).toEqual(["default#connect"]);
+  });
+
+  test("names a nested function by its path through the enclosing scopes", () => {
+    const source = `
+      function outer() {
+        function inner(a, b, c) {}
+        return inner
+      }
+    `;
+    expect(entities(measure(source, { "max-params": 2 }), "max-params")).toEqual(["outer>inner"]);
+  });
+
+  test("names an anonymous callback after the whole call it is passed to", () => {
+    // The receiver is part of the name: `[addEventListener]` alone would make
+    // twins out of two listeners on different elements, and twins are the one
+    // case where identity has to fall back on source position.
+    const source = `
+      class Row {
+        connect() {
+          this.el.addEventListener("click", (a, b, c) => {})
+          document.addEventListener("keydown", (a, b, c) => {})
+        }
+      }
+    `;
+    expect(entities(measure(source, { "max-params": 2 }), "max-params")).toEqual([
+      "Row#connect>[this.el.addEventListener]",
+      "Row#connect>[document.addEventListener]",
+    ]);
+  });
+
+  test("anchors same-named siblings to a digest of their own source", () => {
+    const source = `
+      class Row {
+        connect() {
+          items.map((a, b, c) => { return a })
+          items.map((a, b, c) => { return b })
+        }
+      }
+    `;
+    expect(labelled(entities(measure(source, { "max-params": 2 }), "max-params"))).toEqual([
+      "Row#connect>[items.map]#a",
+      "Row#connect>[items.map]#b",
+    ]);
+  });
+
+  // Siblings that are byte-identical measure identically, so any permutation of
+  // them is a no-op and a plain ordinal is enough to keep them apart.
+  test("falls back to an ordinal only for byte-identical siblings", () => {
+    const source = `
+      class Row {
+        connect() {
+          items.map((a, b, c) => {})
+          items.map((a, b, c) => {})
+        }
+      }
+    `;
+    expect(labelled(entities(measure(source, { "max-params": 2 }), "max-params"))).toEqual([
+      "Row#connect>[items.map]#a(1/2)",
+      "Row#connect>[items.map]#a(2/2)",
+    ]);
+  });
+
+  // The name a reader would use is one level out from the call: every callback
+  // in a React component is `useCallback`, and a component with eleven of them
+  // had eleven entities whose keys all moved when a twelfth was added.
+  test("names a callback by the binding its call sits in", () => {
+    const source = `
+      function Toolbar() {
+        const handleFiles = useCallback((a, b, c) => {}, [])
+        const openPicker = useCallback((a, b, c) => {}, [])
+      }
+    `;
+    expect(entities(measure(source, { "max-params": 2 }), "max-params")).toEqual([
+      "Toolbar>handleFiles[useCallback]",
+      "Toolbar>openPicker[useCallback]",
+    ]);
+  });
+
+  // A `.then` chain has no binding to borrow, so the callee carries the chain
+  // instead. Appending a fourth link leaves the first three keys alone.
+  test("names a chained callback by its position in the chain", () => {
+    const source = `
+      function save() {
+        load().then((a, b, c) => {}).then((a, b, c) => {}).catch((a, b, c) => {})
+      }
+    `;
+    expect(entities(measure(source, { "max-params": 2 }), "max-params")).toEqual([
+      "save>[load().then]",
+      "save>[load().then().then]",
+      "save>[load().then().then().catch]",
+    ]);
+  });
+
+  test("names a function by the binding it is assigned to", () => {
+    const source = `
+      const submit = (a, b, c) => {}
+      const handlers = { retry: function (a, b, c) {} }
+    `;
+    expect(entities(measure(source, { "max-params": 2 }), "max-params")).toEqual(["submit", "retry"]);
+  });
+
+  test("keeps an object method at its key inside an enclosing function", () => {
+    const source = `
+function attachTouchBridge(a, b) {
+  if (a) use(a)
+  if (b) use(b)
+  const bridge = {
+    canStart(a, b, c) {
+      if (a) use(a)
+    }
+  }
+  return bridge
+}
+    `;
+    const measured = measure(source, {
+      complexity: 1,
+      "max-lines-per-function": 1,
+      "max-params": 1,
+    });
+
+    for (const rule of [ "complexity", "max-lines-per-function", "max-params" ]) {
+      expect(entities(measured, rule)).toEqual(["attachTouchBridge", "attachTouchBridge>canStart"]);
+    }
+  });
+
+  test("reports object-method growth below its enclosing function's baseline", () => {
+    const before = measure(`
+function setup(a, b) {
+  if (a) use(a)
+  if (b) use(b)
+  const bridge = { canStart(v) { return v ? 1 : 0 } }
+  return bridge
+}
+    `, { complexity: 1 });
+    const after = measure(`
+function setup(a, b) {
+  if (a) use(a)
+  if (b) use(b)
+  const bridge = { canStart(v) { return v ? 1 : v === 0 ? 0 : -1 } }
+  return bridge
+}
+    `, { complexity: 1 });
+
+    expect(reported(before, after)).toEqual(["setup>canStart"]);
+  });
+
+  test("names an identifier-assigned function by its target", () => {
+    const source = `function setup() { handler = (a, b, c) => {} }`;
+    expect(entities(measure(source, { "max-params": 2 }), "max-params"))
+      .toEqual(["setup>handler"]);
+  });
+
+  test("reports a replacement identifier assignment as new debt", () => {
+    const before = measure("function setup() { first = (a, b, c, d) => {} }", { "max-params": 2 });
+    const after = measure("function setup() { second = (a, b, c) => {} }", { "max-params": 2 });
+
+    expect(reported(before, after)).toEqual(["setup>second"]);
+  });
+});
+
+describe("twin identity across commits", () => {
+  // Two callbacks the naming cannot tell apart by name, sized independently.
+  // The measurements below stand in for the two sides of the merge-base
+  // comparison; only the callbacks are kept, because the method wrapping them
+  // changes size whenever the fixture does and that is not what these tests are
+  // about.
+  function twins(...sizes) {
+    const calls = sizes.map((size) => `        items.map((row) => {\n${body(size)}\n        })`).join("\n");
+    const measured = measure(`
+      class Row {
+        connect() {
+${calls}
+        }
+      }
+    `, { "max-lines-per-function": 2 });
+
+    return Object.fromEntries(Object.entries(measured).filter(([key]) => key.includes("[items.map]")));
+  }
+
+  // The hole this shape exists to close, in the form Codex found it: a plain
+  // ordinal compares SLOTS, so a twin that moved into a smaller slot is checked
+  // against the twin that used to be there. Baselines 12 and 6 against a
+  // reordered 9 and 5 passed — slot 1 read `9 <= 12` and slot 2 read `5 <= 6` —
+  // while the 6-line callback had in fact grown to 9.
+  test("does not hide growth behind a reorder and a compensating shrink", () => {
+    expect(labelled(reported(twins(12, 6), twins(9, 5)))).toEqual([
+      "Row#connect>[items.map]#a",
+      "Row#connect>[items.map]#b",
+    ]);
+  });
+
+  // A deleted twin cannot hand its measurement to a survivor either: the
+  // survivor is anchored to its own body, so growth is measured against its own
+  // baseline rather than the deleted twin's 12.
+  test("does not hand a deleted twin's key to the survivor", () => {
+    const before = twins(12, 6);
+    const after = twins(9);
+
+    expect(Object.keys(after).some((key) => key in before)).toBe(false);
+    expect(reported(before, after)).toEqual(["Row#connect>[items.map]"]);
+  });
+
+  // The anchor is only spelled out when it has to be, so an entity's key does
+  // not carry a digest it does not need. Crossing between "one" and "two" is
+  // therefore a rename, and a rename reads as new debt. That direction is safe
+  // — it is loud about an improvement, never quiet about growth — and it is the
+  // one place a twin's identity still depends on its siblings.
+  test("reports the survivor when deleting a twin leaves it alone in its scope", () => {
+    expect(reported(twins(12, 6), twins(6))).toEqual(["Row#connect>[items.map]"]);
+  });
+
+  // What the old ordinal got wrong in the other direction: moving twins around
+  // is not a change, and the gate should not say it is.
+  test("says nothing when twins are reordered and neither one changed", () => {
+    expect(reported(twins(12, 6), twins(6, 12))).toEqual([]);
+  });
+
+  // The cost of anchoring: an over-budget twin that shrinks but stays over
+  // budget has a new body, so it has a new key and reads as new debt. Recover
+  // by naming the callback, by getting it under budget, or with a waiver.
+  test("reports a twin that shrinks without getting under budget", () => {
+    expect(labelled(reported(twins(12, 6), twins(10, 6)))).toEqual(["Row#connect>[items.map]#a"]);
+  });
+
+  test("says nothing when a twin is deleted and the rest are untouched", () => {
+    expect(reported(twins(12, 8, 6), twins(12, 8))).toEqual([]);
+  });
+
+  // A 32-bit FNV word is small enough to collide on plausible input: these two
+  // markers were found by brute force in a few seconds, and under a single word
+  // both callbacks below digest to 299effeb. Grouping twins by that digest put
+  // two DIFFERENT callbacks back on one ordinal — the slot identity the whole
+  // scheme exists to remove — and a pure reorder of them reported growth that
+  // had not happened. Twins are grouped by source text instead, and the digest
+  // widens until it separates them.
+  const COLLIDING = { big: [ 12, 3893 ], small: [ 6, 250530 ] };
+
+  function collidingTwins(...pairs) {
+    const calls = pairs
+      .map(([ size, marker ]) => `        items.map((row) => {\n${body(size)}\n        const pad = ${marker}\n        })`)
+      .join("\n");
+    const measured = measure(`
+      class Row {
+        connect() {
+${calls}
+        }
+      }
+    `, { "max-lines-per-function": 2 });
+
+    return Object.fromEntries(Object.entries(measured).filter(([key]) => key.includes("[items.map]")));
+  }
+
+  test("separates twins whose bodies collide on a single digest word", () => {
+    const keys = Object.keys(collidingTwins(COLLIDING.big, COLLIDING.small)).map((key) => key.split(" | ")[2]);
+
+    expect(keys).toHaveLength(2);
+    expect(new Set(keys).size).toBe(2);
+    // No survivor fell back on a slot.
+    for (const key of keys) expect(key).not.toMatch(/\(\d+\/\d+\)$/);
+  });
+
+  test("says nothing when colliding twins are reordered and neither one changed", () => {
+    const before = collidingTwins(COLLIDING.big, COLLIDING.small);
+    const after = collidingTwins(COLLIDING.small, COLLIDING.big);
+
+    expect(reported(before, after)).toEqual([]);
+  });
+
+  test("refuses to measure distinct twins when every digest width collides", () => {
+    // Force every FNV word to zero, exercising exhaustion without relying on
+    // finding a 96-bit collision. The real measurement must fail closed.
+    const multiply = jest.spyOn(Math, "imul").mockReturnValue(0);
+    try {
+      expect(() => collidingTwins(COLLIDING.big, COLLIDING.small))
+        .toThrow("Cannot distinguish complexity entities: [items.map]");
+    } finally {
+      multiply.mockRestore();
+    }
+  });
+
+  test("still measures identical twins when every digest width collides", () => {
+    const multiply = jest.spyOn(Math, "imul").mockReturnValue(0);
+    try {
+      expect(Object.keys(collidingTwins(COLLIDING.big, COLLIDING.big))).toHaveLength(2);
+    } finally {
+      multiply.mockRestore();
+    }
+  });
+
+  // The digest normalises whitespace so that reindenting does not move a key.
+  // Collapsing NEWLINES along with the rest was a hole: `max-lines-per-function`
+  // counts lines, so two callbacks differing only in where a template literal's
+  // text wraps measure 5 and 4 while normalising to the same string. They shared
+  // an anchor, fell back on a slot, and a reorder compared each against the
+  // other's baseline.
+  function wrapping(...bodies) {
+    const calls = bodies.map((cb) => `        items.map((row) => {\n${cb}\n          use(t)\n        })`).join("\n");
+    const measured = measure(`
+      class Row {
+        connect() {
+${calls}
+        }
+      }
+    `, { "max-lines-per-function": 2 });
+
+    return Object.fromEntries(Object.entries(measured).filter(([key]) => key.includes("[items.map]")));
+  }
+
+  const WRAPPED = "          const t = `aaa\nbbb`";
+  const ONE_LINE = "          const t = `aaa bbb`";
+
+  test("separates twins that differ only in how a template literal wraps", () => {
+    const keys = Object.keys(wrapping(WRAPPED, ONE_LINE)).map((key) => key.split(" | ")[2]);
+
+    expect(new Set(keys).size).toBe(2);
+    for (const key of keys) expect(key).not.toMatch(/\(\d+\/\d+\)$/);
+  });
+
+  test("says nothing when twins that wrap differently are reordered", () => {
+    expect(reported(wrapping(WRAPPED, ONE_LINE), wrapping(ONE_LINE, WRAPPED))).toEqual([]);
+  });
+
+  // The other half of the same trade: whitespace the rules cannot measure must
+  // NOT move a key, or every reformat reads as new debt.
+  test("keeps a twin's key when it is reindented", () => {
+    const indented = (text) => text.replace(/^ +/gm, (run) => `${run}    `);
+
+    expect(reported(
+      wrapping(WRAPPED, ONE_LINE),
+      wrapping(indented(WRAPPED), indented(ONE_LINE)),
+    )).toEqual([]);
+  });
+
+  // `skipBlankLines` is on, so a blank line cannot change a measurement and
+  // must not change a key either.
+  test("keeps a twin's key when a blank line is added inside it", () => {
+    expect(reported(wrapping(WRAPPED, ONE_LINE), wrapping(`${WRAPPED}\n`, ONE_LINE))).toEqual([]);
+  });
+
+  // "Line break" has to mean what ESLint means by it. It splits lines on
+  // `\r\n`, `\r`, U+2028 and U+2029 as well as `\n`, so all of them are lines
+  // that `max-lines-per-function` counts. Treating U+2028 as ordinary
+  // whitespace collapsed two callbacks measuring 5 and 4 onto one anchor.
+  const SEPARATED = "          const t = `aaa\u2028bbb`";
+
+  test("separates twins that differ by a Unicode line separator", () => {
+    const keys = Object.keys(wrapping(SEPARATED, ONE_LINE)).map((key) => key.split(" | ")[2]);
+
+    expect(new Set(keys).size).toBe(2);
+    for (const key of keys) expect(key).not.toMatch(/\(\d+\/\d+\)$/);
+  });
+
+  test("says nothing when twins differing by a Unicode line separator are reordered", () => {
+    expect(reported(wrapping(SEPARATED, ONE_LINE), wrapping(ONE_LINE, SEPARATED))).toEqual([]);
+  });
+
+  // The stability side of the same rule: a line ending is not something a rule
+  // can measure, so rewriting the file CRLF must leave every key alone.
+  test("keeps a twin's key when line endings change to CRLF", () => {
+    const crlf = (text) => text.replace(/\n/g, "\r\n");
+
+    expect(reported(
+      wrapping(WRAPPED, ONE_LINE),
+      wrapping(crlf(WRAPPED), crlf(ONE_LINE)),
+    )).toEqual([]);
+  });
+
+  // Statements that share a source line are the same problem in the max-depth
+  // fallback, and go through the same `discriminate` the definitions above do:
+  // two `if (x) {` lines with different bodies are two keys, so neither can be
+  // measured against the other's baseline.
+  function guards(...bodies) {
+    return measure(`
+      class Row {
+        render() {
+${bodies.map((tag) => `          if (x) {\n            if (x) {\n              if (y) { return ${tag} }\n            }\n          }`).join("\n")}
+        }
+      }
+    `, { "max-depth": 1 });
+  }
+
+  test("gives statements that share a source line but not a body distinct keys", () => {
+    // The two reported `if (x) {` lines are byte-different only in the `return`
+    // buried inside them, and that is enough: they are separate keys, not two
+    // slots in one.
+    expect(labelled(entities(guards(1, 2), "max-depth"))).toEqual([
+      "Row#render~if (x) {#a",
+      "Row#render~if (y) { return 1 }",
+      "Row#render~if (x) {#b",
+      "Row#render~if (y) { return 2 }",
+    ]);
+  });
+
+  test("says nothing when statement twins are reordered and neither one changed", () => {
+    expect(reported(guards(1, 2), guards(2, 1))).toEqual([]);
+  });
+
+  // Unlike every other measurement here, `max-depth`'s is NOT a property of the
+  // entity's own text: two byte-identical `if (a) { y() }` statements sit at
+  // different depths when one of them is inside another guard, and measure
+  // differently. They shared an anchor and fell back on the ordinal, so the
+  // "byte-identical twins measure identically" that justifies the ordinal did
+  // not hold for statements. A statement's identity carries its depth now.
+  function nested(...guards) {
+    const bodies = guards.map(([ guard, deep ]) => deep
+      ? `        if (${guard}) {\n          if (${guard}) {\n            if (a) { y() }\n          }\n        }`
+      : `        if (${guard}) {\n          if (a) { y() }\n        }`);
+
+    return measure(`
+      function handle(p, q, a) {
+${bodies.join("\n")}
+      }
+    `, { "max-depth": 1 });
+  }
+
+  const DEEP_P = [ "p", true ], SHALLOW_Q = [ "q", false ];
+
+  test("gives byte-identical statements at different depths distinct keys", () => {
+    const keys = entities(nested(DEEP_P, SHALLOW_Q), "max-depth").filter((key) => key.includes("if (a)"));
+
+    expect(new Set(keys).size).toBe(2);
+    for (const key of keys) expect(key).not.toMatch(/\(\d+\/\d+\)$/);
+  });
+
+  test("says nothing when statements at different depths swap source order", () => {
+    expect(reported(nested(DEEP_P, SHALLOW_Q), nested(SHALLOW_Q, DEEP_P))).toEqual([]);
+  });
+
+  // The over-correction to guard against: depth is in the key, so a statement
+  // that genuinely deepens has to still be reported.
+  test("reports a statement that gets deeper", () => {
+    const deeper = reported(nested(SHALLOW_Q), nested([ "q", true ]));
+
+    expect(deeper).toContain("handle~if (a) { y() }");
+  });
+
+  // An earlier version counted enclosing nesting statements instead of taking
+  // ESLint's number, arguing that the key only had to CHANGE when the
+  // measurement changed. It does not: a key has to DETERMINE its measurement.
+  // Both `if (a) { y() }` below sit under three enclosing statements, but the
+  // second hangs off an `else if`, which ESLint does not count — so they
+  // measured 3 and 2 while sharing an anchor and falling back on the ordinal,
+  // and each was compared against the other's baseline.
+  const PLAIN_REGION = `        if (p) {
+          if (p) {
+            if (a) { y() }
+          }
+        }`;
+  const ELSE_IF_REGION = `        if (q) {
+          x()
+        } else if (q) {
+          if (a) { y() }
+        }`;
+
+  function regions(...bodies) {
+    return measure(`
+      function handle(p, q, a) {
+${bodies.join("\n")}
+      }
+    `, { "max-depth": 1 });
+  }
+
+  test("separates byte-identical statements an else-if exempts from a depth level", () => {
+    const measured = regions(PLAIN_REGION, ELSE_IF_REGION);
+    const keys = entities(measured, "max-depth").filter((key) => key.includes("if (a)"));
+
+    expect(new Set(keys).size).toBe(2);
+    // No ordinal: an ordinal here would mean two different measurements
+    // sharing one anchor, which is the defect.
+    for (const key of keys) expect(key).not.toMatch(/\(\d+\/\d+\)$/);
+    expect(new Set(keys.map((key) => measured[`engines/collavre/app/javascript/x.js | max-depth | ${key}`]))).toEqual(new Set([ 3, 2 ]));
+  });
+
+  test("does not compare an else-if-exempt statement against an ordinarily nested one", () => {
+    // Same two statements, swapped. Under the ordinal each inherited the
+    // other's baseline and the swap was silent.
+    expect(reported(regions(PLAIN_REGION, ELSE_IF_REGION), regions(ELSE_IF_REGION, PLAIN_REGION)))
+      .not.toEqual([]);
+  });
+
+  // The sixth variant, and the rule I had argued could not have it: twins sit
+  // in one scope by construction, so surely they nest identically. They do not.
+  // max-nested-callbacks pops on EVERY function exit but pushes only for
+  // functions whose parent is a call, so a function expression that is not a
+  // callback pops a level it never added and everything after it counts lower.
+  function separated(middle) {
+    return measure(`
+a(function () {
+  items.map((row) => { total += row.n })
+${middle}
+  items.map((row) => { total += row.n })
+})
+`, { "max-nested-callbacks": 0 });
+  }
+
+  const NON_CALLBACK = "  const helper = function () { return 1 }";
+
+  test("separates twins a non-callback function expression deflates the count for", () => {
+    const measured = separated(NON_CALLBACK);
+    const keys = entities(measured, "max-nested-callbacks").filter((key) => key.includes("items.map"));
+
+    expect(new Set(keys).size).toBe(2);
+    for (const key of keys) expect(key).not.toMatch(/\(\d+\/\d+\)$/);
+    expect(new Set(keys.map((key) => measured[`engines/collavre/app/javascript/x.js | max-nested-callbacks | ${key}`])))
+      .toEqual(new Set([ 2, 1 ]));
+  });
+
+  test("reports the twin whose callback nesting deepens", () => {
+    // Moving the non-callback above both twins takes the second from 1 to 2.
+    const before = separated(NON_CALLBACK);
+    const after = measure(`
+a(function () {
+${NON_CALLBACK}
+  items.map((row) => { total += row.n })
+  items.map((row) => { total += row.n })
+})
+`, { "max-nested-callbacks": 0 });
+
+    expect(reported(before, after)).not.toEqual([]);
+  });
+
+  // A FunctionDeclaration is not handled by the rule at all, so it neither
+  // pushes nor pops and must NOT separate the twins — the over-correction to
+  // guard against is anchoring on something the measurement does not see.
+  test("keeps twins together across a function declaration, which the rule ignores", () => {
+    const measured = separated("  function helper() { return 1 }");
+    const keys = entities(measured, "max-nested-callbacks").filter((key) => key.includes("items.map"));
+
+    // Nothing separates them: one anchor, and the ordinal that byte-identical
+    // twins are entitled to precisely because they measure identically.
+    expect(new Set(keys.map((key) => key.replace(/\(\d+\/\d+\)$/, ""))).size).toBe(1);
+    for (const key of keys) expect(key).toMatch(/\(\d+\/\d+\)$/);
+    expect(new Set(keys.map((key) => measured[`engines/collavre/app/javascript/x.js | max-nested-callbacks | ${key}`])))
+      .toEqual(new Set([ 2 ]));
+  });
+
+  // ESLint decrements on every one of these statements but only increments on
+  // some, so an if/else-if chain leaves its counter BELOW where it started and
+  // what follows measures too shallow. Mirroring the rule means reproducing
+  // that, not correcting it — the key has to match the number ESLint printed.
+  test("reproduces the depth ESLint reports after an else-if chain", () => {
+    const measured = measure(`
+      function f(a, b, c) {
+        if (a) { g() } else if (b) { g() } else if (c) { g() }
+        while (a) {
+          while (b) { g() }
+        }
+      }
+    `, { "max-depth": 0 });
+
+    // Only the chain's head counts; the two `while`s land at -1 and 0.
+    expect(entities(measured, "max-depth")).toEqual([ "f~if (a) { g() } else if (b) { g() } else if (c) { g() }" ]);
+  });
+});
+
+describe("offense shapes", () => {
+  test("max-lines belongs to the file, not to whatever sits on the overflowing line", () => {
+    const source = `const a = 1\nconst b = 2\nfunction c() { return 3 }\n`;
+    const measured = measure(source, { "max-lines": 1 });
+    expect(entities(measured, "max-lines")).toEqual(["(file)"]);
+    expect(Object.values(measured)).toEqual([3]);
+  });
+
+  test("max-depth falls back to the enclosing scope plus the source line", () => {
+    const source = `
+      class Row {
+        render() {
+          if (a) { if (b) { if (c) { return 1 } } }
+        }
+      }
+    `;
+    // Three `if`s share the line, so all three record the same text and each is
+    // anchored to its own span. The outermost is inside the budget and reports
+    // nothing; the two that do report are distinct keys rather than two slots
+    // in one group, so neither can be measured against the other's baseline.
+    expect(labelled(entities(measure(source, { "max-depth": 1 }), "max-depth"))).toEqual([
+      "Row#render~if (a) { if (b) { if (c) { return 1 } } }#a",
+      "Row#render~if (a) { if (b) { if (c) { return 1 } } }#b",
+    ]);
+  });
+
+  test("records the largest value when one entity trips a rule twice", () => {
+    const source = `
+      function render() {
+        if (a) { if (b) { if (c) { if (d) { return 1 } } } }
+      }
+    `;
+    const measured = measure(source, { "max-depth": 1 });
+    // Three nested offenses on one line, at depths 2, 3 and 4. They are twins
+    // of one group rather than one collapsed key, so the deepest is recorded
+    // rather than being the only one recorded.
+    expect(Math.max(...Object.values(measured))).toBe(4);
+  });
+
+  test("reads the measured value out of every rule in the budget", () => {
+    const source = `
+      class Editor {
+        save(a, b, c, d) {
+          if (a) { if (b) { if (c) { return 1 } } }
+          return a && b || c && d ? 1 : 2
+        }
+      }
+      setTimeout(() => { setTimeout(() => { setTimeout(() => {}) }) })
+    `;
+    const measured = measure(source, {
+      complexity: 1,
+      "max-depth": 1,
+      "max-lines": 1,
+      "max-lines-per-function": 1,
+      "max-nested-callbacks": 1,
+      "max-params": 1,
+    });
+    const seen = new Set(Object.keys(measured).map((key) => key.split(" | ")[1]));
+    expect([...seen].sort()).toEqual(Object.keys(RULES).sort());
+    expect(Object.values(measured).every((value) => Number.isInteger(value) && value > 0)).toBe(true);
+  });
+
+  test("throws rather than guessing when a source file does not parse", () => {
+    expect(() => measure("class {", { "max-params": 1 })).toThrow(/could not be parsed/);
+  });
+
+  test("ignores ESLint's notice that an inline disable comment was refused", () => {
+    // noInlineConfig is on, so `eslint-disable` comments cannot switch the gate
+    // off; ESLint reports that as a rule-less warning, which is not an entity.
+    const source = `/* eslint-disable max-params */\nfunction f(a, b, c) {}\n`;
+    expect(entities(measure(source, { "max-params": 2 }), "max-params")).toEqual(["f"]);
+  });
+});
+
+describe("budget parsing", () => {
+  test("rejects a rule the entity mapping does not cover", () => {
+    expect(() => parseBudget("rules:\n  no-unused-vars: 3\n")).toThrow(/no entity mapping/);
+  });
+
+  test("rejects a threshold that is not a non-negative integer", () => {
+    expect(() => parseBudget("rules:\n  complexity: 2.5\n")).toThrow(/non-negative integers/);
+    expect(() => parseBudget("rules:\n  complexity: -1\n")).toThrow(/non-negative integers/);
+  });
+
+  test("reads include, exclude and rules", () => {
+    const budget = parseBudget(`
+include:
+  - "engines/collavre/**/*.js"
+exclude:
+  - "**/__tests__/**"
+rules:
+  complexity: 13
+`);
+    expect(budget).toEqual({
+      include: ["engines/collavre/**/*.js"],
+      exclude: ["**/__tests__/**"],
+      rules: { complexity: 13 },
+    });
+  });
+
+  test("refuses to honour an inline directive that would silence the gate", () => {
+    expect(eslintConfig({ rules: {} }).linterOptions.noInlineConfig).toBe(true);
+  });
+});

--- a/lib/js_complexity/entity_map.js
+++ b/lib/js_complexity/entity_map.js
@@ -1,0 +1,709 @@
+// Resolves an ESLint offense position to the fully-qualified name of the entity
+// it sits on.
+//
+// The complexity ratchet compares two measurements of the same tree taken at
+// different commits, so an entity has to keep its identity across ordinary
+// editing. A line number does not survive an insertion above it, and a bare
+// function name is not unique inside a file, so neither works as a key on its
+// own. The Ruby half of the ratchet solves this with a Prism walk
+// (ComplexityRatchet::EntityMap); this is the same idea over an ESTree AST.
+//
+// Names read as a path from the outermost scope inward:
+//
+//   TopicsController#connect                    class method
+//   TopicsController.observed                   static class member
+//   CommentForm#submit>[this.el.addEventListener]  anonymous callback, named by
+//                                                  the call it is passed to
+//   Toolbar>handleFiles[useCallback]            callback named by its binding
+//   save>[load().then().then]                   callback named by its chain
+//   parseDraft>normalise                        function nested in a function
+//   CommentForm#submit~if (a) {                 statement fallback (see below)
+//   Row#connect>[items.map]#2842ca41            twin, anchored to its own source
+//
+// Lookup is by CONTAINMENT, not by start position, because ESLint does not
+// report an offense at the node it is about: `getFunctionHeadLoc` puts a method
+// offense on the method name, an arrow offense on the `=>` token, and a
+// max-depth offense on a statement somewhere in the middle. All three are
+// inside the entity, so the innermost scope containing the offense is the
+// answer in every case — as long as a class member's scope carries the
+// MethodDefinition's range rather than the inner FunctionExpression's, which
+// starts after the name.
+//
+// Rules that report on a statement rather than a definition — max-depth is the
+// one in the budget — get the enclosing scope plus the normalised source line,
+// written with a leading `~`. That is the fallback shape the Ruby side uses for
+// Metrics/BlockNesting.
+//
+// TWINS. Two entities in one scope can still end up with the same name: two
+// `items.map(...)` callbacks in one method, or two identical `if` lines. Any
+// scheme that separates them BY POSITION — `(2)`, or `(2/3)` — makes a slot the
+// identity, and a slot is not an identity: the entity in slot 2 after an edit
+// need not be the entity that was in slot 2 before it, so its measurement is
+// compared against somebody else's baseline. Deleting a twin and reordering
+// twins are both ways to reach that, and the second can conceal real growth —
+// baselines 12 and 6 against a reordered 9 and 5 read `9 <= 12` and `5 <= 6`
+// and say nothing, while the 6-line callback has in fact grown to 9.
+//
+// So the first move is to have fewer twins: a callback takes the WHOLE callee
+// including any chain (`[load().then().then]`) and the binding its call sits in
+// (`handleFiles[useCallback]`), which is enough to name all but a handful.
+// What is left is anchored to a digest of its own source — `[items.map]#2842ca41`
+// — so a twin's key depends on the twin and on nothing around it. Siblings can
+// be added, deleted or reordered without touching it, and an edit that changes
+// its measurement changes its key, so growth surfaces as new debt instead of
+// slipping into a neighbour's baseline. Only byte-identical twins still need an
+// ordinal, and those measure identically, so any permutation of them is a
+// no-op — which holds only because the digested text covers everything that
+// feeds the measurement. A statement's therefore includes its DEPTH, and that
+// depth has to be the number ESLint reports rather than an approximation of
+// it; see `depthsOf`. "Byte-identical" is meant literally: twins are grouped by their source
+// text and not by the digest of it, because one 32-bit FNV word collides often
+// enough to find a pair by brute force in seconds, and a collision would put
+// two different entities back on one ordinal. The digest widens a word at a
+// time until it separates them.
+//
+// The digest is spelled out only when a name is shared, so keys stay readable
+// and an ordinary entity does not carry a hash it has no use for. That leaves
+// one seam: going from one such entity to two, or back, renames it. That
+// direction is safe — the gate is loud about a change it cannot attribute,
+// never quiet about growth. See docs/complexity_budget.md.
+
+const FUNCTION_TYPES = new Set([
+  "FunctionDeclaration",
+  "FunctionExpression",
+  "ArrowFunctionExpression",
+]);
+
+const CLASS_TYPES = new Set(["ClassDeclaration", "ClassExpression"]);
+
+// A function written as a class member or an object value is reported at its
+// key, which lies outside the function node. Take the range from the member so
+// containment still finds it.
+const MEMBER_TYPES = new Set(["MethodDefinition", "PropertyDefinition", "Property"]);
+
+// The statements max-depth reports on — ESLint counts a block as nested when it
+// hangs off one of these, and reports the offense at the statement's own start
+// position. Recording them while walking is what lets a `~source line` fallback
+// know how many twins it is one of, the same way the Ruby side records every
+// statement in a scope rather than only the offending ones.
+const NESTING_STATEMENT_TYPES = new Set([
+  "DoWhileStatement",
+  "ForInStatement",
+  "ForOfStatement",
+  "ForStatement",
+  "IfStatement",
+  "SwitchStatement",
+  "TryStatement",
+  "WhileStatement",
+  "WithStatement",
+]);
+
+// max-depth resets its counter inside a function, and inside a static block.
+const DEPTH_ROOTS = new Set([
+  "ArrowFunctionExpression",
+  "FunctionDeclaration",
+  "FunctionExpression",
+  "Program",
+  "StaticBlock",
+]);
+
+// The depth ESLint would report for every statement it counts, mirrored from
+// the rule rather than approximated.
+//
+// An earlier version counted enclosing nesting statements and argued that it
+// only had to CHANGE when ESLint's depth changed, so the exceptions did not
+// need modelling. That was wrong, and it is the same defect as the twin
+// ordinal one level down: a key has to DETERMINE its measurement, and a count
+// that is merely correlated with ESLint's does not. Two byte-identical
+// `if (a) { y() }` statements can both sit under three enclosing statements
+// while measuring 3 and 2, because one of them hangs off an `else if` — so
+// they shared an anchor, fell back on the ordinal, and each was compared
+// against the other's baseline.
+//
+// Mirroring means mirroring the rule's arithmetic, not a tidied-up version of
+// it, because the number that has to match is the one ESLint prints:
+//
+//   * an IfStatement whose PARENT is an IfStatement does not count. That is
+//     broader than `else if` — an unbraced `if (a) if (b) {}` is exempt too.
+//   * every one of these types decrements on exit, including the ones that
+//     never incremented, so an `if`/`else if`/`else if` chain leaves the
+//     counter two BELOW where it started and the statements after it measure
+//     too shallow. That is an upstream quirk; reproducing it is the point,
+//     since the ratchet's job is to key what ESLint actually reported.
+//
+// Statements that do not count get no entry: max-depth cannot report one, so
+// nothing ever needs its key.
+function depthsOf(ast) {
+  const depths = new Map();
+  const counters = [];
+
+  const visit = (node, parent) => {
+    const root = DEPTH_ROOTS.has(node.type);
+    if (root) counters.push(0);
+
+    const nesting = NESTING_STATEMENT_TYPES.has(node.type);
+    if (nesting && !(node.type === "IfStatement" && parent?.type === "IfStatement")) {
+      depths.set(node, ++counters[counters.length - 1]);
+    }
+
+    // Source order, because the counter is sequential rather than lexical: the
+    // drift an if-chain leaves behind applies to whatever is visited next, and
+    // `childNodes` follows object keys.
+    for (const child of [ ...childNodes(node) ].sort(byRange)) visit(child, node);
+
+    if (nesting) counters[counters.length - 1]--;
+    if (root) counters.pop();
+  };
+
+  visit(ast, null);
+  return depths;
+}
+
+function byRange(left, right) {
+  return left.range[0] - right.range[0] || left.range[1] - right.range[1];
+}
+
+// The functions max-nested-callbacks counts. It pushes a function whose PARENT
+// is a call — that is its whole definition of "callback" — and reports the
+// stack's height.
+const CALLBACK_TYPES = new Set(["ArrowFunctionExpression", "FunctionExpression"]);
+
+// The callback-nesting height ESLint would report for every function, mirrored
+// from that rule for the same reason `depthsOf` mirrors max-depth: it is the
+// second measurement here that is not a property of the entity's own text, so a
+// twin's anchor has to carry it or two twins can share an anchor while
+// measuring differently.
+//
+// It was tempting to argue this one away — twins sit in one scope by
+// construction, so surely they nest identically. They do not, because the rule
+// pops on EVERY function exit while pushing only for callbacks. A function
+// expression that is not a callback therefore pops a level it never added, and
+// everything after it in the scope counts one lower:
+//
+//   a(function () {
+//     items.map((row) => { ... })            // 2
+//     const helper = function () { ... }      // pops without having pushed
+//     items.map((row) => { ... })            // 1  — same name, same source
+//   })
+//
+// Byte-identical and same-named, those two shared an anchor and took an
+// ordinal, each compared against the other's baseline. As with `depthsOf` the
+// quirk is reproduced rather than corrected: the key has to match the number
+// ESLint printed. FunctionDeclaration is deliberately absent — the rule does
+// not handle it, so it neither pushes nor pops.
+function callbackDepthsOf(ast) {
+  const depths = new Map();
+  let height = 0;
+
+  const visit = (node, parent) => {
+    const callback = CALLBACK_TYPES.has(node.type);
+    if (callback) {
+      if (parent?.type === "CallExpression") height++;
+      depths.set(node, height);
+    }
+
+    for (const child of [ ...childNodes(node) ].sort(byRange)) visit(child, node);
+
+    // `Array#pop` on an empty stack is a no-op, so the height floors at zero.
+    if (callback) height = Math.max(0, height - 1);
+  };
+
+  visit(ast, null);
+  return depths;
+}
+
+// `parent` is a back-reference ESLint adds while traversing; following it would
+// loop forever. `loc` and `range` hold no nodes, and skipping them keeps the
+// walk off every position object in the file.
+const SKIPPED_KEYS = new Set(["parent", "loc", "range"]);
+
+const MAX_FALLBACK_TEXT = 100;
+
+class Scope {
+  constructor(segment, loc, range) {
+    this.segment = segment;
+    this.range = range;
+    this.start = loc.start;
+    this.end = loc.end;
+    this.children = [];
+    this.statements = [];
+    this.parent = null;
+    this.level = 0;
+    // Filled in by the naming pass, which runs after the whole tree is known:
+    // a scope's key depends on how many twins it has, and the last twin is only
+    // known once the walk is finished.
+    this.name = null;
+    this.anchor = null;
+    // Set for function scopes by the walk; classes and the root never carry a
+    // callback height because no rule reports one on them.
+    this.callbackDepth = 0;
+    // Function scopes may have a wider lookup range than their own node: ESLint
+    // reports a member function at the member key. Keep the lexical range too,
+    // so a function inside a computed key beats the widened value-function
+    // range that overlaps it.
+    this.functionLoc = null;
+    this.keyed = false;
+  }
+
+  contains(line, column) {
+    return locationContains({ start: this.start, end: this.end }, line, column);
+  }
+
+  lexicallyContains(line, column) {
+    return this.functionLoc !== null && locationContains(this.functionLoc, line, column);
+  }
+
+  descendsFrom(other) {
+    for (let scope = this.parent; scope !== null; scope = scope.parent) {
+      if (scope === other) return true;
+    }
+    return false;
+  }
+
+  // Later start wins, and on a tie the earlier end: both mean "more deeply
+  // nested". Comparing widths instead would need the source to convert a
+  // line/column span into a length.
+  innerThan(other) {
+    // A field function includes its member key for ESLint's function-head
+    // location, so its range can contain its own initializer parent's range.
+    // Prefer lexical nesting before comparing these overlapping locations.
+    if (this.level !== other.level) return this.level > other.level;
+    if (this.start.line !== other.start.line) return this.start.line > other.start.line;
+    if (this.start.column !== other.start.column) return this.start.column > other.start.column;
+    if (this.end.line !== other.end.line) return this.end.line < other.end.line;
+    return this.end.column < other.end.column;
+  }
+}
+
+export class EntityMap {
+  static for(ast, source) {
+    return new EntityMap(ast, source);
+  }
+
+  constructor(ast, source) {
+    this.lines = source.split("\n");
+    this.root = new Scope(null, ast.loc, ast.range);
+    this.source = source;
+    this.scopes = [];
+    this.depths = depthsOf(ast);
+    this.callbackDepths = callbackDepthsOf(ast);
+    this.walk(ast, null, null, this.root);
+    nameChildren(this.root, source);
+  }
+
+  // Fully-qualified name of the innermost class or function containing the
+  // offense, or null when the offense sits at file scope.
+  nameAt(line, column) {
+    return this.enclosing(line, column - 1, (scope) => !scope.implicitKind).name;
+  }
+
+  // A field initializer may start at exactly the same position as the
+  // function or class it creates. Select ESLint's code-path kind explicitly
+  // rather than letting containment merge their independent measurements.
+  implicitNameAt(line, column, kind) {
+    const scope = this.enclosing(line, column - 1, (candidate) => candidate.implicitKind === kind);
+    if (scope === this.root) throw new Error(`Cannot locate ${kind} complexity entity at ${line}:${column}`);
+    return scope.name;
+  }
+
+  // Name for an offense that does not sit on a definition. Twins inside one
+  // scope carry their position and their group's size, for the reason the
+  // header gives: two identical `if` lines in one method must not collapse into
+  // one key, and neither may inherit the other's.
+  fallbackAt(line, column) {
+    const scope = this.enclosing(line, column - 1);
+    keyStatements(scope, this.source);
+
+    // Columns are 0-based on nodes and 1-based in messages.
+    const statement = scope.statements.find((candidate) => candidate.line === line && candidate.column === column - 1)
+      ?? scope.statements.find((candidate) => candidate.line === line);
+
+    // An offense that matches no recorded statement — a rule reporting
+    // somewhere this walk does not model — keeps the unqualified name rather
+    // than guessing which statement it belongs to.
+    const text = statement?.key ?? normaliseLine(this.lines[line - 1] ?? "");
+    return `${scope.name ?? ""}~${text}`;
+  }
+
+  // ESLint message columns are 1-based; node columns are 0-based. Callers pass
+  // the message column, so this takes the converted one.
+  enclosing(line, column, accepts = () => true) {
+    const candidates = this.scopes.filter((scope) => accepts(scope) && scope.contains(line, column));
+    const lexicalOwners = candidates.filter((scope) => scope.lexicallyContains(line, column));
+    let best = this.root;
+    for (const scope of candidates) {
+      // A member function's lookup range includes its key because some ESLint
+      // offenses are reported there. For a computed field, that widened range
+      // also overlaps functions executed by the key. Discard a widened-only
+      // match when a lexical function owner is not its ancestor; otherwise an
+      // enclosing function would incorrectly hide an object method whose
+      // offense is reported at the method key.
+      const unrelatedOwner = lexicalOwners.some((owner) => !scope.descendsFrom(owner));
+      if (unrelatedOwner && scope.functionLoc !== null && !scope.lexicallyContains(line, column)) continue;
+      if (best === this.root || scope.innerThan(best)) best = scope;
+    }
+    return best;
+  }
+
+  // `parent` is threaded explicitly rather than read from `node.parent`:
+  // ESLint only sets that back-reference while it traverses, and this map is
+  // also built in tests straight from a parse. The grandparent comes along
+  // because an anonymous callback's best name is usually one level further
+  // out than its call — see `anonymousName`.
+  walk(node, parent, grandparent, enclosing) {
+    // Only the value is an implicit code path. A computed field key executes
+    // in the enclosing context and must not be absorbed into this scope.
+    if (parent?.type === "PropertyDefinition" && parent.value === node) {
+      const initializer = new Scope(`${parent.static ? "." : "#"}${memberName(parent)}(initializer)`, node.loc, node.range);
+      initializer.implicitKind = "class-field-initializer";
+      initializer.level = enclosing.level + 1;
+      initializer.parent = enclosing;
+      enclosing.children.push(initializer);
+      this.scopes.push(initializer);
+      enclosing = initializer;
+    }
+    const segment = segmentFor(node, parent, grandparent);
+    let scope = enclosing;
+
+    if (segment !== null) {
+      const owner = rangeOwner(node, parent);
+      scope = new Scope(segment, owner.loc, owner.range);
+      scope.level = enclosing.level + 1;
+      scope.parent = enclosing;
+      if (node.type === "StaticBlock") scope.implicitKind = "class-static-block";
+      if (FUNCTION_TYPES.has(node.type)) scope.functionLoc = node.loc;
+      scope.callbackDepth = this.callbackDepths.get(node) ?? 0;
+      enclosing.children.push(scope);
+      this.scopes.push(scope);
+    } else if (this.depths.has(node)) {
+      enclosing.statements.push({
+        line: node.loc.start.line,
+        column: node.loc.start.column,
+        range: node.range,
+        depth: this.depths.get(node),
+        text: normaliseLine(this.lines[node.loc.start.line - 1] ?? ""),
+      });
+    }
+
+    for (const child of childNodes(node)) this.walk(child, node, parent, scope);
+  }
+}
+
+function locationContains(loc, line, column) {
+  if (line < loc.start.line || line > loc.end.line) return false;
+  if (line === loc.start.line && column < loc.start.column) return false;
+  if (line === loc.end.line && column > loc.end.column) return false;
+  return true;
+}
+
+// Names a scope's children, then theirs. Source order is imposed here rather
+// than taken from the walk: `childNodes` follows object keys, and a class's
+// `superClass` is visited before its `body` whatever the source says. An
+// ordinal read off a non-source order would move when nothing moved.
+function nameChildren(scope, source) {
+  for (const [ segment, group ] of groupBy(scope.children, (child) => child.segment)) {
+    for (const [ , twins ] of discriminate(group, segment, (child) => definitionBody(source, child))) {
+      twins.forEach((child, index) => {
+        child.name = join(scope.name, ordinal(child.anchor, index, twins.length));
+        nameChildren(child, source);
+      });
+    }
+  }
+}
+
+// Splits a group that shares a name into subgroups that do not, by anchoring
+// each member to a digest of its own source. A lone member keeps the clean
+// name. See the TWINS note in the header for why anchoring beats counting.
+//
+// The subgroups are the distinct BODIES, not the distinct digests. One 32-bit
+// FNV word is small enough that two different bodies really do collide — a
+// brute-force search finds a pair of plausible callbacks in seconds — and two
+// members that share an anchor go on to be told apart by `ordinal`, which is
+// the slot identity the anchor exists to replace. So the digest is widened a
+// word at a time until distinct bodies have distinct anchors. The first width
+// is a plain FNV-1a, so a group that does not actually collide keeps exactly
+// the key it would have had.
+function discriminate(group, name, bodyOf) {
+  if (group.length < 2) {
+    if (group.length === 1) group[0].anchor = name;
+    return groupBy(group, () => name);
+  }
+
+  for (const member of group) member.body = bodyOf(member);
+
+  for (const width of DIGEST_WIDTHS) {
+    for (const member of group) member.anchor = `${name}#${digest(member.body, width)}`;
+    const groups = groupBy(group, (member) => member.anchor);
+    if (separated(groups)) return groups;
+  }
+  throw new Error(`Cannot distinguish complexity entities: ${name} (digest collision at every supported width)`);
+}
+
+// Whether every anchor group holds one body — the property that makes the
+// ordinal below safe. If distinct bodies collide at all three widths, abort
+// measurement rather than compare different entities through positional keys.
+function separated(groups) {
+  return [ ...groups.values() ].every((group) => group.every((member) => member.body === group[0].body));
+}
+
+// Members that are still indistinguishable after anchoring are byte-identical,
+// so they measure identically and any permutation of them is a no-op. A plain
+// ordinal separates them; nothing can hide behind it.
+function ordinal(anchor, index, size) {
+  return size === 1 ? anchor : `${anchor}(${index + 1}/${size})`;
+}
+
+const DIGEST_WIDTHS = [ 1, 2, 3 ];
+
+// `width` FNV-1a runs over the entity's normalised source, each under its own
+// offset basis, concatenated. Written out rather than taken from node:crypto
+// because this has to produce the same digest on both sides of the ratchet and
+// on every Node version that runs it — and because the widths have to nest, so
+// that widening a colliding group cannot disturb one that does not collide.
+function digest(text, width) {
+  let out = "";
+  for (let word = 0; word < width; word += 1) {
+    let hash = (0x811c9dc5 ^ Math.imul(word, 0x9e3779b9)) >>> 0;
+    for (let index = 0; index < text.length; index += 1) {
+      hash ^= text.charCodeAt(index);
+      hash = Math.imul(hash, 0x01000193) >>> 0;
+    }
+    out += hash.toString(16).padStart(8, "0");
+  }
+  return out;
+}
+
+// Reindenting must not move a key, but anything the budget's rules can MEASURE
+// has to move it, or two entities that measure differently end up sharing an
+// anchor and fall back on a slot. So this collapses the whitespace the rules
+// cannot see and keeps the whitespace they can:
+//
+//   - horizontal whitespace never reaches a measurement, so runs of it collapse
+//     to one space and any of it around a newline goes away entirely. Reindent,
+//     retab, trailing spaces and CRLF all leave the digest alone.
+//   - a LINE BREAK does reach one: `max-lines-per-function` counts lines. It is
+//     kept. Collapsing it was a real hole — two callbacks differing only in
+//     where a template literal's text wraps normalised to the same string while
+//     measuring 5 and 4, so they shared an anchor and a reorder compared each
+//     against the other's baseline. A line break is everything ESLint splits
+//     lines on, U+2028 and U+2029 included, not just `\n`.
+//   - runs of newlines collapse to one, because the rules run with
+//     `skipBlankLines`, so a blank line cannot change a measurement either.
+//
+// Comments are the one thing left that moves a digest without moving a
+// measurement (`skipComments` is on), so editing a comment inside an
+// over-budget twin re-keys it and reads as new debt. That is the loud
+// direction, and separating comments from their look-alikes inside strings
+// needs the token stream, which is a lot of machinery for a twin.
+function normalise(text) {
+  return text.replace(BREAK_RUN, "\n").replace(HORIZONTAL_RUN, " ");
+}
+
+function sourceOf(source, node) {
+  return normalise(source.slice(node.range[0], node.range[1]));
+}
+
+// A definition carries its CALLBACK-NESTING HEIGHT as well as its source, for
+// the same reason a statement carries its depth: `max-nested-callbacks` does
+// not measure what the function says, and two byte-identical same-named
+// callbacks in one scope can measure differently. See `callbackDepthsOf`.
+function definitionBody(source, scope) {
+  return `${scope.callbackDepth}\n${sourceOf(source, scope)}`;
+}
+
+// A statement carries its NESTING DEPTH as well as its source, because unlike
+// every other measurement here, `max-depth`'s is not a property of the entity's
+// own text: two byte-identical `if (a) { y() }` statements in one function sit
+// at different depths if one of them is inside another guard, and measure
+// differently. Sharing an anchor, they fell back on the ordinal, which is the
+// slot identity the anchor exists to replace — a reorder then reported offenses
+// that had not happened, and a restructure that genuinely deepened one of them
+// left both their keys unchanged.
+//
+// The depth is ESLint's own, computed by `depthsOf`. Approximating it is not
+// enough and was the fifth variant of this bug: a key has to DETERMINE its
+// measurement, and a count that merely moves when ESLint's moves does not.
+// Two byte-identical statements under three enclosing statements measure 3 and
+// 2 when one hangs off an `else if`, which put them back on a shared anchor
+// and an ordinal — the slot identity this whole scheme exists to remove.
+function statementBody(source, statement) {
+  return `${statement.depth}\n${sourceOf(source, statement)}`;
+}
+
+// "Newline" has to mean what ESLint means by it, not `\n`: it splits a file on
+// `\r\n`, `\r`, `\u2028` and `\u2029` too, so all of them are countable lines to
+// `max-lines-per-function`. Treating U+2028 as horizontal whitespace collapsed
+// two callbacks that measured 5 and 4 onto one anchor. `\v` and `\f` are NOT in
+// ESLint's set, so they stay horizontal.
+const LINE_BREAK = String.raw`\r\n|[\n\r\u2028\u2029]`;
+const HORIZONTAL = String.raw`[^\S\n\r\u2028\u2029]`;
+const BREAK_RUN = new RegExp(`${HORIZONTAL}*(?:${LINE_BREAK})(?:${HORIZONTAL}*(?:${LINE_BREAK}))*${HORIZONTAL}*`, "gu");
+const HORIZONTAL_RUN = new RegExp(`${HORIZONTAL}+`, "gu");
+
+function groupBy(items, key) {
+  const groups = new Map();
+  for (const item of [ ...items ].sort(byPosition)) {
+    const group = groups.get(key(item));
+    if (group) group.push(item);
+    else groups.set(key(item), [ item ]);
+  }
+  return groups;
+}
+
+// Gives every statement in a scope its final key, the same way nameChildren
+// does for nested definitions: statements sharing a source line are anchored to
+// a digest of their own body, and only byte-identical ones fall back on an
+// ordinal. Done once per scope, on first use.
+function keyStatements(scope, source) {
+  if (scope.keyed) return;
+  scope.keyed = true;
+
+  for (const [ text, group ] of groupBy(scope.statements, (statement) => statement.text)) {
+    for (const [ , twins ] of discriminate(group, text, (statement) => statementBody(source, statement))) {
+      twins.forEach((statement, index) => {
+        statement.key = ordinal(statement.anchor, index, twins.length);
+      });
+    }
+  }
+}
+
+function byPosition(left, right) {
+  const leftStart = left.start ?? left;
+  const rightStart = right.start ?? right;
+  return leftStart.line - rightStart.line || leftStart.column - rightStart.column;
+}
+
+function* childNodes(node) {
+  for (const [name, value] of Object.entries(node)) {
+    if (SKIPPED_KEYS.has(name) || value === null || typeof value !== "object") continue;
+
+    for (const candidate of Array.isArray(value) ? value : [ value ]) {
+      if (isNode(candidate)) yield candidate;
+    }
+  }
+}
+
+function isNode(value) {
+  return value !== null && typeof value === "object" && typeof value.type === "string";
+}
+
+function join(prefix, segment) {
+  if (!prefix) return segment;
+
+  return segment.startsWith("#") || segment.startsWith(".") ? `${prefix}${segment}` : `${prefix}>${segment}`;
+}
+
+function rangeOwner(node, parent) {
+  return isMember(node, parent) ? parent : node;
+}
+
+function isMember(node, parent) {
+  return FUNCTION_TYPES.has(node.type) && parent !== null && MEMBER_TYPES.has(parent.type) && parent.value === node;
+}
+
+function segmentFor(node, parent, grandparent) {
+  if (CLASS_TYPES.has(node.type)) return className(node, parent);
+  if (node.type === "StaticBlock") return ".(static block)";
+  if (!FUNCTION_TYPES.has(node.type)) return null;
+
+  return functionName(node, parent, grandparent);
+}
+
+function className(node, parent) {
+  return node.id?.name ?? inferredName(parent) ?? "(anonymous class)";
+}
+
+function functionName(node, parent, grandparent) {
+  if (parent?.type === "PropertyDefinition") return "(function)";
+  if (parent?.type === "MethodDefinition") {
+    // `get x()` and `set x()` share a name; without the kind they would collide
+    // into a twin pair that reads as two unrelated members.
+    const kind = parent.kind === "get" || parent.kind === "set" ? `${parent.kind} ` : "";
+    return `${parent.static ? "." : "#"}${kind}${memberName(parent)}`;
+  }
+  if (node.type === "FunctionDeclaration" && node.id?.name) return node.id.name;
+
+  return inferredName(parent) ?? anonymousName(parent, grandparent);
+}
+
+// `const submit = () => {}` and `{ submit: function () {} }` are named by what
+// they are bound to: that is the name a reader would use for them.
+function inferredName(parent) {
+  if (!parent) return null;
+  // `export default class extends Controller {}` is the shape every Stimulus
+  // controller in this engine uses. "(anonymous class)" would be accurate and
+  // useless; `default` is what the importing side calls it.
+  if (parent.type === "ExportDefaultDeclaration") return "default";
+  if (parent.type === "VariableDeclarator" && parent.id?.type === "Identifier") return parent.id.name;
+  if (parent.type === "Property") return memberName(parent);
+  if (parent.type === "AssignmentExpression") {
+    if (parent.left?.type === "Identifier") return parent.left.name;
+    if (parent.left?.type === "MemberExpression") return memberPath(parent.left);
+  }
+  return null;
+}
+
+// `Editor.prototype.render = function () {}` keeps the whole chain: two classes
+// in one file both assigning `.render` would otherwise share a name, and the
+// position that separated them would depend on which was written first.
+function memberPath(node) {
+  if (node.type === "Identifier") return node.name;
+  if (node.type === "ThisExpression") return "this";
+  // A call in the middle of a chain is rendered but not descended into for its
+  // arguments: `load(a, b).then` is `load().then` whatever it was passed, so
+  // editing an argument does not move the key of a callback further down the
+  // chain.
+  if (node.type === "CallExpression") {
+    const callee = node.callee ? memberPath(node.callee) : null;
+    return callee ? `${callee}()` : null;
+  }
+  if (node.type !== "MemberExpression") return null;
+
+  const object = memberPath(node.object);
+  const property = memberName(node);
+  return object ? `${object}.${property}` : property;
+}
+
+// An anonymous callback is identified by the call it is passed to, plus the
+// binding that call sits in when there is one. Both halves exist to keep the
+// callback OUT of a twin group, because a twin's identity has to fall back on
+// its position among its siblings and a position is not a stable identity —
+// see the TWINS note in the header.
+//
+// The whole callee is kept, not just its last segment: `[map]` alone makes
+// twins out of every `.map` in a method. A chained call renders its object as
+// `foo()`, so the two callbacks in `load().then(a).then(b)` read
+// `[load().then]` and `[load().then().then]` rather than one `[then]` pair —
+// and appending a third `.then` leaves both of them alone.
+//
+// The binding is what makes React components tractable. Every callback in a
+// component is `useCallback`, so a component with eleven of them had eleven
+// twins whose keys all moved the moment a twelfth was added. `const handleFiles
+// = useCallback(...)` is really named `handleFiles`, one level out from the
+// call, and that name survives its siblings.
+function anonymousName(parent, grandparent) {
+  if (parent?.type !== "CallExpression" && parent?.type !== "NewExpression") return "[anonymous]";
+
+  const callee = parent.callee ? memberPath(parent.callee) : null;
+  const call = callee ? `[${callee}]` : "[anonymous]";
+  // A CallExpression can only sit in the positions inferredName reads from as
+  // the bound value, so no further check that the binding is really this call.
+  const binding = inferredName(grandparent);
+  return binding ? `${binding}${call}` : call;
+}
+
+function memberName(node) {
+  const named = node.key ?? node.property;
+  if (!named) return "(computed)";
+  if (named.type === "Identifier") return named.name;
+  if (named.type === "Literal") return String(named.value);
+  if (named.type === "PrivateIdentifier") return `#${named.name}`;
+  return "(computed)";
+}
+
+function normaliseLine(text) {
+  const collapsed = normalise(text.trim());
+  return collapsed.length > MAX_FALLBACK_TEXT
+    ? `${collapsed.slice(0, MAX_FALLBACK_TEXT - 3)}...`
+    : collapsed;
+}

--- a/lib/js_complexity/measure.js
+++ b/lib/js_complexity/measure.js
@@ -1,0 +1,206 @@
+// The JavaScript half of the complexity ratchet: runs ESLint's size and
+// complexity rules over a tree and folds the offenses into
+// {entity key => measured value}, the same shape ComplexityRatchet::Measurement
+// produces for Ruby. bin/complexity_check merges the two and compares them
+// against the merge base entity by entity.
+//
+// Why ESLint's Linter rather than the ESLint class: the ratchet measures a
+// detached checkout of the merge base, which has no node_modules and no
+// eslint.config file of its own. `Linter#verify` takes the config as a value,
+// so nothing is resolved from the tree being measured — this branch's budget is
+// applied to both sides, which is exactly the rule the Ruby half follows.
+//
+// The budget lives in .eslint_metrics.yml and holds ONLY numbers. Rule options
+// that are not thresholds (skipBlankLines, IIFEs) are fixed here on purpose:
+// a budget file that could carry arbitrary rule options would carry the
+// bypasses with them — `max-lines: { max: 300 }` next to an `overrides` entry
+// that silences a directory reads as a budget and acts as an exemption.
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { Linter } from "eslint";
+import { glob } from "glob";
+import yaml from "js-yaml";
+
+import { EntityMap } from "./entity_map.js";
+
+// scope: how an offense maps back to an entity.
+//   file      — the offense is about the whole file (max-lines reports on the
+//               first line past the limit, which belongs to no entity).
+//   function  — the offense is about a definition; the innermost scope
+//               containing it is that definition.
+//   code-path — a function, class field initializer, or class static block;
+//               ESLint's message distinguishes coincident code paths.
+//   statement — the offense is about a statement inside a definition, so it
+//               falls back to "enclosing scope + source line".
+export const RULES = {
+  complexity: {
+    scope: "code-path",
+    options: (max) => ["error", max],
+    value: /has a complexity of (\d+)\. Maximum/,
+  },
+  "max-depth": {
+    scope: "statement",
+    options: (max) => ["error", max],
+    value: /\((\d+)\)\. Maximum/,
+  },
+  "max-lines": {
+    scope: "file",
+    // Blank lines and comments are skipped to match RuboCop's Metrics counters,
+    // which ignore both. Otherwise the same file measures differently on the
+    // two sides of the ratchet and a comment block reads as growth.
+    options: (max) => ["error", { max, skipBlankLines: true, skipComments: true }],
+    value: /\((\d+)\)\. Maximum/,
+  },
+  "max-lines-per-function": {
+    scope: "function",
+    options: (max) => ["error", { max, skipBlankLines: true, skipComments: true, IIFEs: true }],
+    value: /\((\d+)\)\. Maximum/,
+  },
+  "max-nested-callbacks": {
+    scope: "function",
+    options: (max) => ["error", max],
+    value: /\((\d+)\)\. Maximum/,
+  },
+  "max-params": {
+    scope: "function",
+    options: (max) => ["error", max],
+    value: /\((\d+)\)\. Maximum/,
+  },
+};
+
+export const SEPARATOR = " | ";
+
+// The entity name used for a file-scoped offense. Parenthesised so it cannot
+// collide with a real identifier.
+export const FILE_ENTITY = "(file)";
+
+export class BudgetError extends Error {}
+
+export function parseBudget(text) {
+  const budget = yaml.load(text) ?? {};
+  const rules = budget.rules ?? {};
+  const unknown = Object.keys(rules).filter((rule) => !(rule in RULES));
+  if (unknown.length > 0) {
+    throw new BudgetError(
+      `.eslint_metrics.yml enables rules this tool has no entity mapping for: ${unknown.join(", ")}. ` +
+        "Add them to RULES in lib/js_complexity/measure.js first."
+    );
+  }
+  const bad = Object.entries(rules).filter(([, max]) => !Number.isInteger(max) || max < 0);
+  if (bad.length > 0) {
+    throw new BudgetError(
+      `.eslint_metrics.yml thresholds must be non-negative integers: ${bad.map(([rule]) => rule).join(", ")}`
+    );
+  }
+
+  return {
+    include: budget.include ?? [],
+    exclude: budget.exclude ?? [],
+    rules,
+  };
+}
+
+export function eslintConfig(budget) {
+  return {
+    files: ["**/*.js", "**/*.jsx"],
+    languageOptions: {
+      ecmaVersion: "latest",
+      sourceType: "module",
+      parserOptions: { ecmaFeatures: { jsx: true } },
+    },
+    // A file that turns the budget off with an inline comment is the bypass
+    // this gate exists to prevent, so directives are not honoured.
+    linterOptions: { noInlineConfig: true, reportUnusedDisableDirectives: "off" },
+    rules: Object.fromEntries(
+      Object.entries(budget.rules).map(([rule, max]) => [rule, RULES[rule].options(max)])
+    ),
+  };
+}
+
+// Exported for the unit tests: the fold from ESLint messages to ratchet keys is
+// where the entity naming rules live, and it is worth testing without a lint.
+export function foldMessages(relativePath, source, ast, messages) {
+  // A syntax error is worth crashing on: a file that silently fails to parse
+  // measures as zero offenses, which reads as "clean" rather than "unread".
+  // ESLint also hands back no SourceCode at all in that case, so this has to
+  // come before the entity map is built.
+  const fatal = messages.find((message) => message.fatal);
+  if (fatal) {
+    throw new Error(`${relativePath}:${fatal.line ?? "?"} could not be parsed: ${fatal.message}`);
+  }
+
+  const entities = EntityMap.for(ast, source);
+  const measured = {};
+
+  for (const message of messages) {
+    // Rule-less, non-fatal messages are ESLint talking about itself — the one
+    // this config produces is the notice that an `eslint-disable-line` comment
+    // had no effect under noInlineConfig, which is the intended outcome.
+    if (!message.ruleId) continue;
+
+    const rule = RULES[message.ruleId];
+    if (!rule) throw new Error(`unexpected rule ${message.ruleId} in ${relativePath}`);
+
+    const name = entityName(rule.scope, entities, message);
+    const key = [relativePath, message.ruleId, name].join(SEPARATOR);
+    const value = extractValue(rule, message, relativePath);
+    measured[key] = Math.max(measured[key] ?? 0, value);
+  }
+
+  return measured;
+}
+
+function entityName(scope, entities, message) {
+  if (scope === "file") return FILE_ENTITY;
+  if (scope === "statement") return entities.fallbackAt(message.line, message.column);
+  if (scope === "code-path") {
+    if (message.message.startsWith("Class field initializer ")) {
+      return entities.implicitNameAt(message.line, message.column, "class-field-initializer");
+    }
+    if (message.message.startsWith("Class static block ")) {
+      return entities.implicitNameAt(message.line, message.column, "class-static-block");
+    }
+  }
+
+  return entities.nameAt(message.line, message.column) ?? FILE_ENTITY;
+}
+
+function extractValue(rule, message, relativePath) {
+  const match = rule.value.exec(message.message);
+  // Silently counting an unreadable message as 1 would turn a rule whose
+  // wording changed in an ESLint upgrade into an entity that can never grow.
+  if (!match) {
+    throw new Error(`cannot read a measured value out of "${message.message}" (${relativePath})`);
+  }
+  return Number(match[1]);
+}
+
+export async function measure({ root, budget }) {
+  const files = await glob(budget.include, {
+    cwd: root,
+    ignore: budget.exclude,
+    nodir: true,
+    posix: true,
+    dot: false,
+  });
+
+  const linter = new Linter();
+  const config = eslintConfig(budget);
+  const measured = {};
+
+  for (const relativePath of files.sort()) {
+    const source = readFileSync(path.join(root, relativePath), "utf8");
+    const messages = linter.verify(source, config, relativePath);
+    if (messages.length === 0) continue;
+
+    Object.assign(measured, foldMessages(relativePath, source, linter.getSourceCode()?.ast, messages));
+  }
+
+  return measured;
+}
+
+export function loadBudget(configPath) {
+  return parseBudget(readFileSync(configPath, "utf8"));
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
       "devDependencies": {
         "@testing-library/dom": "^10.4.1",
         "esbuild": "^0.28.1",
+        "eslint": "^9.39.5",
         "glob": "^13.0.0",
         "jest": "^30.4.0",
         "jest-environment-jsdom": "^30.4.0",
@@ -1323,6 +1324,232 @@
         "node": ">=18"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+      "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.7.tgz",
+      "integrity": "sha512-F42g89Qd5oAWtp0k0nnSrjziAKza7w8SVT4mStc18LZMaRb4J1HQAHLCalEtDCxrTuksx7NU9qsmeLwpOfPqWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.3.2",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
     "node_modules/@firebase/ai": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@firebase/ai/-/ai-2.2.1.tgz",
@@ -2048,6 +2275,72 @@
       "dependencies": {
         "@hotwired/turbo": "^8.0.13",
         "@rails/actioncable": ">=7.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@iconify/types": {
@@ -3605,6 +3898,13 @@
         "@types/d3-selection": "*"
       }
     },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/geojson": {
       "version": "7946.0.16",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
@@ -3662,6 +3962,13 @@
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "24.4.0",
@@ -4083,6 +4390,16 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/agent-base": {
@@ -5252,6 +5569,13 @@
         }
       }
     },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deepmerge": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
@@ -5444,6 +5768,285 @@
         "node": ">=8"
       }
     },
+    "node_modules/eslint": {
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.5.tgz",
+      "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
+      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.6",
+        "@eslint/js": "9.39.5",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/eslint/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/eslint/node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/eslint/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint/node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/eslint/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/eslint/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -5456,6 +6059,52 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/execa": {
@@ -5545,6 +6194,13 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
     },
@@ -5863,6 +6519,19 @@
       },
       "bin": {
         "which": "bin/which"
+      }
+    },
+    "node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/globby": {
@@ -7680,6 +8349,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -7691,6 +8367,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
     },
@@ -7778,6 +8461,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/lexical": {
@@ -7869,6 +8566,13 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.truncate": {
@@ -8245,6 +8949,24 @@
       "integrity": "sha512-+xyrJmxV9QUBFbSwPROYhOg/FLXry+uuPr4R+B5EaE4556Oc18/8ZC/fL5A+/lbRSwNvA0Alh+C0KpyFWLmLZg==",
       "license": "MIT"
     },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -8573,6 +9295,16 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/pretty-format": {
       "version": "27.5.1",
@@ -9690,6 +10422,19 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -9805,6 +10550,16 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -9955,6 +10710,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "devDependencies": {
     "@testing-library/dom": "^10.4.1",
     "esbuild": "^0.28.1",
+    "eslint": "^9.39.5",
     "glob": "^13.0.0",
     "jest": "^30.4.0",
     "jest-environment-jsdom": "^30.4.0",

--- a/test/lib/complexity_ratchet_eager_loading_test.rb
+++ b/test/lib/complexity_ratchet_eager_loading_test.rb
@@ -3,9 +3,10 @@
 require "test_helper"
 
 class ComplexityRatchetEagerLoadingTest < ActiveSupport::TestCase
-  test "excludes the CI-only complexity ratchet directory from eager loading" do
+  test "excludes the CI-only complexity ratchet directories from eager loading" do
     ignored_paths = Rails.autoloaders.main.instance_variable_get(:@ignored_paths)
 
     assert_includes ignored_paths, Rails.root.join("lib/complexity_ratchet").to_s
+    assert_includes ignored_paths, Rails.root.join("lib/js_complexity").to_s
   end
 end

--- a/test/lib/complexity_ratchet_javascript_test.rb
+++ b/test/lib/complexity_ratchet_javascript_test.rb
@@ -1,0 +1,254 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "tmpdir"
+
+# Not autoloaded: config/application.rb keeps this CI-only tool out of the app's
+# object graph, so the test has to require it by path.
+require Rails.root.join("lib/complexity_ratchet").to_s
+require Rails.root.join("lib/complexity_ratchet/javascript").to_s
+
+# The JavaScript budget is the same ratchet as the Ruby one and needs the same
+# two properties pinned: a measurement that produces stable entity keys, and a
+# budget that can only tighten. The entity naming itself is tested where it
+# lives, in lib/js_complexity/__tests__/measure.test.js.
+class ComplexityRatchetJavascriptBudgetTest < ActiveSupport::TestCase
+  BEFORE = {
+    "include" => [ "engines/collavre/**/*.js" ],
+    "exclude" => [ "**/__tests__/**" ],
+    "rules" => { "complexity" => 13, "max-lines" => 300 }
+  }.freeze
+
+  def verify(after)
+    ComplexityRatchet::Javascript.verify_budget(BEFORE, BEFORE.merge(after))
+  end
+
+  test "accepts an unchanged budget" do
+    assert_empty verify({})
+  end
+
+  test "accepts a tightened threshold and a newly added rule" do
+    assert_empty verify("rules" => { "complexity" => 10, "max-lines" => 300, "max-params" => 4 })
+  end
+
+  # The bypass this exists to catch: both trees are measured with this branch's
+  # budget, so raising a threshold stops the offenses on both sides at once and
+  # the entity-by-entity comparison sees nothing at all.
+  test "rejects a raised threshold" do
+    problem = verify("rules" => { "complexity" => 40, "max-lines" => 300 }).sole
+
+    assert_equal :js_budget_loosened, problem.kind
+    assert_equal "complexity", problem.key
+    assert problem.blocking?
+  end
+
+  test "rejects a rule that is deleted outright" do
+    problem = verify("rules" => { "complexity" => 13 }).sole
+
+    assert_equal :js_budget_disabled, problem.kind
+    assert_equal "max-lines", problem.key
+  end
+
+  test "rejects a threshold that is not a non-negative integer" do
+    assert_equal :js_budget_invalid_max, verify("rules" => BEFORE["rules"].merge("complexity" => -1)).sole.kind
+    assert_equal :js_budget_invalid_max, verify("rules" => BEFORE["rules"].merge("complexity" => 13.5)).sole.kind
+    assert_equal :js_budget_invalid_max, verify("rules" => BEFORE["rules"].merge("complexity" => "13")).sole.kind
+  end
+
+  test "rejects narrowing the measured scope from either side" do
+    dropped = verify("include" => []).sole
+    assert_equal :js_budget_scope_narrowed, dropped.kind
+    assert_includes dropped.message, "include"
+
+    excluded = verify("exclude" => [ "**/__tests__/**", "engines/collavre/app/javascript/controllers/**" ]).sole
+    assert_equal :js_budget_scope_narrowed, excluded.kind
+    assert_includes excluded.message, "exclude"
+  end
+
+  test "accepts widening the measured scope from either side" do
+    assert_empty verify("include" => BEFORE["include"] + [ "engines/collavre/**/*.jsx" ])
+    assert_empty verify("exclude" => [])
+  end
+
+  # An allowlist, not a list of known tricks: a key the comparison cannot judge
+  # is a bypass waiting to be written into it.
+  test "rejects a key the ratchet does not know how to compare" do
+    problem = verify("overrides" => [ { "files" => "**/*", "rules" => {} } ]).sole
+
+    assert_equal :js_budget_unknown_key, problem.kind
+    assert_equal "overrides", problem.key
+  end
+
+  test "has nothing to say when the budget file is new" do
+    assert_empty ComplexityRatchet::Javascript.verify_budget(nil, BEFORE)
+  end
+end
+
+class ComplexityRatchetJavascriptMeasurementTest < ActiveSupport::TestCase
+  BUDGET = <<~YAML
+    include:
+      - "**/*.js"
+    exclude:
+      - "**/__tests__/**"
+    rules:
+      complexity: 2
+      max-params: 2
+  YAML
+
+  TWIN_BUDGET = <<~YAML
+    include:
+      - "**/*.js"
+    exclude: []
+    rules:
+      max-lines-per-function: 2
+  YAML
+
+  # Runs the real Node script against a throwaway tree, which is the part that
+  # cannot be unit-tested from either side: the Ruby half has to survive the
+  # script's actual output, and the script has to measure a tree that has no
+  # node_modules and no config of its own.
+  test "measures a tree with this checkout's tooling and budget" do
+    Dir.mktmpdir do |tree|
+      File.write(File.join(tree, "widget.js"), <<~JS)
+        export class Widget {
+          render(a, b, c) {
+            return a && b || c ? 1 : 2
+          }
+        }
+      JS
+      FileUtils.mkdir_p(File.join(tree, "__tests__"))
+      File.write(File.join(tree, "__tests__", "widget.test.js"), "const f = (a, b, c) => a\n")
+
+      measured = with_budget do |config|
+        ComplexityRatchet::Javascript::Measurement.call(root: tree, tool_root: Rails.root.to_s, config: config)
+      end
+
+      assert_equal(
+        {
+          "widget.js | complexity | Widget#render" => 4,
+          "widget.js | max-params | Widget#render" => 3
+        },
+        measured
+      )
+    end
+  end
+
+  # The Codex reviews on PR #1651 named both halves of this. With an order-only
+  # ordinal a same-named callback is identified by its SLOT, so deleting the
+  # first of two renames the survivor onto the deleted one's key, and reordering
+  # two of them measures each against the other's baseline. The JavaScript unit
+  # tests pin the naming; these pin the thing that actually matters, which is
+  # what the gate does with it.
+  test "reports a surviving twin's growth after its sibling is deleted" do
+    before = measure_twins(12, 6)
+    after  = measure_twins(9)
+
+    assert_empty before.keys & after.keys, "a survivor must not inherit a deleted twin's key"
+    assert_equal [ :new_offense ], check(actual: after, base: before).map(&:kind)
+  end
+
+  # Codex's second case: under a slot ordinal this passed, because slot 1 read
+  # `9 <= 12` and slot 2 read `5 <= 6` while the 6-line callback had grown to 9.
+  test "reports growth hidden behind a reorder and a compensating shrink" do
+    problems = check(actual: measure_twins(9, 5), base: measure_twins(12, 6))
+
+    assert_equal [ :new_offense, :new_offense ], problems.map(&:kind)
+  end
+
+  test "reports growth that moves between reordered twins" do
+    problems = check(actual: measure_twins(9, 12), base: measure_twins(12, 6))
+
+    assert_equal [ :new_offense ], problems.map(&:kind)
+  end
+
+  # A twin is anchored to its own body, so its siblings can come and go around
+  # it without touching its baseline. Under the ordinal this reported.
+  test "says nothing when a twin is deleted and the rest are untouched" do
+    assert_empty check(actual: measure_twins(12, 8), base: measure_twins(12, 8, 6))
+  end
+
+  test "says nothing when twins are reordered and neither one changed" do
+    assert_empty check(actual: measure_twins(6, 12), base: measure_twins(12, 6))
+  end
+
+  # The cost of anchoring, stated as a test so it cannot drift into folklore: an
+  # over-budget twin that shrinks without getting under budget has a new body,
+  # so it has a new key and reads as new debt. Loud about an improvement is
+  # recoverable — name the callback, finish the job, or waive it. Quiet about
+  # growth is not.
+  test "reports a twin that shrinks without getting under budget" do
+    problems = check(actual: measure_twins(10, 6), base: measure_twins(12, 6))
+
+    assert_equal [ :new_offense ], problems.map(&:kind)
+  end
+
+  test "raises with the file and the reason when a tree cannot be measured" do
+    Dir.mktmpdir do |tree|
+      File.write(File.join(tree, "broken.js"), "class {\n")
+
+      error = assert_raises(ComplexityRatchet::Error) do
+        with_budget do |config|
+          ComplexityRatchet::Javascript::Measurement.call(root: tree, tool_root: Rails.root.to_s, config: config)
+        end
+      end
+
+      assert_includes error.message, "broken.js"
+      assert_includes error.message, "could not be parsed"
+    end
+  end
+
+  private
+
+  # A method holding `sizes.length` callbacks that the entity naming cannot tell
+  # apart, each `sizes[i]` statements long. Only the callbacks are returned: the
+  # enclosing method changes size whenever the fixture does, and that is not what
+  # these tests are about.
+  def measure_twins(*sizes)
+    calls = sizes.map { |size| "  items.map((row) => {\n#{Array.new(size) { |i| "    const v#{i} = #{i}" }.join("\n")}\n  })" }
+
+    Dir.mktmpdir do |tree|
+      File.write(File.join(tree, "row.js"), "class Row {\n connect() {\n#{calls.join("\n")}\n }\n}\n")
+
+      measured = with_budget(TWIN_BUDGET) do |config|
+        ComplexityRatchet::Javascript::Measurement.call(root: tree, tool_root: Rails.root.to_s, config: config)
+      end
+
+      measured.select { |key, _value| key.include?("[items.map]") }
+    end
+  end
+
+  def check(actual:, base:)
+    ComplexityRatchet::Check.new(actual: actual, base: base).problems
+  end
+
+  def with_budget(budget = BUDGET)
+    Dir.mktmpdir do |dir|
+      config = File.join(dir, "budget.yml")
+      File.write(config, budget)
+      yield config
+    end
+  end
+end
+
+# The include globs are the whole scope of the gate. A typo in one of them
+# measures nothing at all and reports success, which is the failure mode this
+# design is otherwise built to avoid.
+class ComplexityRatchetJavascriptScopeTest < ActiveSupport::TestCase
+  setup do
+    @budget = YAML.safe_load_file(Rails.root.join(ComplexityRatchet::Javascript::CONFIG_PATH))
+  end
+
+  test "the shipped include globs match the core engine's JavaScript" do
+    matched = Dir.glob(@budget["include"], base: Rails.root.to_s)
+
+    assert_operator matched.size, :>, 100
+    assert_includes matched, "engines/collavre/app/javascript/controllers/index.js"
+  end
+
+  test "every shipped threshold is a rule the measurement can map to an entity" do
+    known = File.read(Rails.root.join("lib/js_complexity/measure.js")).scan(/^  "?([a-z-]+)"?: \{$/).flatten
+
+    assert_includes known, "complexity"
+    assert_empty @budget["rules"].keys - known
+  end
+end


### PR DESCRIPTION
Collavre core controllers and editor/orchestration modules mixed UI behavior with synchronization, persistence, and notification responsibilities. This integration extracts those responsibilities, adds regression coverage, and introduces complexity guards for engines/collavre.

Integrated task PRs:
- #1649: list controller responsibility extraction
- #1650: form controller draft responsibility extraction
- #1651: core complexity guard and regression coverage
- #1652: creative row editor save characterization and shared state
- #1653: Creative trigger-action command extraction
- #1654: topic selection/persistence synchronization state
- #1655: popup fullscreen responsibility extraction
- #1656: orchestrator waiting notification management
- #1660: follow-up complexity reductions, now merged

Validation at integration head b94244049566f735266b4f7cb8aa277e9c420e0a:
- Integration task owner reports Jest 162 suites / 2,341 tests, build, Ruby core 83 runs / 203 assertions, and RuboCop 1,358 files passing.
- Final PR CI: lint, test_js, postgres_schema_load, scan_ruby passed; Rails/system test running as of 2026-09-10 07:24 UTC; complexity failed.

Outstanding work:
- Main comparison still blocks on 17 relocation/extraction measurements. These are not considered resolved until the complexity check passes. Follow-up assigned in topic 19117.
- Latest-head Codex P2: restore scrollToBottom on fullscreen entry (popup_fullscreen.js). Regression fix assigned in topic 19113.
- Unresolved CodeQL code-injection finding in trigger_action_command.rb: validate input/execution path and fix or document false-positive evidence. Assigned in topic 19104.
- Revalidate latest-head Codex review, resolve findings, and obtain all CI checks passing after follow-ups integrate.

Tracking: Collavre creative 10283, topic 17799; final PR monitor connected. Main merge requires separate user authorization.