### PR TITLE
Restore scrolling after fullscreen entry

### DIFF
--- a/engines/collavre/app/javascript/controllers/comments/__tests__/popup_exit_target.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/popup_exit_target.test.js
@@ -1,0 +1,118 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { jest } from '@jest/globals'
+import {
+  findPopupTargetButton,
+  popupExitTarget,
+  restorePopupTargetStyles,
+} from '../popup_exit_target'
+
+describe('popup exit target', () => {
+  test('finds and reveals the creative row button when the current button is missing', () => {
+    document.body.innerHTML = `
+      <creative-tree-row creative-id="42">
+        <button class="comments-btn"></button>
+      </creative-tree-row>
+    `
+    const row = document.querySelector('creative-tree-row')
+    row.scrollIntoView = jest.fn()
+
+    const button = findPopupTargetButton(null, '42')
+
+    expect(button).toBe(document.querySelector('.comments-btn'))
+    expect(row.scrollIntoView).toHaveBeenCalledWith({ behavior: 'instant', block: 'center' })
+  })
+
+  test('places the popup beside a button when the viewport has room', () => {
+    const targetButton = document.createElement('button')
+    targetButton.getBoundingClientRect = () => ({ bottom: 50, right: 100 })
+
+    const target = popupExitTarget({
+      targetButton,
+      savedStyles: { width: '300px', height: '400px' },
+      viewport: { width: 1024, height: 768 },
+    })
+
+    expect(target).toMatchObject({
+      finalTop: '54px',
+      finalRight: '',
+      animTop: 54,
+      animLeft: 108,
+      animWidth: 300,
+      animHeight: 400,
+      exitToRight: true,
+    })
+  })
+
+  test('anchors to the right edge and clamps a low button target', () => {
+    const targetButton = document.createElement('button')
+    targetButton.getBoundingClientRect = () => ({ bottom: 600, right: 1000 })
+
+    const target = popupExitTarget({
+      targetButton,
+      savedStyles: { width: '300px', height: '400px' },
+      viewport: { width: 1024, height: 768 },
+    })
+
+    expect(target).toMatchObject({
+      finalTop: '364px',
+      finalRight: '48px',
+      animTop: 364,
+      animLeft: 676,
+      exitToRight: false,
+    })
+  })
+
+  test('uses saved geometry when no target button is available', () => {
+    const target = popupExitTarget({
+      targetButton: null,
+      savedStyles: { top: '72px', right: '24px', left: '', width: '360px', height: '480px' },
+      viewport: { width: 1024, height: 768 },
+    })
+
+    expect(target).toMatchObject({
+      finalTop: '72px',
+      finalRight: '24px',
+      animTop: 72,
+      animLeft: 640,
+      animWidth: 360,
+      animHeight: 480,
+    })
+  })
+
+  test('falls back to the default popup geometry', () => {
+    const target = popupExitTarget({
+      targetButton: null,
+      savedStyles: null,
+      viewport: { width: 1024, height: 768 },
+    })
+
+    expect(target).toMatchObject({
+      finalTop: '',
+      finalRight: '',
+      finalWidth: '',
+      finalHeight: '',
+      animTop: 100,
+      animLeft: 572,
+      animWidth: 420,
+      animHeight: 640,
+    })
+  })
+
+  test.each([
+    [{ exitToRight: true, animLeft: 108, finalTop: '54px', finalWidth: '300px', finalHeight: '400px' }, { top: '54px', left: '108px', right: '' }],
+    [{ exitToRight: false, finalRight: '48px', finalTop: '364px', finalWidth: '300px', finalHeight: '400px' }, { top: '364px', left: '', right: '48px' }],
+  ])('restores target styles for either horizontal anchor', (target, expected) => {
+    const style = document.createElement('div').style
+
+    restorePopupTargetStyles(style, target)
+
+    expect(style.top).toBe(expected.top)
+    expect(style.left).toBe(expected.left)
+    expect(style.right).toBe(expected.right)
+    expect(style.width).toBe('300px')
+    expect(style.height).toBe('400px')
+  })
+})

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/popup_fullscreen.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/popup_fullscreen.test.js
@@ -70,6 +70,7 @@ describe('PopupFullscreen', () => {
     expect(document.body.classList.contains('chat-fullscreen')).toBe(true)
     expect(callbacks.syncUi).toHaveBeenCalledWith(true)
     expect(window.location.pathname).toBe('/creatives/42/comments/fullscreen')
+    expect(listController.scrollToBottom).toHaveBeenCalledTimes(1)
   })
 
   test('restores the mobile popup and keeps it open in the URL', () => {

--- a/engines/collavre/app/javascript/controllers/comments/popup_exit_target.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_exit_target.js
@@ -1,0 +1,92 @@
+const DEFAULT_WIDTH = 420
+const DEFAULT_HEIGHT = 640
+const DEFAULT_TOP = 100
+
+function popupDimensions(savedStyles) {
+  const finalWidth = savedStyles?.width || ''
+  const finalHeight = savedStyles?.height || ''
+
+  return {
+    finalWidth,
+    finalHeight,
+    animWidth: parseFloat(finalWidth) || DEFAULT_WIDTH,
+    animHeight: parseFloat(finalHeight) || DEFAULT_HEIGHT,
+  }
+}
+
+function buttonTarget(targetButton, dimensions, viewport) {
+  const btnRect = targetButton.getBoundingClientRect()
+  const proposedTop = btnRect.bottom + 4
+  const animTop = proposedTop + dimensions.animHeight > viewport.height
+    ? Math.max(4, viewport.height - dimensions.animHeight - 4)
+    : proposedTop
+  const exitToRight = viewport.width - btnRect.right - 8 >= dimensions.animWidth
+  const rightPx = viewport.width - btnRect.right + 24
+
+  return {
+    ...dimensions,
+    targetButton,
+    finalTop: `${animTop}px`,
+    finalRight: exitToRight ? '' : `${rightPx}px`,
+    animTop,
+    animLeft: exitToRight ? btnRect.right + 8 : viewport.width - rightPx - dimensions.animWidth,
+    exitToRight,
+  }
+}
+
+function savedTarget(savedStyles, dimensions, viewport) {
+  const right = parseFloat(savedStyles.right) || 32
+
+  return {
+    ...dimensions,
+    targetButton: null,
+    finalTop: savedStyles.top || '',
+    finalRight: savedStyles.right || '',
+    animTop: parseFloat(savedStyles.top) || DEFAULT_TOP,
+    animLeft: savedStyles.left
+      ? parseFloat(savedStyles.left)
+      : viewport.width - right - dimensions.animWidth,
+    exitToRight: false,
+  }
+}
+
+export function findPopupTargetButton(currentButton, creativeId) {
+  let targetButton = currentButton
+  if (!targetButton && creativeId) {
+    const row = document.querySelector(`creative-tree-row[creative-id="${creativeId}"]`)
+    targetButton = row?.querySelector('.comments-btn')
+  }
+  targetButton?.closest('creative-tree-row')?.scrollIntoView({ behavior: 'instant', block: 'center' })
+  return targetButton
+}
+
+export function popupExitTarget({ targetButton, savedStyles, viewport }) {
+  const dimensions = popupDimensions(savedStyles)
+  if (targetButton) return buttonTarget(targetButton, dimensions, viewport)
+  if (savedStyles && Object.values(savedStyles).some(value => value)) {
+    return savedTarget(savedStyles, dimensions, viewport)
+  }
+
+  return {
+    ...dimensions,
+    targetButton: null,
+    finalTop: '',
+    finalRight: '',
+    animTop: DEFAULT_TOP,
+    animLeft: viewport.width - 32 - dimensions.animWidth,
+    exitToRight: false,
+  }
+}
+
+export function restorePopupTargetStyles(style, target) {
+  style.top = target.finalTop
+  style.width = target.finalWidth
+  style.height = target.finalHeight
+  if (target.exitToRight) {
+    style.left = `${target.animLeft}px`
+    style.right = ''
+  } else {
+    style.right = target.finalRight
+    style.left = ''
+  }
+}

--- a/engines/collavre/app/javascript/controllers/comments/popup_fullscreen.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_fullscreen.js
@@ -1,3 +1,9 @@
+import {
+  findPopupTargetButton,
+  popupExitTarget,
+  restorePopupTargetStyles,
+} from './popup_exit_target'
+
 export default class PopupFullscreen {
   constructor({
     element,
@@ -23,7 +29,6 @@ export default class PopupFullscreen {
     this.previousUrl = null
     this.enterCleanupTimer = null
     this.enterCleanupFn = null
-    this.exitToRight = false
   }
 
   get active() {
@@ -231,7 +236,13 @@ export default class PopupFullscreen {
   }
 
   exitDesktop(savedStyles, creativeId) {
-    const target = this.desktopExitTarget(savedStyles, creativeId)
+    const targetButton = findPopupTargetButton(this.getCurrentButton(), creativeId)
+    if (targetButton) this.setCurrentButton(targetButton)
+    const target = popupExitTarget({
+      targetButton,
+      savedStyles,
+      viewport: { width: window.innerWidth, height: window.innerHeight },
+    })
     const el = this.element
     const fullscreenRect = el.getBoundingClientRect()
 
@@ -259,81 +270,6 @@ export default class PopupFullscreen {
     this.pushExitUrl(creativeId)
   }
 
-  desktopExitTarget(savedStyles, creativeId) {
-    const targetButton = this.findTargetButton(creativeId)
-    let finalTop = ''
-    let finalRight = ''
-    const finalWidth = savedStyles?.width || ''
-    const finalHeight = savedStyles?.height || ''
-    let animTop
-    let animLeft
-    let animWidth
-    let animHeight
-
-    if (targetButton) {
-      this.setCurrentButton(targetButton)
-      const btnRect = targetButton.getBoundingClientRect()
-      const gap = 8
-      animWidth = parseFloat(finalWidth) || 420
-      animHeight = parseFloat(finalHeight) || 640
-
-      let top = btnRect.bottom + 4
-      if (top + animHeight > window.innerHeight) {
-        top = Math.max(4, window.innerHeight - animHeight - 4)
-      }
-      finalTop = `${top}px`
-
-      if (window.innerWidth - btnRect.right - gap >= animWidth) {
-        this.exitToRight = true
-        animLeft = btnRect.right + gap
-      } else {
-        this.exitToRight = false
-        const rightPx = window.innerWidth - btnRect.right + 24
-        finalRight = `${rightPx}px`
-        animLeft = window.innerWidth - rightPx - animWidth
-      }
-      animTop = top
-    } else if (savedStyles && Object.values(savedStyles).some(value => value)) {
-      const right = parseFloat(savedStyles.right) || 32
-      animWidth = parseFloat(savedStyles.width) || 420
-      animHeight = parseFloat(savedStyles.height) || 640
-      animLeft = savedStyles.left
-        ? parseFloat(savedStyles.left)
-        : window.innerWidth - right - animWidth
-      animTop = parseFloat(savedStyles.top) || 100
-      finalTop = savedStyles.top || ''
-      finalRight = savedStyles.right || ''
-    } else {
-      animWidth = 420
-      animHeight = 640
-      animLeft = window.innerWidth - 32 - animWidth
-      animTop = 100
-    }
-
-    return {
-      targetButton,
-      finalTop,
-      finalRight,
-      finalWidth,
-      finalHeight,
-      animTop,
-      animLeft,
-      animWidth,
-      animHeight,
-    }
-  }
-
-  findTargetButton(creativeId) {
-    let targetButton = this.getCurrentButton()
-    if (!targetButton && creativeId) {
-      const row = document.querySelector(`creative-tree-row[creative-id="${creativeId}"]`)
-      targetButton = row?.querySelector('.comments-btn')
-    }
-    const row = targetButton?.closest('creative-tree-row')
-    row?.scrollIntoView({ behavior: 'instant', block: 'center' })
-    return targetButton
-  }
-
   scheduleExitCleanup(target, savedStyles) {
     const el = this.element
     let cleanupTimer = null
@@ -351,7 +287,7 @@ export default class PopupFullscreen {
       el.style.bottom = ''
 
       if (target.targetButton) {
-        this.restoreTargetButtonStyles(target)
+        restorePopupTargetStyles(el.style, target)
       } else if (savedStyles) {
         this.clearPositionStyles()
         Object.assign(el.style, savedStyles)
@@ -365,20 +301,6 @@ export default class PopupFullscreen {
     }
     el.addEventListener('transitionend', cleanup, { once: true })
     cleanupTimer = setTimeout(cleanup, 300)
-  }
-
-  restoreTargetButtonStyles(target) {
-    const { style } = this.element
-    style.top = target.finalTop
-    style.width = target.finalWidth
-    style.height = target.finalHeight
-    if (this.exitToRight) {
-      style.left = `${target.animLeft}px`
-      style.right = ''
-    } else {
-      style.right = target.finalRight
-      style.left = ''
-    }
   }
 
   pushExitUrl(creativeId) {

--- a/engines/collavre/app/javascript/controllers/comments/popup_fullscreen.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_fullscreen.js
@@ -31,11 +31,9 @@ export default class PopupFullscreen {
   }
 
   toggle() {
-    if (this.active) {
-      this.exit()
-    } else {
-      this.enter()
-    }
+    if (this.active) return this.exit()
+
+    this.enter()
   }
 
   enterImmediate() {
@@ -90,6 +88,7 @@ export default class PopupFullscreen {
     }
 
     this.scheduleEnterCleanup()
+    this.scrollToBottom()
   }
 
   exit() {


### PR DESCRIPTION
## Summary

- restore the post-layout scroll after an already-open popup enters fullscreen
- preserve the extracted fullscreen lifecycle behavior from before PR #1655
- extract desktop exit target selection, geometry, and style restoration from the fullscreen lifecycle
- clear all three popup-owned complexity blockers against `main` without changing budgets or waivers

## Regression evidence

The fullscreen assertion failed before the fix with `Expected number of calls: 1, Received number of calls: 0`. It passes after scheduling `scrollToBottom()` on entry.

Addresses the Codex P2 thread on #1661: https://github.com/sh1nj1/plan42/pull/1661#discussion_r3976554018

## Complexity evidence

`bin/complexity_check --base github/main` reported 17 integration blockers before the follow-up extraction. The popup-owned blockers were:

- `popup_fullscreen.js` file length: 364
- `PopupFullscreen#desktopExitTarget` length: 59
- `PopupFullscreen#desktopExitTarget` complexity: 19

After extracting `popup_exit_target.js`, those three blockers are gone. The command reports only the 14 blockers assigned to the guard topic. `.eslint_metrics.yml` and `.complexity_waivers.yml` are unchanged.

## Validation

- focused popup Jest: 18/18
- full Jest: pass
- `popup_exit_target.js` coverage: 100% lines, 100% functions
- `npm run build`
- `bin/complexity_check --base github/feature/refactor-reduce-dupl`: pass
- `bin/complexity_check --base github/main`: popup blockers 0 (14 separately owned blockers remain)
- `./bin/rubocop -a`: 1,358 files, no offenses