### PR TITLE
Resolve remaining integration complexity relocations

### DIFF
--- a/engines/collavre/app/javascript/controllers/comments/comment_read_tracker.js
+++ b/engines/collavre/app/javascript/controllers/comments/comment_read_tracker.js
@@ -46,7 +46,7 @@ export default class CommentReadTracker {
       if (!controller.element.isConnected || controller.creativeId !== creativeId ||
           (controller.currentTopicId || null) !== topicId) return
 
-      this.updateReadPointer(creativeId, topicId, topicIds, topicWatermarks)
+      this.updateReadPointer({ creativeId, topicId, topicIds, topicWatermarks })
     }, READ_DEBOUNCE_MS)
   }
 
@@ -58,16 +58,10 @@ export default class CommentReadTracker {
     if (controller.markReadTimeout) window.clearTimeout(controller.markReadTimeout)
     controller.markReadTimeout = null
     controller.pendingRead = null
-    this.updateReadPointer(
-      pendingRead.creativeId,
-      pendingRead.topicId,
-      pendingRead.topicIds,
-      pendingRead.topicWatermarks,
-      { keepalive }
-    )
+    this.updateReadPointer({ ...pendingRead, keepalive })
   }
 
-  updateReadPointer(creativeId, topicId, topicIds = null, topicWatermarks = null, { keepalive = false } = {}) {
+  updateReadPointer({ creativeId, topicId, topicIds = null, topicWatermarks = null, keepalive = false }) {
     if (!creativeId) return
 
     this.request('/comment_read_pointers/update', {

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -563,7 +563,7 @@ export default class extends Controller {
             this._autoResize()
             this._updateSubmitButton()
             chatDrafts.set(submittedDraftKey, newerDraft)
-            this._observeDraft(submittedDraftKey, newerDraft, submittedDraftNamespace)
+						this._observeDraft(submittedDraftKey, newerDraft, { namespace: submittedDraftNamespace })
           } else if (hasNewerStoredDraft && submittedChatStillActive) {
             this._restoreDraft()
           } else if (
@@ -573,7 +573,7 @@ export default class extends Controller {
             ownsSubmittedDraftNamespace
           ) {
             chatDrafts.clear(submittedDraftKey)
-            this._observeDraft(submittedDraftKey, null, submittedDraftNamespace)
+						this._observeDraft(submittedDraftKey, null, { namespace: submittedDraftNamespace })
           }
           if (ownsSubmittedDraftNamespace && !submittedHadReview) {
             this._clearMigratedSubmittedSources(submittedDraft)

--- a/engines/collavre/app/javascript/controllers/comments/form_draft_manager.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_draft_manager.js
@@ -1,8 +1,10 @@
 import chatDrafts from '../../lib/chat_drafts'
+import FormDraftMigration from './form_draft_migration'
 
 // Owns the stateful draft lifecycle while the Stimulus controller coordinates UI concerns.
-export default class FormDraftManager {
+export default class FormDraftManager extends FormDraftMigration {
   constructor(form) {
+    super()
     this.form = form
   }
 
@@ -26,28 +28,40 @@ export default class FormDraftManager {
   }
 
   connect() {
-    // Draft persistence: debounce-save unsent input per chat.
-    // _activeDraftKey always identifies the chat whose text is in the textarea.
+    this._initializeDraftState()
+    this._observeDraftClearState()
+    this._defineLifecycleHandlers()
+    this._defineImeHandlers()
+    this._defineDraftInputHandler()
+    this._addDraftEventListeners()
+  }
+
+  _initializeDraftState() {
+    this._initializeDraftIdentityState()
+    this._initializeDraftObservationState()
+  }
+
+  _initializeDraftIdentityState() {
     this._activeDraftKey ??= null
     this._activeDraftCreativeId ??= null
     this._awaitingEffectiveDraftKeyFor ??= null
     this._draftSaveTimer = null
     this._draftSaveSuspendedForPermission ??= false
-    // A cross-tab logout permanently retires the old user's namespace for this
-    // controller lifetime, including Stimulus reconnects in the stale tab.
     this._disabledDraftNamespaces ||= new Set()
     this._draftBackupCleanupPendingNamespaces ||= new Set()
     this._observedDraftClearNonces ||= new Map()
-    // A pending send survives a Stimulus reconnect on this controller instance,
-    // so its completion must keep comparing against the same draft history.
+  }
+
+  _initializeDraftObservationState() {
     this._draftRevisions ||= new Map()
     this._observedDrafts ||= new Map()
     this._observedDisplayedDrafts ||= new Map()
     this._observedDraftRevisions ||= new Map()
     this._observedStoredDraftRevisions ||= new Map()
-    // A linked chat can replace its temporary raw key while its request is in
-    // flight. Keep mutable submission state across that migration/reconnect.
     this._pendingDraftSubmissions ||= new Set()
+  }
+
+  _observeDraftClearState() {
     const draftNamespace = chatDrafts.namespace()
     const draftClearNonce = chatDrafts.clearNonce(draftNamespace)
     const draftClearNoncePending = chatDrafts.clearNoncePending(draftNamespace)
@@ -78,6 +92,9 @@ export default class FormDraftManager {
     ) {
       this._observedDraftClearNonces.set(draftNamespace, draftClearNonce)
     }
+  }
+
+  _defineLifecycleHandlers() {
     this._handlePageHide = () => {
       if (!this.element.isConnected) return
 
@@ -89,6 +106,9 @@ export default class FormDraftManager {
       const clearedNamespace = chatDrafts.namespace()
       this._disableDraftNamespace(clearedNamespace)
     }
+  }
+
+  _defineImeHandlers() {
     this._handleCompositionEnd = () => {
       this._imeCommitPending = true
     }
@@ -102,6 +122,9 @@ export default class FormDraftManager {
 
       this._imeCommitPending = false
     }
+  }
+
+  _defineDraftInputHandler() {
     this._handleDraftInput = (event) => {
       // Consume the composition flag before any early return, so it can never
       // outlive the `input` event that the commit itself fired. Firefox has
@@ -128,6 +151,9 @@ export default class FormDraftManager {
       clearTimeout(this._draftSaveTimer)
       this._draftSaveTimer = setTimeout(() => this._saveDraftNow(), 500)
     }
+  }
+
+  _addDraftEventListeners() {
     this.textareaTarget.addEventListener('compositionend', this._handleCompositionEnd)
     this.textareaTarget.addEventListener('keydown', this._expireImeCommitLatch)
     this.textareaTarget.addEventListener('paste', this._expireImeCommitLatch)
@@ -146,69 +172,6 @@ export default class FormDraftManager {
     this.textareaTarget.removeEventListener('input', this._handleDraftInput)
     window.removeEventListener('pagehide', this._handlePageHide)
     window.removeEventListener('storage', this._handleDraftStorage)
-  }
-
-  handleTopicChange() {
-    // This event fires before onPopupOpened during a chat switch, while the
-    // textarea still contains the outgoing chat's text. Flush before re-keying.
-    const draftPersistenceDisabled = this._draftPersistenceDisabled()
-    const nextDraftKey = draftPersistenceDisabled
-      ? null
-      : this.element.dataset.effectiveCreativeId || this.element.dataset.creativeId || null
-    const nextCreativeId = draftPersistenceDisabled
-      ? null
-      : this.element.dataset.creativeId || null
-    const draftKeyChanged = String(this._activeDraftKey || '') !== String(nextDraftKey || '')
-    const creativeChanged =
-      String(this._activeDraftCreativeId || '') !== String(nextCreativeId || '')
-    const resolvingIncomingDraftKey =
-      this._awaitingEffectiveDraftKeyFor &&
-      String(this._awaitingEffectiveDraftKeyFor) === String(nextCreativeId || '')
-    let keepAwaitingEffectiveDraftKey = false
-    if (draftKeyChanged || creativeChanged) {
-      const previousDraftKey = this._activeDraftKey
-      // onChatWillOpen already flushed the outgoing chat. While the effective
-      // key is loading, save only actual new input; rewriting a restored raw
-      // draft here would make stale text appear newer than the canonical draft.
-      if (!resolvingIncomingDraftKey || this._draftSaveTimer) this._flushDraftSave()
-      this._activeDraftKey = nextDraftKey ? String(nextDraftKey) : null
-      this._activeDraftCreativeId = nextCreativeId ? String(nextCreativeId) : null
-      if (
-	resolvingIncomingDraftKey &&
-	previousDraftKey &&
-	this._activeDraftKey
-      ) {
-	const sourceDraft = chatDrafts.snapshot(previousDraftKey)
-	const moveCompleted = chatDrafts.move(previousDraftKey, this._activeDraftKey)
-	const targetDraft = chatDrafts.snapshot(this._activeDraftKey)
-	const movedBackups = moveCompleted
-	  ? chatDrafts.moveSubmissionBackups(previousDraftKey, this._activeDraftKey)
-	  : new Map()
-	if (moveCompleted && (targetDraft.revision || !sourceDraft.revision)) {
-	  this._rebindPendingDraftSubmissions(
-	    previousDraftKey,
-	    this._activeDraftKey,
-	    sourceDraft,
-	    targetDraft,
-	    movedBackups,
-	  )
-	} else if (!moveCompleted) {
-	  this._trackPartialDraftMigration(
-	    previousDraftKey,
-	    this._activeDraftKey,
-	    sourceDraft,
-	    targetDraft,
-	  )
-	  if (chatDrafts.isNewer(previousDraftKey, this._activeDraftKey)) {
-	    this._activeDraftKey = String(previousDraftKey)
-	    keepAwaitingEffectiveDraftKey = true
-	  }
-	}
-      }
-    }
-    if (resolvingIncomingDraftKey && !keepAwaitingEffectiveDraftKey) {
-      this._awaitingEffectiveDraftKeyFor = null
-    }
   }
 
   onChatWillOpen({ creativeId }) {
@@ -303,278 +266,4 @@ export default class FormDraftManager {
     this._saveDraftNow()
   }
 
-  _saveDraftNow() {
-    if (
-      !this._activeDraftKey ||
-      this._draftPersistenceDisabled() ||
-      this._draftSaveSuspendedForPermission ||
-      this.editingId ||
-      this._shouldSuppressDraftSaveForStash() ||
-      !this._reviewStore.isEmpty
-    ) return
-    if (this._currentTextIsPendingSubmission()) return
-    const draftKey = this._activeDraftKey
-    const text = this.textareaTarget.value
-    const blank = !text.trim()
-    const storedDraft = chatDrafts.snapshot(draftKey)
-    const storedText = storedDraft.text
-    const hasStoredEntry = chatDrafts.updatedAt(draftKey) !== null
-    const observationKey = `${chatDrafts.namespace()}:${draftKey}`
-    const hasObservedDraft = this._observedDrafts?.has(observationKey)
-    const observedText = this._observedDrafts?.get(observationKey)
-    const hasObservedDisplayedDraft =
-      this._observedDisplayedDrafts?.has(observationKey)
-    const observedDisplayedText = hasObservedDisplayedDraft
-      ? this._observedDisplayedDrafts.get(observationKey)
-      : observedText
-    const observedRevision = this._observedDraftRevisions?.get(observationKey) || 0
-    const observedStoredRevision =
-      this._observedStoredDraftRevisions?.get(observationKey) || null
-    const currentRevision = this._draftRevisions?.get(observationKey) || 0
-    const inputChangedLocally = currentRevision !== observedRevision
-    const preserveBlank =
-      blank && Boolean(this._awaitingEffectiveDraftKeyFor) && inputChangedLocally
-    const displayedDraftChanged =
-      (hasObservedDisplayedDraft || hasObservedDraft) &&
-      (observedDisplayedText || '') !== text
-    const draftChangedLocally =
-      inputChangedLocally || displayedDraftChanged
-    const storedDraftChangedOutsideController = hasObservedDraft && (
-      observedText !== storedText || observedStoredRevision !== storedDraft.revision
-    )
-    // An idle tab can retain stale restored text after another tab updates the
-    // same draft. Closing or switching that idle tab must not write it back.
-    if (!draftChangedLocally && storedDraftChangedOutsideController) return
-    if (preserveBlank) {
-      if (storedText !== null || !hasStoredEntry) {
-	chatDrafts.set(draftKey, '', { preserveBlank: true })
-      }
-    } else if (blank) {
-      if (hasStoredEntry) {
-	chatDrafts.clear(draftKey)
-      }
-    } else if (storedText !== text) {
-      chatDrafts.set(draftKey, text)
-    }
-    if (blank && draftChangedLocally) chatDrafts.clearSubmissionBackups(draftKey)
-    this._observeDraft(draftKey)
-  }
-
-  _flushDraftSave() {
-    clearTimeout(this._draftSaveTimer)
-    this._draftSaveTimer = null
-    this._saveDraftNow()
-  }
-
-  _currentTextIsPendingSubmission() {
-    return Boolean(this._currentPendingSubmission())
-  }
-
-  _currentPendingSubmission() {
-    const namespace = chatDrafts.namespace()
-    const key = String(this._activeDraftKey || '')
-
-    return [...(this._pendingDraftSubmissions || [])].find((submission) => (
-      !submission.invalidated &&
-      submission.namespace === namespace &&
-      String(submission.key || '') === key &&
-      !submission.hadStash &&
-      !submission.hadReview &&
-      !submission.editing &&
-      submission.text === this.textareaTarget.value &&
-      (this._draftRevisions?.get(submission.revisionKey) || 0) === submission.keyRevision
-    ))
-  }
-
-  _restoreDraft() {
-    if (
-      !this._activeDraftKey ||
-      this._draftPersistenceDisabled() ||
-      this.editingId
-    ) return
-    if (this.textareaTarget.value.trim()) return
-
-    const draft = chatDrafts.snapshot(this._activeDraftKey)
-    const backup = chatDrafts.latestSubmissionBackup(this._activeDraftKey)
-    const restoreBackup = Boolean(
-      backup?.text &&
-      (draft.updatedAt === null || backup.updatedAt > draft.updatedAt),
-    )
-    if (backup && !restoreBackup) chatDrafts.removeSubmissionBackup(backup.key)
-    const restoredText = restoreBackup ? backup.text : draft.text
-    this._observeDraft(
-      this._activeDraftKey,
-      draft.text,
-      chatDrafts.namespace(),
-      draft.revision,
-      restoredText,
-    )
-    if (restoredText) {
-      this.textareaTarget.value = restoredText
-      requestAnimationFrame(() => this._autoResize())
-    } else if (draft.updatedAt === null) {
-      this._restorePendingSubmittedDraft()
-    }
-  }
-
-  _restorePendingSubmittedDraft() {
-    const namespace = chatDrafts.namespace()
-    const pending = [...(this._pendingDraftSubmissions || [])].find((submission) => (
-      !submission.invalidated &&
-      submission.namespace === namespace &&
-      String(submission.key || '') === String(this._activeDraftKey || '') &&
-      !submission.hadStash &&
-      !submission.hadReview &&
-      !submission.editing
-    ))
-    if (!pending) return
-
-    this.textareaTarget.value = pending.text
-    requestAnimationFrame(() => this._autoResize())
-    this._updateSubmitButton()
-  }
-
-  _draftPersistenceDisabled(namespace = chatDrafts.namespace()) {
-    return this._disabledDraftNamespaces?.has(namespace) ||
-      this._draftBackupCleanupPendingNamespaces?.has(namespace) ||
-      false
-  }
-
-  _disableDraftNamespace(namespace) {
-    this._disabledDraftNamespaces.add(namespace)
-    this.discardDraft()
-    // A timer in this tab may have raced with the logout tab's first clear.
-    chatDrafts.clearAll({ broadcast: false })
-  }
-
-  _observeDraft(
-    draftKey,
-    text,
-    namespace = chatDrafts.namespace(),
-    storedRevision,
-    displayedText,
-  ) {
-    if (!draftKey) return
-    const storedDraft = storedRevision === undefined
-      ? chatDrafts.snapshot(draftKey)
-      : { text, revision: storedRevision }
-    const observationKey = `${namespace}:${draftKey}`
-    this._observedDrafts?.set(observationKey, storedDraft.text)
-    this._observedDisplayedDrafts?.set(
-      observationKey,
-      displayedText === undefined ? storedDraft.text : displayedText,
-    )
-    this._observedDraftRevisions?.set(
-      observationKey,
-      this._draftRevisions?.get(observationKey) || 0,
-    )
-    this._observedStoredDraftRevisions?.set(observationKey, storedDraft.revision)
-  }
-
-  _rebindPendingDraftSubmissions(
-    sourceKey,
-    targetKey,
-    sourceDraft,
-    targetDraft,
-    movedBackups = new Map(),
-  ) {
-    const namespace = chatDrafts.namespace()
-    const targetRevisionKey = `${namespace}:${targetKey}`
-
-    this._pendingDraftSubmissions?.forEach((submission) => {
-      if (
-	submission.namespace !== namespace ||
-	String(submission.key) !== String(sourceKey)
-      ) return
-
-      const targetMatchesStoredBaseline = submission.storedRevision && targetDraft.revision === submission.storedRevision
-      const sourceMatchesSubmission =
-	sourceDraft.revision &&
-	targetDraft.revision === sourceDraft.revision &&
-	targetDraft.text === submission.text
-      const submittedDraftWasUnstored =
-	!submission.storedRevision &&
-	!sourceDraft.revision &&
-	!targetDraft.revision
-      const submittedDraftWasMoved = targetMatchesStoredBaseline || sourceMatchesSubmission || submittedDraftWasUnstored
-      if (
-	sourceDraft.revision &&
-	sourceDraft.text === submission.text
-      ) {
-	submission.migratedSources.push({
-	  key: String(sourceKey),
-	  revision: sourceDraft.revision,
-	})
-      }
-      submission.key = String(targetKey)
-      submission.revisionKey = targetRevisionKey
-      submission.keyRevision = this._draftRevisions?.get(targetRevisionKey) || 0
-      submission.storedRevision = targetDraft.revision
-      submission.storedUpdatedAt = targetDraft.updatedAt
-      submission.storedChangedOutsideController ||=
-	!submittedDraftWasMoved
-      if (submission.backupKey && movedBackups.has(submission.backupKey)) {
-	submission.backupKey = movedBackups.get(submission.backupKey)
-      }
-    })
-  }
-
-  _trackPartialDraftMigration(sourceKey, targetKey, sourceDraft, targetDraft) {
-    if (
-      !sourceDraft.revision ||
-      targetDraft.revision !== sourceDraft.revision
-    ) return
-
-    const namespace = chatDrafts.namespace()
-    this._pendingDraftSubmissions?.forEach((submission) => {
-      if (
-	submission.namespace !== namespace ||
-	String(submission.key) !== String(sourceKey) ||
-	submission.hadStash ||
-	submission.hadReview ||
-	submission.editing ||
-	submission.storedRevision !== sourceDraft.revision
-      ) return
-
-      submission.migratedSources.push({
-	key: String(targetKey),
-	revision: targetDraft.revision,
-      })
-    })
-  }
-
-  _clearMigratedSubmittedSources(submission) {
-    submission.migratedSources.forEach(({ key, revision }) => {
-      if (chatDrafts.revision(key) !== revision) return
-
-      chatDrafts.clear(key)
-      this._observeDraft(key, null, submission.namespace)
-    })
-  }
-
-  _persistFailedSubmissionDraft(submission) {
-    if (
-      submission.invalidated ||
-      submission.hadStash ||
-      submission.hadReview ||
-      submission.editing ||
-      submission.namespace !== chatDrafts.namespace()
-    ) return
-
-    const currentDraft = chatDrafts.snapshot(submission.key)
-    const currentKeyRevision =
-      this._draftRevisions?.get(submission.revisionKey) || 0
-    const submittedChatAdvanced =
-      submission.storedChangedOutsideController ||
-      currentKeyRevision !== submission.keyRevision ||
-      currentDraft.revision !== submission.storedRevision ||
-      currentDraft.updatedAt !== submission.storedUpdatedAt
-    if (submittedChatAdvanced) return
-
-    submission.backupKey ||= chatDrafts.saveSubmissionBackup(
-      submission.key,
-      submission.text,
-      { updatedAt: submission.backupUpdatedAt },
-    )
-  }
 }

--- a/engines/collavre/app/javascript/controllers/comments/form_draft_migration.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_draft_migration.js
@@ -1,0 +1,142 @@
+import chatDrafts from '../../lib/chat_drafts'
+import FormDraftPersistence from './form_draft_persistence'
+
+export default class FormDraftMigration extends FormDraftPersistence {
+	handleTopicChange() {
+		const context = this._nextDraftContext()
+		const resolvingIncomingDraftKey = this._isResolvingDraftKey(context.nextCreativeId)
+		let keepAwaitingEffectiveDraftKey = false
+
+		if (this._draftContextChanged(context)) {
+			keepAwaitingEffectiveDraftKey = this._changeDraftContext(context, resolvingIncomingDraftKey)
+		}
+		if (resolvingIncomingDraftKey && !keepAwaitingEffectiveDraftKey) {
+			this._awaitingEffectiveDraftKeyFor = null
+		}
+	}
+
+	_nextDraftContext() {
+		if (this._draftPersistenceDisabled()) return { nextDraftKey: null, nextCreativeId: null }
+
+		return {
+			nextDraftKey: this.element.dataset.effectiveCreativeId || this.element.dataset.creativeId || null,
+			nextCreativeId: this.element.dataset.creativeId || null,
+		}
+	}
+
+	_isResolvingDraftKey(nextCreativeId) {
+		return Boolean(
+			this._awaitingEffectiveDraftKeyFor &&
+			String(this._awaitingEffectiveDraftKeyFor) === String(nextCreativeId || ''),
+		)
+	}
+
+	_draftContextChanged({ nextDraftKey, nextCreativeId }) {
+		return String(this._activeDraftKey || '') !== String(nextDraftKey || '') ||
+			String(this._activeDraftCreativeId || '') !== String(nextCreativeId || '')
+	}
+
+	_changeDraftContext({ nextDraftKey, nextCreativeId }, resolvingIncomingDraftKey) {
+		const previousDraftKey = this._activeDraftKey
+		if (!resolvingIncomingDraftKey || this._draftSaveTimer) this._flushDraftSave()
+		this._activeDraftKey = nextDraftKey ? String(nextDraftKey) : null
+		this._activeDraftCreativeId = nextCreativeId ? String(nextCreativeId) : null
+		if (!resolvingIncomingDraftKey || !previousDraftKey || !this._activeDraftKey) return false
+
+		return this._migrateDraftKey(previousDraftKey)
+	}
+
+	_migrateDraftKey(sourceKey) {
+		const targetKey = this._activeDraftKey
+		const sourceDraft = chatDrafts.snapshot(sourceKey)
+		const moveCompleted = chatDrafts.move(sourceKey, targetKey)
+		const targetDraft = chatDrafts.snapshot(targetKey)
+		const movedBackups = moveCompleted
+			? chatDrafts.moveSubmissionBackups(sourceKey, targetKey)
+			: new Map()
+		const migration = { sourceKey, targetKey, sourceDraft, targetDraft, movedBackups }
+
+		if (moveCompleted && (targetDraft.revision || !sourceDraft.revision)) {
+			this._rebindPendingDraftSubmissions(migration)
+			return false
+		}
+		if (moveCompleted) return false
+
+		this._trackPartialDraftMigration(sourceKey, targetKey, sourceDraft, targetDraft)
+		if (!chatDrafts.isNewer(sourceKey, targetKey)) return false
+
+		this._activeDraftKey = String(sourceKey)
+		return true
+	}
+
+	_rebindPendingDraftSubmissions(migration) {
+		const namespace = chatDrafts.namespace()
+		const context = {
+			...migration,
+			namespace,
+			targetRevisionKey: `${namespace}:${migration.targetKey}`,
+		}
+		this._pendingDraftSubmissions?.forEach((submission) => {
+			this._rebindPendingDraftSubmission(submission, context)
+		})
+	}
+
+	_rebindPendingDraftSubmission(submission, context) {
+		const { namespace, sourceKey, targetKey, sourceDraft, targetDraft, movedBackups } = context
+		if (submission.namespace !== namespace || String(submission.key) !== String(sourceKey)) return
+
+		const submittedDraftWasMoved = this._submittedDraftWasMoved(submission, context)
+		this._recordMigratedSubmissionSource(submission, context)
+		submission.key = String(targetKey)
+		submission.revisionKey = context.targetRevisionKey
+		submission.keyRevision = this._draftRevisions?.get(context.targetRevisionKey) || 0
+		submission.storedRevision = targetDraft.revision
+		submission.storedUpdatedAt = targetDraft.updatedAt
+		submission.storedChangedOutsideController ||= !submittedDraftWasMoved
+		if (submission.backupKey && movedBackups.has(submission.backupKey)) {
+			submission.backupKey = movedBackups.get(submission.backupKey)
+		}
+	}
+
+	_submittedDraftWasMoved(submission, { sourceDraft, targetDraft }) {
+		const targetMatchesStoredBaseline = submission.storedRevision &&
+			targetDraft.revision === submission.storedRevision
+		const sourceMatchesSubmission = sourceDraft.revision &&
+			targetDraft.revision === sourceDraft.revision &&
+			targetDraft.text === submission.text
+		const submittedDraftWasUnstored = !submission.storedRevision &&
+			!sourceDraft.revision && !targetDraft.revision
+		return targetMatchesStoredBaseline ||
+			sourceMatchesSubmission || submittedDraftWasUnstored
+	}
+
+	_recordMigratedSubmissionSource(submission, { sourceKey, sourceDraft }) {
+		if (sourceDraft.revision && sourceDraft.text === submission.text) {
+			submission.migratedSources.push({
+				key: String(sourceKey),
+				revision: sourceDraft.revision,
+			})
+		}
+	}
+
+	_trackPartialDraftMigration(sourceKey, targetKey, sourceDraft, targetDraft) {
+		if (!sourceDraft.revision || targetDraft.revision !== sourceDraft.revision) return
+
+		const namespace = chatDrafts.namespace()
+		this._pendingDraftSubmissions?.forEach((submission) => {
+			if (
+				submission.namespace !== namespace ||
+				String(submission.key) !== String(sourceKey) ||
+				submission.hadStash ||
+				submission.hadReview ||
+				submission.editing ||
+				submission.storedRevision !== sourceDraft.revision
+			) return
+
+			submission.migratedSources.push({
+				key: String(targetKey),
+				revision: targetDraft.revision,
+			})
+		})
+	}
+}

--- a/engines/collavre/app/javascript/controllers/comments/form_draft_persistence.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_draft_persistence.js
@@ -1,0 +1,228 @@
+import chatDrafts from '../../lib/chat_drafts'
+
+export default class FormDraftPersistence {
+	_saveDraftNow() {
+		if (!this._canPersistCurrentDraft() || this._currentTextIsPendingSubmission()) return
+
+		const snapshot = this._draftSaveSnapshot()
+		if (!snapshot.draftChangedLocally && snapshot.storedDraftChangedOutsideController) return
+
+		this._persistDraftSnapshot(snapshot)
+		if (snapshot.blank && snapshot.draftChangedLocally) {
+			chatDrafts.clearSubmissionBackups(snapshot.draftKey)
+		}
+		this._observeDraft(snapshot.draftKey)
+	}
+
+	_canPersistCurrentDraft() {
+		return Boolean(
+			this._activeDraftKey &&
+			!this._draftPersistenceDisabled() &&
+			!this._draftSaveSuspendedForPermission &&
+			!this.editingId &&
+			!this._shouldSuppressDraftSaveForStash() &&
+			this._reviewStore.isEmpty,
+		)
+	}
+
+	_draftSaveSnapshot() {
+		const draftKey = this._activeDraftKey
+		const text = this.textareaTarget.value
+		const blank = !text.trim()
+		const storedDraft = chatDrafts.snapshot(draftKey)
+		const hasStoredEntry = chatDrafts.updatedAt(draftKey) !== null
+		const observationKey = `${chatDrafts.namespace()}:${draftKey}`
+		const observation = this._draftObservation(observationKey, text)
+
+		return {
+			draftKey,
+			text,
+			blank,
+			storedText: storedDraft.text,
+			hasStoredEntry,
+			preserveBlank: blank && Boolean(this._awaitingEffectiveDraftKeyFor) &&
+				observation.inputChangedLocally,
+			draftChangedLocally: observation.inputChangedLocally || observation.displayedDraftChanged,
+			storedDraftChangedOutsideController: observation.hasObservedDraft && (
+				observation.observedText !== storedDraft.text ||
+				observation.observedStoredRevision !== storedDraft.revision
+			),
+		}
+	}
+
+	_draftObservation(observationKey, text) {
+		const hasObservedDraft = this._observedDrafts?.has(observationKey)
+		const observedText = this._observedDrafts?.get(observationKey)
+		const hasObservedDisplayedDraft = this._observedDisplayedDrafts?.has(observationKey)
+		const observedDisplayedText = hasObservedDisplayedDraft
+			? this._observedDisplayedDrafts.get(observationKey)
+			: observedText
+		const { observedRevision, observedStoredRevision, currentRevision } =
+			this._draftObservationRevisions(observationKey)
+		const inputChangedLocally = currentRevision !== observedRevision
+		const displayedDraftChanged = (hasObservedDisplayedDraft || hasObservedDraft) &&
+			(observedDisplayedText || '') !== text
+
+		return {
+			hasObservedDraft,
+			observedText,
+			observedStoredRevision,
+			inputChangedLocally,
+			displayedDraftChanged,
+		}
+	}
+
+	_draftObservationRevisions(observationKey) {
+		return {
+			observedRevision: this._observedDraftRevisions?.get(observationKey) || 0,
+			observedStoredRevision: this._observedStoredDraftRevisions?.get(observationKey) || null,
+			currentRevision: this._draftRevisions?.get(observationKey) || 0,
+		}
+	}
+
+	_persistDraftSnapshot({ draftKey, text, blank, storedText, hasStoredEntry, preserveBlank }) {
+		if (preserveBlank) {
+			if (storedText !== null || !hasStoredEntry) {
+				chatDrafts.set(draftKey, '', { preserveBlank: true })
+			}
+		} else if (blank) {
+			if (hasStoredEntry) chatDrafts.clear(draftKey)
+		} else if (storedText !== text) {
+			chatDrafts.set(draftKey, text)
+		}
+	}
+
+	_flushDraftSave() {
+		clearTimeout(this._draftSaveTimer)
+		this._draftSaveTimer = null
+		this._saveDraftNow()
+	}
+
+	_currentTextIsPendingSubmission() {
+		return Boolean(this._currentPendingSubmission())
+	}
+
+	_currentPendingSubmission() {
+		const namespace = chatDrafts.namespace()
+		const key = String(this._activeDraftKey || '')
+
+		return [...(this._pendingDraftSubmissions || [])].find((submission) => (
+			!submission.invalidated &&
+			submission.namespace === namespace &&
+			String(submission.key || '') === key &&
+			!submission.hadStash &&
+			!submission.hadReview &&
+			!submission.editing &&
+			submission.text === this.textareaTarget.value &&
+			(this._draftRevisions?.get(submission.revisionKey) || 0) === submission.keyRevision
+		))
+	}
+
+	_restoreDraft() {
+		if (!this._activeDraftKey || this._draftPersistenceDisabled() || this.editingId) return
+		if (this.textareaTarget.value.trim()) return
+
+		const draft = chatDrafts.snapshot(this._activeDraftKey)
+		const backup = chatDrafts.latestSubmissionBackup(this._activeDraftKey)
+		const restoreBackup = Boolean(
+			backup?.text && (draft.updatedAt === null || backup.updatedAt > draft.updatedAt),
+		)
+		if (backup && !restoreBackup) chatDrafts.removeSubmissionBackup(backup.key)
+		const restoredText = restoreBackup ? backup.text : draft.text
+		this._observeDraft(this._activeDraftKey, draft.text, {
+			storedRevision: draft.revision,
+			displayedText: restoredText,
+		})
+		if (restoredText) {
+			this.textareaTarget.value = restoredText
+			requestAnimationFrame(() => this._autoResize())
+		} else if (draft.updatedAt === null) {
+			this._restorePendingSubmittedDraft()
+		}
+	}
+
+	_restorePendingSubmittedDraft() {
+		const namespace = chatDrafts.namespace()
+		const pending = [...(this._pendingDraftSubmissions || [])].find((submission) => (
+			!submission.invalidated &&
+			submission.namespace === namespace &&
+			String(submission.key || '') === String(this._activeDraftKey || '') &&
+			!submission.hadStash &&
+			!submission.hadReview &&
+			!submission.editing
+		))
+		if (!pending) return
+
+		this.textareaTarget.value = pending.text
+		requestAnimationFrame(() => this._autoResize())
+		this._updateSubmitButton()
+	}
+
+	_draftPersistenceDisabled(namespace = chatDrafts.namespace()) {
+		return this._disabledDraftNamespaces?.has(namespace) ||
+			this._draftBackupCleanupPendingNamespaces?.has(namespace) ||
+			false
+	}
+
+	_disableDraftNamespace(namespace) {
+		this._disabledDraftNamespaces.add(namespace)
+		this.discardDraft()
+		chatDrafts.clearAll({ broadcast: false })
+	}
+
+	_observeDraft(draftKey, text, options = {}) {
+		if (!draftKey) return
+		const {
+			namespace = chatDrafts.namespace(),
+			storedRevision,
+			displayedText,
+		} = options
+		const storedDraft = storedRevision === undefined
+			? chatDrafts.snapshot(draftKey)
+			: { text, revision: storedRevision }
+		const observationKey = `${namespace}:${draftKey}`
+		this._observedDrafts?.set(observationKey, storedDraft.text)
+		this._observedDisplayedDrafts?.set(
+			observationKey,
+			displayedText === undefined ? storedDraft.text : displayedText,
+		)
+		this._observedDraftRevisions?.set(
+			observationKey,
+			this._draftRevisions?.get(observationKey) || 0,
+		)
+		this._observedStoredDraftRevisions?.set(observationKey, storedDraft.revision)
+	}
+
+	_clearMigratedSubmittedSources(submission) {
+		submission.migratedSources.forEach(({ key, revision }) => {
+			if (chatDrafts.revision(key) !== revision) return
+
+			chatDrafts.clear(key)
+			this._observeDraft(key, null, { namespace: submission.namespace })
+		})
+	}
+
+	_persistFailedSubmissionDraft(submission) {
+		if (
+			submission.invalidated ||
+			submission.hadStash ||
+			submission.hadReview ||
+			submission.editing ||
+			submission.namespace !== chatDrafts.namespace()
+		) return
+
+		const currentDraft = chatDrafts.snapshot(submission.key)
+		const currentKeyRevision = this._draftRevisions?.get(submission.revisionKey) || 0
+		const submittedChatAdvanced = submission.storedChangedOutsideController ||
+			currentKeyRevision !== submission.keyRevision ||
+			currentDraft.revision !== submission.storedRevision ||
+			currentDraft.updatedAt !== submission.storedUpdatedAt
+		if (submittedChatAdvanced) return
+
+		submission.backupKey ||= chatDrafts.saveSubmissionBackup(
+			submission.key,
+			submission.text,
+			{ updatedAt: submission.backupUpdatedAt },
+		)
+	}
+}

--- a/engines/collavre/app/javascript/controllers/comments/list_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/list_controller.js
@@ -500,13 +500,13 @@ export default class extends Controller {
   }
 
   updateReadPointer(creativeId, topicId, topicIds = null, topicWatermarks = null, { keepalive = false } = {}) {
-    this.getCommentReadTracker().updateReadPointer(
+    this.getCommentReadTracker().updateReadPointer({
       creativeId,
       topicId,
       topicIds,
       topicWatermarks,
-      { keepalive }
-    )
+      keepalive,
+    })
   }
 
   handlePrevMsgUserInput() {

--- a/engines/collavre/app/javascript/controllers/comments/topics/last_topic_save.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics/last_topic_save.js
@@ -1,0 +1,124 @@
+export default class LastTopicSave {
+	constructor(topics) {
+		this.topics = topics
+	}
+
+	enqueue(context) {
+		return this.topics.saveOrderState.enqueue(() => this._save(context))
+	}
+
+	async _save(context) {
+		const claimed = this._claimEcho(context)
+		const saveResult = await this.topics.saveLastTopicWithTimeout(
+			context.creativeId,
+			context.id || null,
+			context.clientId,
+		)
+		const outcome = this._outcome(context, saveResult)
+		if (claimed && outcome.saved) this._handleSaved(context, outcome)
+		this._finish(context, outcome, claimed)
+	}
+
+	_claimEcho({ id, effectiveCreativeId, clientId, generation }) {
+		const topics = this.topics
+		const claimed = generation === topics.subscriptionGenerationFor(effectiveCreativeId)
+		if (!claimed) return false
+
+		const previousTopicId = topics.lastKnownRemoteTopicIdFor(effectiveCreativeId)
+		topics.selfEchoState.claim(clientId, {
+			creativeId: effectiveCreativeId,
+			topicId: id,
+			previousTopicId: previousTopicId === undefined ? topics.serverLastTopicId : previousTopicId,
+			possiblyMissed: topics._popupClosed && !topics.topicsSubscription,
+		})
+		return true
+	}
+
+	_outcome(context, saveResult) {
+		const savedRevision = this.topics.normalizeLastTopicRevision(saveResult?.lastTopicRevision)
+		return {
+			saveResult,
+			savedRevision,
+			saved: saveResult === true || saveResult?.success === true,
+			savedRevisionIsCurrent: this.topics.observeLastTopicRevision(
+				context.effectiveCreativeId,
+				savedRevision,
+			),
+			topicId: context.id ? String(context.id) : "",
+			rejected: saveResult === false || saveResult?.success === false,
+			stale: saveResult?.staleLastTopicSave === true,
+		}
+	}
+
+	_handleSaved(context, outcome) {
+		const topics = this.topics
+		const hasPendingSelfEcho = this._recordAcknowledgement(context, outcome)
+		const echoState = this._echoState(context)
+		if (echoState.cannotArrive) {
+			topics.setLastKnownRemoteTopicId(context.effectiveCreativeId, outcome.topicId)
+			if (echoState.missedDuringDisconnect) {
+				topics.retirePendingSelfEcho(context.clientId)
+			} else {
+				topics.releasePendingSelfEcho(context.clientId)
+			}
+			return
+		}
+
+		if (hasPendingSelfEcho && outcome.savedRevisionIsCurrent) {
+			topics.setLastKnownRemoteTopicId(context.effectiveCreativeId, outcome.topicId)
+		}
+		topics.acknowledgePendingSelfEcho(context.clientId)
+	}
+
+	_recordAcknowledgement({ clientId }, { savedRevision }) {
+		const topics = this.topics
+		const hasPendingSelfEcho = topics.pendingSelfEchoes.includes(clientId)
+		if (!hasPendingSelfEcho) return false
+
+		topics.saveAcknowledgementVersion += 1
+		topics.pendingSelfEchoAcknowledgementVersions.set(
+			clientId,
+			topics.saveAcknowledgementVersion,
+		)
+		if (savedRevision) topics.pendingSelfEchoRemoteRevisions.set(clientId, savedRevision)
+		return true
+	}
+
+	_echoState({ effectiveCreativeId, clientId }) {
+		const topics = this.topics
+		const currentCreativeId = String(topics.creativeId)
+		const currentStreamIsResolved = topics.element.dataset.effectiveCreativeId ||
+			topics.knownEffectiveCreativeIds.has(currentCreativeId)
+		const subscribedToAnotherStream = topics.topicsSubscription && currentStreamIsResolved &&
+			String(topics.effectiveCreativeId) !== String(effectiveCreativeId)
+		const missedDuringDisconnect =
+			topics.possiblyMissedPendingSelfEchoesDuringDisconnect.has(clientId)
+		const missedWhileClosed =
+			topics.possiblyMissedPendingSelfEchoes.has(clientId) && !topics.topicsSubscription
+
+		return {
+			missedDuringDisconnect,
+			cannotArrive: missedWhileClosed || subscribedToAnotherStream || missedDuringDisconnect,
+		}
+	}
+
+	_finish(context, outcome, claimed) {
+		const topics = this.topics
+		if (claimed && outcome.rejected) topics.releasePendingSelfEcho(context.clientId)
+		if (claimed && outcome.saveResult === null) {
+			topics.scheduleAmbiguousPendingSelfEchoRetirement(context.clientId)
+		}
+		const pendingPickMatches = topics.selectionState.pendingPickMatches(
+			context.pendingPick,
+			context.creativeId,
+			outcome.topicId,
+		)
+		if (outcome.stale && pendingPickMatches) topics.selectionState.clearPendingPick()
+		if (outcome.saveResult !== null) {
+			topics.retryDeferredLastTopicReconciliation(context.effectiveCreativeId)
+		}
+		if (outcome.saveResult !== false && pendingPickMatches) {
+			topics.selectionState.clearPendingPick()
+		}
+	}
+}

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -8,6 +8,7 @@ import { alertDialog, confirmDialog } from "../../lib/utils/dialog"
 import { invalidateCreativeTree } from '../../lib/creative_tree_invalidation'
 import PopupToggleGuard from '../../lib/popup_toggle_guard'
 import TopicSelectionRestoreState from './topics/selection_restore_state'
+import LastTopicSave from './topics/last_topic_save'
 import LastTopicSaveOrderState, { LAST_TOPIC_SAVE_WINDOW_NAME_PREFIX } from './topics/save_order_state'
 import LastTopicSelfEchoState from './topics/self_echo_state'
 
@@ -28,6 +29,10 @@ export default class extends Controller {
     get saveOrderState() {
         return this._saveOrderState || (this._saveOrderState = new LastTopicSaveOrderState())
     }
+
+	get lastTopicSave() {
+		return this._lastTopicSave || (this._lastTopicSave = new LastTopicSave(this))
+	}
 
     get selfEchoState() {
         return this._selfEchoState || (this._selfEchoState = new LastTopicSelfEchoState())
@@ -1583,115 +1588,11 @@ export default class extends Controller {
         // sticks need not be the last one picked. Waiting for the one in
         // flight is what makes the order they were picked in the order they
         // are written.
-        const save = this.saveOrderState.enqueue(async () => {
-            // update_last_topic broadcasts to every session of this user, this
-            // one included. Claim the echo here, before the request goes out —
-            // the broadcast is sent server-side before the response is
-            // rendered, so it can beat the save returning.
-            const claimed = generation === this.subscriptionGenerationFor(effectiveCreativeId)
-            if (claimed) {
-                this.selfEchoState.claim(clientId, {
-                    creativeId: effectiveCreativeId,
-                    topicId: id,
-                    previousTopicId: this.lastKnownRemoteTopicIdFor(effectiveCreativeId) === undefined
-                        ? this.serverLastTopicId
-                        : this.lastKnownRemoteTopicIdFor(effectiveCreativeId),
-                    possiblyMissed: this._popupClosed && !this.topicsSubscription,
-                })
-                // A save can wait behind another request while the popup closes. It
-                // takes its claim only when the queue reaches it, after the close
-                // handler has already marked the claims that existed then. Its echo
-                // will also be sent into that closed gap, so mark it at creation.
-            }
-            // A thrown fetch has an unknown outcome: the server may have saved
-            // and broadcast before the connection failed, so keep its claim for
-            // that delayed echo. An HTTP failure is definitive, however, and
-            // update_last_topic returns before broadcasting in that case.
-            const saveResult = await this.saveLastTopicWithTimeout(creativeId, id || null, clientId)
-            const saved = saveResult === true || saveResult?.success === true
-            const savedRevision = this.normalizeLastTopicRevision(saveResult?.lastTopicRevision)
-            const savedRevisionIsCurrent = this.observeLastTopicRevision(
-                effectiveCreativeId,
-                savedRevision
-            )
-            const topicId = id ? String(id) : ""
-            const saveRejected = saveResult === false || saveResult?.success === false
-            const staleLastTopicSave = saveResult?.staleLastTopicSave === true
-            if (claimed && saved) {
-                // The Action Cable echo can arrive before this response. In that
-                // case it has already consumed the claim and removed its metadata;
-                // do not recreate an acknowledgement entry for a completed save.
-                const hasPendingSelfEcho = this.pendingSelfEchoes.includes(clientId)
-                if (hasPendingSelfEcho) {
-                    this.saveAcknowledgementVersion += 1
-                    this.pendingSelfEchoAcknowledgementVersions.set(
-                        clientId,
-                        this.saveAcknowledgementVersion
-                    )
-                    // The response can beat its Action Cable echo. Preserve the
-                    // server-issued revision now so a delayed GET can order this
-                    // acknowledged claim against a newer ABA snapshot.
-                    if (savedRevision) {
-                        this.pendingSelfEchoRemoteRevisions.set(clientId, savedRevision)
-                    }
-                }
-                const currentCreativeId = String(this.creativeId)
-                const currentStreamIsResolved = this.element.dataset.effectiveCreativeId ||
-                    this.knownEffectiveCreativeIds.has(currentCreativeId)
-                const subscribedToAnotherStream = this.topicsSubscription && currentStreamIsResolved &&
-                    String(this.effectiveCreativeId) !== String(effectiveCreativeId)
-                const possiblyMissedDuringDisconnect =
-                    this.possiblyMissedPendingSelfEchoesDuringDisconnect.has(clientId)
-                if ((this.possiblyMissedPendingSelfEchoes.has(clientId) && !this.topicsSubscription) ||
-                    subscribedToAnotherStream ||
-                    possiblyMissedDuringDisconnect) {
-                    // update_last_topic broadcasts before it returns. With the popup
-                    // closed, or after its stream was replaced, that echo was necessarily
-                    // sent somewhere this controller can no longer receive it and cannot
-                    // settle this claim.
-                    // This completed save is also the remote baseline for the next
-                    // queued save, which may have claimed after the popup closed.
-                    this.setLastKnownRemoteTopicId(effectiveCreativeId, topicId)
-                    if (possiblyMissedDuringDisconnect) {
-                        this.retirePendingSelfEcho(clientId)
-                    } else {
-                        this.releasePendingSelfEcho(clientId)
-                    }
-                } else {
-                    // The replacement subscription may have been active before this
-                    // response beat the WebSocket message back to the browser. Keep the
-                    // id to consume that echo, but do not use this acknowledged claim to
-                    // override a later reopen snapshot.
-                    // A completed save establishes the server value that the
-                    // next claim was made from. Without moving this baseline,
-                    // a later closed save compares its reopen snapshot to a
-                    // value from before an earlier local save and mistakes the
-                    // legitimate previous value for another session's update.
-                    // Do not overwrite a newer Action Cable update after this
-                    // save's echo has already been consumed: that echo records
-                    // the baseline at broadcast time, and another message may
-                    // have advanced it before the HTTP response arrived.
-                    if (hasPendingSelfEcho && savedRevisionIsCurrent) {
-                        this.setLastKnownRemoteTopicId(effectiveCreativeId, topicId)
-                    }
-                    this.acknowledgePendingSelfEcho(clientId)
-                }
-            }
-            if (claimed && saveRejected) this.releasePendingSelfEcho(clientId)
-            if (claimed && saveResult === null) {
-                this.scheduleAmbiguousPendingSelfEchoRetirement(clientId)
-            }
-            const rejectedPendingPick = staleLastTopicSave &&
-                this.selectionState.pendingPickMatches(pendingPick, creativeId, topicId)
-            if (rejectedPendingPick) this.selectionState.clearPendingPick()
-            if (saveResult !== null) this.retryDeferredLastTopicReconciliation(effectiveCreativeId)
-            if (saveResult !== false &&
-                this.selectionState.pendingPickMatches(pendingPick, creativeId, topicId)) {
-                this.selectionState.clearPendingPick()
-            }
-        })
-        return save
-    }
+		const context = {
+			id, creativeId, effectiveCreativeId, clientId, pendingPick, generation,
+		}
+		return this.lastTopicSave.enqueue(context)
+	}
 
     // A timed-out fetch can still be running on Rails. Prefix each echo id with
     // a controller-local session and monotonically increasing sequence so Rails

--- a/engines/collavre/app/javascript/modules/__tests__/creative_save_state.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/creative_save_state.test.js
@@ -116,20 +116,21 @@ test('applies server markdown substitutions to cached and live content', () => {
   expect(result.currentApplied).toBe(true)
 })
 
-test('resets baselines and keeps a newer buffer dirty', () => {
+test('resets baselines and preserves dirty state for a newer buffer', () => {
   const snapshot = captureCreativeSaveSnapshot({
     content: 'saved', progress: 1, persistProgress: true, originId: '7',
   })
 
-  expect(resetCreativeSaveState(snapshot, {
-    content: 'newer', progress: 1, originId: '7',
-  })).toEqual({
+  const newerBuffer = { content: 'newer', progress: 1, originId: '7' }
+
+  expect(resetCreativeSaveState(snapshot, newerBuffer, true)).toEqual({
     originalContent: 'saved',
     originalProgress: 1,
     originalOriginId: '7',
     isDirty: true,
     pendingSave: false,
   })
+  expect(resetCreativeSaveState(snapshot, newerBuffer, false).isDirty).toBe(false)
   expect(resetCreativeSaveState(snapshot).isDirty).toBe(false)
 })
 

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -817,7 +817,7 @@ function setupEditorSession() {
               content: markdownMode ? (markdownTextarea?.value || '') : descriptionInput.value,
               progress: readProgressValue(),
               originId: originIdInput?.value || '',
-            });
+	    }, isDirty);
             originalContent = reset.originalContent;
             if (reset.originalProgress !== undefined) originalProgress = reset.originalProgress;
             originalOriginId = reset.originalOriginId;

--- a/engines/collavre/app/javascript/modules/creative_save_state.js
+++ b/engines/collavre/app/javascript/modules/creative_save_state.js
@@ -117,7 +117,7 @@ export function applyCreativeSaveResponse(snapshot, data, {
   }
 }
 
-export function resetCreativeSaveState(snapshot, current = null) {
+export function resetCreativeSaveState(snapshot, current = null, currentDirty = false) {
   const matchesSnapshot = !current || (
     current.content === snapshot.content &&
     current.progress === snapshot.progress &&
@@ -128,7 +128,7 @@ export function resetCreativeSaveState(snapshot, current = null) {
     originalContent: snapshot.content,
     originalProgress: snapshot.persistProgress ? snapshot.progress : undefined,
     originalOriginId: snapshot.originId,
-    isDirty: !matchesSnapshot,
+    isDirty: matchesSnapshot ? false : currentDirty,
     pendingSave: false,
   }
 }


### PR DESCRIPTION
## Summary

- split draft persistence and key migration into focused classes
- move last-topic save response handling into a focused collaborator
- replace five-argument read-pointer and draft-observation calls with options objects
- preserve popup and trigger files for their separately assigned follow-up

## Complexity

- integration target: `Complexity ratchet OK — 588 entities over budget (603 at 254fdc0cd5e0), none grew.`
- `origin/main`: the 14 comment-read, draft, and topic-save blockers are removed
- the only remaining main-comparison blockers are the three separately owned `popup_fullscreen.js` entries
- no threshold, waiver, or ratchet implementation changes

## Validation

- focused Jest: 136 tests passed
- full Jest: 162 suites / 2,341 tests passed
- build passed
- complexity Ruby tests: 83 runs / 203 assertions passed
- RuboCop: 1,358 files, no offenses