### PR TITLE
Stabilize Collavre save and tree refresh system tests

### DIFF
--- a/engines/collavre/test/system/creative_move_menu_system_test.rb
+++ b/engines/collavre/test/system/creative_move_menu_system_test.rb
@@ -292,11 +292,13 @@ class CreativeMoveMenuSystemTest < ApplicationSystemTestCase
 
     # The launcher falls back to the creative on screen, so the move has to land
     # on the source and leave the previously selected child where it is.
+    mark_row_before_tree_refresh(child)
     open_move_menu
     pick_destination
     find('[data-creative-move-target="confirm"]').click
 
     assert_no_selector "dialog[open][data-creative-move-target]"
+    assert_row_replaced_by_tree_refresh(child)
     assert_equal @destination, @source.reload.parent
     assert_equal @source, child.reload.parent
 
@@ -340,6 +342,16 @@ class CreativeMoveMenuSystemTest < ApplicationSystemTestCase
     find('[aria-controls="creative-overflow-menu"]').click
     find("#select-creative-btn").click
     creatives.each { |creative| find("#creative-#{creative.id} .select-creative-checkbox").click }
+  end
+
+  def mark_row_before_tree_refresh(creative)
+    page.execute_script(<<~JS, "#creative-#{creative.id}")
+      document.querySelector(arguments[0]).dataset.beforeMoveRefresh = 'true'
+    JS
+  end
+
+  def assert_row_replaced_by_tree_refresh(creative)
+    assert_no_selector "#creative-#{creative.id}[data-before-move-refresh]", visible: :all, wait: 10
   end
 
   # Fails only the tree JSON request (/creatives?format=json) so the rest of the

--- a/engines/collavre/test/system/creative_progress_toggle_keyboard_test.rb
+++ b/engines/collavre/test/system/creative_progress_toggle_keyboard_test.rb
@@ -60,6 +60,10 @@ class CreativeProgressToggleKeyboardTest < ApplicationSystemTestCase
     press_space
   end
 
+  def wait_for_progress_save
+    assert_no_selector "#{toggle_selector}.progress-toggle-saving", wait: 10
+  end
+
   test "space toggles a leaf between complete and incomplete" do
     assert_selector "#{toggle_selector}[data-current-progress='0']"
 
@@ -67,14 +71,14 @@ class CreativeProgressToggleKeyboardTest < ApplicationSystemTestCase
 
     assert_selector "#{toggle_selector}[data-current-progress='1']", wait: 5
     assert_selector "#{toggle_selector} .progress-toggle-checkbox:checked", visible: :all
-    wait_for_network_idle(timeout: 10)
+    wait_for_progress_save
     assert_equal 1, @leaf.reload.progress
 
     press_space_on_checkbox
 
     assert_selector "#{toggle_selector}[data-current-progress='0']", wait: 5
     assert_no_selector "#{toggle_selector} .progress-toggle-checkbox:checked", visible: :all
-    wait_for_network_idle(timeout: 10)
+    wait_for_progress_save
     assert_equal 0, @leaf.reload.progress
   end
 
@@ -100,7 +104,7 @@ class CreativeProgressToggleKeyboardTest < ApplicationSystemTestCase
     press_space
 
     assert_selector "#{toggle_selector}[data-current-progress='1']", wait: 5
-    wait_for_network_idle(timeout: 10)
+    wait_for_progress_save
     assert_equal 1, @leaf.reload.progress
     # The broadcast for this update re-renders the row a second time, after the
     # PATCH response already did, so focus has to survive both. Hold the
@@ -111,7 +115,7 @@ class CreativeProgressToggleKeyboardTest < ApplicationSystemTestCase
     press_space
 
     assert_selector "#{toggle_selector}[data-current-progress='0']", wait: 5
-    wait_for_network_idle(timeout: 10)
+    wait_for_progress_save
     assert_equal 0, @leaf.reload.progress
   end
 


### PR DESCRIPTION
## Summary

- wait for the progress toggle's real save lifecycle instead of the XHR-only network helper
- wait for the post-move tree row replacement before making a fresh selection
- keep production code and the row-editor save implementation unchanged

## Root cause

Both failures from run 34450816728 are test synchronization races, not product regressions. The progress path uses `fetch` in `creative_tree_row.js`, which the existing XHR-only helper does not observe. The history test starts its second selection before the first move's debounced tree refetch replaces the row. The latter reproduces unchanged at the pre-#1652 base (`d2c8d71f`) with the same seed.

## Verification

- both reported tests: 5 repeated passes each after the change
- both test files together: reported cases pass
- `PARALLEL_WORKERS=4 bundle exec rake test:system`: reported cases pass; one unrelated existing `InlineScriptsTest` race failed
- `bin/rubocop -a`: 1,358 files, no offenses
- `bin/complexity_check --base origin/feature/refactor-reduce-dupl`: pass
