### PR TITLE
Fix DOM XSS in creative HTML emptiness checks

### DIFF
--- a/engines/collavre/app/javascript/modules/__tests__/html_content_empty.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/html_content_empty.test.js
@@ -38,4 +38,15 @@ describe('isHtmlEmpty', () => {
   test('returns false for [data-trix-attachment]-only HTML', () => {
     expect(isHtmlEmpty('<div data-trix-attachment=\'{"sgid":"x"}\'></div>')).toBe(false);
   });
+
+  test('parses untrusted HTML without assigning it to the active document', () => {
+    let activeDocumentSinkUsed = false;
+    const liveDocument = {
+      defaultView: { DOMParser },
+      createElement: () => { activeDocumentSinkUsed = true; }
+    };
+
+    expect(isHtmlEmpty('<img src="invalid" onerror="alert(1)">', liveDocument)).toBe(false);
+    expect(activeDocumentSinkUsed).toBe(false);
+  });
 });

--- a/engines/collavre/app/javascript/modules/html_content_empty.js
+++ b/engines/collavre/app/javascript/modules/html_content_empty.js
@@ -4,9 +4,11 @@
 // don't get discarded silently when switching editor modes.
 export function isHtmlEmpty(html, doc = typeof document !== 'undefined' ? document : null) {
   if (!html) return true;
-  if (!doc) return html.replace(/<[^>]*>/g, '').trim().length === 0;
-  const temp = doc.createElement('div');
-  temp.innerHTML = html;
+  const Parser = doc?.defaultView?.DOMParser ?? globalThis.DOMParser;
+  if (!Parser) return html.replace(/<[^>]*>/g, '').trim().length === 0;
+  // Parse in an inert document: even a detached element in the active document
+  // can execute resource event handlers when untrusted HTML is assigned to it.
+  const temp = new Parser().parseFromString(html, 'text/html').body;
   if (temp.querySelector('img, action-text-attachment, figure.attachment, [data-trix-attachment]')) return false;
   return (temp.textContent || '').trim().length === 0;
 }


### PR DESCRIPTION
## Summary

- parse editable HTML in a detached inert document instead of assigning it to an active-document element
- preserve text and attachment emptiness semantics
- add a regression test that forbids the active-document HTML sink

## Security analysis

CodeQL alert #33 traces DOM-derived editor values from three save/toggle paths into `isHtmlEmpty`. Assigning an attacker-controlled `<img onerror>` payload to `innerHTML` on a detached active-document element still executes the handler in Chrome. `DOMParser.parseFromString(..., "text/html")` keeps the parsed document inert while allowing the same text and attachment queries.

## Verification

- focused Jest: 15 tests passed
- full Jest: 2,342 tests passed
- Ruby: 4,886 tests / 17,084 assertions passed
- system: 134 tests passed, 2 existing skips
- `npm run build`
- `./bin/rubocop -a`
- complexity ratchet against `feature/refactor-reduce-dupl`: no growth

Addresses CodeQL alert #33.