### PR TITLE
fix: restore gateway health probes on PostgreSQL

### DIFF
--- a/engines/collavre/app/models/collavre/agent_gateway.rb
+++ b/engines/collavre/app/models/collavre/agent_gateway.rb
@@ -53,7 +53,8 @@ module Collavre
 
     scope :active, -> { where(active: true) }
     scope :health_probe_targets, -> do
-      active.joins(:agents).merge(User.where(llm_vendor: "cli_proxy")).distinct
+      assigned_gateway_ids = User.where(llm_vendor: "cli_proxy").select(:agent_gateway_id)
+      active.where(id: assigned_gateway_ids)
     end
 
     def chat_capable?

--- a/engines/collavre/test/jobs/gateway_health_jobs_test.rb
+++ b/engines/collavre/test/jobs/gateway_health_jobs_test.rb
@@ -29,6 +29,16 @@ class Collavre::GatewayHealthJobsTest < ActiveSupport::TestCase
     assert_not_includes probed, inactive.id
   end
 
+  test "the target relation loads whole gateway rows without distinct" do
+    assign_gateway
+    assign_gateway
+    relation = Collavre::AgentGateway.health_probe_targets
+
+    assert_equal @gateway, relation.find_by(id: @gateway.id)
+    assert_no_match(/SELECT\s+DISTINCT/i, relation.to_sql,
+      "PostgreSQL cannot apply DISTINCT to the gateway health_engines json column")
+  end
+
   test "the probe records a verdict for the gateway it names" do
     assign_gateway
     body = { "status" => "ok", "engines" => { "ready" => 1, "total" => 1 } }

--- a/script/postgres_query_smoke.rb
+++ b/script/postgres_query_smoke.rb
@@ -57,5 +57,12 @@ check(failures, "AgentResolver.call(name, creative:)") do
     raise("expected the searchable agent to resolve")
 end
 
+# Reached by each queued gateway health probe. Agent gateways carry a json
+# health_engines column, so this relation must not select whole rows with
+# DISTINCT either.
+check(failures, "AgentGateway.health_probe_targets") do
+  Collavre::AgentGateway.health_probe_targets.find_by(id: -1)
+end
+
 abort "\n#{failures.size} PostgreSQL-incompatible query/queries:\n- #{failures.join("\n- ")}" if failures.any?
 puts "\nAll guarded queries execute on PostgreSQL."


### PR DESCRIPTION
## Summary

- replace the whole-row `DISTINCT` gateway target query with an ID subquery
- preserve one probe per active gateway assigned to a CLI proxy agent
- add SQLite SQL-shape coverage and execute the job-path lookup in the PostgreSQL smoke suite

## Root cause

Production PostgreSQL cannot apply `DISTINCT` to `agent_gateways.*` because `health_engines` is a `json` column. Every scheduled health probe failed before contacting the gateway, leaving health verdicts unknown and gateway-backed agents offline.

## Verification

- `bundle exec rake test` (4,984 runs, 17,329 assertions)
- focused gateway/PostgreSQL compatibility tests (11 runs, 45 assertions)
- PostgreSQL 14 schema load and `script/postgres_query_smoke.rb`
- `./bin/rubocop -a` (1,369 files)
- `bin/complexity_check --base origin/main`

## Local system test note

The core Collavre system suite passed (134 runs, 898 assertions). Two existing `collavre_plan` modal visibility tests failed locally; this PR does not modify UI or plan code.