### PR TITLE
feat: add optional vendor endpoint health checks

### DIFF
--- a/config/queue.yml
+++ b/config/queue.yml
@@ -34,12 +34,10 @@ default: &default
       threads: 1
       processes: 1
       polling_interval: 0.1
-    # Dedicated worker for gateway readiness probes. A probe spends up to
-    # OPEN_TIMEOUT + READ_TIMEOUT blocked on an unreachable host, and the sweep
-    # enqueues one per gateway every minute, so on the default worker a handful
-    # of dead gateways would hold its threads and stall user-facing jobs. Keep
-    # enough threads to drain the supported active-gateway count within
-    # AgentGateway::HEALTH_TTL; see docs/agent_gateway_health.md.
+    # Dedicated worker for gateway and vendor endpoint health probes. Probes
+    # spend seconds blocked on unreachable hosts, so they must not hold threads
+    # needed by user-facing jobs. Size this pool to drain all configured probes
+    # within their three-minute TTL; see docs/agent_gateway_health.md.
     - queues: [gateway_health]
       threads: <%= ENV.fetch("GATEWAY_HEALTH_THREADS", 12) %>
       processes: 1

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -11,6 +11,10 @@ production: &production
     class: Collavre::GatewayHealthSweepJob
     queue: gateway_health
     schedule: every minute
+  endpoint_health_sweep:
+    class: Collavre::EndpointHealthSweepJob
+    queue: gateway_health
+    schedule: every minute
   restore_dropped_dispatches:
     class: Collavre::RestoreDroppedDispatchesJob
     queue: default
@@ -37,6 +41,10 @@ desktop:
     class: Collavre::GatewayHealthSweepJob
     queue: gateway_health
     schedule: every minute
+  endpoint_health_sweep:
+    class: Collavre::EndpointHealthSweepJob
+    queue: gateway_health
+    schedule: every minute
   restore_dropped_dispatches:
     class: Collavre::RestoreDroppedDispatchesJob
     queue: default
@@ -61,6 +69,10 @@ development:
     schedule: every minute
   gateway_health_sweep:
     class: Collavre::GatewayHealthSweepJob
+    queue: gateway_health
+    schedule: every minute
+  endpoint_health_sweep:
+    class: Collavre::EndpointHealthSweepJob
     queue: gateway_health
     schedule: every minute
   restore_dropped_dispatches:

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_09_10_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_11_000000) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -1024,6 +1024,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_10_000000) do
     t.json "dismissed_notices"
     t.string "email", null: false
     t.datetime "email_verified_at"
+    t.datetime "endpoint_health_checked_at"
+    t.string "endpoint_health_error"
+    t.integer "endpoint_health_status", default: 0, null: false
     t.integer "failed_login_attempts", default: 0, null: false
     t.string "gateway_url"
     t.string "google_access_token"

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,8 +37,8 @@ thin agent entry point that indexes into this directory.
 - [google-auth.md](google-auth.md)
 - [mcp-configuration.md](mcp-configuration.md)
 - [linked_creative.md](linked_creative.md)
-- [agent_gateway_health.md](agent_gateway_health.md) — how a CLI proxy
-  gateway's `/health/ready` verdict becomes an agent's online dot.
+- [agent_gateway_health.md](agent_gateway_health.md) — how optional vendor
+  endpoint checks and CLI proxy readiness become an agent's online status.
 
 ## Operations & Infrastructure
 

--- a/docs/agent_gateway_health.md
+++ b/docs/agent_gateway_health.md
@@ -1,4 +1,53 @@
-# Agent gateway health and agent presence
+# Agent endpoint health and agent presence
+
+Vendor health checks are optional extensions registered through
+`Collavre::AgentHealth.register(vendor, checker)`. A missing checker means
+Collavre has no liveness evidence for that vendor; it does not block or skip an
+agent call. Checker results are cached on the agent row and are read only for
+status presentation.
+
+A checker implements `initialize(agent:)` and `call`, returning an
+`AgentHealth::Result` with `online`, `offline`, or `unknown`. It may be supplied
+by a satellite engine without adding a dependency from core back to that
+engine:
+
+```ruby
+class VendorEndpointChecker
+  def initialize(agent:)
+    @agent = agent
+  end
+
+  def call
+    Collavre::AgentHealth::Result.new(status: :online)
+  end
+end
+
+Collavre::AgentHealth.register("vendor_name", VendorEndpointChecker)
+```
+
+The probe owns `check_error`; a checker should raise when its own implementation
+cannot produce a valid verdict. The probe contains that exception, records the
+error state, and never changes dispatch behavior.
+
+Core registers an OpenAI-compatible checker. Once a minute it sends
+`GET {gateway_url}/models`, or `GET https://api.openai.com/v1/models` when the
+agent has no custom base URL. It uses the same agent or integration API key as
+the normal OpenAI client. This proves endpoint reachability and, where the
+route supports it, authentication; it deliberately does not make a completion
+request and therefore does not claim that inference for a particular model
+will succeed.
+
+The endpoint checker records `online`, `offline`, `unknown`, or `check_error`.
+An unexpected checker exception is contained and displayed as a health-check
+error. Results expire after three minutes, and changing the vendor, base URL,
+or API key invalidates the cached verdict immediately. Non-administrator URLs
+use the same DNS pinning and private-network rejection policy as CLI proxy
+requests; redirects are not followed.
+
+Endpoint probes share the dedicated `gateway_health` worker with CLI proxy
+probes. For capacity planning, provision at least
+`ceil((gateways * 22 + endpoint agents * 11) / 180)` threads: a legacy gateway
+can consume two 11-second requests, while one endpoint agent consumes one.
 
 An agent whose runs go through a CLI proxy gateway is only usable while that
 gateway can still reach the CLI behind it. Collavre polls each registered
@@ -116,5 +165,5 @@ profile popup is not torn out from under the user. A confirmed 401/403/404 uses
 the same revocation path as the live share event: it disables the composer,
 clears or closes the chat, and invalidates the workspace tree.
 
-Agents on a hosted vendor API publish no liveness evidence either way and are
-left out rather than asserted online.
+Agents for a vendor with no registered checker publish no liveness evidence
+either way and are shown as unknown rather than asserted online or offline.

--- a/docs/agent_gateway_health.md
+++ b/docs/agent_gateway_health.md
@@ -32,7 +32,11 @@ error state, and never changes dispatch behavior.
 Core registers an OpenAI-compatible checker. Once a minute it sends
 `GET {gateway_url}/models`, or `GET https://api.openai.com/v1/models` when the
 agent has no custom base URL. It uses the same agent or integration API key as
-the normal OpenAI client. This proves endpoint reachability and, where the
+the normal OpenAI client. Both paths use `Collavre::OpenaiEndpoint` to restrict
+the shared integration key to the official HTTPS endpoint (including equivalent
+host casing, port 443, and trailing slashes). Custom endpoints use only their
+per-agent key; keyless dispatch retains its non-secret `local-gateway` placeholder
+while the checker omits Authorization. This proves endpoint reachability and, where the
 route supports it, authentication; it deliberately does not make a completion
 request and therefore does not claim that inference for a particular model
 will succeed.

--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -1600,6 +1600,11 @@ body.chat-fullscreen {
 .ai-agent-draggable:active,
 .ai-agent-draggable.dragging {
     cursor: grabbing;
+}
+
+.ai-agent-draggable.dragging {
+    /* Opacity on :active traps the fixed profile menu in a stacking context
+       during a tap, redirecting the native click to content beneath it. */
     opacity: 0.5;
 }
 

--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -385,6 +385,14 @@ body.chat-fullscreen {
     background: var(--color-success);
 }
 
+.comment-user-popup-status.is-check_error .comment-user-popup-status-dot {
+    background: var(--color-danger);
+}
+
+.comment-user-popup-status.is-unknown .comment-user-popup-status-dot {
+    background: var(--color-warning);
+}
+
 .comment-user-popup-guide {
     margin: var(--space-2) var(--space-2) var(--space-1);
     padding-top: var(--space-2);

--- a/engines/collavre/app/components/collavre/comment_user_menu_component.html.erb
+++ b/engines/collavre/app/components/collavre/comment_user_menu_component.html.erb
@@ -25,7 +25,9 @@
         <span class="comment-user-popup-status"
               data-comment-user-menu-target="status"
               data-online-text="<%= t('collavre.comments.participant_online') %>"
-              data-offline-text="<%= t('collavre.comments.participant_offline') %>">
+              data-offline-text="<%= t('collavre.comments.participant_offline') %>"
+              data-unknown-text="<%= t('collavre.comments.participant_health_unknown') %>"
+              data-check-error-text="<%= t('collavre.comments.participant_health_check_error') %>">
           <span class="comment-user-popup-status-dot" aria-hidden="true"></span>
           <span data-comment-user-menu-target="statusLabel"><%= t('collavre.comments.participant_offline') %></span>
         </span>

--- a/engines/collavre/app/controllers/collavre/comments_controller.rb
+++ b/engines/collavre/app/controllers/collavre/comments_controller.rb
@@ -149,10 +149,12 @@ module Collavre
       ActiveRecord::Associations::Preloader.new(records: users, associations: :agent_gateway).call
       live_claude_agent_ids = live_claude_agent_ids_for(users)
       user_data = users.map do |user|
+        liveness_status = user.agent_liveness_status(live_claude_agent_ids: live_claude_agent_ids)
         view_context.user_json(user, email: true, ai_user: true)
                     .merge(
                       profile_url: user_path(user),
-                      agent_online: user.agent_online?(live_claude_agent_ids: live_claude_agent_ids)
+                      agent_online: liveness_status == :online,
+                      agent_health_status: user.ai_user? ? liveness_status : nil
                     )
       end
       response.headers["Cache-Control"] = "no-store"

--- a/engines/collavre/app/controllers/concerns/collavre/users_controller/ai_user_management.rb
+++ b/engines/collavre/app/controllers/concerns/collavre/users_controller/ai_user_management.rb
@@ -75,18 +75,7 @@ module Collavre
 
     def update_ai
       ai_params = params.require(:user).permit(:name, :system_prompt, :llm_vendor, :llm_model, :llm_api_key, :clear_llm_api_key, :gateway_url, :agent_gateway_id, :searchable, :routing_expression, :agent_conf, tools: [])
-      effective_vendor = ai_params[:llm_vendor].presence || @user.llm_vendor
-      if effective_vendor == "cli_proxy" && ai_params.key?(:agent_gateway_id)
-        gateways = gateway_owner_for(@user).owned_agent_gateways
-        gateway = if ai_params[:agent_gateway_id].to_s == @user.agent_gateway_id.to_s
-          gateways.find_by(id: ai_params[:agent_gateway_id])
-        else
-          gateways.active.find_by(id: ai_params[:agent_gateway_id])
-        end
-        ai_params[:agent_gateway_id] = gateway&.id
-      elsif ai_params.key?(:llm_vendor)
-        ai_params[:agent_gateway_id] = nil
-      end
+      assign_ai_gateway(ai_params)
       clear_llm_api_key = ActiveModel::Type::Boolean.new.cast(ai_params.delete(:clear_llm_api_key))
       @has_stored_llm_api_key = @user.llm_api_key.present?
       @clear_llm_api_key = clear_llm_api_key
@@ -171,8 +160,23 @@ module Collavre
       end
     end
 
+    def assign_ai_gateway(ai_params)
+      effective_vendor = (ai_params[:llm_vendor].presence || @user.llm_vendor).to_s.strip.downcase
+      if effective_vendor == "cli_proxy" && ai_params.key?(:agent_gateway_id)
+        gateways = gateway_owner_for(@user).owned_agent_gateways
+        gateway = if ai_params[:agent_gateway_id].to_s == @user.agent_gateway_id.to_s
+          gateways.find_by(id: ai_params[:agent_gateway_id])
+        else
+          gateways.active.find_by(id: ai_params[:agent_gateway_id])
+        end
+        ai_params[:agent_gateway_id] = gateway&.id
+      elsif effective_vendor != "cli_proxy" && ai_params.key?(:llm_vendor)
+        ai_params[:agent_gateway_id] = nil
+      end
+    end
+
     def selected_agent_gateway
-      return unless params[:llm_vendor] == "cli_proxy"
+      return unless params[:llm_vendor].to_s.strip.downcase == "cli_proxy"
 
       Current.user.owned_agent_gateways.active.find_by(id: params[:agent_gateway_id])
     end

--- a/engines/collavre/app/javascript/comments/__tests__/user_menu.test.js
+++ b/engines/collavre/app/javascript/comments/__tests__/user_menu.test.js
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { createUserMenu } from '../user_menu'
+import { createUserMenu, healthStateFor, healthStateForUserId } from '../user_menu'
 
 const LABELS = {
   open: 'Open %{name}\'s profile menu',
@@ -10,6 +10,8 @@ const LABELS = {
   dragGuide: 'Drag this avatar to a topic.',
   online: 'Online',
   offline: 'Offline',
+  unknown: 'Health status unavailable',
+  check_error: 'Health check error',
 }
 
 const USER = {
@@ -23,6 +25,31 @@ const USER = {
 }
 
 describe('createUserMenu', () => {
+  test('maps presence and endpoint health evidence to display states', () => {
+    expect(healthStateFor(null, [], LABELS)).toEqual({ online: false, kind: 'offline', label: 'Offline' })
+    expect(healthStateFor({ ...USER, ai_user: false }, [], LABELS))
+      .toEqual({ online: false, kind: 'offline', label: 'Offline' })
+    expect(healthStateFor({ ...USER, ai_user: true }, [9], LABELS))
+      .toEqual({ online: true, kind: 'online', label: 'Online' })
+    expect(healthStateFor({ ...USER, ai_user: true, agent_online: true }, [], LABELS))
+      .toEqual({ online: true, kind: 'online', label: 'Online' })
+    expect(healthStateFor({ ...USER, ai_user: true, agent_health_status: 'offline' }, [], LABELS))
+      .toEqual({ online: false, kind: 'offline', label: 'Offline' })
+    expect(healthStateFor({ ...USER, ai_user: true, agent_health_status: 'invalid' }, [], LABELS))
+      .toEqual({ online: false, kind: 'unknown', label: 'Health status unavailable' })
+  })
+
+  test('resolves display state by user id with a chat-presence fallback', () => {
+    const users = [{ ...USER, ai_user: true, agent_health_status: 'check_error' }]
+
+    expect(healthStateForUserId(users, 9, [], LABELS))
+      .toEqual({ online: false, kind: 'check_error', label: 'Health check error' })
+    expect(healthStateForUserId(users, 10, [10], LABELS))
+      .toEqual({ online: true, kind: 'online', label: 'Online' })
+    expect(healthStateForUserId(null, 10, [], LABELS))
+      .toEqual({ online: false, kind: 'offline', label: 'Offline' })
+  })
+
   test('builds the complete online profile menu without drag guidance', () => {
     const menu = createUserMenu({
       user: USER,
@@ -64,5 +91,20 @@ describe('createUserMenu', () => {
     expect(menu.querySelector('.comment-user-popup-status').classList.contains('is-online')).toBe(false)
     expect(menu.querySelector('[data-comment-user-menu-target="statusLabel"]').textContent).toBe('Offline')
     expect(menu.querySelector('.comment-user-popup-guide').textContent).toBe(LABELS.dragGuide)
+  })
+
+  test('shows a checker error separately from ordinary offline state', () => {
+    const menu = createUserMenu({
+      user: USER,
+      online: false,
+      healthStatus: 'check_error',
+      statusText: LABELS.check_error,
+      labels: LABELS,
+      menuId: 'participant-user-menu-9',
+    })
+
+    expect(menu.querySelector('.comment-user-popup-status').classList.contains('is-check_error')).toBe(true)
+    expect(menu.querySelector('[data-comment-user-menu-target="statusLabel"]').textContent)
+      .toBe('Health check error')
   })
 })

--- a/engines/collavre/app/javascript/comments/user_menu.js
+++ b/engines/collavre/app/javascript/comments/user_menu.js
@@ -27,7 +27,30 @@ function avatarElement(user, size, classes) {
   return wrapper
 }
 
-function menuHeader(user, online, labels) {
+export function healthStateFor(user, presentIds, labels) {
+  if (!user) return { online: false, kind: 'offline', label: labels.offline }
+
+  const present = (presentIds || []).some((id) => String(id) === String(user.id))
+  if (present || user.agent_online === true) {
+    return { online: true, kind: 'online', label: labels.online }
+  }
+  if (!user.ai_user) return { online: false, kind: 'offline', label: labels.offline }
+
+  const kind = ['offline', 'unknown', 'check_error'].includes(user.agent_health_status)
+    ? user.agent_health_status
+    : 'unknown'
+  return { online: false, kind, label: labels[kind] }
+}
+
+export function healthStateForUserId(users, userId, presentIds, labels) {
+  const user = (users || []).find((entry) => String(entry.id) === String(userId))
+  if (user) return healthStateFor(user, presentIds, labels)
+
+  const online = (presentIds || []).some((id) => String(id) === String(userId))
+  return { online, kind: online ? 'online' : 'offline', label: online ? labels.online : labels.offline }
+}
+
+function menuHeader(user, state, labels) {
   const header = document.createElement('div')
   header.className = 'comment-user-popup-header'
   header.appendChild(avatarElement(user, 36, 'avatar'))
@@ -45,7 +68,7 @@ function menuHeader(user, online, labels) {
   identity.appendChild(email)
 
   const status = document.createElement('span')
-  status.className = `comment-user-popup-status${online ? ' is-online' : ''}`
+  status.className = `comment-user-popup-status is-${state.kind}`
   status.dataset.commentUserMenuTarget = 'status'
   status.dataset.onlineText = labels.online
   status.dataset.offlineText = labels.offline
@@ -57,7 +80,7 @@ function menuHeader(user, online, labels) {
 
   const statusLabel = document.createElement('span')
   statusLabel.dataset.commentUserMenuTarget = 'statusLabel'
-  statusLabel.textContent = online ? labels.online : labels.offline
+  statusLabel.textContent = state.label
   status.appendChild(statusLabel)
   identity.appendChild(status)
   header.appendChild(identity)
@@ -65,7 +88,12 @@ function menuHeader(user, online, labels) {
   return header
 }
 
-export function createUserMenu({ user, online, labels, menuId, draggable = false }) {
+export function createUserMenu({ user, online, healthStatus, statusText, labels, menuId, draggable = false }) {
+  const state = {
+    online,
+    kind: healthStatus || (online ? 'online' : 'offline'),
+    label: statusText || (online ? labels.online : labels.offline),
+  }
   const root = document.createElement('div')
   root.className = 'popup-menu-wrapper comment-user-menu'
   root.dataset.controller = 'popup-menu comment-user-menu'
@@ -89,7 +117,7 @@ export function createUserMenu({ user, online, labels, menuId, draggable = false
   menu.dataset.popupMenuTarget = 'menu'
   menu.dataset.action = 'click->popup-menu#menuClick'
   menu.setAttribute('role', 'menu')
-  menu.appendChild(menuHeader(user, online, labels))
+  menu.appendChild(menuHeader(user, state, labels))
 
   const profile = document.createElement('a')
   profile.href = user.profile_url

--- a/engines/collavre/app/javascript/comments/user_menu.js
+++ b/engines/collavre/app/javascript/comments/user_menu.js
@@ -88,12 +88,16 @@ function menuHeader(user, state, labels) {
   return header
 }
 
-export function createUserMenu({ user, online, healthStatus, statusText, labels, menuId, draggable = false }) {
-  const state = {
+function menuState(online, healthStatus, statusText, labels) {
+  return {
     online,
     kind: healthStatus || (online ? 'online' : 'offline'),
     label: statusText || (online ? labels.online : labels.offline),
   }
+}
+
+export function createUserMenu({ user, online, healthStatus, statusText, labels, menuId, draggable = false }) {
+  const state = menuState(online, healthStatus, statusText, labels)
   const root = document.createElement('div')
   root.className = 'popup-menu-wrapper comment-user-menu'
   root.dataset.controller = 'popup-menu comment-user-menu'

--- a/engines/collavre/app/javascript/controllers/__tests__/comment_user_menu_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/comment_user_menu_controller.test.js
@@ -61,16 +61,32 @@ describe('CommentUserMenuController', () => {
   // A gateway-backed agent is online without being present in the chat, and the
   // avatar on its message must not contradict the one in the participant strip.
   test('defers to the presence controller so agent liveness reads the same everywhere', () => {
-    const presence = { isUserOnline: jest.fn(() => true) }
+    const presence = {
+      userHealthState: jest.fn(() => ({ online: true, kind: 'online', label: 'Online' }))
+    }
     jest.spyOn(application, 'getControllerForElementAndIdentifier').mockImplementation((_element, identifier) => (
       identifier === 'comments--presence' ? presence : null
     ))
 
     popup.dispatchEvent(new CustomEvent('comments--presence:changed', { detail: { presentIds: [] } }))
 
-    expect(presence.isUserOnline).toHaveBeenCalledWith(9, [])
+    expect(presence.userHealthState).toHaveBeenCalledWith(9, [])
     expect(controller.statusTarget.classList.contains('is-online')).toBe(true)
     expect(controller.statusLabelTarget.textContent).toBe('Online')
+  })
+
+  test('shows a checker error returned by the presence controller', () => {
+    const presence = {
+      userHealthState: jest.fn(() => ({ online: false, kind: 'check_error', label: 'Health check error' }))
+    }
+    jest.spyOn(application, 'getControllerForElementAndIdentifier').mockImplementation((_element, identifier) => (
+      identifier === 'comments--presence' ? presence : null
+    ))
+
+    controller.updatePresence([])
+
+    expect(controller.statusTarget.classList.contains('is-check_error')).toBe(true)
+    expect(controller.statusLabelTarget.textContent).toBe('Health check error')
   })
 
   test('inserts a mention and focuses the composer', () => {

--- a/engines/collavre/app/javascript/controllers/comment_user_menu_controller.js
+++ b/engines/collavre/app/javascript/controllers/comment_user_menu_controller.js
@@ -64,12 +64,20 @@ export default class extends Controller {
     // gateway-backed agent reads the same on its message avatar as it does on
     // the participant strip. Without a presence controller (this menu rendered
     // outside the chat popup) chat presence is all there is.
-    const online = this.presenceController
-      ? this.presenceController.isUserOnline(this.userIdValue, presentIds)
-      : presentIds.some((id) => String(id) === String(this.userIdValue))
-    this.statusTarget.classList.toggle('is-online', online)
-    this.statusLabelTarget.textContent = online
-      ? this.statusTarget.dataset.onlineText
-      : this.statusTarget.dataset.offlineText
+    const state = this.presenceController
+      ? this.presenceController.userHealthState(this.userIdValue, presentIds)
+      : this.fallbackHealthState(presentIds)
+    this.statusTarget.classList.remove('is-online', 'is-offline', 'is-unknown', 'is-check_error')
+    this.statusTarget.classList.add(`is-${state.kind}`)
+    this.statusLabelTarget.textContent = state.label
+  }
+
+  fallbackHealthState(presentIds) {
+    const online = presentIds.some((id) => String(id) === String(this.userIdValue))
+    return {
+      online,
+      kind: online ? 'online' : 'offline',
+      label: online ? this.statusTarget.dataset.onlineText : this.statusTarget.dataset.offlineText,
+    }
   }
 }

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/presence_controller_agent_online.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/presence_controller_agent_online.test.js
@@ -80,6 +80,16 @@ describe('CommentsPresenceController — gateway-backed agent liveness', () => {
         expect(isMenuOnline(2)).toBe(false)
     })
 
+    test('message avatars resolve the same health state by participant id', () => {
+        controller.participantsData = [{ ...AGENT, agent_online: false, agent_health_status: 'check_error' }]
+
+        expect(controller.userHealthState(2, [])).toEqual(expect.objectContaining({
+            online: false,
+            kind: 'check_error',
+            label: 'Health check error'
+        }))
+    })
+
     test('checker errors and unsupported checkers have distinct status labels', () => {
         controller.participantsData = [
             { ...AGENT, agent_online: false, agent_health_status: 'check_error' },

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/presence_controller_agent_online.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/presence_controller_agent_online.test.js
@@ -32,6 +32,8 @@ describe('CommentsPresenceController — gateway-backed agent liveness', () => {
                data-close-label="Close"
                data-participant-online-text="Online"
                data-participant-offline-text="Offline"
+               data-participant-health-unknown-text="Health status unavailable"
+               data-participant-health-check-error-text="Health check error"
                data-participant-search-placeholder-text="Search users..."
                data-user-menu-open-text="Open %{name}'s profile menu"
                data-user-menu-view-profile-text="View profile"
@@ -78,6 +80,19 @@ describe('CommentsPresenceController — gateway-backed agent liveness', () => {
         expect(isMenuOnline(2)).toBe(false)
     })
 
+    test('checker errors and unsupported checkers have distinct status labels', () => {
+        controller.participantsData = [
+            { ...AGENT, agent_online: false, agent_health_status: 'check_error' },
+            { ...AGENT, id: 3, agent_online: false, agent_health_status: 'unknown' }
+        ]
+        controller.renderParticipants([])
+
+        const statuses = Array.from(controller.participantsTarget
+            .querySelectorAll('[data-comment-user-menu-target="statusLabel"]'))
+            .map((label) => label.textContent)
+        expect(statuses).toEqual(['Health check error', 'Health status unavailable'])
+    })
+
     // Read receipts answer "who has seen this", which an agent nobody is sitting
     // in front of has not. Gateway liveness must not leak into that answer.
     test('agent liveness is kept out of read receipts and the presence event', () => {
@@ -99,6 +114,20 @@ describe('CommentsPresenceController — gateway-backed agent liveness', () => {
         expect(controller.updateRenderedParticipantPresence([])).toBe(true)
         expect(isMenuOnline(2)).toBe(true)
         expect(isMenuOnline(1)).toBe(false)
+    })
+
+    test('an in-place refresh changes the status kind without replacing the menu', () => {
+        controller.participantsData = [{ ...AGENT, agent_online: false, agent_health_status: 'unknown' }]
+        controller.renderParticipants([])
+        const menu = controller.participantsTarget.querySelector('.comment-user-menu')
+
+        controller.participantsData = [{ ...AGENT, agent_online: false, agent_health_status: 'check_error' }]
+        expect(controller.updateRenderedParticipantPresence([])).toBe(true)
+
+        expect(controller.participantsTarget.querySelector('.comment-user-menu')).toBe(menu)
+        expect(menu.querySelector('.comment-user-popup-status').classList.contains('is-check_error')).toBe(true)
+        expect(menu.querySelector('[data-comment-user-menu-target="statusLabel"]').textContent)
+            .toBe('Health check error')
     })
 
     test('the refresh timer runs while the chat is open and stops when it closes', () => {

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/presence_controller_participant_list.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/presence_controller_participant_list.test.js
@@ -183,7 +183,7 @@ describe('CommentsPresenceController — pinned add/list buttons', () => {
             },
             {
                 id: 2, label: 'Grace', avatarUrl: '/avatars/2.png', iconKey: null,
-                muted: true, statusLabel: 'Offline'
+                muted: true, statusLabel: 'Health status unavailable'
             }
         ])
     })

--- a/engines/collavre/app/javascript/controllers/comments/presence_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/presence_controller.js
@@ -360,8 +360,6 @@ export default class extends Controller {
   // separate: `presentIds` is who has this creative open, and it alone drives
   // read receipts. An agent is online when its gateway says it can run, whether
   // or not anyone is watching.
-  isParticipantOnline(user, presentIds) { return this.participantHealthState(user, presentIds).online }
-
   participantHealthState(user, presentIds) { return healthStateFor(user, presentIds, this.participantUserMenuLabels) }
 
   // The same answer by id, for the avatars rendered on each message: an agent in

--- a/engines/collavre/app/javascript/controllers/comments/presence_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/presence_controller.js
@@ -6,7 +6,7 @@ import csrfFetch from '../../lib/api/csrf_fetch'
 import { alertDialog } from '../../lib/utils/dialog'
 import PopupToggleGuard from '../../lib/popup_toggle_guard'
 import { elementAnchor } from '../../lib/common_popup'
-import { createUserMenu } from '../../comments/user_menu'
+import { createUserMenu, healthStateFor, healthStateForUserId } from '../../comments/user_menu'
 
 const TYPING_TIMEOUT = 3000
 const AGENT_TASK_POLL_INTERVAL = 15000 // Poll active task statuses every 15s
@@ -360,21 +360,15 @@ export default class extends Controller {
   // separate: `presentIds` is who has this creative open, and it alone drives
   // read receipts. An agent is online when its gateway says it can run, whether
   // or not anyone is watching.
-  isParticipantOnline(user, presentIds) {
-    if (!user) return false
-    return (presentIds || []).some((id) => String(id) === String(user.id)) || user.agent_online === true
-  }
+  isParticipantOnline(user, presentIds) { return this.participantHealthState(user, presentIds).online }
+
+  participantHealthState(user, presentIds) { return healthStateFor(user, presentIds, this.participantUserMenuLabels) }
 
   // The same answer by id, for the avatars rendered on each message: an agent in
   // the message list and the same agent in the participant strip must not
-  // disagree about whether it is online.
-  isUserOnline(userId, presentIds = this.currentPresentIds) {
-    const user = (this.participantsData || []).find((entry) => String(entry.id) === String(userId))
-    // A comment author who is no longer a participant still gets the plain
-    // chat-presence answer: absence from the list is not evidence of anything.
-    if (!user) return (presentIds || []).some((id) => String(id) === String(userId))
-
-    return this.isParticipantOnline(user, presentIds)
+  // disagree about whether it is online or why its health is unknown.
+  userHealthState(userId, presentIds = this.currentPresentIds) {
+    return healthStateForUserId(this.participantsData, userId, presentIds, this.participantUserMenuLabels)
   }
 
   _isCurrentParticipantLoad(loadVersion, creativeId) {
@@ -569,10 +563,12 @@ export default class extends Controller {
     }
     this.participantsTarget.innerHTML = ''
     this.participantsData.forEach((user) => {
-      const online = this.isParticipantOnline(user, presentIds)
+      const state = this.participantHealthState(user, presentIds)
       const wrapper = createUserMenu({
         user,
-        online,
+        online: state.online,
+        healthStatus: state.kind,
+        statusText: state.label,
         labels: this.participantUserMenuLabels,
         menuId: `participant-user-menu-${user.id}`,
         draggable: Boolean(user.ai_user)
@@ -603,13 +599,14 @@ export default class extends Controller {
     if (!matchesParticipants) return false
 
     menus.forEach((menu, index) => {
-      const online = this.isParticipantOnline(this.participantsData[index], presentIds)
-      menu.querySelector('.comment-presence-avatar')?.classList.toggle('inactive', !online)
+      const state = this.participantHealthState(this.participantsData[index], presentIds)
+      menu.querySelector('.comment-presence-avatar')?.classList.toggle('inactive', !state.online)
       const status = menu.querySelector('.comment-user-popup-status')
-      status?.classList.toggle('is-online', online)
       const statusLabel = menu.querySelector('[data-comment-user-menu-target="statusLabel"]')
       if (status && statusLabel) {
-        statusLabel.textContent = online ? status.dataset.onlineText : status.dataset.offlineText
+        status.classList.remove('is-online', 'is-offline', 'is-unknown', 'is-check_error')
+        status.classList.add(`is-${state.kind}`)
+        statusLabel.textContent = state.label
       }
     })
     return true
@@ -622,7 +619,9 @@ export default class extends Controller {
       mention: this.element.dataset.userMenuMentionText || 'Mention',
       dragGuide: this.element.dataset.userMenuAgentDragGuideText || '',
       online: this.element.dataset.participantOnlineText || 'Online',
-      offline: this.element.dataset.participantOfflineText || 'Offline'
+      offline: this.element.dataset.participantOfflineText || 'Offline',
+      unknown: this.element.dataset.participantHealthUnknownText || 'Health status unavailable',
+      check_error: this.element.dataset.participantHealthCheckErrorText || 'Health check error'
     }
   }
 
@@ -732,16 +731,14 @@ export default class extends Controller {
     const present = presentIds || []
     return (this.participantsData || []).map((user) => {
       // Offline reads the same here as it does on the avatar strip.
-      const online = this.isParticipantOnline(user, present)
+      const state = this.participantHealthState(user, present)
       return {
         id: user.id,
         label: user.name,
         avatarUrl: user.avatar_url,
         iconKey: user.avatar_url ? null : 'user',
-        muted: !online,
-        statusLabel: online
-          ? (this.element.dataset.participantOnlineText || 'Online')
-          : (this.element.dataset.participantOfflineText || 'Offline')
+        muted: !state.online,
+        statusLabel: state.label
       }
     })
   }

--- a/engines/collavre/app/jobs/collavre/endpoint_health_probe_job.rb
+++ b/engines/collavre/app/jobs/collavre/endpoint_health_probe_job.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Collavre
+  class EndpointHealthProbeJob < ApplicationJob
+    CONCURRENCY_DURATION = 1.day
+    queue_as :gateway_health
+
+    limits_concurrency to: 1,
+      key: ->(agent_id) { agent_id },
+      duration: CONCURRENCY_DURATION,
+      on_conflict: :discard
+
+    def perform(agent_id)
+      agent = User.ai_agents.find_by(id: agent_id)
+      return unless agent && AgentHealth.checker_for(agent.llm_vendor)
+
+      AgentHealth::Probe.new(agent: agent).call
+    rescue StandardError => e
+      Rails.logger.error("[EndpointHealthProbeJob] agent=#{agent_id} orchestration_error=#{e.class}")
+    end
+  end
+end

--- a/engines/collavre/app/jobs/collavre/endpoint_health_sweep_job.rb
+++ b/engines/collavre/app/jobs/collavre/endpoint_health_sweep_job.rb
@@ -14,7 +14,7 @@ module Collavre
       vendors = AgentHealth.vendors
       return if vendors.empty?
 
-      User.ai_agents.where("LOWER(llm_vendor) IN (?)", vendors).pluck(:id).each do |agent_id|
+      User.ai_agents.where("LOWER(TRIM(llm_vendor)) IN (?)", vendors).pluck(:id).each do |agent_id|
         EndpointHealthProbeJob.perform_later(agent_id)
       end
     end

--- a/engines/collavre/app/jobs/collavre/endpoint_health_sweep_job.rb
+++ b/engines/collavre/app/jobs/collavre/endpoint_health_sweep_job.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Collavre
+  class EndpointHealthSweepJob < ApplicationJob
+    CONCURRENCY_DURATION = 1.day
+    queue_as :gateway_health
+
+    limits_concurrency to: 1,
+      key: -> { "endpoint-health-sweep" },
+      duration: CONCURRENCY_DURATION,
+      on_conflict: :discard
+
+    def perform
+      vendors = AgentHealth.vendors
+      return if vendors.empty?
+
+      User.ai_agents.where("LOWER(llm_vendor) IN (?)", vendors).pluck(:id).each do |agent_id|
+        EndpointHealthProbeJob.perform_later(agent_id)
+      end
+    end
+  end
+end

--- a/engines/collavre/app/jobs/collavre/endpoint_health_sweep_job.rb
+++ b/engines/collavre/app/jobs/collavre/endpoint_health_sweep_job.rb
@@ -14,7 +14,7 @@ module Collavre
       vendors = AgentHealth.vendors
       return if vendors.empty?
 
-      User.ai_agents.where("LOWER(TRIM(llm_vendor)) IN (?)", vendors).pluck(:id).each do |agent_id|
+      User.ai_agents.with_llm_vendors(vendors).pluck(:id).each do |agent_id|
         EndpointHealthProbeJob.perform_later(agent_id)
       end
     end

--- a/engines/collavre/app/models/collavre/agent_gateway.rb
+++ b/engines/collavre/app/models/collavre/agent_gateway.rb
@@ -53,7 +53,7 @@ module Collavre
 
     scope :active, -> { where(active: true) }
     scope :health_probe_targets, -> do
-      assigned_gateway_ids = User.where("LOWER(TRIM(llm_vendor)) = ?", "cli_proxy").select(:agent_gateway_id)
+      assigned_gateway_ids = User.with_llm_vendors([ "cli_proxy" ]).select(:agent_gateway_id)
       active.where(id: assigned_gateway_ids)
     end
 

--- a/engines/collavre/app/models/collavre/agent_gateway.rb
+++ b/engines/collavre/app/models/collavre/agent_gateway.rb
@@ -53,7 +53,7 @@ module Collavre
 
     scope :active, -> { where(active: true) }
     scope :health_probe_targets, -> do
-      assigned_gateway_ids = User.where(llm_vendor: "cli_proxy").select(:agent_gateway_id)
+      assigned_gateway_ids = User.where("LOWER(TRIM(llm_vendor)) = ?", "cli_proxy").select(:agent_gateway_id)
       active.where(id: assigned_gateway_ids)
     end
 

--- a/engines/collavre/app/models/collavre/user.rb
+++ b/engines/collavre/app/models/collavre/user.rb
@@ -189,7 +189,7 @@ module Collavre
     end
 
     def cli_proxy_agent?
-      llm_vendor == "cli_proxy" && agent_gateway.present?
+      llm_vendor.to_s.strip.downcase == "cli_proxy" && agent_gateway.present?
     end
 
     def gateway_accessible_to?(user)
@@ -265,7 +265,7 @@ module Collavre
               inclusion: { in: ActiveSupport::TimeZone.all.map { |z| z.tzinfo.identifier } },
               allow_nil: true
     def cli_proxy_gateway_belongs_to_creator
-      return unless llm_vendor == "cli_proxy"
+      return unless llm_vendor.to_s.strip.downcase == "cli_proxy"
 
       validate_cli_proxy_gateway(agent_gateway)
     end
@@ -274,7 +274,7 @@ module Collavre
     # gateway checks immediately before writing the agent while holding the
     # same row lock used by a completion-key removal.
     def serialize_cli_proxy_gateway_assignment
-      return yield unless llm_vendor == "cli_proxy" && agent_gateway_id.present?
+      return yield unless llm_vendor.to_s.strip.downcase == "cli_proxy" && agent_gateway_id.present?
 
       gateway = AgentGateway.find_by(id: agent_gateway_id)
       return yield unless gateway

--- a/engines/collavre/app/models/concerns/collavre/agent_liveness.rb
+++ b/engines/collavre/app/models/concerns/collavre/agent_liveness.rb
@@ -10,6 +10,19 @@ module Collavre
   module AgentLiveness
     extend ActiveSupport::Concern
 
+    ENDPOINT_HEALTH_TTL = 3.minutes
+    ENDPOINT_HEALTH_CONFIGURATION_ATTRIBUTES = %w[llm_vendor llm_api_key gateway_url].freeze
+
+    included do
+      enum :endpoint_health_status,
+           { unknown: 0, online: 1, offline: 2, check_error: 3 },
+           prefix: :endpoint_health,
+           default: :unknown
+
+      after_update :invalidate_endpoint_health_after_configuration_change,
+                   if: :endpoint_health_configuration_changed?
+    end
+
     def claude_channel_agent?
       llm_model == "claude-code"
     end
@@ -30,11 +43,45 @@ module Collavre
       agent_gateway.health_serves_engine?(CliProxy::AdapterEngine.for_model(llm_model))
     end
 
-    # Only the two agent kinds that publish evidence either way. An agent on a
-    # hosted vendor API publishes none, so it stays out rather than being
-    # asserted online on nothing.
+    def endpoint_health_supported?
+      AgentHealth.checker_for(llm_vendor).present?
+    end
+
+    def endpoint_health_fresh?
+      endpoint_health_checked_at.present? && endpoint_health_checked_at > ENDPOINT_HEALTH_TTL.ago
+    end
+
+    def endpoint_online?
+      endpoint_health_supported? && endpoint_health_fresh? && endpoint_health_online?
+    end
+
+    def agent_liveness_status(live_claude_agent_ids: nil)
+      return :online if claude_channel_online?(live_agent_ids: live_claude_agent_ids)
+      return :online if gateway_online? || endpoint_online?
+      return :offline if claude_channel_agent? || cli_proxy_agent?
+      return :unknown unless ai_user? && endpoint_health_supported? && endpoint_health_fresh?
+
+      endpoint_health_status.to_sym
+    end
+
+    # Only presence sources and registered health checkers publish evidence.
+    # Other vendors stay unknown rather than being asserted online on nothing.
     def agent_online?(live_claude_agent_ids: nil)
-      claude_channel_online?(live_agent_ids: live_claude_agent_ids) || gateway_online?
+      agent_liveness_status(live_claude_agent_ids:) == :online
+    end
+
+    private
+
+    def endpoint_health_configuration_changed?
+      (saved_changes.keys & ENDPOINT_HEALTH_CONFIGURATION_ATTRIBUTES).any?
+    end
+
+    def invalidate_endpoint_health_after_configuration_change
+      update_columns(
+        endpoint_health_status: self.class.endpoint_health_statuses.fetch("unknown"),
+        endpoint_health_error: nil,
+        endpoint_health_checked_at: nil
+      )
     end
   end
 end

--- a/engines/collavre/app/models/concerns/collavre/agent_liveness.rb
+++ b/engines/collavre/app/models/concerns/collavre/agent_liveness.rb
@@ -14,6 +14,13 @@ module Collavre
     ENDPOINT_HEALTH_CONFIGURATION_ATTRIBUTES = %w[llm_vendor llm_api_key gateway_url].freeze
 
     included do
+      # SQL TRIM/LOWER differ from Ruby for control whitespace and Unicode.
+      # Normalize distinct stored spellings, then filter rows by their exact values.
+      scope :with_llm_vendors, ->(vendors) do
+        spellings = distinct.pluck(:llm_vendor).select { |value| vendors.include?(value.to_s.strip.downcase) }
+        where(llm_vendor: spellings)
+      end
+
       enum :endpoint_health_status,
            { unknown: 0, online: 1, offline: 2, check_error: 3 },
            prefix: :endpoint_health,

--- a/engines/collavre/app/services/collavre/agent_health.rb
+++ b/engines/collavre/app/services/collavre/agent_health.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Collavre
+  # Registry for optional, vendor-owned agent health checkers.
+  #
+  # A checker is observational only: registering or removing one changes the
+  # status shown in the UI, never whether Collavre attempts an agent call.
+  module AgentHealth
+    Result = Struct.new(:status, :error, keyword_init: true)
+
+    class << self
+      def register(vendor, checker)
+        normalized_vendor = normalize_vendor(vendor)
+        raise ArgumentError, "vendor is required" if normalized_vendor.empty?
+        raise ArgumentError, "checker must be instantiable" unless checker.respond_to?(:new)
+
+        checkers[normalized_vendor] = checker
+      end
+
+      def unregister(vendor)
+        checkers.delete(normalize_vendor(vendor))
+      end
+
+      def checker_for(vendor)
+        checkers[normalize_vendor(vendor)]
+      end
+
+      def vendors
+        checkers.keys.freeze
+      end
+
+      private
+
+      def checkers
+        @checkers ||= {}
+      end
+
+      def normalize_vendor(vendor)
+        vendor.to_s.strip.downcase
+      end
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/agent_health/openai_endpoint_checker.rb
+++ b/engines/collavre/app/services/collavre/agent_health/openai_endpoint_checker.rb
@@ -54,9 +54,14 @@ module Collavre
 
       def request_headers
         headers = { "Accept" => "application/json" }
-        api_key = @agent.llm_api_key.presence || IntegrationSettings.fetch(:openai_api_key)
+        api_key = @agent.llm_api_key.presence
+        api_key ||= IntegrationSettings.fetch(:openai_api_key) if official_endpoint?
         headers["Authorization"] = "Bearer #{api_key}" if api_key.present?
         headers
+      end
+
+      def official_endpoint?
+        @agent.gateway_url.blank? || @agent.gateway_url.to_s.sub(%r{/+\z}, "") == DEFAULT_BASE_URL
       end
 
       def endpoint_policy

--- a/engines/collavre/app/services/collavre/agent_health/openai_endpoint_checker.rb
+++ b/engines/collavre/app/services/collavre/agent_health/openai_endpoint_checker.rb
@@ -61,7 +61,13 @@ module Collavre
       end
 
       def official_endpoint?
-        @agent.gateway_url.blank? || @agent.gateway_url.to_s.sub(%r{/+\z}, "") == DEFAULT_BASE_URL
+        uri = URI.parse(@agent.gateway_url.presence || DEFAULT_BASE_URL)
+        default_uri = URI.parse(DEFAULT_BASE_URL)
+        uri.userinfo.blank? && uri.query.blank? && uri.fragment.blank? &&
+          uri.scheme.to_s.downcase == default_uri.scheme && uri.host.to_s.downcase == default_uri.host &&
+          uri.port == default_uri.port && uri.path.to_s.sub(%r{/+\z}, "") == default_uri.path
+      rescue URI::InvalidURIError
+        false
       end
 
       def endpoint_policy

--- a/engines/collavre/app/services/collavre/agent_health/openai_endpoint_checker.rb
+++ b/engines/collavre/app/services/collavre/agent_health/openai_endpoint_checker.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "uri"
+
+module Collavre
+  module AgentHealth
+    # Verifies only OpenAI-compatible endpoint reachability and authentication.
+    # It deliberately avoids completion requests, which can incur cost or have
+    # provider-specific side effects.
+    class OpenaiEndpointChecker
+      DEFAULT_BASE_URL = "https://api.openai.com/v1"
+      OPEN_TIMEOUT = 3
+      READ_TIMEOUT = 8
+      REQUEST_TIMEOUT = OPEN_TIMEOUT + READ_TIMEOUT
+      MAX_RESPONSE_BYTES = 64 * 1024
+
+      class InvalidEndpoint < StandardError; end
+
+      def initialize(agent:, client: nil)
+        @agent = agent
+        @client = client || HttpClient.new(
+          open_timeout: OPEN_TIMEOUT,
+          read_timeout: READ_TIMEOUT,
+          request_timeout: REQUEST_TIMEOUT,
+          max_response_bytes: MAX_RESPONSE_BYTES,
+          endpoint_policy: endpoint_policy
+        )
+      end
+
+      def call
+        response = @client.get(models_url, headers: request_headers)
+        result_for(response)
+      rescue InvalidEndpoint, CliProxy::EndpointPolicy::UnsafeEndpoint
+        Result.new(status: :offline, error: "invalid_endpoint")
+      rescue HttpClient::ConnectionError
+        Result.new(status: :offline, error: "connection_failed")
+      rescue HttpClient::ResponseTooLarge
+        Result.new(status: :unknown, error: "response_too_large")
+      end
+
+      private
+
+      def models_url
+        uri = URI.parse(@agent.gateway_url.presence || DEFAULT_BASE_URL)
+        valid = uri.is_a?(URI::HTTP) && uri.host.present? && uri.userinfo.blank? && uri.query.blank? && uri.fragment.blank?
+        raise InvalidEndpoint unless valid
+
+        base_path = uri.path.to_s.sub(%r{/+\z}, "")
+        uri.path = base_path.end_with?("/models") ? base_path : "#{base_path}/models"
+        uri.to_s
+      rescue URI::InvalidURIError
+        raise InvalidEndpoint
+      end
+
+      def request_headers
+        headers = { "Accept" => "application/json" }
+        api_key = @agent.llm_api_key.presence || IntegrationSettings.fetch(:openai_api_key)
+        headers["Authorization"] = "Bearer #{api_key}" if api_key.present?
+        headers
+      end
+
+      def endpoint_policy
+        return if @agent.creator&.system_admin?
+
+        CliProxy::EndpointPolicy.new
+      end
+
+      def result_for(response)
+        case response.code
+        when 200..299
+          Result.new(status: :online)
+        when 401, 403
+          Result.new(status: :offline, error: "authentication_failed")
+        when 404, 405
+          Result.new(status: :unknown, error: "models_endpoint_unsupported")
+        when 408, 425, 429, 500..599
+          Result.new(status: :offline, error: "http_#{response.code}")
+        else
+          Result.new(status: :unknown, error: "http_#{response.code}")
+        end
+      end
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/agent_health/openai_endpoint_checker.rb
+++ b/engines/collavre/app/services/collavre/agent_health/openai_endpoint_checker.rb
@@ -8,7 +8,7 @@ module Collavre
     # It deliberately avoids completion requests, which can incur cost or have
     # provider-specific side effects.
     class OpenaiEndpointChecker
-      DEFAULT_BASE_URL = "https://api.openai.com/v1"
+      DEFAULT_BASE_URL = OpenaiEndpoint::DEFAULT_BASE_URL
       OPEN_TIMEOUT = 3
       READ_TIMEOUT = 8
       REQUEST_TIMEOUT = OPEN_TIMEOUT + READ_TIMEOUT
@@ -54,20 +54,9 @@ module Collavre
 
       def request_headers
         headers = { "Accept" => "application/json" }
-        api_key = @agent.llm_api_key.presence
-        api_key ||= IntegrationSettings.fetch(:openai_api_key) if official_endpoint?
+        api_key = OpenaiEndpoint.api_key(base_url: @agent.gateway_url, api_key: @agent.llm_api_key)
         headers["Authorization"] = "Bearer #{api_key}" if api_key.present?
         headers
-      end
-
-      def official_endpoint?
-        uri = URI.parse(@agent.gateway_url.presence || DEFAULT_BASE_URL)
-        default_uri = URI.parse(DEFAULT_BASE_URL)
-        uri.userinfo.blank? && uri.query.blank? && uri.fragment.blank? &&
-          uri.scheme.to_s.downcase == default_uri.scheme && uri.host.to_s.downcase == default_uri.host &&
-          uri.port == default_uri.port && uri.path.to_s.sub(%r{/+\z}, "") == default_uri.path
-      rescue URI::InvalidURIError
-        false
       end
 
       def endpoint_policy

--- a/engines/collavre/app/services/collavre/agent_health/probe.rb
+++ b/engines/collavre/app/services/collavre/agent_health/probe.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Collavre
+  module AgentHealth
+    # Executes one optional vendor checker and stores its observational result.
+    class Probe
+      VALID_STATUSES = %i[online offline unknown].freeze
+      ERROR_LIMIT = 255
+
+      def initialize(agent:)
+        @agent = agent
+        @configuration_updated_at = agent.updated_at
+      end
+
+      def call
+        checker = AgentHealth.checker_for(@agent.llm_vendor)
+        return :unsupported unless checker
+
+        result = checker.new(agent: @agent).call
+        raise ArgumentError, "health checker returned an invalid result" unless valid_result?(result)
+
+        record(result.status.to_sym, result.error)
+      rescue StandardError => e
+        Rails.logger.error(
+          "[AgentHealth::Probe] agent=#{@agent.id} vendor=#{@agent.llm_vendor} checker_error=#{e.class}"
+        )
+        record(:check_error, e.class.name)
+      end
+
+      private
+
+      def valid_result?(result)
+        result.is_a?(Result) && VALID_STATUSES.include?(result.status.to_sym)
+      end
+
+      def record(status, error)
+        User.where(id: @agent.id, updated_at: @configuration_updated_at).update_all(
+          endpoint_health_status: User.endpoint_health_statuses.fetch(status.to_s),
+          endpoint_health_error: error&.to_s&.truncate(ERROR_LIMIT),
+          endpoint_health_checked_at: Time.current
+        )
+        status
+      end
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/agent_session_abort.rb
+++ b/engines/collavre/app/services/collavre/agent_session_abort.rb
@@ -7,11 +7,11 @@ module Collavre
   class AgentSessionAbort
     class << self
       def register(vendor, handler)
-        registry[vendor.to_s.downcase] = handler
+        registry[vendor.to_s.strip.downcase] = handler
       end
 
       def call(agent:, task:, creative: nil, comment: nil)
-        handler = registry[agent&.llm_vendor&.downcase]
+        handler = registry[agent&.llm_vendor&.strip&.downcase]
         return unless handler
 
         handler.call(agent: agent, task: task, creative: creative, comment: comment)

--- a/engines/collavre/app/services/collavre/ai_client.rb
+++ b/engines/collavre/app/services/collavre/ai_client.rb
@@ -96,7 +96,7 @@ module Collavre
     # propagates out of #chat as a cancellation, not an "⚠️ AI Error" delta.
     def initialize(vendor:, model:, system_prompt:, llm_api_key: nil, gateway_url: nil, context: {},
                    log_interactions: true, before_tool_call: nil, request_timeout_seconds: nil)
-      @vendor = vendor
+      @vendor = vendor.to_s.strip.downcase
       @model = model
       @system_prompt = system_prompt
       @llm_api_key = llm_api_key

--- a/engines/collavre/app/services/collavre/ai_client.rb
+++ b/engines/collavre/app/services/collavre/ai_client.rb
@@ -310,7 +310,7 @@ module Collavre
           api_key = gateway.completion_key
           base_url = gateway.completion_base_url
         else
-          api_key = @llm_api_key.presence || IntegrationSettings.fetch(:openai_api_key)
+          api_key = OpenaiEndpoint.api_key(base_url: @gateway_url, api_key: @llm_api_key)
           base_url = @gateway_url.presence
         end
         # A custom OpenAI-compatible gateway (local Ollama / LM Studio, etc.) needs

--- a/engines/collavre/app/services/collavre/ai_client.rb
+++ b/engines/collavre/app/services/collavre/ai_client.rb
@@ -58,7 +58,7 @@ module Collavre
 
       # Append a vendor <select> option ([label, value]). Idempotent by value.
       def register_vendor_option(label, value)
-        value = value.to_s
+        value = value.to_s.strip.downcase
         return if BASE_VENDOR_OPTIONS.any? { |_l, v| v == value }
         return if registered_vendor_options.any? { |_l, v| v == value }
 
@@ -77,11 +77,11 @@ module Collavre
       end
 
       def register_session_vendor(vendor)
-        session_vendors << vendor.to_s.downcase
+        session_vendors << vendor.to_s.strip.downcase
       end
 
       def vendor_supports_session?(vendor)
-        session_vendors.include?(vendor.to_s.downcase)
+        session_vendors.include?(vendor.to_s.strip.downcase)
       end
     end
 

--- a/engines/collavre/app/services/collavre/openai_endpoint.rb
+++ b/engines/collavre/app/services/collavre/openai_endpoint.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "uri"
+
+module Collavre
+  # Shared credentials may only be used with the official OpenAI API endpoint.
+  module OpenaiEndpoint
+    DEFAULT_BASE_URL = "https://api.openai.com/v1"
+
+    def self.api_key(base_url:, api_key:)
+      api_key.presence || (IntegrationSettings.fetch(:openai_api_key) if official?(base_url))
+    end
+
+    def self.official?(base_url)
+      uri = URI.parse(base_url.presence || DEFAULT_BASE_URL)
+      default_uri = URI.parse(DEFAULT_BASE_URL)
+      uri.userinfo.blank? && uri.query.blank? && uri.fragment.blank? &&
+        uri.scheme.to_s.downcase == default_uri.scheme && uri.host.to_s.downcase == default_uri.host &&
+        uri.port == default_uri.port && uri.path.to_s.sub(%r{/+\z}, "") == default_uri.path
+    rescue URI::InvalidURIError
+      false
+    end
+  end
+end

--- a/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
@@ -57,6 +57,8 @@
      data-participant-search-placeholder-text="<%= t('collavre.comments.participant_search_placeholder') %>"
      data-participant-online-text="<%= t('collavre.comments.participant_online') %>"
      data-participant-offline-text="<%= t('collavre.comments.participant_offline') %>"
+     data-participant-health-unknown-text="<%= t('collavre.comments.participant_health_unknown') %>"
+     data-participant-health-check-error-text="<%= t('collavre.comments.participant_health_check_error') %>"
      data-user-menu-open-text="<%= t('collavre.comments.user_menu.open', name: '%{name}') %>"
      data-user-menu-view-profile-text="<%= t('collavre.comments.user_menu.view_profile') %>"
      data-user-menu-mention-text="<%= t('collavre.comments.user_menu.mention') %>"

--- a/engines/collavre/config/initializers/agent_health.rb
+++ b/engines/collavre/config/initializers/agent_health.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Rails.application.config.to_prepare do
+  Collavre::AgentHealth.register("openai", Collavre::AgentHealth::OpenaiEndpointChecker)
+end

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -170,6 +170,8 @@ en:
       participant_search_placeholder: Search users...
       participant_online: Online
       participant_offline: Offline
+      participant_health_unknown: Health status unavailable
+      participant_health_check_error: Health check error
       user_menu:
         open: "Open %{name}'s profile menu"
         view_profile: View profile

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -167,6 +167,8 @@ ko:
       participant_search_placeholder: 사용자 검색...
       participant_online: 온라인
       participant_offline: 오프라인
+      participant_health_unknown: 상태 확인 불가
+      participant_health_check_error: 헬스 체크 오류
       user_menu:
         open: "%{name} 프로필 메뉴 열기"
         view_profile: 프로필 보기

--- a/engines/collavre/db/migrate/20260911000000_add_endpoint_health_to_users.rb
+++ b/engines/collavre/db/migrate/20260911000000_add_endpoint_health_to_users.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddEndpointHealthToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :endpoint_health_status, :integer, default: 0, null: false
+    add_column :users, :endpoint_health_checked_at, :datetime
+    add_column :users, :endpoint_health_error, :string
+  end
+end

--- a/engines/collavre/test/controllers/comments_controller_test.rb
+++ b/engines/collavre/test/controllers/comments_controller_test.rb
@@ -1446,6 +1446,31 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
                  "a human's presence is chat presence, and does not travel here"
   end
 
+  test "participants exposes endpoint health errors independently from dispatch" do
+    agent = Collavre::User.create!(
+      name: "OpenAI Agent", email: "openai-participants@ai.local", password: SecureRandom.hex(24),
+      system_prompt: "Help", llm_vendor: "openai", llm_model: "gpt-test", created_by_id: @user.id
+    )
+    Collavre::CreativeShare.create!(creative: @creative, user: agent, permission: :feedback)
+    agent.update_columns(
+      endpoint_health_status: 3,
+      endpoint_health_checked_at: Time.current,
+      endpoint_health_error: "RuntimeError: checker failed"
+    )
+
+    get participants_creative_comments_path(@creative), headers: { "Accept" => "application/json" }
+
+    health = participant_json(agent)
+    assert_equal false, health["agent_online"]
+    assert_equal "check_error", health["agent_health_status"]
+    assert_nil participant_json(@user)["agent_health_status"]
+
+    agent.update_columns(endpoint_health_status: 1, endpoint_health_checked_at: Time.current)
+    get participants_creative_comments_path(@creative), headers: { "Accept" => "application/json" }
+    assert_equal "online", participant_json(agent)["agent_health_status"]
+    assert_equal true, participant_json(agent)["agent_online"]
+  end
+
   test "participants batches Claude Channel subscription liveness" do
     agents = 2.times.map do |index|
       agent = Collavre::User.create!(

--- a/engines/collavre/test/controllers/users_controller_ai_test.rb
+++ b/engines/collavre/test/controllers/users_controller_ai_test.rb
@@ -87,7 +87,7 @@ class UsersControllerAiTest < ActionDispatch::IntegrationTest
         ai_id: "proxy_bot",
         name: "Proxy Bot",
         system_prompt: "Help",
-        llm_vendor: "cli_proxy",
+        llm_vendor: " CLI_PROXY ",
         llm_model: "paperclip/claude_local",
         agent_gateway_id: gateway.id
       }
@@ -96,6 +96,20 @@ class UsersControllerAiTest < ActionDispatch::IntegrationTest
     agent = Collavre::User.find_by!(email: "proxy_bot@ai.local")
     assert_equal gateway, agent.agent_gateway
     assert_equal @admin.id, agent.created_by_id
+    assert agent.cli_proxy_agent?
+    assert_includes Collavre::AgentGateway.health_probe_targets, gateway
+
+    patch update_ai_user_url(agent), params: {
+      user: { name: "Renamed proxy", llm_vendor: " CLI_PROXY ", agent_gateway_id: gateway.id }
+    }
+    assert_redirected_to user_path(@admin, tab: "contacts")
+    assert_equal gateway, agent.reload.agent_gateway
+
+    patch update_ai_user_url(agent), params: {
+      user: { name: "Preserved proxy", llm_vendor: " CLI_PROXY " }
+    }
+    assert_redirected_to user_path(@admin, tab: "contacts")
+    assert_equal gateway, agent.reload.agent_gateway
   end
 
   test "does not offer or assign a provisioning-only gateway to a CLI Proxy agent" do

--- a/engines/collavre/test/jobs/endpoint_health_jobs_test.rb
+++ b/engines/collavre/test/jobs/endpoint_health_jobs_test.rb
@@ -43,14 +43,25 @@ module Collavre
     end
 
     test "sweep normalizes vendor whitespace and case" do
-      @agent.update_column(:llm_vendor, " JOB-VENDOR ")
-      probed = []
+      [ " ", "\t", "\n", "\r", "\f", "\v" ].each do |whitespace|
+        @agent.update_column(:llm_vendor, "#{whitespace}JOB-VENDOR#{whitespace}")
+        probed = []
 
-      EndpointHealthProbeJob.stub(:perform_later, ->(id) { probed << id }) do
-        EndpointHealthSweepJob.perform_now
+        EndpointHealthProbeJob.stub(:perform_later, ->(id) { probed << id }) do
+          EndpointHealthSweepJob.perform_now
+        end
+
+        assert_includes probed, @agent.id, "Missing vendor padded with #{whitespace.inspect}"
       end
+    end
 
-      assert_includes probed, @agent.id
+    test "vendor filtering preserves its relation and ignores internal whitespace" do
+      human = users(:one)
+      human.update_columns(llm_vendor: "job-vendor", llm_model: nil)
+      @agent.update_column(:llm_vendor, "job-\tvendor")
+
+      assert_empty User.where(id: @agent.id).with_llm_vendors([ "job-vendor" ]).pluck(:id)
+      assert_includes User.with_llm_vendors([ "job-vendor" ]).pluck(:id), human.id
     end
 
     test "probe job executes the registered checker" do

--- a/engines/collavre/test/jobs/endpoint_health_jobs_test.rb
+++ b/engines/collavre/test/jobs/endpoint_health_jobs_test.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  class EndpointHealthJobsTest < ActiveJob::TestCase
+    class Checker
+      def initialize(agent:); end
+
+      def call
+        AgentHealth::Result.new(status: :online)
+      end
+    end
+
+    setup do
+      @agent = Collavre::User.create!(
+        name: "Job Agent",
+        email: "job-agent@example.test",
+        password: SecureRandom.hex(24),
+        llm_vendor: "job-vendor",
+        llm_model: "job-model"
+      )
+      AgentHealth.register("job-vendor", Checker)
+    end
+
+    teardown { AgentHealth.unregister("job-vendor") }
+
+    test "sweep enqueues only agents with registered vendor checkers" do
+      probed = []
+
+      EndpointHealthProbeJob.stub(:perform_later, ->(id) { probed << id }) do
+        EndpointHealthSweepJob.perform_now
+      end
+
+      assert_includes probed, @agent.id
+      assert_not_includes probed, users(:ai_bot).id
+
+      probed.clear
+      EndpointHealthProbeJob.stub(:perform_later, ->(id) { probed << id }) do
+        AgentHealth.stub(:vendors, []) { EndpointHealthSweepJob.perform_now }
+      end
+      assert_empty probed
+    end
+
+    test "probe job executes the registered checker" do
+      EndpointHealthProbeJob.perform_now(@agent.id)
+
+      assert_predicate @agent.reload, :endpoint_health_online?
+    end
+
+    test "probe job ignores missing agents and removed checkers" do
+      assert_nothing_raised { EndpointHealthProbeJob.perform_now(-1) }
+
+      AgentHealth.unregister("job-vendor")
+      assert_nothing_raised { EndpointHealthProbeJob.perform_now(@agent.id) }
+      assert_predicate @agent.reload, :endpoint_health_unknown?
+    end
+
+    test "probe job contains unexpected orchestration errors" do
+      AgentHealth::Probe.stub(:new, ->(**) { raise RuntimeError, "boom" }) do
+        assert_nothing_raised { EndpointHealthProbeJob.perform_now(@agent.id) }
+      end
+    end
+
+    test "jobs use the dedicated health queue and recurring schedule" do
+      assert_equal "gateway_health", EndpointHealthProbeJob.new.queue_name
+      assert_equal "gateway_health", EndpointHealthSweepJob.new.queue_name
+      assert_equal 1, EndpointHealthProbeJob.new(@agent.id).concurrency_limit
+      assert_equal 1.day, EndpointHealthProbeJob.new(@agent.id).concurrency_duration
+      assert_equal :discard, EndpointHealthProbeJob.concurrency_on_conflict
+      assert_equal "Collavre::EndpointHealthProbeJob/#{@agent.id}", EndpointHealthProbeJob.new(@agent.id).concurrency_key
+      assert_equal "Collavre::EndpointHealthSweepJob/endpoint-health-sweep", EndpointHealthSweepJob.new.concurrency_key
+
+      config = YAML.load(ERB.new(Rails.root.join("config/recurring.yml").read).result, aliases: true)
+      %w[production desktop development].each do |environment|
+        recurring = config.fetch(environment).fetch("endpoint_health_sweep")
+        assert_equal "Collavre::EndpointHealthSweepJob", recurring.fetch("class")
+        assert_equal "gateway_health", recurring.fetch("queue")
+        assert_equal "every minute", recurring.fetch("schedule")
+      end
+    end
+  end
+end

--- a/engines/collavre/test/jobs/endpoint_health_jobs_test.rb
+++ b/engines/collavre/test/jobs/endpoint_health_jobs_test.rb
@@ -42,6 +42,17 @@ module Collavre
       assert_empty probed
     end
 
+    test "sweep normalizes vendor whitespace and case" do
+      @agent.update_column(:llm_vendor, " JOB-VENDOR ")
+      probed = []
+
+      EndpointHealthProbeJob.stub(:perform_later, ->(id) { probed << id }) do
+        EndpointHealthSweepJob.perform_now
+      end
+
+      assert_includes probed, @agent.id
+    end
+
     test "probe job executes the registered checker" do
       EndpointHealthProbeJob.perform_now(@agent.id)
 

--- a/engines/collavre/test/jobs/gateway_health_jobs_test.rb
+++ b/engines/collavre/test/jobs/gateway_health_jobs_test.rb
@@ -39,6 +39,19 @@ class Collavre::GatewayHealthJobsTest < ActiveSupport::TestCase
       "PostgreSQL cannot apply DISTINCT to the gateway health_engines json column")
   end
 
+  test "gateway targets recognize every persisted Ruby whitespace variant" do
+    agent = assign_gateway
+
+    [ " ", "\t", "\n", "\r", "\f", "\v" ].each do |whitespace|
+      agent.update_column(:llm_vendor, "#{whitespace}CLI_PROXY#{whitespace}")
+
+      assert_includes Collavre::AgentGateway.health_probe_targets.pluck(:id), @gateway.id
+    end
+
+    agent.update_column(:llm_vendor, "cli_\tproxy")
+    assert_not_includes Collavre::AgentGateway.health_probe_targets.pluck(:id), @gateway.id
+  end
+
   test "the probe records a verdict for the gateway it names" do
     assign_gateway
     body = { "status" => "ok", "engines" => { "ready" => 1, "total" => 1 } }

--- a/engines/collavre/test/models/user_test.rb
+++ b/engines/collavre/test/models/user_test.rb
@@ -379,6 +379,53 @@ class UserTest < ActiveSupport::TestCase
     assert_not users(:one).agent_online?
   end
 
+  test "a registered endpoint checker contributes fresh liveness state" do
+    agent = users(:ai_bot)
+    agent.update!(llm_vendor: "openai")
+
+    assert_equal :unknown, agent.agent_liveness_status
+
+    agent.update_columns(endpoint_health_status: 1, endpoint_health_checked_at: Time.current)
+    assert_equal :online, agent.reload.agent_liveness_status
+    assert_predicate agent, :agent_online?
+
+    agent.update_columns(endpoint_health_status: 2, endpoint_health_checked_at: Time.current)
+    assert_equal :offline, agent.reload.agent_liveness_status
+
+    agent.update_columns(endpoint_health_status: 3, endpoint_health_checked_at: Time.current)
+    assert_equal :check_error, agent.reload.agent_liveness_status
+
+    agent.update_columns(endpoint_health_status: 1, endpoint_health_checked_at: 4.minutes.ago)
+    assert_equal :unknown, agent.reload.agent_liveness_status
+    assert_not agent.agent_online?
+  end
+
+  test "an unregistered checker stays unknown and never makes an agent online" do
+    agent = users(:ai_bot)
+    agent.update!(llm_vendor: "vendor-without-checker")
+    agent.update_columns(endpoint_health_status: 1, endpoint_health_checked_at: Time.current)
+
+    assert_not agent.endpoint_health_supported?
+    assert_equal :unknown, agent.reload.agent_liveness_status
+    assert_not agent.agent_online?
+  end
+
+  test "changing endpoint configuration invalidates the cached verdict" do
+    agent = users(:ai_bot)
+    agent.update!(llm_vendor: "openai", gateway_url: "https://old.example.test/v1")
+    agent.update_columns(
+      endpoint_health_status: 1,
+      endpoint_health_checked_at: Time.current,
+      endpoint_health_error: "old"
+    )
+
+    agent.update!(gateway_url: "https://new.example.test/v1")
+
+    assert_predicate agent, :endpoint_health_unknown?
+    assert_nil agent.endpoint_health_checked_at
+    assert_nil agent.endpoint_health_error
+  end
+
   private
 
   def create_cli_proxy_agent(owner, gateway, model)

--- a/engines/collavre/test/models/user_test.rb
+++ b/engines/collavre/test/models/user_test.rb
@@ -123,7 +123,7 @@ class UserTest < ActiveSupport::TestCase
       name: "Invalid CLI agent",
       email: "invalid-cli-agent@ai.local",
       password: SecureRandom.hex(24),
-      llm_vendor: "cli_proxy",
+      llm_vendor: " CLI_PROXY ",
       llm_model: "paperclip/claude_local",
       created_by_id: owner.id,
       agent_gateway: gateway
@@ -145,7 +145,7 @@ class UserTest < ActiveSupport::TestCase
       name: "Keyless CLI agent",
       email: "keyless-cli-agent@ai.local",
       password: SecureRandom.hex(24),
-      llm_vendor: "cli_proxy",
+      llm_vendor: " CLI_PROXY ",
       llm_model: "paperclip/claude_local",
       created_by_id: owner.id,
       agent_gateway: gateway

--- a/engines/collavre/test/services/agent_health/openai_endpoint_checker_test.rb
+++ b/engines/collavre/test/services/agent_health/openai_endpoint_checker_test.rb
@@ -66,11 +66,22 @@ module Collavre
         @agent.update!(llm_api_key: nil)
         client = RecordingClient.new
 
-        IntegrationSettings.stub(:fetch, nil) do
+        IntegrationSettings.stub(:fetch, "shared-key") do
           OpenaiEndpointChecker.new(agent: @agent, client: client).call
         end
 
         assert_not client.headers.key?("Authorization")
+      end
+
+      test "uses the integration key when the official endpoint is configured explicitly" do
+        @agent.update!(gateway_url: "https://api.openai.com/v1/", llm_api_key: nil)
+        client = RecordingClient.new
+
+        IntegrationSettings.stub(:fetch, "shared-key") do
+          OpenaiEndpointChecker.new(agent: @agent, client: client).call
+        end
+
+        assert_equal "Bearer shared-key", client.headers["Authorization"]
       end
 
       test "does not append models twice" do

--- a/engines/collavre/test/services/agent_health/openai_endpoint_checker_test.rb
+++ b/engines/collavre/test/services/agent_health/openai_endpoint_checker_test.rb
@@ -73,15 +73,17 @@ module Collavre
         assert_not client.headers.key?("Authorization")
       end
 
-      test "uses the integration key when the official endpoint is configured explicitly" do
-        @agent.update!(gateway_url: "https://api.openai.com/v1/", llm_api_key: nil)
-        client = RecordingClient.new
+      test "uses the integration key for normalized forms of the official endpoint" do
+        [ "https://API.OPENAI.COM/v1", "https://api.openai.com:443/v1/" ].each do |gateway_url|
+          @agent.update!(gateway_url: gateway_url, llm_api_key: nil)
+          client = RecordingClient.new
 
-        IntegrationSettings.stub(:fetch, "shared-key") do
-          OpenaiEndpointChecker.new(agent: @agent, client: client).call
+          IntegrationSettings.stub(:fetch, "shared-key") do
+            OpenaiEndpointChecker.new(agent: @agent, client: client).call
+          end
+
+          assert_equal "Bearer shared-key", client.headers["Authorization"], gateway_url
         end
-
-        assert_equal "Bearer shared-key", client.headers["Authorization"]
       end
 
       test "does not append models twice" do

--- a/engines/collavre/test/services/agent_health/openai_endpoint_checker_test.rb
+++ b/engines/collavre/test/services/agent_health/openai_endpoint_checker_test.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  module AgentHealth
+    class OpenaiEndpointCheckerTest < ActiveSupport::TestCase
+      Response = Struct.new(:code, keyword_init: true)
+
+      class RecordingClient
+        attr_reader :url, :headers
+
+        def initialize(response: Response.new(code: 200), error: nil)
+          @response = response
+          @error = error
+        end
+
+        def get(url, headers:)
+          @url = url
+          @headers = headers
+          raise @error if @error
+
+          @response
+        end
+      end
+
+      setup do
+        @owner = users(:one)
+        @agent = Collavre::User.create!(
+          name: "Endpoint Agent",
+          email: "endpoint-agent@example.test",
+          password: SecureRandom.hex(24),
+          llm_vendor: "openai",
+          llm_model: "gpt-test",
+          llm_api_key: "secret-key",
+          gateway_url: "https://gateway.example.test/v1/",
+          created_by_id: @owner.id
+        )
+      end
+
+      test "checks the models endpoint with the configured bearer key" do
+        client = RecordingClient.new
+
+        result = OpenaiEndpointChecker.new(agent: @agent, client: client).call
+
+        assert_equal :online, result.status
+        assert_nil result.error
+        assert_equal "https://gateway.example.test/v1/models", client.url
+        assert_equal "Bearer secret-key", client.headers["Authorization"]
+        assert_equal "application/json", client.headers["Accept"]
+      end
+
+      test "uses the official endpoint and integration key when agent settings are blank" do
+        @agent.update!(gateway_url: nil, llm_api_key: nil)
+        client = RecordingClient.new
+
+        IntegrationSettings.stub(:fetch, "shared-key") do
+          OpenaiEndpointChecker.new(agent: @agent, client: client).call
+        end
+
+        assert_equal "https://api.openai.com/v1/models", client.url
+        assert_equal "Bearer shared-key", client.headers["Authorization"]
+      end
+
+      test "does not send authorization when a keyless endpoint is configured" do
+        @agent.update!(llm_api_key: nil)
+        client = RecordingClient.new
+
+        IntegrationSettings.stub(:fetch, nil) do
+          OpenaiEndpointChecker.new(agent: @agent, client: client).call
+        end
+
+        assert_not client.headers.key?("Authorization")
+      end
+
+      test "does not append models twice" do
+        @agent.update!(gateway_url: "https://gateway.example.test/v1/models")
+        client = RecordingClient.new
+
+        OpenaiEndpointChecker.new(agent: @agent, client: client).call
+
+        assert_equal "https://gateway.example.test/v1/models", client.url
+      end
+
+      test "maps HTTP responses without making a completion request" do
+        expectations = {
+          204 => [ :online, nil ],
+          401 => [ :offline, "authentication_failed" ],
+          403 => [ :offline, "authentication_failed" ],
+          404 => [ :unknown, "models_endpoint_unsupported" ],
+          405 => [ :unknown, "models_endpoint_unsupported" ],
+          408 => [ :offline, "http_408" ],
+          425 => [ :offline, "http_425" ],
+          429 => [ :offline, "http_429" ],
+          503 => [ :offline, "http_503" ],
+          400 => [ :unknown, "http_400" ]
+        }
+
+        expectations.each do |code, (status, error)|
+          client = RecordingClient.new(response: Response.new(code: code))
+          result = OpenaiEndpointChecker.new(agent: @agent, client: client).call
+
+          assert_equal status, result.status, "HTTP #{code}"
+          error.nil? ? assert_nil(result.error, "HTTP #{code}") : assert_equal(error, result.error, "HTTP #{code}")
+        end
+      end
+
+      test "maps transport and oversized response errors" do
+        connection = RecordingClient.new(error: HttpClient::ConnectionError.new("secret host failed"))
+        oversized = RecordingClient.new(error: HttpClient::ResponseTooLarge.new("too large"))
+
+        assert_equal "connection_failed", OpenaiEndpointChecker.new(agent: @agent, client: connection).call.error
+        oversized_result = OpenaiEndpointChecker.new(agent: @agent, client: oversized).call
+        assert_equal :unknown, oversized_result.status
+        assert_equal "response_too_large", oversized_result.error
+      end
+
+      test "rejects malformed and policy-blocked endpoints" do
+        @agent.update!(gateway_url: "not a URL")
+        assert_equal "invalid_endpoint", OpenaiEndpointChecker.new(agent: @agent).call.error
+
+        non_admin = users(:two)
+        @agent.update!(created_by_id: non_admin.id, gateway_url: "http://127.0.0.1:11434/v1")
+        assert_equal "invalid_endpoint", OpenaiEndpointChecker.new(agent: @agent).call.error
+      end
+
+      test "applies endpoint policy for non-admin owners and bypasses it for administrators" do
+        assert_nil OpenaiEndpointChecker.new(agent: @agent, client: RecordingClient.new).send(:endpoint_policy)
+
+        @agent.update!(created_by_id: users(:two).id)
+        policy = OpenaiEndpointChecker.new(agent: @agent, client: RecordingClient.new).send(:endpoint_policy)
+        assert_instance_of CliProxy::EndpointPolicy, policy
+      end
+    end
+  end
+end

--- a/engines/collavre/test/services/agent_health/probe_test.rb
+++ b/engines/collavre/test/services/agent_health/probe_test.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  module AgentHealth
+    class ProbeTest < ActiveSupport::TestCase
+      class OnlineChecker
+        def initialize(agent:)
+          @agent = agent
+        end
+
+        def call
+          Result.new(status: :online, error: nil)
+        end
+      end
+
+      class ErrorChecker
+        def initialize(agent:); end
+
+        def call
+          raise RuntimeError, "checker exploded"
+        end
+      end
+
+      class InvalidChecker
+        def initialize(agent:); end
+
+        def call
+          Object.new
+        end
+      end
+
+      setup do
+        @agent = Collavre::User.create!(
+          name: "Probe Agent",
+          email: "probe-agent@example.test",
+          password: SecureRandom.hex(24),
+          llm_vendor: "probe-vendor",
+          llm_model: "probe-model"
+        )
+      end
+
+      teardown { AgentHealth.unregister("probe-vendor") }
+
+      test "records a valid checker result without changing agent configuration timestamp" do
+        AgentHealth.register("probe-vendor", OnlineChecker)
+        configured_at = @agent.updated_at
+
+        assert_equal :online, Probe.new(agent: @agent).call
+
+        @agent.reload
+        assert_predicate @agent, :endpoint_health_online?
+        assert_not_nil @agent.endpoint_health_checked_at
+        assert_nil @agent.endpoint_health_error
+        assert_equal configured_at, @agent.updated_at
+      end
+
+      test "records checker exceptions as visible check errors without re-raising" do
+        AgentHealth.register("probe-vendor", ErrorChecker)
+
+        assert_equal :check_error, Probe.new(agent: @agent).call
+
+        @agent.reload
+        assert_predicate @agent, :endpoint_health_check_error?
+        assert_equal "RuntimeError", @agent.endpoint_health_error
+      end
+
+      test "records invalid checker results as check errors" do
+        AgentHealth.register("probe-vendor", InvalidChecker)
+
+        assert_equal :check_error, Probe.new(agent: @agent).call
+        assert_equal "ArgumentError", @agent.reload.endpoint_health_error
+      end
+
+      test "does nothing when no checker is registered" do
+        checked_at = @agent.endpoint_health_checked_at
+
+        assert_equal :unsupported, Probe.new(agent: @agent).call
+        assert_nil checked_at
+        assert_nil @agent.reload.endpoint_health_checked_at
+        assert_predicate @agent, :endpoint_health_unknown?
+      end
+
+      test "does not write a result over changed endpoint configuration" do
+        checker = Class.new do
+          def initialize(agent:)
+            @agent = agent
+          end
+
+          def call
+            @agent.update!(gateway_url: "https://changed.example.test/v1")
+            Result.new(status: :online)
+          end
+        end
+        AgentHealth.register("probe-vendor", checker)
+
+        assert_equal :online, Probe.new(agent: @agent).call
+        assert_predicate @agent.reload, :endpoint_health_unknown?
+        assert_nil @agent.endpoint_health_checked_at
+      end
+
+      test "truncates stored checker errors" do
+        checker = Class.new do
+          def initialize(agent:); end
+
+          def call
+            Result.new(status: :offline, error: "x" * 300)
+          end
+        end
+        AgentHealth.register("probe-vendor", checker)
+
+        Probe.new(agent: @agent).call
+
+        assert_equal Probe::ERROR_LIMIT, @agent.reload.endpoint_health_error.length
+      end
+    end
+  end
+end

--- a/engines/collavre/test/services/agent_health_test.rb
+++ b/engines/collavre/test/services/agent_health_test.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  class AgentHealthTest < ActiveSupport::TestCase
+    class Checker
+      def initialize(agent:); end
+    end
+
+    teardown { AgentHealth.unregister("test-vendor") }
+
+    test "registers and resolves checkers by normalized vendor" do
+      AgentHealth.register(" Test-Vendor ", Checker)
+
+      assert_equal Checker, AgentHealth.checker_for("TEST-VENDOR")
+      assert_includes AgentHealth.vendors, "test-vendor"
+    end
+
+    test "unregisters a checker without affecting unknown vendors" do
+      AgentHealth.register("test-vendor", Checker)
+
+      assert_equal Checker, AgentHealth.unregister("TEST-VENDOR")
+      assert_nil AgentHealth.checker_for("test-vendor")
+      assert_nil AgentHealth.unregister("missing-vendor")
+    end
+
+    test "rejects an empty vendor and a non-instantiable checker" do
+      assert_raises(ArgumentError) { AgentHealth.register(" ", Checker) }
+      assert_raises(ArgumentError) { AgentHealth.register("test-vendor", Object.new) }
+    end
+  end
+end

--- a/engines/collavre/test/services/ai_client_test.rb
+++ b/engines/collavre/test/services/ai_client_test.rb
@@ -266,6 +266,34 @@ class AiClientTest < ActiveSupport::TestCase
     assert mock_config.verify
   end
 
+  test "build_conversation normalizes vendor whitespace and case" do
+    client = AiClient.new(
+      vendor: " OpenAI ",
+      model: "gpt-test",
+      system_prompt: nil,
+      llm_api_key: "agent-key",
+      gateway_url: "https://gateway.example.test/v1"
+    )
+    fake_chat = FakeConversation.new
+    chat_options = nil
+    mock_context = Object.new
+    mock_context.define_singleton_method(:chat) do |**options|
+      chat_options = options
+      fake_chat
+    end
+    mock_config = Minitest::Mock.new
+    mock_config.expect(:openai_api_key=, nil, [ "agent-key" ])
+    mock_config.expect(:openai_api_base=, nil, [ "https://gateway.example.test/v1" ])
+    mock_config.expect(:request_timeout=, 1800, [ 1800 ])
+
+    RubyLLM.stub(:context, ->(&block) { block.call(mock_config); mock_context }) do
+      client.send(:build_conversation)
+    end
+
+    assert_equal :openai, chat_options[:provider]
+    assert mock_config.verify
+  end
+
   test "build_conversation sets X-Session-Id header from creative and topic" do
     creative = OpenStruct.new(id: 42)
     comment = OpenStruct.new(topic_id: 7)

--- a/engines/collavre/test/services/ai_client_test.rb
+++ b/engines/collavre/test/services/ai_client_test.rb
@@ -294,6 +294,38 @@ class AiClientTest < ActiveSupport::TestCase
     assert mock_config.verify
   end
 
+  test "OpenAI dispatch only falls back to the integration key for official endpoints" do
+    endpoints = {
+      nil => "shared-key",
+      "https://api.openai.com/v1" => "shared-key",
+      "https://API.OPENAI.COM/v1" => "shared-key",
+      "https://api.openai.com:443/v1/" => "shared-key",
+      "https://gateway.example.test/v1" => "local-gateway"
+    }
+
+    [ "openai", " OpenAI " ].each do |vendor|
+      endpoints.each do |gateway_url, expected_key|
+        [ nil, "agent-key" ].each do |agent_key|
+          client = AiClient.new(vendor: vendor, model: "gpt-test", system_prompt: nil,
+                                gateway_url: gateway_url, llm_api_key: agent_key)
+          config = OpenStruct.new
+          fake_chat = FakeConversation.new
+          mock_context = Object.new
+          mock_context.define_singleton_method(:chat) { |**| fake_chat }
+
+          Collavre::IntegrationSettings.stub(:fetch, "shared-key") do
+            RubyLLM.stub(:context, ->(&block) { block.call(config); mock_context }) do
+              client.send(:build_conversation)
+            end
+          end
+
+          assert_equal agent_key || expected_key, config.openai_api_key, "#{vendor}: #{gateway_url}"
+          assert_equal gateway_url, config.openai_api_base if gateway_url
+        end
+      end
+    end
+  end
+
   test "build_conversation sets X-Session-Id header from creative and topic" do
     creative = OpenStruct.new(id: 42)
     comment = OpenStruct.new(topic_id: 7)

--- a/engines/collavre/test/services/ai_client_test.rb
+++ b/engines/collavre/test/services/ai_client_test.rb
@@ -266,6 +266,17 @@ class AiClientTest < ActiveSupport::TestCase
     assert mock_config.verify
   end
 
+  test "vendor options normalize values and avoid duplicates" do
+    AiClient.register_vendor_option("Test", " Test-Vendor ")
+    AiClient.register_vendor_option("Duplicate", "TEST-VENDOR")
+    AiClient.register_vendor_option("Built-in", " OpenAI ")
+
+    assert_equal [ [ "Test", "test-vendor" ] ], AiClient.vendor_options.select { |_label, value| value == "test-vendor" }
+    assert_equal [ [ "OpenAI", "openai" ] ], AiClient.vendor_options.select { |_label, value| value == "openai" }
+  ensure
+    AiClient.registered_vendor_options.reject! { |_label, value| value == "test-vendor" }
+  end
+
   test "build_conversation normalizes vendor whitespace and case" do
     client = AiClient.new(
       vendor: " OpenAI ",

--- a/engines/collavre/test/services/collavre/agent_session_abort_test.rb
+++ b/engines/collavre/test/services/collavre/agent_session_abort_test.rb
@@ -6,6 +6,16 @@ module Collavre
       AgentSessionAbort.registry.delete("test-vendor")
     end
 
+    test "normalizes vendors for registration and abort lookup" do
+      called = false
+      AgentSessionAbort.register(" Test-Vendor ", ->(**) { called = true })
+      agent = User.new(llm_vendor: " TEST-VENDOR ")
+
+      AgentSessionAbort.call(agent: agent, task: Object.new)
+
+      assert called
+    end
+
     test "dispatches to the handler registered for the agent's vendor (case-insensitive)" do
       received = nil
       AgentSessionAbort.register("test-vendor", lambda { |agent:, task:, creative:, comment:|

--- a/engines/collavre/test/services/collavre/ai_agent/session_context_resolver_test.rb
+++ b/engines/collavre/test/services/collavre/ai_agent/session_context_resolver_test.rb
@@ -126,6 +126,22 @@ module Collavre
         assert_equal @system_prompt, result[:system_prompt]
       end
 
+      test "normalizes registered and stored vendors for incremental session payloads" do
+        AiClient.register_session_vendor(" Test-Stateful ")
+        agent = User.new(llm_vendor: " TEST-Stateful ")
+        messages_data = { messages: @full_messages, first_message: false, context_changed: false }
+
+        assert agent.supports_session?
+        result = SessionContextResolver.new(
+          agent: agent, messages_data: messages_data, system_prompt: @system_prompt
+        ).resolve
+
+        assert_equal [ @full_messages.last ], result[:messages]
+        assert_nil result[:system_prompt]
+      ensure
+        AiClient.session_vendors.delete("test-stateful")
+      end
+
       private
 
       def build_agent(supports_session:)

--- a/engines/collavre/test/services/openai_endpoint_test.rb
+++ b/engines/collavre/test/services/openai_endpoint_test.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  class OpenaiEndpointTest < ActiveSupport::TestCase
+    test "recognizes the default endpoint and equivalent official URLs" do
+      [ nil, "", "https://api.openai.com/v1", "https://API.OPENAI.COM/v1",
+        "https://api.openai.com:443/v1/" ].each do |url|
+        assert OpenaiEndpoint.official?(url), url.inspect
+      end
+    end
+
+    test "never fetches shared credentials for custom or malformed endpoints" do
+      urls = [
+        "https://gateway.example.test/v1", "http://api.openai.com/v1",
+        "https://api.openai.com:444/v1", "https://api.openai.com/v2",
+        "https://api.openai.com.example.test/v1", "https://user@api.openai.com/v1",
+        "https://api.openai.com/v1?redirect=evil", "https://api.openai.com/v1#fragment",
+        "not a URL", "mailto:test@example.test"
+      ]
+      IntegrationSettings.stub(:fetch, ->(*) { flunk "Custom endpoints must not fetch shared credentials" }) do
+        urls.each do |url|
+          assert_not OpenaiEndpoint.official?(url), url
+          assert_nil OpenaiEndpoint.api_key(base_url: url, api_key: nil), url
+          assert_equal "agent-key", OpenaiEndpoint.api_key(base_url: url, api_key: "agent-key")
+        end
+      end
+    end
+
+    test "prefers the agent key and tolerates missing integration credentials" do
+      IntegrationSettings.stub(:fetch, nil) do
+        assert_nil OpenaiEndpoint.api_key(base_url: nil, api_key: nil)
+        assert_equal "agent-key", OpenaiEndpoint.api_key(base_url: nil, api_key: "agent-key")
+      end
+    end
+  end
+end

--- a/engines/collavre_openclaw/app/services/collavre_openclaw/ai_client_extension.rb
+++ b/engines/collavre_openclaw/app/services/collavre_openclaw/ai_client_extension.rb
@@ -8,7 +8,7 @@ module CollavreOpenclaw
       end
 
       def register_adapter(vendor, adapter_class)
-        adapter_registry[vendor.to_s.downcase] = adapter_class
+        adapter_registry[vendor.to_s.strip.downcase] = adapter_class
       end
     end
 

--- a/engines/collavre_openclaw/test/services/ai_client_extension_test.rb
+++ b/engines/collavre_openclaw/test/services/ai_client_extension_test.rb
@@ -78,6 +78,17 @@ module CollavreOpenclaw
       [ { role: :user, parts: [ { text: "안녀하세요" } ] } ]
     end
 
+    test "normalizes adapter registration and dispatch vendors" do
+      Collavre::AiClient.adapter_registry.delete("faketest")
+      Collavre::AiClient.register_adapter(" FakeTest ", FakeAdapter)
+      assert_equal FakeAdapter, Collavre::AiClient.adapter_registry["faketest"]
+      client = Collavre::AiClient.new(
+        vendor: " FAKETEST ", model: "m", system_prompt: "s", log_interactions: false
+      )
+
+      assert_equal "ok", client.chat(messages)
+    end
+
     test "does not log the interaction when log_interactions is false" do
       client = build_client(log_interactions: false)
       logged = false

--- a/script/postgres_query_smoke.rb
+++ b/script/postgres_query_smoke.rb
@@ -32,7 +32,7 @@ actor = Collavre::User.create!(
 )
 Collavre::Current.user = actor
 creative = Collavre::Creative.create!(description: "Smoke Host", user: actor)
-Collavre::User.create!(
+reviewer = Collavre::User.create!(
   name: "Smoke Reviewer", email: "smoke-agent-#{suffix}@example.test", password: "password123",
   llm_vendor: "google", llm_model: "gemini-1.5-flash", searchable: true
 )
@@ -62,6 +62,12 @@ end
 # DISTINCT either.
 check(failures, "AgentGateway.health_probe_targets") do
   Collavre::AgentGateway.health_probe_targets.find_by(id: -1)
+end
+
+check(failures, "User.with_llm_vendors normalizes control whitespace") do
+  reviewer.update_column(:llm_vendor, "\tGoOgLe\r\n")
+  Collavre::User.ai_agents.with_llm_vendors([ "google" ]).exists?(reviewer.id) ||
+    raise("expected the tab-padded vendor to match")
 end
 
 abort "\n#{failures.size} PostgreSQL-incompatible query/queries:\n- #{failures.join("\n- ")}" if failures.any?


### PR DESCRIPTION
## Summary

Agents using ordinary OpenAI-compatible endpoints previously appeared offline because endpoint health was limited to CLI gateways. Add optional vendor checkers that report endpoint reachability independently of agent dispatch.

- Register vendor checkers and cache results with a three-minute TTL and configuration-change invalidation.
- Probe OpenAI-compatible endpoints with `GET /models`, without inference requests. Dispatch and probes share credential selection: integration keys are restricted to the normalized official OpenAI endpoint; custom endpoints use per-agent credentials or the existing non-secret dispatch placeholder.
- Show offline, unknown, and checker-error states without exposing secrets or exception messages. Missing checkers do not block calls.
- Normalize vendor names consistently across dispatch, session and adapter registries, session cancellation, CLI Proxy gateway assignment/validation, and health sweep selection. Preserve the assigned CLI gateway when an update omits its ID.
- Match stored vendor spellings with Ruby normalization in both health queries, including tabs and line breaks; verify PostgreSQL behavior in CI.
- Run endpoint probes on the dedicated health queue with the existing endpoint policy protections.
- Keep agent profile menus clickable on touch devices: apply opacity only during actual dragging, avoiding an active-state stacking context that redirected menu clicks to underlying content.

## Validation

- Credential selection, dispatch, and OpenAI checker tests: 56 tests / 256 assertions passed.
- Vendor/session/adapter regression tests: 68 tests / 253 assertions passed; strengthened adapter regression rerun: 9 tests / 28 assertions passed.
- User, gateway, AI management controller, and gateway health job tests: 94 tests / 526 assertions passed after building JavaScript assets.
- Rubocop: 1,382 files, no offenses. Complexity ratchet: no growth; three existing violations removed.
- The shared credential policy and OpenAI checker have no uncovered executable lines in local targeted coverage.
- Health query regression tests: 16 tests / 94 assertions passed, covering six whitespace characters, case, and relation scoping.
- Profile menu system tests: 10 tests / 80 assertions passed after reproducing and fixing the mobile click failure; existing assertions retained.
- Rebased on main 8aaf57bd. Full CI, CodeQL, and patch coverage run on each PR update.