### PR TITLE
Fix avatar popup profile and mention actions

### DIFF
--- a/engines/collavre/app/components/collavre/comment_user_menu_component.html.erb
+++ b/engines/collavre/app/components/collavre/comment_user_menu_component.html.erb
@@ -32,7 +32,10 @@
       </div>
     </div>
 
-    <a href="<%= profile_path %>" class="popup-menu-item" role="menuitem">
+    <a href="<%= profile_path %>"
+       class="popup-menu-item"
+       data-action="click->comment-user-menu#visitProfile"
+       role="menuitem">
       <%= t('collavre.comments.user_menu.view_profile') %>
     </a>
     <button type="button"

--- a/engines/collavre/app/javascript/comments/__tests__/user_menu.test.js
+++ b/engines/collavre/app/javascript/comments/__tests__/user_menu.test.js
@@ -43,6 +43,8 @@ describe('createUserMenu', () => {
     expect(menu.querySelector('.comment-user-popup-status').classList.contains('is-online')).toBe(true)
     expect(menu.querySelector('[data-comment-user-menu-target="statusLabel"]').textContent).toBe('Online')
     expect(menu.querySelector('a.popup-menu-item').getAttribute('href')).toBe('/users/9')
+    expect(menu.querySelector('a.popup-menu-item').dataset.action)
+      .toBe('click->comment-user-menu#visitProfile')
     expect(menu.querySelector('button.popup-menu-item').textContent).toBe('Mention')
     expect(menu.querySelector('.comment-user-popup-guide')).toBeNull()
   })

--- a/engines/collavre/app/javascript/comments/user_menu.js
+++ b/engines/collavre/app/javascript/comments/user_menu.js
@@ -94,6 +94,7 @@ export function createUserMenu({ user, online, labels, menuId, draggable = false
   const profile = document.createElement('a')
   profile.href = user.profile_url
   profile.className = 'popup-menu-item'
+  profile.dataset.action = 'click->comment-user-menu#visitProfile'
   profile.setAttribute('role', 'menuitem')
   profile.textContent = labels.viewProfile
   menu.appendChild(profile)

--- a/engines/collavre/app/javascript/controllers/__tests__/comment_user_menu_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/comment_user_menu_controller.test.js
@@ -76,20 +76,36 @@ describe('CommentUserMenuController', () => {
   test('inserts a mention and focuses the composer', () => {
     const textareaTarget = { focus: jest.fn() }
     const mentionMenu = { insertMention: jest.fn(), textareaTarget }
-    jest.spyOn(application, 'getControllerForElementAndIdentifier').mockImplementation((_element, identifier) => (
-      identifier === 'comments--mention-menu' ? mentionMenu : null
-    ))
+    const popupMenu = { hide: jest.fn() }
+    jest.spyOn(application, 'getControllerForElementAndIdentifier').mockImplementation((_element, identifier) => {
+      if (identifier === 'comments--mention-menu') return mentionMenu
+      if (identifier === 'popup-menu') return popupMenu
+      return null
+    })
+    const event = { stopPropagation: jest.fn() }
 
-    controller.mention()
+    controller.mention(event)
 
+    expect(event.stopPropagation).toHaveBeenCalled()
     expect(mentionMenu.insertMention).toHaveBeenCalledWith({ id: 9, name: 'Agent One' })
     expect(textareaTarget.focus).toHaveBeenCalled()
+    expect(popupMenu.hide).toHaveBeenCalled()
   })
 
-  test('does nothing when the mention controller is unavailable', () => {
+  test('keeps the menu open when the mention controller is unavailable', () => {
     jest.spyOn(application, 'getControllerForElementAndIdentifier').mockReturnValue(null)
+    const event = { stopPropagation: jest.fn() }
 
-    expect(() => controller.mention()).not.toThrow()
+    expect(() => controller.mention(event)).not.toThrow()
+    expect(event.stopPropagation).toHaveBeenCalled()
+  })
+
+  test('keeps profile navigation from being interrupted by the popup close handler', () => {
+    const event = { stopPropagation: jest.fn() }
+
+    controller.visitProfile(event)
+
+    expect(event.stopPropagation).toHaveBeenCalled()
   })
 
   test('removes the presence listener when disconnected', () => {

--- a/engines/collavre/app/javascript/controllers/comment_user_menu_controller.js
+++ b/engines/collavre/app/javascript/controllers/comment_user_menu_controller.js
@@ -18,7 +18,18 @@ export default class extends Controller {
     this.popupElement?.removeEventListener('comments--presence:changed', this.handlePresenceChanged)
   }
 
-  mention() {
+  visitProfile(event) {
+    // Keep the link in the document until its native navigation runs. The
+    // parent popup's delegated click handler otherwise hides it during the
+    // same event, which can cancel the link activation in some browsers.
+    event.stopPropagation()
+  }
+
+  mention(event) {
+    // This action owns both the command and its close behavior. If the chat
+    // composer is unavailable, leave the menu open instead of making a failed
+    // mention look successful.
+    event?.stopPropagation()
     const mentionMenu = this.application.getControllerForElementAndIdentifier(
       this.popupElement,
       'comments--mention-menu'
@@ -27,6 +38,7 @@ export default class extends Controller {
 
     mentionMenu.insertMention({ id: this.userIdValue, name: this.userNameValue })
     mentionMenu.textareaTarget?.focus()
+    this.popupMenuController?.hide()
   }
 
   handlePresenceChanged(event) {
@@ -39,6 +51,10 @@ export default class extends Controller {
 
   get presenceController() {
     return this.application.getControllerForElementAndIdentifier(this.popupElement, 'comments--presence')
+  }
+
+  get popupMenuController() {
+    return this.application.getControllerForElementAndIdentifier(this.element, 'popup-menu')
   }
 
   updatePresence(presentIds) {

--- a/engines/collavre/test/components/comment_user_menu_component_test.rb
+++ b/engines/collavre/test/components/comment_user_menu_component_test.rb
@@ -11,8 +11,9 @@ class CommentUserMenuComponentTest < ViewComponent::TestCase
     assert_selector ".comment-user-popup-identity strong", text: user.display_name
     assert_selector ".comment-user-popup-email", text: user.email
     assert_selector ".comment-user-popup-status", text: I18n.t("collavre.comments.participant_offline")
-    assert_selector "a.popup-menu-item[href='#{Collavre::Engine.routes.url_helpers.user_path(user)}']",
-      text: I18n.t("collavre.comments.user_menu.view_profile")
+    profile_selector = "a.popup-menu-item[href='#{Collavre::Engine.routes.url_helpers.user_path(user)}']" \
+      "[data-action='click->comment-user-menu#visitProfile']"
+    assert_selector profile_selector, text: I18n.t("collavre.comments.user_menu.view_profile")
     assert_selector "button[data-action='click->comment-user-menu#mention']",
       text: I18n.t("collavre.comments.user_menu.mention")
     assert_no_selector "[draggable='true']"

--- a/engines/collavre/test/system/chat_bar_list_popup_test.rb
+++ b/engines/collavre/test/system/chat_bar_list_popup_test.rb
@@ -176,4 +176,73 @@ class ChatBarListPopupTest < ApplicationSystemTestCase
 
     assert_operator bottom, :<=, keyboard_top
   end
+
+  test "message author menu actions work on mobile" do
+    comment = Comment.create!(creative: @creative, user: @user, content: "Mobile menu actions")
+    resize_window_to(390, 844)
+    open_comments_popup
+
+    trigger_selector = "#comment_#{comment.id} .comment-user-menu-trigger"
+    menu_selector = "#user_menu_comment_#{comment.id}"
+
+    touch = page.driver.browser.action
+    touch.add_pointer_input(:touch, "finger")
+    touch.click(find(trigger_selector).native, device: "finger").perform
+    within menu_selector do
+      touch = page.driver.browser.action
+      touch.add_pointer_input(:touch, "finger")
+      touch.click(find_button(I18n.t("collavre.comments.user_menu.mention")).native, device: "finger").perform
+    end
+    assert_equal "@#{@user.name}: ", find("#new-comment-form textarea").value
+
+    touch = page.driver.browser.action
+    touch.add_pointer_input(:touch, "finger")
+    touch.click(find(trigger_selector).native, device: "finger").perform
+    within menu_selector do
+      touch = page.driver.browser.action
+      touch.add_pointer_input(:touch, "finger")
+      touch.click(find_link(I18n.t("collavre.comments.user_menu.view_profile")).native, device: "finger").perform
+    end
+    assert_current_path Collavre::Engine.routes.url_helpers.user_path(@user)
+  end
+
+  test "draggable agent menu actions work on mobile" do
+    agent = User.create!(
+      email: "chat-bar-agent@ai.local",
+      password: SystemHelpers::PASSWORD,
+      name: "ChatBarAgent",
+      email_verified_at: Time.current,
+      notifications_enabled: false,
+      llm_vendor: "google",
+      llm_model: "gemini-1.5-flash",
+      system_prompt: "Test agent"
+    )
+    CreativeShare.create!(creative: @creative, user: agent, permission: :feedback)
+    resize_window_to(390, 844)
+    open_comments_popup
+
+    trigger_selector = "[data-comment-user-menu-user-id-value='#{agent.id}'] .comment-user-menu-trigger"
+    menu_selector = "#participant-user-menu-#{agent.id}"
+    assert_selector trigger_selector, wait: 10
+
+    touch = page.driver.browser.action
+    touch.add_pointer_input(:touch, "finger")
+    touch.click(find(trigger_selector).native, device: "finger").perform
+    within menu_selector do
+      touch = page.driver.browser.action
+      touch.add_pointer_input(:touch, "finger")
+      touch.click(find_button(I18n.t("collavre.comments.user_menu.mention")).native, device: "finger").perform
+    end
+    assert_equal "@#{agent.name}: ", find("#new-comment-form textarea").value
+
+    touch = page.driver.browser.action
+    touch.add_pointer_input(:touch, "finger")
+    touch.click(find(trigger_selector).native, device: "finger").perform
+    within menu_selector do
+      touch = page.driver.browser.action
+      touch.add_pointer_input(:touch, "finger")
+      touch.click(find_link(I18n.t("collavre.comments.user_menu.view_profile")).native, device: "finger").perform
+    end
+    assert_current_path Collavre::Engine.routes.url_helpers.user_path(agent)
+  end
 end


### PR DESCRIPTION
## Summary

- keep profile links mounted until native navigation completes
- let mention actions insert text before closing their popup
- cover message-author and draggable-agent actions with mobile touch regression tests

## Testing

- `mise exec -- env PARALLEL_WORKERS=1 bin/rails test engines/collavre/test/components/comment_user_menu_component_test.rb engines/collavre/test/system/chat_bar_list_popup_test.rb`
- `mise exec -- env PARALLEL_WORKERS=1 bin/rails test engines/collavre/test/system/inline_scripts_test.rb:206`
- `mise exec -- npm test -- --coverage --runInBand engines/collavre/app/javascript/comments/__tests__/user_menu.test.js engines/collavre/app/javascript/controllers/__tests__/comment_user_menu_controller.test.js`
- `mise exec -- bin/rubocop`
- `mise exec -- bin/complexity_check --base origin/main`