### PR TITLE
fix(history): avoid PostgreSQL JSON distinct projection

### DIFF
--- a/engines/collavre/app/services/collavre/comments/list_response.rb
+++ b/engines/collavre/app/services/collavre/comments/list_response.rb
@@ -33,7 +33,7 @@ module Collavre
 
       def render_history
         change_sets = CreativeChangeSet.for_creative_scope(@history_scope_creative)
-          .visible_by_default.includes(:creative_changes, :user)
+          .visible_by_default.preload(:creative_changes, :user)
         change_sets = Creatives::HistoryPage.new(
           scope: change_sets,
           user: Current.user,

--- a/engines/collavre/test/controllers/comments_controller_test.rb
+++ b/engines/collavre/test/controllers/comments_controller_test.rb
@@ -46,6 +46,29 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
     assert_equal I18n.t("collavre.creative_history.read_only"), response.parsed_body["error"]
   end
 
+  test "History keeps JSON snapshots out of the distinct change set query" do
+    Collavre::Creatives::History.track(actor: @user, origin: :tool, anchor: @creative) do
+      @creative.update!(progress: 0.75)
+    end
+    history_topic = @creative.reload.history_topic
+    history_queries = []
+    subscriber = lambda do |_name, _start, _finish, _id, payload|
+      sql = payload[:sql].to_s
+      history_queries << sql if sql.include?("SELECT DISTINCT") && sql.include?('FROM "creative_change_sets"')
+    end
+
+    ActiveSupport::Notifications.subscribed(subscriber, "sql.active_record") do
+      get creative_comments_path(@creative), params: { topic_id: history_topic.id }
+    end
+
+    assert_response :success
+    assert_not_empty history_queries
+    history_queries.each do |query|
+      assert_not_includes query, '"creative_changes"."before"'
+      assert_not_includes query, '"creative_changes"."after"'
+    end
+  end
+
   test "History hides revert and restore controls from a read-only viewer" do
     Collavre::Creatives::History.track(actor: @user, origin: :tool, anchor: @creative) do
       @creative.update!(progress: 0.75)


### PR DESCRIPTION
## Summary

- preload History change rows separately from the distinct ChangeSet scope
- keep JSON `before`/`after` snapshots out of PostgreSQL `DISTINCT` projections
- add a regression assertion against the generated History query

## Root cause

Opening a History topic combined `DISTINCT` with eager loading. Active Record expanded the select list to include `creative_changes.before` and `creative_changes.after`, both portable `json` columns. PostgreSQL cannot apply equality for `json`, so the request failed with `PG::UndefinedFunction`.

## Testing

- `bin/rails test engines/collavre/test/services/collavre/creatives/history_test.rb engines/collavre/test/controllers/comments_controller_test.rb` (128 tests, 553 assertions)
- `./bin/rubocop -a` (1,369 files)
- `bin/complexity_check`
