### PR TITLE
Prevent avatar popup actions from starting touch drags

### DIFF
--- a/engines/collavre/app/javascript/lib/dnd/__tests__/touch_bridge.test.js
+++ b/engines/collavre/app/javascript/lib/dnd/__tests__/touch_bridge.test.js
@@ -224,6 +224,17 @@ test('editable controls retain native touch behavior', () => {
   expect(jest.getTimerCount()).toBe(0)
 })
 
+test.each(['a', 'button'])('popup menu %s actions never start a long-press drag', (tagName) => {
+  const action = document.createElement(tagName)
+  action.setAttribute('role', 'menuitem')
+  source.appendChild(action)
+
+  expect(touch('touchstart', 50, action).defaultPrevented).toBe(false)
+  expect(jest.getTimerCount()).toBe(0)
+  jest.advanceTimersByTime(400)
+  expect(document.querySelector('.touch-drag-proxy')).toBeNull()
+})
+
 test('hit tests receive the actual nested pointer target instead of its zone ancestor', () => {
   const form = document.createElement('form')
   zone.appendChild(form)

--- a/engines/collavre/app/javascript/lib/dnd/touch_bridge.js
+++ b/engines/collavre/app/javascript/lib/dnd/touch_bridge.js
@@ -52,7 +52,7 @@ function attachTouchBridge({ root, registry }) {
       if (!registry.getDragSource(touch.target)) return false
       // Editing keeps native focus and selection. Other sources retain native
       // taps and swipes until the long press commits; no synthetic click replay.
-      if (touch.target.closest('input, textarea, select, [contenteditable]:not([contenteditable="false"])')) return false
+      if (touch.target.closest('input, textarea, select, [role="menuitem"], [contenteditable]:not([contenteditable="false"])')) return false
       return true
     },
     getDropTargets: () => registry.getDropTargets(),


### PR DESCRIPTION
## Summary

- exclude popup menu actions from the mobile long-press drag bridge
- preserve avatar dragging from the trigger while keeping profile and mention actions native
- add regression coverage for both link and button menu items

## Context

This follows #1668 after its CI run exposed a touch-through race in the draggable-agent profile action.

## Testing

- `mise exec -- npm test -- --coverage --runInBand engines/collavre/app/javascript/lib/dnd/__tests__/touch_bridge.test.js engines/collavre/app/javascript/comments/__tests__/user_menu.test.js engines/collavre/app/javascript/controllers/__tests__/comment_user_menu_controller.test.js`
- `mise exec -- env PARALLEL_WORKERS=1 bin/rails test engines/collavre/test/system/chat_bar_list_popup_test.rb`
- `mise exec -- bin/complexity_check --base origin/main`