### PR TITLE
fix(orchestration): route to every mentioned agent, not just the first

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_09_11_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_11_020000) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false

--- a/engines/collavre/app/models/collavre/user.rb
+++ b/engines/collavre/app/models/collavre/user.rb
@@ -241,6 +241,12 @@ module Collavre
     end
 
     normalizes :email, with: ->(e) { e.strip.downcase }
+    # A name is written back as the canonical mention "@name:", and mention
+    # parsing stops a name at a line break so that a colon-free mention on one
+    # line cannot swallow the next line's mention. A stored line break would
+    # therefore make that user's own canonical mention unresolvable, so names
+    # are kept to a single line.
+    normalizes :name, with: ->(n) { n.to_s.gsub(/[^\S\r\n]*[\r\n]+[^\S\r\n]*/, " ").strip }
     normalizes :timezone, with: ->(tz) do
       tz = tz.to_s.strip
       next if tz.blank?
@@ -280,12 +286,10 @@ module Collavre
       return yield unless gateway
 
       gateway.with_lock do
-        begin
-          @cli_proxy_gateway_assignment_lock = gateway
-          yield
-        ensure
-          @cli_proxy_gateway_assignment_lock = nil
-        end
+        @cli_proxy_gateway_assignment_lock = gateway
+        yield
+      ensure
+        @cli_proxy_gateway_assignment_lock = nil
       end
     end
 

--- a/engines/collavre/app/services/collavre/ai_agent/a2a_dispatcher.rb
+++ b/engines/collavre/app/services/collavre/ai_agent/a2a_dispatcher.rb
@@ -26,15 +26,25 @@ module Collavre
 
         creative = @reply_comment.creative
         record_interactions(mentioned_agents, creative)
-        dispatch_event(creative)
+        dispatch_event(creative, mentioned_agents)
       rescue StandardError => e
         Rails.logger.error("[AiAgent::A2aDispatcher] A2A dispatch failed: #{e.message}")
       end
 
       private
 
+      # The agents this reply hands off to: every mentioned AI agent except the
+      # one that wrote it.
+      #
+      # Excluding the author matters now that the dispatch names its targets
+      # instead of leaving them to be re-derived downstream. An agent quoting
+      # its own name — echoing the mention it was addressed by, signing off —
+      # would otherwise be handed its own reply as a fresh trigger, and unlike a
+      # real handoff nothing else in the chain can tell that apart from work.
       def find_mentioned_agents
-        MentionParser.resolve_all_users(@reply_comment.content).select(&:ai_user?)
+        MentionParser.resolve_all_users(@reply_comment.content)
+                     .select(&:ai_user?)
+                     .reject { |user| user.id == @agent.id }
       end
 
       def record_interactions(mentioned_agents, creative)
@@ -53,7 +63,7 @@ module Collavre
         end
       end
 
-      def dispatch_event(creative)
+      def dispatch_event(creative, mentioned_agents)
         payload = {
           comment: {
             id: @reply_comment.id,
@@ -65,7 +75,15 @@ module Collavre
             description: creative&.description
           },
           topic: { id: @reply_comment.topic_id },
-          chat: { content: @reply_comment.content }
+          chat: {
+            content: @reply_comment.content,
+            # The targets this dispatch already resolved, rather than the content
+            # alone. Re-deriving them downstream re-runs the same name lookup
+            # against a different clock and a different roster, and any answer it
+            # reaches that differs from this one silently drops an agent we have
+            # already recorded a handoff to.
+            mentioned_users: mentioned_agents.map { |user| user.as_json(only: [ :id, :name, :email ]) }
+          }
         }
         # Always carry the resolved principal, including an explicit nil. Nil
         # means the current anchor could not prove a human identity; omitting the

--- a/engines/collavre/app/services/collavre/mention_parser.rb
+++ b/engines/collavre/app/services/collavre/mention_parser.rb
@@ -6,30 +6,49 @@ module Collavre
     # Characters allowed before @ in mentions (besides start-of-text)
     MENTION_PREFIX_CHARS = /[\s:.,;\n\r]/
 
+    # The name part of a canonical mention. Spaces are allowed (agents are named
+    # things like "GitHub PR Analyzer"), but "@" and line breaks are not: a lazy
+    # "anything up to the next colon" would let a colon-free mention on one line
+    # swallow the rest of the line plus the next line's "@", collapsing two
+    # mentions into one unresolvable name.
+    MENTION_NAME = /[^:@\n\r]+?/
+
     # Canonical mention: @name: (with colon separator)
     # Matches at start of text or after whitespace/punctuation/newline
-    MENTION_PATTERN = /(?:\A|(?<=#{MENTION_PREFIX_CHARS}))@([^:]+?):\s*/
+    MENTION_PATTERN = /(?:\A|(?<=#{MENTION_PREFIX_CHARS}))@(#{MENTION_NAME}):\s*/
 
     # Mention without colon: @name followed by whitespace (start-of-text only
-    # to avoid false positives like email addresses)
-    MENTION_LOOSE_PATTERN = /\A@(\S+)\s+/
+    # to avoid false positives like email addresses). The name excludes ":" so
+    # a canonical "@name:" is never also read as the loose name "name:".
+    MENTION_LOOSE_PATTERN = /\A@([^:\s]+)\s+/
 
     # Scan pattern: finds all @name: mentions anywhere in text
-    MENTION_SCAN_PATTERN = /(?:^|(?<=#{MENTION_PREFIX_CHARS}))@([^:]+?):/
+    MENTION_SCAN_PATTERN = /(?:^|(?<=#{MENTION_PREFIX_CHARS}))@(#{MENTION_NAME}):/
+
+    # A canonical mention occupying start-of-text, where the loose form would
+    # otherwise also match and truncate the name at its first space.
+    MENTION_CANONICAL_AT_START = /\A@#{MENTION_NAME}:/
 
     # Extract the first mentioned name from text (returns nil if no mention found)
     def self.extract_name(text)
-      return nil if text.blank?
-
-      match = text.match(MENTION_PATTERN) || text.match(MENTION_LOOSE_PATTERN)
-      match ? match[1].strip : nil
+      extract_all_names(text).first
     end
 
-    # Extract all mentioned names from text
+    # Extract all mentioned names from text, in the order they appear.
     def self.extract_all_names(text)
       return [] if text.blank?
 
-      text.scan(MENTION_SCAN_PATTERN).flatten.map(&:strip).uniq
+      names = text.scan(MENTION_SCAN_PATTERN).flatten
+
+      # The loose form only ever matches at start-of-text, so whatever it finds
+      # precedes every canonical mention — unless a canonical one already owns
+      # that position, in which case it has the more complete name.
+      unless text.match?(MENTION_CANONICAL_AT_START)
+        loose = text.match(MENTION_LOOSE_PATTERN)
+        names.unshift(loose[1]) if loose
+      end
+
+      names.map(&:strip).reject(&:blank?).uniq
     end
 
     # Find a User by case-insensitive name match
@@ -41,11 +60,10 @@ module Collavre
 
     # Extract mention and resolve to a User in one step
     def self.resolve_user(text)
-      name = extract_name(text)
-      name ? find_user_by_name(name) : nil
+      resolve_all_users(text).first
     end
 
-    # Resolve all mentioned users from text (finds mentions anywhere)
+    # Resolve all mentioned users from text, in mention order.
     def self.resolve_all_users(text)
       extract_all_names(text).filter_map { |name| find_user_by_name(name) }.uniq
     end

--- a/engines/collavre/app/services/collavre/mention_parser.rb
+++ b/engines/collavre/app/services/collavre/mention_parser.rb
@@ -65,8 +65,23 @@ module Collavre
     end
 
     # Resolve all mentioned users from text, in mention order.
+    #
+    # One lookup for the whole body, not one per name: a comment carries as many
+    # mentions as its author typed, and this runs inside the synchronous
+    # after-commit dispatch, so a per-name query would put the mention count
+    # directly on the critical path. Order comes back from the mention list
+    # rather than from the rows, which arrive in whatever order the database
+    # picked.
     def self.resolve_all_users(text)
-      extract_all_names(text).filter_map { |name| find_user_by_name(name) }.uniq
+      keys = extract_all_names(text).map { |name| name.strip.downcase }.uniq
+      return [] if keys.empty?
+
+      # Ordered by id, and first-wins, so two names differing only in case
+      # resolve to the same row find_user_by_name would have returned.
+      by_key = User.where("LOWER(name) IN (?)", keys).order(:id)
+                   .each_with_object({}) { |user, acc| acc[user.name.to_s.downcase] ||= user }
+
+      keys.filter_map { |key| by_key[key] }
     end
 
     # Strip self-mention prefix from text (both @name: and @name formats)

--- a/engines/collavre/app/services/collavre/mention_parser.rb
+++ b/engines/collavre/app/services/collavre/mention_parser.rb
@@ -7,11 +7,12 @@ module Collavre
     MENTION_PREFIX_CHARS = /[\s:.,;\n\r]/
 
     # The name part of a canonical mention. Spaces are allowed (agents are named
-    # things like "GitHub PR Analyzer"), but "@" and line breaks are not: a lazy
+    # things like "GitHub PR Analyzer"), but line breaks are not: a lazy
     # "anything up to the next colon" would let a colon-free mention on one line
     # swallow the rest of the line plus the next line's "@", collapsing two
-    # mentions into one unresolvable name.
-    MENTION_NAME = /[^:@\n\r]+?/
+    # mentions into one unresolvable name. At signs remain valid because user
+    # names have no corresponding model restriction.
+    MENTION_NAME = /[^:\n\r]+?/
 
     # Canonical mention: @name: (with colon separator)
     # Matches at start of text or after whitespace/punctuation/newline

--- a/engines/collavre/app/services/collavre/orchestration/arbiter.rb
+++ b/engines/collavre/app/services/collavre/orchestration/arbiter.rb
@@ -33,7 +33,7 @@ module Collavre
         return candidates if review_message?
 
         # Mentions are forced routing too: the Matcher already narrowed candidates
-        # to the single @mentioned agent. Arbitration must not second-guess it —
+        # to the @mentioned agents. Arbitration must not second-guess it —
         # with a topic primary agent pinned, arbitration_strategy is
         # "primary_first", and a mention of any OTHER agent would otherwise be
         # dropped for not being the primary. Explicitly inviting a second agent
@@ -71,13 +71,19 @@ module Collavre
       end
 
       # True when the Matcher routed by @mention (mirrors Matcher#match_by_mention).
-      # Only an AI mention produces candidates; a human mention yields [] and never
-      # reaches the Arbiter.
+      # Only an AI mention produces candidates; a mention naming nobody but humans
+      # yields [] and never reaches the Arbiter.
+      #
+      # Reads the mentions through the same ContextBuilder reader the Matcher
+      # uses: asked separately, the two would drift, and this side losing sight
+      # of a mention re-imposes the arbitration the mention exists to escape —
+      # in a pinned topic, primary_first would drop every non-primary agent that
+      # was explicitly invited.
       def mention_routed?
-        mentioned_id = @context.dig("chat", "mentioned_user", "id")
-        return false if mentioned_id.blank?
+        ids = SystemEvents::ContextBuilder.mentioned_ids_in(@context)
+        return false if ids.empty?
 
-        User.find_by(id: mentioned_id)&.ai_user? || false
+        User.where(id: ids).any?(&:ai_user?)
       end
 
       def apply_strategy(strategy, candidates)

--- a/engines/collavre/app/services/collavre/orchestration/loop_breaker.rb
+++ b/engines/collavre/app/services/collavre/orchestration/loop_breaker.rb
@@ -239,15 +239,20 @@ module Collavre
         return {} if interactions.size < 2
 
         pair_counts = Hash.new(0)
+        previous_by_pair = {}
         sorted = interactions.sort_by { |i| i[:at] }
 
-        sorted.each_cons(2) do |prev, curr|
-          # Count as exchange if direction reversed (A→B then B→A)
-          if prev[:from] == curr[:to] && prev[:to] == curr[:from]
-            # Normalize pair key (smaller id first)
-            pair = [ prev[:from], prev[:to] ].sort
+        sorted.each do |interaction|
+          pair = [ interaction[:from], interaction[:to] ].sort
+          previous = previous_by_pair[pair]
+
+          # Count direction reversals within this pair. Unrelated fan-out edges
+          # must not hide an otherwise consecutive exchange between two agents.
+          if previous && previous[:from] == interaction[:to] && previous[:to] == interaction[:from]
             pair_counts[pair] += 1
           end
+
+          previous_by_pair[pair] = interaction
         end
 
         pair_counts

--- a/engines/collavre/app/services/collavre/orchestration/matcher.rb
+++ b/engines/collavre/app/services/collavre/orchestration/matcher.rb
@@ -5,9 +5,10 @@ module Collavre
     # Matcher determines which AI agents are qualified to respond to an event.
     #
     # Matching strategies (in priority order):
-    # 1. Mention-based: If a user is @mentioned, route exclusively to that user
-    #    - If mentioned user is AI agent → route to that agent only
-    #    - If mentioned user is human → no AI agents respond
+    # 1. Mention-based: If any user is @mentioned, route exclusively to the
+    #    mentioned users
+    #    - Every mentioned AI agent responds, in mention order
+    #    - If only humans are mentioned → no AI agents respond
     # 2. Primary-agent assignment: If the topic has a primary_agent, that agent is
     #    the topic's sole ambient responder (see #match_by_primary_agent)
     # 3. Expression-based: Evaluate each agent's routing_expression (Liquid)
@@ -105,9 +106,7 @@ module Collavre
         return true if matched_comment&.review_message? &&
           matched_comment.quoted_comment&.user_id == agent.id
 
-        mentioned_id = @context.dig("chat", "mentioned_user", "id") ||
-          @context.dig(:chat, :mentioned_user, :id)
-        mentioned_id.present? && mentioned_id.to_i == agent.id
+        SystemEvents::ContextBuilder.mentioned_ids_in(@context).include?(agent.id)
       end
 
       # Public because #match is not the only door onto a dispatch: a restore
@@ -160,26 +159,48 @@ module Collavre
 
       # Returns Array of agents if mention found, nil if no mention
       # When mention IS found, this is exclusive routing
+      #
+      # Every mentioned agent is routed to, not just the first: "@someone:
+      # report / @agent: your turn" is the shape the agent system prompt asks
+      # for, and reading one mention makes the exclusivity below hinge on which
+      # name happened to come first — a leading human silently swallowing the
+      # handoff that follows it.
+      #
+      # So exclusivity keys on "no AI was mentioned" rather than "the mention
+      # was a human": a mention that names only people still blocks every agent,
+      # and an agent named alongside them is still invited.
       def match_by_mention
-        mentioned_user_data = @context.dig("chat", "mentioned_user")
-        return nil unless mentioned_user_data && mentioned_user_data["id"]
-
-        mentioned_user = User.find_by(id: mentioned_user_data["id"])
-        return nil unless mentioned_user
+        mentioned_users = mentioned_users_in_order
+        return nil if mentioned_users.empty?
 
         # Mention found — exclusive routing
-        # If mentioned user is not an AI agent, no AI agents should receive it
-        return [] unless mentioned_user.ai_user?
+        # If no mentioned user is an AI agent, no AI agents should receive it
+        agents = mentioned_users.select(&:ai_user?)
+        return [] if agents.empty?
 
-        # Permission check for mentioned AI agent
-        return [] unless has_creative_permission?(mentioned_user)
+        # Permission check for mentioned AI agents, plus inbox confinement: a
+        # live Claude Channel session agent must not be pulled into an ordinary
+        # inbox topic, even by an explicit @mention (see #eligible_in_inbox?).
+        #
+        # Dropping the ineligible ones still leaves this exclusive — an empty
+        # result blocks rather than falling through, so an unroutable mention
+        # cannot turn into an ambient event answered by someone else entirely.
+        agents.select { |agent| has_creative_permission?(agent) && eligible_in_inbox?(agent) }
+      end
 
-        # Inbox confinement applies to mentions too: a live Claude Channel
-        # session agent must not be pulled into an ordinary inbox topic, even by
-        # an explicit @mention (see #eligible_in_inbox?).
-        return [] unless eligible_in_inbox?(mentioned_user)
+      # The mentioned users, in mention order — empty when nobody was mentioned
+      # or no mentioned name resolves to a user (which falls through to the next
+      # routing strategy, exactly as an unresolvable single mention always has).
+      #
+      # Ordered explicitly: `where(id:)` returns rows in whatever order the
+      # planner picks, and the order agents are matched in is the order they
+      # take the floor.
+      def mentioned_users_in_order
+        ids = SystemEvents::ContextBuilder.mentioned_ids_in(@context)
+        return [] if ids.empty?
 
-        [ mentioned_user ]
+        by_id = User.where(id: ids).index_by(&:id)
+        ids.filter_map { |id| by_id[id] }
       end
 
       # Returns [primary_agent] when the topic has one, nil when it does not.

--- a/engines/collavre/app/services/collavre/orchestration/selection.rb
+++ b/engines/collavre/app/services/collavre/orchestration/selection.rb
@@ -30,13 +30,30 @@ module Collavre
       private
 
       def candidates_for_contexts
-        candidates = Matcher.new(@context).match
+        base = Matcher.new(@context).match
+        candidates = base
         @candidate_overrides.each do |agent_id, override|
           candidates = candidates.reject { |agent| agent.id == agent_id }
           overridden = Matcher.new(@context.deep_merge(override.deep_stringify_keys)).match
           candidates.concat(overridden.select { |agent| agent.id == agent_id })
         end
-        candidates.uniq(&:id).sort_by(&:id)
+        restore_match_order(candidates.uniq(&:id), base)
+      end
+
+      # The Matcher's order is the floor order: Scheduler#schedule walks the
+      # array and, under topic_max_concurrent_jobs, admits whom it reaches
+      # first. For mentions that order is the order the names were written, so
+      # sorting by id here would let "@second: your turn" answer ahead of
+      # "@first:" purely for having the smaller id.
+      #
+      # Rebuilding an override's candidate appends it, so restore each agent to
+      # its position in the unoverridden match. An agent the base match did not
+      # produce has no such position and sorts last, by id for determinism —
+      # every Matcher path already returns a stable order (mention order, or
+      # `order(:id)` for expression routing), so nothing else needs sorting.
+      def restore_match_order(candidates, base)
+        base_order = base.each_with_index.to_h { |agent, index| [ agent.id, index ] }
+        candidates.sort_by { |agent| [ base_order[agent.id] || base_order.size, agent.id ] }
       end
     end
   end

--- a/engines/collavre/app/services/collavre/system_events/context_builder.rb
+++ b/engines/collavre/app/services/collavre/system_events/context_builder.rb
@@ -11,7 +11,8 @@ module Collavre
 
         # Add helper objects/functions
         if ctx["chat"]
-          ctx["chat"]["mentioned_user"] ||= mentioned_user(ctx["chat"])
+          ctx["chat"]["mentioned_users"] ||= default_mentioned_users(ctx["chat"])
+          ctx["chat"]["mentioned_user"] ||= ctx["chat"]["mentioned_users"].first
         end
 
         # Add sender context for A2A communication
@@ -52,18 +53,46 @@ module Collavre
       # that belongs to someone else.
       #
       # The block is rebuilt rather than merged onto: a mention that finds
-      # nobody must leave the key absent, since Matcher reads its presence as
+      # nobody must leave the keys absent, since Matcher reads their presence as
       # the mention that outranks the assignment.
       def self.reanchor_chat(content)
         chat = { "content" => content }
-        mention = mentioned_user_for(content)
-        mention ? chat.merge("mentioned_user" => mention) : chat
+        mentions = mentioned_users_for(content)
+        return chat if mentions.empty?
+
+        chat.merge("mentioned_users" => mentions, "mentioned_user" => mentions.first)
       end
 
-      def self.mentioned_user_for(content)
-        return nil unless content
+      # Every mentioned user, in mention order. Plural because a comment that
+      # names two agents has to reach both: routing that keeps only the first
+      # silently drops the rest, and "@someone: report / @agent: your turn" —
+      # the shape the agent system prompt asks for — puts the human first.
+      def self.mentioned_users_for(content)
+        return [] unless content
 
-        MentionParser.resolve_user(content)&.as_json(only: [ :id, :name, :email ])
+        MentionParser.resolve_all_users(content).map { |user| user.as_json(only: [ :id, :name, :email ]) }
+      end
+
+      # The mentioned user ids carried by a payload, whatever shape it is in.
+      #
+      # The one reader for "who was mentioned", shared by Matcher and Arbiter:
+      # they ask the same question on either side of a dispatch, and two private
+      # copies of this lookup would drift the moment one of them learned about a
+      # new key. Reads the plural key, falling back to the singular one so a task
+      # queued before the plural key existed still routes to its agent.
+      def self.mentioned_ids_in(context)
+        chat = context["chat"] || context[:chat]
+        return [] unless chat.is_a?(Hash)
+
+        entries = chat["mentioned_users"] || chat[:mentioned_users]
+        entries = [ chat["mentioned_user"] || chat[:mentioned_user] ] if entries.nil?
+
+        Array(entries).filter_map do |entry|
+          next unless entry.is_a?(Hash)
+
+          id = entry["id"] || entry[:id]
+          id&.to_i
+        end
       end
 
       # Point a payload's sender at the comment the trigger has just been moved
@@ -91,8 +120,14 @@ module Collavre
         self.class.sender_context_for(User.find_by(id: user_id))
       end
 
-      def mentioned_user(chat_context)
-        self.class.mentioned_user_for(chat_context["content"])
+      # A payload that already named its targets keeps them: its producer
+      # resolved the mention against the roster it saw, and re-deriving from the
+      # raw content would widen an in-flight single-target task into everyone
+      # its text happens to name.
+      def default_mentioned_users(chat_context)
+        return [ chat_context["mentioned_user"] ] if chat_context["mentioned_user"]
+
+        self.class.mentioned_users_for(chat_context["content"])
       end
     end
   end

--- a/engines/collavre/db/migrate/20260911020000_normalize_user_names_to_single_line.rb
+++ b/engines/collavre/db/migrate/20260911020000_normalize_user_names_to_single_line.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class NormalizeUserNamesToSingleLine < ActiveRecord::Migration[8.0]
+  # Deliberately not Collavre::User: a data migration has to keep working after
+  # the model moves on, and loading the real model here would run its callbacks
+  # and validations against a schema from the future.
+  class MigrationUser < ActiveRecord::Base
+    self.table_name = "users"
+  end
+
+  # Matches Collavre::User's name normalization. Mention parsing stops a name at
+  # a line break, so a stored line break leaves that user's own canonical
+  # mention "@name:" unresolvable and the mention falls through to ambient
+  # routing. The normalization keeps new names to a single line; this brings
+  # rows written before it in line.
+  LINE_BREAK_RUN = /[^\S\r\n]*[\r\n]+[^\S\r\n]*/
+
+  def up
+    MigrationUser.where("name LIKE ? OR name LIKE ?", "%\n%", "%\r%").find_each do |user|
+      normalized = user.name.to_s.gsub(LINE_BREAK_RUN, " ").strip
+      next if normalized == user.name || normalized.blank?
+
+      MigrationUser.where(id: user.id).update_all(name: normalized)
+    end
+  end
+
+  def down
+    # Irreversible: the original line breaks are not recoverable, and the names
+    # are valid either way.
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/engines/collavre/test/models/user_test.rb
+++ b/engines/collavre/test/models/user_test.rb
@@ -1,6 +1,31 @@
 require "test_helper"
 
 class UserTest < ActiveSupport::TestCase
+  test "collapses line breaks in name to a single line" do
+    user = User.create!(email: "multiline_name@example.com", password: "password123", name: "Line\nBreak Agent")
+
+    assert_equal "Line Break Agent", user.name
+  end
+
+  test "collapses a line break run with surrounding spaces to one space" do
+    user = User.create!(email: "multiline_padded@example.com", password: "password123", name: "Line \r\n  Break")
+
+    assert_equal "Line Break", user.name
+  end
+
+  test "strips surrounding whitespace from name" do
+    user = User.create!(email: "padded_name@example.com", password: "password123", name: "  Padded Agent  ")
+
+    assert_equal "Padded Agent", user.name
+  end
+
+  test "keeps a blank name invalid rather than normalizing it into one" do
+    user = User.new(email: "blank_name@example.com", password: "password123", name: "\n \n")
+
+    assert_not user.valid?
+    assert_includes user.errors[:name], "can't be blank"
+  end
+
   test "requires valid email" do
     user = User.new(email: "bad", password: "password123", password_confirmation: "password123", name: "Bad")
     assert_not user.valid?

--- a/engines/collavre/test/services/collavre/ai_agent/a2a_dispatcher_test.rb
+++ b/engines/collavre/test/services/collavre/ai_agent/a2a_dispatcher_test.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  module AiAgent
+    class A2aDispatcherTest < ActiveSupport::TestCase
+      include ActiveJob::TestHelper
+
+      setup do
+        @original_adapter = ActiveJob::Base.queue_adapter
+        ActiveJob::Base.queue_adapter = :test
+        # LoopBreaker's ping-pong history is cached per creative and outlives the
+        # test transaction, so a second dispatch onto the shared fixture creative
+        # would be throttled by whatever ran before it.
+        Rails.cache.clear
+        @creative = creatives(:tshirt)
+        @human = users(:one)
+        @speaker = build_agent("dispatch_speaker@example.com", "Dispatch Speaker")
+        @first = build_agent("dispatch_first@example.com", "Dispatch First")
+        @second = build_agent("dispatch_second@example.com", "Dispatch Second")
+      end
+
+      teardown do
+        ActiveJob::Base.queue_adapter = @original_adapter
+      end
+
+      test "every mentioned agent is scheduled" do
+        dispatch("@Dispatch Second: you first\n@Dispatch First: then you")
+
+        # Unordered: the topic runs one turn at a time, so the second agent is
+        # parked as a waiter rather than enqueued. Both were routed to, which is
+        # what used to be lost.
+        assert_equal [ @first.id, @second.id ], routed_agent_ids.sort
+      end
+
+      test "the payload names every mentioned agent, in mention order" do
+        dispatch("@Dispatch Second: you first\n@Dispatch First: then you")
+
+        assert_equal [ @second.id, @first.id ], dispatched_mentioned_ids
+      end
+
+      test "a mention behind a human report still reaches the agent" do
+        # The regression: the agent system prompt asks for "report to the
+        # requester, then hand off", and the handoff used to be dropped because
+        # the human's name came first.
+        dispatch("@#{@human.name}: done\n@Dispatch First: your turn")
+
+        assert_equal [ @first.id ], routed_agent_ids
+      end
+
+      test "the speaker's own mention is not dispatched back to itself" do
+        dispatch("@Dispatch Speaker: noted\n@Dispatch First: your turn")
+
+        assert_equal [ @first.id ], routed_agent_ids
+      end
+
+      test "a reply that mentions only its own author dispatches nothing" do
+        # Quoting your own name is not a handoff. Routing it would hand the
+        # agent its own reply as a new trigger — a turn that re-triggers itself.
+        dispatch("@Dispatch Speaker: noted, continuing")
+
+        assert_empty routed_agent_ids
+      end
+
+      test "the speaker is left out of the loop-prevention record too" do
+        dispatch("@Dispatch Speaker: noted\n@Dispatch First: your turn")
+
+        # A self-interaction logged here counts toward ping-pong detection and
+        # would throttle the agent for talking to itself.
+        assert_equal [ @first.id ], Array(Rails.cache.read(ping_pong_key)).map { |i| i[:to] }
+      end
+
+      private
+
+      def ping_pong_key
+        "#{Orchestration::LoopBreaker::CACHE_PREFIX}:ping_pong_history:#{@creative.id}"
+      end
+
+      def build_agent(email, name)
+        agent = User.create!(
+          email: email,
+          name: name,
+          password: "password123",
+          llm_vendor: "google",
+          llm_model: "gemini-1.5-flash",
+          searchable: true
+        )
+        share = CreativeShare.find_or_create_by!(creative: @creative, user: agent)
+        share.update!(permission: "feedback")
+        CreativeSharesCache.find_or_create_by!(
+          creative_id: @creative.id, user_id: agent.id, permission: :feedback
+        )
+        agent
+      end
+
+      def dispatch(content)
+        @reply = Comment.create!(
+          creative: @creative, user: @speaker, content: content, skip_dispatch: true
+        )
+        context = {
+          "creative" => { "id" => @creative.id },
+          "topic" => { "id" => @reply.topic_id }
+        }
+        A2aDispatcher.new(agent: @speaker, reply_comment: @reply, context: context).dispatch
+      end
+
+      def agent_jobs
+        ActiveJob::Base.queue_adapter.enqueued_jobs.select { |job| job["job_class"] == "Collavre::AiAgentJob" }
+      end
+
+      # Every agent this dispatch reached: enqueued for an immediate turn, or
+      # parked as a queued waiter behind whoever holds the topic slot.
+      def routed_agent_ids
+        (agent_jobs.map { |job| job[:args].first } + Task.where(creative_id: @creative.id).pluck(:agent_id)).uniq
+      end
+
+      def dispatched_mentioned_ids
+        SystemEvents::ContextBuilder.mentioned_ids_in(agent_jobs.first[:args][2])
+      end
+    end
+  end
+end

--- a/engines/collavre/test/services/collavre/mention_parser_test.rb
+++ b/engines/collavre/test/services/collavre/mention_parser_test.rb
@@ -119,6 +119,11 @@ module Collavre
         MentionParser.extract_all_names("@John Doe: report\n@GitHub PR Analyzer: review")
     end
 
+    test "extract_all_names keeps at signs inside canonical names" do
+      assert_equal [ "ops@example.com", "Astra" ],
+        MentionParser.extract_all_names("@ops@example.com: investigate\n@Astra: review")
+    end
+
     test "extract_all_names stops a canonical name at a newline" do
       # Without a newline boundary the lazy name match swallows the whole first
       # line plus the next "@", yielding one unresolvable name instead of two.
@@ -150,6 +155,12 @@ module Collavre
       resolved = MentionParser.resolve_all_users("@OrderFirst done\n@OrderSecond: your turn")
 
       assert_equal [ first.id, second.id ], resolved.map(&:id)
+    end
+
+    test "resolve_all_users finds a canonical mention whose name contains an at sign" do
+      user = User.create!(name: "ops@example.com", email: "ops_mention@example.com", password: "password")
+
+      assert_equal [ user.id ], MentionParser.resolve_all_users("@ops@example.com: investigate").map(&:id)
     end
   end
 end

--- a/engines/collavre/test/services/collavre/mention_parser_test.rb
+++ b/engines/collavre/test/services/collavre/mention_parser_test.rb
@@ -162,5 +162,64 @@ module Collavre
 
       assert_equal [ user.id ], MentionParser.resolve_all_users("@ops@example.com: investigate").map(&:id)
     end
+
+    test "resolve_all_users resolves every mention in a single query" do
+      names = 5.times.map do |i|
+        User.create!(name: "BatchAgent#{i}", email: "batch_agent_#{i}@example.com", password: "password").name
+      end
+      text = names.map { |name| "@#{name}: go" }.join("\n")
+
+      selects = capture_user_selects { MentionParser.resolve_all_users(text) }
+
+      assert_equal 1, selects.size,
+        "expected one lookup for #{names.size} mentions, got #{selects.size}:\n#{selects.join("\n")}"
+    end
+
+    test "resolve_all_users keeps mention order when resolved in one query" do
+      # Descending ids so a query returning rows in primary-key order cannot
+      # accidentally match the mention order.
+      third = User.create!(name: "BatchOrderC", email: "batch_order_c@example.com", password: "password")
+      second = User.create!(name: "BatchOrderB", email: "batch_order_b@example.com", password: "password")
+      first = User.create!(name: "BatchOrderA", email: "batch_order_a@example.com", password: "password")
+
+      resolved = MentionParser.resolve_all_users("@BatchOrderC: one\n@BatchOrderB: two\n@BatchOrderA: three")
+
+      assert_equal [ third.id, second.id, first.id ], resolved.map(&:id)
+    end
+
+    test "resolve_all_users matches a name stored with surrounding whitespace" do
+      user = User.create!(name: "  PaddedAgent  ", email: "padded_agent@example.com", password: "password")
+
+      assert_equal [ user.id ], MentionParser.resolve_all_users("@PaddedAgent: go").map(&:id)
+    end
+
+    test "resolve_all_users resolves a mention of a name written with line breaks" do
+      # The canonical mention is "@" + name + ":", so a stored line break would
+      # split the name across the newline boundary the parser enforces. Names
+      # are normalized to a single line so the canonical form stays parseable.
+      user = User.create!(name: "Line\nBreak Agent", email: "line_break_agent@example.com", password: "password")
+
+      assert_equal [ user.id ], MentionParser.resolve_all_users("@#{user.name}: investigate").map(&:id)
+    end
+
+    private
+
+    def capture_user_selects
+      queries = []
+      subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
+        sql = payload[:sql]
+        next if payload[:name] == "SCHEMA" || payload[:cached]
+
+        queries << sql if sql.match?(/\ASELECT\b/i) && sql.match?(/\bFROM\s+"?users"?/i)
+      end
+
+      begin
+        yield
+      ensure
+        ActiveSupport::Notifications.unsubscribe(subscriber)
+      end
+
+      queries
+    end
   end
 end

--- a/engines/collavre/test/services/collavre/mention_parser_test.rb
+++ b/engines/collavre/test/services/collavre/mention_parser_test.rb
@@ -102,5 +102,54 @@ module Collavre
       # email-like patterns should not match
       assert_nil MentionParser.extract_name("user@agent: test")
     end
+
+    # --- Multi-mention extraction (ordered) ---
+
+    test "extract_all_names returns every mention in text order" do
+      assert_equal [ "Vrex", "Astra" ],
+        MentionParser.extract_all_names("@Vrex please review\n@Astra: confirm")
+    end
+
+    test "extract_all_names does not double-count a canonical mention at start" do
+      assert_equal [ "Astra" ], MentionParser.extract_all_names("@Astra: confirm")
+    end
+
+    test "extract_all_names keeps multi-word canonical names whole" do
+      assert_equal [ "John Doe", "GitHub PR Analyzer" ],
+        MentionParser.extract_all_names("@John Doe: report\n@GitHub PR Analyzer: review")
+    end
+
+    test "extract_all_names stops a canonical name at a newline" do
+      # Without a newline boundary the lazy name match swallows the whole first
+      # line plus the next "@", yielding one unresolvable name instead of two.
+      assert_equal [ "Astra" ], MentionParser.extract_all_names("plain line\n@Astra: confirm")
+    end
+
+    test "extract_name returns the first mention in text order" do
+      assert_equal "Vrex", MentionParser.extract_name("@Vrex please review\n@Astra: confirm")
+    end
+
+    test "extract_all_names first entry always equals extract_name" do
+      [
+        "@Astra: confirm",
+        "@Vrex please review",
+        "@Vrex please review\n@Astra: confirm",
+        "@John Doe: report\n@Astra: confirm",
+        "hello @Astra: confirm"
+      ].each do |text|
+        assert_equal MentionParser.extract_name(text),
+          MentionParser.extract_all_names(text).first,
+          "mismatch for #{text.inspect}"
+      end
+    end
+
+    test "resolve_all_users preserves mention order" do
+      first = User.create!(name: "OrderFirst", email: "order_first@example.com", password: "password")
+      second = User.create!(name: "OrderSecond", email: "order_second@example.com", password: "password")
+
+      resolved = MentionParser.resolve_all_users("@OrderFirst done\n@OrderSecond: your turn")
+
+      assert_equal [ first.id, second.id ], resolved.map(&:id)
+    end
   end
 end

--- a/engines/collavre/test/services/collavre/orchestration/arbiter_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/arbiter_test.rb
@@ -113,6 +113,28 @@ module Collavre
         assert_equal [ @agent3 ], selected
       end
 
+      test "multi-mention routing bypasses arbitration in a pinned topic" do
+        @topic.set_primary_agent!(@agent1)
+        context = @context.merge(
+          "chat" => { "mentioned_users" => [ { "id" => @agent2.id }, { "id" => @agent3.id } ] }
+        )
+
+        selected = Arbiter.new(context).select([ @agent2, @agent3 ])
+
+        # Both were explicitly invited; primary_first would otherwise drop both
+        # for not being @agent1.
+        assert_equal [ @agent2, @agent3 ], selected
+      end
+
+      test "a mention naming only humans does not bypass arbitration" do
+        @topic.set_primary_agent!(@agent1)
+        context = @context.merge("chat" => { "mentioned_users" => [ { "id" => @user.id } ] })
+
+        selected = Arbiter.new(context).select([ @agent2, @agent3 ])
+
+        assert_empty selected
+      end
+
       test "topic primary agent takes the floor over other candidates" do
         @topic.set_primary_agent!(@agent2)
 

--- a/engines/collavre/test/services/collavre/orchestration/loop_breaker_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/loop_breaker_test.rb
@@ -76,6 +76,33 @@ module Collavre
         assert_equal @creative.id, result.details[:creative_id]
       end
 
+      test "detects ping-pong when another agent pair is interleaved" do
+        agent3 = Collavre::User.create!(
+          name: "agent-3",
+          email: "agent3-#{SecureRandom.hex(4)}@test.test",
+          password: "password123",
+          llm_vendor: "openai",
+          llm_model: "gpt-4"
+        )
+        create_policy(@enabled_config)
+        breaker = LoopBreaker.new(@context, policy_resolver: PolicyResolver.new(@context))
+
+        breaker.record_interaction(@agent1.id, @agent2.id, @creative.id)
+        breaker.record_interaction(@agent1.id, agent3.id, @creative.id)
+        breaker.record_interaction(@agent2.id, @agent1.id, @creative.id)
+        breaker.record_interaction(@agent1.id, agent3.id, @creative.id)
+        breaker.record_interaction(@agent1.id, @agent2.id, @creative.id)
+        breaker.record_interaction(@agent1.id, agent3.id, @creative.id)
+        breaker.record_interaction(@agent2.id, @agent1.id, @creative.id)
+
+        result = breaker.check
+
+        assert result.should_break?
+        assert_equal :ping_pong, result.reason
+        assert_equal [ @agent1.id, @agent2.id ].sort, result.details[:agents]
+        assert_equal 3, result.details[:exchange_count]
+      end
+
       test "allows interactions below ping-pong threshold" do
         policy = create_policy(@enabled_config)
         resolver = PolicyResolver.new(@context)

--- a/engines/collavre/test/services/collavre/orchestration/matcher_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/matcher_test.rb
@@ -72,6 +72,113 @@ module Collavre
         assert_empty result
       end
 
+      # --- Multi-mention routing ---
+
+      test "routes to the AI agent mentioned after a human" do
+        # The shape the agent system prompt asks for: report to the requester,
+        # then hand off. Keeping only the first mention drops the handoff.
+        other = build_agent(routing_expression: nil)
+        grant_feedback(other)
+
+        context = {
+          "event_name" => "comment_created",
+          "creative" => { "id" => @creative.id },
+          "chat" => {
+            "mentioned_users" => [ { "id" => @user.id }, { "id" => other.id } ]
+          }
+        }
+
+        assert_equal [ other ], Matcher.new(context).match
+      end
+
+      test "routes to every mentioned AI agent, in mention order" do
+        other = build_agent(routing_expression: nil)
+        grant_feedback(other)
+
+        context = {
+          "event_name" => "comment_created",
+          "creative" => { "id" => @creative.id },
+          "chat" => {
+            "mentioned_users" => [ { "id" => other.id }, { "id" => @ai_agent.id } ]
+          }
+        }
+
+        assert_equal [ other, @ai_agent ], Matcher.new(context).match
+      end
+
+      test "returns empty array when only humans are mentioned" do
+        context = {
+          "event_name" => "comment_created",
+          "creative" => { "id" => @creative.id },
+          "chat" => {
+            "mentioned_users" => [ { "id" => @user.id }, { "id" => users(:two).id } ]
+          }
+        }
+
+        assert_empty Matcher.new(context).match
+      end
+
+      test "drops only the mentioned agents that lack permission" do
+        other = build_agent(routing_expression: nil)  # no feedback on @creative
+
+        context = {
+          "event_name" => "comment_created",
+          "creative" => { "id" => @creative.id },
+          "chat" => {
+            "mentioned_users" => [ { "id" => other.id }, { "id" => @ai_agent.id } ]
+          }
+        }
+
+        assert_equal [ @ai_agent ], Matcher.new(context).match
+      end
+
+      test "returns empty array when no mentioned AI agent is permitted" do
+        # Blocked, not fallen through: an unroutable mention must not become an
+        # ambient event that some other agent answers.
+        other = build_agent(routing_expression: "true")
+        grant_feedback(other)
+        unpermitted = build_agent(routing_expression: nil)
+
+        context = {
+          "event_name" => "comment_created",
+          "creative" => { "id" => @creative.id },
+          "chat" => {
+            "mentioned_users" => [ { "id" => unpermitted.id } ]
+          }
+        }
+
+        assert_empty Matcher.new(context).match
+      end
+
+      test "falls through when no mentioned name resolves to a user" do
+        @ai_agent.update!(routing_expression: "true")
+
+        context = {
+          "event_name" => "comment_created",
+          "creative" => { "id" => @creative.id },
+          "chat" => { "mentioned_users" => [ { "id" => -1 } ] }
+        }
+
+        assert_equal [ @ai_agent ], Matcher.new(context).match
+      end
+
+      test "assignment_permits? allows any agent named in a multi-mention" do
+        other = build_agent(routing_expression: nil)
+        grant_feedback(other)
+        topic = @creative.topics.create!(name: "Assigned yet co-mentioned", user: @user)
+        topic.set_primary_agent!(@ai_agent)
+
+        matcher = Matcher.new(
+          "creative" => { "id" => @creative.id },
+          "topic" => { "id" => topic.id },
+          "chat" => { "mentioned_users" => [ { "id" => @user.id }, { "id" => other.id } ] }
+        )
+
+        # Without this the second-named agent's deferred task is cancelled the
+        # moment a pin lands, even though it was explicitly invited.
+        assert matcher.assignment_permits?(other)
+      end
+
       # --- Expression-based routing ---
 
       test "matches agent with matching routing expression" do

--- a/engines/collavre/test/services/collavre/orchestration/selection_mention_order_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/selection_mention_order_test.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  module Orchestration
+    # Mention order is who takes the floor: Scheduler#schedule walks the agent
+    # array in order and, under topic_max_concurrent_jobs, admits the ones it
+    # reaches first and defers the rest. Selection sits between the Matcher that
+    # establishes that order and the Scheduler that spends it, so the order has
+    # to survive the trip.
+    class SelectionMentionOrderTest < ActiveSupport::TestCase
+      setup do
+        @user = users(:one)
+        @low_id_agent = users(:ai_bot)
+        @creative = creatives(:tshirt)
+
+        @low_id_agent.update!(searchable: true, routing_expression: nil)
+        grant_feedback(@low_id_agent)
+
+        # Created now, so its id sorts AFTER the fixture agent's — mentioning it
+        # first is exactly the case an id sort silently reverses.
+        @high_id_agent = build_agent
+        grant_feedback(@high_id_agent)
+
+        User.where.not(llm_vendor: nil).update_all(routing_expression: nil)
+      end
+
+      test "keeps the mention order when the later-mentioned agent has the lower id" do
+        selected = select_for([ @high_id_agent, @low_id_agent ])
+
+        assert_equal [ @high_id_agent.id, @low_id_agent.id ], selected.map(&:id)
+      end
+
+      test "keeps the mention order when it already agrees with id order" do
+        selected = select_for([ @low_id_agent, @high_id_agent ])
+
+        assert_equal [ @low_id_agent.id, @high_id_agent.id ], selected.map(&:id)
+      end
+
+      test "schedules the first-mentioned agent immediately when the topic admits one" do
+        topic = @creative.topics.create!(name: "Floor control", user: @user)
+        context = mention_context([ @high_id_agent, @low_id_agent ]).merge(
+          "topic" => { "id" => topic.id }
+        )
+        policy_resolver = PolicyResolver.new(context)
+        policy_resolver.stub(:topic_max_concurrent_jobs, 1) do
+          agents = Selection.new(context, policy_resolver: policy_resolver).call.agents
+          decisions = Scheduler.new(context, policy_resolver: policy_resolver).schedule(agents)
+
+          immediate = decisions.select { |d| d[:timing] == :immediate }.map { |d| d[:agent].id }
+          assert_equal [ @high_id_agent.id ], immediate
+        end
+      end
+
+      private
+
+      def select_for(agents)
+        context = mention_context(agents)
+        Selection.new(context, policy_resolver: PolicyResolver.new(context)).call.agents
+      end
+
+      def mention_context(agents)
+        {
+          "event_name" => "comment_created",
+          "creative" => { "id" => @creative.id },
+          "chat" => { "mentioned_users" => agents.map { |a| { "id" => a.id } } }
+        }
+      end
+
+      def build_agent
+        User.create!(
+          name: "Agent #{SecureRandom.hex(3)}",
+          email: "agent_#{SecureRandom.hex(4)}@example.com",
+          password: "password",
+          llm_vendor: "openai",
+          searchable: true,
+          routing_expression: nil
+        )
+      end
+
+      def grant_feedback(agent, creative: @creative)
+        share = CreativeShare.find_or_create_by!(creative: creative, user: agent)
+        share.update!(permission: "feedback")
+        CreativeSharesCache.find_or_create_by!(
+          creative_id: creative.id, user_id: agent.id, permission: :feedback
+        )
+      end
+    end
+  end
+end

--- a/engines/collavre/test/services/collavre/system_events/context_builder_test.rb
+++ b/engines/collavre/test/services/collavre/system_events/context_builder_test.rb
@@ -126,6 +126,98 @@ module Collavre
         assert_equal "custom_value", result["custom_key"]
         assert_equal @creative.id, result["creative"]["id"]
       end
+
+      # --- Multi-mention context ---
+
+      test "builds mentioned_users for every mentioned user in order" do
+        context = {
+          chat: { content: "@John: done\n@dev-agent: your turn" },
+          creative: { id: @creative.id }
+        }
+
+        result = ContextBuilder.new(context).build
+
+        assert_equal [ @human_user.id, @ai_agent.id ],
+          result["chat"]["mentioned_users"].map { |u| u["id"] }
+      end
+
+      test "mentioned_user stays the first entry of mentioned_users" do
+        context = {
+          chat: { content: "@John: done\n@dev-agent: your turn" },
+          creative: { id: @creative.id }
+        }
+
+        result = ContextBuilder.new(context).build
+
+        assert_equal result["chat"]["mentioned_users"].first, result["chat"]["mentioned_user"]
+      end
+
+      test "an explicitly supplied mentioned_users list is not recomputed" do
+        context = {
+          chat: {
+            content: "@John: done\n@dev-agent: your turn",
+            mentioned_users: [ { "id" => @ai_agent.id, "name" => @ai_agent.name } ]
+          },
+          creative: { id: @creative.id }
+        }
+
+        result = ContextBuilder.new(context).build
+
+        assert_equal [ @ai_agent.id ], result["chat"]["mentioned_users"].map { |u| u["id"] }
+        assert_equal @ai_agent.id, result["chat"]["mentioned_user"]["id"]
+      end
+
+      test "a legacy payload carrying only mentioned_user keeps its single target" do
+        # An in-flight task predating the plural key must not widen: its content
+        # names two people but its producer resolved exactly one.
+        context = {
+          chat: {
+            content: "@John: done\n@dev-agent: your turn",
+            mentioned_user: { "id" => @ai_agent.id, "name" => @ai_agent.name }
+          },
+          creative: { id: @creative.id }
+        }
+
+        result = ContextBuilder.new(context).build
+
+        assert_equal [ @ai_agent.id ], result["chat"]["mentioned_users"].map { |u| u["id"] }
+      end
+
+      test "reanchor_chat carries both mention keys" do
+        chat = ContextBuilder.reanchor_chat("@John: done\n@dev-agent: your turn")
+
+        assert_equal [ @human_user.id, @ai_agent.id ], chat["mentioned_users"].map { |u| u["id"] }
+        assert_equal @human_user.id, chat["mentioned_user"]["id"]
+      end
+
+      test "reanchor_chat omits both mention keys when nobody is mentioned" do
+        chat = ContextBuilder.reanchor_chat("no mention at all")
+
+        refute chat.key?("mentioned_users")
+        refute chat.key?("mentioned_user")
+      end
+
+      test "mentioned_ids_in reads the plural key" do
+        context = { "chat" => { "mentioned_users" => [ { "id" => @human_user.id }, { "id" => @ai_agent.id } ] } }
+
+        assert_equal [ @human_user.id, @ai_agent.id ], ContextBuilder.mentioned_ids_in(context)
+      end
+
+      test "mentioned_ids_in falls back to the singular key" do
+        context = { "chat" => { "mentioned_user" => { "id" => @ai_agent.id } } }
+
+        assert_equal [ @ai_agent.id ], ContextBuilder.mentioned_ids_in(context)
+      end
+
+      test "mentioned_ids_in accepts symbol keys" do
+        context = { chat: { mentioned_user: { id: @ai_agent.id } } }
+
+        assert_equal [ @ai_agent.id ], ContextBuilder.mentioned_ids_in(context)
+      end
+
+      test "mentioned_ids_in returns empty without a chat block" do
+        assert_empty ContextBuilder.mentioned_ids_in({ "creative" => { "id" => @creative.id } })
+      end
     end
   end
 end


### PR DESCRIPTION
## Problem

A comment naming two users only ever reached the first of them.

The entire mention path narrowed to a single name: `MentionParser.extract_name` returned the leading mention, `ContextBuilder` resolved that one into `chat.mentioned_user`, and `Matcher#match_by_mention` read the singular key. Exclusivity therefore hinged on whichever name happened to come *first* — a leading **human** mention made the matcher return `[]`, silently swallowing every AI agent named after it.

That is exactly the shape the agent system prompt asks for:

```
- 완료되면 반드시 @{요청자}: 멘션으로 결과를 보고하세요
- 다른 Agent 호출: @이름: 요청내용
```

So agents routinely wrote themselves out of their own handoffs. Notifications were unaffected — `Comment#mentioned_users` was already plural — which is why the symptom read as *"the mention notified them, but nothing ran."*

### Evidence

Production data, A2A mentions by week and how many were blocked by a human-first mention:

| Week | A2A mentions | Succeeded | Human-first blocked | Blocked % |
|---|---|---|---|---|
| W30 | 271 | 270 | 0 | 0% |
| W31 | 103 | 36 | **62** | **60%** |
| W32 | 22 | 20 | 1 | 5% |

The defect is deterministic, not intermittent: it fires whenever a human mention precedes an agent mention. W31's spike tracks the period when that phrasing became routine.

A second, related defect: even with no human involved, mentioning two agents only ever dispatched the first.

## Fix

Carry the mentions as a **list**, end to end. No migration, no API change.

- **`MentionParser`** — `extract_all_names` returns every mention in text order, and `extract_name` is now its first element, so the two can no longer disagree. The loose (colon-free) form was invisible to the old plural scan; it is folded in at the one position it can occupy. Mention names now stop at `@` and at a line break, so a colon-free line cannot swallow the next line's mention.
- **`ContextBuilder`** — adds `chat.mentioned_users`; `chat.mentioned_user` is kept as its first entry. **The singular key must stay:** migration `20251204161133` sets every AI agent's default `routing_expression` to `chat.mentioned_user.id == agent.id`, and in-flight payloads carry only that key. `mentioned_ids_in` is the single reader shared by Matcher and Arbiter, falling back to the singular key so already-queued work still routes.
- **`Matcher`** — routes to every mentioned agent, in mention order. Exclusivity now keys on *"no AI was mentioned"* rather than *"the first mention was a human"*: a mention naming only people still blocks every agent, and an agent named alongside them is still invited. `assignment_permits?` matches any named agent, so a deferred second agent is no longer cancelled on promotion.
- **`Arbiter`** — mirrors the Matcher through the same reader. Without this, a pinned topic's `primary_first` strategy would drop the very non-primary agents the mention exists to invite.
- **`A2aDispatcher`** — names the agents it already resolved in the payload instead of leaving them to be re-derived downstream, and **excludes the replying agent**. Self-exclusion is required *by* the plural routing, not incidental to it: an agent quoting its own name would otherwise be handed its own reply as fresh work.

## Behaviour change

Exactly one rule moves: the mention block-vs-route decision. Everything else is preserved.

| Mention | Before | After |
|---|---|---|
| `@agent:` | routes | routes |
| `@human:` | blocks all | blocks all |
| `@human: … @agent:` | **blocks all** | routes to agent |
| `@agentA: … @agentB:` | **A only** | A and B |
| unresolvable name | falls through | falls through |
| mentioned agent lacks permission | blocks | blocks |

## Tests

Added across 5 files, covering both defects and every regression risk raised in review:

- **parser** — text order; loose-then-canonical (`@Vrex review\n@Astra: confirm` → `["Vrex", "Astra"]`); no double-count of a canonical mention at start; multi-word names kept whole; names stop at newline; `extract_all_names.first == extract_name`
- **context builder** — plural/singular alias agreement, explicit list not recomputed, legacy singular-only payload keeps its single target, `reanchor_chat` omits **both** keys when nobody is mentioned, symbol keys
- **matcher** — agent after a human, every agent in order, humans-only → `[]`, partial permission drop, no permitted agent → `[]`, unresolvable → fall through, `assignment_permits?` under multi-mention
- **arbiter** — multi-mention bypasses arbitration in a pinned topic; humans-only mention does not
- **dispatcher** — every agent scheduled, payload order, mention behind a human report, self-mention excluded from both dispatch and the loop-prevention record

### Verification

| Check | Result |
|---|---|
| Targeted suites (parser, context builder, matcher, arbiter, dispatcher) | 115 runs, 0 failures |
| `engines/collavre/test/{services,jobs,models}` | **2553 runs, 8107 assertions, 0 failures, 0 errors** |
| A2A entry points (agents + comments controllers) | 166 runs, 0 failures |
| Rubocop (all 10 touched files) | clean |
| Complexity ratchet (Ruby) | 0 new debt, 0 grown |

The broader controller sweep reports 165 errors, all `The asset 'application.js'/'slide_view.js' was not found in the load path` — a local environment issue (assets unbuilt, no `node_modules`), unrelated to this change and with zero failures.

## Notes

- **Fan-out is intentional.** Mentioning two agents now gets two responders. The mention path deliberately bypasses `max_responders`, so there is no cap — but naming two agents *is* the user's explicit request, and LoopBreaker still bounds ping-pong.
- **Prompt wording was left alone.** Removing the "report to @requester" instruction would mask the symptom while leaving a human who mentions two agents just as broken.