### PR TITLE
fix(history): render only changed diff hunks in the History topic

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -1776,6 +1776,13 @@ body.chat-fullscreen {
   color: var(--text-primary);
 }
 
+.creative-history-split .diff-gap td {
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+  text-align: center;
+  width: auto;
+}
+
 .creative-history-revert {
   margin-top: 10px;
 }

--- a/engines/collavre/app/services/collavre/creatives/change_set_diff.rb
+++ b/engines/collavre/app/services/collavre/creatives/change_set_diff.rb
@@ -6,6 +6,9 @@ module Collavre
   module Creatives
     class ChangeSetDiff
       BLOCK_SEPARATOR = "\n\n---\n\n"
+      # Git-style hunks: only lines within this many lines of a change are rendered.
+      CONTEXT_LINES = 3
+      GAP_ACTION = "~"
 
       def initialize(change_set, user:)
         @change_set = change_set
@@ -14,6 +17,7 @@ module Collavre
         @changes_by_id = @changes.index_by(&:creative_id)
         @candidate_nodes = nil
         @parent_ids = {}
+        @node_markdown = {}
       end
 
       def groups
@@ -79,17 +83,18 @@ module Collavre
       def build_group(root_id)
         before = visible_document(root_id, :before)
         after = visible_document(root_id, :after)
-        additions, deletions = line_counts(before, after)
+        line_diff = Diff::LCS.sdiff(before.lines, after.lines)
+        rows = hunk_rows(line_diff)
         {
           root_id: root_id,
           label: label_for(root_id),
           before: before,
           after: after,
-          additions: additions,
-          deletions: deletions,
+          additions: line_diff.count { |change| %w[+ !].include?(change.action) },
+          deletions: line_diff.count { |change| %w[- !].include?(change.action) },
           moved: moved_in_group?(root_id),
-          inline_html: inline_html(before, after),
-          split_rows: split_rows(before, after)
+          inline_html: inline_html(rows),
+          split_rows: rows
         }
       end
 
@@ -116,15 +121,30 @@ module Collavre
       end
 
       def document(root_id, state)
-        nodes = candidate_nodes(root_id).to_h { |creative| [ creative.id, History.snapshot(creative) ] }
+        nodes = base_snapshots.dup
         @changes.each do |change|
           snapshot = change.public_send(state)
           snapshot.empty? ? nodes.delete(change.creative_id) : nodes[change.creative_id] = snapshot
         end
-        ordered_node_ids(root_id, nodes).filter_map { |id| markdown_for(nodes[id]) }.join(BLOCK_SEPARATOR)
+        ordered_node_ids(root_id, nodes)
+          .filter_map { |id| node_markdown(id, nodes[id], state) }
+          .join(BLOCK_SEPARATOR)
       end
 
-      def candidate_nodes(_root_id)
+      def base_snapshots
+        @base_snapshots ||= candidate_nodes.to_h { |creative| [ creative.id, History.snapshot(creative) ] }
+      end
+
+      # Untouched nodes render identically in both states and in every group, so
+      # convert each one to markdown once instead of per document rebuild.
+      def node_markdown(id, snapshot, state)
+        return nil if snapshot.nil?
+
+        key = [ id, @changes_by_id.key?(id) ? state : :base ]
+        @node_markdown[key] ||= markdown_for(snapshot)
+      end
+
+      def candidate_nodes
         @candidate_nodes ||= begin
           root_ids = [ @change_set.anchor_creative_id, *@changes_by_id.keys ].compact.select(&:positive?)
           descendant_ids = CreativeHierarchy.where(ancestor_id: root_ids).pluck(:descendant_id)
@@ -161,7 +181,52 @@ module Collavre
         markdown_for(snapshot || {}).lines.first.to_s.sub(/\A#+\s*/, "").strip.presence || "##{root_id}"
       end
 
-      def inline_html(before, after)
+      # Renders changed lines plus CONTEXT_LINES around them. Documents are whole
+      # subtrees, so emitting every unchanged line grows the payload without bound.
+      def hunk_rows(line_diff)
+        kept = kept_line_indexes(line_diff)
+        rows = []
+        skipped = 0
+        line_diff.each_with_index do |change, index|
+          next skipped += 1 unless kept.include?(index)
+
+          rows << gap_row(skipped) if skipped.positive?
+          skipped = 0
+          rows << { action: change.action, before: change.old_element.to_s, after: change.new_element.to_s }
+        end
+        rows << gap_row(skipped) if skipped.positive?
+        rows
+      end
+
+      def kept_line_indexes(line_diff)
+        last = line_diff.size - 1
+        line_diff.each_index.reduce(Set.new) do |kept, index|
+          next kept if line_diff[index].action == "="
+
+          kept.merge([ index - CONTEXT_LINES, 0 ].max..[ index + CONTEXT_LINES, last ].min)
+        end
+      end
+
+      def gap_row(skipped)
+        { action: GAP_ACTION, before: "", after: "", skipped: skipped }
+      end
+
+      def inline_html(rows)
+        rows.map { |row| inline_row_html(row) }.join
+      end
+
+      def inline_row_html(row)
+        return gap_html(row[:skipped]) if row[:action] == GAP_ACTION
+        return ERB::Util.html_escape(row[:before]) if row[:action] == "="
+
+        token_html(row[:before], row[:after])
+      end
+
+      def gap_html(skipped)
+        ERB::Util.html_escape("#{I18n.t('collavre.creative_history.skipped_lines', count: skipped)}\n")
+      end
+
+      def token_html(before, after)
         Diff::LCS.sdiff(tokens(before), tokens(after)).map do |change|
           old_value = ERB::Util.html_escape(change.old_element.to_s)
           new_value = ERB::Util.html_escape(change.new_element.to_s)
@@ -172,19 +237,6 @@ module Collavre
           else "<del>#{old_value}</del><ins>#{new_value}</ins>"
           end
         end.join
-      end
-
-      def split_rows(before, after)
-        Diff::LCS.sdiff(before.lines, after.lines).map do |change|
-          { action: change.action, before: change.old_element.to_s, after: change.new_element.to_s }
-        end
-      end
-
-      def line_counts(before, after)
-        changes = Diff::LCS.sdiff(before.lines, after.lines)
-        additions = changes.count { |change| %w[+ !].include?(change.action) }
-        deletions = changes.count { |change| %w[- !].include?(change.action) }
-        [ additions, deletions ]
       end
 
       def tokens(markdown)

--- a/engines/collavre/app/views/collavre/creative_change_sets/_list.html.erb
+++ b/engines/collavre/app/views/collavre/creative_change_sets/_list.html.erb
@@ -50,10 +50,16 @@
                 </thead>
                 <tbody>
                   <% group[:split_rows].each do |row| %>
-                    <tr class="diff-<%= row[:action] == "=" ? "same" : "changed" %>">
-                      <td><%= row[:before] %></td>
-                      <td><%= row[:after] %></td>
-                    </tr>
+                    <% if row[:action] == Collavre::Creatives::ChangeSetDiff::GAP_ACTION %>
+                      <tr class="diff-gap">
+                        <td colspan="2"><%= t("collavre.creative_history.skipped_lines", count: row[:skipped]) %></td>
+                      </tr>
+                    <% else %>
+                      <tr class="diff-<%= row[:action] == "=" ? "same" : "changed" %>">
+                        <td><%= row[:before] %></td>
+                        <td><%= row[:after] %></td>
+                      </tr>
+                    <% end %>
                   <% end %>
                 </tbody>
               </table>

--- a/engines/collavre/config/locales/creative_history.en.yml
+++ b/engines/collavre/config/locales/creative_history.en.yml
@@ -9,6 +9,9 @@ en:
         one: 1 creative
         other: "%{count} creatives"
       inline: Inline diff
+      skipped_lines:
+        one: "… 1 unchanged line"
+        other: "… %{count} unchanged lines"
       split: Split diff
       before: Before
       after: After

--- a/engines/collavre/config/locales/creative_history.ko.yml
+++ b/engines/collavre/config/locales/creative_history.ko.yml
@@ -7,6 +7,7 @@ ko:
       default_summary: 크리에이티브 수정
       changed_count: "크리에이티브 %{count}개"
       inline: 인라인 diff
+      skipped_lines: "… 변경되지 않은 %{count}줄"
       split: 분할 diff
       before: 이전
       after: 이후

--- a/engines/collavre/test/services/collavre/creatives/change_set_diff_test.rb
+++ b/engines/collavre/test/services/collavre/creatives/change_set_diff_test.rb
@@ -40,6 +40,97 @@ module Collavre
         assert_equal 1, group.fetch(:deletions)
       end
 
+      test "renders only changed hunks with surrounding context for a large document" do
+        before_lines = Array.new(400) { |index| "line #{index}" }
+        after_lines = before_lines.dup
+        after_lines[200] = "line 200 edited"
+        large = Creative.create!(
+          description: after_lines.join("\n"), user: @user, parent: @root,
+          data: { "content_type" => "markdown", "markdown_source" => after_lines.join("\n") }
+        )
+        @change_set.creative_changes.create!(
+          creative: large, operation: "update",
+          before: History.snapshot(large).merge("markdown_source" => before_lines.join("\n")),
+          after: History.snapshot(large), position: 1
+        )
+
+        group = ChangeSetDiff.new(@change_set, user: @user).groups.sole
+        rows = group.fetch(:split_rows)
+
+        assert_operator rows.size, :<, 40, "unchanged lines must not be rendered"
+        assert rows.any? { |row| row.fetch(:after).include?("line 200 edited") }
+        assert_not rows.any? { |row| row.fetch(:before).include?("line 10 ") || row.fetch(:before).strip == "line 10" }
+        assert_not_includes group.fetch(:inline_html), "line 10\n"
+        assert_includes group.fetch(:inline_html), "edited"
+      end
+
+      test "marks elided regions with a gap row carrying the skipped line count" do
+        before_lines = Array.new(400) { |index| "line #{index}" }
+        after_lines = before_lines.dup
+        after_lines[200] = "line 200 edited"
+        large = Creative.create!(
+          description: after_lines.join("\n"), user: @user, parent: @root,
+          data: { "content_type" => "markdown", "markdown_source" => after_lines.join("\n") }
+        )
+        @change_set.creative_changes.create!(
+          creative: large, operation: "update",
+          before: History.snapshot(large).merge("markdown_source" => before_lines.join("\n")),
+          after: History.snapshot(large), position: 1
+        )
+
+        group = ChangeSetDiff.new(@change_set, user: @user).groups.sole
+        gaps = group.fetch(:split_rows).select { |row| row.fetch(:action) == ChangeSetDiff::GAP_ACTION }
+
+        rendered = group.fetch(:split_rows).size - gaps.size
+        assert_operator gaps.size, :>=, 2
+        assert gaps.all? { |gap| gap.fetch(:skipped).positive? }
+        # Every line of the document is either rendered or accounted for by a gap.
+        assert_equal group.fetch(:after).lines.size,
+                     rendered + gaps.sum { |gap| gap.fetch(:skipped) }
+        assert_includes group.fetch(:inline_html),
+                        I18n.t("collavre.creative_history.skipped_lines", count: gaps.first.fetch(:skipped))
+      end
+
+      test "still counts additions and deletions across the whole document" do
+        before_lines = Array.new(400) { |index| "line #{index}" }
+        after_lines = before_lines.dup
+        after_lines[10] = "line 10 edited"
+        after_lines[300] = "line 300 edited"
+        large = Creative.create!(
+          description: after_lines.join("\n"), user: @user, parent: @root,
+          data: { "content_type" => "markdown", "markdown_source" => after_lines.join("\n") }
+        )
+        @change_set.creative_changes.create!(
+          creative: large, operation: "update",
+          before: History.snapshot(large).merge("markdown_source" => before_lines.join("\n")),
+          after: History.snapshot(large), position: 1
+        )
+
+        group = ChangeSetDiff.new(@change_set, user: @user).groups.sole
+
+        # Two edited lines here plus the single-line edit recorded in setup.
+        assert_equal 3, group.fetch(:additions)
+        assert_equal 3, group.fetch(:deletions)
+      end
+
+      test "converts an untouched node to markdown once across both document states" do
+        4.times { |index| Creative.create!(description: "<p>Stable #{index}</p>", user: @user, parent: @root) }
+        conversions = Hash.new(0)
+        converter = MarkdownConverter.method(:html_to_markdown)
+        counting = lambda do |html|
+          conversions[html] += 1
+          converter.call(html)
+        end
+        group = MarkdownConverter.stub(:html_to_markdown, counting) do
+          ChangeSetDiff.new(@change_set, user: @user).groups.sole
+        end
+
+        assert_includes group.fetch(:before), "Stable 0"
+        # before and after rebuild the same document; untouched nodes convert once.
+        assert_equal 1, conversions["<p>Stable 0</p>"]
+        assert_equal 1, conversions["<p>Stable 3</p>"]
+      end
+
       test "renders touched roots outside the anchor as separate groups" do
         outside = Creative.create!(description: "Outside", user: @user)
         @change_set.creative_changes.create!(


### PR DESCRIPTION
## Problem

Opening a creative's **History** topic left the comments popup stuck on `로딩 중...` / `Loading...` forever.

`#comments-list` is seeded with `t('app.loading')` and is only replaced once the `GET /creatives/:id/comments` fetch resolves. For a History topic that fetch never resolved:

```
path=/creatives/16711/comments query=topic_id=18855
  status=200 dur=26273ms resp_content_length=19096524   # 19 MB, 26 s
...
  status=502 dur=30001ms  "Unable to proxy request: context canceled"
```

Topic 18855 is that creative's History topic. The 30 s proxy timeout fired before the response landed, so the list markup never arrived and the placeholder stayed on screen. The oversized renders also saturated the request threads, so ordinary topics on the same creative started returning 502 as collateral.

## Root cause

`ChangeSetDiff#document` rebuilds each group's **entire subtree** into one markdown string, and the renderer emitted all of it:

- `inline_html` ran a word-level LCS over the whole document and emitted every token, unchanged ones included.
- `split_rows` emitted one table row per document line, unchanged ones included — and `_list.html.erb` renders every row with both a before and an after cell.

So the document was serialized roughly three times per group whether or not anything in it changed. Measured on the affected creative:

| change set | groups | rows | unchanged rows | inline HTML | split cells | render |
|---|---|---|---|---|---|---|
| 137 | 11 | 72,720 | 72,716 | 7.11 MB | 14.16 MB | 14.2 s |
| 145 | 11 | 42,347 | 42,346 | 3.73 MB | 7.42 MB | 7.0 s |
| 149 | 6 | 6,122 | 6,122 | 1.43 MB | 2.86 MB | 1.6 s |

Change set 137 changed **4 lines** and rendered **72,720**. Cost scaled with document size rather than with the size of the change, so it grew without bound as the creative grew.

## Fix

Render git-style hunks. Lines within `CONTEXT_LINES` (3) of a change are kept; runs of untouched lines collapse into a single gap row carrying the skipped line count, rendered as `… 12 unchanged lines`. `inline_html` is built from those same rows, so the token-level LCS now runs only on lines that actually changed instead of on the whole document.

Addition and deletion counts still come from the full-document line diff, so the `+N −M` stats are unchanged. The single line diff per group is now shared between the counts and the rows, replacing three separate LCS passes.

Two related hot spots in the same path are also memoized: `base_snapshots` (the untouched-node snapshots were rebuilt on every `document()` call) and `node_markdown` (an untouched node renders identically in both states and in every group, so it is converted once rather than once per rebuild).

## Result

Re-measured against the same production change sets:

| | before | after |
|---|---|---|
| diff markup | 36.7 MB | 2.5 KB |
| rendered rows | 121,189 | 39 |
| render time | 22.9 s | 5.5 s |

Well inside the proxy timeout, so the list renders and the placeholder is replaced.

## Tests

New coverage in `change_set_diff_test.rb`:

- a 400-line document with one edited line renders under 40 rows and omits distant unchanged lines
- gap rows carry a positive skipped count, and rendered rows plus skipped lines account for every line of the document
- additions and deletions are still counted across the whole document, not just the rendered hunks
- an untouched node is converted to markdown exactly once across both document states

`167 runs, 735 assertions, 0 failures, 0 errors` across `test/services/collavre/creatives/` and `comments_controller_test.rb`. Rubocop clean, complexity ratchet OK, i18n added for `en` and `ko`.

## Follow-up (not in this PR)

A change set that rewrites a large document end to end still has every line inside a hunk, so its diff stays proportional to the document. If that shows up in practice, the next step is a per-group render cap with an explicit "diff too large to display" state — but that truncates real content, so it is a product decision rather than a bug fix.