### PR TITLE
feat: support one-time cron jobs

### DIFF
--- a/engines/collavre/app/jobs/collavre/cron_scheduler_job.rb
+++ b/engines/collavre/app/jobs/collavre/cron_scheduler_job.rb
@@ -75,7 +75,9 @@ module Collavre
 
       args = task.arguments || []
       if args.is_a?(Array) && args.first.is_a?(Hash)
-        job_class.perform_later(**args.first.symbolize_keys.except(:once))
+        keyword_args = args.first.symbolize_keys
+        keyword_args = keyword_args.except(:once) if task.class_name == CronActionJob.name
+        job_class.perform_later(**keyword_args)
       elsif args.is_a?(Array)
         job_class.perform_later(*args)
       else
@@ -106,6 +108,8 @@ module Collavre
     end
 
     def run_once?(task)
+      return false unless task.class_name == CronActionJob.name
+
       args = task.arguments
       return false unless args.is_a?(Array) && args.first.is_a?(Hash)
 

--- a/engines/collavre/app/jobs/collavre/cron_scheduler_job.rb
+++ b/engines/collavre/app/jobs/collavre/cron_scheduler_job.rb
@@ -33,7 +33,8 @@ module Collavre
         next unless schedule_matches?(task, now)
         next if already_dispatched?(task, now)
 
-        enqueue_task(task)
+        next unless dispatch_task(task)
+
         mark_dispatched(task, now)
       end
     ensure
@@ -69,12 +70,12 @@ module Collavre
       job_class = task.class_name.safe_constantize
       unless job_class
         Rails.logger.warn("[CronScheduler] Unknown job class: #{task.class_name} for task #{task.key}")
-        return
+        return false
       end
 
       args = task.arguments || []
       if args.is_a?(Array) && args.first.is_a?(Hash)
-        job_class.perform_later(**args.first.symbolize_keys)
+        job_class.perform_later(**args.first.symbolize_keys.except(:once))
       elsif args.is_a?(Array)
         job_class.perform_later(*args)
       else
@@ -82,8 +83,38 @@ module Collavre
       end
 
       Rails.logger.info("[CronScheduler] Enqueued #{task.class_name} for task #{task.key}")
+      true
     rescue StandardError => e
       Rails.logger.error("[CronScheduler] Failed to enqueue #{task.key}: #{e.message}")
+      false
+    end
+
+    def dispatch_task(task)
+      return enqueue_task(task) unless run_once?(task)
+
+      creative = once_task_creative(task)
+      enqueued = task.with_lock do
+        next false unless enqueue_task(task)
+
+        task.destroy!
+        true
+      end
+      Crons::ChangeBroadcaster.call(creative) if enqueued && creative
+      enqueued
+    rescue ActiveRecord::RecordNotFound
+      false
+    end
+
+    def run_once?(task)
+      args = task.arguments
+      return false unless args.is_a?(Array) && args.first.is_a?(Hash)
+
+      args.first.with_indifferent_access[:once] == true
+    end
+
+    def once_task_creative(task)
+      args = task.arguments.first.with_indifferent_access
+      Creative.find_by(id: args[:creative_id])
     end
 
     def reschedule

--- a/engines/collavre/app/services/collavre/tools/cron_create_service.rb
+++ b/engines/collavre/app/services/collavre/tools/cron_create_service.rb
@@ -7,13 +7,14 @@ module Tools
     extend ToolMeta
 
     tool_name "cron_create"
-    tool_description "Create a new recurring scheduled job. The job will periodically post a message to a creative's topic, creating the named topic when it does not exist, and triggering agent orchestration. Schedule uses cron syntax (e.g., '*/5 * * * *' for every 5 minutes, '0 9 * * *' for daily at 9am)."
+    tool_description "Create a scheduled job. It posts a message to a creative's topic, creating the named topic when it does not exist, and triggers agent orchestration. Jobs recur by default; set once to true to remove the schedule after its first successful enqueue. Schedule uses cron syntax (e.g., '*/5 * * * *' for every 5 minutes, '0 9 * * *' for daily at 9am)."
 
     tool_param :creative_id, description: "The creative ID to post recurring messages to.", required: true
     tool_param :topic_name, description: "The topic name within the creative to post to. Missing topics are created automatically. Use 'Main' for the default main topic.", required: true
     tool_param :schedule, description: "Cron schedule expression (e.g., '0 9 * * *' for daily at 9am, '*/30 * * * *' for every 30 minutes).", required: true
     tool_param :message, description: "The message content to post on each execution. This triggers the agent orchestration pipeline.", required: true
     tool_param :description, description: "Human-readable description of what this cron job does.", required: false
+    tool_param :once, description: "Run only on the first matching schedule, then remove the job. Defaults to false.", required: false
 
     sig do
       params(
@@ -21,10 +22,11 @@ module Tools
         topic_name: String,
         schedule: String,
         message: String,
-        description: T.nilable(String)
+        description: T.nilable(String),
+        once: T::Boolean
       ).returns(T::Hash[Symbol, T.untyped])
     end
-    def call(creative_id:, topic_name:, schedule:, message:, description: nil)
+    def call(creative_id:, topic_name:, schedule:, message:, description: nil, once: false)
       raise "Current.user is required" unless Current.user
 
       creative = Creative.find_by(id: creative_id)
@@ -43,27 +45,32 @@ module Tools
       key = "cron_#{creative_id}_#{SecureRandom.hex(4)}"
 
       task = create_task(
-        topic: topic, creative: creative, creative_id: creative_id, topic_created: topic_created,
-        key: key, schedule: schedule, message: message, description: description
+        topic: topic, creative: creative, topic_created: topic_created,
+        key: key, schedule: schedule, message: message, description: description, once: once
       )
       return task if task.is_a?(Hash) && task[:error]
 
       topic_created ? broadcast_topic_created(topic) : Crons::ChangeBroadcaster.call(creative)
 
+      task_result(task, creative_id: creative_id, topic_name: topic_name, once: once)
+    end
+
+    private
+
+    def task_result(task, creative_id:, topic_name:, once:)
       {
         success: true,
         key: task.key,
         schedule: task.schedule,
         description: task.description,
+        once: once,
         creative_id: creative_id,
         topic_name: topic_name,
         next_run: task.next_time&.iso8601
       }
     end
 
-    private
-
-    def create_task(topic:, creative:, creative_id:, key:, schedule:, message:, description:, topic_created:)
+    def create_task(topic:, creative:, key:, schedule:, message:, description:, once:, topic_created:)
       creation_error = nil
       retained_created_topic = false
       task = topic.with_lock do
@@ -73,8 +80,8 @@ module Tools
         end
 
         persist_task(
-          topic: topic, creative_id: creative_id, key: key, schedule: schedule,
-          message: message, description: description
+          topic: topic, creative_id: creative.id, key: key, schedule: schedule,
+          message: message, description: description, once: once
         )
       rescue StandardError => e
         retained_created_topic = clean_up_failed_topic_creation(topic) if topic_created
@@ -101,7 +108,7 @@ module Tools
       false
     end
 
-    def persist_task(topic:, creative_id:, key:, schedule:, message:, description:)
+    def persist_task(topic:, creative_id:, key:, schedule:, message:, description:, once:)
       SolidQueue::RecurringTask.create!(
         key: key,
         class_name: "Collavre::CronActionJob",
@@ -113,7 +120,8 @@ module Tools
           creative_id: creative_id,
           topic_id: topic.id,
           agent_id: Current.user.id,
-          message: message
+          message: message,
+          once: once
         } ]
       )
     end

--- a/engines/collavre/app/services/collavre/tools/cron_list_service.rb
+++ b/engines/collavre/app/services/collavre/tools/cron_list_service.rb
@@ -40,7 +40,7 @@ module Tools
           creative_id: task_creative_id,
           topic_id: args["topic_id"],
           agent_id: args["agent_id"],
-          message: args["message"],
+          message: args["message"], once: args["once"] == true,
           created_at: task.created_at&.iso8601
         }
       end

--- a/engines/collavre/app/services/collavre/topics/orphaned_cron_notifier.rb
+++ b/engines/collavre/app/services/collavre/topics/orphaned_cron_notifier.rb
@@ -72,6 +72,7 @@ module Collavre
           message: args["message"],
           description: task.description
         }
+        payload[:once] = true if args["once"] == true
 
         "/cron_create #{JSON.generate(payload)}"
       end

--- a/engines/collavre/test/jobs/collavre/cron_scheduler_job_test.rb
+++ b/engines/collavre/test/jobs/collavre/cron_scheduler_job_test.rb
@@ -102,6 +102,80 @@ module Collavre
       end
     end
 
+    test "removes a run-once task after its first enqueue" do
+      creative = creatives(:tshirt)
+      task = SolidQueue::RecurringTask.create!(
+        key: "cron_test_once",
+        class_name: "Collavre::CronActionJob",
+        schedule: "*/5 * * * *",
+        queue_name: "default",
+        static: false,
+        arguments: [ { creative_id: creative.id, topic_id: nil, agent_id: 1, message: "test", once: true } ]
+      )
+
+      changed_creative = nil
+      Crons::ChangeBroadcaster.stub(:call, ->(value) { changed_creative = value }) do
+        assert_enqueued_with(
+          job: Collavre::CronActionJob,
+          args: [ { creative_id: creative.id, topic_id: nil, agent_id: 1, message: "test" } ]
+        ) do
+          CronSchedulerJob.perform_now
+        end
+      end
+
+      assert_not SolidQueue::RecurringTask.exists?(task.id)
+      assert_equal creative, changed_creative
+    end
+
+    test "keeps a run-once task when enqueueing fails" do
+      task = SolidQueue::RecurringTask.create!(
+        key: "cron_test_once_retry",
+        class_name: "Collavre::CronActionJob",
+        schedule: "*/5 * * * *",
+        queue_name: "default",
+        static: false,
+        arguments: [ { creative_id: 1, topic_id: nil, agent_id: 1, message: "test", once: true } ]
+      )
+
+      Collavre::CronActionJob.stub(:perform_later, ->(**) { raise "queue unavailable" }) do
+        CronSchedulerJob.perform_now
+      end
+
+      assert SolidQueue::RecurringTask.exists?(task.id)
+    end
+
+    test "keeps a run-once task with an unknown job class" do
+      Collavre.const_set(:EphemeralCronJob, Class.new(ApplicationJob))
+      task = SolidQueue::RecurringTask.create!(
+        key: "cron_test_once_unknown",
+        class_name: "Collavre::EphemeralCronJob",
+        schedule: "*/5 * * * *",
+        queue_name: "default",
+        static: false,
+        arguments: [ { creative_id: 1, once: true } ]
+      )
+      Collavre.send(:remove_const, :EphemeralCronJob)
+
+      CronSchedulerJob.perform_now
+
+      assert SolidQueue::RecurringTask.exists?(task.id)
+    ensure
+      Collavre.send(:remove_const, :EphemeralCronJob) if Collavre.const_defined?(:EphemeralCronJob, false)
+    end
+
+    test "handles a run-once task removed by another scheduler" do
+      task = Struct.new(:arguments).new([ { creative_id: 1, once: true } ])
+      def task.with_lock = raise(ActiveRecord::RecordNotFound)
+
+      assert_equal false, CronSchedulerJob.new.send(:dispatch_task, task)
+    end
+
+    test "treats malformed arguments as recurring" do
+      task = Struct.new(:arguments).new(nil)
+
+      assert_equal false, CronSchedulerJob.new.send(:run_once?, task)
+    end
+
     test "reschedules itself after perform" do
       assert_enqueued_with(job: Collavre::CronSchedulerJob) do
         CronSchedulerJob.perform_now

--- a/engines/collavre/test/jobs/collavre/cron_scheduler_job_test.rb
+++ b/engines/collavre/test/jobs/collavre/cron_scheduler_job_test.rb
@@ -6,6 +6,10 @@ module Collavre
   class CronSchedulerJobTest < ActiveSupport::TestCase
     include ActiveJob::TestHelper
 
+    class UnrelatedRecurringJob < ApplicationJob
+      def perform(once:); end
+    end
+
     setup do
       @now = Time.zone.parse("2026-02-20 10:05:00")
       travel_to @now
@@ -163,15 +167,35 @@ module Collavre
       Collavre.send(:remove_const, :EphemeralCronJob) if Collavre.const_defined?(:EphemeralCronJob, false)
     end
 
+    test "preserves once arguments for unrelated dynamic tasks" do
+      task = SolidQueue::RecurringTask.create!(
+        key: "unrelated_dynamic_task",
+        class_name: UnrelatedRecurringJob.name,
+        schedule: "*/5 * * * *",
+        queue_name: "default",
+        static: false,
+        arguments: [ { once: true } ]
+      )
+
+      assert_enqueued_with(job: UnrelatedRecurringJob, args: [ { once: true } ]) do
+        CronSchedulerJob.perform_now
+      end
+
+      assert SolidQueue::RecurringTask.exists?(task.id)
+    end
+
     test "handles a run-once task removed by another scheduler" do
-      task = Struct.new(:arguments).new([ { creative_id: 1, once: true } ])
+      task = Struct.new(:class_name, :arguments).new(
+        CronActionJob.name,
+        [ { creative_id: 1, once: true } ]
+      )
       def task.with_lock = raise(ActiveRecord::RecordNotFound)
 
       assert_equal false, CronSchedulerJob.new.send(:dispatch_task, task)
     end
 
     test "treats malformed arguments as recurring" do
-      task = Struct.new(:arguments).new(nil)
+      task = Struct.new(:class_name, :arguments).new(CronActionJob.name, nil)
 
       assert_equal false, CronSchedulerJob.new.send(:run_once?, task)
     end

--- a/engines/collavre/test/services/collavre/tools/cron_create_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/cron_create_service_test.rb
@@ -90,6 +90,24 @@ module Collavre
         assert_equal @topic.id, args[:topic_id]
         assert_equal @user.id, args[:agent_id]
         assert_equal "Test message", args[:message]
+        assert_equal false, args[:once]
+        assert_equal false, result[:once]
+      end
+
+      test "creates a job that runs once" do
+        result = CronCreateService.new.call(
+          creative_id: @creative.id,
+          topic_name: "Cron Test Topic",
+          schedule: "0 9 * * *",
+          message: "One-time message",
+          once: true
+        )
+
+        assert result[:success]
+        assert_equal true, result[:once]
+
+        task = SolidQueue::RecurringTask.find_by!(key: result[:key])
+        assert_equal true, task.arguments.first[:once]
       end
 
       test "rejects invalid cron schedule" do

--- a/engines/collavre/test/services/collavre/tools/cron_list_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/cron_list_service_test.rb
@@ -82,6 +82,17 @@ module Collavre
         assert_equal "0 9 * * *", job[:schedule]
         assert_equal "Test cron", job[:description]
         assert_equal "Hello", job[:message]
+        assert_equal false, job[:once]
+      end
+
+      test "identifies a run-once job" do
+        arguments = @task.arguments.first.merge(once: true)
+        @task.update!(arguments: [ arguments ])
+
+        result = CronListService.new.call(creative_id: @creative.id)
+        job = result[:cron_jobs].find { |candidate| candidate[:key] == @task.key }
+
+        assert_equal true, job[:once]
       end
     end
   end

--- a/engines/collavre/test/services/collavre/topics/orphaned_cron_notifier_test.rb
+++ b/engines/collavre/test/services/collavre/topics/orphaned_cron_notifier_test.rb
@@ -19,7 +19,7 @@ module Collavre
         @topic = @creative.topics.create!(name: "Counseling", user: @user)
       end
 
-      def create_cron(creative_id:, topic_id:, message: "@Ming: do the thing", description: nil)
+      def create_cron(creative_id:, topic_id:, message: "@Ming: do the thing", description: nil, once: false)
         SolidQueue::RecurringTask.create!(
           key: "cron_#{creative_id}_#{SecureRandom.hex(4)}",
           class_name: "Collavre::CronActionJob",
@@ -31,7 +31,8 @@ module Collavre
             creative_id: creative_id,
             topic_id: topic_id,
             agent_id: @user.id,
-            message: message
+            message: message,
+            once: once
           } ]
         )
       end
@@ -83,6 +84,20 @@ module Collavre
           OrphanedCronNotifier.new(topic_id: deleted_id, topic_name: "Counseling").call
         end
         assert SolidQueue::RecurringTask.exists?(key: cron.key)
+      end
+
+      test "preserves the run-once option in the recreation command" do
+        create_cron(creative_id: @creative.id, topic_id: @topic.id, once: true)
+        deleted_name = @topic.name
+        deleted_id = @topic.id
+        @topic.destroy!
+
+        OrphanedCronNotifier.new(topic_id: deleted_id, topic_name: deleted_name).call
+
+        notice = @creative.comments.where(user_id: nil).order(:created_at).last
+        command = notice.content.lines.find { |line| line.start_with?("/cron_create ") }
+        payload = JSON.parse(command.delete_prefix("/cron_create "))
+        assert_equal true, payload.fetch("once")
       end
 
       test "deletes every matching cron before posting notices" do


### PR DESCRIPTION
## Summary

- add an optional once boolean to cron_create while preserving recurring behavior by default
- atomically enqueue and remove one-time recurring tasks on their first matching schedule
- expose the mode through cron_list and preserve it in orphaned-topic recreation commands
- keep one-time tasks available for retry when enqueueing fails

## Tests

- mise exec -- bin/rails test engines/collavre/test/services/collavre/tools/cron_create_service_test.rb engines/collavre/test/jobs/collavre/cron_scheduler_job_test.rb engines/collavre/test/services/collavre/tools/cron_list_service_test.rb engines/collavre/test/services/collavre/topics/orphaned_cron_notifier_test.rb
- mise exec -- ./bin/rubocop -a
- mise exec -- bin/complexity_check