### PR TITLE
fix: move mobile workspace tree toggle to bottom

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/workspace.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/workspace.css
@@ -298,11 +298,15 @@ body.creative-workspace .indent3 {
         overflow: visible;
     }
 
-    /* The floating chat is rendered after the tree in the workspace shell and
-       uses the modal layer. Keep the opened tree above it so its rows remain
-       visible and tappable on one-panel screens. */
+    /* Keep the closed handle below the floating chat so it cannot intercept
+       taps on the comment form. Raise only the opened tree above the chat so
+       its rows and close handle remain tappable on one-panel screens. */
     .creative-workspace-tree-region {
-	z-index: calc(var(--layer-modal) + 1);
+        z-index: calc(var(--layer-modal) - 1);
+    }
+
+    .creative-workspace-tree-region.is-open {
+        z-index: calc(var(--layer-modal) + 1);
     }
 
     .creative-workspace-shell {

--- a/engines/collavre/app/assets/stylesheets/collavre/workspace.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/workspace.css
@@ -314,12 +314,10 @@ body.creative-workspace .indent3 {
         max-width: var(--max-width);
     }
 
-    /* In the two-panel band the handle's default offset lands in the left
-       gutter main leaves itself. One-panel main runs flush to the edge, so the
-       same offset would sit on top of the breadcrumb row — park the handle in
-       the nav's empty left corner instead, where it reads as the menu button
-       it effectively is. */
+    /* Keep the drawer handle in easy thumb reach on one-panel screens while
+       clearing the device's bottom safe area. */
     .creative-workspace-tree-toggle {
-        top: var(--space-3);
+        top: auto;
+        bottom: calc(var(--space-3) + env(safe-area-inset-bottom, 0px));
     }
 }

--- a/engines/collavre/app/assets/stylesheets/collavre/workspace.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/workspace.css
@@ -318,6 +318,13 @@ body.creative-workspace .indent3 {
         max-width: var(--max-width);
     }
 
+    /* Reserve the handle's width outside the scrolling content so row controls
+       never pass underneath it, including in long creative lists. */
+    .creative-workspace-shell > main {
+        margin-left: 2.75rem;
+        width: calc(100% - 2.75rem);
+    }
+
     /* Keep the drawer handle in easy thumb reach on one-panel screens while
        clearing the device's bottom safe area. */
     .creative-workspace-tree-toggle {

--- a/engines/collavre/test/system/workspace_tree_drawer_test.rb
+++ b/engines/collavre/test/system/workspace_tree_drawer_test.rb
@@ -131,6 +131,20 @@ class WorkspaceTreeDrawerTest < ApplicationSystemTestCase
     assert_equal "contain", computed_style(".creative-workspace-tree-nav", "overscroll-behavior-y")
   end
 
+  test "the mobile drawer handle stays near the bottom for one-handed reach" do
+    visit_workspace(MOBILE_WIDTH)
+
+    position = page.evaluate_script(<<~JS)
+      (function () {
+        var rect = document.querySelector('.creative-workspace-tree-toggle').getBoundingClientRect();
+        return { centerY: rect.top + rect.height / 2, bottom: rect.bottom, viewportHeight: window.innerHeight };
+      })();
+    JS
+
+    assert_operator position.fetch("centerY"), :>, position.fetch("viewportHeight") * 0.75
+    assert_operator position.fetch("bottom"), :<=, position.fetch("viewportHeight")
+  end
+
   private
 
   def visit_workspace(width)

--- a/engines/collavre/test/system/workspace_tree_drawer_test.rb
+++ b/engines/collavre/test/system/workspace_tree_drawer_test.rb
@@ -88,6 +88,40 @@ class WorkspaceTreeDrawerTest < ApplicationSystemTestCase
     assert_tree_covers_floating_chat
   end
 
+  [ MOBILE_WIDTH, 600 ].each do |width|
+    test "the mobile chat receives taps over the closed drawer handle at #{width}px" do
+      visit_workspace(width)
+      assert_toggle_within_viewport
+
+      within("#creative-#{@creative.id}") { find(".comments-btn").click }
+      assert_selector "#comments-popup.open"
+
+      # Hit-test the overlap itself: visibility alone cannot detect a button
+      # intercepting taps intended for the bottom sheet's form.
+      assert_selector "#comments-popup.open" do |popup|
+        page.evaluate_script(<<~JS, popup)
+          (() => {
+            const rect = document.querySelector('.creative-workspace-tree-toggle').getBoundingClientRect();
+            const target = document.elementFromPoint(rect.left + rect.width / 2, rect.top + rect.height / 2);
+            return arguments[0].contains(target);
+          })();
+        JS
+      end
+
+      find("#new-comment-form textarea").set("Mobile comment")
+      check "comment-private"
+      assert_checked_field "comment-private"
+
+      find("#close-comments-btn").click
+      assert_no_selector "#comments-popup.open"
+      assert_toggle_within_viewport
+      find(".creative-workspace-tree-toggle").click
+      assert_selector ".creative-workspace-tree-region.is-open"
+      assert_drawer_settled(open: true)
+      assert_toggle_within_viewport
+    end
+  end
+
   # The handle is a fixed overlay. In the two-panel band it lands in the gutter
   # main leaves itself, but one-panel main runs flush to the left edge, so the
   # same offset would sit on top of the breadcrumb row and eat taps meant for it.

--- a/engines/collavre/test/system/workspace_tree_drawer_test.rb
+++ b/engines/collavre/test/system/workspace_tree_drawer_test.rb
@@ -30,6 +30,10 @@ class WorkspaceTreeDrawerTest < ApplicationSystemTestCase
     sign_in_via_ui(@user)
   end
 
+  teardown do
+    page.driver.browser.execute_cdp("Emulation.clearDeviceMetricsOverride")
+  end
+
   [ MOBILE_WIDTH, TWO_PANEL_WIDTH ].each do |width|
     test "the tree collapses to a reachable drawer at #{width}px" do
       visit_workspace(width)
@@ -122,9 +126,47 @@ class WorkspaceTreeDrawerTest < ApplicationSystemTestCase
     end
   end
 
-  # The handle is a fixed overlay. In the two-panel band it lands in the gutter
-  # main leaves itself, but one-panel main runs flush to the left edge, so the
-  # same offset would sit on top of the breadcrumb row and eat taps meant for it.
+  [ 375, MOBILE_WIDTH, 767 ].each do |width|
+    test "scrolled row controls stay clear of the mobile drawer handle at #{width}px" do
+      branches = Array.new(35) do |index|
+        branch = Creative.create!(description: "Scroll branch #{index}", user: @user)
+        Creative.create!(description: "Scroll leaf #{index}", user: @user, parent: branch)
+        branch
+      end
+      visit_workspace(width)
+      row_selector = "#creative-#{branches[20].id}"
+      control = find("#{row_selector} .creative-toggle-btn")
+
+      # Align a real row control with the fixed handle after document scrolling.
+      # Initial-position checks with a short list cannot exercise this overlap.
+      page.execute_script(<<~JS, control)
+        const rect = arguments[0].getBoundingClientRect();
+        const handle = document.querySelector('.creative-workspace-tree-toggle').getBoundingClientRect();
+        window.scrollBy(0, rect.top + rect.height / 2 - handle.top - handle.height / 2);
+      JS
+      assert_operator page.evaluate_script("window.scrollY"), :>, 0
+      assert_selector "#{row_selector} .creative-toggle-btn" do |button|
+        page.evaluate_script(<<~JS, button)
+          (() => {
+            const rect = arguments[0].getBoundingClientRect();
+            const handle = document.querySelector('.creative-workspace-tree-toggle').getBoundingClientRect();
+            const centerY = rect.top + rect.height / 2;
+            return centerY > handle.top && centerY < handle.bottom && rect.left >= handle.right &&
+              arguments[0].contains(document.elementFromPoint(rect.left + rect.width / 2, centerY));
+          })();
+        JS
+      end
+
+      control.click
+      assert_selector "creative-tree-row[dom-id='creative-#{branches[20].id}'][expanded]"
+      assert_no_selector ".creative-workspace-tree-region.is-open"
+      assert_toggle_within_viewport
+      find(".creative-workspace-tree-toggle").click
+      assert_selector ".creative-workspace-tree-region.is-open"
+    end
+  end
+
+  # Check initial placement too, including the unchanged two-panel gutter.
   [ MOBILE_WIDTH, TWO_PANEL_WIDTH ].each do |width|
     test "the closed drawer handle covers no control in the content column at #{width}px" do
       visit_workspace(width)
@@ -183,7 +225,11 @@ class WorkspaceTreeDrawerTest < ApplicationSystemTestCase
 
   def visit_workspace(width)
     resize_window_to(width, 800)
+    # Chrome can clamp desktop windows to 500px; pin the actual CSS viewport.
+    page.driver.browser.execute_cdp("Emulation.setDeviceMetricsOverride",
+      width: width, height: 800, deviceScaleFactor: 1, mobile: false)
     visit collavre.creatives_path
+    assert_equal width, page.evaluate_script("window.innerWidth")
     assert_selector ".creative-workspace-shell"
   end
 


### PR DESCRIPTION
## Summary

Move the workspace tree toggle to the bottom of mobile screens for one-handed access, respecting the device safe area. Reserve a 2.75rem gutter outside the scrolling content so row controls cannot pass under the handle. Tablet placement is unchanged.

Keep the closed handle below the mobile chat sheet and the opened drawer above it, preserving access to both the comment form and tree.

## Validation

- Drawer system suite: 15 tests, 135 assertions, no failures. Includes long-list scrolling at 375px, 430px, and 767px, row expansion without opening the drawer, and chat interaction at 430px and 600px.
- The scrolling regression tests failed before the gutter fix. Pin and assert the CSS viewport through Chrome emulation so narrow-screen coverage is not limited by Chrome's minimum desktop window width.
- Changed-file RuboCop and the complexity ratchet pass.
- Initial implementation validation: full system suite (140 tests, 2 existing skips), workspace tree controller JS tests, and full RuboCop passed. Only the affected suite was rerun for review follow-ups.

## Known baseline issue

The initial full unit-test run reported 11 Active Record encryption configuration errors in the GitHub webhook and reprovision suites after earlier tests mutated shared process state. The failing files passed independently, as recorded in the initial validation.
