### PR TITLE
feat: open creative images in the shared chat viewer

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/image_lightbox.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/image_lightbox.css
@@ -73,6 +73,10 @@
   gap: var(--space-1, 0.25rem);
 }
 
+.image-lightbox-btn[hidden] {
+  display: none;
+}
+
 .image-lightbox-btn:hover {
   background: rgba(255, 255, 255, 0.15);
   color: #fff;

--- a/engines/collavre/app/assets/stylesheets/collavre/image_lightbox.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/image_lightbox.css
@@ -143,3 +143,10 @@
     max-width: 96%;
   }
 }
+
+/* Keep keyboard focus visible on images that open the shared viewer. */
+.creative-content img[role="button"]:focus-visible,
+.creative-title-content img[role="button"]:focus-visible {
+  outline: 2px solid currentcolor;
+  outline-offset: 3px;
+}

--- a/engines/collavre/app/javascript/controllers/__tests__/creative_image_lightbox_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/creative_image_lightbox_controller.test.js
@@ -281,6 +281,57 @@ test.each([
   expect(link.getAttribute('aria-label')).toBe(attributes.startsWith('aria-label=') ? 'Original image' : null)
 })
 
+test.each(['alt', 'caption'])('releases generated link labels when %s arrives and restores them when removed', async (source) => {
+  const image = document.querySelector('#second')
+  const link = image.closest('a')
+  image.alt = ''
+  await settle()
+  expect(link.getAttribute('aria-label')).toBe('이미지 열기')
+
+  if (source === 'alt') image.alt = 'Updated description'
+  else link.insertAdjacentHTML('beforeend', '<span>Documentation</span>')
+  await settle()
+  expect(link.hasAttribute('aria-label')).toBe(false)
+  expect(link.getAttribute('aria-haspopup')).toBe(source === 'alt' ? 'dialog' : null)
+
+  if (source === 'alt') image.alt = ''
+  else link.querySelector('span').remove()
+  await settle()
+  expect(link.getAttribute('aria-label')).toBe('이미지 열기')
+  expect(link.getAttribute('aria-haspopup')).toBe('dialog')
+})
+
+test('preserves an authored label that replaces the generated fallback', async () => {
+  const image = document.querySelector('#second')
+  const link = image.closest('a')
+  image.alt = ''
+  await settle()
+  expect(link.getAttribute('aria-label')).toBe('이미지 열기')
+  link.setAttribute('aria-label', 'Author supplied name')
+  image.alt = 'Updated description'
+  await settle()
+  expect(link.getAttribute('aria-label')).toBe('Author supplied name')
+  link.insertAdjacentHTML('beforeend', '<span>Documentation</span>')
+  await settle()
+  expect(link.getAttribute('aria-label')).toBe('Author supplied name')
+})
+
+test('keeps generated label ownership across controller reconnection', async () => {
+  const image = document.querySelector('#second')
+  const link = image.closest('a')
+  const main = document.querySelector('main')
+  image.alt = ''
+  await settle()
+  main.remove()
+  await settle()
+  document.body.append(main)
+  await settle()
+  expect(link.getAttribute('aria-label')).toBe('이미지 열기')
+  image.alt = 'Description after reconnect'
+  await settle()
+  expect(link.hasAttribute('aria-label')).toBe(false)
+})
+
 test('makes an image keyboard accessible when its source arrives later', async () => {
   document.querySelector('#missing').src = '/loaded.png'
   await settle()

--- a/engines/collavre/app/javascript/controllers/__tests__/creative_image_lightbox_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/creative_image_lightbox_controller.test.js
@@ -73,6 +73,24 @@ test('opens title images and preserves zoom, keyboard navigation and close', () 
   expect(dialog()).toBeNull()
 })
 
+test('preserves image descriptions on every carousel entry and clears missing or empty alt text', () => {
+  const description = 'Architecture: "Client" < API & 서버'
+  document.querySelector('#second').alt = description
+  document.querySelector('.creative-content').insertAdjacentHTML('beforeend', `
+    <img src="/decorative.png" alt=""><img src="/undescribed.png">`)
+
+  click('#second')
+  expect(dialog().querySelector('img').alt).toBe(description)
+  click('.image-lightbox-prev')
+  expect(dialog().querySelector('img').alt).toBe('First')
+  click('.image-lightbox-prev')
+  expect(dialog().querySelector('img').alt).toBe('')
+  click('.image-lightbox-prev')
+  expect(dialog().querySelector('img').alt).toBe('')
+  click('.image-lightbox-prev')
+  expect(dialog().querySelector('img').alt).toBe(description)
+})
+
 test.each(['#text', '#empty', '#missing', '#editor', '#form', '#avatar'])('ignores %s', (selector) => {
   expect(click(selector)).toBe(true)
   expect(dialog()).toBeNull()
@@ -145,6 +163,7 @@ test('chat attachments retain their index, download and delete controls', async 
   await settle()
   click('#chat-second')
   expect(dialog().querySelector('img').src).toBe('http://localhost/chat-second.png')
+  expect(dialog().querySelector('img').alt).toBe('')
   expect(dialog().querySelector('.image-lightbox-delete').hidden).toBe(false)
   expect(dialog().querySelector('.image-lightbox-download-one').hidden).toBe(false)
   expect(dialog().querySelector('.image-lightbox-download-all')).not.toBeNull()

--- a/engines/collavre/app/javascript/controllers/__tests__/creative_image_lightbox_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/creative_image_lightbox_controller.test.js
@@ -1,0 +1,112 @@
+import { jest } from '@jest/globals'
+import { Application } from '@hotwired/stimulus'
+import CreativeImageLightboxController from '../creative_image_lightbox_controller'
+import ImageLightboxController from '../image_lightbox_controller'
+
+let application
+const settle = () => new Promise((resolve) => setTimeout(resolve, 0))
+const dialog = () => document.querySelector('.image-lightbox-dialog')
+const click = (selector) => document.querySelector(selector).dispatchEvent(new window.MouseEvent('click', { bubbles: true, cancelable: true }))
+
+beforeEach(async () => {
+  globalThis.KeyboardEvent = window.KeyboardEvent
+  globalThis.MouseEvent = window.MouseEvent
+  window.HTMLDialogElement.prototype.showModal = function () { this.setAttribute('open', '') }
+  window.HTMLDialogElement.prototype.close = function () { this.removeAttribute('open') }
+  document.body.innerHTML = `
+    <main data-controller="creative-image-lightbox" data-action="click->creative-image-lightbox#open:capture"
+      data-creative-image-lightbox-i18n-close-value="닫기" data-creative-image-lightbox-i18n-zoom-in-value="확대">
+      <creative-tree-row id="row"><div class="creative-content">
+        <p id="text">Text</p><img id="first" src="/first.png" alt="First">
+        <a href="/unwanted-navigation"><img id="second" src="/second.png" alt="Second"></a>
+        <img id="empty" src=""><img id="missing">
+      </div></creative-tree-row>
+      <creative-tree-row><div class="creative-title-content"><img id="title" src="/title.png"></div></creative-tree-row>
+      <div contenteditable="true"><div class="creative-content"><img id="editor" src="/editor.png"></div></div>
+      <div class="inline-edit-form"><div class="creative-content"><img id="form" src="/form.png"></div></div>
+      <img id="avatar" src="/avatar.png">
+    </main>`
+  application = Application.start()
+  application.register('creative-image-lightbox', CreativeImageLightboxController)
+  application.register('image-lightbox', ImageLightboxController)
+  await settle()
+})
+
+afterEach(async () => {
+  document.body.innerHTML = ''
+  await settle()
+  application.stop()
+  jest.restoreAllMocks()
+})
+
+test('opens the clicked image, blocks navigation and scopes the carousel to its creative', () => {
+  const onClick = jest.fn()
+  document.querySelector('#row').addEventListener('click', onClick)
+  expect(click('#second')).toBe(false)
+  expect(onClick).not.toHaveBeenCalled()
+  expect(dialog().querySelector('img').src).toBe('http://localhost/second.png')
+  expect(dialog().querySelector('.image-lightbox-counter').textContent).toBe('2 / 2')
+  click('.image-lightbox-next')
+  expect(dialog().querySelector('img').src).toBe('http://localhost/first.png')
+  click('.image-lightbox-prev')
+  expect(dialog().querySelector('img').src).toBe('http://localhost/second.png')
+  expect(dialog().querySelector('.image-lightbox-delete').hidden).toBe(true)
+  expect(dialog().querySelector('.image-lightbox-download-one').hidden).toBe(true)
+  expect(dialog().querySelector('.image-lightbox-download-all')).toBeNull()
+  expect(dialog().querySelector('.image-lightbox-close').title).toBe('닫기')
+  expect(dialog().querySelector('.image-lightbox-zoom-in').title).toBe('확대')
+})
+
+test('opens title images and preserves zoom, keyboard navigation and close', () => {
+  click('#title')
+  expect(dialog().querySelector('.image-lightbox-counter').textContent).toBe('1 / 1')
+  expect(dialog().querySelector('.image-lightbox-next').style.visibility).toBe('hidden')
+  click('.image-lightbox-zoom-in')
+  expect(dialog().querySelector('img').style.transform).toContain('scale(1.25)')
+  click('.image-lightbox-close')
+  expect(dialog()).toBeNull()
+  click('#first')
+  document.dispatchEvent(new window.KeyboardEvent('keydown', { key: 'ArrowRight' }))
+  expect(dialog().querySelector('img').src).toBe('http://localhost/second.png')
+  document.dispatchEvent(new window.KeyboardEvent('keydown', { key: 'Escape' }))
+  expect(dialog()).toBeNull()
+})
+
+test.each(['#text', '#empty', '#missing', '#editor', '#form', '#avatar'])('ignores %s', (selector) => {
+  expect(click(selector)).toBe(true)
+  expect(dialog()).toBeNull()
+})
+
+test('leaves select mode to the row selection handler', () => {
+  document.querySelector('#row').selectMode = true
+  click('#first')
+  expect(dialog()).toBeNull()
+})
+
+test('uses fresh images after a streamed update and closes on disconnect', async () => {
+  document.querySelector('.creative-content').innerHTML = '<img id="fresh" src="/fresh.png">'
+  click('#fresh')
+  expect(dialog().querySelector('img').src).toBe('http://localhost/fresh.png')
+  document.querySelector('main').remove()
+  await settle()
+  expect(dialog()).toBeNull()
+})
+
+test('chat attachments retain their index, download and delete controls', async () => {
+  document.body.insertAdjacentHTML('beforeend', `
+    <div data-controller="image-lightbox" data-image-lightbox-download-all-url-value="/comments/1/download_images">
+      <a id="chat-first" data-action="click->image-lightbox#open" data-image-lightbox-index-param="0" data-full-src="/chat-first.png"></a>
+      <a id="chat-second" data-action="click->image-lightbox#open" data-image-lightbox-index-param="1" data-full-src="/chat-second.png"></a>
+    </div>`)
+  await settle()
+  click('#chat-second')
+  expect(dialog().querySelector('img').src).toBe('http://localhost/chat-second.png')
+  expect(dialog().querySelector('.image-lightbox-delete').hidden).toBe(false)
+  expect(dialog().querySelector('.image-lightbox-download-one').hidden).toBe(false)
+  expect(dialog().querySelector('.image-lightbox-download-all')).not.toBeNull()
+  jest.useFakeTimers()
+  click('.image-lightbox-download-one')
+  expect(document.querySelector('iframe').getAttribute('src')).toBe('/comments/1/download_images?index=1')
+  jest.runOnlyPendingTimers()
+  jest.useRealTimers()
+})

--- a/engines/collavre/app/javascript/controllers/__tests__/creative_image_lightbox_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/creative_image_lightbox_controller.test.js
@@ -132,9 +132,22 @@ test('toolbar selection selects the image row without opening the viewer, then r
   expect(onClick).toHaveBeenCalledTimes(1)
   expect(content.querySelector('input').checked).toBe(true)
   expect(dialog()).toBeNull()
-  expect(keydown('.creative-content a', 'Enter')).toBe(false)
-  keydown('#first', ' ')
-  expect(dialog()).toBeNull()
+  const onDocumentKeydown = jest.fn()
+  document.addEventListener('keydown', onDocumentKeydown)
+  try {
+    for (const selector of ['#first', '#title', '.creative-content a']) {
+      for (const key of ['Enter', ' ']) {
+        expect(keydown(selector, key)).toBe(false)
+        expect(onDocumentKeydown).not.toHaveBeenCalled()
+        expect(dialog()).toBeNull()
+        expect(content.querySelector('input').checked).toBe(true)
+      }
+    }
+    expect(keydown('#first', 'Tab')).toBe(true)
+    expect(onDocumentKeydown).toHaveBeenCalledTimes(1)
+  } finally {
+    document.removeEventListener('keydown', onDocumentKeydown)
+  }
 
   click('#select')
   expect(content.querySelector('input').checked).toBe(false)

--- a/engines/collavre/app/javascript/controllers/__tests__/creative_image_lightbox_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/creative_image_lightbox_controller.test.js
@@ -241,6 +241,46 @@ test('preserves pointer navigation on the text portion of a mixed image link', (
   expect(dialog()).toBeNull()
 })
 
+test('preserves keyboard navigation on mixed image links', async () => {
+  const link = document.querySelector('#second').closest('a')
+  link.href = '#documentation'
+  link.insertAdjacentHTML('beforeend', '<span>Documentation</span>')
+  await settle()
+  expect(keydown('.creative-content a', 'Enter')).toBe(true)
+  expect(click('.creative-content a')).toBe(true)
+  expect(dialog()).toBeNull()
+  expect(link.hasAttribute('aria-haspopup')).toBe(false)
+  expect(click('#second')).toBe(false)
+  expect(dialog().querySelector('img').alt).toBe('Second')
+})
+
+test.each(['', null])('names otherwise unnamed image links with alt %s', async (alt) => {
+  const image = document.querySelector('#second')
+  if (alt === null) image.removeAttribute('alt')
+  else image.alt = alt
+  await settle()
+  const link = image.closest('a')
+  expect(link.getAttribute('aria-label')).toBe('이미지 열기')
+  expect(link.getAttribute('aria-haspopup')).toBe('dialog')
+  expect(click('.creative-content a')).toBe(false)
+  expect(dialog()).not.toBeNull()
+})
+
+test.each([
+  ['aria-label="Original image"', '<img src="/named.png" alt="">'],
+  ['aria-labelledby="text"', '<img src="/named.png">'],
+  ['title="Original image"', '<img src="/named.png">'],
+  ['', '<img src="/named.png" alt="Description">'],
+  ['', '<img src="/named.png"><span>Documentation</span>'],
+  ['', '<img src="/named.png"><img src="/other.png" alt="Other description">']
+])('preserves existing link names: %s %s', async (attributes, content) => {
+  document.querySelector('.creative-content').insertAdjacentHTML('beforeend',
+    `<a id="named-link" href="/original" ${attributes}>${content}</a>`)
+  await settle()
+  const link = document.querySelector('#named-link')
+  expect(link.getAttribute('aria-label')).toBe(attributes.startsWith('aria-label=') ? 'Original image' : null)
+})
+
 test('makes an image keyboard accessible when its source arrives later', async () => {
   document.querySelector('#missing').src = '/loaded.png'
   await settle()

--- a/engines/collavre/app/javascript/controllers/__tests__/creative_image_lightbox_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/creative_image_lightbox_controller.test.js
@@ -2,6 +2,7 @@ import { jest } from '@jest/globals'
 import { Application } from '@hotwired/stimulus'
 import CreativeImageLightboxController from '../creative_image_lightbox_controller'
 import ImageLightboxController from '../image_lightbox_controller'
+import SelectModeController from '../creatives/select_mode_controller'
 
 let application
 const settle = () => new Promise((resolve) => setTimeout(resolve, 0))
@@ -77,10 +78,46 @@ test.each(['#text', '#empty', '#missing', '#editor', '#form', '#avatar'])('ignor
   expect(dialog()).toBeNull()
 })
 
-test('leaves select mode to the row selection handler', () => {
+test('leaves explicit row select mode to the row selection handler', () => {
   document.querySelector('#row').selectMode = true
   click('#first')
   expect(dialog()).toBeNull()
+})
+
+test('toolbar selection selects the image row without opening the viewer, then restores viewing', async () => {
+  const main = document.querySelector('main')
+  main.dataset.controller += ' creatives--select-mode'
+  main.insertAdjacentHTML('afterbegin', `
+    <button id="select" data-action="creatives--select-mode#toggle">Select</button>`)
+  const content = document.querySelector('#row .creative-content')
+  content.classList.add('creative-row')
+  content.setAttribute('data-creatives--select-mode-target', 'row')
+  content.insertAdjacentHTML('afterbegin', `
+    <input type="checkbox" class="select-creative-checkbox" data-creatives--select-mode-target="checkbox">`)
+  application.register('creatives--select-mode', SelectModeController)
+  await settle()
+
+  click('#select')
+  expect(document.querySelector('#row').selectMode).toBeUndefined()
+  document.querySelector('#first').dispatchEvent(new window.MouseEvent('mousedown', { bubbles: true, cancelable: true }))
+  document.dispatchEvent(new window.MouseEvent('mouseup', { bubbles: true }))
+  click('#first')
+  expect(content.querySelector('input').checked).toBe(true)
+  expect(content.classList.contains('selected')).toBe(true)
+  expect(dialog()).toBeNull()
+  click('#title')
+  expect(dialog()).toBeNull()
+
+  click('#select')
+  expect(content.querySelector('input').checked).toBe(false)
+  click('#first')
+  expect(dialog().querySelector('img').src).toBe('http://localhost/first.png')
+})
+
+test('opens images when the selection controller has not connected', () => {
+  document.querySelector('main').dataset.controller += ' creatives--select-mode'
+  click('#first')
+  expect(dialog().querySelector('img').src).toBe('http://localhost/first.png')
 })
 
 test('uses fresh images after a streamed update and closes on disconnect', async () => {

--- a/engines/collavre/app/javascript/controllers/__tests__/creative_image_lightbox_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/creative_image_lightbox_controller.test.js
@@ -108,6 +108,13 @@ test('toolbar selection selects the image row without opening the viewer, then r
   click('#title')
   expect(dialog()).toBeNull()
 
+  const onClick = jest.fn()
+  content.addEventListener('click', onClick)
+  expect(click('#second')).toBe(false)
+  expect(onClick).toHaveBeenCalledTimes(1)
+  expect(content.querySelector('input').checked).toBe(true)
+  expect(dialog()).toBeNull()
+
   click('#select')
   expect(content.querySelector('input').checked).toBe(false)
   click('#first')

--- a/engines/collavre/app/javascript/controllers/__tests__/creative_image_lightbox_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/creative_image_lightbox_controller.test.js
@@ -15,8 +15,8 @@ beforeEach(async () => {
   window.HTMLDialogElement.prototype.showModal = function () { this.setAttribute('open', '') }
   window.HTMLDialogElement.prototype.close = function () { this.removeAttribute('open') }
   document.body.innerHTML = `
-    <main data-controller="creative-image-lightbox" data-action="click->creative-image-lightbox#open:capture"
-      data-creative-image-lightbox-i18n-close-value="닫기" data-creative-image-lightbox-i18n-zoom-in-value="확대">
+    <main data-controller="creative-image-lightbox" data-action="click->creative-image-lightbox#open:capture keydown->creative-image-lightbox#openFromKeyboard:capture"
+      data-creative-image-lightbox-i18n-open-value="이미지 열기" data-creative-image-lightbox-i18n-close-value="닫기" data-creative-image-lightbox-i18n-zoom-in-value="확대">
       <creative-tree-row id="row"><div class="creative-content">
         <p id="text">Text</p><img id="first" src="/first.png" alt="First">
         <a href="/unwanted-navigation"><img id="second" src="/second.png" alt="Second"></a>
@@ -132,6 +132,9 @@ test('toolbar selection selects the image row without opening the viewer, then r
   expect(onClick).toHaveBeenCalledTimes(1)
   expect(content.querySelector('input').checked).toBe(true)
   expect(dialog()).toBeNull()
+  expect(keydown('.creative-content a', 'Enter')).toBe(false)
+  keydown('#first', ' ')
+  expect(dialog()).toBeNull()
 
   click('#select')
   expect(content.querySelector('input').checked).toBe(false)
@@ -172,4 +175,77 @@ test('chat attachments retain their index, download and delete controls', async 
   expect(document.querySelector('iframe').getAttribute('src')).toBe('/comments/1/download_images?index=1')
   jest.runOnlyPendingTimers()
   jest.useRealTimers()
+})
+
+const keydown = (selector, key) => document.querySelector(selector).dispatchEvent(
+  new window.KeyboardEvent('keydown', { key, bubbles: true, cancelable: true }))
+
+test('makes non-linked list and title images accessible without duplicate link tab stops', () => {
+  for (const selector of ['#first', '#title']) {
+    const image = document.querySelector(selector)
+    expect(image.tabIndex).toBe(0)
+    expect(image.getAttribute('role')).toBe('button')
+    expect(image.getAttribute('aria-haspopup')).toBe('dialog')
+    image.focus()
+    expect(document.activeElement).toBe(image)
+  }
+  expect(document.querySelector('#first').getAttribute('aria-label')).toBe('First')
+  expect(document.querySelector('#title').getAttribute('aria-label')).toBe('이미지 열기')
+  expect(document.querySelector('#second').hasAttribute('tabindex')).toBe(false)
+  expect(document.querySelector('#second').closest('a').getAttribute('aria-haspopup')).toBe('dialog')
+  for (const selector of ['#empty', '#missing', '#editor', '#form', '#avatar']) {
+    expect(document.querySelector(selector).hasAttribute('tabindex')).toBe(false)
+  }
+})
+
+test.each(['Enter', ' '])('opens a focused image with %s without triggering row editing', (key) => {
+  const onKeydown = jest.fn()
+  document.querySelector('#row').addEventListener('keydown', onKeydown)
+  document.querySelector('#first').focus()
+  expect(keydown('#first', key)).toBe(false)
+  expect(onKeydown).not.toHaveBeenCalled()
+  expect(dialog().querySelector('img').alt).toBe('First')
+})
+
+test('opens a linked image on the native keyboard click from its anchor', () => {
+  expect(click('.creative-content a')).toBe(false)
+  expect(dialog().querySelector('img').alt).toBe('Second')
+})
+
+test('ignores unrelated keys and ordinary text links', () => {
+  expect(keydown('#first', 'Tab')).toBe(true)
+  expect(keydown('#text', 'Enter')).toBe(true)
+  document.querySelector('.creative-content').insertAdjacentHTML('beforeend', '<a id="text-link">Text link</a>')
+  expect(click('#text-link')).toBe(true)
+  expect(dialog()).toBeNull()
+})
+
+test('prepares streamed images and updated descriptions for keyboard activation', async () => {
+  const content = document.querySelector('.creative-content')
+  content.innerHTML = '<img id="fresh" src="/fresh.png" alt="Fresh">'
+  await settle()
+  expect(document.querySelector('#fresh').tabIndex).toBe(0)
+  document.querySelector('#fresh').alt = 'Updated'
+  await settle()
+  expect(document.querySelector('#fresh').getAttribute('aria-label')).toBe('Updated')
+  expect(keydown('#fresh', 'Enter')).toBe(false)
+  expect(dialog().querySelector('img').alt).toBe('Updated')
+})
+
+test('preserves pointer navigation on the text portion of a mixed image link', () => {
+  const link = document.querySelector('.creative-content a')
+  link.href = '#original'
+  link.insertAdjacentHTML('beforeend', '<span id="link-caption">Visit original</span>')
+  expect(document.querySelector('#link-caption').dispatchEvent(
+    new window.MouseEvent('click', { detail: 1, bubbles: true, cancelable: true }))).toBe(true)
+  expect(dialog()).toBeNull()
+})
+
+test('makes an image keyboard accessible when its source arrives later', async () => {
+  document.querySelector('#missing').src = '/loaded.png'
+  await settle()
+  document.querySelector('#missing').focus()
+  expect(document.activeElement.id).toBe('missing')
+  expect(keydown('#missing', 'Enter')).toBe(false)
+  expect(dialog().querySelector('img').src).toBe('http://localhost/loaded.png')
 })

--- a/engines/collavre/app/javascript/controllers/creative_image_lightbox_controller.js
+++ b/engines/collavre/app/javascript/controllers/creative_image_lightbox_controller.js
@@ -2,8 +2,50 @@ import ImageLightboxController from "./image_lightbox_controller"
 
 // Delegate from the creative list so streamed rows and title images work too.
 export default class extends ImageLightboxController {
-  open(event) {
+  static values = { ...ImageLightboxController.values, i18nOpen: String }
+
+  connect() {
+    super.connect()
+    this._prepareImages()
+    this._imageObserver = new MutationObserver(() => this._prepareImages())
+    this._imageObserver.observe(this.element, {
+      childList: true, subtree: true, attributes: true, attributeFilter: ["src", "alt"]
+    })
+  }
+
+  disconnect() {
+    this._imageObserver.disconnect()
+    super.disconnect()
+  }
+
+  _prepareImages() {
+    this.element.querySelectorAll('.creative-content img[src], .creative-title-content img[src]').forEach((image) => {
+      if (!image.getAttribute("src") || image.closest('[contenteditable="true"], .inline-edit-form')) return
+      const link = image.closest("a[href]")
+      if (link) {
+        link.setAttribute("aria-haspopup", "dialog")
+        return
+      }
+      image.tabIndex = 0
+      image.setAttribute("role", "button")
+      image.setAttribute("aria-haspopup", "dialog")
+      image.setAttribute("aria-label", image.alt || this.i18nOpenValue)
+    })
+  }
+
+  openFromKeyboard(event) {
+    if (event.key === "Enter" || event.key === " ") this.open(event)
+  }
+
+  _imageForEvent(event) {
     const image = event.target.closest("img")
+    if (image) return image
+    // Native keyboard/assistive-technology clicks target the link, not its image.
+    if (event.detail === 0) return event.target.closest("a")?.querySelector('img[src]:not([src=""])')
+  }
+
+  open(event) {
+    const image = this._imageForEvent(event)
     const content = image?.closest(".creative-content, .creative-title-content")
     if (!content || image.closest('[contenteditable="true"], .inline-edit-form')) return
     if (this._selectionActive(content)) {

--- a/engines/collavre/app/javascript/controllers/creative_image_lightbox_controller.js
+++ b/engines/collavre/app/javascript/controllers/creative_image_lightbox_controller.js
@@ -76,7 +76,11 @@ export default class extends ImageLightboxController {
     const content = image?.closest(".creative-content, .creative-title-content")
     if (!content || image.closest('[contenteditable="true"], .inline-edit-form')) return
     if (this._selectionActive(content)) {
-      if (image.closest("a")) event.preventDefault()
+      if (event.type === "keydown") {
+        // Suppress document shortcuts while preserving pointer row selection.
+        event.preventDefault()
+        event.stopPropagation()
+      } else if (image.closest("a")) event.preventDefault()
       return
     }
 

--- a/engines/collavre/app/javascript/controllers/creative_image_lightbox_controller.js
+++ b/engines/collavre/app/javascript/controllers/creative_image_lightbox_controller.js
@@ -17,7 +17,7 @@ export default class extends ImageLightboxController {
 
     event.preventDefault()
     event.stopPropagation()
-    this._openImages(images.map((img) => ({ fullSrc: img.src, filename: img.alt })), index)
+    this._openImages(images.map((img) => ({ fullSrc: img.src, alt: img.alt })), index)
   }
 
   _selectionActive(content) {

--- a/engines/collavre/app/javascript/controllers/creative_image_lightbox_controller.js
+++ b/engines/collavre/app/javascript/controllers/creative_image_lightbox_controller.js
@@ -1,0 +1,19 @@
+import ImageLightboxController from "./image_lightbox_controller"
+
+// Delegate from the creative list so streamed rows and title images work too.
+export default class extends ImageLightboxController {
+  open(event) {
+    const image = event.target.closest("img")
+    const content = image?.closest(".creative-content, .creative-title-content")
+    if (!content || image.closest('[contenteditable="true"], .inline-edit-form')) return
+    if (content.closest("creative-tree-row")?.selectMode) return
+
+    const images = Array.from(content.querySelectorAll("img[src]")).filter((img) => img.getAttribute("src"))
+    const index = images.indexOf(image)
+    if (index < 0) return
+
+    event.preventDefault()
+    event.stopPropagation()
+    this._openImages(images.map((img) => ({ fullSrc: img.src, filename: img.alt })), index)
+  }
+}

--- a/engines/collavre/app/javascript/controllers/creative_image_lightbox_controller.js
+++ b/engines/collavre/app/javascript/controllers/creative_image_lightbox_controller.js
@@ -23,7 +23,7 @@ export default class extends ImageLightboxController {
       if (!image.getAttribute("src") || image.closest('[contenteditable="true"], .inline-edit-form')) return
       const link = image.closest("a[href]")
       if (link) {
-        link.setAttribute("aria-haspopup", "dialog")
+        this._prepareLink(link)
         return
       }
       image.tabIndex = 0
@@ -31,6 +31,17 @@ export default class extends ImageLightboxController {
       image.setAttribute("aria-haspopup", "dialog")
       image.setAttribute("aria-label", image.alt || this.i18nOpenValue)
     })
+  }
+
+  _prepareLink(link) {
+    if (link.textContent.trim()) {
+      link.removeAttribute("aria-haspopup")
+      return
+    }
+    link.setAttribute("aria-haspopup", "dialog")
+    const named = ["aria-label", "aria-labelledby", "title"].some((name) => link.getAttribute(name)?.trim()) ||
+      Array.from(link.querySelectorAll("img")).some((image) => image.alt.trim())
+    if (!named) link.setAttribute("aria-label", this.i18nOpenValue)
   }
 
   openFromKeyboard(event) {
@@ -41,7 +52,10 @@ export default class extends ImageLightboxController {
     const image = event.target.closest("img")
     if (image) return image
     // Native keyboard/assistive-technology clicks target the link, not its image.
-    if (event.detail === 0) return event.target.closest("a")?.querySelector('img[src]:not([src=""])')
+    if (event.detail !== 0) return null
+    const link = event.target.closest("a")
+    // Mixed text/image links retain keyboard navigation to their destination.
+    return link && !link.textContent.trim() ? link.querySelector('img[src]:not([src=""])') : null
   }
 
   open(event) {

--- a/engines/collavre/app/javascript/controllers/creative_image_lightbox_controller.js
+++ b/engines/collavre/app/javascript/controllers/creative_image_lightbox_controller.js
@@ -6,6 +6,7 @@ export default class extends ImageLightboxController {
 
   connect() {
     super.connect()
+    this._generatedLinkLabels ||= new WeakMap()
     this._prepareImages()
     this._imageObserver = new MutationObserver(() => this._prepareImages())
     this._imageObserver.observe(this.element, {
@@ -34,6 +35,7 @@ export default class extends ImageLightboxController {
   }
 
   _prepareLink(link) {
+    this._clearGeneratedLinkLabel(link)
     if (link.textContent.trim()) {
       link.removeAttribute("aria-haspopup")
       return
@@ -41,7 +43,18 @@ export default class extends ImageLightboxController {
     link.setAttribute("aria-haspopup", "dialog")
     const named = ["aria-label", "aria-labelledby", "title"].some((name) => link.getAttribute(name)?.trim()) ||
       Array.from(link.querySelectorAll("img")).some((image) => image.alt.trim())
-    if (!named) link.setAttribute("aria-label", this.i18nOpenValue)
+    if (!named) {
+      link.setAttribute("aria-label", this.i18nOpenValue)
+      this._generatedLinkLabels.set(link, this.i18nOpenValue)
+    }
+  }
+
+  _clearGeneratedLinkLabel(link) {
+    // Recompute only our fallback; preserve names supplied by the content author.
+    if (link.getAttribute("aria-label") === this._generatedLinkLabels.get(link)) {
+      link.removeAttribute("aria-label")
+    }
+    this._generatedLinkLabels.delete(link)
   }
 
   openFromKeyboard(event) {

--- a/engines/collavre/app/javascript/controllers/creative_image_lightbox_controller.js
+++ b/engines/collavre/app/javascript/controllers/creative_image_lightbox_controller.js
@@ -6,7 +6,7 @@ export default class extends ImageLightboxController {
     const image = event.target.closest("img")
     const content = image?.closest(".creative-content, .creative-title-content")
     if (!content || image.closest('[contenteditable="true"], .inline-edit-form')) return
-    if (content.closest("creative-tree-row")?.selectMode) return
+    if (this._selectionActive(content)) return
 
     const images = Array.from(content.querySelectorAll("img[src]")).filter((img) => img.getAttribute("src"))
     const index = images.indexOf(image)
@@ -15,5 +15,12 @@ export default class extends ImageLightboxController {
     event.preventDefault()
     event.stopPropagation()
     this._openImages(images.map((img) => ({ fullSrc: img.src, filename: img.alt })), index)
+  }
+
+  _selectionActive(content) {
+    if (content.closest("creative-tree-row")?.selectMode) return true
+
+    const scope = content.closest('[data-controller~="creatives--select-mode"]')
+    return scope && this.application.getControllerForElementAndIdentifier(scope, "creatives--select-mode")?.active
   }
 }

--- a/engines/collavre/app/javascript/controllers/creative_image_lightbox_controller.js
+++ b/engines/collavre/app/javascript/controllers/creative_image_lightbox_controller.js
@@ -6,7 +6,10 @@ export default class extends ImageLightboxController {
     const image = event.target.closest("img")
     const content = image?.closest(".creative-content, .creative-title-content")
     if (!content || image.closest('[contenteditable="true"], .inline-edit-form')) return
-    if (this._selectionActive(content)) return
+    if (this._selectionActive(content)) {
+      if (image.closest("a")) event.preventDefault()
+      return
+    }
 
     const images = Array.from(content.querySelectorAll("img[src]")).filter((img) => img.getAttribute("src"))
     const index = images.indexOf(image)

--- a/engines/collavre/app/javascript/controllers/image_lightbox_controller.js
+++ b/engines/collavre/app/javascript/controllers/image_lightbox_controller.js
@@ -1,19 +1,11 @@
 import { Controller } from "@hotwired/stimulus"
+import imageLightboxValues from "./image_lightbox_values"
 import { confirmDialog } from "../lib/utils/dialog"
 
 // Connects to data-controller="image-lightbox"
 // Provides a fullscreen image carousel with navigation, download, and zoom
 export default class extends Controller {
-  static values = {
-    downloadAllUrl: String,
-    i18nClose: { type: String, default: "Close" },
-    i18nPrevious: { type: String, default: "Previous" },
-    i18nNext: { type: String, default: "Next" },
-    i18nDownload: { type: String, default: "Download" },
-    i18nDownloadAll: { type: String, default: "Download all" },
-    i18nDelete: { type: String, default: "Delete" },
-    i18nDeleteConfirm: { type: String, default: "Delete this image?" }
-  }
+  static values = imageLightboxValues
 
   connect() {
     this._boundKeydown = this._handleKeydown.bind(this)
@@ -28,8 +20,12 @@ export default class extends Controller {
     event.stopPropagation()
 
     const link = event.currentTarget
-    this._images = this._collectImages()
-    this._currentIndex = parseInt(link.dataset.imageLightboxIndexParam, 10) || 0
+    this._openImages(this._collectImages(), parseInt(link.dataset.imageLightboxIndexParam, 10) || 0)
+  }
+
+  _openImages(images, index) {
+    this._images = images
+    this._currentIndex = index
 
     this._createDialog()
     this._showImage()
@@ -200,12 +196,12 @@ export default class extends Controller {
         <div class="image-lightbox-toolbar">
           <span class="image-lightbox-counter"></span>
           <div class="image-lightbox-toolbar-actions">
-            <button class="image-lightbox-btn image-lightbox-zoom-in" type="button" title="Zoom in">🔍+</button>
-            <button class="image-lightbox-btn image-lightbox-zoom-out" type="button" title="Zoom out">🔍−</button>
-            <button class="image-lightbox-btn image-lightbox-zoom-reset" type="button" title="Reset zoom">1:1</button>
-            <button class="image-lightbox-btn image-lightbox-download-one" type="button" title="${this.i18nDownloadValue}">⬇ <span class="image-lightbox-btn-label">${this.i18nDownloadValue}</span></button>
+            <button class="image-lightbox-btn image-lightbox-zoom-in" type="button" title="${this.i18nZoomInValue}">🔍+</button>
+            <button class="image-lightbox-btn image-lightbox-zoom-out" type="button" title="${this.i18nZoomOutValue}">🔍−</button>
+            <button class="image-lightbox-btn image-lightbox-zoom-reset" type="button" title="${this.i18nZoomResetValue}">1:1</button>
+            <button ${this.hasDownloadAllUrlValue ? "" : "hidden"} class="image-lightbox-btn image-lightbox-download-one" type="button" title="${this.i18nDownloadValue}">⬇ <span class="image-lightbox-btn-label">${this.i18nDownloadValue}</span></button>
             ${this.hasDownloadAllUrlValue ? `<button class="image-lightbox-btn image-lightbox-download-all" type="button" title="${this.i18nDownloadAllValue}">📥 <span class="image-lightbox-btn-label">${this.i18nDownloadAllValue}</span></button>` : ""}
-            <button class="image-lightbox-btn image-lightbox-delete" type="button" title="${this.i18nDeleteValue}">🗑 <span class="image-lightbox-btn-label">${this.i18nDeleteValue}</span></button>
+            <button ${this.hasDownloadAllUrlValue ? "" : "hidden"} class="image-lightbox-btn image-lightbox-delete" type="button" title="${this.i18nDeleteValue}">🗑 <span class="image-lightbox-btn-label">${this.i18nDeleteValue}</span></button>
             <button class="image-lightbox-btn image-lightbox-close" type="button" title="${this.i18nCloseValue}">✕ <span class="image-lightbox-btn-label">${this.i18nCloseValue}</span></button>
           </div>
         </div>

--- a/engines/collavre/app/javascript/controllers/image_lightbox_controller.js
+++ b/engines/collavre/app/javascript/controllers/image_lightbox_controller.js
@@ -235,6 +235,7 @@ export default class extends Controller {
     this._resetZoom()
 
     imgEl.src = img.fullSrc
+    imgEl.alt = img.alt || ""
 
     // Show image once loaded (or immediately if cached)
     const showImg = () => { imgEl.style.opacity = "1" }

--- a/engines/collavre/app/javascript/controllers/image_lightbox_values.js
+++ b/engines/collavre/app/javascript/controllers/image_lightbox_values.js
@@ -1,0 +1,13 @@
+export default {
+  downloadAllUrl: String,
+  i18nZoomIn: { type: String, default: "Zoom in" },
+  i18nZoomOut: { type: String, default: "Zoom out" },
+  i18nZoomReset: { type: String, default: "Reset zoom" },
+  i18nClose: { type: String, default: "Close" },
+  i18nPrevious: { type: String, default: "Previous" },
+  i18nNext: { type: String, default: "Next" },
+  i18nDownload: { type: String, default: "Download" },
+  i18nDownloadAll: { type: String, default: "Download all" },
+  i18nDelete: { type: String, default: "Delete" },
+  i18nDeleteConfirm: { type: String, default: "Delete this image?" }
+}

--- a/engines/collavre/app/javascript/controllers/index.js
+++ b/engines/collavre/app/javascript/controllers/index.js
@@ -90,6 +90,7 @@ export {
   OrgChartController,
   ShareModalController,
   ImageLightboxController,
+  CreativeImageLightboxController,
   SearchPopupController,
   CommentBadgeController,
   LandingVideoController,
@@ -103,6 +104,11 @@ export {
   CreativeHistoryController,
   CreativeHistoryUndoController,
   CronBadgeController
+}
+
+function registerImageLightboxControllers(application) {
+  application.register("image-lightbox", ImageLightboxController)
+  application.register("creative-image-lightbox", CreativeImageLightboxController)
 }
 
 // Registration function for use with a Stimulus application
@@ -144,8 +150,7 @@ export function registerControllers(application) {
   application.register("comment-version", CommentVersionController)
   application.register("org-chart", OrgChartController)
   application.register("share-modal", ShareModalController)
-  application.register("image-lightbox", ImageLightboxController)
-  application.register("creative-image-lightbox", CreativeImageLightboxController)
+  registerImageLightboxControllers(application)
   application.register("search-popup", SearchPopupController)
   application.register("comment-badge", CommentBadgeController)
   application.register("landing-video", LandingVideoController)

--- a/engines/collavre/app/javascript/controllers/index.js
+++ b/engines/collavre/app/javascript/controllers/index.js
@@ -39,6 +39,7 @@ import CommentVersionController from "./comment_version_controller"
 import OrgChartController from "./org_chart_controller"
 import CommentBadgeController from "./comment_badge_controller"
 import ShareModalController from "./share_modal_controller"
+import CreativeImageLightboxController from "./creative_image_lightbox_controller"
 import ImageLightboxController from "./image_lightbox_controller"
 import SearchPopupController from "./search_popup_controller"
 import LandingVideoController from "./landing_video_controller"
@@ -144,6 +145,7 @@ export function registerControllers(application) {
   application.register("org-chart", OrgChartController)
   application.register("share-modal", ShareModalController)
   application.register("image-lightbox", ImageLightboxController)
+  application.register("creative-image-lightbox", CreativeImageLightboxController)
   application.register("search-popup", SearchPopupController)
   application.register("comment-badge", CommentBadgeController)
   application.register("landing-video", LandingVideoController)

--- a/engines/collavre/app/views/collavre/comments/_comment.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comment.html.erb
@@ -124,6 +124,9 @@
     <% images_list = comment.images.to_a %>
     <div class="comment-attachments"
          data-controller="image-lightbox"
+         data-image-lightbox-i18n-zoom-in-value="<%= t('collavre.comments.lightbox.zoom_in') %>"
+         data-image-lightbox-i18n-zoom-out-value="<%= t('collavre.comments.lightbox.zoom_out') %>"
+         data-image-lightbox-i18n-zoom-reset-value="<%= t('collavre.comments.lightbox.zoom_reset') %>"
          data-image-lightbox-download-all-url-value="<%= collavre.download_images_creative_comment_path(comment.creative, comment) %>"
          data-image-lightbox-i18n-close-value="<%= t('collavre.comments.lightbox.close') %>"
          data-image-lightbox-i18n-previous-value="<%= t('collavre.comments.lightbox.previous') %>"

--- a/engines/collavre/app/views/collavre/creatives/index.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/index.html.erb
@@ -36,7 +36,14 @@
       ) %>
 <% end %>
 
-<div data-controller="creatives--import creatives--select-mode creatives--drag-drop creatives--expansion creatives--row-editor share-modal"
+<div data-controller="creatives--import creatives--select-mode creatives--drag-drop creatives--expansion creatives--row-editor share-modal creative-image-lightbox"
+     data-action="click->creative-image-lightbox#open:capture"
+     data-creative-image-lightbox-i18n-close-value="<%= t('collavre.comments.lightbox.close') %>"
+     data-creative-image-lightbox-i18n-previous-value="<%= t('collavre.comments.lightbox.previous') %>"
+     data-creative-image-lightbox-i18n-next-value="<%= t('collavre.comments.lightbox.next') %>"
+     data-creative-image-lightbox-i18n-zoom-in-value="<%= t('collavre.comments.lightbox.zoom_in') %>"
+     data-creative-image-lightbox-i18n-zoom-out-value="<%= t('collavre.comments.lightbox.zoom_out') %>"
+     data-creative-image-lightbox-i18n-zoom-reset-value="<%= t('collavre.comments.lightbox.zoom_reset') %>"
      data-creatives--import-parent-id-value="<%= @parent_creative&.id %>"
      data-creatives--import-uploading-value="<%= t('collavre.creatives.index.import_uploading') %>"
      data-creatives--import-success-value="<%= t('collavre.creatives.index.import_success') %>"

--- a/engines/collavre/app/views/collavre/creatives/index.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/index.html.erb
@@ -37,7 +37,8 @@
 <% end %>
 
 <div data-controller="creatives--import creatives--select-mode creatives--drag-drop creatives--expansion creatives--row-editor share-modal creative-image-lightbox"
-     data-action="click->creative-image-lightbox#open:capture"
+     data-action="click->creative-image-lightbox#open:capture keydown->creative-image-lightbox#openFromKeyboard:capture"
+     data-creative-image-lightbox-i18n-open-value="<%= t('collavre.comments.lightbox.open_image') %>"
      data-creative-image-lightbox-i18n-close-value="<%= t('collavre.comments.lightbox.close') %>"
      data-creative-image-lightbox-i18n-previous-value="<%= t('collavre.comments.lightbox.previous') %>"
      data-creative-image-lightbox-i18n-next-value="<%= t('collavre.comments.lightbox.next') %>"

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -239,6 +239,9 @@ en:
         csv: CSV
         excel: Excel
       lightbox:
+        zoom_in: Zoom in
+        zoom_out: Zoom out
+        zoom_reset: Reset zoom
         close: Close
         previous: Previous
         next: Next

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -239,6 +239,7 @@ en:
         csv: CSV
         excel: Excel
       lightbox:
+        open_image: Open image
         zoom_in: Zoom in
         zoom_out: Zoom out
         zoom_reset: Reset zoom

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -236,6 +236,9 @@ ko:
         csv: CSV
         excel: Excel
       lightbox:
+        zoom_in: 확대
+        zoom_out: 축소
+        zoom_reset: 확대/축소 초기화
         close: 닫기
         previous: 이전
         next: 다음

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -236,6 +236,7 @@ ko:
         csv: CSV
         excel: Excel
       lightbox:
+        open_image: 이미지 열기
         zoom_in: 확대
         zoom_out: 축소
         zoom_reset: 확대/축소 초기화

--- a/engines/collavre/test/system/creative_image_lightbox_test.rb
+++ b/engines/collavre/test/system/creative_image_lightbox_test.rb
@@ -28,6 +28,15 @@ class CreativeImageLightboxTest < ApplicationSystemTestCase
     assert_selector "#creative-#{@creative.id} .select-creative-checkbox:checked"
     assert_no_selector ".image-lightbox-dialog"
 
+    first = find("#creative-#{@creative.id} img[alt='First']")
+    page.execute_script("arguments[0].focus()", first)
+    [ :enter, :space ].each do |key|
+      page.driver.browser.action.send_keys(key).perform
+      assert_no_selector "#inline-edit-form"
+      assert_no_selector ".image-lightbox-dialog"
+      assert_selector "#creative-#{@creative.id} .select-creative-checkbox:checked"
+    end
+
     find('[aria-controls="creative-overflow-menu"]').click
     find("#select-creative-btn").click
     assert_no_selector "#creative-#{@creative.id} .select-creative-checkbox:checked", visible: :all

--- a/engines/collavre/test/system/creative_image_lightbox_test.rb
+++ b/engines/collavre/test/system/creative_image_lightbox_test.rb
@@ -1,0 +1,41 @@
+require_relative "../application_system_test_case"
+
+class CreativeImageLightboxTest < ApplicationSystemTestCase
+  setup do
+    @user = User.create!(email: "image-viewer@example.com", password: SystemHelpers::PASSWORD,
+                         name: "Image Viewer", email_verified_at: Time.current, notifications_enabled: false)
+    @creative = Creative.create!(user: @user, description: "Image gallery")
+    file = Rails.root.join("engines/collavre/test/fixtures/files/small.png")
+    %w[first.png second.png].each do |filename|
+      File.open(file) do |io|
+        blob = ActiveStorage::Blob.create_and_upload!(io: io, filename: filename, content_type: "image/png")
+        @creative.files.attach(blob)
+      end
+    end
+    urls = @creative.files.map { |image| Rails.application.routes.url_helpers.rails_blob_path(image, only_path: true) }
+    @creative.update!(description: "<p>Image gallery</p><img src='#{urls.first}' alt='First' width='80' height='80'><a href='/creatives'><img src='#{urls.last}' alt='Second' width='80' height='80'></a>")
+    resize_window_to
+    sign_in_via_ui(@user)
+  end
+
+  test "list and title images open the chat viewer without navigation" do
+    visit collavre.creatives_path
+    find("#creative-#{@creative.id} img[alt='Second']").click
+    assert_selector ".image-lightbox-dialog[open] .image-lightbox-counter", text: "2 / 2"
+    assert_no_selector ".image-lightbox-delete"
+    assert_no_selector ".image-lightbox-download-one"
+    find(".image-lightbox-prev").click
+    assert_selector ".image-lightbox-counter", text: "1 / 2"
+    find(".image-lightbox-zoom-in").click
+    assert_match "scale(1.25)", find(".image-lightbox-image")[:style]
+    find(".image-lightbox-close").click
+    assert_no_selector ".image-lightbox-dialog"
+
+    visit collavre.creatives_path(id: @creative.id)
+    find(".creative-title-content img[alt='First']").click
+    assert_selector ".image-lightbox-dialog[open] .image-lightbox-counter", text: "1 / 2"
+    page.driver.browser.action.send_keys(:escape).perform
+    assert_no_selector ".image-lightbox-dialog"
+    assert_current_path collavre.creatives_path(id: @creative.id)
+  end
+end

--- a/engines/collavre/test/system/creative_image_lightbox_test.rb
+++ b/engines/collavre/test/system/creative_image_lightbox_test.rb
@@ -35,6 +35,42 @@ class CreativeImageLightboxTest < ApplicationSystemTestCase
     assert_selector ".image-lightbox-dialog[open] .image-lightbox-counter", text: "1 / 2"
   end
 
+  test "keyboard users can focus images and open the viewer from images and links" do
+    [ collavre.creatives_path, collavre.creatives_path(id: @creative.id) ].each do |path|
+      visit path
+      if path.include?("?")
+        # The title page opens chat automatically; finish that transition first.
+        assert_docked_comments_loaded
+      end
+      scope = path.include?("?") ? ".creative-title-content" : "#creative-#{@creative.id}"
+      first = find("#{scope} img[alt='First'][role='button']")
+      link = find("#{scope} a:has(img[alt='Second'])")
+      page.execute_script("arguments[0].focus()", link)
+      assert_equal link, page.evaluate_script("document.activeElement")
+      page.driver.browser.action.key_down(:shift).send_keys(:tab).key_up(:shift).perform
+      assert_equal first, page.evaluate_script("document.activeElement")
+
+      page.driver.browser.action.send_keys(:space).perform
+      assert_selector ".image-lightbox-dialog[open] .image-lightbox-counter", text: "1 / 2"
+      page.driver.browser.action.send_keys(:escape).perform
+      assert_no_selector ".image-lightbox-dialog"
+      assert_equal first, page.evaluate_script("document.activeElement")
+
+      page.driver.browser.action.send_keys(:enter).perform
+      assert_selector ".image-lightbox-dialog[open] .image-lightbox-counter", text: "1 / 2"
+      page.driver.browser.action.send_keys(:escape).perform
+      assert_no_selector ".image-lightbox-dialog"
+      page.driver.browser.action.send_keys(:tab).perform
+      assert_equal link, page.evaluate_script("document.activeElement")
+      page.driver.browser.action.send_keys(:enter).perform
+      assert_selector ".image-lightbox-dialog[open] .image-lightbox-counter", text: "2 / 2"
+      page.driver.browser.action.send_keys(:escape).perform
+      assert_no_selector ".image-lightbox-dialog"
+      assert_equal link, page.evaluate_script("document.activeElement")
+      assert_current_path path
+    end
+  end
+
   test "list and title images open the chat viewer without navigation" do
     visit collavre.creatives_path
     find("#creative-#{@creative.id} img[alt='Second']").click

--- a/engines/collavre/test/system/creative_image_lightbox_test.rb
+++ b/engines/collavre/test/system/creative_image_lightbox_test.rb
@@ -18,6 +18,23 @@ class CreativeImageLightboxTest < ApplicationSystemTestCase
     sign_in_via_ui(@user)
   end
 
+  test "selection mode selects image rows and restores the viewer when cancelled" do
+    visit collavre.creatives_path
+    assert_selector "#creative-#{@creative.id} img[alt='First']"
+    find('[aria-controls="creative-overflow-menu"]').click
+    find("#select-creative-btn").click
+
+    find("#creative-#{@creative.id} img[alt='First']").click
+    assert_selector "#creative-#{@creative.id} .select-creative-checkbox:checked"
+    assert_no_selector ".image-lightbox-dialog"
+
+    find('[aria-controls="creative-overflow-menu"]').click
+    find("#select-creative-btn").click
+    assert_no_selector "#creative-#{@creative.id} .select-creative-checkbox:checked", visible: :all
+    find("#creative-#{@creative.id} img[alt='First']").click
+    assert_selector ".image-lightbox-dialog[open] .image-lightbox-counter", text: "1 / 2"
+  end
+
   test "list and title images open the chat viewer without navigation" do
     visit collavre.creatives_path
     find("#creative-#{@creative.id} img[alt='Second']").click


### PR DESCRIPTION
Images in creative bodies and titles now open the existing chat image viewer at the selected image, with the carousel scoped to that creative. The shared viewer retains image descriptions as users navigate and reuses its zoom, navigation, and close controls. Unsupported download/delete controls are hidden; chat attachment controls retain their existing behavior.

Keyboard users can reach unlinked images with Tab and open them with Enter or Space. Image-only links also open the viewer when activated from the keyboard or assistive technology; mixed text/image links retain keyboard navigation to their destination. Images receive visible focus and accessible names, with an English/Korean fallback for missing descriptions. Streamed images receive the same behavior. Generated link labels are recalculated when descriptions or captions change, while author-supplied names are preserved. Active toolbar selection suppresses the viewer and linked-image navigation, while editing and ordinary pointer clicks on link captions retain their behavior.

Validation:
- 35 focused JavaScript tests passed; the creative image controller has 100% statement, branch, function, and line coverage. Regression tests reproduced both keyboard activation failures and stale generated labels before their fixes; label tests also cover description removal, author overrides, and controller reconnection.
- Three browser system tests passed on the keyboard activation revision (43 assertions), covering list/title images, real Tab navigation, Enter/Space activation, focus restoration after closing, carousel navigation, zoom, and selection mode.
- RuboCop for the changed system test, complexity ratchet, and asset build passed.
- New focus CSS passed Stylelint. Whole-file Stylelint still reports three pre-existing hardcoded colors, reproduced on the previous commit.
- Only change-specific tests were run locally, per project workflow; CI validates the full suite.
