### PR TITLE
fix: restore full-width mobile workspace content

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/workspace.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/workspace.css
@@ -318,13 +318,6 @@ body.creative-workspace .indent3 {
         max-width: var(--max-width);
     }
 
-    /* Reserve the handle's width outside the scrolling content so row controls
-       never pass underneath it, including in long creative lists. */
-    .creative-workspace-shell > main {
-        margin-left: 2.75rem;
-        width: calc(100% - 2.75rem);
-    }
-
     /* Keep the drawer handle in easy thumb reach on one-panel screens while
        clearing the device's bottom safe area. */
     .creative-workspace-tree-toggle {

--- a/engines/collavre/test/system/workspace_tree_drawer_test.rb
+++ b/engines/collavre/test/system/workspace_tree_drawer_test.rb
@@ -184,29 +184,28 @@ class WorkspaceTreeDrawerTest < ApplicationSystemTestCase
     end
   end
 
-  # Check initial placement too, including the unchanged two-panel gutter.
-  [ MOBILE_WIDTH, TWO_PANEL_WIDTH ].each do |width|
-    test "the closed drawer handle covers no control in the content column at #{width}px" do
-      visit_workspace(width)
-      assert_selector ".creative-workspace-tree-toggle"
+  # Only the two-panel layout reserves a gutter; mobile allows temporary overlap
+  # and relies on the full-width and scroll-clearance tests above.
+  test "the closed drawer handle covers no control in the two-panel content column" do
+    visit_workspace(TWO_PANEL_WIDTH)
+    assert_selector ".creative-workspace-tree-toggle"
 
-      covered = page.evaluate_script(<<~JS)
-        (function () {
-          var handle = document.querySelector('.creative-workspace-tree-toggle').getBoundingClientRect();
-          var controls = document.querySelectorAll('main a, main button, main input, main [role="button"]');
-          return Array.prototype.filter.call(controls, function (control) {
-            var rect = control.getBoundingClientRect();
-            if (rect.width === 0 || rect.height === 0) return false;
-            return rect.left < handle.right && rect.right > handle.left &&
-                   rect.top < handle.bottom && rect.bottom > handle.top;
-          }).map(function (control) {
-            return (control.textContent || control.getAttribute('aria-label') || control.tagName).trim();
-          });
-        })();
-      JS
+    covered = page.evaluate_script(<<~JS)
+      (function () {
+        var handle = document.querySelector('.creative-workspace-tree-toggle').getBoundingClientRect();
+        var controls = document.querySelectorAll('main a, main button, main input, main [role="button"]');
+        return Array.prototype.filter.call(controls, function (control) {
+          var rect = control.getBoundingClientRect();
+          if (rect.width === 0 || rect.height === 0) return false;
+          return rect.left < handle.right && rect.right > handle.left &&
+                 rect.top < handle.bottom && rect.bottom > handle.top;
+        }).map(function (control) {
+          return (control.textContent || control.getAttribute('aria-label') || control.tagName).trim();
+        });
+      })();
+    JS
 
-      assert_empty covered, "the drawer handle overlaps content controls: #{covered.inspect}"
-    end
+    assert_empty covered, "the drawer handle overlaps content controls: #{covered.inspect}"
   end
 
   test "the tree keeps its own column and hides the toggle at three-panel width" do

--- a/engines/collavre/test/system/workspace_tree_drawer_test.rb
+++ b/engines/collavre/test/system/workspace_tree_drawer_test.rb
@@ -127,22 +127,22 @@ class WorkspaceTreeDrawerTest < ApplicationSystemTestCase
   end
 
   [ 375, MOBILE_WIDTH, 767 ].each do |width|
-    test "scrolled row controls stay clear of the mobile drawer handle at #{width}px" do
+    test "row controls can scroll above the floating mobile drawer handle at #{width}px" do
       branches = Array.new(35) do |index|
         branch = Creative.create!(description: "Scroll branch #{index}", user: @user)
         Creative.create!(description: "Scroll leaf #{index}", user: @user, parent: branch)
         branch
       end
       visit_workspace(width)
-      row_selector = "#creative-#{branches[20].id}"
+      row_selector = "#creative-#{branches.last.id}"
       control = find("#{row_selector} .creative-toggle-btn")
 
-      # Align a real row control with the fixed handle after document scrolling.
-      # Initial-position checks with a short list cannot exercise this overlap.
+      # The floating handle must not reserve a full-height gutter. Even a row
+      # near the end of a long list must scroll above it to remain operable.
       page.execute_script(<<~JS, control)
         const rect = arguments[0].getBoundingClientRect();
         const handle = document.querySelector('.creative-workspace-tree-toggle').getBoundingClientRect();
-        window.scrollBy(0, rect.top + rect.height / 2 - handle.top - handle.height / 2);
+        window.scrollBy(0, rect.bottom - handle.top + 16);
       JS
       assert_operator page.evaluate_script("window.scrollY"), :>, 0
       assert_selector "#{row_selector} .creative-toggle-btn" do |button|
@@ -151,18 +151,36 @@ class WorkspaceTreeDrawerTest < ApplicationSystemTestCase
             const rect = arguments[0].getBoundingClientRect();
             const handle = document.querySelector('.creative-workspace-tree-toggle').getBoundingClientRect();
             const centerY = rect.top + rect.height / 2;
-            return centerY > handle.top && centerY < handle.bottom && rect.left >= handle.right &&
+            return rect.top >= 0 && rect.bottom < handle.top &&
               arguments[0].contains(document.elementFromPoint(rect.left + rect.width / 2, centerY));
           })();
         JS
       end
 
       control.click
-      assert_selector "creative-tree-row[dom-id='creative-#{branches[20].id}'][expanded]"
+      assert_selector "creative-tree-row[dom-id='creative-#{branches.last.id}'][expanded]"
       assert_no_selector ".creative-workspace-tree-region.is-open"
       assert_toggle_within_viewport
       find(".creative-workspace-tree-toggle").click
       assert_selector ".creative-workspace-tree-region.is-open"
+    end
+  end
+
+  [ 375, MOBILE_WIDTH, 767 ].each do |width|
+    test "mobile content uses the full width without a drawer gutter at #{width}px" do
+      visit_workspace(width)
+
+      bounds = page.evaluate_script(<<~JS)
+        (() => {
+          const main = document.querySelector('.creative-workspace-shell > main').getBoundingClientRect();
+          return { left: main.left, right: main.right, viewport: window.innerWidth,
+            pageWidth: document.documentElement.scrollWidth };
+        })();
+      JS
+
+      assert_in_delta 0, bounds.fetch("left"), 1
+      assert_in_delta bounds.fetch("viewport"), bounds.fetch("right"), 1
+      assert_operator bounds.fetch("pageWidth"), :<=, bounds.fetch("viewport")
     end
   end
 


### PR DESCRIPTION
Remove the 44px left gutter introduced by #1674 so mobile workspace content uses the full screen width again. Keep the tree toggle floating at the bottom with its existing safe-area offset and chat-sheet stacking behavior.

The floating handle can temporarily cover a row while scrolling. Users can scroll that row above the handle; this preserves the requested full-width layout without adding a dedicated side or bottom bar. Replace the former gutter-specific assertion with coverage that a row near the end of a long list can scroll above the handle and expand normally.

The no-overlap assertion applies only to the two-panel layout, where the gutter remains. Mobile behavior is covered by the full-width and scroll-clearance regressions.

Validation:
- Drawer system suite: 17 tests, 150 assertions, no failures or errors.
- New full-width regressions at 375px, 430px, and 767px reproduce the previous 44px gap and pass after removal.
- Existing chat-sheet, tablet, and desktop regressions pass.
- Changed-file RuboCop and the complexity ratchet pass.
- Mobile preview checked at 375px: content bounds span 0–375px with no horizontal gutter.

Only the relevant test suite was run, per project workflow.

