### PR TITLE
feat: browse images across the creative list

### DIFF
--- a/engines/collavre/app/javascript/controllers/__tests__/creative_image_lightbox_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/creative_image_lightbox_controller.test.js
@@ -40,15 +40,19 @@ afterEach(async () => {
   jest.restoreAllMocks()
 })
 
-test('opens the clicked image, blocks navigation and scopes the carousel to its creative', () => {
+test('opens the clicked image, blocks navigation and navigates across the creative list in DOM order', () => {
   const onClick = jest.fn()
   document.querySelector('#row').addEventListener('click', onClick)
   expect(click('#second')).toBe(false)
   expect(onClick).not.toHaveBeenCalled()
   expect(dialog().querySelector('img').src).toBe('http://localhost/second.png')
-  expect(dialog().querySelector('.image-lightbox-counter').textContent).toBe('2 / 2')
+  expect(dialog().querySelector('.image-lightbox-counter').textContent).toBe('2 / 3')
+  click('.image-lightbox-next')
+  expect(dialog().querySelector('img').src).toBe('http://localhost/title.png')
   click('.image-lightbox-next')
   expect(dialog().querySelector('img').src).toBe('http://localhost/first.png')
+  click('.image-lightbox-prev')
+  expect(dialog().querySelector('img').src).toBe('http://localhost/title.png')
   click('.image-lightbox-prev')
   expect(dialog().querySelector('img').src).toBe('http://localhost/second.png')
   expect(dialog().querySelector('.image-lightbox-delete').hidden).toBe(true)
@@ -60,8 +64,8 @@ test('opens the clicked image, blocks navigation and scopes the carousel to its 
 
 test('opens title images and preserves zoom, keyboard navigation and close', () => {
   click('#title')
-  expect(dialog().querySelector('.image-lightbox-counter').textContent).toBe('1 / 1')
-  expect(dialog().querySelector('.image-lightbox-next').style.visibility).toBe('hidden')
+  expect(dialog().querySelector('.image-lightbox-counter').textContent).toBe('3 / 3')
+  expect(dialog().querySelector('.image-lightbox-next').style.visibility).toBe('visible')
   click('.image-lightbox-zoom-in')
   expect(dialog().querySelector('img').style.transform).toContain('scale(1.25)')
   click('.image-lightbox-close')
@@ -83,6 +87,8 @@ test('preserves image descriptions on every carousel entry and clears missing or
   expect(dialog().querySelector('img').alt).toBe(description)
   click('.image-lightbox-prev')
   expect(dialog().querySelector('img').alt).toBe('First')
+  click('.image-lightbox-prev')
+  expect(dialog().querySelector('img').alt).toBe('')
   click('.image-lightbox-prev')
   expect(dialog().querySelector('img').alt).toBe('')
   click('.image-lightbox-prev')
@@ -352,4 +358,29 @@ test('makes an image keyboard accessible when its source arrives later', async (
   expect(document.activeElement.id).toBe('missing')
   expect(keydown('#missing', 'Enter')).toBe(false)
   expect(dialog().querySelector('img').src).toBe('http://localhost/loaded.png')
+})
+
+test('rebuilds the gallery across rows on each open and preserves duplicate image positions', () => {
+  const titleRow = document.querySelector('#title').closest('creative-tree-row')
+  titleRow.insertAdjacentHTML('afterend', `
+    <creative-tree-row id="streamed"><div class="creative-content"><img id="duplicate" src="/first.png" alt="Duplicate"></div></creative-tree-row>`)
+  click('#duplicate')
+  expect(dialog().querySelector('.image-lightbox-counter').textContent).toBe('4 / 4')
+  expect(dialog().querySelector('img').alt).toBe('Duplicate')
+  click('.image-lightbox-close')
+  document.querySelector('#row').remove()
+  titleRow.before(document.querySelector('#streamed'))
+  click('#title')
+  expect(dialog().querySelector('.image-lightbox-counter').textContent).toBe('2 / 2')
+  click('.image-lightbox-prev')
+  expect(dialog().querySelector('img').alt).toBe('Duplicate')
+})
+
+test('excludes images outside the current list and editor images inside a creative', () => {
+  document.body.insertAdjacentHTML('beforeend', '<div class="creative-content"><img src="/outside.png"></div>')
+  document.querySelector('.creative-content').insertAdjacentHTML('beforeend', `
+    <div contenteditable="true"><img src="/nested-editor.png"></div>
+    <div class="inline-edit-form"><img src="/nested-form.png"></div>`)
+  click('#first')
+  expect(dialog().querySelector('.image-lightbox-counter').textContent).toBe('1 / 3')
 })

--- a/engines/collavre/app/javascript/controllers/__tests__/creative_image_lightbox_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/creative_image_lightbox_controller.test.js
@@ -24,7 +24,7 @@ beforeEach(async () => {
       </div></creative-tree-row>
       <creative-tree-row><div class="creative-title-content"><img id="title" src="/title.png"></div></creative-tree-row>
       <div contenteditable="true"><div class="creative-content"><img id="editor" src="/editor.png"></div></div>
-      <div class="inline-edit-form"><div class="creative-content"><img id="form" src="/form.png"></div></div>
+      <div class="inline-edit-form-shell"><div class="creative-content"><img id="form" src="/form.png"></div></div>
       <img id="avatar" src="/avatar.png">
     </main>`
   application = Application.start()
@@ -380,7 +380,69 @@ test('excludes images outside the current list and editor images inside a creati
   document.body.insertAdjacentHTML('beforeend', '<div class="creative-content"><img src="/outside.png"></div>')
   document.querySelector('.creative-content').insertAdjacentHTML('beforeend', `
     <div contenteditable="true"><img src="/nested-editor.png"></div>
-    <div class="inline-edit-form"><img src="/nested-form.png"></div>`)
+    <div class="inline-edit-form-shell"><img src="/nested-form.png"></div>`)
   click('#first')
   expect(dialog().querySelector('.image-lightbox-counter').textContent).toBe('1 / 3')
+})
+
+
+test.each([
+  ['collapsed subtree', '<div class="creative-children" data-expanded="false" style="display:none">'],
+  ['row being edited', '<div class="creative-row" style="display:none">'],
+  ['hidden ancestor', '<div hidden>']
+])('excludes images inside a %s from the gallery', (_name, container) => {
+  document.querySelector('main').insertAdjacentHTML('beforeend', `${container}
+    <creative-tree-row><div class="creative-content"><img id="hidden-image" src="/hidden.png"></div></creative-tree-row>
+  </div>`)
+  expect(click('#hidden-image')).toBe(true)
+  expect(dialog()).toBeNull()
+  click('#title')
+  expect(dialog().querySelector('.image-lightbox-counter').textContent).toBe('3 / 3')
+  click('.image-lightbox-next')
+  expect(dialog().querySelector('img').alt).toBe('First')
+  click('.image-lightbox-prev')
+  expect(dialog().querySelector('img').src).toBe('http://localhost/title.png')
+})
+
+test.each(['hidden', 'display'])('excludes an image directly hidden with %s', (mechanism) => {
+  const image = document.querySelector('#second')
+  if (mechanism === 'hidden') image.hidden = true
+  else image.style.display = 'none'
+  click('#title')
+  expect(dialog().querySelector('.image-lightbox-counter').textContent).toBe('2 / 2')
+  click('.image-lightbox-prev')
+  expect(dialog().querySelector('img').alt).toBe('First')
+})
+
+test('prepares collapsed images and rebuilds the gallery after expanding and collapsing loaded rows', async () => {
+  document.querySelector('main').insertAdjacentHTML('beforeend', `
+    <div id="children" class="creative-children" data-expanded="false" style="display:none">
+      <creative-tree-row><div class="creative-content"><img id="child-image" src="/child.png" alt="Child"></div></creative-tree-row>
+    </div>`)
+  await settle()
+  const children = document.querySelector('#children')
+  const child = document.querySelector('#child-image')
+  expect(child.tabIndex).toBe(0)
+  expect(child.getAttribute('role')).toBe('button')
+  expect(child.getAttribute('aria-haspopup')).toBe('dialog')
+  expect(child.getAttribute('aria-label')).toBe('Child')
+
+  children.style.display = ''
+  children.dataset.expanded = 'true'
+  child.focus()
+  expect(document.activeElement).toBe(child)
+  expect(keydown('#child-image', 'Enter')).toBe(false)
+  expect(dialog().querySelector('.image-lightbox-counter').textContent).toBe('4 / 4')
+  expect(dialog().querySelector('img').alt).toBe('Child')
+  click('.image-lightbox-close')
+
+  children.style.display = 'none'
+  children.dataset.expanded = 'false'
+  click('#title')
+  expect(dialog().querySelector('.image-lightbox-counter').textContent).toBe('3 / 3')
+  click('.image-lightbox-close')
+  children.style.display = ''
+  children.dataset.expanded = 'true'
+  expect(keydown('#child-image', ' ')).toBe(false)
+  expect(dialog().querySelector('.image-lightbox-counter').textContent).toBe('4 / 4')
 })

--- a/engines/collavre/app/javascript/controllers/creative_image_lightbox_controller.js
+++ b/engines/collavre/app/javascript/controllers/creative_image_lightbox_controller.js
@@ -35,7 +35,14 @@ export default class extends ImageLightboxController {
 
   _listImages() {
     return Array.from(this.element.querySelectorAll('.creative-content img[src], .creative-title-content img[src]'))
-      .filter((image) => image.getAttribute("src") && !image.closest('[contenteditable="true"], .inline-edit-form'))
+      .filter((image) => image.getAttribute("src") && !image.closest('[contenteditable="true"], .inline-edit-form-shell'))
+  }
+
+  _hiddenInList(image) {
+    for (let element = image; element && element !== this.element; element = element.parentElement) {
+      if (element.hidden || element.style.display === "none") return true
+    }
+    return false
   }
 
   _prepareLink(link) {
@@ -78,7 +85,7 @@ export default class extends ImageLightboxController {
   open(event) {
     const image = this._imageForEvent(event)
     const content = image?.closest(".creative-content, .creative-title-content")
-    if (!content || image.closest('[contenteditable="true"], .inline-edit-form')) return
+    if (!content || image.closest('[contenteditable="true"], .inline-edit-form-shell')) return
     if (this._selectionActive(content)) {
       if (event.type === "keydown") {
         // Suppress document shortcuts while preserving pointer row selection.
@@ -88,7 +95,8 @@ export default class extends ImageLightboxController {
       return
     }
 
-    const images = this._listImages()
+    // Keep hidden images prepared for keyboard access when their rows are revealed.
+    const images = this._listImages().filter((image) => !this._hiddenInList(image))
     const index = images.indexOf(image)
     if (index < 0) return
 

--- a/engines/collavre/app/javascript/controllers/creative_image_lightbox_controller.js
+++ b/engines/collavre/app/javascript/controllers/creative_image_lightbox_controller.js
@@ -20,8 +20,7 @@ export default class extends ImageLightboxController {
   }
 
   _prepareImages() {
-    this.element.querySelectorAll('.creative-content img[src], .creative-title-content img[src]').forEach((image) => {
-      if (!image.getAttribute("src") || image.closest('[contenteditable="true"], .inline-edit-form')) return
+    this._listImages().forEach((image) => {
       const link = image.closest("a[href]")
       if (link) {
         this._prepareLink(link)
@@ -32,6 +31,11 @@ export default class extends ImageLightboxController {
       image.setAttribute("aria-haspopup", "dialog")
       image.setAttribute("aria-label", image.alt || this.i18nOpenValue)
     })
+  }
+
+  _listImages() {
+    return Array.from(this.element.querySelectorAll('.creative-content img[src], .creative-title-content img[src]'))
+      .filter((image) => image.getAttribute("src") && !image.closest('[contenteditable="true"], .inline-edit-form'))
   }
 
   _prepareLink(link) {
@@ -84,7 +88,7 @@ export default class extends ImageLightboxController {
       return
     }
 
-    const images = Array.from(content.querySelectorAll("img[src]")).filter((img) => img.getAttribute("src"))
+    const images = this._listImages()
     const index = images.indexOf(image)
     if (index < 0) return
 

--- a/engines/collavre/test/system/creative_image_lightbox_test.rb
+++ b/engines/collavre/test/system/creative_image_lightbox_test.rb
@@ -40,6 +40,52 @@ class CreativeImageLightboxTest < ApplicationSystemTestCase
     assert_current_path collavre.creatives_path
   end
 
+  test "collapsed child images are excluded and regain keyboard access when expanded" do
+    child = Creative.create!(user: @user, parent: @creative, description: "Child gallery")
+    child.update!(description: @creative.description.sub("First", "Child"))
+    visit collavre.creatives_path
+    parent_row = "creative-tree-row[dom-id='creative-#{@creative.id}']"
+    child_image = "#creative-#{child.id} img[alt='Child']"
+
+    find("#{parent_row} .creative-toggle-btn").click
+    assert_selector child_image
+    find("#{parent_row} .creative-toggle-btn").click
+    assert_no_selector child_image
+    assert_selector child_image, visible: :hidden
+    find("#creative-#{@creative.id} img[alt='First']").click
+    assert_selector ".image-lightbox-counter", text: "1 / 2"
+    find(".image-lightbox-next").click
+    assert_selector ".image-lightbox-image[alt='Second']"
+    find(".image-lightbox-next").click
+    assert_selector ".image-lightbox-image[alt='First']"
+    find(".image-lightbox-close").click
+
+    find("#{parent_row} .creative-toggle-btn").click
+    image = find("#{child_image}[role='button'][tabindex='0']")
+    page.execute_script("arguments[0].focus()", image)
+    page.driver.browser.action.send_keys(:enter).perform
+    assert_selector ".image-lightbox-counter", text: "3 / 4"
+    assert_selector ".image-lightbox-image[alt='Child']"
+  end
+
+  test "images in a row being edited are excluded until editing closes" do
+    sibling = Creative.create!(user: @user, description: @creative.description)
+    visit collavre.creatives_path
+    row = "creative-tree-row[dom-id='creative-#{sibling.id}']"
+    find("#{row} .creative-row").hover
+    find("#{row} .edit-inline-btn").click
+    assert_selector "#inline-edit-form-element"
+    assert_selector "#creative-#{sibling.id} img[alt='First']", visible: :hidden
+
+    find("#creative-#{@creative.id} img[alt='First']").click
+    assert_selector ".image-lightbox-counter", text: "1 / 2"
+    find(".image-lightbox-close").click
+    find("#inline-close").click
+    assert_no_selector "#inline-edit-form-element"
+    find("#creative-#{@creative.id} img[alt='First']").click
+    assert_selector ".image-lightbox-counter", text: %r{[13] / 4}
+  end
+
   test "selection mode selects image rows and restores the viewer when cancelled" do
     visit collavre.creatives_path
     assert_selector "#creative-#{@creative.id} img[alt='First']"

--- a/engines/collavre/test/system/creative_image_lightbox_test.rb
+++ b/engines/collavre/test/system/creative_image_lightbox_test.rb
@@ -18,6 +18,28 @@ class CreativeImageLightboxTest < ApplicationSystemTestCase
     sign_in_via_ui(@user)
   end
 
+  test "the gallery navigates images across creative rows in list order" do
+    sibling = Creative.create!(user: @user, description: "Another gallery")
+    sibling.files.attach(@creative.files.first.blob)
+    url = Rails.application.routes.url_helpers.rails_blob_path(sibling.files.first, only_path: true)
+    sibling.update!(description: "<img src='#{url}' alt='Sibling' width='80' height='80'>")
+
+    visit collavre.creatives_path
+    assert_selector "#creative-#{sibling.id} img[alt='Sibling']"
+    images = all(".creative-content img[src]")
+    expected_alts = images.map { |image| image[:alt] }
+    assert_equal 3, expected_alts.size
+    images.last.click
+    assert_selector ".image-lightbox-counter", text: "3 / 3"
+    find(".image-lightbox-next").click
+    assert_selector ".image-lightbox-image[alt='#{expected_alts.first}']"
+    find(".image-lightbox-prev").click
+    assert_selector ".image-lightbox-image[alt='#{expected_alts.last}']"
+    page.driver.browser.action.send_keys(:arrow_left).perform
+    assert_selector ".image-lightbox-image[alt='#{expected_alts[1]}']"
+    assert_current_path collavre.creatives_path
+  end
+
   test "selection mode selects image rows and restores the viewer when cancelled" do
     visit collavre.creatives_path
     assert_selector "#creative-#{@creative.id} img[alt='First']"


### PR DESCRIPTION
Opening a creative image previously limited the carousel to that creative. The viewer now includes images across the currently visible creative list, including title images, in DOM order and starts at the clicked image.

The gallery is rebuilt on each open so added, removed, reordered, expanded, and collapsed rows are reflected. Images hidden by collapsed subtrees, rows being edited, or the `hidden` attribute are excluded, along with empty sources, inline editors, avatars, and images outside the list. Unloaded creatives are not fetched.

Visibility filtering applies only when opening the gallery. Hidden images still receive keyboard accessibility attributes so revealing an already-loaded subtree does not require another preparation pass. The editor guard uses the actual `.inline-edit-form-shell` class. Selection mode and chat attachment behavior are preserved.

Validation:
- Focused JavaScript suite: 43 tests passed; controller statement, branch, function, and line coverage all 100%.
- Focused browser suite: 6 tests, 72 assertions passed, including collapse/re-expand keyboard access and hiding/restoring a row during editing.
- An initial browser run encountered a focus race in the existing title keyboard test; the subsequent complete focused run passed.
- RuboCop: 1,407 files passed. Complexity ratchet and asset build passed.
