### PR TITLE
fix(collavre): make the cron badge count follow its host's theme token

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/creatives.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/creatives.css
@@ -1045,7 +1045,13 @@ creative-tree-row.is-being-edited .creative-tree {
     padding: 0 var(--space-2);
     border-radius: var(--radius-round, 9999px);
     background: transparent;
-    color: var(--text-muted);
+
+    /* Inherit the host row's text color instead of pinning --text-muted.
+       On a selected topic chip the background flips to --color-secondary-active
+       and the chip text to --color-badge-text; a pinned muted grey left the
+       count at ~1.1:1 contrast there, invisible in dark mode. Inheriting keeps
+       the count on whatever token the surrounding text already resolved to. */
+    color: inherit;
     font-size: var(--text-0);
     white-space: nowrap;
     border: 0;
@@ -1078,7 +1084,7 @@ creative-tree-row.is-being-edited .creative-tree {
 
 .cron-task {
     padding: var(--space-2) 0;
-    border-top: var(--border-1) solid var(--border-muted);
+    border-top: var(--border-1) solid var(--border-color);
 }
 
 .cron-task:first-of-type {
@@ -1093,7 +1099,7 @@ creative-tree-row.is-being-edited .creative-tree {
     margin-bottom: var(--space-1);
     color: var(--text-muted);
     font-size: var(--text-0);
-    font-weight: var(--weight-semibold);
+    font-weight: var(--weight-6);
 }
 
 .cron-task code,

--- a/engines/collavre/test/assets/cron_badge_css_test.rb
+++ b/engines/collavre/test/assets/cron_badge_css_test.rb
@@ -1,0 +1,51 @@
+require "test_helper"
+
+# The cron badge renders inside two different hosts — the creative list row and
+# the topic chip — whose text color comes from different tokens, and the topic
+# chip swaps its color again when selected. Guard the stylesheet against
+# re-pinning a single color (which goes invisible on the selected chip) and
+# against referencing tokens design_tokens.css never defines (which silently
+# collapses to currentColor / the light fallback in dark mode).
+class CronBadgeCssTest < ActiveSupport::TestCase
+  STYLESHEET_DIR = Collavre::Engine.root.join("app/assets/stylesheets/collavre")
+  CRON_SELECTORS = %w[
+    .creative-cron-badge
+    .popup-menu.cron-badge-popup
+    .cron-badge-popup-title
+    .cron-task
+    .cron-task-label
+    .cron-task-message-input
+  ].freeze
+
+  setup do
+    @css = STYLESHEET_DIR.join("creatives.css").read
+    @defined_tokens = STYLESHEET_DIR.join("design_tokens.css").read.scan(/^\s*(--[a-z0-9-]+):/).flatten.to_set
+  end
+
+  test "badge count inherits its host's text color instead of pinning one token" do
+    declarations = rule_body(".creative-cron-badge")
+
+    assert_match(/color:\s*inherit\s*;/, declarations,
+                 "cron badge must inherit the topic chip / creative row text color")
+    refute_match(/color:\s*var\(--text-muted\)/, declarations,
+                 "a pinned muted grey drops to ~1.1:1 contrast on the selected topic chip")
+  end
+
+  test "every design token the cron badge references is defined" do
+    CRON_SELECTORS.each do |selector|
+      rule_body(selector).scan(/var\((--[a-z0-9-]+)/) do |(token)|
+        assert_includes @defined_tokens, token,
+                        "#{selector} references #{token}, which design_tokens.css does not define " \
+                        "(it would fall back to the light value in dark mode)"
+      end
+    end
+  end
+
+  private
+
+  def rule_body(selector)
+    match = @css.match(/^#{Regexp.escape(selector)}\s*\{(.*?)\}/m)
+    assert match, "#{selector} rule not found in creatives.css"
+    match[1]
+  end
+end

--- a/engines/collavre/test/system/topic_cron_badge_theme_test.rb
+++ b/engines/collavre/test/system/topic_cron_badge_theme_test.rb
@@ -1,0 +1,86 @@
+require_relative "../application_system_test_case"
+
+# The cron badge sits inside the topic chip, whose text color flips when the
+# chip is selected. Pinning the badge to --text-muted left the count at ~1.1:1
+# against the selected chip's accent fill — invisible in dark mode.
+class TopicCronBadgeThemeTest < ApplicationSystemTestCase
+  setup do
+    @user = User.create!(
+      email: "cron-badge-theme@example.com",
+      password: SystemHelpers::PASSWORD,
+      name: "CronBadgeThemeUser",
+      email_verified_at: Time.current,
+      notifications_enabled: false,
+      theme: "dark"
+    )
+    @creative = Creative.create!(description: "Scheduled root", user: @user)
+    @topic = Collavre::Topic.create!(name: "Alpha", creative: @creative, user: @user)
+    @task = SolidQueue::RecurringTask.create!(
+      key: "cron_#{@creative.id}_theme",
+      class_name: "Collavre::CronActionJob",
+      schedule: "0 9 * * *",
+      static: false,
+      arguments: [ { creative_id: @creative.id, topic_id: @topic.id, message: "Daily summary" } ]
+    )
+
+    resize_window_to
+    sign_in_via_ui(@user)
+  end
+
+  teardown do
+    @task.destroy! if @task&.persisted?
+  end
+
+  test "badge count uses the topic label color in dark mode, selected or not" do
+    open_comments_popup
+
+    assert_includes page.evaluate_script("document.body.className").split, "dark-mode"
+
+    assert_equal(*chip_and_badge_color(".topic-tag:not(.active)"),
+                 "idle topic chip badge must read like its label")
+
+    # Click the chip itself, not its centre — the badge and the archive/delete
+    # buttons sit there and swallow the selection click.
+    select_topic_chip("Alpha")
+    assert_selector "#comment-topics .topic-tag.active .creative-cron-badge", wait: 5
+
+    assert_equal(*chip_and_badge_color(".topic-tag.active"),
+                 "selected topic chip badge must read like its label")
+  end
+
+  private
+
+  def select_topic_chip(name)
+    chip = find("#comment-topics .topic-tag", text: name)
+    page.execute_script("arguments[0].click()", chip)
+  end
+
+  def open_comments_popup
+    visit root_path
+    assert_selector "#creative-#{@creative.id}", wait: 5
+    find("#creative-#{@creative.id}").hover
+    within("#creative-#{@creative.id}") { find(".comments-btn").click }
+    assert_selector "#comments-popup", wait: 5
+    assert_selector "#comment-topics .topic-tag .creative-cron-badge", wait: 10
+    assert_docked_comments_loaded
+  end
+
+  # Returns [chip label color, badge color] for the first chip matching
+  # +chip_selector+ that actually carries a cron badge.
+  def chip_and_badge_color(chip_selector)
+    colors = page.evaluate_script(<<~JS)
+      (() => {
+        const chip = Array.from(
+          document.querySelectorAll('#comment-topics #{chip_selector}')
+        ).find(node => node.querySelector('.creative-cron-badge'))
+        if (!chip) return null
+        return [
+          getComputedStyle(chip).color,
+          getComputedStyle(chip.querySelector('.creative-cron-badge')).color
+        ]
+      })()
+    JS
+    assert colors, "no topic chip matching #{chip_selector} carries a cron badge"
+    colors
+  end
+end


### PR DESCRIPTION
## Problem

The scheduled-task badge pinned its count color to `--text-muted`. That token
does not track the state of the chip the badge lives in, so on a **selected**
topic chip — where the fill becomes `--color-secondary-active` and the label
becomes `--color-badge-text` — the count dropped to **1.14:1** contrast in dark
mode. Effectively invisible. Light mode had the same defect at 1.43:1.

On an idle chip the count was legible but still visibly dimmer than the topic
label sitting right next to it (7.64:1 vs 14.76:1).

## Fix

`.creative-cron-badge` now uses `color: inherit`, so the count resolves to
whichever token the surrounding label already resolved to:

| context | before | after |
|---|---|---|
| idle topic chip, dark | `--text-muted` — 7.64:1 | `--color-text` — 14.76:1 |
| selected topic chip, dark | `--text-muted` — **1.14:1** | `--color-badge-text` — 2.64:1 |
| selected topic chip, light | `--text-muted` — **1.43:1** | `--color-badge-text` — 3.98:1 |
| creative list row | `--text-muted` — 7.64:1 / 5.74:1 | unchanged (inherits `.creative-row-end`) |

Ratios measured from computed styles in headless Chromium against both themes.

Two more declarations in the badge popup pointed at tokens `design_tokens.css`
never defines, so they silently fell back:

- `.cron-task` divider used `--border-muted` → collapsed to `currentColor`
- `.cron-task-label` used `--weight-semibold` → lost its weight entirely

Both now use real tokens (`--border-color`, `--weight-6`).

## Tests

- `engines/collavre/test/assets/cron_badge_css_test.rb` — asserts the badge
  inherits rather than pinning a color, and that every `var(--*)` the cron
  rules reference is defined in `design_tokens.css`.
- `engines/collavre/test/system/topic_cron_badge_theme_test.rb` — dark-mode
  system test comparing the badge's computed color against the chip label, both
  idle and selected.

Both fail on `main` and pass here. `creative_cron_badge_alignment_test`,
`topic_list_popup_test`, `topics_controller_test`, and the component suite stay
green; `stylelint` output on `creatives.css` is unchanged from baseline.

## Out of scope

The selected topic chip's own label is white on `--color-active`, which is
2.64:1 dark / 3.98:1 light — still under WCAG AA. That is the existing chip
design and affects every topic label, not just the badge. Worth a separate
look at `--color-secondary-active`.