### PR TITLE
fix: unblock dependency CI and handle deleted creative preference saves

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
 
+      # ActiveStorage initializes its Vips transformer during Rails boot.
+      - name: Install image processing runtime
+        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y libvips
+
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
 
-      # ActiveStorage initializes its Vips transformer during Rails boot.
+      # ActiveStorage 8.1.3.1 eagerly loads its Vips transformer during Rails boot.
       - name: Install image processing runtime
         run: sudo apt-get update && sudo apt-get install --no-install-recommends -y libvips
 

--- a/Gemfile
+++ b/Gemfile
@@ -45,17 +45,12 @@ gem "thruster", require: false
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 gem "image_processing", "~> 2.0"
-# The variant processor is Rails 8's default, :vips, so ImageProcessing::Vips needs ruby-vips.
-# image_processing 1.x pulls it in transitively; 2.0 makes it a soft dependency instead, and
-# ImageProcessing::Vips is only resolved when a variant is actually processed — a missing
-# ruby-vips boots fine and raises on the first avatar or comment image instead. Depending on it
-# here keeps that bump from turning into a runtime failure. (Dockerfile installs libvips, the
-# C library this binds to.)
-#
-# require: false because naming the gem is only meant to pin the bundle, not to change when it
-# loads: an auto-required ruby-vips dlopens libvips during boot, so every environment that merely
-# boots the app -- the postgres_schema_load CI job, say -- would suddenly need the C library
-# installed. image_processing requires it on its own when a variant is actually processed.
+# Rails defaults to the :vips variant processor. image_processing 2.0 makes ruby-vips a soft
+# dependency, so declare it explicitly for avatar and comment image processing.
+# require: false leaves loading to ActiveStorage/image_processing rather than Bundler.
+# ActiveStorage 8.1.3.1 eagerly loads its Vips transformer during boot, so this option does not
+# remove the native libvips requirement from boot-only environments. Dockerfile and both Rails
+# CI jobs (including postgres_schema_load) install that C library.
 gem "ruby-vips", "~> 2.0", require: false
 
 # Use AWS S3 for Active Storage

--- a/engines/collavre/app/controllers/collavre/user_creative_preferences_controller.rb
+++ b/engines/collavre/app/controllers/collavre/user_creative_preferences_controller.rb
@@ -1,9 +1,7 @@
 module Collavre
   class UserCreativePreferencesController < ApplicationController
     MAX_LAST_TOPIC_SAVE_SESSIONS = 32
-    # A concurrent collapse can delete the row between the lookup and the lock.
-    # Retrying twice covers that race; beyond it the row is not coming back.
-    MAX_PREFERENCE_LOCK_ATTEMPTS = 3
+    include Persistence
 
     def toggle
       creative_id = params[:creative_id]
@@ -161,43 +159,6 @@ module Collavre
       record.last_topic_save_sequences = sequences
       record.last_topic_save_session_id = session_id
       record.last_topic_save_sequence = sequence
-    end
-
-    # insert_all uses the unique preference key as the first-insert fence.
-    # A row lock alone cannot serialize two requests that both see no row.
-    def preference_for(creative_id)
-      now = Time.current
-      attributes = { creative_id: creative_id, user_id: Current.user.id, expanded_status: {}, created_at: now, updated_at: now }
-      UserCreativePreference.insert_all([ attributes ], unique_by: :index_user_creative_preferences_on_creative_id_and_user_id)
-      UserCreativePreference.find_by!(creative_id: creative_id, user_id: Current.user.id)
-    end
-
-    # A collapse can remove an empty row after it is found but before with_lock
-    # reloads it. Reacquire by the unique preference key so every save path
-    # shares the same first-insert and deletion-race handling.
-    #
-    # Only the lookup/lock window is retried, and only a bounded number of
-    # times: once the row is locked the block owns the transaction, so a
-    # RecordNotFound it raises itself must propagate rather than replay the
-    # block, and a row that keeps vanishing must surface instead of spinning.
-    def with_preference(creative_id)
-      attempts = 0
-      locked = false
-
-      begin
-        record = preference_for(creative_id)
-        record.with_lock do
-          locked = true
-          yield record
-        end
-      rescue ActiveRecord::RecordNotFound
-        raise if locked
-
-        attempts += 1
-        raise if attempts >= MAX_PREFERENCE_LOCK_ATTEMPTS
-
-        retry
-      end
     end
 
     # Preserve the legacy single-session columns while a rolling deploy may

--- a/engines/collavre/app/controllers/concerns/collavre/user_creative_preferences_controller/persistence.rb
+++ b/engines/collavre/app/controllers/concerns/collavre/user_creative_preferences_controller/persistence.rb
@@ -6,10 +6,6 @@ module Collavre
     # Retrying twice covers that race; beyond it the row is not coming back.
     MAX_PREFERENCE_LOCK_ATTEMPTS = 3
 
-    included do
-      rescue_from ActiveRecord::InvalidForeignKey, with: :handle_deleted_preference_creative
-    end
-
     private
 
     # insert_all uses the unique preference key as the first-insert fence.
@@ -17,8 +13,19 @@ module Collavre
     def preference_for(creative_id)
       now = Time.current
       attributes = { creative_id: creative_id, user_id: Current.user.id, expanded_status: {}, created_at: now, updated_at: now }
-      UserCreativePreference.insert_all([ attributes ], unique_by: :index_user_creative_preferences_on_creative_id_and_user_id)
+      insert_preference(attributes)
       UserCreativePreference.find_by!(creative_id: creative_id, user_id: Current.user.id)
+    end
+
+    def insert_preference(attributes)
+      UserCreativePreference.transaction(requires_new: true) do
+        UserCreativePreference.insert_all([ attributes ], unique_by: :index_user_creative_preferences_on_creative_id_and_user_id)
+      end
+    rescue ActiveRecord::InvalidForeignKey
+      # Only the initial insert is covered, after its savepoint has rolled back.
+      # Check the actual origin id being written, not the linked request id.
+      Creative.find(attributes[:creative_id]) if attributes[:creative_id].present?
+      raise
     end
 
     # A collapse can remove an empty row after it is found but before with_lock
@@ -47,15 +54,6 @@ module Collavre
 
         retry
       end
-    end
-
-    # Run after the failed save transaction has unwound, so PostgreSQL can
-    # query again. A delayed browser save for a deleted creative is a 404;
-    # violations involving a live creative must still surface as errors.
-    def handle_deleted_preference_creative(error)
-      raise error if params[:creative_id].blank? || Creative.exists?(params[:creative_id])
-
-      head :not_found
     end
   end
 end

--- a/engines/collavre/app/controllers/concerns/collavre/user_creative_preferences_controller/persistence.rb
+++ b/engines/collavre/app/controllers/concerns/collavre/user_creative_preferences_controller/persistence.rb
@@ -1,0 +1,61 @@
+module Collavre
+  module UserCreativePreferencesController::Persistence
+    extend ActiveSupport::Concern
+
+    # A concurrent collapse can delete the row between the lookup and the lock.
+    # Retrying twice covers that race; beyond it the row is not coming back.
+    MAX_PREFERENCE_LOCK_ATTEMPTS = 3
+
+    included do
+      rescue_from ActiveRecord::InvalidForeignKey, with: :handle_deleted_preference_creative
+    end
+
+    private
+
+    # insert_all uses the unique preference key as the first-insert fence.
+    # A row lock alone cannot serialize two requests that both see no row.
+    def preference_for(creative_id)
+      now = Time.current
+      attributes = { creative_id: creative_id, user_id: Current.user.id, expanded_status: {}, created_at: now, updated_at: now }
+      UserCreativePreference.insert_all([ attributes ], unique_by: :index_user_creative_preferences_on_creative_id_and_user_id)
+      UserCreativePreference.find_by!(creative_id: creative_id, user_id: Current.user.id)
+    end
+
+    # A collapse can remove an empty row after it is found but before with_lock
+    # reloads it. Reacquire by the unique preference key so every save path
+    # shares the same first-insert and deletion-race handling.
+    #
+    # Only the lookup/lock window is retried, and only a bounded number of
+    # times: once the row is locked the block owns the transaction, so a
+    # RecordNotFound it raises itself must propagate rather than replay the
+    # block, and a row that keeps vanishing must surface instead of spinning.
+    def with_preference(creative_id)
+      attempts = 0
+      locked = false
+
+      begin
+        record = preference_for(creative_id)
+        record.with_lock do
+          locked = true
+          yield record
+        end
+      rescue ActiveRecord::RecordNotFound
+        raise if locked
+
+        attempts += 1
+        raise if attempts >= MAX_PREFERENCE_LOCK_ATTEMPTS
+
+        retry
+      end
+    end
+
+    # Run after the failed save transaction has unwound, so PostgreSQL can
+    # query again. A delayed browser save for a deleted creative is a 404;
+    # violations involving a live creative must still surface as errors.
+    def handle_deleted_preference_creative(error)
+      raise error if params[:creative_id].blank? || Creative.exists?(params[:creative_id])
+
+      head :not_found
+    end
+  end
+end

--- a/engines/collavre/test/controllers/user_creative_preferences_deletion_test.rb
+++ b/engines/collavre/test/controllers/user_creative_preferences_deletion_test.rb
@@ -1,0 +1,72 @@
+require "test_helper"
+
+class UserCreativePreferencesDeletionTest < ActionDispatch::IntegrationTest
+  include ActionCable::TestHelper
+
+  setup do
+    @user = users(:one)
+    sign_in_as(@user, password: "password")
+    @creative = Collavre::Creative.create!(user: @user, description: "Deletion race")
+    @path = "/creatives/#{@creative.id}/user_creative_preferences/update_last_topic"
+  end
+
+  test "issuing a fence after the creative disappears returns not found" do
+    delete_creative_before_preference_insert do
+      post @path, as: :json
+    end
+
+    assert_response :not_found
+    assert_no_preference
+  end
+
+  test "saving All Messages after the creative disappears does not broadcast" do
+    stream = "user_#{@user.id}_creative_#{@creative.id}"
+    assert_no_broadcasts(Collavre::TopicsChannel.broadcasting_for(stream)) do
+      delete_creative_before_preference_insert do
+        patch @path, params: { last_topic_id: nil }, as: :json
+      end
+    end
+
+    assert_response :not_found
+    assert_no_preference
+  end
+
+  test "expansion save racing with creative deletion returns not found" do
+    delete_creative_before_preference_insert do
+      post "/creative_expanded_states/toggle",
+           params: { creative_id: @creative.id, node_id: @creative.id, expanded: true }, as: :json
+    end
+
+    assert_response :not_found
+    assert_no_preference
+  end
+
+  test "an unrelated foreign key violation still raises" do
+    error = ActiveRecord::InvalidForeignKey.new("unrelated foreign key")
+    Collavre::UserCreativePreference.stub(:insert_all, ->(*) { raise error }) do
+      assert_same error, assert_raises(ActiveRecord::InvalidForeignKey) { post @path, as: :json }
+    end
+  end
+
+  test "root expansion preferences still work without a creative id" do
+    post "/creative_expanded_states/toggle", params: { node_id: @creative.id, expanded: true }, as: :json
+
+    assert_response :success
+    preference = Collavre::UserCreativePreference.find_by!(creative_id: nil, user_id: @user.id)
+    assert_equal({ @creative.id.to_s => true }, preference.expanded_status)
+  end
+
+  private
+
+  def delete_creative_before_preference_insert
+    insert = Collavre::UserCreativePreference.method(:insert_all)
+    Collavre::UserCreativePreference.stub(:insert_all, lambda { |*args, **options|
+      @creative.destroy!
+      insert.call(*args, **options)
+    }) { yield }
+  end
+
+  def assert_no_preference
+    assert_not Collavre::UserCreativePreference.exists?(creative_id: @creative.id, user_id: @user.id)
+  end
+end

--- a/engines/collavre/test/controllers/user_creative_preferences_deletion_test.rb
+++ b/engines/collavre/test/controllers/user_creative_preferences_deletion_test.rb
@@ -48,6 +48,16 @@ class UserCreativePreferencesDeletionTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "a foreign key violation outside the insert still raises after creative deletion" do
+    error = ActiveRecord::InvalidForeignKey.new("unrelated foreign key")
+    Collavre::UserCreativePreference.stub(:find_by!, lambda { |*|
+      @creative.destroy!
+      raise error
+    }) do
+      assert_same error, assert_raises(ActiveRecord::InvalidForeignKey) { post @path, as: :json }
+    end
+  end
+
   test "root expansion preferences still work without a creative id" do
     post "/creative_expanded_states/toggle", params: { node_id: @creative.id, expanded: true }, as: :json
 
@@ -59,10 +69,11 @@ class UserCreativePreferencesDeletionTest < ActionDispatch::IntegrationTest
   private
 
   def delete_creative_before_preference_insert
-    insert = Collavre::UserCreativePreference.method(:insert_all)
-    Collavre::UserCreativePreference.stub(:insert_all, lambda { |*args, **options|
-      @creative.destroy!
-      insert.call(*args, **options)
+    transaction = Collavre::UserCreativePreference.method(:transaction)
+    Collavre::UserCreativePreference.stub(:transaction, lambda { |**options, &block|
+      # The concurrent deletion commits before the insert's savepoint begins.
+      @creative.destroy! unless @creative.destroyed?
+      transaction.call(**options, &block)
     }) { yield }
   end
 

--- a/engines/collavre/test/support/system_helpers.rb
+++ b/engines/collavre/test/support/system_helpers.rb
@@ -44,6 +44,12 @@ module SystemHelpers
         })(arguments[0])
       JS
     end
+    # Opening chat can schedule composer focus and scrolling after list loading.
+    # Let that render finish before a test moves focus or opens a lazy frame.
+    page.evaluate_async_script(<<~JS)
+      const done = arguments[0];
+      requestAnimationFrame(() => requestAnimationFrame(() => done()));
+    JS
   end
 
   def wait_for_network_idle(timeout: Capybara.default_max_wait_time)

--- a/engines/collavre/test/system/comment_activity_duration_test.rb
+++ b/engines/collavre/test/system/comment_activity_duration_test.rb
@@ -32,13 +32,13 @@ class CommentActivityDurationTest < ApplicationSystemTestCase
     within("#comment_#{@reply.id}") do
       assert_no_selector ".comment-execution-time"
       assert_selector "time[datetime]"
-      find(".comment-activity-log-block summary").click
+      open_activity_logs
       assert_selector ".activity-time", text: /ago\s*\(1m 23s\)/
       assert_no_selector ".activity-log-duration"
     end
     within("#comment_#{@reviewed.id}") do
       assert_no_selector ".comment-execution-time"
-      find(".comment-activity-log-block summary").click
+      open_activity_logs
       assert_selector ".activity-time .activity-execution-time", text: "(20s)"
     end
     within("#comment_#{@historical.id}") do
@@ -50,13 +50,22 @@ class CommentActivityDurationTest < ApplicationSystemTestCase
       assert_no_selector ".comment-activity-log-block"
     end
     within("#comment_#{@logged.id}") do
-      find(".comment-activity-log-block summary").click
+      open_activity_logs
       assert_selector ".activity-name", text: "LLM"
       assert_no_selector ".activity-log-duration, .activity-execution-time"
     end
   end
 
   private
+
+  def open_activity_logs
+    find(".comment-activity-log-block summary").click
+    # Turbo's lazy frame below the summary may still be outside the chat's
+    # scroll viewport. Bring it into view so its request actually starts.
+    frame = find("turbo-frame[id^='activity_log_details_']", visible: :all)
+    page.execute_script("arguments[0].scrollIntoView({ block: 'center' })", frame)
+    assert_selector ".activity-log-list"
+  end
 
   def create_reviewed_reply
     @reviewed = Comment.create!(creative: @creative, user: @user, content: "Draft")

--- a/engines/collavre/test/system/creative_image_lightbox_test.rb
+++ b/engines/collavre/test/system/creative_image_lightbox_test.rb
@@ -118,6 +118,8 @@ class CreativeImageLightboxTest < ApplicationSystemTestCase
       if path.include?("?")
         # The title page opens chat automatically; finish that transition first.
         assert_docked_comments_loaded
+        # Composer focus is scheduled in the animation frame after list loading.
+        assert_selector "#comments-popup textarea:focus"
       end
       scope = path.include?("?") ? ".creative-title-content" : "#creative-#{@creative.id}"
       first = find("#{scope} img[alt='First'][role='button']")

--- a/engines/collavre/test/system/creative_image_lightbox_test.rb
+++ b/engines/collavre/test/system/creative_image_lightbox_test.rb
@@ -118,8 +118,6 @@ class CreativeImageLightboxTest < ApplicationSystemTestCase
       if path.include?("?")
         # The title page opens chat automatically; finish that transition first.
         assert_docked_comments_loaded
-        # Composer focus is scheduled in the animation frame after list loading.
-        assert_selector "#comments-popup textarea:focus"
       end
       scope = path.include?("?") ? ".creative-title-content" : "#creative-#{@creative.id}"
       first = find("#{scope} img[alt='First'][role='button']")

--- a/engines/collavre/test/system/workflow_rule_editor_test.rb
+++ b/engines/collavre/test/system/workflow_rule_editor_test.rb
@@ -7,6 +7,7 @@ class WorkflowRuleEditorTest < ApplicationSystemTestCase
   include WorkflowCreativeHelper
 
   setup do
+    resize_window_to
     @user = users(:one)
     @user.update!(email_verified_at: Time.current, locale: "en")
     @workflow = create_workflow


### PR DESCRIPTION
Dependency PRs #1472/#1476 cannot boot ActiveStorage 8.1.3.1 in the PostgreSQL CI job without `libvips` ([failing run](https://github.com/sh1nj1/plan42/actions/runs/32812015008)). PR #1586 also hit a foreign-key error when a delayed preference save raced with creative deletion ([failing run](https://github.com/sh1nj1/plan42/actions/runs/34661909016)).

Install the Vips runtime in the PostgreSQL job and correct the Gemfile's boot-requirement comment. Recover only around the initial preference insert, using a savepoint and the actual origin ID: a deleted creative returns 404, while foreign-key errors outside that insert continue to raise. Extract the existing bounded preference-lock retry logic without changing its behavior.

Stabilize browser interactions by scrolling the lazy activity frame into view, letting scheduled chat focus/scroll rendering finish, and resetting the workflow editor test's viewport.

Validation:
- [Linux CI on final SHA `fc3e0c28f`](https://github.com/sh1nj1/plan42/actions/runs/34730121477): all 14 GitHub checks passed. Ruby: 5,860 runs, 0 failures/errors, 2 existing skips. Core system tests: 158 runs, 0 failures/errors, 1 existing skip. JavaScript: 2,531 tests passed. PostgreSQL schema/query smoke checks, lint, complexity, security scans, and patch coverage passed.
- PostgreSQL 14 deletion regressions: 6 tests / 20 assertions passed. Final controller/retry coverage: 31 tests / 145 assertions passed. Host tests: 193 passed.
- Vrex independently approved `314876bd` in Collavre topic 19332, including 41 system-test runs covering the shared helper's additional callers and the persistence regressions.
- Follow-up `fc3e0c28f` changes only Gemfile comments. Ruby syntax, RuboCop, and pre-push checks passed. Vrex verified all four comment claims against gem sources and CI configuration; final review closure is pending. Both this SHA and its executable-code-identical parent passed all 14 GitHub checks.

Known limitation: local macOS repeated browser runs still show intermittent lazy activity-frame loading and lightbox focus failures. Vrex's alternating main/branch runs found an improvement, but not complete elimination; a passing Linux run does not establish that these flakes are gone. No checks were skipped or assertions weakened to obtain the Linux result.

After this fix lands, rebase #1610, #1586, #1476, and #1472 and rerun their CI. The channel-chip authentication and chat-filter fixes are already on main; this PR's green run does not replace validation of those dependency branches.
